### PR TITLE
[REVIEW] Support for fancy iterator in LinAlg::reduce_rows_by_key and bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 - PR #277: Added row- and column-wise weighted mean primitive
 - PR #424: Added a grid-sync struct for inter-block synchronization
+- PR #430: Adding R-Squared Score to ml primitives
 
 ## Improvements
 
 - PR #295: Improve build-time and the interface e.g., enable bool-OutType, for distance()
 - PR #390: Update docs version
 - PR #272: Add stream parameters to cublas and cusolver wrapper functions
+- PR #431: Add support for fancy iterator input types to LinAlg::reduce_rows_by_key
 
 ## Bug Fixes
 
@@ -20,6 +22,7 @@
 - PR #422: Issue in the PCA tests was solved and CI can run with driver 418
 - PR #409: Add entry to gitmodules to ignore build artifacts
 - PR #412: Fix for svdQR function in ml-prims
+- PR #434: Fixing bug in CSR tests
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/ml-prims/src/linalg/reduce_rows_by_key.h
+++ b/ml-prims/src/linalg/reduce_rows_by_key.h
@@ -49,7 +49,7 @@ void convert_array(IteratorT1 dst, IteratorT2 src, int n, cudaStream_t st) {
   dim3 grid, block;
   block.x = 256;
 
-  grid.x  = (n + block.x - 1)/block.x;
+  grid.x  = ceildiv(n, (int)block.x);
   grid.x = std::min(grid.x, MAX_BLOCKS);
     
   convert_array_kernel<<<grid,block,0,st>>>(dst, src, n);
@@ -174,7 +174,7 @@ void sum_rows_by_key_small_nkeys(const DataIteratorT d_A,
   block.x = SUM_ROWS_SMALL_K_DIMX;
   block.y = 1; // Necessary
 
-  grid.x = (nrows + block.x -1) / grid.x;
+  grid.x = ceildiv(nrows, (int)block.x);
   grid.x = std::min(grid.x, 32u); 
   grid.y = ncols; 
   grid.y = std::min(grid.y, MAX_BLOCKS);
@@ -255,7 +255,7 @@ void sum_rows_by_key_large_nkeys_colmajor(const DataIteratorT d_A,
   block.x = SUM_ROWS_SMALL_K_DIMX;
   block.y = 1; // Necessary
 
-  grid.x = (nrows + block.x -1) / grid.x;
+  grid.x = ceildiv(nrows, (int)block.x);
   grid.x = std::min(grid.x, 32u);
   grid.y = ncols; 
   grid.y = std::min(grid.y, MAX_BLOCKS);
@@ -335,7 +335,7 @@ void sum_rows_by_key_large_nkeys_rowmajor( const DataIteratorT d_A,
   dim3 grid, block;
   block.x = 256; //Adjust me!
   block.y = 1; //Don't adjust me!
-  grid.x = (ncols+block.x-1)/block.x;
+  grid.x = ceildiv(ncols, (int)block.x);
   grid.y = nkeys;
   grid.z = std::max(40960000/nkeys/ncols, (int)1); //Adjust me!
   grid.z = std::min(grid.z, (unsigned int)nrows);

--- a/ml-prims/src/linalg/reduce_rows_by_key.h
+++ b/ml-prims/src/linalg/reduce_rows_by_key.h
@@ -25,48 +25,50 @@
 
 
 namespace MLCommon {
-namespace LinAlg {
+  namespace LinAlg {
 
-//
-// Small helper function to convert from int->char and char->int 
-// Transform ncols*nrows read of int in 2*nrows reads of int + ncols*rows reads of chars
-// Gives 20% perf boost in Coral2s case 
-//
+    //
+    // Small helper function to convert from int->char and char->int 
+    // Transform ncols*nrows read of int in 2*nrows reads of int + ncols*rows reads of chars
+    //
 
-template<typename T1, typename T2>
-void __global__ convert_array_kernel(T1 *dst, T2 *src, int n) {
-    for(int idx = blockDim.x * blockIdx.x + threadIdx.x;
-            idx < n;
-            idx += gridDim.x * blockDim.x) {
-            dst[idx] = src[idx];
+    template<typename IteratorT1,
+	     typename IteratorT2>
+    void __global__ convert_array_kernel(IteratorT1 dst, IteratorT2 src, int n) {
+      for(int idx = blockDim.x * blockIdx.x + threadIdx.x;
+	  idx < n;
+	  idx += gridDim.x * blockDim.x) {
+	dst[idx] = src[idx];
+      }
     }
-}
 
-template<typename T1, typename T2>
-void convert_array(T1 *dst, T2 *src, int n, cudaStream_t st) {
-    dim3 grid, block;
-    block.x = 256;
 
-    grid.x  = (n + block.x - 1)/block.x;
-    grid.x = std::min(grid.x, MAX_BLOCKS);
+    template<typename IteratorT1,
+	     typename IteratorT2>
+    void convert_array(IteratorT1 dst, IteratorT2 src, int n, cudaStream_t st) {
+      dim3 grid, block;
+      block.x = 256;
+
+      grid.x  = (n + block.x - 1)/block.x;
+      grid.x = std::min(grid.x, MAX_BLOCKS);
     
-    convert_array_kernel<<<grid,block,0,st>>>(dst, src, n);
-}
+      convert_array_kernel<<<grid,block,0,st>>>(dst, src, n);
+    }
 
 
-template <typename T>
-struct quad
-{
-   T x,y,z,w;
-};
-//
-// Functor for reduce by key, small k
-//
-template <typename T>
-struct quadSum
-{
-    __host__ __device__ __forceinline__ quad<T> operator()(const quad<T> &a, const quad<T> &b) const
+    template <typename T>
+    struct quad
     {
+      T x,y,z,w;
+    };
+    //
+    // Functor for reduce by key, small k
+    //
+    template <typename T>
+    struct quadSum
+    {
+      __host__ __device__ __forceinline__ quad<T> operator()(const quad<T> &a, const quad<T> &b) const
+      {
         // wasting a double4..
         quad<T> c;
         c.x = a.x + b.x; 
@@ -75,267 +77,325 @@ struct quadSum
         c.w = a.w + b.w; 
 
         return c;
-    }
-};
+      }
+    };
 
-//
-// Reduce by keys
-// We need to sum each dimension by labels
-// The labels are not adjacent
-//
+    //
+    // Reduce by keys
+    // We need to sum each dimension by labels
+    // The labels are not adjacent
+    //
 
-//
-// Reduce by keys - for keys <= 4
-//
+    //
+    // Reduce by keys - for keys <= 4
+    //
 
 #define SUM_ROWS_SMALL_K_DIMX 256
 #define SUM_ROWS_BY_KEY_SMALL_K_MAX_K 4 
-template <typename DataType>
-__launch_bounds__(SUM_ROWS_SMALL_K_DIMX, 4)
-__global__ void sum_rows_by_key_small_nkeys_kernel(const DataType *d_A, int lda, char *d_keys, int nrows, int ncols, int nkeys, DataType *d_sums) {
-        typedef cub::BlockReduce<quad<DataType>, SUM_ROWS_SMALL_K_DIMX> BlockReduce;
-        __shared__ typename BlockReduce::TempStorage temp_storage;
+    template <typename DataIteratorT>
+    __launch_bounds__(SUM_ROWS_SMALL_K_DIMX, 4)
+      __global__ void sum_rows_by_key_small_nkeys_kernel(const DataIteratorT d_A,
+							 int lda,
+							 char *d_keys,
+							 int nrows,
+							 int ncols,
+							 int nkeys,
+							 DataIteratorT d_sums) {
+      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+      typedef cub::BlockReduce<quad<DataType>, SUM_ROWS_SMALL_K_DIMX> BlockReduce;
+      __shared__ typename BlockReduce::TempStorage temp_storage;
 
-        for(int idim = blockIdx.y;
-                idim < ncols;
-                idim += gridDim.y) {
+      for(int idim = blockIdx.y;
+	  idim < ncols;
+	  idim += gridDim.y) {
 
-            if(idim != blockIdx.y)
-                __syncthreads(); // we're reusing temp_storage
+	if(idim != blockIdx.y)
+	  __syncthreads(); // we're reusing temp_storage
 
-            // threadIdx.x stores partial sum for current dim and key=threadIdx.x in this reg
-            quad<DataType> thread_sums;
-            thread_sums.x = 0.0;
-            thread_sums.y = 0.0;
-            thread_sums.z = 0.0;
-            thread_sums.w = 0.0;
+	// threadIdx.x stores partial sum for current dim and key=threadIdx.x in this reg
+	quad<DataType> thread_sums;
+	thread_sums.x = 0.0;
+	thread_sums.y = 0.0;
+	thread_sums.z = 0.0;
+	thread_sums.w = 0.0;
 
-            // May use vectorized load - not necessary for doubles
-            for(int block_offset_irow = blockIdx.x * blockDim.x;
-                    block_offset_irow < nrows; // we will syncthreads() inside the loop, no CTA divergence
-                    block_offset_irow += blockDim.x * gridDim.x) {
+	// May use vectorized load - not necessary for doubles
+	for(int block_offset_irow = blockIdx.x * blockDim.x;
+	    block_offset_irow < nrows; // we will syncthreads() inside the loop, no CTA divergence
+	    block_offset_irow += blockDim.x * gridDim.x) {
 
-                int irow = block_offset_irow + threadIdx.x;
-                DataType val = (irow < nrows) ? d_A[irow * lda + idim] : 0.0;
-                // we are not reusing the keys - after profiling 
-                // d_keys is mainly loaded from L2, and this kernel is DRAM BW bounded
-                // (experimentation gave a 10% speed up - not worth the many code lines added)
-                int row_key = (irow < nrows) ? d_keys[irow] : -1;
+	  int irow = block_offset_irow + threadIdx.x;
+	  DataType val = (irow < nrows) ? d_A[irow * lda + idim] : 0.0;
+	  // we are not reusing the keys - after profiling 
+	  // d_keys is mainly loaded from L2, and this kernel is DRAM BW bounded
+	  // (experimentation gave a 10% speed up - not worth the many code lines added)
+	  int row_key = (irow < nrows) ? d_keys[irow] : -1;
 
-                thread_sums.x += (row_key == 0) ? val : 0.0;
-                thread_sums.y += (row_key == 1) ? val : 0.0;
-                thread_sums.z += (row_key == 2) ? val : 0.0;
-                thread_sums.w += (row_key == 3) ? val : 0.0;
-            }
+	  thread_sums.x += (row_key == 0) ? val : 0.0;
+	  thread_sums.y += (row_key == 1) ? val : 0.0;
+	  thread_sums.z += (row_key == 2) ? val : 0.0;
+	  thread_sums.w += (row_key == 3) ? val : 0.0;
+	}
 
-            // End of column
-            // Saving local sums back to global mem
+	// End of column
+	// Saving local sums back to global mem
 
-            // Strided access
-
-
-            // Reducing by key
-            thread_sums = BlockReduce(temp_storage).Reduce(thread_sums, quadSum<DataType>());
-
-            if(threadIdx.x < 32) {
-                // We only need 4
-                thread_sums = cub::ShuffleIndex<32>(thread_sums, 0, 0xffffffff);
-                if (threadIdx.x < nkeys) {
-                   if(threadIdx.x == 0)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.x);
-                   if(threadIdx.x == 1)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.y);
-                   if(threadIdx.x == 2)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.z);
-                   if(threadIdx.x == 3)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.w);
-                }
-            }
-        }
-
-}
+	// Strided access
 
 
-template <typename DataType>
-void sum_rows_by_key_small_nkeys(const DataType *d_A, int lda, char *d_keys, int nrows, int ncols, int nkeys, DataType *d_sums, cudaStream_t st) {
-        dim3 grid,block;
-        block.x = SUM_ROWS_SMALL_K_DIMX;
-        block.y = 1; // Necessary
+	// Reducing by key
+	thread_sums = BlockReduce(temp_storage).Reduce(thread_sums, quadSum<DataType>());
 
-        grid.x = (nrows + block.x -1) / grid.x;
-        grid.x = std::min(grid.x, 32u); 
-        grid.y = ncols; 
-        grid.y = std::min(grid.y, MAX_BLOCKS);
-        sum_rows_by_key_small_nkeys_kernel<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, nkeys, d_sums);   
-}
+	if(threadIdx.x < 32) {
+	  // We only need 4
+	  thread_sums = cub::ShuffleIndex<32>(thread_sums, 0, 0xffffffff);
+	  if (threadIdx.x < nkeys) {
+	    if(threadIdx.x == 0)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.x);
+	    if(threadIdx.x == 1)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.y);
+	    if(threadIdx.x == 2)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.z);
+	    if(threadIdx.x == 3)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.w);
+	  }
+	}
+      }
+
+    }
 
 
-//
-// Reduce by keys - large number of keys
-// Computing a "weigthed histogram" with local histograms in smem
-// Keeping it simple - not optimized
-//
+    template <typename DataIteratorT>
+    void sum_rows_by_key_small_nkeys(const DataIteratorT d_A,
+				     int lda,
+				     char *d_keys,
+				     int nrows,
+				     int ncols,
+				     int nkeys,
+				     DataIteratorT d_sums,
+				     cudaStream_t st) {
+      dim3 grid,block;
+      block.x = SUM_ROWS_SMALL_K_DIMX;
+      block.y = 1; // Necessary
+
+      grid.x = (nrows + block.x -1) / grid.x;
+      grid.x = std::min(grid.x, 32u); 
+      grid.y = ncols; 
+      grid.y = std::min(grid.y, MAX_BLOCKS);
+      sum_rows_by_key_small_nkeys_kernel<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, nkeys, d_sums);   
+    }
+
+
+    //
+    // Reduce by keys - large number of keys
+    // Computing a "weigthed histogram" with local histograms in smem
+    // Keeping it simple - not optimized
+    //
 
 #define SUM_ROWS_BY_KEY_LARGE_K_MAX_K 1024 
