### PR TITLE
[REVIEW] Row- and column-wise weighted mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-...
+- PR #277: Added row- and column-wise weighted mean primitive
 
 ## Improvements
 

--- a/ml-prims/src/stats/weighted_mean.h
+++ b/ml-prims/src/stats/weighted_mean.h
@@ -39,7 +39,7 @@ void rowWeightedMean(Type *mu, const Type *data, const Type *weights, int D, int
     Type C = D;
     LinAlg::coalescedReduction(mu, data, D, N, (Type)0,
             false, stream,
-            [weights]__device__(Type v, int i){ return v-weights[i]; },
+            [weights]__device__(Type v, int i){ return v*weights[i]; },
             []__device__(Type a, Type b){ return a+b; },
             [C]__device__(Type v){ return v/C; });
 }
@@ -61,7 +61,7 @@ void colWeightedMean(Type *mu, const Type *data, const Type *weights, int D, int
     Type C = N;
     LinAlg::stridedReduction(mu, data, D, N, (Type)0,
             false, stream,
-            [weights]__device__(Type v, int i){ return v-weights[i]; },
+            [weights]__device__(Type v, int i){ return v*weights[i]; },
             []__device__(Type a, Type b){ return a+b; },
             [C]__device__(Type v){ return v/C; });
 }

--- a/ml-prims/src/stats/weighted_mean.h
+++ b/ml-prims/src/stats/weighted_mean.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "linalg/coalesced_reduction.h"
+#include "linalg/strided_reduction.h"
+
+namespace MLCommon {
+namespace Stats {
+
+/**
+ * @brief Compute the row-wise weighted mean of the input matrix
+ *
+ * @tparam Type the data type
+ * @param mu the output mean vector
+ * @param data the input matrix (assumed to be row-major)
+ * @param weights per-column means
+ * @param D number of columns of data
+ * @param N number of rows of data
+ * @param stream cuda streamkto launch work on
+ */
+template <typename Type>
+void rowWeightedMean(Type *mu, const Type *data, const Type *weights, int D, int N,
+        cudaStream_t stream = 0) {
+    Type C = D;
+    LinAlg::coalescedReduction(mu, data, D, N, (Type)0,
+            false, stream,
+            [weights]__device__(Type v, int i){ return v-weights[i]; },
+            []__device__(Type a, Type b){ return a+b; },
+            [C]__device__(Type v){ return v/C; });
+}
+
+/**
+ * @brief Compute the column-wise weighted mean of the input matrix
+ *
+ * @tparam Type the data type
+ * @param mu the output mean vector
+ * @param data the input matrix (assumed to be column-major)
+ * @param weights per-column means
+ * @param D number of columns of data
+ * @param N number of rows of data
+ * @param stream cuda streamkto launch work on
+ */
+template <typename Type>
+void colWeightedMean(Type *mu, const Type *data, const Type *weights, int D, int N,
+        cudaStream_t stream = 0) {
+    Type C = N;
+    LinAlg::stridedReduction(mu, data, D, N, (Type)0,
+            false, stream,
+            [weights]__device__(Type v, int i){ return v-weights[i]; },
+            []__device__(Type a, Type b){ return a+b; },
+            [C]__device__(Type v){ return v/C; });
+}
+
+}; // end namespace Stats
+}; // end namespace MLCommon

