### PR TITLE
[REVIEW] Remove pca `randomized` solver option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #44: Distance calculation ML primitives
 - PR #69: Ridge (L2 Regularized) Linear Regression
 - PR #103: Linear Kalman Filter
+- PR #117: Pip install support
 
 ## Improvements
 
@@ -14,6 +15,8 @@
 - PR #44: Refactored DBSCAN to use ML primitives
 - PR #91: Pytest cleanup and sklearn toyset datasets based pytests for kmeans and dbscan
 - PR #75: C++ example to use kmeans
+- PR #117: Use cmake extension to find any zlib installed in system
+- PR #94: Add cmake flag to set ABI compatibility
 
 ## Bug Fixes
 

--- a/python/cuML/pca/pca_wrapper.pyx
+++ b/python/cuML/pca/pca_wrapper.pyx
@@ -123,7 +123,7 @@ class PCA:
 
     def __init__(self, n_components=1, copy=True, whiten=False, tol=1e-7,
                  iterated_power=15, random_state=None, svd_solver='auto'):
-        if svd_solver in ['full', 'auto', 'randomized', 'jacobi']:
+        if svd_solver in ['full', 'auto', 'jacobi']:
             c_algorithm = self._get_algorithm_c_name(svd_solver)
         else:
             msg = "algorithm {!r} is not supported"
@@ -148,7 +148,7 @@ class PCA:
             'full': COV_EIG_DQ,
             'auto': COV_EIG_DQ,
             # 'arpack': NOT_SUPPORTED,
-            'randomized': RANDOMIZED,
+            # 'randomized': NOT_SUPPORTED,
             'jacobi': COV_EIG_JACOBI
         }[algorithm]
 


### PR DESCRIPTION
- Solves issue #98 by removing `randomized` pca solver option
- tsvd already did not expose `randomized` solver option. 
- Updates changelog with some missing PRs