-template <typename DataType, typename KeyType>
-__global__ void sum_rows_by_key_large_nkeys_kernel_colmajor(const DataType *d_A, int lda, KeyType *d_keys, int nrows, int ncols, int key_offset, int nkeys, DataType *d_sums) {
-        __shared__ DataType local_sums[SUM_ROWS_BY_KEY_LARGE_K_MAX_K];
+    template <typename DataIteratorT,
+	      typename KeysIteratorT>
+    __global__ void sum_rows_by_key_large_nkeys_kernel_colmajor(const DataIteratorT d_A,
+								int lda,
+								KeysIteratorT d_keys,
+								int nrows,
+								int ncols,
+								int key_offset,
+								int nkeys,
+								DataIteratorT d_sums) {
+      typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
+      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+      __shared__ DataType local_sums[SUM_ROWS_BY_KEY_LARGE_K_MAX_K];
 
-        for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x)
-            local_sums[local_key] = 0.0;
+      for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x)
+	local_sums[local_key] = 0.0;
 
-        for(int idim = blockIdx.y;
-                idim < ncols;
-                idim += gridDim.y) {
+      for(int idim = blockIdx.y;
+	  idim < ncols;
+	  idim += gridDim.y) {
             
-               __syncthreads(); // local_sums
+	__syncthreads(); // local_sums
                
-               // At this point local_sums if full of zeros 
+	// At this point local_sums if full of zeros 
 
-               for(int irow = blockIdx.x * blockDim.x + threadIdx.x;
-                       irow < nrows;
-                       irow += blockDim.x * gridDim.x) {
-                    // Branch div in this loop - not an issue with current code 
-                    DataType val  = d_A[idim*lda + irow];
-                    int local_key = d_keys[irow] - key_offset;
+	for(int irow = blockIdx.x * blockDim.x + threadIdx.x;
+	    irow < nrows;
+	    irow += blockDim.x * gridDim.x) {
+	  // Branch div in this loop - not an issue with current code 
+	  DataType val  = d_A[idim*lda + irow];
+	  int local_key = d_keys[irow] - key_offset;
 
-                    // We could load next val here
-                    myAtomicAdd(&local_sums[local_key], val);
-               }
+	  // We could load next val here
+	  myAtomicAdd(&local_sums[local_key], val);
+	}
                 
-               __syncthreads(); // local_sums
+	__syncthreads(); // local_sums
                 
-                for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x) {
-                    DataType local_sum = local_sums[local_key];
+	for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x) {
+	  DataType local_sum = local_sums[local_key];
 
-                    if(local_sum != 0.0) {
-                        KeyType global_key = key_offset + local_key;
-                        myAtomicAdd(&d_sums[global_key*ncols + idim], local_sum);
-                        local_sums[local_key] = 0.0;
-                    }
-                }
-        }
+	  if(local_sum != 0.0) {
+	    KeyType global_key = key_offset + local_key;
+	    myAtomicAdd(&d_sums[global_key*ncols + idim], local_sum);
+	    local_sums[local_key] = 0.0;
+	  }
+	}
+      }
         
