### PR TITLE
Fix gcc 7 warnings and errors

### DIFF
--- a/cuML/src/glm/glm.cu
+++ b/cuML/src/glm/glm.cu
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#pragma once
-
 #include "ols.h"
 #include "glm_c.h"
 

--- a/cuML/test/dbscan_test.cu
+++ b/cuML/test/dbscan_test.cu
@@ -22,6 +22,7 @@
 #include "dbscan/dbscan.h"
 #include <linalg/cublas_wrappers.h>
 #include <iostream>
+#include <vector>
 
 namespace ML {
 
@@ -53,13 +54,15 @@ protected:
 
 		allocate(data, len);
 
-		T data_h[len] = { 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 8.0, 7.0, 8.0, 8.0, 25.0, 80.0 };
-		updateDevice(data, data_h, len);
+		std::vector<T> data_h = { 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 8.0, 7.0, 8.0, 8.0, 25.0, 80.0 };
+		data_h.resize(len);
+		updateDevice(data, data_h.data(), len);
 
 		allocate(labels, params.n_row);
 		allocate(labels_ref, params.n_row);
-		int labels_ref_h[len] = { 0, 0, 0, 1, 1, -1 };
-		updateDevice(labels_ref, labels_ref_h, params.n_row);
+		std::vector<int> labels_ref_h = { 0, 0, 0, 1, 1, -1 };
+		labels_ref_h.resize(len);
+		updateDevice(labels_ref, labels_ref_h.data(), params.n_row);
 
 		T eps = 3.0;
 		int min_pts = 2;

--- a/cuML/test/kmeans_test.cu
+++ b/cuML/test/kmeans_test.cu
@@ -1,5 +1,6 @@
 
 #include "kmeans/kmeans.cu"
+#include <vector>
 #include <gtest/gtest.h>
 #include <cuda_utils.h>
 #include <test_utils.h>
@@ -34,16 +35,18 @@ protected:
         allocate(centroids_ref, k * n);
 
         // make testdata on host
-        T h_srcdata[n * m] =
-            {1.0,1.0,3.0,4.0, 1.0,2.0,2.0,3.0};
-        updateDevice(d_srcdata, h_srcdata, m*n);
+        std::vector<T> h_srcdata = {1.0,1.0,3.0,4.0, 1.0,2.0,2.0,3.0};
+        h_srcdata.resize(n * m);
+        updateDevice(d_srcdata, h_srcdata.data(), m*n);
 
         // make and assign reference output
-        int h_labels_ref_fit[m] = {1, 1, 0, 0};
-        updateDevice(labels_ref_fit, h_labels_ref_fit, m);
+        std::vector<int> h_labels_ref_fit = {1, 1, 0, 0};
+        h_labels_ref_fit.resize(m);
+        updateDevice(labels_ref_fit, h_labels_ref_fit.data(), m);
 
-        T h_centroids_ref[k * n] = {3.5,2.5, 1.0,1.5};
-        updateDevice(centroids_ref, h_centroids_ref, k * n);
+        std::vector<T> h_centroids_ref = {3.5,2.5, 1.0,1.5};
+        h_centroids_ref.resize(k * n);
+        updateDevice(centroids_ref, h_centroids_ref.data(), k * n);
 
         // The actual kmeans api calls
         // fit

--- a/cuML/test/ols.cu
+++ b/cuML/test/ols.cu
@@ -15,6 +15,7 @@
  */
 
 #include "glm/ols.h"
+#include <vector>
 #include <gtest/gtest.h>
 #include <cuda_utils.h>
 #include <test_utils.h>
@@ -64,32 +65,41 @@ protected:
 		allocate(pred3, params.n_row_2);
 		allocate(pred3_ref, params.n_row_2);
 
-		T data_h[len] = { 1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0, 3.0 };
-		updateDevice(data, data_h, len);
+		std::vector<T> data_h = { 1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0, 3.0 };
+		data_h.resize(len);
+		updateDevice(data, data_h.data(), len);
 
-		T labels_h[params.n_row] = { 6.0, 8.0, 9.0, 11.0 };
-		updateDevice(labels, labels_h, params.n_row);
+		std::vector<T> labels_h = { 6.0, 8.0, 9.0, 11.0 };
+		labels_h.resize(params.n_row);
+		updateDevice(labels, labels_h.data(), params.n_row);
 
-		T coef_ref_h[params.n_col] = { 2.090908, 2.5454557 };
-		updateDevice(coef_ref, coef_ref_h, params.n_col);
+		std::vector<T> coef_ref_h = { 2.090908, 2.5454557 };
+		coef_ref_h.resize(params.n_col);
+		updateDevice(coef_ref, coef_ref_h.data(), params.n_col);
 
-		T coef2_ref_h[params.n_col] = { 1.000001 , 1.9999998 };
-		updateDevice(coef2_ref, coef2_ref_h, params.n_col);
+		std::vector<T> coef2_ref_h = { 1.000001 , 1.9999998 };
+		coef2_ref_h.resize(params.n_col);
+		updateDevice(coef2_ref, coef2_ref_h.data(), params.n_col);
 
-		T coef3_ref_h[params.n_col] = { 0.99999 , 2.00000 };
-		updateDevice(coef3_ref, coef3_ref_h, params.n_col);
+		std::vector<T> coef3_ref_h = { 0.99999 , 2.00000 };
+		coef3_ref_h.resize(params.n_col);
+		updateDevice(coef3_ref, coef3_ref_h.data(), params.n_col);
 
-		T pred_data_h[len2] = { 3.0, 2.0, 5.0, 5.0 };
-		updateDevice(pred_data, pred_data_h, len2);
+		std::vector<T> pred_data_h = { 3.0, 2.0, 5.0, 5.0 };
+		pred_data_h.resize(len2);
+		updateDevice(pred_data, pred_data_h.data(), len2);
 
-		T pred_ref_h[params.n_row_2] = { 19.0, 16.9090 };
-		updateDevice(pred_ref, pred_ref_h, params.n_row_2);
+		std::vector<T> pred_ref_h = { 19.0, 16.9090 };
+		pred_ref_h.resize(params.n_row_2);
+		updateDevice(pred_ref, pred_ref_h.data(), params.n_row_2);
 
-		T pred2_ref_h[params.n_row_2] = { 16.0, 15.0 };
-		updateDevice(pred2_ref, pred2_ref_h, params.n_row_2);
+		std::vector<T> pred2_ref_h = { 16.0, 15.0 };
+		pred2_ref_h.resize(params.n_row_2);
+		updateDevice(pred2_ref, pred2_ref_h.data(), params.n_row_2);
 
-		T pred3_ref_h[params.n_row_2] = { 16.0, 15.0 };
-		updateDevice(pred3_ref, pred3_ref_h, params.n_row_2);
+		std::vector<T> pred3_ref_h = { 16.0, 15.0 };
+		pred3_ref_h.resize(params.n_row_2);
+		updateDevice(pred3_ref, pred3_ref_h.data(), params.n_row_2);
 
 		intercept = T(0);
 
@@ -100,8 +110,8 @@ protected:
 		olsPredict(pred_data, params.n_row_2, params.n_col, coef, intercept, pred,
 				cublas_handle);
 
-		updateDevice(data, data_h, len);
-		updateDevice(labels, labels_h, params.n_row);
+		updateDevice(data, data_h.data(), len);
+		updateDevice(labels, labels_h.data(), params.n_row);
 
 		intercept2 = T(0);
 		olsFit(data, params.n_row, params.n_col, labels, coef2,
@@ -112,8 +122,8 @@ protected:
 						cublas_handle);
 
 
-		updateDevice(data, data_h, len);
-		updateDevice(labels, labels_h, params.n_row);
+		updateDevice(data, data_h.data(), len);
+		updateDevice(labels, labels_h.data(), params.n_row);
 
 		intercept3 = T(0);
 		olsFit(data, params.n_row, params.n_col, labels, coef3,

--- a/cuML/test/pca_test.cu
+++ b/cuML/test/pca_test.cu
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <vector>
 #include "random/rng.h"
 #include "test_utils.h"
 #include <cuda_utils.h>
@@ -65,11 +66,13 @@ protected:
 		allocate(trans_data, len);
 		allocate(trans_data_ref, len);
 
-		T data_h[len] = { 1.0, 2.0, 5.0, 4.0, 2.0, 1.0 };
-		updateDevice(data, data_h, len);
+		std::vector<T> data_h = { 1.0, 2.0, 5.0, 4.0, 2.0, 1.0 };
+		data_h.resize(len);
+		updateDevice(data, data_h.data(), len);
 
-		T trans_data_ref_h[len] = { -2.3231, -0.3517, 2.6748, -0.3979, 0.6571, -0.2592 };
-		updateDevice(trans_data_ref, trans_data_ref_h, len);
+		std::vector<T> trans_data_ref_h = { -2.3231, -0.3517, 2.6748, -0.3979, 0.6571, -0.2592 };
+		trans_data_ref_h.resize(len);
+		updateDevice(trans_data_ref, trans_data_ref_h.data(), len);
 
 		int len_comp = params.n_col * params.n_col;
 		allocate(components, len_comp);
@@ -79,14 +82,16 @@ protected:
 		allocate(mean, params.n_col);
 		allocate(noise_vars, 1);
 
-		T components_ref_h[len_comp] = { 0.8163, 0.5776, -0.5776,  0.8163 };
-		T explained_vars_ref_h[params.n_col] = { 6.338, 0.3287 };
+		std::vector<T> components_ref_h = { 0.8163, 0.5776, -0.5776,  0.8163 };
+		components_ref_h.resize(len_comp);
+		std::vector<T> explained_vars_ref_h = { 6.338, 0.3287 };
+		explained_vars_ref_h.resize(params.n_col);
 
 		allocate(components_ref, len_comp);
 		allocate(explained_vars_ref, params.n_col);
 
-		updateDevice(components_ref, components_ref_h, len_comp);
-		updateDevice(explained_vars_ref, explained_vars_ref_h, params.n_col);
+		updateDevice(components_ref, components_ref_h.data(), len_comp);
+		updateDevice(explained_vars_ref, explained_vars_ref_h.data(), params.n_col);
 
 		paramsPCA prms;
 		prms.n_cols = params.n_col;

--- a/cuML/test/tsvd_test.cu
+++ b/cuML/test/tsvd_test.cu
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <vector>
 #include "random/rng.h"
 #include "test_utils.h"
 #include <cuda_utils.h>
@@ -59,18 +60,20 @@ protected:
 
 		allocate(data, len);
 
-		T data_h[len] = { 1.0, 2.0, 4.0, 2.0, 4.0, 5.0, 5.0, 4.0, 2.0, 1.0, 6.0, 4.0 };
-		updateDevice(data, data_h, len);
+		std::vector<T> data_h = { 1.0, 2.0, 4.0, 2.0, 4.0, 5.0, 5.0, 4.0, 2.0, 1.0, 6.0, 4.0 };
+		data_h.resize(len);
+		updateDevice(data, data_h.data(), len);
 
 		int len_comp = params.n_col * params.n_col;
 		allocate(components, len_comp);
 		allocate(singular_vals, params.n_col);
 
-		T components_ref_h[len_comp] = { -0.3951, 0.1532, 0.9058, -0.7111, -0.6752, -0.1959, -0.5816, 0.7215,
+		std::vector<T> components_ref_h = { -0.3951, 0.1532, 0.9058, -0.7111, -0.6752, -0.1959, -0.5816, 0.7215,
 		                                 -0.3757 };
+		components_ref_h.resize(len_comp);
 
 		allocate(components_ref, len_comp);
-		updateDevice(components_ref, components_ref_h, len_comp);
+		updateDevice(components_ref, components_ref_h.data(), len_comp);
 
 		paramsTSVD prms;
 		prms.n_cols = params.n_col;


### PR DESCRIPTION
This patch fixes compiler warnings with GCC 7.3.0 and compiler errors with GCC 7.1.1.