--- a/ml-prims/test/CMakeLists.txt
+++ b/ml-prims/test/CMakeLists.txt
@@ -58,7 +58,8 @@ add_executable(mlcommon_test
   sum.cu
   svd.cu
   transpose.cu
-  unary_op.cu)
+  unary_op.cu
+  weighted_mean.cu)
 
 target_link_libraries(mlcommon_test
   ${GTEST_LIBNAME}

--- a/ml-prims/test/weighted_mean.cu
+++ b/ml-prims/test/weighted_mean.cu
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "cuda_utils.h"
+#include "stats/weighted_mean.h"
+#include "random/rng.h"
+#include "test_utils.h"
+#include <thrust/device_vector.h>
+
+namespace MLCommon {
+namespace Stats {
+
+template <typename T>
+struct WeightedMeanInputs {
+  T tolerance;
+  int M, N;
+  unsigned long long int seed;
+};
+
+template <typename T>
+::std::ostream &operator<<(::std::ostream &os, const WeightedMeanInputs<T> &I) {
+  return os << "{ " << I.tolerance << ", " << I.M << ", " << I.N << ", "
+    << I.seed << "}" << std::endl;
+}
+
+
+///// weighted row-wise mean test and support functions
+template <typename T>
+void naiveRowWeightedMean(T* R, T* D, T* W, int M, int N, bool rowMajor){
+  int istr = rowMajor ? 1 : M;
+  int jstr = rowMajor ? N : 1;
+
+  for(int j=0; j<M; j++){
+    R[j] = (T)0;
+    for(int i=0; i<N; i++){
+      R[j] += (W[i]*D[i*istr + j*jstr] - R[j])/(T)(i+1);
+    }
+  }
+}
+
+template <typename T>
+class RowWeightedMeanTest : public ::testing::TestWithParam<WeightedMeanInputs<T>> {
+protected:
+  void SetUp() override {
+    params = ::testing::TestWithParam<WeightedMeanInputs<T>>::GetParam();
+    Random::Rng r(params.seed);
+    int rows = params.M, cols = params.N, len = rows*cols;
+
+    //device-side data
+    din.resize(len);
+    dweights.resize(cols);
+    dexp.resize(rows);
+    dact.resize(rows);
+
+    //create random matrix and weights
+    r.uniform(din.data().get(), len, T(-1.0), T(1.0));
+    r.uniform(dweights.data().get(), cols, T(-1.0), T(1.0));
+    
+    //host-side data
+    thrust::host_vector<T> hin = din;
+    thrust::host_vector<T> hweights = dweights;
+    thrust::host_vector<T> hact (rows);
+
+    //compute naive result & copy to GPU
+    naiveRowWeightedMean(hact.data(), hin.data(), hweights.data(), rows, cols,
+        true);
+    dact = hact;
+
+    //compute ml-prims result
+    rowWeightedMean(dexp.data().get(), din.data().get(), dweights.data().get(),
+        cols, rows);
+  }
+
+  void TearDown() override {}
+
+protected:
+  WeightedMeanInputs<T> params;
+  thrust::host_vector<T> hin, hweights;
+  thrust::device_vector<T> din, dweights, dexp, dact;
+};
+
+
+///// weighted column-wise mean test and support functions
+template <typename T>
+void naiveColWeightedMean(T* R, T* D, T* W, int M, int N, bool rowMajor){
+  int istr = rowMajor ? 1 : M;
+  int jstr = rowMajor ? N : 1;
+
+  for(int i=0; i<M; i++){
+    R[i] = (T)0;
+    for(int j=0; j<N; j++){
+      R[i] += (W[j]*D[i*istr + j*jstr] - R[i])/(T)(j+1);
+    }
+  }
+}
+
+template <typename T>
+class ColWeightedMeanTest : public ::testing::TestWithParam<WeightedMeanInputs<T>> {
+  void SetUp() override {
+    params = ::testing::TestWithParam<WeightedMeanInputs<T>>::GetParam();
+    Random::Rng r(params.seed);
+    int rows = params.M, cols = params.N, len = rows*cols;
+
+    //device-side data
+    din.resize(len);
+    dweights.resize(rows);
+    dexp.resize(cols);
+    dact.resize(cols);
+
+    //create random matrix and weights
+    r.uniform(din.data().get(), len, T(-1.0), T(1.0));
+    r.uniform(dweights.data().get(), rows, T(-1.0), T(1.0));
+    
+    //host-side data
+    thrust::host_vector<T> hin = din;
+    thrust::host_vector<T> hweights = dweights;
+    thrust::host_vector<T> hact (cols);
+
+    //compute naive result & copy to GPU
+    naiveColWeightedMean(hact.data(), hin.data(), hweights.data(), rows, cols,
+        true);
+    dact = hact;
+
+    //compute ml-prims result
+    colWeightedMean(dexp.data().get(), din.data().get(), dweights.data().get(),
+        cols, rows);
+  }
+
+  void TearDown() override {}
+
+protected:
+  WeightedMeanInputs<T> params;
+  thrust::host_vector<T> hin, hweights;
+  thrust::device_vector<T> din, dweights, dexp, dact;
+};
+
+
+////// Parameter sets and test instantiation
+static const float tolF = 128*std::numeric_limits<float>::epsilon();
+static const double tolD = 128*std::numeric_limits<double>::epsilon();
+
+const std::vector<WeightedMeanInputs<float>> inputsf = {
+  {tolF, 1024,  32, 1234},
+  {tolF, 1024,  64, 1234},
+  {tolF, 1024, 128, 1234},
+  {tolF, 1024, 256, 1234},
+  {tolF, 1024,  32, 1234},
+  {tolF, 1024,  64, 1234},
+  {tolF, 1024, 128, 1234},
+  {tolF, 1024, 256, 1234}
+};
+
+const std::vector<WeightedMeanInputs<double>> inputsd = {
+  {tolD, 1024,  32, 1234},
+  {tolD, 1024,  64, 1234},
+  {tolD, 1024, 128, 1234},
+  {tolD, 1024, 256, 1234},
+  {tolD, 1024,  32, 1234},
+  {tolD, 1024,  64, 1234},
+  {tolD, 1024, 128, 1234},
+  {tolD, 1024, 256, 1234}
+};
+
+
+using RowWeightedMeanTestF = RowWeightedMeanTest<float>;
+TEST_P(RowWeightedMeanTestF, Result){
+  ASSERT_TRUE(devArrMatch(dexp.data().get(), dact.data().get(), params.M,
+        CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(RowWeightedMeanTest, RowWeightedMeanTestF,
+    ::testing::ValuesIn(inputsf));
+
+using RowWeightedMeanTestD = RowWeightedMeanTest<double>;
+TEST_P(RowWeightedMeanTestD, Result){
+  ASSERT_TRUE(devArrMatch(dexp.data().get(), dact.data().get(), params.M,
+        CompareApprox<double>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(RowWeightedMeanTest, RowWeightedMeanTestD,
+    ::testing::ValuesIn(inputsd));
+
+
+using ColWeightedMeanTestF = ColWeightedMeanTest<float>;
+TEST_P(ColWeightedMeanTestF, Result){
+  ASSERT_TRUE(devArrMatch(dexp.data().get(), dact.data().get(), params.M,
+        CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(ColWeightedMeanTest, ColWeightedMeanTestF,
+    ::testing::ValuesIn(inputsf));
+
+using ColWeightedMeanTestD = ColWeightedMeanTest<double>;
+TEST_P(ColWeightedMeanTestD, Result){
+  ASSERT_TRUE(devArrMatch(dexp.data().get(), dact.data().get(), params.M,
+        CompareApprox<double>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(ColWeightedMeanTest, ColWeightedMeanTestD,
+    ::testing::ValuesIn(inputsd));
+
+}; // end namespace Stats
+}; // end namespace MLCommon

--- a/ml-prims/test/weighted_mean.cu
+++ b/ml-prims/test/weighted_mean.cu
@@ -44,10 +44,15 @@ void naiveRowWeightedMean(T* R, T* D, T* W, int M, int N, bool rowMajor){
   int istr = rowMajor ? 1 : M;
   int jstr = rowMajor ? N : 1;
 
+  //sum the weights
+  T WS = 0;
+  for(int i=0; i<N; i++) WS += W[i];
+
   for(int j=0; j<M; j++){
     R[j] = (T)0;
     for(int i=0; i<N; i++){
-      R[j] += (W[i]*D[i*istr + j*jstr] - R[j])/(T)(i+1);
+      //R[j] += (W[i]*D[i*istr + j*jstr] - R[j])/(T)(i+1);
+      R[j] += (W[i]*D[i*istr + j*jstr])/WS;
     }
   }
 }
@@ -103,10 +108,15 @@ void naiveColWeightedMean(T* R, T* D, T* W, int M, int N, bool rowMajor){
   int istr = rowMajor ? 1 : M;
   int jstr = rowMajor ? N : 1;
 
+  //sum the weights
+  T WS = 0;
+  for(int j=0; j<M; j++) WS += W[j];
+
   for(int i=0; i<N; i++){
     R[i] = (T)0;
     for(int j=0; j<M; j++){
-      R[i] += (W[j]*D[i*istr + j*jstr] - R[i])/(T)(j+1);
+      //R[i] += (W[j]*D[i*istr + j*jstr] - R[i])/(T)(j+1);
+      R[i] += (W[j]*D[i*istr + j*jstr])/WS;
     }
   }
 }
@@ -160,7 +170,7 @@ static const float tolF = 128*std::numeric_limits<float>::epsilon();
 static const double tolD = 128*std::numeric_limits<double>::epsilon();
 
 const std::vector<WeightedMeanInputs<float>> inputsf = {
-  {tolF, 4,  4, 1234},
+  {tolF,    4,   4, 1234},
   {tolF, 1024,  32, 1234},
   {tolF, 1024,  64, 1234},
   {tolF, 1024, 128, 1234},
@@ -172,6 +182,7 @@ const std::vector<WeightedMeanInputs<float>> inputsf = {
 };
 
 const std::vector<WeightedMeanInputs<double>> inputsd = {
+  {tolD,    4,   4, 1234},
   {tolD, 1024,  32, 1234},
   {tolD, 1024,  64, 1234},
   {tolD, 1024, 128, 1234},


### PR DESCRIPTION
This adds primitives for the computation of row- and column-wise weighted mean, built on strided and coalesced reductions.