### PR TITLE
[FIX] Readded accidentally deleted cudaEventCreateWithFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
 
 ## Bug Fixes
 
-...
-
+- PR #334: Fixed segfault in `ML::cumlHandle_impl::destroyResources`
 
 # cuML 0.6.0 (Date TBD)
 

--- a/cuML/src/common/cumlHandle.cpp
+++ b/cuML/src/common/cumlHandle.cpp
@@ -316,6 +316,7 @@ void cumlHandle_impl::createResources()
         CUDA_CHECK( cudaStreamCreate(&stream) );
         _streams.push_back(stream);
     }
+    CUDA_CHECK( cudaEventCreateWithFlags( &_event, cudaEventDisableTiming ) );
 }
 
 void cumlHandle_impl::destroyResources()


### PR DESCRIPTION
Using `ML::cumlHandle` without this causes segfault. 