-}
+    }
 
-template <typename DataType, typename KeyType>
-void sum_rows_by_key_large_nkeys_colmajor(const DataType *d_A, int lda, 
-                    KeyType *d_keys, int nrows, int ncols, int key_offset, 
-                    int nkeys, DataType *d_sums, cudaStream_t st) {
-        dim3 grid,block;
-        block.x = SUM_ROWS_SMALL_K_DIMX;
-        block.y = 1; // Necessary
+    template <typename DataIteratorT,
+	      typename KeysIteratorT>
+    void sum_rows_by_key_large_nkeys_colmajor(const DataIteratorT d_A,
+					      int lda, 
+					      KeysIteratorT d_keys,
+					      int nrows,
+					      int ncols,
+					      int key_offset, 
+					      int nkeys,
+					      DataIteratorT d_sums,
+					      cudaStream_t st) {
+      dim3 grid,block;
+      block.x = SUM_ROWS_SMALL_K_DIMX;
+      block.y = 1; // Necessary
 
-        grid.x = (nrows + block.x -1) / grid.x;
-        grid.x = std::min(grid.x, 32u);
-        grid.y = ncols; 
-        grid.y = std::min(grid.y, MAX_BLOCKS);
-        sum_rows_by_key_large_nkeys_kernel_colmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
-}
+      grid.x = (nrows + block.x -1) / grid.x;
+      grid.x = std::min(grid.x, 32u);
+      grid.y = ncols; 
+      grid.y = std::min(grid.y, MAX_BLOCKS);
+      sum_rows_by_key_large_nkeys_kernel_colmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
+    }
 
 #define RRBK_SHMEM_SZ 32
-//#define RRBK_SHMEM
-template <typename DataType, typename KeyType>
-__global__ void sum_rows_by_key_large_nkeys_kernel_rowmajor(const DataType *d_A, int lda, KeyType *d_keys, int nrows, int ncols, int key_offset, int nkeys, DataType *d_sums) {
+    //#define RRBK_SHMEM
+    template <typename DataIteratorT,
+	      typename KeysIteratorT>
+    __global__ void sum_rows_by_key_large_nkeys_kernel_rowmajor(const DataIteratorT d_A,
+								int lda,
+								KeysIteratorT d_keys,
+								int nrows,
+								int ncols,
+								int key_offset,
+								int nkeys,
+								DataIteratorT d_sums) {
+      typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
+      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
 
-        #ifdef RRBK_SHMEM
-        __shared__ KeyType sh_keys[RRBK_SHMEM_SZ];
-        #endif
-        int rows_per_partition = nrows/gridDim.z+1;
-        int start_row = blockIdx.z*rows_per_partition;
-        int end_row = start_row + rows_per_partition;
-        end_row = end_row > nrows ? nrows : end_row;
+#ifdef RRBK_SHMEM
+      __shared__ KeyType sh_keys[RRBK_SHMEM_SZ];
+#endif
+      int rows_per_partition = nrows/gridDim.z+1;
+      int start_row = blockIdx.z*rows_per_partition;
+      int end_row = start_row + rows_per_partition;
+      end_row = end_row > nrows ? nrows : end_row;
 
-        KeyType this_key = blockIdx.y;
-        if (this_key >= nkeys) return;
-        int this_col = threadIdx.x + blockIdx.x*blockDim.x;
-        if (this_col >= ncols) return;
+      KeyType this_key = blockIdx.y;
+      if (this_key >= nkeys) return;
+      int this_col = threadIdx.x + blockIdx.x*blockDim.x;
+      if (this_col >= ncols) return;
         
-        DataType sum = 0.0;
+      DataType sum = 0.0;
 
-        #ifdef RRBK_SHMEM
-        int sh_key_inx = 0;
-        #endif
-        for (int r = start_row; r < end_row; r++) {
-            #ifdef RRBK_SHMEM
-            if (0 == sh_key_inx%RRBK_SHMEM_SZ) {
-               for (int x=threadIdx.x;x<RRBK_SHMEM_SZ;x+=blockDim.x)
-                   sh_keys[x] = d_keys[r+x];
-               __syncthreads();
-            }
-            if (sh_keys[sh_key_inx] != this_key) continue; //No divergence since this_key is the
-                                                 // same for the whole block
-            sh_key_inx++;
-            #else
-            if (d_keys[r] != this_key) continue; //No divergence since this_key is the
-                                                 // same for the whole block
-            #endif
-            //if ((end_row-start_row) / (r-start_row) != this_key) continue;
-            sum += __ldcg(&d_A[r*lda+this_col]);
-        }
+#ifdef RRBK_SHMEM
+      int sh_key_inx = 0;
+#endif
+      for (int r = start_row; r < end_row; r++) {
+#ifdef RRBK_SHMEM
+	if (0 == sh_key_inx%RRBK_SHMEM_SZ) {
+	  for (int x=threadIdx.x;x<RRBK_SHMEM_SZ;x+=blockDim.x)
+	    sh_keys[x] = d_keys[r+x];
+	  __syncthreads();
+	}
+	if (sh_keys[sh_key_inx] != this_key) continue; //No divergence since this_key is the
+	// same for the whole block
+	sh_key_inx++;
+#else
+	if (d_keys[r] != this_key) continue; //No divergence since this_key is the
+	// same for the whole block
+#endif
+	//if ((end_row-start_row) / (r-start_row) != this_key) continue;
+	sum += __ldcg(&d_A[r*lda+this_col]);
+      }
         
-        if (sum != 0.0) myAtomicAdd(&d_sums[this_key*ncols+this_col], sum);
-}
+      if (sum != 0.0) myAtomicAdd(&d_sums[this_key*ncols+this_col], sum);
+    }
 
