### PR TITLE
[gpuCI] Auto-merge branch-0.5 to branch-0.6 [skip ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -48,10 +48,6 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-# Conda environment updates
-sed_runner 's/cuml=.*/cuml='"${NEXT_SHORT_TAG}*"'/g' conda_environments/builddocs_py36.yml
-sed_runner 's/libcuml .*/libcuml '"${NEXT_SHORT_TAG}*"'/g' conda-recipes/cuml/meta.yaml
-
 # RTD update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
 sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.5` that creates a PR to keep `branch-0.6` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.