### PR TITLE
Exposing cumlHandle in the cuML interface and corresponding cython changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #277: Added row- and column-wise weighted mean primitive
+- PR #396: Exposing cumlHandle to the cuML interface and python world
 
 ## Improvements
 

--- a/cuML/src/pca/pca.cu
+++ b/cuML/src/pca/pca.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,123 +24,59 @@ namespace ML {
 using namespace MLCommon;
 
 
-void pcaFit(float *input, float *components, float *explained_var,
-		float *explained_var_ratio, float *singular_vals, float *mu,
-		float *noise_vars, paramsPCA prms) {
-
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	cusolverDnHandle_t cusolver_handle = NULL;
-	CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
-
-	pcaFit(input, components, explained_var, explained_var_ratio, singular_vals,
-			mu, noise_vars, prms, cublas_handle, cusolver_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
-	CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
+void pcaFit(cumlHandle& handle, float *input, float *components,
+            float *explained_var, float *explained_var_ratio,
+            float *singular_vals, float *mu, float *noise_vars,
+            paramsPCA prms) {
+    pcaFit(handle.getImpl(), input, components, explained_var,
+           explained_var_ratio, singular_vals, mu, noise_vars, prms);
 }
 
-void pcaFit(double *input, double *components, double *explained_var,
-		double *explained_var_ratio, double *singular_vals, double *mu,
-		double *noise_vars, paramsPCA prms) {
-
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	cusolverDnHandle_t cusolver_handle = NULL;
-	CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
-
-	pcaFit(input, components, explained_var, explained_var_ratio, singular_vals,
-			mu, noise_vars, prms, cublas_handle, cusolver_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
-	CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
+void pcaFit(cumlHandle& handle, double *input, double *components,
+            double *explained_var, double *explained_var_ratio,
+            double *singular_vals, double *mu, double *noise_vars,
+            paramsPCA prms) {
+    pcaFit(handle.getImpl(), input, components, explained_var,
+           explained_var_ratio, singular_vals, mu, noise_vars, prms);
 }
 
-void pcaFitTransform(float *input, float *trans_input, float *components,
-		float *explained_var, float *explained_var_ratio, float *singular_vals,
-		float *mu, float *noise_vars, paramsPCA prms) {
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	cusolverDnHandle_t cusolver_handle = NULL;
-	CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
-
-	pcaFitTransform(input, trans_input, components, explained_var,
-			explained_var_ratio, singular_vals, mu, noise_vars, prms,
-			cublas_handle, cusolver_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
-	CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
-
+void pcaFitTransform(cumlHandle& handle, float *input, float *trans_input,
+                     float *components, float *explained_var,
+                     float *explained_var_ratio, float *singular_vals,
+                     float *mu, float *noise_vars, paramsPCA prms) {
+    pcaFitTransform(handle.getImpl(), input, trans_input, components,
+                    explained_var, explained_var_ratio, singular_vals, mu,
+                    noise_vars, prms);
 }
 
-void pcaFitTransform(double *input, double *trans_input, double *components,
-		double *explained_var, double *explained_var_ratio,
-		double *singular_vals, double *mu, double *noise_vars, paramsPCA prms) {
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	cusolverDnHandle_t cusolver_handle = NULL;
-	CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
-
-	pcaFitTransform(input, trans_input, components, explained_var,
-			explained_var_ratio, singular_vals, mu, noise_vars, prms,
-			cublas_handle, cusolver_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
-	CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
-
+void pcaFitTransform(cumlHandle& handle, double *input, double *trans_input,
+                     double *components, double *explained_var,
+                     double *explained_var_ratio, double *singular_vals,
+                     double *mu, double *noise_vars, paramsPCA prms) {
+    pcaFitTransform(handle.getImpl(), input, trans_input, components,
+                    explained_var, explained_var_ratio, singular_vals, mu,
+                    noise_vars, prms);
 }
 
-void pcaInverseTransform(float *trans_input, float *components,
-		float *singular_vals, float *mu, float *input, paramsPCA prms) {
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	pcaInverseTransform(trans_input, components, singular_vals, mu, input, prms,
-			cublas_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
+void pcaInverseTransform(cumlHandle& handle, float *trans_input, float *components,
+                         float *singular_vals, float *mu, float *input, paramsPCA prms) {
+    pcaInverseTransform(handle.getImpl(), trans_input, components, singular_vals, mu, input, prms);
 }
 
-void pcaInverseTransform(double *trans_input, double *components,
-		double *singular_vals, double *mu, double *input, paramsPCA prms) {
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	pcaInverseTransform(trans_input, components, singular_vals, mu, input, prms,
-			cublas_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
+void pcaInverseTransform(cumlHandle& handle, double *trans_input, double *components,
+                         double *singular_vals, double *mu, double *input, paramsPCA prms) {
+    pcaInverseTransform(handle.getImpl(), trans_input, components, singular_vals, mu, input, prms);
 }
 
 
-void pcaTransform(float *input, float *components, float *trans_input,
-		float *singular_vals, float *mu, paramsPCA prms) {
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	pcaTransform(input, components, trans_input, singular_vals, mu, prms,
-			cublas_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
+void pcaTransform(cumlHandle& handle, float *input, float *components, float *trans_input,
+                  float *singular_vals, float *mu, paramsPCA prms) {
+    pcaTransform(handle.getImpl(), input, components, trans_input, singular_vals, mu, prms);
 }
 
-void pcaTransform(double *input, double *components, double *trans_input,
-		double *singular_vals, double *mu, paramsPCA prms) {
-	cublasHandle_t cublas_handle;
-	CUBLAS_CHECK(cublasCreate(&cublas_handle));
-
-	pcaTransform(input, components, trans_input, singular_vals, mu, prms,
-			cublas_handle);
-
-	CUBLAS_CHECK(cublasDestroy(cublas_handle));
+void pcaTransform(cumlHandle& handle, double *input, double *components, double *trans_input,
+                  double *singular_vals, double *mu, paramsPCA prms) {
+    pcaTransform(handle.getImpl(), input, components, trans_input, singular_vals, mu, prms);
 }
 
-/** @} */
-
-}
-;
-// end namespace ML
+}; // end namespace ML

--- a/cuML/src/pca/pca_c.h
+++ b/cuML/src/pca/pca_c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,26 +17,28 @@
 #pragma once
 
 #include "ml_utils.h"
+#include "cuML.hpp"
 
-namespace ML{
 
-void pcaFit(float *input, float *components, float *explained_var,
-                    float *explained_var_ratio, float *singular_vals, float *mu,
-                    float *noise_vars, paramsPCA prms);
-void pcaFit(double *input, double *components, double *explained_var,
-                    double *explained_var_ratio, double *singular_vals, double *mu,
-                    double *noise_vars, paramsPCA prms);
-void pcaFitTransform(float *input, float *trans_input, float *components, float *explained_var,
-                    float *explained_var_ratio, float *singular_vals, float *mu,
-                    float *noise_vars, paramsPCA prms);
-void pcaFitTransform(double *input, double *trans_input, double *components, double *explained_var,
-                    double *explained_var_ratio, double *singular_vals, double *mu,
-                    double *noise_vars, paramsPCA prms);
-void pcaInverseTransform(float *trans_input, float *components, float *singular_vals, float *mu,
+namespace ML {
+
+void pcaFit(cumlHandle& handle, float *input, float *components, float *explained_var,
+            float *explained_var_ratio, float *singular_vals, float *mu,
+            float *noise_vars, paramsPCA prms);
+void pcaFit(cumlHandle& handle, double *input, double *components, double *explained_var,
+            double *explained_var_ratio, double *singular_vals, double *mu,
+            double *noise_vars, paramsPCA prms);
+void pcaFitTransform(cumlHandle& handle, float *input, float *trans_input, float *components,
+                     float *explained_var, float *explained_var_ratio, float *singular_vals,
+                     float *mu, float *noise_vars, paramsPCA prms);
+void pcaFitTransform(cumlHandle& handle, double *input, double *trans_input, double *components,
+                     double *explained_var, double *explained_var_ratio, double *singular_vals,
+                     double *mu, double *noise_vars, paramsPCA prms);
+void pcaInverseTransform(cumlHandle& handle, float *trans_input, float *components, float *singular_vals, float *mu,
                     float *input, paramsPCA prms);
-void pcaInverseTransform(double *trans_input, double *components, double *singular_vals, double *mu,
+void pcaInverseTransform(cumlHandle& handle, double *trans_input, double *components, double *singular_vals, double *mu,
                     double *input, paramsPCA prms);
-void pcaTransform(float *input, float *components, float *trans_input, float *singular_vals, float *mu, paramsPCA prms);
-void pcaTransform(double *input, double *components, double *trans_input, double *singular_vals, double *mu, paramsPCA prms);
-}
+void pcaTransform(cumlHandle& handle, float *input, float *components, float *trans_input, float *singular_vals, float *mu, paramsPCA prms);
+void pcaTransform(cumlHandle& handle, double *input, double *components, double *trans_input, double *singular_vals, double *mu, paramsPCA prms);
 
+}; // end namespace ML

--- a/python/DEVELOPER_GUIDE.md
+++ b/python/DEVELOPER_GUIDE.md
@@ -17,8 +17,9 @@ Refer to the section on thread safety in [C++ DEVELOPER_GUIDE.md](../cuML/DEVELO
 ## Creating class for a new ML algo
 1. Make sure that this algo has been implemented in the C++ side. Refer to [C++ DEVELOPER_GUIDE.md](../cuML/DEVELOPER_GUIDE.md) for guidelines on developing in C++.
 2. Create a corresponding algoName.pyx file inside `python/cuml` folder.
-3. We try to match the corresponding scikit-learn's interface as closely as possible. Refer to their [developer guide](https://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects) on API design of sklearn objects for details.
-4. Always make sure to have your class inherit from `cuml.common.base.Base` class as your parent/ancestor.
+3. Note that the folder structure inside here should reflect sklearn's. Example, `pca.pyx` should be kept inside the `decomposition` sub-folder of `python/cuml`.
+4. We try to match the corresponding scikit-learn's interface as closely as possible. Refer to their [developer guide](https://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects) on API design of sklearn objects for details.
+5. Always make sure to have your class inherit from `cuml.common.base.Base` class as your parent/ancestor.
 
 ## Error handling
 If you are trying to call into cuda runtime APIs inside `cuml.common.cuda`, in case of any errors, they'll raise a `cuml.common.cuda.CudaRtError`. For example:

--- a/python/DEVELOPER_GUIDE.md
+++ b/python/DEVELOPER_GUIDE.md
@@ -22,13 +22,13 @@ Refer to the section on thread safety in [C++ DEVELOPER_GUIDE.md](../cuML/DEVELO
 5. Always make sure to have your class inherit from `cuml.common.base.Base` class as your parent/ancestor.
 
 ## Error handling
-If you are trying to call into cuda runtime APIs inside `cuml.common.cuda`, in case of any errors, they'll raise a `cuml.common.cuda.CudaRtError`. For example:
+If you are trying to call into cuda runtime APIs inside `cuml.common.cuda`, in case of any errors, they'll raise a `cuml.common.cuda.CudaRuntimeError`. For example:
 ```python
-from cuml.common.cuda import Stream, CudaRtError
+from cuml.common.cuda import Stream, CudaRuntimeError
 try:
     s = Stream()
     s.sync
-except CudaRtError as cre:
+except CudaRuntimeError as cre:
     print("Cuda Error! '%s'" % str(cre))
 ```
 

--- a/python/DEVELOPER_GUIDE.md
+++ b/python/DEVELOPER_GUIDE.md
@@ -1,0 +1,67 @@
+# cuML python developer guide
+This document summarizes rules and best practices for contributions to the cuML python component of rapidsai/cuml. This is a living document and contributions for clarifications or fixes and issue reports are highly welcome.
+
+## General
+Please start by reading:
+1. [CONTRIBUTING.md](../CONTRIBUTING.md).
+2. [C++ DEVELOPER_GUIDE.md](../cuML/DEVELOPER_GUIDE.md)
+3. [Python cuML README.md](README.md)
+
+## Thread safety
+Refer to the section on thread safety in [C++ DEVELOPER_GUIDE.md](../cuML/DEVELOPER_GUIDE.md#thread-safety)
+
+## Coding style
+1. [PEP8](https://www.python.org/dev/peps/pep-0008)
+2. [sklearn coding guidelines](https://scikit-learn.org/stable/developers/contributing.html#coding-guidelines)
+
+## Creating class for a new ML algo
+1. Make sure that this algo has been implemented in the C++ side. Refer to [C++ DEVELOPER_GUIDE.md](../cuML/DEVELOPER_GUIDE.md) for guidelines on developing in C++.
+2. Create a corresponding algoName.pyx file inside `python/cuml` folder.
+3. We try to match the corresponding scikit-learn's interface as closely as possible. Refer to their [developer guide](https://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects) on API design of sklearn objects for details.
+4. Always make sure to have your class inherit from `cuml.common.base.Base` class as your parent/ancestor.
+
+## Error handling
+If you are trying to call into cuda runtime APIs inside `cuml.common.cuda`, in case of any errors, they'll raise a `cuml.common.cuda.CudaRtError`. For example:
+```python
+from cuml.common.cuda import Stream, CudaRtError
+try:
+    s = Stream()
+    s.sync
+except CudaRtError as cre:
+    print("Cuda Error! '%s'" % str(cre))
+```
+
+## Logging
+TBD
+
+## Documentation
+We mostly follow [PEP 257](https://www.python.org/dev/peps/pep-0257/) style docstrings for documenting the interfaces.
+
+## Testing and Unit Testing
+We use [https://docs.pytest.org/en/latest/]() for writing and running tests. To see existing examples, refer to any of these `cuml/test/test_*.py` files.
+
+## Device and Host memory allocations
+TODO: talk about enabling RMM here when it is ready
+
+## Asynchronous operations and stream ordering
+If you want to schedule 2 algos (for whatever reasons) concurrently, it is better to create 2 separate streams and assign them to 2 separate handles. Finally, schedule the 2 algos using these handles.
+```python
+from cuml.common.cuda import Stream
+from cuml.common.handle import Handle
+s1 = Stream()
+h1 = Handle()
+h1.setStream(s1)
+s2 = Stream()
+h2 = Handle()
+h2.setStream(s2)
+algo1 = cuml.Algo1(handle=h1, ...)
+algo2 = cuml.Algo2(handle=h2, ...)
+algo1.fit(X1, y1)
+algo2.fit(X2, y2)
+```
+To know more underlying details about stream ordering refer to the corresponding section of [C++ DEVELOPER_GUIDE.md](../cuML/DEVELOPER_GUIDE.md#asynchronous-operations-and-stream-ordering)
+
+## Multi GPU
+The multi GPU paradigm of cuML is **O**ne **P**rocess per **G**PU (OPG).
+
+TODO: Add more details.

--- a/python/cuml/common/__init__.py
+++ b/python/cuml/common/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+import cuml.common.handle
+import cuml.common.cuda
+
+
+class Base:
+    """
+    Base class for all the ML algos. It handles some of the common operations
+    across all algos. Every ML algo class exposed at cython level must inherit
+    from this class.
+    """
+
+    def __init__(self, handle=None, verbose=False):
+        """
+        Constructor. All children must call init method of this base class!
+
+        Parameters
+        ----------
+        handle : cuml.common.handle.Handle
+               If it is None, a new one is created just for this class
+        verbose : bool
+                Whether to print debug spews
+        """
+        if handle is None:
+            self.handle = cuml.common.handle.Handle()
+            self.stream = cuml.common.cuda.Stream()
+            self.handle.setStream(self.stream)
+        else:
+            self.handle = handle
+        self.verbose = verbose
+
+
+    def get_param_names(self):
+        """
+        Returns a list of parameter names owned by this class. It is expected
+        that every child class overrides this method and appends its extra set
+        of parameter that it needs. This will simplify the `get_params` and
+        `set_params` methods. (Refer below)
+        """
+        return ["handle", "verbose"]
+
+
+    def get_params(self, deep=True):
+        """
+        Returns a dict of all params owned by this class. If the child class has
+        appropriately overridden the `get_param_names` method, then it doesn't
+        have to override this method
+        """
+        params = dict()
+        variables = self.get_param_names()
+        for key in variables:
+            var_value = getattr(self, key, None)
+            params[key] = var_value
+        return params
+
+
+    def set_params(self, **params):
+        """
+        Accepts a dict of params and updates the corresponding ones owned by
+        this class. If the child class has appropriately overridden the
+        `get_param_names` method, then it doesn't have to override this method
+        """
+        if not params:
+            return self
+        variables = self.get_param_names()
+        for key, value in params.items():
+            if key not in variables:
+                raise ValueError("Bad param '%s' passed to set_params" % key)
+            else:
+                setattr(self, key, value)
+        return self

--- a/python/cuml/common/cuda.pxd
+++ b/python/cuml/common/cuda.pxd
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+# Populate this with more typedef's (eg: events) as and when needed
+cdef extern from * nogil:
+    ctypedef void* _Stream "cudaStream_t"
+    ctypedef int   _Error  "cudaError_t"
+
+
+# Populate this with more runtime api method declarations as and when needed
+cdef extern from "cuda_runtime_api.h" nogil:
+    _Error cudaStreamCreate(_Stream* s)
+    _Error cudaStreamDestroy(_Stream s)
+    _Error cudaStreamSynchronize(_Stream s)
+    _Error cudaGetLastError()
+    const char* cudaGetErrorString(_Error e)
+    const char* cudaGetErrorName(_Error e)

--- a/python/cuml/common/cuda.pyx
+++ b/python/cuml/common/cuda.pyx
@@ -20,7 +20,7 @@
 # cython: language_level = 3
 
 
-class CudaRtError(RuntimeError):
+class CudaRuntimeError(RuntimeError):
     def __init__(self, extraMsg=None):
         cdef _Error e = cudaGetLastError()
         cdef bytes errMsg = cudaGetErrorString(e)
@@ -28,7 +28,7 @@ class CudaRtError(RuntimeError):
         msg = "Error! %s reason='%s'" % (errName.decode(), errMsg.decode())
         if extraMsg is not None:
             msg += " extraMsg='%s'" % extraMsg
-        super(CudaRtError, self).__init__(msg)
+        super(CudaRuntimeError, self).__init__(msg)
 
 
 cdef class Stream:
@@ -50,7 +50,7 @@ cdef class Stream:
         cdef _Stream stream;
         cdef _Error e = cudaStreamCreate(&stream)
         if e != 0:
-            raise CudaRtError("Stream create")
+            raise CudaRuntimeError("Stream create")
         self.s = <size_t>stream
 
     def __dealloc__(self):
@@ -58,7 +58,7 @@ cdef class Stream:
         cdef _Stream stream = <_Stream>self.s
         cdef _Error e = cudaStreamDestroy(stream)
         if e != 0:
-            raise CudaRtError("Stream destroy")
+            raise CudaRuntimeError("Stream destroy")
 
     def sync(self):
         """
@@ -68,7 +68,7 @@ cdef class Stream:
         cdef _Stream stream = <_Stream>self.s
         cdef _Error e = cudaStreamSynchronize(stream)
         if e != 0:
-            raise CudaRtError("Stream sync")
+            raise CudaRuntimeError("Stream sync")
 
     def getStream(self):
         return self.s

--- a/python/cuml/common/cuda.pyx
+++ b/python/cuml/common/cuda.pyx
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+class CudaRtError(RuntimeError):
+    def __init__(self, extraMsg=None):
+        cdef _Error e = cudaGetLastError()
+        cdef bytes errMsg = cudaGetErrorString(e)
+        cdef bytes errName = cudaGetErrorName(e)
+        msg = "Error! %s reason='%s'" % (errName.decode(), errMsg.decode())
+        if extraMsg is not None:
+            msg += " extraMsg='%s'" % extraMsg
+        super(CudaRtError, self).__init__(msg)
+
+
+cdef class Stream:
+    """
+    Stream represents a thin-wrapper around cudaStream_t and its operations.
+    """
+
+    # NOTE:
+    # If we store _Stream directly, this always leads to the following error:
+    #   "Cannot convert Python object to '_Stream'"
+    # I was unable to find a good solution to this in reasonable time. Also,
+    # since cudaStream_t is a pointer anyways, storing it as an integer should
+    # be just fine (although, that certainly is ugly and hacky!).
+    cdef size_t s
+
+    def __cinit__(self):
+        if self.s != 0:
+            return
+        cdef _Stream stream;
+        cdef _Error e = cudaStreamCreate(&stream)
+        if e != 0:
+            raise CudaRtError("Stream create")
+        self.s = <size_t>stream
+
+    def __dealloc__(self):
+        self.sync()
+        cdef _Stream stream = <_Stream>self.s
+        cdef _Error e = cudaStreamDestroy(stream)
+        if e != 0:
+            raise CudaRtError("Stream destroy")
+
+    def sync(self):
+        """
+        Synchronize on the cudastream owned by this object. Note that this could
+        raise exception due to issues with previous asynchronous launches!
+        """
+        cdef _Stream stream = <_Stream>self.s
+        cdef _Error e = cudaStreamSynchronize(stream)
+        if e != 0:
+            raise CudaRtError("Stream sync")
+
+    def getStream(self):
+        return self.s

--- a/python/cuml/common/handle.pxd
+++ b/python/cuml/common/handle.pxd
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+from libcpp.memory cimport shared_ptr
+cimport cuml.common.cuda
+
+
+cdef extern from "cuML.hpp" namespace "ML" nogil:
+    cdef cppclass deviceAllocator:
+        pass
+
+    cdef cppclass cumlHandle:
+        cumlHandle() except +
+        void setStream(cuml.common.cuda._Stream s)
+        void setDeviceAllocator(shared_ptr[deviceAllocator] a)

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+
+from libcpp.memory cimport shared_ptr
+from cuml.common.cuda cimport _Stream
+
+
+cdef extern from "common/rmmAllocatorAdapter.hpp" namespace "ML" nogil:
+    cdef cppclass rmmAllocatorAdapter(deviceAllocator):
+        pass
+
+
+# TODO: name this properly!
+cdef class Handle:
+    """
+    Handle is a lightweight python wrapper around the corresponding C++ class
+    of cumlHandle exposed by cuML's C++ interface. Refer to the header file
+    cuML.hpp for interface level details of this struct
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        import cuml
+        from cuml.common.cuda import Stream
+        stream = Stream()
+        handle = cuml.common.handle.Handle()
+        handle.setStream(stream)
+        handle.enableRMM()   # Enable RMM as the device-side allocator
+
+        # call ML algos here
+
+        # final synchronization of all work launched/dependent on this stream
+        stream.sync()
+        del handle  # optional!
+    """
+
+    # ML::cumlHandle doesn't have copy operator. So, use pointer for the object
+    # python world cannot access to this raw object directly, hence use 'size_t'!
+    cdef size_t h
+
+    def __cinit__(self):
+        self.h = <size_t>(new cumlHandle())
+
+    def __dealloc_(self):
+        h_ = <cumlHandle*>self.h
+        del h_
+
+    def setStream(self, stream):
+        cdef size_t s = <size_t>stream.getStream()
+        cdef cumlHandle* h_ = <cumlHandle*>self.h
+        h_.setStream(<_Stream>s)
+
+    # TODO: in future, maybe we should just enable RMM by default!?
+    def enableRMM(self):
+        """
+        Enables to use RMM as the allocator for all device memory allocations
+        inside cuML C++ world. Currently, there are only 2 kinds of allocators.
+        First, the usual cudaMalloc/Free, which is the default for cumlHandle.
+        Second, the allocator based on RMM. So, this function, basically makes
+        the cumlHandle use a more efficient allocator, instead of the default.
+        """
+        cdef shared_ptr[deviceAllocator] rmmAlloc = shared_ptr[deviceAllocator](new rmmAllocatorAdapter())
+        cdef cumlHandle* h_ = <cumlHandle*>self.h
+        h_.setDeviceAllocator(rmmAlloc)
+
+    def getHandle(self):
+        return self.h

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,9 +34,18 @@ if os.environ.get('CUDA_HOME', False):
     cuda_lib_dir = os.path.join(os.environ.get('CUDA_HOME'), 'lib64')
     cuda_include_dir = os.path.join(os.environ.get('CUDA_HOME'), 'include')
 
+
+rmm_include_dir = '/include'
+rmm_lib_dir = '/lib'
+
+if os.environ.get('CONDA_PREFIX', None):
+    conda_prefix = os.environ.get('CONDA_PREFIX')
+    rmm_include_dir = conda_prefix + rmm_include_dir
+    rmm_lib_dir = conda_prefix + rmm_lib_dir
+
 exc_list = []
 
-libs = ['cuda', 'cuml']
+libs = ['cuda', 'cuml', 'rmm']
 
 if "--multigpu" not in sys.argv:
     exc_list.append('cuml/linear_model/linear_regression_mg.pyx')
@@ -44,6 +53,7 @@ if "--multigpu" not in sys.argv:
 else:
     libs.append('cumlMG')
     sys.argv.remove("--multigpu")
+
 
 extensions = [
     Extension("*",
@@ -54,9 +64,11 @@ extensions = [
                             '../cuML/external/ml-prims/external/cutlass',
                             '../cuML/external/cutlass',
                             '../cuML/external/ml-prims/external/cub',
-                            cuda_include_dir],
+                            cuda_include_dir,
+                            rmm_include_dir],
               library_dirs=[get_python_lib()],
-              runtime_library_dirs=[cuda_lib_dir],
+              runtime_library_dirs=[cuda_lib_dir,
+                                    rmm_lib_dir],
               libraries=libs,
               language='c++',
               extra_compile_args=['-std=c++11'])


### PR DESCRIPTION
This is a split of the PR #331. It focuses on:
1. Exposing cumlHandle in the cuML interface for PCA algo (as a PoC)
2. Corresponding cython changes needed for:
  2a. exposing cumlHandle and relevant cuda APIs to the cython world
  2b. base class to reduce code duplication for exposing cumlHandle in the cuML python classes

@dantegd to migrate his python-related reviews here.

@jirikraus for reviewing C++ side of things