### PR TITLE
[REVIEW] Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of what you expected to happen.
  - Linux Distro/Architecture: [Ubuntu 16.04 amd64]
  - GPU Model/Driver: [V100 and driver 396.44]
  - CUDA: [9.2]
- - Method of cuDF install: [conda, Docker, or from source]
+ - Method of cuDF & cuML install: [conda, Docker, or from source]
    - If method of install is [conda], run `conda list` and include results here
    - If method of install is [Docker], provide `docker pull` & `docker run` commands used
    - If method of install is [from source], provide versions of `cmake` & `gcc/g++` and commit hash of build

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve cuML
+title: "[BUG]"
+labels: "? - Needs Triage, bug"
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps/Code to reproduce bug**
+Follow this guide http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports to craft a minimal bug report. This helps us reproduce the issue you're having and resolve the issue more quickly.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment details (please complete the following information):**
+ - Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
+ - Linux Distro/Architecture: [Ubuntu 16.04 amd64]
+ - GPU Model/Driver: [V100 and driver 396.44]
+ - CUDA: [9.2]
+ - Method of cuDF install: [conda, Docker, or from source]
+   - If method of install is [conda], run `conda list` and include results here
+   - If method of install is [Docker], provide `docker pull` & `docker run` commands used
+   - If method of install is [from source], provide versions of `cmake` & `gcc/g++` and commit hash of build
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,0 +1,35 @@
+---
+name: Documentation request
+about: Report incorrect or needed documentation
+title: "[DOC]"
+labels: "? - Needs Triage, doc"
+assignees: ''
+
+---
+
+## Report incorrect documentation
+
+**Location of incorrect documentation**
+Provide links and line numbers if applicable.
+
+**Describe the problems or issues found in the documentation**
+A clear and concise description of what you found to be incorrect.
+
+**Steps taken to verify documentation is incorrect**
+List any steps you have taken:
+
+**Suggested fix for documentation**
+Detail proposed changes to fix the documentation if you have any.
+
+---
+
+## Report needed documentation
+
+**Report needed documentation**
+A clear and concise description of what documentation you believe it is needed and why.
+
+**Describe the documentation you'd like**
+A clear and concise description of what you want to happen.
+
+**Steps taken to search for needed documentation**
+List any steps you have taken:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for cuML
+title: "[FEA]"
+labels: feature request, ? - Needs Triage
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I wish I could use cuML to do [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context, code examples, or references to existing implementations about the feature request here.

--- a/.github/ISSUE_TEMPLATE/submit-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-question.md
@@ -1,0 +1,10 @@
+---
+name: Submit question
+about: Ask a general question about cuML
+title: "[QST]"
+labels: "? - Needs Triage, question"
+assignees: ''
+
+---
+
+**What is your question?**


### PR DESCRIPTION
Issue templates based off of the ones used in cuDF for capturing the common issue types of: bug, feature request, documentation, and questions