### PR TITLE
[REVIEW] Remove numpy cimport from cython and setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Bug Fixes
 
+- PR #188 Avoid using numpy via cimport to prevent ABI issues in Cython compilation
+
 
 # cuML 0.5.0 (28 Jan 2019)
 

--- a/python/cuML/dbscan/c_dbscan.pxd
+++ b/python/cuML/dbscan/c_dbscan.pxd
@@ -1,23 +1,22 @@
 import numpy as np
-cimport numpy as np
 from libcpp cimport bool
 np.import_array
 
 cdef extern from "dbscan/dbscan_c.h" namespace "ML":
 
-    cdef void dbscanFit(float *input, 
-                   int n_rows, 
-                   int n_cols, 
-                   float eps, 
+    cdef void dbscanFit(float *input,
+                   int n_rows,
+                   int n_cols,
+                   float eps,
                    int min_pts,
 		           int *labels)
 
-    cdef void dbscanFit(double *input, 
-                   int n_rows, 
-                   int n_cols, 
-                   double eps, 
+    cdef void dbscanFit(double *input,
+                   int n_rows,
+                   int n_cols,
+                   double eps,
                    int min_pts,
 		           int *labels)
 
 
- 
+

--- a/python/cuML/dbscan/c_dbscan.pxd
+++ b/python/cuML/dbscan/c_dbscan.pxd
@@ -1,6 +1,5 @@
 import numpy as np
 from libcpp cimport bool
-np.import_array
 
 cdef extern from "dbscan/dbscan_c.h" namespace "ML":
 

--- a/python/cuML/kmeans/c_kmeans.pxd
+++ b/python/cuML/kmeans/c_kmeans.pxd
@@ -1,5 +1,4 @@
 import numpy as np
-np.import_array
 
 cdef extern from "kmeans/kmeans_c.h" namespace "ML":
 

--- a/python/cuML/kmeans/c_kmeans.pxd
+++ b/python/cuML/kmeans/c_kmeans.pxd
@@ -1,5 +1,4 @@
 import numpy as np
-cimport numpy as np
 np.import_array
 
 cdef extern from "kmeans/kmeans_c.h" namespace "ML":

--- a/python/cuML/linear_model/linear_regression.pyx
+++ b/python/cuML/linear_model/linear_regression.pyx
@@ -15,7 +15,6 @@
 
 cimport ols
 import numpy as np
-cimport numpy as np
 from numba import cuda
 import cudf
 from libcpp cimport bool

--- a/python/cuML/linear_model/ridge.pyx
+++ b/python/cuML/linear_model/ridge.pyx
@@ -15,7 +15,6 @@
 
 cimport ridge
 import numpy as np
-cimport numpy as np
 from numba import cuda
 import cudf
 from libcpp cimport bool

--- a/python/cuML/pca/c_pca.pxd
+++ b/python/cuML/pca/c_pca.pxd
@@ -1,5 +1,4 @@
 import numpy as np
-cimport numpy as np
 from libcpp cimport bool
 np.import_array
 

--- a/python/cuML/pca/c_pca.pxd
+++ b/python/cuML/pca/c_pca.pxd
@@ -1,6 +1,5 @@
 import numpy as np
 from libcpp cimport bool
-np.import_array
 
 cdef extern from "ml_utils.h" namespace "ML":
 

--- a/python/cuML/pca/pca_wrapper.pyx
+++ b/python/cuML/pca/pca_wrapper.pyx
@@ -15,7 +15,6 @@
 
 cimport c_pca
 import numpy as np
-cimport numpy as np
 from numba import cuda
 import cudf
 from libcpp cimport bool

--- a/python/cuML/tsvd/c_tsvd.pxd
+++ b/python/cuML/tsvd/c_tsvd.pxd
@@ -1,6 +1,5 @@
 import numpy as np
 from libcpp cimport bool
-np.import_array
 
 cdef extern from "ml_utils.h" namespace "ML":
 

--- a/python/cuML/tsvd/c_tsvd.pxd
+++ b/python/cuML/tsvd/c_tsvd.pxd
@@ -1,5 +1,4 @@
 import numpy as np
-cimport numpy as np
 from libcpp cimport bool
 np.import_array
 
@@ -34,12 +33,12 @@ cdef extern from "ml_utils.h" namespace "ML":
 cdef extern from "tsvd/tsvd_c.h" namespace "ML":
 
     cdef void tsvdFit(float *input,
-                      float *components,                 
+                      float *components,
                       float *singular_vals,
                       paramsTSVD prms)
 
     cdef void tsvdFit(double *input,
-                      double *components,                    
+                      double *components,
                       double *singular_vals,
                       paramsTSVD prms)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,18 +28,12 @@ install_requires = [
     'cython'
 ]
 
-try:
-    numpy_include = numpy.get_include()
-except AttributeError:
-    numpy_include = numpy.get_numpy_include()
-
 cython_files = ['cuML/cuml.pyx']
 
 extensions = [
     Extension("cuml",
               sources=cython_files,
-              include_dirs=[numpy_include,
-                            '../cuML/src',
+              include_dirs=['../cuML/src',
                             '../cuML/external/ml-prims/src',
                             '../cuML/external/ml-prims/external/cutlass',
                             '../cuML/external/cutlass',


### PR DESCRIPTION
Removed a few accidentally included `cimport numpy` from cython files and removing it from `setup.py`. This follows https://github.com/rapidsai/cudf/pull/842