-template <typename DataType, typename KeyType>
-void sum_rows_by_key_large_nkeys_rowmajor( const DataType *d_A, int lda, 
-                    KeyType *d_keys, int nrows, int ncols, int key_offset, 
-                    int nkeys, DataType *d_sums, cudaStream_t st)  {
-        // x-dim refers to the column in the input data
-        // y-dim refers to the key
-        // z-dim refers to a partitioning of the rows among the threadblocks
-        dim3 grid, block;
-        block.x = 256; //Adjust me!
-        block.y = 1; //Don't adjust me!
-        grid.x = (ncols+block.x-1)/block.x;
-        grid.y = nkeys;
-        grid.z = std::max(40960000/nkeys/ncols, (int)1); //Adjust me!
-        grid.z = std::min(grid.z, (unsigned int)nrows);
-        grid.z = std::min(grid.z, MAX_BLOCKS);
-        //std::cout << "block = " << block.x << ", " << block.y << std::endl;
-        //std::cout << "grid = " << grid.x << ", " << grid.y << ", " << grid.z << std::endl;
-        cudaMemset(d_sums, 0, sizeof(DataType)*nkeys*ncols);
-        sum_rows_by_key_large_nkeys_kernel_rowmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
-}
+    template <typename DataIteratorT,
+	      typename KeysIteratorT>
+    void sum_rows_by_key_large_nkeys_rowmajor( const DataIteratorT d_A,
+					       int lda, 
+					       KeysIteratorT d_keys,
+					       int nrows,
+					       int ncols,
+					       int key_offset, 
+					       int nkeys,
+					       DataIteratorT d_sums,
+					       cudaStream_t st)  {
+      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
 
+      // x-dim refers to the column in the input data
+      // y-dim refers to the key
+      // z-dim refers to a partitioning of the rows among the threadblocks
+      dim3 grid, block;
+      block.x = 256; //Adjust me!
+      block.y = 1; //Don't adjust me!
+      grid.x = (ncols+block.x-1)/block.x;
+      grid.y = nkeys;
+      grid.z = std::max(40960000/nkeys/ncols, (int)1); //Adjust me!
+      grid.z = std::min(grid.z, (unsigned int)nrows);
+      grid.z = std::min(grid.z, MAX_BLOCKS);
+      //std::cout << "block = " << block.x << ", " << block.y << std::endl;
+      //std::cout << "grid = " << grid.x << ", " << grid.y << ", " << grid.z << std::endl;
+      cudaMemset(d_sums, 0, sizeof(DataType)*nkeys*ncols);
+      sum_rows_by_key_large_nkeys_kernel_rowmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
+    }
 
-
-/**
- * @brief Computes the reduction of matrix rows for each given key 
- * @tparam DataType the data type for d_A
- * @tparam KeyType the data type d_keys
- * @param[in] d_A Input data array (lda x nrows)
- * @param[in] lda Real row size for input data, d_A
- * @param[in] d_keys Keys for each row (1 x nrows)
- * @param d_keys_char Scratch memory for conversion of keys to char
- * @param[in] nrows Number of rows in d_A and d_keys
- * @param[in] ncols Number of data columns in d_A
- * @param[in] nkeys Number of unique keys in d_keys 
- * @param[out] d_sums Row sums by key (ncols x d_keys)
- * @param[in] stream CUDA stream
- */
-//TODO template for reduction type
-template <typename DataType, typename KeyType>
-void reduce_rows_by_key(const DataType *d_A, int lda, KeyType *d_keys, 
-                        char *d_keys_char, int nrows, int ncols, int nkeys, 
-                        DataType *d_sums, cudaStream_t stream = 0) {
-    // Following kernel needs memset
-    cudaMemsetAsync(d_sums, 0, ncols * nkeys * sizeof(int), stream);
+ 
+    
+    /**
+     * @brief Computes the reduction of matrix rows for each given key 
+     * @tparam DataIteratorT Random-access iterator type, for reading input matrix (may be a simple pointer type)
+     * @tparam KeysIteratorT Random-access iterator type, for reading input keys (may be a simple pointer type)
+     * @param[in]  d_A         Input data array (lda x nrows)
+     * @param[in]  lda         Real row size for input data, d_A
+     * @param[in]  d_keys      Keys for each row (1 x nrows)
+     * @param      d_keys_char Scratch memory for conversion of keys to char
+     * @param[in]  nrows       Number of rows in d_A and d_keys
+     * @param[in]  ncols       Number of data columns in d_A
+     * @param[in]  nkeys       Number of unique keys in d_keys 
+     * @param[out] d_sums      Row sums by key (ncols x d_keys)
+     * @param[in]  stream      CUDA stream
+     */
+    template <typename DataIteratorT,
+	      typename KeysIteratorT>
+    void reduce_rows_by_key(const DataIteratorT d_A,
+			    int lda,
+			    const KeysIteratorT d_keys, 
+			    char *d_keys_char,
+			    int nrows,
+			    int ncols,
+			    int nkeys, 
+			    DataIteratorT d_sums,
+			    cudaStream_t stream) {
+      typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
+      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+      
+      // Following kernel needs memset
+      cudaMemsetAsync(d_sums, 0, ncols * nkeys * sizeof(DataType), stream);
    
 
-    if(nkeys <= SUM_ROWS_BY_KEY_SMALL_K_MAX_K) {
+      if(nkeys <= SUM_ROWS_BY_KEY_SMALL_K_MAX_K) {
         // sum_rows_by_key_small_k is BW bounded. d_keys is loaded ncols time - avoiding wasting BW
         // with doubles we have ~20% speed up - with floats we can hope something around 2x
         // Converting d_keys to char
         convert_array(d_keys_char, d_keys, nrows, stream);
         sum_rows_by_key_small_nkeys(d_A, lda, d_keys_char, nrows, ncols, nkeys, d_sums, stream);
-        convert_array(d_keys, d_keys_char, nrows, stream);
-    } else {
+      } else {
         for(KeyType key_offset = 0;
-                key_offset < nkeys;
-                key_offset += SUM_ROWS_BY_KEY_LARGE_K_MAX_K) {
-            KeyType this_call_nkeys = std::min(SUM_ROWS_BY_KEY_LARGE_K_MAX_K, nkeys);
-            sum_rows_by_key_large_nkeys_rowmajor(d_A, lda, d_keys, nrows, ncols, key_offset, this_call_nkeys, d_sums, stream);
+	    key_offset < nkeys;
+	    key_offset += SUM_ROWS_BY_KEY_LARGE_K_MAX_K) {
+	  KeyType this_call_nkeys = std::min(SUM_ROWS_BY_KEY_LARGE_K_MAX_K, nkeys);
+	  sum_rows_by_key_large_nkeys_rowmajor(d_A, lda, d_keys, nrows, ncols, key_offset, this_call_nkeys, d_sums, stream);
         }
-    }
+      }
     
-}
+    }
 
