### PR TITLE
[REVIEW] Fix Dockerfile, major README re-organization

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,7 +2,7 @@
 
 To install cuML from source, ensure the dependencies are met:
 
-1. [cuDF](https://github.com/rapidsai/cudf) (>=0.5.0)
+1. [cuDF](https://github.com/rapidsai/cudf) (>=0.5.1)
 2. zlib Provided by zlib1g-dev in Ubuntu 16.04
 3. cmake (>= 3.12.4)
 4. CUDA (>= 9.2)
@@ -83,6 +83,28 @@ $ py.test cuML/test --collect-only
 ```bash
 $ python setup.py install
 ```
+
+cuML's core structure contains:
+
+1. ***cuML***:
+  C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
+  - Single GPU Truncated Singular Value Decomposition (tSVD)
+  - Single GPU Principal Component Analysis (PCA)
+  - Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
+  - Single GPU Kalman Filtering
+  - Multi-GPU K-Means Clustering
+  - Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
+
+2. ***python***:
+  Python bindings for the above algorithms, including interfaces for [cuDF](https://github.com/rapidsai/cudf). These bindings connect the data to C++/CUDA based cuML and ml-prims libraries without leaving GPU memory.
+
+3. ***ml-prims***:
+  Low level machine learning primitives header only library, used in cuML algorithms. Includes:
+  - Linear Algebra
+  - Statistics
+  - Basic Matrix Operations
+  - Distance Functions
+  - Random Number Generation
 
 ## External
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #114: Building faiss C++ api into libcuml
 - PR #64: Using FAISS C++ API in cuML and exposing bindings through cython
 - PR #208: Issue ml-common-3: Math.h: swap thrust::for_each with binaryOp,unaryOp
+- PR #209: Simplify README.md, move build instructions to BUILD.md
 
 ## Bug Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,24 @@
 # From: https://github.com/rapidsai/cudf/blob/master/Dockerfile
 FROM cudf
 
-RUN apt install -y zlib1g-dev
+ENV CONDA_ENV=cudf
 
-ARG CUDA_MAJOR=9
-ARG CUDA_MINOR=2
-RUN source activate cudf && conda install -c pytorch faiss-gpu cuda${CUDA_MAJOR}${CUDA_MINOR}
-RUN source activate cudf && conda install -c anaconda cython
-
+ADD thirdparty /cuml/thirdparty
 ADD ml-prims /cuml/ml-prims
 ADD cuML /cuml/cuML
 WORKDIR /cuml/cuML
-RUN source activate cudf && \
+RUN source activate ${CONDA_ENV} && \
     mkdir build && \
     cd build && \
-    cmake .. && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX && \
     make -j && \
     make install
 
 ADD python /cuml/python
 WORKDIR /cuml/python
-RUN source activate cudf && \
+RUN source activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     python setup.py install
 
 ADD docs /cuml/docs
+WORKDIR /cuml

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ conda install -c nvidia -c rapidsai -c conda-forge -c pytorch -c defaults cuml
 ```
 
 #### Pip
-cuML can also be installed using pip. Select the package based on your version of CUDA:
+cuML can also be installed using pip. Select the package based on your version of CUDA.
+
+*Note:* Pip has no faiss-gpu package: If installing cuML from pip and you plan to use cuml.KNN, you must install [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
+
 ```bash
 # cuda 9.2
 pip install cuml-cuda92
@@ -65,14 +68,12 @@ You also need to ensure `libomp` and `libopenblas` are installed:
 apt install libopenblas-base libomp-dev
 ```
 
-*Note:* Pip has no faiss-gpu package: If installing cuML from pip and you plan to use cuml.KNN, you must install [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
-
-
 **NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
 
 The cuML repository contains:
 
-1. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
+1. ***cuML***:
+  C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
   - Single GPU Truncated Singular Value Decomposition (tSVD)
   - Single GPU Principal Component Analysis (PCA)
   - Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
@@ -80,9 +81,11 @@ The cuML repository contains:
   - Multi-GPU K-Means Clustering
   - Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
 
-2. ***python***: Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
+2. ***python***:
+  Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
 
-3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components:
+3. ***ml-prims***:
+  Low level machine learning primitives used in cuML. ml-prims is comprised of the following components:
   - Linear Algebra
   - Statistics
   - Basic Matrix Operations
@@ -96,7 +99,6 @@ Algorithms in progress:
 - Elastic-Net
 - Logistic Regression
 - UMAP
-
 
 More ML algorithms in cuML and more ML primitives in ml-prims are being worked on. Goals for future versions include more algorithms and multi-gpu versions of the algorithms and primitives.
 
@@ -121,7 +123,6 @@ Please use GitHub issues and pull requests to report bugs and add or request fun
 ## Contact
 
 Find out more details on the [RAPIDS site](https://rapids.ai/community.html)
-
 
 ## <div align="left"><img src="img/rapids_logo.png" width="265px"/></div> Open GPU Data Science
 

--- a/README.md
+++ b/README.md
@@ -106,17 +106,6 @@ cuML's core structure contains:
 ### Build from Source
 [Instructions](docs/build.md)
 
-## External
-
-The external folders contains submodules that this project in-turn depends on. Appropriate location flags
-will be automatically populated in the main `CMakeLists.txt` file for these.
-
-Current external submodules are:
-
-- [CUTLASS](https://github.com/NVIDIA/cutlass)
-- [Google Test](https://github.com/google/googletest)
-- [CUB](https://github.com/NVlabs/cub)
-
 ## Contributing
 
 Please use GitHub issues and pull requests to report bugs and add or request functionality.

--- a/README.md
+++ b/README.md
@@ -35,21 +35,13 @@ For additional examples, browse our complete [API documentation](https://rapidsa
 ### Supported Algorithms:
 
 - Truncated Singular Value Decomposition (tSVD)
-
 - Principal Component Analysis (PCA)
-
 - Density-based spatial clustering of applications with noise (DBSCAN)
-
 - K-Means Clustering
-
 - K-Nearest Neighbors (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use)
-
 - Linear Regression (Ordinary Least Squares)
-
 - Ridge Regression
-
 - Kalman Filter
-
 
 ## Installation
 
@@ -81,21 +73,21 @@ apt install libopenblas-base libomp-dev
 The cuML repository contains:
 
 1. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
-  a) Single GPU Truncated Singular Value Decomposition (tSVD)
-  b) Single GPU Principal Component Analysis (PCA)
-  c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
-  d) Single GPU Kalman Filtering
-  e) Multi-GPU K-Means Clustering
-  f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
+  - Single GPU Truncated Singular Value Decomposition (tSVD)
+  - Single GPU Principal Component Analysis (PCA)
+  - Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
+  - Single GPU Kalman Filtering
+  - Multi-GPU K-Means Clustering
+  - Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
 
 2. ***python***: Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
 
 3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components:
-  a) Linear Algebra
-  b) Statistics
-  c) Basic Matrix Operations
-  d) Distance Functions
-  e) Random Number Generation
+  - Linear Algebra
+  - Statistics
+  - Basic Matrix Operations
+  - Distance Functions
+  - Random Number Generation
 
 Algorithms in progress:
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,6 @@ cuML is a suite of libraries that implement machine learning algorithms and shar
 
 cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
 
-#### Supported Algorithms:
-
-- Truncated Singular Value Decomposition (tSVD),
-
-- Principal Component Analysis (PCA),
-
-- Density-based spatial clustering of applications with noise (DBSCAN),
-
-- K-Means Clustering,
-
-- K-Nearest Neighbors (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use),
-
-- Linear Regression (Ordinary Least Squares),
-
-- Ridge Regression.
-
-- Kalman Filter.
-
 As an example, the following Python snippet loads input and computes DBSCAN clusters, all on GPU:
 ```
 import cudf
@@ -49,6 +31,24 @@ dtype: int32
 ```
 
 For additional examples, browse our complete [API documentation](https://rapidsai.github.io/projects/cuml/en/latest/index.html), or check out our more detailed [walkthrough notebooks](https://github.com/rapidsai/notebooks/tree/master/cuml).
+
+#### Supported Algorithms:
+
+- Truncated Singular Value Decomposition (tSVD),
+
+- Principal Component Analysis (PCA),
+
+- Density-based spatial clustering of applications with noise (DBSCAN),
+
+- K-Means Clustering,
+
+- K-Nearest Neighbors (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use),
+
+- Linear Regression (Ordinary Least Squares),
+
+- Ridge Regression.
+
+- Kalman Filter.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - RAPIDS Machine Learning Algorithms</div>
+# <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - Machine Learning Algorithms</div>
 
 cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other RAPIDS projects.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ cuML's core structure contains:
   - Random Number Generation
 
 ### Build from Source
-See [docs/build.md]
+[Instructions](docs/build.md)
 
 ## External
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - RAPIDS Machine Learning Algorithms</div>
 
-Machine learning is a fundamental capability of RAPIDS, the GPU accelerated data science ecosystem. cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other RAPIDS projects. cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
+cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other RAPIDS projects.
+
+cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
 
 #### Supported Algorithms:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cuML's core structure contains:
   - Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
 
 2. ***python***:
-  for the above algorithms, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without leaving GPU memory.
+  Python bindings for the above algorithms, including interfaces for [cuDF](https://github.com/rapidsai/cudf). These bindings connect the data to C++/CUDA based cuML and ml-prims libraries without leaving GPU memory.
 
 3. ***ml-prims***:
   Low level machine learning primitives used in cuML. Includes:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ dtype: int32
 
 For additional examples, browse our complete [API documentation](https://rapidsai.github.io/projects/cuml/en/latest/index.html), or check out our more detailed [walkthrough notebooks](https://github.com/rapidsai/notebooks/tree/master/cuml).
 
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
+
 ### Supported Algorithms:
 
 - Truncated Singular Value Decomposition (tSVD)
@@ -43,7 +45,22 @@ For additional examples, browse our complete [API documentation](https://rapidsa
 - Ridge Regression
 - Kalman Filter
 
+Algorithms in progress:
+
+- More Kalman Filter versions
+- Lasso
+- Elastic-Net
+- Logistic Regression
+- UMAP
+
+More ML algorithms in cuML and more ML primitives in ml-prims are being worked on. Goals for future versions include more algorithms and multi-gpu versions of the algorithms and primitives.
+
 ## Installation
+
+Ensure `libomp` and `libopenblas` are installed:
+```bash
+sudo apt install libopenblas-base libomp-dev
+```
 
 #### Conda
 cuML can be installed using the `rapidsai` conda channel:
@@ -63,14 +80,8 @@ pip install cuml-cuda92
 # cuda 10.0
 pip install cuml-cuda100
 ```
-You also need to ensure `libomp` and `libopenblas` are installed:
-```bash
-apt install libopenblas-base libomp-dev
-```
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
-
-The cuML repository contains:
+cuML's core structure contains:
 
 1. ***cuML***:
   C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
@@ -82,25 +93,15 @@ The cuML repository contains:
   - Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
 
 2. ***python***:
-  Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
+  for the above algorithms, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without leaving GPU memory.
 
 3. ***ml-prims***:
-  Low level machine learning primitives used in cuML. ml-prims is comprised of the following components:
+  Low level machine learning primitives used in cuML. Includes:
   - Linear Algebra
   - Statistics
   - Basic Matrix Operations
   - Distance Functions
   - Random Number Generation
-
-Algorithms in progress:
-
-- More Kalman Filter versions
-- Lasso
-- Elastic-Net
-- Logistic Regression
-- UMAP
-
-More ML algorithms in cuML and more ML primitives in ml-prims are being worked on. Goals for future versions include more algorithms and multi-gpu versions of the algorithms and primitives.
 
 ### Build from Source
 See [docs/build.md]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - Machine Learning Algorithms</div>
+# <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - GPU Machine Learning Algorithms</div>
 
-cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other [RAPIDS](https://rapids.ai/) projects.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
+
+cuML is a suite of libraries that implement machine learning algorithms and mathematical primitives functions that share compatible APIs with other [RAPIDS](https://rapids.ai/) projects.
 
 cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
 
@@ -32,18 +34,16 @@ dtype: int32
 
 For additional examples, browse our complete [API documentation](https://rapidsai.github.io/projects/cuml/en/latest/index.html), or check out our more detailed [walkthrough notebooks](https://github.com/rapidsai/notebooks/tree/master/cuml).
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
-
 ### Supported Algorithms:
 
-- Truncated Singular Value Decomposition (tSVD)
-- Principal Component Analysis (PCA)
-- Density-based spatial clustering of applications with noise (DBSCAN)
-- K-Means Clustering
-- K-Nearest Neighbors (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use)
-- Linear Regression (Ordinary Least Squares)
-- Ridge Regression
-- Kalman Filter
+- Truncated Singular Value Decomposition (tSVD) - Single GPU
+- Principal Component Analysis (PCA) - Single GPU
+- Density-based spatial clustering of applications with noise (DBSCAN) - Single GPU
+- K-Means Clustering - Multi-GPU
+- K-Nearest Neighbors - Multi-GPU (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use)
+- Linear Regression (Ordinary Least Squares) - Single GPU
+- Ridge Regression - Single GPU
+- Kalman Filter - Single GPU
 
 Algorithms in progress:
 
@@ -57,7 +57,7 @@ More ML algorithms in cuML and more ML primitives in ml-prims are being worked o
 
 ## Installation
 
-Ensure `libomp` and `libopenblas` are installed:
+Ensure `libomp` and `libopenblas` are installed, for example via apt:
 ```bash
 sudo apt install libopenblas-base libomp-dev
 ```
@@ -81,30 +81,8 @@ pip install cuml-cuda92
 pip install cuml-cuda100
 ```
 
-cuML's core structure contains:
-
-1. ***cuML***:
-  C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
-  - Single GPU Truncated Singular Value Decomposition (tSVD)
-  - Single GPU Principal Component Analysis (PCA)
-  - Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
-  - Single GPU Kalman Filtering
-  - Multi-GPU K-Means Clustering
-  - Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
-
-2. ***python***:
-  Python bindings for the above algorithms, including interfaces for [cuDF](https://github.com/rapidsai/cudf). These bindings connect the data to C++/CUDA based cuML and ml-prims libraries without leaving GPU memory.
-
-3. ***ml-prims***:
-  Low level machine learning primitives used in cuML. Includes:
-  - Linear Algebra
-  - Statistics
-  - Basic Matrix Operations
-  - Distance Functions
-  - Random Number Generation
-
-### Build from Source
-[Instructions](docs/build.md)
+#### Build/Install from Source
+See build [instructions](BUILD.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ cuML is a suite of libraries that implement machine learning algorithms and math
 cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
 
 As an example, the following Python snippet loads input and computes DBSCAN clusters, all on GPU:
-```
+```python
 import cudf
 from cuml import DBSCAN
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,8 @@
 # <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - RAPIDS Machine Learning Algorithms</div>
 
-Machine learning is a fundamental capability of RAPIDS. cuML is a suite of libraries that implements a machine learning algorithms within the RAPIDS data science ecosystem. cuML enables data scientists, researchers, and software engineers to run traditional ML tasks on GPUs without going into the details of CUDA programming.
+Machine learning is a fundamental capability of RAPIDS, the GPU accelerated data science ecosystem. cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other RAPIDS projects. cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
-
-The cuML repository contains:
-
-1. ***python***: Python based GPU Dataframe (GDF) machine learning package that takes [cuDF](https://github.com/rapidsai/cudf) dataframes as input. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
-
-2. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms;
-   a) Single GPU Truncated Singular Value Decomposition (tSVD),
-   b) Single GPU Principal Component Analysis (PCA),
-   c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN),
-   d) Single GPU Kalman Filtering,
-   e) Multi-GPU K-Means Clustering,
-   f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss)).
-
-3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components;
-   a) Linear Algebra,
-   b) Statistics,
-   c) Basic Matrix Operations,
-   d) Distance Functions,
-   e) Random Number Generation.
-
-#### Available Algorithms:
+#### Supported Algorithms:
 
 - Truncated Singular Value Decomposition (tSVD),
 
@@ -41,25 +20,35 @@ The cuML repository contains:
 
 - Kalman Filter.
 
-Upcoming algorithms:
+As an example, the following Python snippet loads input and computes DBSCAN clusters, all on GPU:
+```
+import cudf
+from cuml import DBSCAN
 
-- More Kalman Filter versions, 
+# Create and populate a GPU DataFrame
+gdf_float = cudf.DataFrame()
+gdf_float['0'] = [1.0, 2.0, 5.0]
+gdf_float['1'] = [4.0, 2.0, 1.0]
+gdf_float['2'] = [4.0, 2.0, 1.0]
 
-- Lasso,
+# Setup and fit clusters
+dbscan_float = DBSCAN(eps=1.0, min_samples=1)
+dbscan_float.fit(gdf_float)
 
-- Elastic-Net,
+print(dbsca_float.labels_)
+```
 
-- Logistic Regression,
+Output:
+```
+0    0
+1    1
+2    2
+dtype: int32
+```
 
-- UMAP
+For additional examples, browse our complete [API documentation](https://rapidsai.github.io/projects/cuml/en/latest/index.html), or check out our more detailed [walkthrough notebooks](https://github.com/rapidsai/notebooks/tree/master/cuml).
 
-
-More ML algorithms in cuML and more ML primitives in ml-prims are being added currently. Example notebooks are provided in the python folder to test the functionality and performance. Goals for future versions include more algorithms and multi-gpu versions of the algorithms and primitives.
-
-The installation option provided currently consists on building from source. Upcoming versions will add `pip` and `conda` options, along docker containers. They will be available in the coming weeks.
-
-
-## Setup
+## Installation
 
 ### Conda
 cuML can be installed using the `rapidsai` conda channel:
@@ -83,103 +72,45 @@ apt install libopenblas-base libomp-dev
 
 *Note:* There is no faiss-gpu package installable by pip, so the KNN algorithm will not work unless you install [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
 
-### Dependencies for Installing/Building from Source:
 
-To install cuML from source, ensure the dependencies are met:
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
 
-1. [cuDF](https://github.com/rapidsai/cudf) (>=0.5.0)
-2. zlib Provided by zlib1g-dev in Ubuntu 16.04
-3. cmake (>= 3.12.4)
-4. CUDA (>= 9.2)
-5. Cython (>= 0.29)
-6. gcc (>=5.4.0)
-7. BLAS - Any BLAS compatible with Cmake's [FindBLAS](https://cmake.org/cmake/help/v3.12/module/FindBLAS.html)
+The cuML repository contains:
 
-```bash
-# cuda 9.2
-conda install -c pytorch faiss-gpu cuda92
+1. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms;
+   a) Single GPU Truncated Singular Value Decomposition (tSVD),
+   b) Single GPU Principal Component Analysis (PCA),
+   c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN),
+   d) Single GPU Kalman Filtering,
+   e) Multi-GPU K-Means Clustering,
+   f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss)).
 
