### PR TITLE
[REVIEW] Moving setup.py to project root for readthedocs.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM pygdf
 ADD ml-prims /cuML/ml-prims
 ADD cuML /cuML/cuML
 ADD python /cuML/python
+ADD setup.py /cuML/setup.py
 
-WORKDIR /cuML/python
+WORKDIR /cuML
 RUN source activate gdf && conda install cython
 RUN source activate gdf && python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -119,8 +119,8 @@ except AttributeError:
 
 
 ext = Extension('cuML',
-                sources=['../cuML/src/pca/pca.cu', '../cuML/src/tsvd/tsvd.cu', '../cuML/src/dbscan/dbscan.cu', 'cuML/cuml.pyx'],
-                depends=['../cuML/src/tsvd/tsvd.cu'],
+                sources=['cuML/src/pca/pca.cu', 'cuML/src/tsvd/tsvd.cu', 'cuML/src/dbscan/dbscan.cu', 'python/cuML/cuml.pyx'],
+                depends=['cuML/src/tsvd/tsvd.cu'],
                 library_dirs=[CUDA['lib64']],
                 libraries=['cudart','cublas','cusolver'],
                 language='c++',
@@ -128,7 +128,7 @@ ext = Extension('cuML',
                 # this syntax is specific to this build system
                 extra_compile_args={'gcc': ['-std=c++11'],
                                     'nvcc': ['-arch=sm_60', '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'",'-std=c++11','--expt-extended-lambda']},
-                include_dirs = [numpy_include, CUDA['include'], '../cuML/src', '../cuML/external/ml-prims/src','../cuML/external/ml-prims/external/cutlass', '../cuML/external/cutlass','../cuML/external/ml-prims/external/cub'],
+                include_dirs = [numpy_include, CUDA['include'], 'cuML/src', 'cuML/external/ml-prims/src','cuML/external/ml-prims/external/cutlass', 'cuML/external/cutlass','cuML/external/ml-prims/external/cub'],
                 extra_link_args=["-std=c++11"])
 
 


### PR DESCRIPTION
Builds of HTML for cuml.readthedocs.io are failing.

This is because sphinx, which generates the HTML, needs to be able to import the Python module to read the docstrings. cuML is pyx, which Sphinx can't naturally understand (at least as far as I've been able to figure out). As a result, the doc build setup as it stands needs to "python setup.py install" this library before docs can be built.

Unfortunately, readthedocs.io [doesn't yet support](https://github.com/rtfd/readthedocs.org/issues/4354) configuring the environment to "cd ${subdir} && python setup.py install".

The workaround I came up with is to move setup.py to project root. Perhaps future build setup can either be more flexible, or the readthedocs configuration improvements let us move this back into the "python" subdirectory.