-}; // end namespace LinAlg
+  }; // end namespace LinAlg
 }; // end namespace MLCommon

--- a/ml-prims/src/linalg/reduce_rows_by_key.h
+++ b/ml-prims/src/linalg/reduce_rows_by_key.h
@@ -25,377 +25,377 @@
 
 
 namespace MLCommon {
-  namespace LinAlg {
+namespace LinAlg {
 
-    //
-    // Small helper function to convert from int->char and char->int 
-    // Transform ncols*nrows read of int in 2*nrows reads of int + ncols*rows reads of chars
-    //
+//
+// Small helper function to convert from int->char and char->int 
+// Transform ncols*nrows read of int in 2*nrows reads of int + ncols*rows reads of chars
+//
 
-    template<typename IteratorT1,
-	     typename IteratorT2>
-    void __global__ convert_array_kernel(IteratorT1 dst, IteratorT2 src, int n) {
-      for(int idx = blockDim.x * blockIdx.x + threadIdx.x;
-	  idx < n;
-	  idx += gridDim.x * blockDim.x) {
-	dst[idx] = src[idx];
-      }
-    }
+template<typename IteratorT1,
+	 typename IteratorT2>
+void __global__ convert_array_kernel(IteratorT1 dst, IteratorT2 src, int n) {
+  for(int idx = blockDim.x * blockIdx.x + threadIdx.x;
+      idx < n;
+      idx += gridDim.x * blockDim.x) {
+    dst[idx] = src[idx];
+  }
+}
 
 
-    template<typename IteratorT1,
-	     typename IteratorT2>
-    void convert_array(IteratorT1 dst, IteratorT2 src, int n, cudaStream_t st) {
-      dim3 grid, block;
-      block.x = 256;
+template<typename IteratorT1,
+	 typename IteratorT2>
+void convert_array(IteratorT1 dst, IteratorT2 src, int n, cudaStream_t st) {
+  dim3 grid, block;
+  block.x = 256;
 
-      grid.x  = (n + block.x - 1)/block.x;
-      grid.x = std::min(grid.x, MAX_BLOCKS);
+  grid.x  = (n + block.x - 1)/block.x;
+  grid.x = std::min(grid.x, MAX_BLOCKS);
     
-      convert_array_kernel<<<grid,block,0,st>>>(dst, src, n);
-    }
+  convert_array_kernel<<<grid,block,0,st>>>(dst, src, n);
+}
 
 
-    template <typename T>
-    struct quad
-    {
-      T x,y,z,w;
-    };
-    //
-    // Functor for reduce by key, small k
-    //
-    template <typename T>
-    struct quadSum
-    {
-      __host__ __device__ __forceinline__ quad<T> operator()(const quad<T> &a, const quad<T> &b) const
-      {
-        // wasting a double4..
-        quad<T> c;
-        c.x = a.x + b.x; 
-        c.y = a.y + b.y; 
-        c.z = a.z + b.z; 
-        c.w = a.w + b.w; 
+template <typename T>
+struct quad
+{
+  T x,y,z,w;
+};
+//
+// Functor for reduce by key, small k
+//
+template <typename T>
+struct quadSum
+{
+  __host__ __device__ __forceinline__ quad<T> operator()(const quad<T> &a, const quad<T> &b) const
+  {
+    // wasting a double4..
+    quad<T> c;
+    c.x = a.x + b.x; 
+    c.y = a.y + b.y; 
+    c.z = a.z + b.z; 
+    c.w = a.w + b.w; 
 
-        return c;
-      }
-    };
+    return c;
+  }
+};
 
-    //
-    // Reduce by keys
-    // We need to sum each dimension by labels
-    // The labels are not adjacent
-    //
+//
+// Reduce by keys
+// We need to sum each dimension by labels
+// The labels are not adjacent
+//
 
-    //
-    // Reduce by keys - for keys <= 4
-    //
+//
+// Reduce by keys - for keys <= 4
+//
 
 #define SUM_ROWS_SMALL_K_DIMX 256
 #define SUM_ROWS_BY_KEY_SMALL_K_MAX_K 4 
-    template <typename DataIteratorT>
-    __launch_bounds__(SUM_ROWS_SMALL_K_DIMX, 4)
-      __global__ void sum_rows_by_key_small_nkeys_kernel(const DataIteratorT d_A,
-							 int lda,
-							 char *d_keys,
-							 int nrows,
-							 int ncols,
-							 int nkeys,
-							 DataIteratorT d_sums) {
-      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
-      typedef cub::BlockReduce<quad<DataType>, SUM_ROWS_SMALL_K_DIMX> BlockReduce;
-      __shared__ typename BlockReduce::TempStorage temp_storage;
+template <typename DataIteratorT>
+__launch_bounds__(SUM_ROWS_SMALL_K_DIMX, 4)
+  __global__ void sum_rows_by_key_small_nkeys_kernel(const DataIteratorT d_A,
+						     int lda,
+						     char *d_keys,
+						     int nrows,
+						     int ncols,
+						     int nkeys,
+						     DataIteratorT d_sums) {
+  typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+  typedef cub::BlockReduce<quad<DataType>, SUM_ROWS_SMALL_K_DIMX> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
 
-      for(int idim = blockIdx.y;
-	  idim < ncols;
-	  idim += gridDim.y) {
+  for(int idim = blockIdx.y;
+      idim < ncols;
+      idim += gridDim.y) {
 
-	if(idim != blockIdx.y)
-	  __syncthreads(); // we're reusing temp_storage
+    if(idim != blockIdx.y)
+      __syncthreads(); // we're reusing temp_storage
 
-	// threadIdx.x stores partial sum for current dim and key=threadIdx.x in this reg
-	quad<DataType> thread_sums;
-	thread_sums.x = 0.0;
-	thread_sums.y = 0.0;
-	thread_sums.z = 0.0;
-	thread_sums.w = 0.0;
+    // threadIdx.x stores partial sum for current dim and key=threadIdx.x in this reg
+    quad<DataType> thread_sums;
+    thread_sums.x = 0.0;
+    thread_sums.y = 0.0;
+    thread_sums.z = 0.0;
+    thread_sums.w = 0.0;
 
-	// May use vectorized load - not necessary for doubles
-	for(int block_offset_irow = blockIdx.x * blockDim.x;
-	    block_offset_irow < nrows; // we will syncthreads() inside the loop, no CTA divergence
-	    block_offset_irow += blockDim.x * gridDim.x) {
+    // May use vectorized load - not necessary for doubles
+    for(int block_offset_irow = blockIdx.x * blockDim.x;
+	block_offset_irow < nrows; // we will syncthreads() inside the loop, no CTA divergence
+	block_offset_irow += blockDim.x * gridDim.x) {
 
-	  int irow = block_offset_irow + threadIdx.x;
-	  DataType val = (irow < nrows) ? d_A[irow * lda + idim] : 0.0;
-	  // we are not reusing the keys - after profiling 
-	  // d_keys is mainly loaded from L2, and this kernel is DRAM BW bounded
-	  // (experimentation gave a 10% speed up - not worth the many code lines added)
-	  int row_key = (irow < nrows) ? d_keys[irow] : -1;
+      int irow = block_offset_irow + threadIdx.x;
+      DataType val = (irow < nrows) ? d_A[irow * lda + idim] : 0.0;
+      // we are not reusing the keys - after profiling 
+      // d_keys is mainly loaded from L2, and this kernel is DRAM BW bounded
+      // (experimentation gave a 10% speed up - not worth the many code lines added)
+      int row_key = (irow < nrows) ? d_keys[irow] : -1;
 
-	  thread_sums.x += (row_key == 0) ? val : 0.0;
-	  thread_sums.y += (row_key == 1) ? val : 0.0;
-	  thread_sums.z += (row_key == 2) ? val : 0.0;
-	  thread_sums.w += (row_key == 3) ? val : 0.0;
-	}
+      thread_sums.x += (row_key == 0) ? val : 0.0;
+      thread_sums.y += (row_key == 1) ? val : 0.0;
+      thread_sums.z += (row_key == 2) ? val : 0.0;
+      thread_sums.w += (row_key == 3) ? val : 0.0;
+    }
 
-	// End of column
-	// Saving local sums back to global mem
+    // End of column
+    // Saving local sums back to global mem
 
-	// Strided access
+    // Strided access
 
 
-	// Reducing by key
-	thread_sums = BlockReduce(temp_storage).Reduce(thread_sums, quadSum<DataType>());
+    // Reducing by key
+    thread_sums = BlockReduce(temp_storage).Reduce(thread_sums, quadSum<DataType>());
 
-	if(threadIdx.x < 32) {
-	  // We only need 4
-	  thread_sums = cub::ShuffleIndex<32>(thread_sums, 0, 0xffffffff);
-	  if (threadIdx.x < nkeys) {
-	    if(threadIdx.x == 0)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.x);
-	    if(threadIdx.x == 1)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.y);
-	    if(threadIdx.x == 2)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.z);
-	    if(threadIdx.x == 3)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.w);
-	  }
-	}
+    if(threadIdx.x < 32) {
+      // We only need 4
+      thread_sums = cub::ShuffleIndex<32>(thread_sums, 0, 0xffffffff);
+      if (threadIdx.x < nkeys) {
+	if(threadIdx.x == 0)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.x);
+	if(threadIdx.x == 1)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.y);
+	if(threadIdx.x == 2)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.z);
+	if(threadIdx.x == 3)    myAtomicAdd(&d_sums[threadIdx.x*ncols + idim], thread_sums.w);
       }
-
     }