-# cuda 10.0
-conda install -c pytorch faiss-gpu cuda100
-```
+2. ***python***: Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
 
-### Installing from Source:
+3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components;
+   a) Linear Algebra,
+   b) Statistics,
+   c) Basic Matrix Operations,
+   d) Distance Functions,
+   e) Random Number Generation.
 
-Once dependencies are present, follow the steps below:
+Algorithms in progress:
 
-1. Clone the repository.
-```bash
-$ git clone --recurse-submodules https://github.com/rapidsai/cuml.git
-```
+- More Kalman Filter versions, 
 
-2. Build and install `libcuml` (the C++/CUDA library containing the cuML algorithms), starting from the repository root folder:
-```bash
-$ cd cuML
-$ mkdir build
-$ cd build
-$ cmake ..
-```
+- Lasso,
 
-If using a conda environment (recommended currently), then cmake can be configured appropriately via:
+- Elastic-Net,
 
-```bash
-$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
-```
+- Logistic Regression,
 
-Note: The following warning message is dependent upon the version of cmake and the `CMAKE_INSTALL_PREFIX` used. If this warning is displayed, the build should still run succesfully. We are currently working to resolve this open issue. You can silence this warning by adding `-DCMAKE_IGNORE_PATH=$CONDA_PREFIX/lib` to your `cmake` command.
-```
-Cannot generate a safe runtime search path for target ml_test because files
-in some directories may conflict with libraries in implicit directories:
-```
-
-The configuration script will print the BLAS found on the search path. If the version found does not match the version intended, use the flag `-DBLAS_LIBRARIES=/path/to/blas.so` with the `cmake` command to force your own version. 
+- UMAP
 
 
-3. Build `libcuml`:
+More ML algorithms in cuML and more ML primitives in ml-prims are being worked on. Goals for future versions include more algorithms and multi-gpu versions of the algorithms and primitives.
 
-```bash
-$ make -j
-$ make install
-```
-
-To run tests (optional):
-
-```bash
-$ ./ml_test
-```
-
-If you want a list of the available tests:
-```bash
-$ ./ml_test --gtest_list_tests
-```
-
-4. Build the `cuml` python package:
-
-```bash
-$ cd ../../python
-$ python setup.py build_ext --inplace
-```
-
-To run Python tests (optional):
-
-```bash
-$ py.test -v
-```
-
-If you want a list of the available tests:
-```bash
-$ py.test cuML/test --collect-only
-```
-
-5. Finally, install the Python package to your Python path:
-
-```bash
-$ python setup.py install
-```
-
-### Python Notebooks
-
-Demo notebooks for the cuML Python algorithms can be found in the [rapidsai/notebooks](https://github.com/rapidsai/notebooks/tree/master/cuml) repository on Github.
+### Build from Source
+See [docs/build.md]
 
 ## External
 
@@ -194,7 +125,7 @@ Current external submodules are:
 
 ## Contributing
 
-Please use issues and pull requests to report bugs and add functionality.
+Please use GitHub issues and pull requests to report bugs and add or request functionality.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -34,21 +34,21 @@ For additional examples, browse our complete [API documentation](https://rapidsa
 
 ### Supported Algorithms:
 
-- Truncated Singular Value Decomposition (tSVD),
+- Truncated Singular Value Decomposition (tSVD)
 
-- Principal Component Analysis (PCA),
+- Principal Component Analysis (PCA)
 
-- Density-based spatial clustering of applications with noise (DBSCAN),
+- Density-based spatial clustering of applications with noise (DBSCAN)
 
-- K-Means Clustering,
+- K-Means Clustering
 
-- K-Nearest Neighbors (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use),
+- K-Nearest Neighbors (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use)
 
-- Linear Regression (Ordinary Least Squares),
+- Linear Regression (Ordinary Least Squares)
 
-- Ridge Regression.
+- Ridge Regression
 
-- Kalman Filter.
+- Kalman Filter
 
 
 ## Installation
@@ -73,7 +73,7 @@ You also need to ensure `libomp` and `libopenblas` are installed:
 apt install libopenblas-base libomp-dev
 ```
 
