### PR TITLE
[REVIEW] Fix for qn c++11 destructor warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,12 @@
 - PR #422: Issue in the PCA tests was solved and CI can run with driver 418
 - PR #409: Add entry to gitmodules to ignore build artifacts
 - PR #412: Fix for svdQR function in ml-prims
-- PR #438: Code that depended on FAISS was building everytime. 
+- PR #438: Code that depended on FAISS was building everytime.
 - PR #358: Fixed an issue when switching streams on MLCommon::device_buffer and MLCommon::host_buffer
 - PR #434: Fixing bug in CSR tests
 - PR #443: Remove defaults channel from ci scripts
 - PR #459: Fix for runtime library path of pip package
+- PR #464: Fix for C++11 destructor warning in qn
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/cuML/src/glm/qn/simple_mat.h
+++ b/cuML/src/glm/qn/simple_mat.h
@@ -303,7 +303,7 @@ template <typename T> struct SimpleVecOwning : SimpleVec<T> {
 
   SimpleVecOwning(int n) : Super(), allocated(false) { reset(n); }
 
-  ~SimpleVecOwning() { CUDA_CHECK(cudaFree(Super::data)); }
+  ~SimpleVecOwning() noexcept(false) { CUDA_CHECK(cudaFree(Super::data)); }
 
   void reset(int n) {
     if (allocated) {
@@ -332,7 +332,7 @@ template <typename T> struct SimpleMatOwning : SimpleMat<T> {
     reset(m, n);
   }
 
-  ~SimpleMatOwning() { CUDA_CHECK(cudaFree(Super::data)); }
+  ~SimpleMatOwning() noexcept(false) { CUDA_CHECK(cudaFree(Super::data)); }
   void reset(int m, int n) {
 
     if (allocated) {


### PR DESCRIPTION
While merging PR #405 didn't realize that there was a new warning being thrown. This PR adds `noexcept(false)` to remove the C++11 destructor warning that was being thrown. 

Warning for context: 

``` In instantiation of ‘ML::SimpleVecOwning<T>::~SimpleVecOwning() [with T = double]’:
/cuML/test/quasi_newton.cu:147:44:   required from here
/cuML/src/glm/qn/simple_mat.h:306:475: warning: throw will always call terminate() [-Wterminate]
   ~SimpleVecOwning() { CUDA_CHECK(cudaFree(Super::data)); }
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^
/cuML/src/glm/qn/simple_mat.h:306:475: note: in C++11 destructors default to noexcept```