+  }
+
+}
 
 
-    template <typename DataIteratorT>
-    void sum_rows_by_key_small_nkeys(const DataIteratorT d_A,
-				     int lda,
-				     char *d_keys,
-				     int nrows,
-				     int ncols,
-				     int nkeys,
-				     DataIteratorT d_sums,
-				     cudaStream_t st) {
-      dim3 grid,block;
-      block.x = SUM_ROWS_SMALL_K_DIMX;
-      block.y = 1; // Necessary
+template <typename DataIteratorT>
+void sum_rows_by_key_small_nkeys(const DataIteratorT d_A,
+				 int lda,
+				 char *d_keys,
+				 int nrows,
+				 int ncols,
+				 int nkeys,
+				 DataIteratorT d_sums,
+				 cudaStream_t st) {
+  dim3 grid,block;
+  block.x = SUM_ROWS_SMALL_K_DIMX;
+  block.y = 1; // Necessary
 
-      grid.x = (nrows + block.x -1) / grid.x;
-      grid.x = std::min(grid.x, 32u); 
-      grid.y = ncols; 
-      grid.y = std::min(grid.y, MAX_BLOCKS);
-      sum_rows_by_key_small_nkeys_kernel<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, nkeys, d_sums);   
-    }
+  grid.x = (nrows + block.x -1) / grid.x;
+  grid.x = std::min(grid.x, 32u); 
+  grid.y = ncols; 
+  grid.y = std::min(grid.y, MAX_BLOCKS);
+  sum_rows_by_key_small_nkeys_kernel<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, nkeys, d_sums);   
+}
 
 
-    //
-    // Reduce by keys - large number of keys
-    // Computing a "weigthed histogram" with local histograms in smem
-    // Keeping it simple - not optimized
-    //
+//
+// Reduce by keys - large number of keys
+// Computing a "weigthed histogram" with local histograms in smem
+// Keeping it simple - not optimized
+//
 
 #define SUM_ROWS_BY_KEY_LARGE_K_MAX_K 1024 
-    template <typename DataIteratorT,
-	      typename KeysIteratorT>
-    __global__ void sum_rows_by_key_large_nkeys_kernel_colmajor(const DataIteratorT d_A,
-								int lda,
-								KeysIteratorT d_keys,
-								int nrows,
-								int ncols,
-								int key_offset,
-								int nkeys,
-								DataIteratorT d_sums) {
-      typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
-      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
-      __shared__ DataType local_sums[SUM_ROWS_BY_KEY_LARGE_K_MAX_K];
+template <typename DataIteratorT,
+	  typename KeysIteratorT>
+__global__ void sum_rows_by_key_large_nkeys_kernel_colmajor(const DataIteratorT d_A,
+							    int lda,
+							    KeysIteratorT d_keys,
+							    int nrows,
+							    int ncols,
+							    int key_offset,
+							    int nkeys,
+							    DataIteratorT d_sums) {
+  typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
+  typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+  __shared__ DataType local_sums[SUM_ROWS_BY_KEY_LARGE_K_MAX_K];
 
-      for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x)
-	local_sums[local_key] = 0.0;
+  for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x)
+    local_sums[local_key] = 0.0;
 
-      for(int idim = blockIdx.y;
-	  idim < ncols;
-	  idim += gridDim.y) {
+  for(int idim = blockIdx.y;
+      idim < ncols;
+      idim += gridDim.y) {
             
-	__syncthreads(); // local_sums
+    __syncthreads(); // local_sums
                
-	// At this point local_sums if full of zeros 
+    // At this point local_sums if full of zeros 
 
-	for(int irow = blockIdx.x * blockDim.x + threadIdx.x;
-	    irow < nrows;
-	    irow += blockDim.x * gridDim.x) {
-	  // Branch div in this loop - not an issue with current code 
-	  DataType val  = d_A[idim*lda + irow];
-	  int local_key = d_keys[irow] - key_offset;
+    for(int irow = blockIdx.x * blockDim.x + threadIdx.x;
+	irow < nrows;
+	irow += blockDim.x * gridDim.x) {
+      // Branch div in this loop - not an issue with current code 
+      DataType val  = d_A[idim*lda + irow];
+      int local_key = d_keys[irow] - key_offset;
 
-	  // We could load next val here
-	  myAtomicAdd(&local_sums[local_key], val);
-	}
+      // We could load next val here
+      myAtomicAdd(&local_sums[local_key], val);
+    }
                 
-	__syncthreads(); // local_sums
+    __syncthreads(); // local_sums
                 
-	for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x) {
-	  DataType local_sum = local_sums[local_key];
+    for(int local_key=threadIdx.x; local_key<nkeys; local_key+=blockDim.x) {
+      DataType local_sum = local_sums[local_key];
 
-	  if(local_sum != 0.0) {
-	    KeyType global_key = key_offset + local_key;
-	    myAtomicAdd(&d_sums[global_key*ncols + idim], local_sum);
-	    local_sums[local_key] = 0.0;
-	  }
-	}
+      if(local_sum != 0.0) {
+	KeyType global_key = key_offset + local_key;
+	myAtomicAdd(&d_sums[global_key*ncols + idim], local_sum);
+	local_sums[local_key] = 0.0;
       }
+    }
+  }
         
