### PR TITLE
[gpuCI] Auto-merge branch-0.5 to branch-0.6 [skip ci]

### DIFF
--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -107,7 +107,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ptx},code=comp
 
 ## other compiler options
 
-option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
+option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" OFF)
 
 if(NOT CMAKE_CXX11_ABI)
         message(STATUS "Disabling the GLIBCXX11 ABI")


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.5` that creates a PR to keep `branch-0.6` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.