### PR TITLE
[REVIEW] Bug fix: LinAlg::unaryOp with 0-length input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #202: Adding back ability for users to define their own BLAS
 - PR #201: Pass CMAKE CUDA path to faiss/configure script
 - PR #200 Avoid using numpy via cimport in KNN
+- PR #228: Bug fix: LinAlg::unaryOp with 0-length input
 
 
 # cuML 0.5.1 (05 Feb 2019)

--- a/ml-prims/src/linalg/unary_op.h
+++ b/ml-prims/src/linalg/unary_op.h
@@ -62,6 +62,8 @@ void unaryOpImpl(math_t *out, const math_t *in, int len,
 template <typename math_t, typename Lambda, int TPB = 256>
 void unaryOp(math_t *out, const math_t *in, int len, Lambda op,
              cudaStream_t stream = 0) {
+  if(len <= 0) return; //silently skip in case of 0 length input
+
   size_t bytes = len * sizeof(math_t);
   uint64_t inAddr = uint64_t(in);
   uint64_t outAddr = uint64_t(out);


### PR DESCRIPTION
Added check to unaryOp to guard against the execution of 0-size kernels