### PR TITLE
[REVIEW] Add git ignore dirty to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "thirdparty/cuml/faiss"]
 	path = thirdparty/cuml/faiss
 	url = https://github.com/facebookresearch/faiss
+    ignore = dirty
 [submodule "external/googletest"]
     path = thirdparty/cuml/googletest
     url = https://github.com/google/googletest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - PR #334: Fixed segfault in `ML::cumlHandle_impl::destroyResources`
 - PR #349: Developer guide clarifications for cumlHandle and cumlHandle_impl
 - PR #399: Skip PCA tests to allow CI to run with driver 418
-- PR #405: Add entry to gitmodules to ignore build artifacts
+- PR #409: Add entry to gitmodules to ignore build artifacts
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #334: Fixed segfault in `ML::cumlHandle_impl::destroyResources`
 - PR #349: Developer guide clarifications for cumlHandle and cumlHandle_impl
 - PR #399: Skip PCA tests to allow CI to run with driver 418
+- PR #405: Add entry to gitmodules to ignore build artifacts
 
 # cuML 0.6.0 (22 Mar 2019)
 


### PR DESCRIPTION
Added `ignore=dirty` entry to gitmodules file to make git ignore linking/building  artifacts. 