-    }
+}
 
-    template <typename DataIteratorT,
-	      typename KeysIteratorT>
-    void sum_rows_by_key_large_nkeys_colmajor(const DataIteratorT d_A,
-					      int lda, 
-					      KeysIteratorT d_keys,
-					      int nrows,
-					      int ncols,
-					      int key_offset, 
-					      int nkeys,
-					      DataIteratorT d_sums,
-					      cudaStream_t st) {
-      dim3 grid,block;
-      block.x = SUM_ROWS_SMALL_K_DIMX;
-      block.y = 1; // Necessary
+template <typename DataIteratorT,
+	  typename KeysIteratorT>
+void sum_rows_by_key_large_nkeys_colmajor(const DataIteratorT d_A,
+					  int lda, 
+					  KeysIteratorT d_keys,
+					  int nrows,
+					  int ncols,
+					  int key_offset, 
+					  int nkeys,
+					  DataIteratorT d_sums,
+					  cudaStream_t st) {
+  dim3 grid,block;
+  block.x = SUM_ROWS_SMALL_K_DIMX;
+  block.y = 1; // Necessary
 
-      grid.x = (nrows + block.x -1) / grid.x;
-      grid.x = std::min(grid.x, 32u);
-      grid.y = ncols; 
-      grid.y = std::min(grid.y, MAX_BLOCKS);
-      sum_rows_by_key_large_nkeys_kernel_colmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
-    }
+  grid.x = (nrows + block.x -1) / grid.x;
+  grid.x = std::min(grid.x, 32u);
+  grid.y = ncols; 
+  grid.y = std::min(grid.y, MAX_BLOCKS);
+  sum_rows_by_key_large_nkeys_kernel_colmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
+}
 
 #define RRBK_SHMEM_SZ 32
-    //#define RRBK_SHMEM
-    template <typename DataIteratorT,
-	      typename KeysIteratorT>
-    __global__ void sum_rows_by_key_large_nkeys_kernel_rowmajor(const DataIteratorT d_A,
-								int lda,
-								KeysIteratorT d_keys,
-								int nrows,
-								int ncols,
-								int key_offset,
-								int nkeys,
-								DataIteratorT d_sums) {
-      typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
-      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+//#define RRBK_SHMEM
+template <typename DataIteratorT,
+	  typename KeysIteratorT>
+__global__ void sum_rows_by_key_large_nkeys_kernel_rowmajor(const DataIteratorT d_A,
+							    int lda,
+							    KeysIteratorT d_keys,
+							    int nrows,
+							    int ncols,
+							    int key_offset,
+							    int nkeys,
+							    DataIteratorT d_sums) {
+  typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
+  typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
 
 #ifdef RRBK_SHMEM
-      __shared__ KeyType sh_keys[RRBK_SHMEM_SZ];
+  __shared__ KeyType sh_keys[RRBK_SHMEM_SZ];
 #endif
-      int rows_per_partition = nrows/gridDim.z+1;
-      int start_row = blockIdx.z*rows_per_partition;
-      int end_row = start_row + rows_per_partition;
-      end_row = end_row > nrows ? nrows : end_row;
+  int rows_per_partition = nrows/gridDim.z+1;
+  int start_row = blockIdx.z*rows_per_partition;
+  int end_row = start_row + rows_per_partition;
+  end_row = end_row > nrows ? nrows : end_row;
 
-      KeyType this_key = blockIdx.y;
-      if (this_key >= nkeys) return;
-      int this_col = threadIdx.x + blockIdx.x*blockDim.x;
-      if (this_col >= ncols) return;
+  KeyType this_key = blockIdx.y;
+  if (this_key >= nkeys) return;
+  int this_col = threadIdx.x + blockIdx.x*blockDim.x;
+  if (this_col >= ncols) return;
         
-      DataType sum = 0.0;
+  DataType sum = 0.0;
 
 #ifdef RRBK_SHMEM
-      int sh_key_inx = 0;
+  int sh_key_inx = 0;
 #endif
-      for (int r = start_row; r < end_row; r++) {
+  for (int r = start_row; r < end_row; r++) {
 #ifdef RRBK_SHMEM
-	if (0 == sh_key_inx%RRBK_SHMEM_SZ) {
-	  for (int x=threadIdx.x;x<RRBK_SHMEM_SZ;x+=blockDim.x)
-	    sh_keys[x] = d_keys[r+x];
-	  __syncthreads();
-	}
-	if (sh_keys[sh_key_inx] != this_key) continue; //No divergence since this_key is the
-	// same for the whole block
-	sh_key_inx++;
+    if (0 == sh_key_inx%RRBK_SHMEM_SZ) {
+      for (int x=threadIdx.x;x<RRBK_SHMEM_SZ;x+=blockDim.x)
+	sh_keys[x] = d_keys[r+x];
+      __syncthreads();
+    }
+    if (sh_keys[sh_key_inx] != this_key) continue; //No divergence since this_key is the
+    // same for the whole block
+    sh_key_inx++;
 #else
-	if (d_keys[r] != this_key) continue; //No divergence since this_key is the
-	// same for the whole block
+    if (d_keys[r] != this_key) continue; //No divergence since this_key is the
+    // same for the whole block
 #endif
-	//if ((end_row-start_row) / (r-start_row) != this_key) continue;
-	sum += __ldcg(&d_A[r*lda+this_col]);
-      }
+    //if ((end_row-start_row) / (r-start_row) != this_key) continue;
+    sum += __ldcg(&d_A[r*lda+this_col]);
+  }
         
-      if (sum != 0.0) myAtomicAdd(&d_sums[this_key*ncols+this_col], sum);
-    }
+  if (sum != 0.0) myAtomicAdd(&d_sums[this_key*ncols+this_col], sum);
+}
 
-    template <typename DataIteratorT,
-	      typename KeysIteratorT>
-    void sum_rows_by_key_large_nkeys_rowmajor( const DataIteratorT d_A,
-					       int lda, 
-					       KeysIteratorT d_keys,
-					       int nrows,
-					       int ncols,
-					       int key_offset, 
-					       int nkeys,
-					       DataIteratorT d_sums,
-					       cudaStream_t st)  {
-      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+template <typename DataIteratorT,
+	  typename KeysIteratorT>
+void sum_rows_by_key_large_nkeys_rowmajor( const DataIteratorT d_A,
+					   int lda, 
+					   KeysIteratorT d_keys,
+					   int nrows,
+					   int ncols,
+					   int key_offset, 
+					   int nkeys,
+					   DataIteratorT d_sums,
+					   cudaStream_t st)  {
+  typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
 
-      // x-dim refers to the column in the input data
-      // y-dim refers to the key
-      // z-dim refers to a partitioning of the rows among the threadblocks
-      dim3 grid, block;
-      block.x = 256; //Adjust me!
-      block.y = 1; //Don't adjust me!
-      grid.x = (ncols+block.x-1)/block.x;
-      grid.y = nkeys;
-      grid.z = std::max(40960000/nkeys/ncols, (int)1); //Adjust me!
-      grid.z = std::min(grid.z, (unsigned int)nrows);
-      grid.z = std::min(grid.z, MAX_BLOCKS);
-      //std::cout << "block = " << block.x << ", " << block.y << std::endl;
-      //std::cout << "grid = " << grid.x << ", " << grid.y << ", " << grid.z << std::endl;
-      cudaMemset(d_sums, 0, sizeof(DataType)*nkeys*ncols);
-      sum_rows_by_key_large_nkeys_kernel_rowmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
-    }
+  // x-dim refers to the column in the input data
+  // y-dim refers to the key
+  // z-dim refers to a partitioning of the rows among the threadblocks
+  dim3 grid, block;
+  block.x = 256; //Adjust me!
+  block.y = 1; //Don't adjust me!
+  grid.x = (ncols+block.x-1)/block.x;
+  grid.y = nkeys;
+  grid.z = std::max(40960000/nkeys/ncols, (int)1); //Adjust me!
+  grid.z = std::min(grid.z, (unsigned int)nrows);
+  grid.z = std::min(grid.z, MAX_BLOCKS);
+  //std::cout << "block = " << block.x << ", " << block.y << std::endl;
+  //std::cout << "grid = " << grid.x << ", " << grid.y << ", " << grid.z << std::endl;
+  cudaMemset(d_sums, 0, sizeof(DataType)*nkeys*ncols);
+  sum_rows_by_key_large_nkeys_kernel_rowmajor<<<grid,block,0,st>>>(d_A, lda, d_keys, nrows, ncols, key_offset, nkeys, d_sums);   
+}
 
  
     
