### PR TITLE
[gpuCI] Auto-merge branch-0.5 to branch-0.6 [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Machine learning is a fundamental capability of RAPIDS. cuML is a suite of libraries that implements a machine learning algorithms within the RAPIDS data science ecosystem. cuML enables data scientists, researchers, and software engineers to run traditional ML tasks on GPUs without going into the details of CUDA programming.
 
-_Note: You are potentially viewing a bleeding-edge README.md, which is subject to change between released versions. You can find the readme for the latest release [here](https://github.com/rapidsai/cuml/blob/master/README.md)._
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
 
 The cuML repository contains:
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.5` that creates a PR to keep `branch-0.6` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.