### PR TITLE
[HOTFIX] [REVIEW] Removing FAISS build requirement from README. This could confuse read…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PR #345: Run python import as part of package build to trigger compilation
 - PR #347: Lowering memory usage of kNN.
 - PR #355: Fixing issues with very large numpy inputs to SPMG OLS and tSVD.
+- PR #357: Removing FAISS requirement from README
 
 # cuML 0.5.1 (05 Feb 2019)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For additional examples, browse our complete [API documentation](https://rapidsa
 - Principal Component Analysis (PCA) - Single GPU
 - Density-based spatial clustering of applications with noise (DBSCAN) - Single GPU
 - K-Means Clustering - Multi-GPU
-- K-Nearest Neighbors - Multi-GPU (Requires [Faiss](https://github.com/facebookresearch/faiss) installation to use)
+- K-Nearest Neighbors - Multi-GPU
 - Ridge Regression - Single GPU
 - Kalman Filter - Single GPU
 - UMAP


### PR DESCRIPTION
I noticed this last-minute bug when I was reviewing the README late last night. 

Since FAISS is included in the thirdparty modules, and because users no longer need to install it separately in order to build cuML, we should not be misleading in our README by specifying that FAISS is a requirement for the kNN Algorithm.

The other justification for this change is consistency- if our README is to contain notes about FAISS being required in order to build cuML, we should probably include a note about K-Means requiring h20ai-gpu (until it is replaced with a non-h20 version). 