### PR TITLE
[WIP] Adding on-device and D2D support for Python kNN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 python/cuML/cuml.cpp
 log
 .DS_Store
+.ipynb_checkpoints/
 
 ## eclipse
 .project

--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(cuml SHARED
             src/tsvd/tsvd.cu
             src/dbscan/dbscan.cu
             src/kmeans/kmeans.cu
+	    src/knn/knn.cu
             )
 
 target_link_libraries(cuml

--- a/cuML/src/knn/knn.cu
+++ b/cuML/src/knn/knn.cu
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "knn_c.h"
+#include <faiss/IndexFlat.h>
+#include <faiss/gpu/GpuIndexFlat.h>
+#include <faiss/gpu/GpuIndexIVFFlat.h>
+#include <faiss/gpu/StandardGpuResources.h>
+
+namespace ML {
+
+using namespace MLCommon;
+
+class kNN {
+
+    faiss::gpu::GpuIndexFlatL2 index_flat;
+    
+    public:
+
+	kNN::kNN() {}
+	kNN::~kNN() {}
+
+        void kNN::fit(float *input, int N, int D) {
+            
+	    faiss::gpu::StandardGpuResources res;
+            this->index_flat(&res, D);
+	    index_flat.add(N, input);
+        }
+
+
+        void kNN::search(float *search_items, int search_items_size, long *res_I, float *res_D, int k) {
+	    
+            index_flat.search(search_items_size, search_items, k, res_D, res_I);
+        }
+
+}
+
+
+/** @} */
+
+}
+;
+// end namespace ML

--- a/cuML/src/knn/knn_c.h
+++ b/cuML/src/knn/knn_c.h
@@ -1,0 +1,17 @@
+
+#include <faiss/gpu/GpuIndexFlatL2.h>
+
+namespace ML {
+
+    using namespace MLCommon;
+
+    class kNN {
+        
+        faiss:gpu::GpuIndexFlatL2 index_flat;
+        kNN();
+        ~kNN();
+        void search(float *search_items, int search_items_size, long *res_I, float *res_D, int k);
+	void fit(float *input, int N, int D);
+
+    };
+}

--- a/python/cuML/knn/c_knn.pxd
+++ b/python/cuML/knn/c_knn.pxd
@@ -1,0 +1,10 @@
+import numpy as np
+cimport numpy as np
+from libcpp cimport bool
+np.import_array
+
+cdef extern from "knn/knn_c.h" namespace "ML":
+
+    cdef cppclass kNN:
+	kNN() except +
+	void search(float *search_items, int search_items_size, long *res_I, float *res_D, int k); 

--- a/python/cuML/knn/knn_wrapper.py
+++ b/python/cuML/knn/knn_wrapper.py
@@ -93,7 +93,9 @@ class KNN:
 
     def fit(self, X):
         if (isinstance(X, cudf.DataFrame)):
-            X = np.array(X.as_gpu_matrix(order = "C"), np.float32, copy = False)
+            gpu_mat = X.as_gpu_matrix(order = "C")
+            X = np.array(gpu_mat, gpu_mat.dtype, copy = False)
+
         assert len(X.shape) == 2, 'data should be two dimensional'
         n_dims = X.shape[1]
         if self.params.n_gpus == 1:
@@ -111,7 +113,8 @@ class KNN:
 
     def query(self, X, k):
         if (isinstance(X, cudf.DataFrame)):
-            X = np.array(X.as_gpu_matrix(order = "C"), np.float32, copy = False)
+            gpu_mat = X.as_gpu_matrix(order = "C")
+            X = np.array(gpu_mat, gpu_mat.dtype, copy = False)
         D, I = self._gpu_index.search(X, k)
         D = self.to_cudf(D, col='distance')
         I = self.to_cudf(I, col='index')

--- a/python/cuML/test/test_knn.py
+++ b/python/cuML/test/test_knn.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from cuml import KNN as cumlKNN
+from sklearn.neighbors import KDTree as skKNN
+import pandas as pd
+import cudf
+import numpy as np
+
+
+from sklearn.metrics import mean_squared_error
+def array_equal(a,b,threshold=1e-2,with_sign=True,metric='mse'):
+    a = to_nparray(a)
+    b = to_nparray(b)
+    if with_sign == False:
+        a,b = np.abs(a),np.abs(b)
+    if metric=='mse':
+        error = mean_squared_error(a,b)
+    else:
+        error = np.sum(a!=b)/(a.shape[0]*a.shape[1])
+    res = error<threshold
+    return res
+
+def to_nparray(x):
+    if isinstance(x,np.ndarray) or isinstance(x,pd.DataFrame):
+        return np.array(x)
+    elif isinstance(x,np.float64):
+        return np.array([x])
+    elif isinstance(x,cudf.DataFrame) or isinstance(x,cudf.Series):
+        return x.to_pandas().values
+    return x     
+
+@pytest.mark.parametrize('datatype', [np.float32, np.float32])
+@pytest.mark.parametrize('input_type', ['dataframe', 'ndarray'])
+def test_knn_predict(datatype, input_type):
+
+    X = np.array([[1, 2], [2, 2], [2, 3], [8, 7], [8, 8], [25, 80]],
+                 dtype=datatype)
+    skknn = skKNN(X)
+    sk_d, sk_i = skknn.query(X, 2)
+
+
+    if input_type == 'dataframe':
+        gdf = cudf.DataFrame()
+        gdf['0'] = np.asarray([1, 2, 2, 8, 8, 25], dtype=datatype)
+        gdf['1'] = np.asarray([2, 2, 3, 7, 8, 80], dtype=datatype)
+        cumlknn = cumlKNN()
+        cumlknn.fit(gdf)
+
+        cuml_d, cuml_i = cumlknn.query(gdf, 2)
+    else:
+        cumlknn = cumlKNN()
+        cumlknn.fit(X)
+        cuml_d, cuml_i = cumlknn.query(X, 2)
+
+    assert array_equal(cuml_i, sk_i)
+
+

--- a/python/notebooks/knn_demo.ipynb
+++ b/python/notebooks/knn_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,12 +108,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "use mortgage data\n",
+      "data (50, 40)\n",
+      "CPU times: user 5.66 s, sys: 692 ms, total: 6.35 s\n",
+      "Wall time: 6.35 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
-    "nrows = 2**16\n",
+    "nrows = 50\n",
     "ncols = 40\n",
     "\n",
     "X = load_data(nrows,ncols)\n",
@@ -122,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,9 +142,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4 ms, sys: 0 ns, total: 4 ms\n",
+      "Wall time: 1.02 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "knn_sk = skKNN(X)\n",
@@ -142,9 +162,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 412 ms, sys: 528 ms, total: 940 ms\n",
+      "Wall time: 993 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "X = cudf.DataFrame.from_pandas(X)"
@@ -152,21 +181,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 424 ms, sys: 300 ms, total: 724 ms\n",
+      "Wall time: 898 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "knn_cuml = cumlKNN(n_gpus=1)\n",
-    "knn_cuml.fit(X)\n",
+    "knn_cuml.fit(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished Searching!\n"
+     ]
+    }
+   ],
+   "source": [
     "D_cuml,I_cuml = knn_cuml.query(X,n_neighbors)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "compare knn: cuml vs sklearn distances NOT equal\n",
+      "compare knn: cuml vs sklearn indexes equal\n"
+     ]
+    }
+   ],
    "source": [
     "passed = array_equal(D_sk,D_cuml)\n",
     "message = 'compare knn: cuml vs sklearn distances %s'%('equal'if passed else 'NOT equal')\n",
@@ -175,20 +238,13 @@
     "message = 'compare knn: cuml vs sklearn indexes %s'%('equal'if passed else 'NOT equal')\n",
     "print(message)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:dev_env]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-dev_env-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -200,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.5.5"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/knn_demo.ipynb
+++ b/python/notebooks/knn_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -117,8 +117,8 @@
      "text": [
       "use mortgage data\n",
       "data (50, 40)\n",
-      "CPU times: user 5.61 s, sys: 740 ms, total: 6.35 s\n",
-      "Wall time: 6.34 s\n"
+      "CPU times: user 5.74 s, sys: 616 ms, total: 6.36 s\n",
+      "Wall time: 6.36 s\n"
      ]
     }
    ],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +150,7 @@
      "output_type": "stream",
      "text": [
       "CPU times: user 0 ns, sys: 0 ns, total: 0 ns\n",
-      "Wall time: 959 µs\n"
+      "Wall time: 1.1 ms\n"
      ]
     }
    ],
