### PR TITLE
[REVIEW] Adding metrics API to ml-prims. Beginning with R^2 score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - PR #277: Added row- and column-wise weighted mean primitive
 - PR #424: Added a grid-sync struct for inter-block synchronization
+- PR #430: Adding R-Squared Score to ml primitives
 
 ## Improvements
 

--- a/cuML/src/metrics/metrics.h
+++ b/cuML/src/metrics/metrics.h
@@ -1,0 +1,36 @@
+/*
+ * metrics.h
+ *
+ *  Created on: Apr 2, 2019
+ *      Author: cjnolet
+ */
+
+#pragma once
+
+#include "metrics/metrics.h"
+
+namespace ML {
+
+    namespace Metrics {
+
+        /**
+         * Calculates the "Coefficient of Determination" (R-Squared) score
+         * normalizing the sum of squared errors by the total sum of squares.
+         *
+         * This score indicates the proportionate amount of variation in an
+         * expected response variable is explained by the independent variables
+         * in a linear regression model. The larger the R-squared value, the
+         * more variability is explained by the linear regression model.
+         *
+         * @param y: Array of ground-truth response variables
+         * @param y_hat: Array of predicted response variables
+         * @param n: Number of elements in y and y_hat
+         * @return: The R-squared value.
+         */
+        template <typename T>
+        T r_squared(T *y, T *y_hat, int n) {
+            return MLCommon::Metrics::r_squared(y, y_hat, n);
+        }
+    }
+
+}

--- a/cuML/src/metrics/metrics.h
+++ b/cuML/src/metrics/metrics.h
@@ -1,8 +1,17 @@
 /*
- * metrics.h
+ * Copyright (c) 2019, NVIDIA CORPORATION.
  *
- *  Created on: Apr 2, 2019
- *      Author: cjnolet
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once
@@ -32,5 +41,4 @@ namespace ML {
             return MLCommon::Metrics::r_squared(y, y_hat, n);
         }
     }
-
 }

--- a/cuML/src/metrics/metrics.h
+++ b/cuML/src/metrics/metrics.h
@@ -37,8 +37,8 @@ namespace ML {
          * @return: The R-squared value.
          */
         template <typename T>
-        T r_squared(T *y, T *y_hat, int n) {
-            return MLCommon::Metrics::r_squared(y, y_hat, n);
+        T r2_score(T *y, T *y_hat, int n) {
+            return MLCommon::Metrics::r2_score(y, y_hat, n);
         }
     }
 }

--- a/ml-prims/src/metrics/metrics.h
+++ b/ml-prims/src/metrics/metrics.h
@@ -44,7 +44,7 @@ namespace MLCommon {
          * @param n: Number of elements in y and y_hat
          * @return: The R-squared value.
          */
-        math_t r_squared(math_t *y, math_t *y_hat, int n) {
+        math_t r2_score(math_t *y, math_t *y_hat, int n) {
 
             math_t *y_bar;
             MLCommon::allocate(y_bar, 1);

--- a/ml-prims/src/metrics/metrics.h
+++ b/ml-prims/src/metrics/metrics.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "linalg/eltwise.h"
+#include "stats/mean.h"
+#include "linalg/subtract.h"
+#include "linalg/power.h"
+
+#include <thrust/reduce.h>
+#include <thrust/device_ptr.h>
+
+namespace MLCommon {
+    namespace Metrics {
+        template<typename math_t>
+        math_t r_squared(math_t *y, math_t *y_hat, int n) {
+
+            math_t *y_bar;
+            MLCommon::allocate(y_bar, 1);
+
+            MLCommon::Stats::mean(y_bar, y, 1, n, false, false);
+            CUDA_CHECK(cudaPeekAtLastError());
+
+            math_t *ssr_arr;
+            MLCommon::allocate(ssr_arr, n);
+
+            MLCommon::LinAlg::eltwiseSub(ssr_arr, y, y_hat, n);
+            MLCommon::LinAlg::powerScalar(ssr_arr, ssr_arr, 2.0f, n);
+            CUDA_CHECK(cudaPeekAtLastError());
+
+            math_t *ssto_arr;
+            MLCommon::allocate(ssto_arr, n);
+
+            MLCommon::LinAlg::subtractDevScalar(ssto_arr, y, y_bar, n);
+            MLCommon::LinAlg::powerScalar(ssto_arr, ssto_arr, 2.0f, n);
+            CUDA_CHECK(cudaPeekAtLastError());
+
+            thrust::device_ptr<math_t> d_ssr = thrust::device_pointer_cast(ssr_arr);
+            thrust::device_ptr<math_t> d_ssto = thrust::device_pointer_cast(ssto_arr);
+
+            math_t ssr = thrust::reduce(d_ssr, d_ssr+n);
+            math_t ssto = thrust::reduce(d_ssto, d_ssto+n);
+
+            CUDA_CHECK(cudaFree(y_bar));
+            CUDA_CHECK(cudaFree(ssr_arr));
+            CUDA_CHECK(cudaFree(ssto_arr));
+
+            return 1.0 - ssr/ssto;
+        }
+
+
+
+    }
+}
+

--- a/ml-prims/src/metrics/metrics.h
+++ b/ml-prims/src/metrics/metrics.h
@@ -21,6 +21,8 @@
 #include "linalg/subtract.h"
 #include "linalg/power.h"
 
+#include "common/cuml_allocator.hpp"
+
 #include <thrust/reduce.h>
 #include <thrust/device_ptr.h>
 
@@ -76,9 +78,6 @@ namespace MLCommon {
 
             return 1.0 - sse/ssto;
         }
-
-
-
     }
 }
 

--- a/ml-prims/test/CMakeLists.txt
+++ b/ml-prims/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(mlcommon_test
   matrix_vector_op.cu
   mean.cu
   mean_center.cu
+  metrics.cu
   mvg.cu
   multiply.cu
   norm.cu

--- a/ml-prims/test/metrics.cu
+++ b/ml-prims/test/metrics.cu
@@ -34,7 +34,8 @@ protected:
 
 };
 
-TEST(MetricsTest, Result) {
+typedef MetricsTest MetricsTestHighScore;
+TEST(MetricsTestHighScore, Result) {
 
     float y[5] = {0.1, 0.2, 0.3, 0.4, 0.5};
     float y_hat[5] = {0.12, 0.22, 0.32, 0.42, 0.52};
@@ -51,5 +52,27 @@ TEST(MetricsTest, Result) {
     float result = MLCommon::Metrics::r_squared(d_y, d_y_hat, 5);
     ASSERT_TRUE(result == 0.98f);
 }
+
+typedef MetricsTest MetricsTestLowScore;
+TEST(MetricsTestLowScore, Result) {
+
+    float y[5] = {0.1, 0.2, 0.3, 0.4, 0.5};
+    float y_hat[5] = {0.012, 0.022, 0.032, 0.042, 0.052};
+
+    float *d_y;
+    MLCommon::allocate(d_y, 5);
+
+    float *d_y_hat;
+    MLCommon::allocate(d_y_hat, 5);
+
+    MLCommon::updateDevice(d_y_hat, y_hat, 5);
+    MLCommon::updateDevice(d_y, y, 5);
+
+    float result = MLCommon::Metrics::r_squared(d_y, d_y_hat, 5);
+
+    std::cout << "Result: " << result - -3.4012f << std::endl;
+    ASSERT_TRUE(result - -3.4012f < 0.00001);
+}
+
 }}
 

--- a/ml-prims/test/metrics.cu
+++ b/ml-prims/test/metrics.cu
@@ -19,6 +19,8 @@
 #include "random/rng.h"
 #include "test_utils.h"
 
+#include "device_allocator.h"
+
 #include <iostream>
 
 namespace MLCommon {
@@ -48,8 +50,6 @@ TEST(MetricsTest, Result) {
 
     float result = MLCommon::Metrics::r_squared(d_y, d_y_hat, 5);
     ASSERT_TRUE(result == 0.98f);
-
-
 }
 }}
 