-*Note:* There is no faiss-gpu package installable by pip; cuml.KNN requires also installing [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
+*Note:* Pip has no faiss-gpu package: If installing cuML from pip and you plan to use cuml.KNN, you must install [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
 
 
 **NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
@@ -81,42 +81,28 @@ apt install libopenblas-base libomp-dev
 The cuML repository contains:
 
 1. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
-
-   a) Single GPU Truncated Singular Value Decomposition (tSVD)
-
-   b) Single GPU Principal Component Analysis (PCA)
-
-   c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
-
-   d) Single GPU Kalman Filtering
-
-   e) Multi-GPU K-Means Clustering
-
-   f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
+  a) Single GPU Truncated Singular Value Decomposition (tSVD)
+  b) Single GPU Principal Component Analysis (PCA)
+  c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
+  d) Single GPU Kalman Filtering
+  e) Multi-GPU K-Means Clustering
+  f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
 
 2. ***python***: Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
 
 3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components:
-   a) Linear Algebra
-
-   b) Statistics
-
-   c) Basic Matrix Operations
-
-   d) Distance Functions
-
-   e) Random Number Generation
+  a) Linear Algebra
+  b) Statistics
+  c) Basic Matrix Operations
+  d) Distance Functions
+  e) Random Number Generation
 
 Algorithms in progress:
 
 - More Kalman Filter versions
