### PR TITLE
add ignored argument to fit_transform to map to sklearn implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-- PR #249: Single GPU Stochastic Gradient Descent for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties. 
+- PR #249: Single GPU Stochastic Gradient Descent for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties.
 - PR #247 : Added "proper" CUDA API to cuML
 - PR #235: NearestNeighbors MG Support
 - PR #261: UMAP Algorithm
@@ -38,6 +38,7 @@
 - PR #275: Kmeans use of faster gpu_matrix
 - PR #288: Add n_neighbors to NearestNeighbors constructor
 - PR #302: Added FutureWarning for deprecation of current kmeans algorithm
+- PR #330: Added ignored argument to pca.fit_transform to map to sklearn's implemenation
 
 ## Bug Fixes
 

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -379,7 +379,7 @@ class PCA:
 
         return self
 
-    def fit_transform(self, X):
+    def fit_transform(self, X, y=None):
         """
         Fit the model with X and apply the dimensionality reduction on X.
 
@@ -387,6 +387,8 @@ class PCA:
         ----------
         X : cuDF DataFrame, shape (n_samples, n_features)
           training data (floats or doubles), where n_samples is the number of samples, and n_features is the number of features.
+
+        y : ignored
 
         Returns
         -------
@@ -548,10 +550,10 @@ class PCA:
         variables = ['copy', 'iterated_power', 'n_components', 'random_state','svd_solver','tol','whiten']
         for key in variables:
             var_value = getattr(self.params,key,None)
-            params[key] = var_value  
+            params[key] = var_value
             if 'svd_solver'== key:
                 params[key] = getattr(self, key, None)
-            		 
+
         return params
 
 
@@ -567,5 +569,5 @@ class PCA:
                     setattr(self, key, value)
                 else:
                     setattr(self.params, key, value)
-			
+
         return self


### PR DESCRIPTION
This PR adds an ignored argument to `fit_transform` this is necessary to run PCA through sklearn's pipeline and maps to [sklearn's implementation](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/decomposition/pca.py#L342-L368)

cc @dantegd @Salonijain27 