-    /**
-     * @brief Computes the reduction of matrix rows for each given key 
-     * @tparam DataIteratorT Random-access iterator type, for reading input matrix (may be a simple pointer type)
-     * @tparam KeysIteratorT Random-access iterator type, for reading input keys (may be a simple pointer type)
-     * @param[in]  d_A         Input data array (lda x nrows)
-     * @param[in]  lda         Real row size for input data, d_A
-     * @param[in]  d_keys      Keys for each row (1 x nrows)
-     * @param      d_keys_char Scratch memory for conversion of keys to char
-     * @param[in]  nrows       Number of rows in d_A and d_keys
-     * @param[in]  ncols       Number of data columns in d_A
-     * @param[in]  nkeys       Number of unique keys in d_keys 
-     * @param[out] d_sums      Row sums by key (ncols x d_keys)
-     * @param[in]  stream      CUDA stream
-     */
-    template <typename DataIteratorT,
-	      typename KeysIteratorT>
-    void reduce_rows_by_key(const DataIteratorT d_A,
-			    int lda,
-			    const KeysIteratorT d_keys, 
-			    char *d_keys_char,
-			    int nrows,
-			    int ncols,
-			    int nkeys, 
-			    DataIteratorT d_sums,
-			    cudaStream_t stream) {
-      typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
-      typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
+/**
+ * @brief Computes the reduction of matrix rows for each given key 
+ * @tparam DataIteratorT Random-access iterator type, for reading input matrix (may be a simple pointer type)
+ * @tparam KeysIteratorT Random-access iterator type, for reading input keys (may be a simple pointer type)
+ * @param[in]  d_A         Input data array (lda x nrows)
+ * @param[in]  lda         Real row size for input data, d_A
+ * @param[in]  d_keys      Keys for each row (1 x nrows)
+ * @param      d_keys_char Scratch memory for conversion of keys to char
+ * @param[in]  nrows       Number of rows in d_A and d_keys
+ * @param[in]  ncols       Number of data columns in d_A
+ * @param[in]  nkeys       Number of unique keys in d_keys 
+ * @param[out] d_sums      Row sums by key (ncols x d_keys)
+ * @param[in]  stream      CUDA stream
+ */
+template <typename DataIteratorT,
+	  typename KeysIteratorT>
+void reduce_rows_by_key(const DataIteratorT d_A,
+			int lda,
+			const KeysIteratorT d_keys, 
+			char *d_keys_char,
+			int nrows,
+			int ncols,
+			int nkeys, 
+			DataIteratorT d_sums,
+			cudaStream_t stream) {
+  typedef typename std::iterator_traits<KeysIteratorT>::value_type KeyType;
+  typedef typename std::iterator_traits<DataIteratorT>::value_type DataType;
       
-      // Following kernel needs memset
-      cudaMemsetAsync(d_sums, 0, ncols * nkeys * sizeof(DataType), stream);
+  // Following kernel needs memset
+  cudaMemsetAsync(d_sums, 0, ncols * nkeys * sizeof(DataType), stream);
    
 
-      if(nkeys <= SUM_ROWS_BY_KEY_SMALL_K_MAX_K) {
-        // sum_rows_by_key_small_k is BW bounded. d_keys is loaded ncols time - avoiding wasting BW
-        // with doubles we have ~20% speed up - with floats we can hope something around 2x
-        // Converting d_keys to char
-        convert_array(d_keys_char, d_keys, nrows, stream);
-        sum_rows_by_key_small_nkeys(d_A, lda, d_keys_char, nrows, ncols, nkeys, d_sums, stream);
-      } else {
-        for(KeyType key_offset = 0;
-	    key_offset < nkeys;
-	    key_offset += SUM_ROWS_BY_KEY_LARGE_K_MAX_K) {
-	  KeyType this_call_nkeys = std::min(SUM_ROWS_BY_KEY_LARGE_K_MAX_K, nkeys);
-	  sum_rows_by_key_large_nkeys_rowmajor(d_A, lda, d_keys, nrows, ncols, key_offset, this_call_nkeys, d_sums, stream);
-        }
-      }
-    
+  if(nkeys <= SUM_ROWS_BY_KEY_SMALL_K_MAX_K) {
+    // sum_rows_by_key_small_k is BW bounded. d_keys is loaded ncols time - avoiding wasting BW
+    // with doubles we have ~20% speed up - with floats we can hope something around 2x
+    // Converting d_keys to char
+    convert_array(d_keys_char, d_keys, nrows, stream);
+    sum_rows_by_key_small_nkeys(d_A, lda, d_keys_char, nrows, ncols, nkeys, d_sums, stream);
+  } else {
+    for(KeyType key_offset = 0;
+	key_offset < nkeys;
+	key_offset += SUM_ROWS_BY_KEY_LARGE_K_MAX_K) {
+      KeyType this_call_nkeys = std::min(SUM_ROWS_BY_KEY_LARGE_K_MAX_K, nkeys);
+      sum_rows_by_key_large_nkeys_rowmajor(d_A, lda, d_keys, nrows, ncols, key_offset, this_call_nkeys, d_sums, stream);
     }
+  }
+    
+}
 
-  }; // end namespace LinAlg
+}; // end namespace LinAlg
 }; // end namespace MLCommon

--- a/ml-prims/src/linalg/reduce_rows_by_key.h
+++ b/ml-prims/src/linalg/reduce_rows_by_key.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2019, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ml-prims/test/reduce_rows_by_key.cu
+++ b/ml-prims/test/reduce_rows_by_key.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2019, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This branch provides following changes to LinAlg::reduce_rows_by_key ml-prim - 
1) Changed template params to support random access iterator type or other fancy iterators (e.g. cub::TransformInputIterator). This functionality is useful when keys are non POD types.
2) `d_keys` must be const
3) Removed the second call to `convert_array` method - input keys must not be modified 
4) Bug fix, changed
` cudaMemsetAsync(d_sums, 0, ncols * nkeys * sizeof(int), stream);`
 to
 `cudaMemsetAsync(d_sums, 0, ncols * nkeys * sizeof(DataType), stream);`

Tagging @LeviBarnes and @teju85 for review.