--- a/ml-prims/test/metrics.cu
+++ b/ml-prims/test/metrics.cu
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "metrics/metrics.h"
+#include <gtest/gtest.h>
+#include "random/rng.h"
+#include "test_utils.h"
+
+#include <iostream>
+
+namespace MLCommon {
+namespace Metrics {
+
+class MetricsTest : public ::testing::Test {
+protected:
+  void SetUp() override {}
+
+  void TearDown() override {}
+
+};
+
+TEST(MetricsTest, Result) {
+
+    float y[5] = {0.1, 0.2, 0.3, 0.4, 0.5};
+    float y_hat[5] = {0.12, 0.22, 0.32, 0.42, 0.52};
+
+    float *d_y;
+    MLCommon::allocate(d_y, 5);
+
+    float *d_y_hat;
+    MLCommon::allocate(d_y_hat, 5);
+
+    MLCommon::updateDevice(d_y_hat, y_hat, 5);
+    MLCommon::updateDevice(d_y, y, 5);
+
+    float result = MLCommon::Metrics::r_squared(d_y, d_y_hat, 5);
+    ASSERT_TRUE(result == 0.98f);
+
+
+}
+}}
+

--- a/ml-prims/test/metrics.cu
+++ b/ml-prims/test/metrics.cu
@@ -49,7 +49,7 @@ TEST(MetricsTestHighScore, Result) {
     MLCommon::updateDevice(d_y_hat, y_hat, 5);
     MLCommon::updateDevice(d_y, y, 5);
 
-    float result = MLCommon::Metrics::r_squared(d_y, d_y_hat, 5);
+    float result = MLCommon::Metrics::r2_score(d_y, d_y_hat, 5);
     ASSERT_TRUE(result == 0.98f);
 }
 
@@ -68,7 +68,7 @@ TEST(MetricsTestLowScore, Result) {
     MLCommon::updateDevice(d_y_hat, y_hat, 5);
     MLCommon::updateDevice(d_y, y, 5);
 
-    float result = MLCommon::Metrics::r_squared(d_y, d_y_hat, 5);
+    float result = MLCommon::Metrics::r2_score(d_y, d_y_hat, 5);
 
     std::cout << "Result: " << result - -3.4012f << std::endl;
     ASSERT_TRUE(result - -3.4012f < 0.00001);


### PR DESCRIPTION
This is the first model evaluation score in support of @quasiben and the gpu-accelerating dask-ml hyper-param optimization. 

@dantegd will be wrapping this in Cython to expose through the Python API. How do you guys feel about keeping doing this in separate PRs to keep the changes short and sweet?