### PR TITLE
[REVIEW] Support for passing index in the main_op for reduction kernels + custom output type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #209: Simplify README.md, move build instructions to BUILD.md
 - PR #225: Support for generating random integers
 - PR #215: Refactored LinAlg::norm to Stats::rowNorm and added Stats::colNorm
+- PR #234: Support for custom output type and passing index value to main_op in *Reduction kernels
 
 ## Bug Fixes
 

--- a/ml-prims/src/cuda_utils.h
+++ b/ml-prims/src/cuda_utils.h
@@ -347,9 +347,10 @@ HDI double myPow(double x, double power) {
  * @defgroup Pow Power function
  * @{
  */
-template <typename Type>
+// IdxType mostly to be used for MainLambda in *Reduction kernels
+template <typename Type, typename IdxType = int>
 struct Nop {
-  HDI Type operator()(Type in) { return in; }
+  HDI Type operator()(Type in, IdxType i = 0) { return in; }
 };
 
 template <typename Type>

--- a/ml-prims/src/linalg/coalesced_reduction.h
+++ b/ml-prims/src/linalg/coalesced_reduction.h
@@ -24,17 +24,6 @@ namespace MLCommon {
 namespace LinAlg {
 
 
-template <typename Type, typename IdxType>
-struct MainNop {
-  HDI Type operator()(Type in, IdxType i) { return in; }
-};
-
-template <typename Type>
-struct Sum {
-  HDI Type operator()(Type a, Type b) { return a + b; }
-};
-
-
 // Kernel (based on norm.h) to perform reductions along the coalesced dimension
 // of the matrix, i.e. reduce along rows for row major or reduce along columns
 // for column major layout. Kernel does an inplace reduction adding to original
@@ -80,7 +69,7 @@ __global__ void coalescedReductionKernel(OutType *dots, const InType *data, int 
  * <pre>OutType (*ReduceLambda)(OutType);</pre>
  * @tparam FinalLambda the final lambda applied before STG (eg: Sqrt for L2 norm)
  * It must be a 'callable' supporting the following input and output:
- * <pre>OutType (*ReduceLambda)(OutType);</pre>
+ * <pre>OutType (*FinalLambda)(OutType);</pre>
  * @param dots the output reduction vector
  * @param data the input matrix
  * @param D leading dimension of data
@@ -93,13 +82,13 @@ __global__ void coalescedReductionKernel(OutType *dots, const InType *data, int 
  * @param stream cuda stream where to launch work
  */
 template <typename InType, typename OutType = InType, typename IdxType = int,
-          typename MainLambda = MainNop<InType, IdxType>,
+          typename MainLambda = Nop<InType, IdxType>,
           typename ReduceLambda = Sum<OutType>,
           typename FinalLambda = Nop<OutType>>
 void coalescedReduction(OutType *dots, const InType *data, int D, int N, OutType init,
                         bool inplace = false,
                         cudaStream_t stream = 0,
-                        MainLambda main_op = MainNop<InType, IdxType>(),
+                        MainLambda main_op = Nop<InType, IdxType>(),
                         ReduceLambda reduce_op = Sum<OutType>(),
                         FinalLambda final_op = Nop<OutType>()) {
   // One block per reduction

--- a/ml-prims/src/linalg/norm.h
+++ b/ml-prims/src/linalg/norm.h
@@ -44,12 +44,12 @@ void rowNorm(Type *dots, const Type *data, int D, int N, NormType type,
     case L1Norm:
       LinAlg::coalescedReduction(dots, data, D, N, (Type)0,
                                  false, stream,
-                                 [] __device__(Type in) { return myAbs(in); });
+                                 [] __device__(Type in, int i) { return myAbs(in); });
       break;
     case L2Norm:
       LinAlg::coalescedReduction(dots, data, D, N, (Type)0,
                                  false, stream,
-                                 [] __device__(Type in) { return in * in; });
+                                 [] __device__(Type in, int i) { return in * in; });
       break;
     default:
       ASSERT(false, "Invalid norm type passed! [%d]", type);
@@ -80,13 +80,13 @@ void rowNorm(Type *dots, const Type *data, int D, int N, NormType type,
     case L1Norm:
       LinAlg::coalescedReduction(dots, data, D, N, (Type)0,
                                  false, stream,
-                                 [] __device__(Type in) { return myAbs(in); }, 
+                                 [] __device__(Type in, int i) { return myAbs(in); }, 
                                  [] __device__(Type a, Type b) { return a+b; }, fin_op);
       break;
     case L2Norm:
       LinAlg::coalescedReduction(dots, data, D, N, (Type)0,
                                  false, stream,
-                                 [] __device__(Type in) { return in * in; },
+                                 [] __device__(Type in, int i) { return in * in; },
                                  [] __device__(Type a, Type b) { return a+b; }, fin_op);
       break;
     default:
@@ -112,12 +112,12 @@ void colNorm(Type *dots, const Type *data, int D, int N, NormType type,
     case L1Norm:
       LinAlg::stridedReduction(dots, data, D, N, (Type)0,
                                false, stream,
-                               [] __device__(Type v) { return myAbs(v); });
+                               [] __device__(Type v, int i) { return myAbs(v); });
       break;
     case L2Norm:
       LinAlg::stridedReduction(dots, data, D, N, (Type)0,
                                false, stream,
-                               [] __device__(Type v) { return v * v; });
+                               [] __device__(Type v, int i) { return v * v; });
       break;
     default:
       ASSERT(false, "Invalid norm type passed! [%d]", type);
@@ -142,14 +142,14 @@ void colNorm(Type *dots, const Type *data, int D, int N, NormType type,
     case L1Norm:
       LinAlg::stridedReduction(dots, data, D, N, (Type)0,
                                false, stream,
-                               [] __device__(Type v) { return myAbs(v); },
+                               [] __device__(Type v, int i) { return myAbs(v); },
                                [] __device__(Type a, Type b) { return a + b; },
                                fin_op);
       break;
     case L2Norm:
       LinAlg::stridedReduction(dots, data, D, N, (Type)0,
                                false, stream,
-                               [] __device__(Type v) { return v * v; },
+                               [] __device__(Type v, int i) { return v * v; },
                                [] __device__(Type a, Type b) { return a + b; },
                                fin_op);
       break;

--- a/ml-prims/src/linalg/strided_reduction.h
+++ b/ml-prims/src/linalg/strided_reduction.h
@@ -20,7 +20,6 @@
 #include "cuda_utils.h"
 #include "linalg/unary_op.h"
 #include <type_traits>
-#include "coalesced_reduction.h"
 
 
 namespace MLCommon {
@@ -113,7 +112,7 @@ __global__ void stridedReductionKernel(OutType *dots, const InType *data, int D,
  * <pre>OutType (*ReduceLambda)(OutType);</pre>
  * @tparam FinalLambda the final lambda applied before STG (eg: Sqrt for L2 norm)
  * It must be a 'callable' supporting the following input and output:
- * <pre>OutType (*ReduceLambda)(OutType);</pre>
+ * <pre>OutType (*FinalLambda)(OutType);</pre>
  * @param dots the output reduction vector
  * @param data the input matrix
  * @param D leading dimension of data
@@ -126,12 +125,12 @@ __global__ void stridedReductionKernel(OutType *dots, const InType *data, int D,
  * @param stream cuda stream where to launch work
  */
 template <typename InType, typename OutType = InType, typename IdxType = int,
-          typename MainLambda = MainNop<InType, IdxType>,
+          typename MainLambda = Nop<InType, IdxType>,
           typename ReduceLambda = Sum<OutType>,
           typename FinalLambda = Nop<OutType>>
 void stridedReduction(OutType *dots, const InType *data, int D, int N, OutType init,
                       bool inplace = false, cudaStream_t stream = 0,
-                      MainLambda main_op = MainNop<InType, IdxType>(),
+                      MainLambda main_op = Nop<InType, IdxType>(),
                       ReduceLambda reduce_op = Sum<OutType>(),
                       FinalLambda final_op = Nop<OutType>()) {
   ///@todo: this extra should go away once we have eliminated the need

--- a/ml-prims/test/coalesced_reduction.cu
+++ b/ml-prims/test/coalesced_reduction.cu
@@ -65,7 +65,7 @@ void coalescedReductionLaunch(T *dots, const T *data, int cols, int rows,
                               bool inplace = false) {
   coalescedReduction(dots, data, cols, rows, (T)0,
                      inplace, 0,
-                     [] __device__(T in) { return in * in; });
+                     [] __device__(T in, int i) { return in * in; });
 }
 
 template <typename T>

--- a/ml-prims/test/strided_reduction.cu
+++ b/ml-prims/test/strided_reduction.cu
@@ -36,7 +36,7 @@ struct stridedReductionInputs {
 template <typename T>
 void stridedReductionLaunch(T *dots, const T *data, int cols, int rows) {
   stridedReduction(dots, data, cols, rows, (T)0, false, 0,
-                   [] __device__(T in) { return in * in; });
+                   [] __device__(T in, int i) { return in * in; });
 }
 
 


### PR DESCRIPTION
Such changes in ml-prims will help reuse the *Reduction kernels for argmin/argmax operations as well.