### PR TITLE
[REVIEW] Solve issue 196 without reintroducing numpy cimport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - PR #144: Dockerfile update and docs for LinearRegression and Kalman Filter.
 - PR #167: Integrating full-n-final ml-prims repo inside cuml
 - PR #114: Building faiss C++ api into libcuml
-- PR #64:
+- PR #64: Using FAISS C++ API in cuML and exposing bindings through cython
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 ## New Features
 
-- ...
+
 
 ## Improvements
 
 - PR #144: Dockerfile update and docs for LinearRegression and Kalman Filter.
 - PR #167: Integrating full-n-final ml-prims repo inside cuml
+- PR #114: Building faiss C++ api into libcuml
+- PR #64:
 
 ## Bug Fixes
 
 - PR #193: Fix AttributeError in PCA and TSVD
+- PR #200 Avoid using numpy via cimport in KNN
 
 
 # cuML 0.5.1 (05 Feb 2019)

--- a/python/cuML/knn/knn.pxd
+++ b/python/cuML/knn/knn.pxd
@@ -14,9 +14,7 @@
 #
 
 import numpy as np
-cimport numpy as np
 from libcpp cimport bool
-np.import_array
 
 cdef extern from "knn/knn.h" namespace "ML":
 


### PR DESCRIPTION
Closes issue #196 

Avoid cimport numpy due to abi compatibility issues it caused in cuDF. 