### PR TITLE
[REVIEW] ENH Added new cmake variable to support switching GLIBCXX11 ABI

### DIFF
--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -54,7 +54,9 @@ option(KERNELINFO "Enable kernel resource usage info" OFF)
 option(DEBUG "Get a debug build" OFF)
 
 ###################################################################################################
-# - NVCC Options  ---------------------------------------------------------------------------------
+# - Compiler Options  -----------------------------------------------------------------------------
+
+## nvcc options
 
 if(OPENMP_FOUND)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler ${OpenMP_CXX_FLAGS}")
@@ -92,7 +94,26 @@ endforeach()
 # It is assumed that the last arch in the 'archs' is the latest!
 list(GET GPU_ARCHS -1 ptx)
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ptx},code=compute_${ptx}")
+
 ## end nvcc options
+
+## other compiler options
+
+option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
+
+if(NOT CMAKE_CXX11_ABI)
+        message(STATUS "Disabling the GLIBCXX11 ABI")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
+elseif(CMAKE_CXX11_ABI)
+    message(STATUS "Enabling the GLIBCXX11 ABI")
+endif(NOT CMAKE_CXX11_ABI)
+
+
+## end of other compiler options
+
+
 
 ###################################################################################################
 # - include paths ---------------------------------------------------------------------------------


### PR DESCRIPTION
Added new CMake flag  to quickly turn on/off the GLIBCXX11 ABI for consistency with the rest of the RAPIDS ecosystem and future proofing. On by default. 