@@ -162,15 +162,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 144 ms, sys: 4 ms, total: 148 ms\n",
-      "Wall time: 144 ms\n"
+      "CPU times: user 140 ms, sys: 0 ns, total: 140 ms\n",
+      "Wall time: 141 ms\n"
      ]
     }
    ],
@@ -181,15 +181,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 44 ms, sys: 144 ms, total: 188 ms\n",
-      "Wall time: 183 ms\n"
+      "  C_CONTIGUOUS : True\n",
+      "  F_CONTIGUOUS : False\n",
+      "  OWNDATA : False\n",
+      "  WRITEABLE : True\n",
+      "  ALIGNED : True\n",
+      "  WRITEBACKIFCOPY : False\n",
+      "  UPDATEIFCOPY : False\n",
+      "CPU times: user 44 ms, sys: 136 ms, total: 180 ms\n",
+      "Wall time: 180 ms\n"
      ]
     }
    ],
@@ -201,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {

--- a/python/notebooks/knn_demo.ipynb
+++ b/python/notebooks/knn_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -117,8 +117,8 @@
      "text": [
       "use mortgage data\n",
       "data (50, 40)\n",
-      "CPU times: user 5.66 s, sys: 692 ms, total: 6.35 s\n",
-      "Wall time: 6.35 s\n"
+      "CPU times: user 5.61 s, sys: 740 ms, total: 6.35 s\n",
+      "Wall time: 6.34 s\n"
      ]
     }
    ],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,15 +142,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4 ms, sys: 0 ns, total: 4 ms\n",
-      "Wall time: 1.02 ms\n"
+      "CPU times: user 0 ns, sys: 0 ns, total: 0 ns\n",
+      "Wall time: 959 µs\n"
      ]
     }
    ],
@@ -162,15 +162,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 412 ms, sys: 528 ms, total: 940 ms\n",
-      "Wall time: 993 ms\n"
+      "CPU times: user 144 ms, sys: 4 ms, total: 148 ms\n",
+      "Wall time: 144 ms\n"
      ]
     }
    ],
@@ -181,15 +181,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 424 ms, sys: 300 ms, total: 724 ms\n",
-      "Wall time: 898 ms\n"
+      "CPU times: user 44 ms, sys: 144 ms, total: 188 ms\n",
+      "Wall time: 183 ms\n"
      ]
     }
    ],
@@ -201,24 +201,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished Searching!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "D_cuml,I_cuml = knn_cuml.query(X,n_neighbors)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -238,6 +230,13 @@
     "message = 'compare knn: cuml vs sklearn indexes %s'%('equal'if passed else 'NOT equal')\n",
     "print(message)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Modifying kNN wrapper to convert cudf dataframe to row-major Numba array and wrap it in a Numpy array (without copying it). FAISS should use the CUDA array underneath
without going back to the host (on-device or d2d) since it knows how to work with
managed CUDA memory.