### PR TITLE
[REVIEW] Fix RTD Builds

### DIFF
--- a/conda_environments/builddocs_py36.yml
+++ b/conda_environments/builddocs_py36.yml
@@ -1,16 +1,17 @@
-name: builddocs_py35
+name: builddocs_py36
 channels:
-- gpuopenanalytics/label/dev
+- mikewendt
+- rapidsai
+- pytorch
 - conda-forge
 - numba
 - defaults
 dependencies:
-- python=3.5.*
-- pytest
+- python=3.6.*
+- cuml=0.2.0.*
 - cudatoolkit=9.2
+- nvdriver=396.44
 - cudf=0.2.0
-- numba>=0.40.0dev
-- pandas=0.20.*
 - pyarrow=0.10.*
 - cython=0.28.5
 - pip:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,34 +1,34 @@
 cuML API Reference
 ====================
 
-.. currentmodule:: cuML.DBSCAN
+.. currentmodule:: cuml.DBSCAN
 
 K-Nearest Neighbors
 -------------------
 
-.. autoclass:: cuML.KNN
+.. autoclass:: cuml.KNN
     :members:
 
 K-Means
 -------------------
 
-.. autoclass:: cuML.KMeans
+.. autoclass:: cuml.KMeans
     :members:
 
 DBSCAN
 ---------
 
-.. autoclass:: cuML.DBSCAN
+.. autoclass:: cuml.DBSCAN
     :members:
     
 PCA
 ---------
 
-.. autoclass:: cuML.PCA
+.. autoclass:: cuml.PCA
     :members:
 
 Truncated SVD
 -------------
 
-.. autoclass:: cuML.TruncatedSVD
+.. autoclass:: cuml.TruncatedSVD
     :members:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
+build:
+   image: latest
+
 python:
-   version: 3.5
+   version: 3.6
 
 conda:
-    file: conda_environments/builddocs_py35.yml
+   file: conda_environments/builddocs_py36.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,6 +3,7 @@ build:
 
 python:
    version: 3.6
+   setup_py_install: false
 
 conda:
    file: conda_environments/builddocs_py36.yml


### PR DESCRIPTION
Use `cuml` conda package instead of building from source, given the complexities of building cuml with CUDA.

Docs built from this PR > https://cuml.readthedocs.io/en/fix-readthedocs-build/