### PR TITLE
RAPML-100: update CMakeLists.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,15 @@ $ cd cuML
 $ mkdir build
 $ cd build
 $ cmake ..
-$ make -j
+$ make -j 
+$ # Instead of previous step if you like you can use cmake directly
+$ cmake --build . --config Release -- -j
 $ ./ml_test
 ```
 
-To test the python package:
-
+To list available test:
+```bash
+$./ml_test --gtest_list_tests
 ```
 $ py.test python/cuML/test
 ```

--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -90,17 +90,16 @@ include_directories(src
 
 add_subdirectory(${GTEST_DIR}/googletest ${PROJECT_BINARY_DIR}/googletest)
 
-add_executable(ml_test
-  test/pca_test.cu
-  test/tsvd_test.cu
-  test/dbscan_test.cu
-  test/kmeans_test.cu
-  )
+# Append source file in recursive manner, append header files to target for work with them in IDE
+file(GLOB_RECURSE ml_prims_header "${MLPRIMS_DIR}/src/*.h" "${MLPRIMS_DIR}/src/*.hpp")
+file(GLOB_RECURSE cuml_test_cuda_sources "test/*.cu")
 
+add_executable(ml_test ${cuml_test_cuda_sources} ${ml_prims_header})
 target_link_libraries(ml_test
   ${GTEST_LIBNAME}
-  cublas
-  curand
-  cusolver
+  ${CUDA_cublas_LIBRARY}
+  ${CUDA_curand_LIBRARY}
+  ${CUDA_cusolver_LIBRARY}
+  ${CUDA_CUDART_LIBRARY}
   pthread
   z)

--- a/ml-prims/CMakeLists.txt
+++ b/ml-prims/CMakeLists.txt
@@ -60,41 +60,22 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ptx},code=comp
 include_directories(src
   ${GTEST_DIR}/googletest/include
   ${CUTLASS_DIR}
-  ${CUB_DIR})
+  ${CUB_DIR}
+  ${CUDA_TOOLKIT_INCLUDE} # This include directory inplicitly available for course compiled with nvcc, but not for pure host compiler
+)
 
 add_subdirectory(${GTEST_DIR}/googletest ${PROJECT_BINARY_DIR}/googletest)
 
-add_executable(mlcommon_test
-  test/add.cu
-  test/binary_op.cu
-  test/cuda_utils.cu
-  test/cov.cu
-  test/eig.cu
-  test/eltwise.cu
-  test/eltwise2d.cu
-  test/gemm.cu
-  test/kselection.cu
-  test/math.cu
-  test/matrix.cu
-  test/matrix_vector_op.cu
-  test/mean.cu
-  test/mean_center.cu
-  test/mnist.cu
-  test/mvg.cu
-  test/norm.cu
-  test/rng.cu
-  test/rsvd.cu
-  test/stddev.cu
-  test/subtract.cu
-  test/svd.cu
-  test/transpose.cu
-  test/unary_op.cu
-  test/vector_broadcast.cu)
+# Alternative for find sources and headers
+file(GLOB_RECURSE cpp_and_cuda_sources "test/*.cpp" "test/*.c" "test/*.cu")
+
+add_executable(mlcommon_test ${cpp_and_cuda_sources})
 
 target_link_libraries(mlcommon_test
   ${GTEST_LIBNAME}
-  cublas
-  curand
-  cusolver
+  ${CUDA_cublas_LIBRARY}
+  ${CUDA_curand_LIBRARY}
+  ${CUDA_cusolver_LIBRARY}
+  ${CUDA_CUDART_LIBRARY}
   pthread
   z)


### PR DESCRIPTION
What I proposed

1. make some minor updates with CMakeLists.txt in README.md
2. fixup: correct way to link with different CUDA libraries in project files. How it is done currently is nor correct.
3. fixup: make project buildable when from C++ source files CUDA Runtime is using. CUDA runtime just have been forgotten to be linked.
4. Instead enumerate source files by hands for compile target - just use wildcard glob expression to include them in compile target.

Only one reason why project is buildable is that currently all source files has cuda extension and go through nvcc CUDA compiler and 2,3 is well-defined thing for him