### PR TITLE
[REVIEW] Issue ml-common-3: Math.h: swap thrust::for_each with binaryOp,unaryOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #194: Added new ml-prims for supporting LASSO regression.
 - PR #114: Building faiss C++ api into libcuml
 - PR #64: Using FAISS C++ API in cuML and exposing bindings through cython
+- PR #208: Issue ml-common-3: Math.h: swap thrust::for_each with binaryOp,unaryOp
 
 ## Bug Fixes
 

--- a/cuML/src/pca/pca.h
+++ b/cuML/src/pca/pca.h
@@ -35,9 +35,9 @@ using namespace MLCommon;
 
 template<typename math_t>
 void truncCompExpVars(math_t *in, math_t *components, math_t *explained_var,
-		math_t *explained_var_ratio, paramsTSVD prms,
+                      math_t *explained_var_ratio, paramsTSVD prms,
                       cusolverDnHandle_t cusolver_handle, cublasHandle_t cublas_handle,
-    DeviceAllocator &mgr) {
+                      DeviceAllocator &mgr) {
 
 	math_t *components_all;
 	math_t *explained_var_all;
@@ -54,7 +54,7 @@ void truncCompExpVars(math_t *in, math_t *components, math_t *explained_var,
 	Matrix::truncZeroOrigin(components_all, prms.n_cols, components,
 			prms.n_components, prms.n_cols);
 
-	Matrix::ratio(explained_var_all, explained_var_ratio_all, prms.n_cols);
+  Matrix::ratio(explained_var_all, explained_var_ratio_all, prms.n_cols, mgr);
 
 	Matrix::truncZeroOrigin(explained_var_all, prms.n_cols, explained_var,
 			prms.n_components, 1);

--- a/cuML/src/tsvd/tsvd.h
+++ b/cuML/src/tsvd/tsvd.h
@@ -64,7 +64,8 @@ void calCompExpVarsSvd(math_t *in, math_t *components, math_t *singular_vals,
 	LinAlg::transpose(components_temp, components, prms.n_cols,
 			prms.n_components, cublas_handle);
 	Matrix::power(singular_vals, explained_vars, math_t(1), prms.n_components);
-	Matrix::ratio(explained_vars, explained_var_ratio, prms.n_components);
+  auto mgr = makeDefaultAllocator();
+  Matrix::ratio(explained_vars, explained_var_ratio, prms.n_components, mgr);
 
 	if (components_temp)
 		CUDA_CHECK(cudaFree(components_temp));

--- a/ml-prims/src/matrix/math.h
+++ b/ml-prims/src/matrix/math.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
-#include <thrust/inner_product.h>
 #include "linalg/matrix_vector_op.h"
+#include "linalg/binary_op.h"
+#include "linalg/unary_op.h"
+#include "linalg/map_then_reduce.h"
 
 namespace MLCommon {
 namespace Matrix {
@@ -32,12 +34,12 @@ namespace Matrix {
  */
 template <typename math_t>
 void power(math_t *inout, math_t scalar, int len) {
-  auto counting = thrust::make_counting_iterator(0);
+
   auto d_A = inout;
 
-  thrust::for_each(counting, counting + len, [=] __device__(int idx) {
-    d_A[idx] = d_A[idx] * d_A[idx] * scalar;
-  });
+  MLCommon::LinAlg::binaryOp(d_A, d_A, d_A, len,
+                             [=] __device__(math_t a, math_t b)
+                             {return scalar * a * b;});
 }
 
 /**
@@ -51,13 +53,13 @@ void power(math_t *inout, math_t scalar, int len) {
  */
 template <typename math_t>
 void power(math_t *in, math_t *out, math_t scalar, int len) {
-  auto counting = thrust::make_counting_iterator(0);
   auto d_src = in;
   auto d_dest = out;
 
-  thrust::for_each(counting, counting + len, [=] __device__(int idx) {
-    d_dest[idx] = d_src[idx] * d_src[idx] * scalar;
-  });
+  MLCommon::LinAlg::binaryOp(d_dest, d_src, d_src, len,
+                             [=] __device__(math_t a, math_t b)
+                             {return scalar * a * b;});
+
 }
 
 /**
@@ -96,13 +98,12 @@ void power(math_t *in, math_t *out, int len) {
 template <typename math_t>
 void seqRoot(math_t* inout, math_t scalar, int len) {
 
-	auto counting = thrust::make_counting_iterator(0);
 	auto d_A = inout;
 
-    thrust::for_each(counting, counting + len, [=]__device__(int idx)
-	{
-    	d_A[idx] = sqrt(d_A[idx] * scalar);
-	});
+  MLCommon::LinAlg::unaryOp(d_A, d_A, len,
+                             [=] __device__(math_t a)
+                             {return sqrt(a * scalar);});
+  
 }
 
 /**
@@ -116,23 +117,22 @@ void seqRoot(math_t* inout, math_t scalar, int len) {
 template<typename math_t>
 void seqRoot(math_t* in, math_t* out, math_t scalar, int len, bool set_neg_zero = false) {
 
-	auto counting = thrust::make_counting_iterator(0);
 	auto d_src = in;
 	auto d_dest = out;
 
-    thrust::for_each(counting, counting + len, [=]__device__(int idx)
-	{
-    	if (set_neg_zero) {
-    		if (d_src[idx] < math_t(0)) {
-    			d_dest[idx] = math_t(0);
-    		} else {
-    			d_dest[idx] = sqrt(d_src[idx] * scalar);
-    		}
-    	} else {
-    		d_dest[idx] = sqrt(d_src[idx] * scalar);
-    	}
-
-	});
+  MLCommon::LinAlg::unaryOp(d_dest, d_src, len,
+                            [=] __device__(math_t a)
+                            {
+                              if (set_neg_zero) {
+                                if (a < math_t(0)) {
+                                  return math_t(0);
+                                } else {
+                                  return sqrt(a * scalar);
+                                }
+                              } else {
+                                return sqrt(a * scalar);
+                              }
+                            });
 }
 
 /**
@@ -154,32 +154,6 @@ void seqRoot(math_t* inout, int len) {
 	seqRoot(inout, inout, scalar, len);
 }
 
-/**
- * @defgroup inverse math operation on the input matrix. Reciprocal of every
- * element in the input matrix
- * @param inout: input matrix and also the result is stored
- * @param scalar: every element is multiplied with scalar
- * @param len: number elements of input matrix
- * @{
- */
-template <typename math_t>
-void reciprocal(math_t* inout, math_t scalar, int len, bool setzero = false,
-                math_t thres = 1e-15) {
-    auto counting = thrust::make_counting_iterator(0);
-    auto d_A = inout;
-    thrust::for_each(counting, counting + len, [=]__device__(int idx)
-	{
-            if (setzero) {
-                if (d_A[idx] <= thres) {
-                    d_A[idx] = math_t(0);
-                } else {
-                    d_A[idx] = scalar / d_A[idx];
-                }
-            } else {
-    		d_A[idx] = scalar / d_A[idx];
-            }
-        });
-}
 
 /**
  * @defgroup sets the small values to zero based on a defined threshold
@@ -190,31 +164,61 @@ void reciprocal(math_t* inout, math_t scalar, int len, bool setzero = false,
  */
 template <typename math_t>
 void setSmallValuesZero(math_t* inout, int len, math_t thres = 1e-15) {
-
-	auto counting = thrust::make_counting_iterator(0);
 	auto d_A = inout;
 
-    thrust::for_each(counting, counting + len, [=]__device__(int idx)
-	{
-    	if (d_A[idx] <= thres) {
-            d_A[idx] = math_t(0);
-        } else {
-            d_A[idx] = d_A[idx];
-        }
-	});
+  MLCommon::LinAlg::unaryOp(d_A, d_A, len, [=] __device__(math_t a){
+                                             if(a <= thres && -a <= thres) {
+                                               return math_t(0);
+                                             }
+                                             else {
+                                               return a;
+                                             }
+                                           });
 }
 
-template <typename Type, int TPB=256>
-void setSmallValuesZero(Type* inout, const Type* vec, int n_row, int n_col, Type thres) {
-
-	matrixVectorOp(inout, vec, n_col, n_row, false,
-			        		[] __device__ (Type a, Type b) {
-			                       if (b < Type(1e-10))
-			                      	   return Type(0);
-			                       else
-			        		           return a;
-                                                });
+template <typename math_t>
+void setSmallValuesZero(math_t* out, const math_t* in, int len, math_t thres = 1e-15) {
+  MLCommon::LinAlg::unaryOp(out, in, len, [=] __device__(math_t a)
+                                             {
+                                               if(a <= thres && -a <= thres) {
+                                                 return math_t(0);
+                                               }
+                                               else {
+                                                 return a;
+                                               }
+                                             });  
 }
+
+
+/**
+ * @defgroup inverse math operation on the input matrix. Reciprocal of every
+ * element in the input matrix
+ * @param inout: input matrix and also the result is stored
+ * @param scalar: every element is multiplied with scalar
+ * @param len: number elements of input matrix
+ * @param setzero: (default false) when true and |value|<thres, avoid dividing by (almost) zero
+ * @param thres: Threshold to avoid dividing by zero (|value| < thres -> result = 0)
+ * @{
+ */
+template <typename math_t>
+void reciprocal(math_t* inout, math_t scalar, int len, bool setzero = false,
+                math_t thres = 1e-15) {
+  auto d_A = inout;
+  MLCommon::LinAlg::unaryOp(d_A, d_A, len, [=]__device__(math_t a){
+                                             if (setzero) {
+                                               if (abs(a) <= thres) {
+                                                 return math_t(0);
+                                               } else {
+                                                 return scalar / a;
+                                               }
+                                             }
+                                             else {
+                                               return scalar / a;
+                                             }
+                                           }
+    );  
+}
+
 
 /**
  * @defgroup inverse math operation on the input matrix. Reciprocal of every
@@ -227,13 +231,12 @@ void setSmallValuesZero(Type* inout, const Type* vec, int n_row, int n_col, Type
  */
 template <typename math_t>
 void reciprocal(math_t *in, math_t *out, math_t scalar, int len) {
-  auto counting = thrust::make_counting_iterator(0);
   auto d_src = in;
   auto d_dest = out;
 
-  thrust::for_each(counting, counting + len, [=] __device__(int idx) {
-    d_dest[idx] = scalar / d_src[idx];
-  });
+  MLCommon::LinAlg::unaryOp(d_dest, d_src, len, [=]__device__(math_t a){
+                                                  return scalar / a;
+                                                });
 }
 
 /**
@@ -273,64 +276,79 @@ void reciprocal(math_t *in, math_t *out, int len) {
  * @{
  */
 
-// TODO: Check with Thejaswi if he can come up with faster approach to this
-// function.
 template <typename math_t>
 void ratio(math_t *src, math_t *dest, int len) {
-  auto counting = thrust::make_counting_iterator(0);
   auto d_src = src;
-  auto s = len;
   auto d_dest = dest;
 
-  thrust::for_each(counting, counting + len, [=] __device__(int idx) {
-    math_t total = 0.0;
-    for (int i = 0; i < s; i++) {
-      total += d_src[i];
-    }
-    if (total != 0.0) {
-      d_dest[idx] = d_src[idx] / total;
-    }
-  });
+  math_t* d_sum;
+  allocate(d_sum, 1);
+  auto no_op = [] __device__(math_t in) { return in; };
+  MLCommon::LinAlg::mapThenSumReduce(d_sum, len, no_op, 0, src);
+
+  MLCommon::LinAlg::unaryOp(d_dest, d_src, len, [=] __device__(math_t a)
+                                                { return a / (*d_sum); });
+
+  CUDA_CHECK(cudaFree(d_sum));
+}
+
+
+// Utility kernel needed for signFlip.
+// Computes the argmax(abs(d_in)) column-wise in a DxN matrix followed by
+// flipping the sign if the |max| value for each column is negative.
+template <typename T, int TPB>
+__global__ void signFlipKernel(T* d_in, int D, int N) {
+  typedef cub::BlockReduce<cub::KeyValuePair<int, T>, TPB> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  // compute maxIndex=argMax (with abs()) index for column
+  using KVP = cub::KeyValuePair<int, T>;
+  int rowStart = blockIdx.x * D;
+  KVP thread_data(0,0);
+  for(int i = threadIdx.x; i < D; i += TPB) {
+    int idx = rowStart + i;
+    thread_data = cub::ArgMax()(thread_data, KVP(idx, abs(d_in[idx])));
+  }
+  auto maxKV = BlockReduce(temp_storage).Reduce(thread_data, cub::ArgMax());
+
+  // flip column sign if d_in[maxIndex] < 0
+  __shared__ bool need_sign_flip;
+  if(threadIdx.x == 0) {
+    need_sign_flip = d_in[maxKV.key] < T(0);
+  }
+  __syncthreads();
+
+  if(need_sign_flip) {
+    for(int i = threadIdx.x; i < D; i += TPB) {
+      int idx = rowStart + i;
+      d_in[idx] = -d_in[idx];
+    }    
+  }
 }
 
 /**
  * @defgroup sign flip for PCA. This is used to stabilize the sign of column
- * major eigen vectors
+ * major eigen vectors. Flips the sign if the column has negative |max|.
  * @param inout: input matrix. Result also stored in this parameter
  * @param n_rows: number of rows of input matrix
  * @param n_cols: number of columns of input matrix
  * @{
  */
-// TODO: Check with Thejaswi if he can come up with faster approach to this
-// function.
 template <typename math_t>
-void signFlip(math_t *inout, int n_rows, int n_cols) {
-  auto counting = thrust::make_counting_iterator(0);
-  auto m = n_rows;
-
-  thrust::for_each(counting, counting + n_cols, [=] __device__(int idx) {
-    int d_i = idx * m;
-    int end = d_i + m;
-
-    math_t max = 0.0;
-    int max_index = 0;
-    for (int i = d_i; i < end; i++) {
-      math_t val = inout[i];
-      if (val < 0.0) {
-        val = -val;
-      }
-      if (val > max) {
-        max = val;
-        max_index = i;
-      }
-    }
-
-    if (inout[max_index] < 0.0) {
-      for (int i = d_i; i < end; i++) {
-        inout[i] = -inout[i];
-      }
-    }
-  });
+void signFlip(math_t *inout, int n_rows, int n_cols) {  
+  int D = n_rows;
+  int N = n_cols;
+  auto data = inout;
+  if (D <= 32) {
+    signFlipKernel<math_t, 32><<<N, 32>>>(data, D, N);
+  } else if(D <= 64) {
+    signFlipKernel<math_t, 64><<<N, 64>>>(data, D, N);
+  } else if(D <= 128) {
+    signFlipKernel<math_t, 128><<<N, 128>>>(data, D, N);
+  } else {
+    signFlipKernel<math_t, 256><<<N, 256>>>(data, D, N);
+  }
+  CUDA_CHECK(cudaPeekAtLastError());
 }
 
 template <typename Type, int TPB = 256>

--- a/ml-prims/test/math.cu
+++ b/ml-prims/test/math.cu
@@ -142,7 +142,8 @@ protected:
     naiveSqrt(in_sqrt, out_sqrt_ref, len);
     seqRoot(in_sqrt, len);
 
-    ratio(in_ratio, in_ratio, 4);
+    auto mgr = makeDefaultAllocator();
+    ratio(in_ratio, in_ratio, 4, mgr);
 
     naiveSignFlip(in_sign_flip, out_sign_flip_ref, params.n_row, params.n_col);
     signFlip(in_sign_flip, params.n_row, params.n_col);


### PR DESCRIPTION
This fixes issue 3 from ml-common repo. Basically remove thrust::for_each from math.h. Mostly this could be replaced with binaryOp and unaryOp, but `signFlip` needed a custom kernel due to it's slightly peculiar argmax(abs(x)) operation on columns. Some tests were added and some possible bugs fixed with thresholds only checking less than, without an absolute value.

* Replacement in `power()` function.
* Replacement in `seqRoot()` function.
* Updated math.h `reciprocal()` functions to use unaryOp
* Fixed bug in `reciprocal()` `setzero` option which would set any value <=
  threshold to zero (including any negative numbers).
* Added test case with test for `setzero`.
* Replaced `thrust::for_each` usage in `ratio()`. The original implementation
  did a sum-reduce for each item, which is now replaced by an explicit
  sum-reduction via a call to map reduce.
* Fixed `setSmallValuesZero()` to use `unaryOp`. Also fixed a potential bug
  where it didn't use absolute value in the check (i.e., negative numbers were
  "small").
* Added test for setSmallValuesZero
* Fixed signFlip to use a native kernel instead of thurst::for_each. It wasn't
  possible to re-use another reduction primitive because of the inherent ArgMax
  reduction, which would require extending `coalesced_reduction` with additional
  internal template types.
* Extended signFlip test case to test negative case.
* Removed last thrust calls