### PR TITLE
Fixing dbscan crash issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.swp
+__pycache__/
+build/
+cuml.egg-info/
+dist/
+python/cuML/cuml.cpp

--- a/cuML/src/dbscan/dbscan.cu
+++ b/cuML/src/dbscan/dbscan.cu
@@ -23,66 +23,58 @@ namespace ML {
 
 using namespace Dbscan;
 
+int computeBatchCount(int n_rows) {
+    int n_batches = 1;
+    // HACK HACK HACK: there seems to be a weird overflow bug with cutlass gemm kernels
+    // hence, artifically limiting to a smaller batchsize!
+    ///@todo: in future, when we bump up the underlying cutlass version, this should go away
+    // paving way to cudaMemGetInfo based workspace allocation
+    static const size_t MaxElems = (size_t)1024 * 1024 * 1024 * 2;  // 2e9
+    while(true) {
+        size_t batchSize = ceildiv<size_t>(n_rows, n_batches);
+        if(batchSize * n_rows < MaxElems)
+            break;
+        ++n_batches;
+    }
+    return n_batches;
+}
+
 void dbscanFit(float *input, int n_rows, int n_cols, float eps, int min_pts,
 		       int *labels) {
+    int algoVd = 502;
+    int algoAdj = 1;
+    int algoCcl = 2;
+    int n_batches = computeBatchCount(n_rows);
+    size_t workspaceSize = Dbscan::run(input, n_rows, n_cols, eps, min_pts,
+                                       labels, algoVd, algoAdj, algoCcl, NULL,
+                                       n_batches, 0);
 
-	int algoVd = 401;
-	int algoAdj = 1;
-	int algoCcl = 2;
-	int n_batches = 1;
-	int workspaceSize;
+    char* workspace;
+    CUDA_CHECK(cudaMalloc((void** )&workspace, workspaceSize));
 
-	size_t free, total;
-	CUDA_CHECK(cudaMemGetInfo(&free, &total));
+    Dbscan::run(input, n_rows, n_cols, eps, min_pts, labels, algoVd, algoAdj,
+                algoCcl, workspace, n_batches, 0);
 
-	while (true) {
-		workspaceSize = Dbscan::run(input, n_rows, n_cols, eps, min_pts,
-				labels, algoVd, algoAdj, algoCcl, NULL, n_batches, 0);
-
-		if (workspaceSize < free)
-			break;
-
-		n_batches++;
-	}
-
-	char* workspace;
-	CUDA_CHECK(cudaMalloc((void** )&workspace, workspaceSize));
-
-	Dbscan::run(input, n_rows, n_cols, eps, min_pts, labels, algoVd, algoAdj,
-			algoCcl, workspace, n_batches, 0);
-
-	CUDA_CHECK(cudaFree(workspace));
+    CUDA_CHECK(cudaFree(workspace));
 }
 
 void dbscanFit(double *input, int n_rows, int n_cols, double eps, int min_pts,
 		       int *labels) {
+    int algoVd = 502;
+    int algoAdj = 1;
+    int algoCcl = 2;
+    int n_batches = computeBatchCount(n_rows);
+    size_t workspaceSize = Dbscan::run(input, n_rows, n_cols, eps, min_pts,
+                                       labels, algoVd, algoAdj, algoCcl, NULL,
+                                       n_batches, 0);
 
-	int algoVd = 401;
-	int algoAdj = 1;
-	int algoCcl = 2;
-	int n_batches = 1;
-	int workspaceSize;
+    char* workspace;
+    CUDA_CHECK(cudaMalloc((void** )&workspace, workspaceSize));
 
-	size_t free, total;
-	CUDA_CHECK(cudaMemGetInfo(&free, &total));
+    Dbscan::run(input, n_rows, n_cols, eps, min_pts, labels, algoVd, algoAdj,
+                algoCcl, workspace, n_batches, 0);
 
-	while (true) {
-		workspaceSize = Dbscan::run(input, n_rows, n_cols, eps, min_pts,
-				labels, algoVd, algoAdj, algoCcl, NULL, n_batches, 0);
-
-		if (workspaceSize < free)
-			break;
-
-		n_batches++;
-	}
-
-	char* workspace;
-	CUDA_CHECK(cudaMalloc((void** )&workspace, workspaceSize));
-
-	Dbscan::run(input, n_rows, n_cols, eps, min_pts, labels, algoVd, algoAdj,
-			algoCcl, workspace, n_batches, 0);
-
-	CUDA_CHECK(cudaFree(workspace));
+    CUDA_CHECK(cudaFree(workspace));
 }
 
 /** @} */

--- a/cuML/src/dbscan/runner.h
+++ b/cuML/src/dbscan/runner.h
@@ -106,7 +106,6 @@ size_t run(Type_f* x, Type N, Type D, Type_f eps, Type minPts, Type* labels,
     Type_f* dots = (Type_f*)temp;
 	// Running VertexDeg
 	for (int i = 0; i < nBatches; i++) {
-            fflush(stdout);
 		Type *adj_graph = NULL;
 		int startVertexId = i * batchSize;
                 int nPoints = min(N-startVertexId, batchSize);

--- a/cuML/src/dbscan/vertexdeg/algo4.h
+++ b/cuML/src/dbscan/vertexdeg/algo4.h
@@ -80,8 +80,11 @@ void launcher(Pack<value_t> data, cudaStream_t stream, int startVertexId, int ba
     epilogue_op_t epilogue(data.eps, data.vd, batchSize);
     epsneigh_dispatch<TilingStrategy, value_t, bool, cutlass::math_operation_scalar,
                       epilogue_op_t, ds_accummulate<value_t, value_t> > edis;
-    auto res = edis(data.N, batchSize, data.D, data.x, data.x + startVertexId*data.D,
-                    data.adj, epilogue, stream, false, false);
+    int m = data.N;
+    int n = min(data.N - startVertexId, batchSize);
+    int k = data.D;
+    auto res = edis(m, n, k, data.x, data.x + startVertexId*data.D, data.adj,
+                    epilogue, stream, false, false);
     CUDA_CHECK(res.result);
 }
 

--- a/cuML/src/dbscan/vertexdeg/runner.h
+++ b/cuML/src/dbscan/vertexdeg/runner.h
@@ -37,9 +37,9 @@ void run(bool* adj, int* vd, Type* x, Type* dots, Type eps, int N, int D,
     // case 400:
     //     Algo4::launcher<Type, tiling_strategy::Small>(data, stream, startVertexId, batchSize);
     //     break;
-    case 401:
-        Algo4::launcher<Type, tiling_strategy::Medium>(data, stream, startVertexId, batchSize);
-        break;
+    // case 401:
+    //     Algo4::launcher<Type, tiling_strategy::Medium>(data, stream, startVertexId, batchSize);
+    //     break;
     // case 402:
     //     Algo4::launcher<Type, tiling_strategy::Large>(data, stream, startVertexId, batchSize);
     //     break;
@@ -58,9 +58,9 @@ void run(bool* adj, int* vd, Type* x, Type* dots, Type eps, int N, int D,
     // case 501:
     //     Algo5::launcher<Type, tiling_strategy::Medium>(data, stream, startVertexId, batchSize);
     //     break;
-    // case 502:
-    //     Algo5::launcher<Type, tiling_strategy::Large>(data, stream, startVertexId, batchSize);
-    //     break;
+    case 502:
+        Algo5::launcher<Type, tiling_strategy::Large>(data, stream, startVertexId, batchSize);
+        break;
     // case 503:
     //     Algo5::launcher<Type, tiling_strategy::Tall>(data, stream, startVertexId, batchSize);
     //     break;

--- a/cuML/src/utils.h
+++ b/cuML/src/utils.h
@@ -40,10 +40,13 @@ namespace Dbscan {
     } while(0)
 
 
-inline int ceildiv(int a, int b) {
+template <typename IntType>
+IntType ceildiv(IntType a, IntType b) {
     return ((a + b - 1) / b);
 }
-inline int alignSize(int a, int b) {
+
+template <typename IntType>
+IntType alignSize(IntType a, IntType b) {
     return ceildiv(a,b)*b;
 }
 


### PR DESCRIPTION
  - updated .gitignore to look out for and exclude cython build files
  - due to a bug in cutlass 'batchSize' cannot be more than 2G elements.
    Hence, updated the workspace computation logic to limit under this value.
  - this should be fixed once we migrate to newer version of cutlass
  - fixed various locations where potential integer overflows could occur
  - updated the batchSize computation for the last iteration in case of
    partially covered rows

I also switched to a different cutlass gemm kernel variant which should give decent perf across varied dataset sizes.