### PR TITLE
Fea ext rand int support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #114: Building faiss C++ api into libcuml
 - PR #64: Using FAISS C++ API in cuML and exposing bindings through cython
 - PR #208: Issue ml-common-3: Math.h: swap thrust::for_each with binaryOp,unaryOp
+- PR #225: Support for generating random integers
 
 ## Bug Fixes
 

--- a/cuML/test/dbscan_test.cu
+++ b/cuML/test/dbscan_test.cu
@@ -48,7 +48,7 @@ protected:
 	void basicTest() {
 
 		params = ::testing::TestWithParam<DbscanInputs<T>>::GetParam();
-		Random::Rng<T> r(params.seed);
+		Random::Rng r(params.seed);
 		int len = params.len;
 
 		allocate(data, len);

--- a/cuML/test/pca_test.cu
+++ b/cuML/test/pca_test.cu
@@ -58,7 +58,7 @@ protected:
 		CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
 
 		params = ::testing::TestWithParam<PcaInputs<T>>::GetParam();
-		Random::Rng<T> r(params.seed, MLCommon::Random::GenTaps);
+		Random::Rng r(params.seed, MLCommon::Random::GenTaps);
 		int len = params.len;
 
 		allocate(data, len);
@@ -125,7 +125,7 @@ protected:
 		CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
 
 		params = ::testing::TestWithParam<PcaInputs<T>>::GetParam();
-		Random::Rng<T> r(params.seed, MLCommon::Random::GenTaps);
+		Random::Rng r(params.seed, MLCommon::Random::GenTaps);
 		int len = params.len2;
 
 		paramsPCA prms;

--- a/cuML/test/tsvd_test.cu
+++ b/cuML/test/tsvd_test.cu
@@ -55,7 +55,7 @@ protected:
 		CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
 
 		params = ::testing::TestWithParam<TsvdInputs<T>>::GetParam();
-		Random::Rng<T> r(params.seed, MLCommon::Random::GenTaps);
+		Random::Rng r(params.seed, MLCommon::Random::GenTaps);
 		int len = params.len;
 
 		allocate(data, len);
@@ -98,7 +98,7 @@ protected:
 		CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
 
 		params = ::testing::TestWithParam<TsvdInputs<T>>::GetParam();
-		Random::Rng<T> r(params.seed, MLCommon::Random::GenTaps);
+		Random::Rng r(params.seed, MLCommon::Random::GenTaps);
 		int len = params.len2;
 
 		paramsTSVD prms;

--- a/ml-prims/src/linalg/rsvd.h
+++ b/ml-prims/src/linalg/rsvd.h
@@ -82,8 +82,8 @@ void rsvdFixedRank(math_t *M, int n_rows, int n_cols, math_t *&S_vec,
 
   // build random matrix
   math_t *RN = (math_t *)mgr.alloc(sizeof(math_t) * n * l);
-  Random::Rng<math_t> rng(484);
-  rng.normal(RN, n * l, 0.0, alpha, stream);
+  Random::Rng rng(484);
+  rng.normal(RN, n * l, math_t(0.0), alpha, stream);
 
   // multiply to get matrix of random samples Y
   math_t *Y = (math_t *)mgr.alloc(sizeof(math_t) * m * l);

--- a/ml-prims/src/random/rng_impl.h
+++ b/ml-prims/src/random/rng_impl.h
@@ -25,61 +25,42 @@ namespace MLCommon {
 namespace Random {
 namespace detail {
 
-/**
- * @defgroup PhiloxGenerator Philox-based random number generator
- * @{
- */
+/** Philox-based random number generator */
 // Courtesy: Jakub Szuppe
-/** base class for philox based RNG's */
-struct PhiloxGeneratorBase {
+struct PhiloxGenerator {
   /**
    * @brief ctor. Initializes the state for RNG
    * @param seed random seed (can be same across all threads)
    * @param subsequence as found in curand docs
    * @param offset as found in curand docs
    */
-  DI PhiloxGeneratorBase(uint64_t seed, uint64_t subsequence, uint64_t offset) {
+  DI PhiloxGenerator(uint64_t seed, uint64_t subsequence, uint64_t offset) {
     curand_init(seed, subsequence, offset, &state);
   }
 
-protected:
+  /**
+   * @defgroup NextRand Generate the next random number
+   * @{
+   */
+  DI void next(float& ret) { ret = curand_uniform(&(this->state)); }
+  DI void next(double& ret) { ret = curand_uniform_double(&(this->state)); }
+  DI void next(uint32_t& ret) { ret = curand(&(this->state)); }
+  DI void next(uint64_t& ret) {
+    uint32_t a, b;
+    next(a);
+    next(b);
+    ret = (uint64_t)a | ((uint64_t)b << 32);
+  }
+  /** @} */
+
+private:
   /** the state for RNG */
   curandStatePhilox4_32_10_t state;
 };
 
-template <class T>
-struct PhiloxGenerator;
 
-template <>
-struct PhiloxGenerator<float> : public PhiloxGeneratorBase {
-  using PhiloxGeneratorBase::PhiloxGeneratorBase;
-
-  DI float next() { return curand_uniform(&(this->state)); }
-
-  typedef float MathType;
-};
-
-template <>
-struct PhiloxGenerator<double> : public PhiloxGeneratorBase {
-  using PhiloxGeneratorBase::PhiloxGeneratorBase;
-
-  DI double next() { return curand_uniform_double(&(this->state)); }
-
-  typedef double MathType;
-};
-/** @} */
-
-
-/**
- * @defgroup TapsGenerator Taps-based random number generator
- * @{
- */
+/** LFSR taps-filter for generating random numbers. */
 // Courtesy: Vinay Deshpande
-/**
- * @brief LFSR taps-filter for generating random numbers. This is SUPER-slow,
- * but in my experience, generates "better quality" random numbers.
- */
-template <typename Type>
 struct TapsGenerator {
   /**
    * @brief ctor. Initializes the state for RNG
@@ -96,33 +77,40 @@ struct TapsGenerator {
     state = seed + delta + 1;
   }
 
-  /** generate the next uniform random number between 0.0 and 1.0 */
-  DI Type next() {
+  /**
+   * @defgroup NextRand Generate the next random number
+   * @{
+   */
+  template <typename Type>
+  DI void next(Type& ret) {
+    constexpr double ULL_LARGE = 1.8446744073709551614e19;
+    uint64_t val;
+    next(val);
+    ret = static_cast<Type>(val);
+    ret /= static_cast<Type>(ULL_LARGE);
+  }
+  DI void next(uint64_t& ret) {
     constexpr uint64_t TAPS = 0x8000100040002000ULL;
     constexpr int ROUNDS = 128;
-    constexpr double ULL_LARGE = 1.8446744073709551614e19;
     for (int i = 0; i < ROUNDS; i++)
       state = (state >> 1) ^ (-(state & 1ULL) & TAPS);
-    Type res = static_cast<Type>(state);
-    res /= static_cast<Type>(ULL_LARGE);
-    return res;
+    ret = state;
   }
-
-  typedef Type MathType;
+  DI void next(uint32_t& ret) {
+    uint64_t val;
+    next(val);
+    ret = (uint32_t)val;
+  }
+  /** @} */
 
 private:
   /** the state for RNG */
   uint64_t state;
 };
-/** @} */
 
 
-/**
- * @defgroup Kiss99Generator Kiss99-based random number generator
- * @{
- */
+/** Kiss99-based random number generator */
 // Courtesy: Vinay Deshpande
-template <typename Type>
 struct Kiss99Generator {
   /**
    * @brief ctor. Initializes the state for RNG
@@ -134,9 +122,19 @@ struct Kiss99Generator {
     initKiss99((uint32_t)seed);
   }
 
-  /** generate the next uniform random number between 0.0 and 1.0 */
-  DI Type next() {
+  /**
+   * @defgroup NextRand Generate the next random number
+   * @{
+   */
+  template <typename Type>
+  DI void next(Type& ret) {
     constexpr double U_LARGE = 4.294967295e9;
+    uint32_t val;
+    next(val);
+    ret = static_cast<Type>(val);
+    ret /= static_cast<Type>(U_LARGE);
+  }
+  DI void next(uint32_t& ret) {
     uint32_t MWC;
     z = 36969 * (z & 65535) + (z >> 16);
     w = 18000 * (w & 65535) + (w >> 16);
@@ -146,12 +144,15 @@ struct Kiss99Generator {
     jsr ^= (jsr << 5);
     jcong = 69069 * jcong + 1234567;
     MWC = ((MWC ^ jcong) + jsr);
-    Type res = static_cast<Type>(MWC);
-    res /= static_cast<Type>(U_LARGE);
-    return res;
+    ret = MWC;
   }
-
-  typedef Type MathType;
+  DI void next(uint64_t& ret) {
+    uint32_t a, b;
+    next(a);
+    next(b);
+    ret = (uint64_t)a | ((uint64_t)b << 32);
+  }
+  /** @} */
 
 private:
   /** one of the kiss99 states */
@@ -195,7 +196,6 @@ private:
     jcong = hash;
   }
 };
-/** @} */
 
 
 /**
@@ -204,12 +204,11 @@ private:
  */
 template <typename GenType>
 struct Generator {
-  typedef typename GenType::MathType MathType;
-
   DI Generator(uint64_t seed, uint64_t subsequence, uint64_t offset)
     : gen(seed, subsequence, offset) {}
 
-  DI MathType next() { return gen.next(); }
+  template <typename Type>
+  DI void next(Type& ret) { gen.next(ret); }
 
 private:
   /** the actual generator */

--- a/ml-prims/src/random/rng_impl.h
+++ b/ml-prims/src/random/rng_impl.h
@@ -51,6 +51,16 @@ struct PhiloxGenerator {
     next(b);
     ret = (uint64_t)a | ((uint64_t)b << 32);
   }
+  DI void next(int32_t& ret) {
+      uint32_t val;
+      next(val);
+      ret = int32_t(val & 0x7fffffff);
+  }
+  DI void next(int64_t& ret) {
+      uint64_t val;
+      next(val);
+      ret = int64_t(val & 0x7fffffffffffffff);
+  }
   /** @} */
 
 private:
@@ -100,6 +110,16 @@ struct TapsGenerator {
     uint64_t val;
     next(val);
     ret = (uint32_t)val;
+  }
+  DI void next(int32_t& ret) {
+      uint32_t val;
+      next(val);
+      ret = int32_t(val & 0x7fffffff);
+  }
+  DI void next(int64_t& ret) {
+      uint64_t val;
+      next(val);
+      ret = int64_t(val & 0x7fffffffffffffff);
   }
   /** @} */
 
@@ -151,6 +171,16 @@ struct Kiss99Generator {
     next(a);
     next(b);
     ret = (uint64_t)a | ((uint64_t)b << 32);
+  }
+  DI void next(int32_t& ret) {
+      uint32_t val;
+      next(val);
+      ret = int32_t(val & 0x7fffffff);
+  }
+  DI void next(int64_t& ret) {
+      uint64_t val;
+      next(val);
+      ret = int64_t(val & 0x7fffffffffffffff);
   }
   /** @} */
 

--- a/ml-prims/test/CMakeLists.txt
+++ b/ml-prims/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(mlcommon_test
   permute.cu
   power.cu
   rng.cu
+  rng_int.cu
   rsvd.cu
   sqrt.cu
   stddev.cu

--- a/ml-prims/test/add.cu
+++ b/ml-prims/test/add.cu
@@ -30,7 +30,7 @@ class AddTest : public ::testing::TestWithParam<AddInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<AddInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     allocate(in1, len);
     allocate(in2, len);

--- a/ml-prims/test/binary_op.cu
+++ b/ml-prims/test/binary_op.cu
@@ -37,7 +37,7 @@ class BinaryOpTest : public ::testing::TestWithParam<BinaryOpInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<BinaryOpInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     allocate(in1, len);
     allocate(in2, len);

--- a/ml-prims/test/coalesced_reduction.cu
+++ b/ml-prims/test/coalesced_reduction.cu
@@ -73,13 +73,13 @@ class coalescedReductionTest : public ::testing::TestWithParam<coalescedReductio
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<coalescedReductionInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int rows = params.rows, cols = params.cols;
     int len = rows * cols;
     allocate(data, len);
     allocate(dots_exp, rows);
     allocate(dots_act, rows);
-    r.uniform(data, len, -1.f, 1.f);
+    r.uniform(data, len, T(-1.0), T(1.0));
     naiveReduction(dots_exp, data, cols, rows);
 
     // Perform reduction with default inplace = false first

--- a/ml-prims/test/cov.cu
+++ b/ml-prims/test/cov.cu
@@ -43,7 +43,7 @@ protected:
   void SetUp() override {
     CUBLAS_CHECK(cublasCreate(&handle));
     params = ::testing::TestWithParam<CovInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int rows = params.rows, cols = params.cols;
     int len = rows * cols;
     T var = params.var;

--- a/ml-prims/test/distance.cu
+++ b/ml-prims/test/distance.cu
@@ -141,7 +141,7 @@ class DistanceTest : public ::testing::TestWithParam<DistanceInputs<T>> {
 public:
   void SetUp() override {
     params = ::testing::TestWithParam<DistanceInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int m = params.m;
     int n = params.n;
     int k = params.k;

--- a/ml-prims/test/distance_adj.cu
+++ b/ml-prims/test/distance_adj.cu
@@ -70,7 +70,7 @@ class DistanceAdjTest : public ::testing::TestWithParam<DistanceAdjInputs<T>> {
 public:
   void SetUp() override {
     params = ::testing::TestWithParam<DistanceAdjInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int m = params.m;
     int n = params.n;
     int k = params.k;

--- a/ml-prims/test/divide.cu
+++ b/ml-prims/test/divide.cu
@@ -45,7 +45,7 @@ class DivideTest : public ::testing::TestWithParam<UnaryOpInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<UnaryOpInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
 
     allocate(in, len);

--- a/ml-prims/test/eig.cu
+++ b/ml-prims/test/eig.cu
@@ -48,7 +48,7 @@ protected:
     auto mgr = makeDefaultAllocator();
 
     params = ::testing::TestWithParam<EigInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
 
     allocate(cov_matrix, len);

--- a/ml-prims/test/eltwise.cu
+++ b/ml-prims/test/eltwise.cu
@@ -63,7 +63,7 @@ class ScalarMultiplyTest
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<ScalarMultiplyInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     T scalar = params.scalar;
     allocate(in, len);
@@ -148,7 +148,7 @@ class EltwiseAddTest : public ::testing::TestWithParam<EltwiseAddInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<EltwiseAddInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     allocate(in1, len);
     allocate(in2, len);

--- a/ml-prims/test/eltwise2d.cu
+++ b/ml-prims/test/eltwise2d.cu
@@ -78,7 +78,7 @@ class Eltwise2dTest : public ::testing::TestWithParam<Eltwise2dInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<Eltwise2dInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     auto w = params.w;
     auto h = params.h;
     auto len = w * h;

--- a/ml-prims/test/kselection.cu
+++ b/ml-prims/test/kselection.cu
@@ -132,7 +132,7 @@ class WarpTopKTest : public ::testing::TestWithParam<WarpTopKInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<WarpTopKInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     allocate(arr, params.rows * params.cols);
     allocate(outk, params.rows * params.k);
     allocate(outv, params.rows * params.k);

--- a/ml-prims/test/map_then_reduce.cu
+++ b/ml-prims/test/map_then_reduce.cu
@@ -68,7 +68,7 @@ class MapReduceTest : public ::testing::TestWithParam<MapReduceInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<MapReduceInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     auto len = params.len;
     allocate(in, len);
     allocate(out_ref, len);

--- a/ml-prims/test/math.cu
+++ b/ml-prims/test/math.cu
@@ -113,7 +113,7 @@ class MathTest : public ::testing::TestWithParam<MathInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<MathInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
 
     allocate(in_power, len);

--- a/ml-prims/test/matrix.cu
+++ b/ml-prims/test/matrix.cu
@@ -40,7 +40,7 @@ class MatrixTest : public ::testing::TestWithParam<MatrixInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<MatrixInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.n_row * params.n_col;
     allocate(in1, len);
     allocate(in2, len);

--- a/ml-prims/test/matrix_vector_op.cu
+++ b/ml-prims/test/matrix_vector_op.cu
@@ -51,7 +51,7 @@ class MatVecOpTest : public ::testing::TestWithParam<MatVecOpInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<MatVecOpInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int N = params.rows, D = params.cols;
     int len = N * D;
     allocate(in, len);

--- a/ml-prims/test/mean.cu
+++ b/ml-prims/test/mean.cu
@@ -43,7 +43,7 @@ class MeanTest : public ::testing::TestWithParam<MeanInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<MeanInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
 
     int rows = params.rows, cols = params.cols;
     int len = rows * cols;

--- a/ml-prims/test/mean_center.cu
+++ b/ml-prims/test/mean_center.cu
@@ -44,7 +44,7 @@ class MeanCenterTest : public ::testing::TestWithParam<MeanCenterInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<MeanCenterInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int rows = params.rows, cols = params.cols;
     int len = rows * cols;
     allocate(out, len);

--- a/ml-prims/test/multiply.cu
+++ b/ml-prims/test/multiply.cu
@@ -28,7 +28,7 @@ class MultiplyTest : public ::testing::TestWithParam<UnaryOpInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<UnaryOpInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
 
     allocate(in, len);

--- a/ml-prims/test/norm.cu
+++ b/ml-prims/test/norm.cu
@@ -69,13 +69,13 @@ class NormTest : public ::testing::TestWithParam<NormInputs<T>> {
 public:
   void SetUp() override {
     params = ::testing::TestWithParam<NormInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int rows = params.rows, cols = params.cols;
     int len = rows * cols;
     allocate(data, len);
     allocate(dots_exp, rows);
     allocate(dots_act, rows);
-    r.uniform(data, len, -1.f, 1.f);
+    r.uniform(data, len, T(-1.0), T(1.0));
     naiveNorm(dots_exp, data, cols, rows, params.type, params.do_sqrt);
     if (params.do_sqrt) {
       auto fin_op = [] __device__(T in) { return mySqrt(in); };

--- a/ml-prims/test/opg_distance.cu
+++ b/ml-prims/test/opg_distance.cu
@@ -315,7 +315,7 @@ void assignTasks(std::vector<Worker<T>*>& workers, int n_gpu,
         allocate(task->d_X, x_len);
         allocate(task->d_Y, y_len);
         allocate(task->dist, dist_len);
-        Random::Rng<T> r(seed);
+        Random::Rng r(seed);
         r.uniform(task->d_X, x_len, T(-1.0), T(1.0));
         r.uniform(task->d_Y, y_len, T(-1.0), T(1.0));
 				worker->enqueue(task);

--- a/ml-prims/test/permute.cu
+++ b/ml-prims/test/permute.cu
@@ -46,7 +46,7 @@ protected:
     if(params.needShuffle) {
       params.needPerms = true;
     }
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int N = params.N;
     int D = params.D;
     int len = N * D;

--- a/ml-prims/test/power.cu
+++ b/ml-prims/test/power.cu
@@ -73,7 +73,7 @@ class PowerTest : public ::testing::TestWithParam<PowerInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<PowerInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     allocate(in1, len);
     allocate(in2, len);

--- a/ml-prims/test/rng.cu
+++ b/ml-prims/test/rng.cu
@@ -77,7 +77,7 @@ class RngTest : public ::testing::TestWithParam<RngInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<RngInputs<T>>::GetParam();
-    Rng<T> r(params.seed, params.gtype);
+    Rng r(params.seed, params.gtype);
     allocate(data, params.len);
     allocate(stats, 2, true);
     switch (params.type) {

--- a/ml-prims/test/rng_int.cu
+++ b/ml-prims/test/rng_int.cu
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <cub/cub.cuh>
+#include "cuda_utils.h"
+#include "random/rng.h"
+#include "test_utils.h"
+
+
+namespace MLCommon {
+namespace Random {
+
+enum RandomType {
+  RNG_Uniform
+};
+
+template <typename T, int TPB>
+__global__ void meanKernel(float *out, const T *data, int len) {
+  typedef cub::BlockReduce<float, TPB> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  float val = tid < len ? data[tid] : T(0);
+  float x = BlockReduce(temp_storage).Sum(val);
+  __syncthreads();
+  float xx = BlockReduce(temp_storage).Sum(val * val);
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    myAtomicAdd(out, x);
+    myAtomicAdd(out + 1, xx);
+  }
+}
+
+template <typename T>
+struct RngInputs {
+  float tolerance;
+  int len;
+  // start, end: for uniform
+  // mean, sigma: for normal/lognormal
+  // mean, beta: for gumbel
+  // mean, scale: for logistic and laplace
+  // lambda: for exponential
+  // sigma: for rayleigh
+  T start, end;
+  RandomType type;
+  GeneratorType gtype;
+  unsigned long long int seed;
+};
+
+template <typename T>
+::std::ostream &operator<<(::std::ostream &os, const RngInputs<T> &dims) {
+  return os;
+}
+
+template <typename T>
+class RngTest : public ::testing::TestWithParam<RngInputs<T>> {
+protected:
+  void SetUp() override {
+    params = ::testing::TestWithParam<RngInputs<T>>::GetParam();
+    Rng r(params.seed, params.gtype);
+    allocate(data, params.len);
+    allocate(stats, 2, true);
+    switch (params.type) {
+      case RNG_Uniform:
+        r.uniformInt(data, params.len, params.start, params.end);
+        break;
+    };
+    static const int threads = 128;
+    meanKernel<T, threads><<<ceildiv(params.len, threads), threads>>>(
+      stats, data, params.len);
+    updateHost<float>(h_stats, stats, 2);
+    h_stats[0] /= params.len;
+    h_stats[1] = (h_stats[1] / params.len) - (h_stats[0] * h_stats[0]);
+  }
+
+  void TearDown() override {
+    CUDA_CHECK(cudaFree(data));
+    CUDA_CHECK(cudaFree(stats));
+  }
+
+  void getExpectedMeanVar(float meanvar[2]) {
+    switch (params.type) {
+      case RNG_Uniform:
+        meanvar[0] = (params.start + params.end) * 0.5f;
+        meanvar[1] = params.end - params.start;
+        meanvar[1] = meanvar[1] * meanvar[1] / 12.f;
+        break;
+    };
+  }
+
+protected:
+  RngInputs<T> params;
+  T *data;
+  float *stats;
+  float h_stats[2]; // mean, var
+};
+
+typedef RngTest<uint32_t> RngTestU32;
+const std::vector<RngInputs<uint32_t>> inputs_u32 = {
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL}};
+TEST_P(RngTestU32, Result) {
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(
+    match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(
+    match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(RngTests, RngTestU32, ::testing::ValuesIn(inputs_u32));
+
+} // end namespace Random
+} // end namespace MLCommon

--- a/ml-prims/test/rng_int.cu
+++ b/ml-prims/test/rng_int.cu
@@ -112,10 +112,8 @@ typedef RngTest<uint32_t> RngTestU32;
 const std::vector<RngInputs<uint32_t>> inputs_u32 = {
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
-
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
-
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL}};
 TEST_P(RngTestU32, Result) {
@@ -127,6 +125,60 @@ TEST_P(RngTestU32, Result) {
     match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
 }
 INSTANTIATE_TEST_CASE_P(RngTests, RngTestU32, ::testing::ValuesIn(inputs_u32));
+
+typedef RngTest<uint64_t> RngTestU64;
+const std::vector<RngInputs<uint64_t>> inputs_u64 = {
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL}};
+TEST_P(RngTestU64, Result) {
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(
+    match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(
+    match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(RngTests, RngTestU64, ::testing::ValuesIn(inputs_u64));
+
+typedef RngTest<int32_t> RngTestS32;
+const std::vector<RngInputs<int32_t>> inputs_s32 = {
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL}};
+TEST_P(RngTestS32, Result) {
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(
+    match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(
+    match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(RngTests, RngTestS32, ::testing::ValuesIn(inputs_s32));
+
+typedef RngTest<int64_t> RngTestS64;
+const std::vector<RngInputs<int64_t>> inputs_s64 = {
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenTaps, 1234ULL},
+  {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL},
+  {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenKiss99, 1234ULL}};
+TEST_P(RngTestS64, Result) {
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(
+    match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(
+    match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(RngTests, RngTestS64, ::testing::ValuesIn(inputs_s64));
 
 } // end namespace Random
 } // end namespace MLCommon

--- a/ml-prims/test/rsvd.cu
+++ b/ml-prims/test/rsvd.cu
@@ -52,7 +52,7 @@ protected:
 
     params = ::testing::TestWithParam<RsvdInputs<T>>::GetParam();
     // rSVD seems to be very sensitive to the random number sequence as well!
-    Random::Rng<T> r(params.seed, Random::GenTaps);
+    Random::Rng r(params.seed, Random::GenTaps);
     int m = params.n_row, n = params.n_col;
     T eig_svd_tol = 1.e-7;
     int max_sweeps = 100;

--- a/ml-prims/test/sqrt.cu
+++ b/ml-prims/test/sqrt.cu
@@ -56,7 +56,7 @@ class SqrtTest : public ::testing::TestWithParam<SqrtInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<SqrtInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     allocate(in1, len);
     allocate(out_ref, len);

--- a/ml-prims/test/stddev.cu
+++ b/ml-prims/test/stddev.cu
@@ -43,7 +43,7 @@ class StdDevTest : public ::testing::TestWithParam<StdDevInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<StdDevInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int rows = params.rows, cols = params.cols;
     int len = rows * cols;
     allocate(data, len);

--- a/ml-prims/test/strided_reduction.cu
+++ b/ml-prims/test/strided_reduction.cu
@@ -73,14 +73,14 @@ class stridedReductionTest : public ::testing::TestWithParam<stridedReductionInp
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<stridedReductionInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int rows = params.rows, cols = params.cols;
     int len = rows*cols;
 
     allocate(data, len);
     allocate(dots_exp, cols); //expected dot products (from test)
     allocate(dots_act, cols); //actual dot products (from prim)
-    r.uniform(data, len, -1.f, 1.f); //initialize matrix to random
+    r.uniform(data, len, T(-1.0), T(1.0)); //initialize matrix to random
 
     unaryAndGemv(dots_exp, data, cols, rows);
     stridedReductionLaunch(dots_act, data, cols, rows);

--- a/ml-prims/test/subtract.cu
+++ b/ml-prims/test/subtract.cu
@@ -73,7 +73,7 @@ class SubtractTest : public ::testing::TestWithParam<SubtractInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<SubtractInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     allocate(in1, len);
     allocate(in2, len);

--- a/ml-prims/test/svd.cu
+++ b/ml-prims/test/svd.cu
@@ -48,7 +48,7 @@ protected:
     CUBLAS_CHECK(cublasCreate(&cublasH));
 
     params = ::testing::TestWithParam<SvdInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
 
     allocate(data, len);

--- a/ml-prims/test/ternary_op.cu
+++ b/ml-prims/test/ternary_op.cu
@@ -30,7 +30,7 @@ class ternaryOpTest : public ::testing::TestWithParam<BinaryOpInputs<T>> {
 public:
   void SetUp() override {
     params = ::testing::TestWithParam<BinaryOpInputs<T>>::GetParam();
-    Random::Rng<T> rng(params.seed);
+    Random::Rng rng(params.seed);
 
     int len = params.len;
     allocate(in1, len);

--- a/ml-prims/test/unary_op.cu
+++ b/ml-prims/test/unary_op.cu
@@ -38,7 +38,7 @@ class UnaryOpTest : public ::testing::TestWithParam<UnaryOpInputs<T>> {
 protected:
   void SetUp() override {
     params = ::testing::TestWithParam<UnaryOpInputs<T>>::GetParam();
-    Random::Rng<T> r(params.seed);
+    Random::Rng r(params.seed);
     int len = params.len;
     T scalar = params.scalar;
     allocate(in, len);

--- a/ml-prims/test/vector_broadcast.cu
+++ b/ml-prims/test/vector_broadcast.cu
@@ -71,7 +71,7 @@ class VecBcastTest: public ::testing::TestWithParam<VecBcastInputs<T> > {
 protected:
     void SetUp() override {
         params = ::testing::TestWithParam<VecBcastInputs<T>>::GetParam();
-        Random::Rng<T> r(params.seed);
+        Random::Rng r(params.seed);
         int rows = params.rows;
         int cols = params.cols;
         int len = rows * cols;


### PR DESCRIPTION
1. Support for generating random integers from `Rng` class
2. Migrated template parameter into each method of `Rng`
3. Updates to the rng_impl to handle different types.
4. Updates to all users of `Rng` class for all the above changes.