### PR TITLE
[gpuCI] Auto-merge branch-0.5 to branch-0.6 [skip ci]

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,12 +28,12 @@ requirements:
     - cython
     - cmake 3.12
     - cudf 0.5*
-    - libcuml {{ version }}
+    - libcuml={{ version }}
   run:
     - python x.x
     - setuptools
     - cudf 0.5*
-    - libcuml {{ version }}
+    - libcuml={{ version }}
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.5` that creates a PR to keep `branch-0.6` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.