-
 - Lasso
-
 - Elastic-Net
-
 - Logistic Regression
-
 - UMAP
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="left"><img src="img/rapids_logo.png" width="90px"/>&nbsp;cuML - Machine Learning Algorithms</div>
 
-cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other RAPIDS projects.
+cuML is a suite of libraries that implement machine learning algorithms and share compatible APIs with other [RAPIDS](https://rapids.ai/) projects.
 
 cuML enables data scientists, researchers, and software engineers to run traditional tabular ML tasks on GPUs without going into the details of CUDA programming.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dtype: int32
 
 For additional examples, browse our complete [API documentation](https://rapidsai.github.io/projects/cuml/en/latest/index.html), or check out our more detailed [walkthrough notebooks](https://github.com/rapidsai/notebooks/tree/master/cuml).
 
-#### Supported Algorithms:
+### Supported Algorithms:
 
 - Truncated Singular Value Decomposition (tSVD),
 
@@ -50,15 +50,16 @@ For additional examples, browse our complete [API documentation](https://rapidsa
 
 - Kalman Filter.
 
+
 ## Installation
 
-### Conda
+#### Conda
 cuML can be installed using the `rapidsai` conda channel:
 ```bash
 conda install -c nvidia -c rapidsai -c conda-forge -c pytorch -c defaults cuml
 ```
 
-### Pip
+#### Pip
 cuML can also be installed using pip. Select the package based on your version of CUDA:
 ```bash
 # cuda 9.2
@@ -72,39 +73,49 @@ You also need to ensure `libomp` and `libopenblas` are installed:
 apt install libopenblas-base libomp-dev
 ```
 
-*Note:* There is no faiss-gpu package installable by pip, so the KNN algorithm will not work unless you install [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
+*Note:* There is no faiss-gpu package installable by pip; cuml.KNN requires also installing [Faiss](https://github.com/facebookresearch/faiss) manually or via conda (see below).
 
 
 **NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cuml/blob/master/README.md) ensure you are on the `master` branch.
 
 The cuML repository contains:
 
-1. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms;
-   a) Single GPU Truncated Singular Value Decomposition (tSVD),
-   b) Single GPU Principal Component Analysis (PCA),
-   c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN),
-   d) Single GPU Kalman Filtering,
-   e) Multi-GPU K-Means Clustering,
-   f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss)).
+1. ***cuML***: C++/CUDA machine learning algorithms. This library currently includes the following six algorithms:
+
+   a) Single GPU Truncated Singular Value Decomposition (tSVD)
+
+   b) Single GPU Principal Component Analysis (PCA)
+
+   c) Single GPU Density-based Spatial Clustering of Applications with Noise (DBSCAN)
+
+   d) Single GPU Kalman Filtering
+
+   e) Multi-GPU K-Means Clustering
+
+   f) Multi-GPU K-Nearest Neighbors (Uses [Faiss](https://github.com/facebookresearch/faiss))
 
 2. ***python***: Python bindings for the above, including interfaces for [cuDF](https://github.com/rapidsai/cudf) GPU dataframes. cuML connects the data to C++/CUDA based cuML and ml-prims libraries without ever leaving GPU memory.
 
-3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components;
-   a) Linear Algebra,
-   b) Statistics,
-   c) Basic Matrix Operations,
-   d) Distance Functions,
-   e) Random Number Generation.
+3. ***ml-prims***: Low level machine learning primitives used in cuML. ml-prims is comprised of the following components:
+   a) Linear Algebra
+
+   b) Statistics
+
+   c) Basic Matrix Operations
+
+   d) Distance Functions
+
+   e) Random Number Generation
 
 Algorithms in progress:
 
