### PR TITLE
[REVIEW] Fix: Removed cuda_free of unused variable in tsvd_test.cu

### DIFF
--- a/cuML/test/tsvd_test.cu
+++ b/cuML/test/tsvd_test.cu
@@ -142,7 +142,6 @@ protected:
 		CUDA_CHECK(cudaFree(components));
 		CUDA_CHECK(cudaFree(singular_vals));
 		CUDA_CHECK(cudaFree(components_ref));
-		CUDA_CHECK(cudaFree(explained_vars_ref));
 		CUDA_CHECK(cudaFree(data2));
 		CUDA_CHECK(cudaFree(data2_trans));
 		CUDA_CHECK(cudaFree(data2_back));


### PR DESCRIPTION
This PR removes an unnecesasary cuda_free in the tsvd test that would cause the tests to fail unpredictably. With this PR the whole test suite is now clean and passing reliably to my knowledge. 

Test coverage will be further expanded in follow up PRs. 