-- More Kalman Filter versions, 
+- More Kalman Filter versions
 
-- Lasso,
+- Lasso
 
-- Elastic-Net,
+- Elastic-Net
 
-- Logistic Regression,
+- Logistic Regression
 
 - UMAP
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -83,3 +83,14 @@ $ py.test cuML/test --collect-only
 ```bash
 $ python setup.py install
 ```
+
+## External
+
+The external folders contains submodules that this project in-turn depends on. Appropriate location flags
+will be automatically populated in the main `CMakeLists.txt` file for these.
+
+Current external submodules are:
+
+- [CUTLASS](https://github.com/NVIDIA/cutlass)
+- [Google Test](https://github.com/google/googletest)
+- [CUB](https://github.com/NVlabs/cub)

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,85 @@
+### Dependencies for Installing/Building from Source:
+
+To install cuML from source, ensure the dependencies are met:
+
+1. [cuDF](https://github.com/rapidsai/cudf) (>=0.5.0)
+2. zlib Provided by zlib1g-dev in Ubuntu 16.04
+3. cmake (>= 3.12.4)
+4. CUDA (>= 9.2)
+5. Cython (>= 0.29)
+6. gcc (>=5.4.0)
+7. BLAS - Any BLAS compatible with Cmake's [FindBLAS](https://cmake.org/cmake/help/v3.12/module/FindBLAS.html)
+
+### Installing from Source:
+
+Once dependencies are present, follow the steps below:
+
+1. Clone the repository.
+```bash
+$ git clone --recurse-submodules https://github.com/rapidsai/cuml.git
+```
+
+2. Build and install `libcuml` (the C++/CUDA library containing the cuML algorithms), starting from the repository root folder:
+```bash
+$ cd cuML
+$ mkdir build
+$ cd build
+$ cmake ..
+```
+
+If using a conda environment (recommended currently), then cmake can be configured appropriately via:
+
+```bash
+$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+```
+
+Note: The following warning message is dependent upon the version of cmake and the `CMAKE_INSTALL_PREFIX` used. If this warning is displayed, the build should still run succesfully. We are currently working to resolve this open issue. You can silence this warning by adding `-DCMAKE_IGNORE_PATH=$CONDA_PREFIX/lib` to your `cmake` command.
+```
+Cannot generate a safe runtime search path for target ml_test because files
+in some directories may conflict with libraries in implicit directories:
+```
+
+The configuration script will print the BLAS found on the search path. If the version found does not match the version intended, use the flag `-DBLAS_LIBRARIES=/path/to/blas.so` with the `cmake` command to force your own version. 
+
+
+3. Build `libcuml`:
+
+```bash
+$ make -j
+$ make install
+```
+
+To run tests (optional):
+
+```bash
+$ ./ml_test
+```
+
+If you want a list of the available tests:
+```bash
+$ ./ml_test --gtest_list_tests
+```
+
+4. Build the `cuml` python package:
+
+```bash
+$ cd ../../python
+$ python setup.py build_ext --inplace
+```
+
+To run Python tests (optional):
+
+```bash
+$ py.test -v
+```
+
+If you want a list of the available tests:
+```bash
+$ py.test cuML/test --collect-only
+```
+
+5. Finally, install the Python package to your Python path:
+
+```bash
+$ python setup.py install
+```


### PR DESCRIPTION
cuML users have commented that their first experience with it was via README.md.

They noted being overwhelmed by the lengthy build instructions, didn't find it easy to understand what the library is (no examples, no link to API docs), and got confused on install vs build commands.

This PR:
1. moves all build instructions into a separate build.md file
2. adds a simple example, moves notebook and doc links immediately after it
3. Fixes the broken dev container (Dockerfile)