### PR TITLE
column major support in LinAlg::*Norm methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #443: Remove defaults channel from ci scripts
 - PR #459: Fix for runtime library path of pip package
 - PR #464: Fix for C++11 destructor warning in qn
+- PR #466: Add support for column-major in LinAlg::*Norm methods
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/cuML/src/glm/preprocess.h
+++ b/cuML/src/glm/preprocess.h
@@ -49,8 +49,8 @@ void preProcessData(math_t *input, int n_rows, int n_cols, math_t *labels,
 		Stats::meanCenter(labels, labels, mu_labels, 1, n_rows, false, true);
 
 		if (normalize) {
-			LinAlg::colNorm(norm2_input, input, n_cols, n_rows, LinAlg::L2Norm,
-                    []__device__(math_t v){ return MLCommon::mySqrt(v); });
+			LinAlg::colNorm(norm2_input, input, n_cols, n_rows, LinAlg::L2Norm, false,
+                                        []__device__(math_t v){ return MLCommon::mySqrt(v); });
 			Matrix::matrixVectorBinaryDivSkipZero(input, norm2_input, n_rows, n_cols, false, true, true);
 		}
 	}

--- a/cuML/src/glm/preprocess.h
+++ b/cuML/src/glm/preprocess.h
@@ -34,7 +34,7 @@ template<typename math_t>
 void preProcessData(math_t *input, int n_rows, int n_cols, math_t *labels,
 		math_t *intercept, math_t *mu_input, math_t *mu_labels, math_t *norm2_input,
 		bool fit_intercept, bool normalize, cublasHandle_t cublas_handle,
-		cusolverDnHandle_t cusolver_handle) {
+                cusolverDnHandle_t cusolver_handle, cudaStream_t stream = 0) {
 
 	ASSERT(n_cols > 0,
 			"Parameter n_cols: number of columns cannot be less than one");
@@ -50,6 +50,7 @@ void preProcessData(math_t *input, int n_rows, int n_cols, math_t *labels,
 
 		if (normalize) {
 			LinAlg::colNorm(norm2_input, input, n_cols, n_rows, LinAlg::L2Norm, false,
+                                        stream,
                                         []__device__(math_t v){ return MLCommon::mySqrt(v); });
 			Matrix::matrixVectorBinaryDivSkipZero(input, norm2_input, n_rows, n_cols, false, true, true);
 		}

--- a/cuML/src/glm/qn/simple_mat.h
+++ b/cuML/src/glm/qn/simple_mat.h
@@ -246,7 +246,7 @@ inline T nrm2(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0) {
 template <typename T>
 inline T nrm1(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0){
   MLCommon::LinAlg::rowNorm(tmp_dev, u.data,  u.len, 1, MLCommon::LinAlg::L1Norm,
-                            MLCommon::Nop<T>(), stream);
+                            true, MLCommon::Nop<T>(), stream);
   T tmp_host;
   MLCommon::updateHost(&tmp_host, tmp_dev, 1);
   return tmp_host;

--- a/cuML/src/glm/qn/simple_mat.h
+++ b/cuML/src/glm/qn/simple_mat.h
@@ -246,7 +246,7 @@ inline T nrm2(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0) {
 template <typename T>
 inline T nrm1(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0){
   MLCommon::LinAlg::rowNorm(tmp_dev, u.data,  u.len, 1, MLCommon::LinAlg::L1Norm,
-                            stream);
+                            MLCommon::Nop<T>(), stream);
   T tmp_host;
   MLCommon::updateHost(&tmp_host, tmp_dev, 1);
   return tmp_host;

--- a/cuML/src/glm/qn/simple_mat.h
+++ b/cuML/src/glm/qn/simple_mat.h
@@ -246,7 +246,7 @@ inline T nrm2(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0) {
 template <typename T>
 inline T nrm1(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0){
   MLCommon::LinAlg::rowNorm(tmp_dev, u.data,  u.len, 1, MLCommon::LinAlg::L1Norm,
-                            true, MLCommon::Nop<T>(), stream);
+                            true, stream, MLCommon::Nop<T>());
   T tmp_host;
   MLCommon::updateHost(&tmp_host, tmp_dev, 1);
   return tmp_host;

--- a/ml-prims/src/cuda_utils.h
+++ b/ml-prims/src/cuda_utils.h
@@ -324,13 +324,23 @@ HDI double myPow(double x, double power) {
 /** @} */
 
 /**
- * @defgroup Pow Power function
+ * @defgroup LambdaOps Lambda operations in reduction kernels
  * @{
  */
 // IdxType mostly to be used for MainLambda in *Reduction kernels
 template <typename Type, typename IdxType = int>
 struct Nop {
   HDI Type operator()(Type in, IdxType i = 0) { return in; }
+};
+
+template <typename Type, typename IdxType = int>
+struct L1Op {
+  HDI Type operator()(Type in, IdxType i = 0) { return myAbs(in); }
+};
+
+template <typename Type, typename IdxType = int>
+struct L2Op {
+  HDI Type operator()(Type in, IdxType i = 0) { return in * in; }
 };
 
 template <typename Type>

--- a/ml-prims/src/distance/algo1.h
+++ b/ml-prims/src/distance/algo1.h
@@ -82,10 +82,10 @@ void distanceAlgo1(int m, int n, int k, InType const *pA, InType const *pB,
   InType *row_vec = workspace;
   if (pA != pB) {
     row_vec += m;
-    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, norm_op, stream);
-    LinAlg::rowNorm(row_vec, pB, k, n, LinAlg::L2Norm, norm_op, stream);
+    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, true, norm_op, stream);
+    LinAlg::rowNorm(row_vec, pB, k, n, LinAlg::L2Norm, true, norm_op, stream);
   } else {
-    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, norm_op, stream);
+    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, true, norm_op, stream);
   }
 
   typedef typename cutlass::Shape<8, 8, 8> AccumulatorsPerThread_;

--- a/ml-prims/src/distance/algo1.h
+++ b/ml-prims/src/distance/algo1.h
@@ -82,10 +82,10 @@ void distanceAlgo1(int m, int n, int k, InType const *pA, InType const *pB,
   InType *row_vec = workspace;
   if (pA != pB) {
     row_vec += m;
-    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, true, norm_op, stream);
-    LinAlg::rowNorm(row_vec, pB, k, n, LinAlg::L2Norm, true, norm_op, stream);
+    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, true, stream, norm_op);
+    LinAlg::rowNorm(row_vec, pB, k, n, LinAlg::L2Norm, true, stream, norm_op);
   } else {
-    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, true, norm_op, stream);
+    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, true, stream, norm_op);
   }
 
   typedef typename cutlass::Shape<8, 8, 8> AccumulatorsPerThread_;

--- a/ml-prims/src/functions/penalty.h
+++ b/ml-prims/src/functions/penalty.h
@@ -36,9 +36,9 @@ enum penalty{
 
 template<typename math_t>
 void lasso(math_t *out, const math_t *coef, const int len,
-		const math_t alpha) {
-    LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L1Norm, true);
-    LinAlg::scalarMultiply(out, out, alpha, 1);
+           const math_t alpha, cudaStream_t stream = 0) {
+    LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L1Norm, true, stream);
+    LinAlg::scalarMultiply(out, out, alpha, 1, stream);
 }
 
 template<typename math_t>
@@ -50,9 +50,9 @@ void lassoGrad(math_t *grad, const math_t *coef, const int len,
 
 template<typename math_t>
 void ridge(math_t *out, const math_t *coef, const int len,
-		const math_t alpha) {
-    LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L2Norm, true);
-    LinAlg::scalarMultiply(out, out, alpha, 1);
+           const math_t alpha, cudaStream_t stream = 0) {
+    LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L2Norm, true, stream);
+    LinAlg::scalarMultiply(out, out, alpha, 1, stream);
 }
 
 template<typename math_t>

--- a/ml-prims/src/functions/penalty.h
+++ b/ml-prims/src/functions/penalty.h
@@ -37,9 +37,8 @@ enum penalty{
 template<typename math_t>
 void lasso(math_t *out, const math_t *coef, const int len,
 		const math_t alpha) {
-
-	LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L1Norm);
-	LinAlg::scalarMultiply(out, out, alpha, 1);
+    LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L1Norm, true);
+    LinAlg::scalarMultiply(out, out, alpha, 1);
 }
 
 template<typename math_t>
@@ -52,10 +51,8 @@ void lassoGrad(math_t *grad, const math_t *coef, const int len,
 template<typename math_t>
 void ridge(math_t *out, const math_t *coef, const int len,
 		const math_t alpha) {
-
-	LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L2Norm);
-	LinAlg::scalarMultiply(out, out, alpha, 1);
-
+    LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L2Norm, true);
+    LinAlg::scalarMultiply(out, out, alpha, 1);
 }
 
 template<typename math_t>

--- a/ml-prims/src/linalg/norm.h
+++ b/ml-prims/src/linalg/norm.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include "linalg/coalesced_reduction.h"
-#include "linalg/strided_reduction.h"
+#include "linalg/reduce.h"
 
 
 namespace MLCommon {
@@ -48,15 +47,16 @@ enum NormType { L1Norm = 0, L2Norm };
  */
 template <typename Type, typename Lambda = Nop<Type>>
 void rowNorm(Type *dots, const Type *data, int D, int N, NormType type,
-             Lambda fin_op = Nop<Type>(), cudaStream_t stream = 0) {
+             bool rowMajor, Lambda fin_op = Nop<Type>(),
+             cudaStream_t stream = 0) {
   switch (type) {
     case L1Norm:
-      LinAlg::coalescedReduction(dots, data, D, N, (Type)0, false, stream,
-                                 L1Op<Type>(), Sum<Type>(), fin_op);
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, false, stream,
+                     L1Op<Type>(), Sum<Type>(), fin_op);
       break;
     case L2Norm:
-      LinAlg::coalescedReduction(dots, data, D, N, (Type)0, false, stream,
-                                 L2Op<Type>(), Sum<Type>(), fin_op);
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, false, stream,
+                     L2Op<Type>(), Sum<Type>(), fin_op);
       break;
     default:
       ASSERT(false, "Invalid norm type passed! [%d]", type);
@@ -78,15 +78,16 @@ void rowNorm(Type *dots, const Type *data, int D, int N, NormType type,
  */
 template <typename Type, typename Lambda = Nop<Type>>
 void colNorm(Type *dots, const Type *data, int D, int N, NormType type,
-             Lambda fin_op = Nop<Type>(), cudaStream_t stream = 0) {
+             bool rowMajor, Lambda fin_op = Nop<Type>(),
+             cudaStream_t stream = 0) {
   switch (type) {
     case L1Norm:
-      LinAlg::stridedReduction(dots, data, D, N, (Type)0, false, stream,
-                               L1Op<Type>(), Sum<Type>(), fin_op);
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, false, stream,
+                     L1Op<Type>(), Sum<Type>(), fin_op);
       break;
     case L2Norm:
-      LinAlg::stridedReduction(dots, data, D, N, (Type)0, false, stream,
-                               L2Op<Type>(), Sum<Type>(), fin_op);
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, false, stream,
+                     L2Op<Type>(), Sum<Type>(), fin_op);
       break;
     default:
       ASSERT(false, "Invalid norm type passed! [%d]", type);

--- a/ml-prims/src/linalg/norm.h
+++ b/ml-prims/src/linalg/norm.h
@@ -51,11 +51,11 @@ void rowNorm(Type *dots, const Type *data, int D, int N, NormType type,
              cudaStream_t stream = 0) {
   switch (type) {
     case L1Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, false, stream,
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
                      L1Op<Type>(), Sum<Type>(), fin_op);
       break;
     case L2Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, false, stream,
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
                      L2Op<Type>(), Sum<Type>(), fin_op);
       break;
     default:
@@ -82,11 +82,11 @@ void colNorm(Type *dots, const Type *data, int D, int N, NormType type,
              cudaStream_t stream = 0) {
   switch (type) {
     case L1Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, false, stream,
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
                      L1Op<Type>(), Sum<Type>(), fin_op);
       break;
     case L2Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, false, stream,
+      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
                      L2Op<Type>(), Sum<Type>(), fin_op);
       break;
     default:

--- a/ml-prims/src/linalg/reduce.h
+++ b/ml-prims/src/linalg/reduce.h
@@ -48,8 +48,8 @@ namespace LinAlg {
  * @param init initial value to use for the reduction
  * @param rowMajor input matrix is row-major or not
  * @param alongRows whether to reduce along rows or columns
- * @param inplace reduction result added inplace or overwrites old values?
  * @param stream cuda stream where to launch work
+ * @param inplace reduction result added inplace or overwrites old values?
  * @param main_op elementwise operation to apply before reduction
  * @param reduce_op binary reduction operation
  * @param final_op elementwise operation to apply before storing results
@@ -59,8 +59,8 @@ template <typename InType, typename OutType = InType, typename IdxType = int,
           typename ReduceLambda = Sum<OutType>,
           typename FinalLambda = Nop<OutType>>
 void reduce(OutType *dots, const InType *data, int D, int N, OutType init,
-            bool rowMajor, bool alongRows, bool inplace,
-            cudaStream_t stream,
+            bool rowMajor, bool alongRows, cudaStream_t stream,
+            bool inplace = false,
             MainLambda main_op = Nop<InType, IdxType>(),
             ReduceLambda reduce_op = Sum<OutType>(),
             FinalLambda final_op = Nop<OutType>()) {

--- a/ml-prims/src/linalg/reduce.h
+++ b/ml-prims/src/linalg/reduce.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cuda_utils.h"
+#include "coalesced_reduction.h"
+#include "strided_reduction.h"
+
+
+namespace MLCommon {
+namespace LinAlg {
+
+
+/**
+ * @brief Compute reduction of the input matrix along the requested dimension
+ *
+ * @tparam InType the data type of the input
+ * @tparam OutType the data type of the output (as well as the data type for
+ *  which reduction is performed)
+ * @tparam IdxType data type of the indices of the array
+ * @tparam MainLambda Unary lambda applied while acculumation (eg: L1 or L2 norm)
+ * It must be a 'callable' supporting the following input and output:
+ * <pre>OutType (*MainLambda)(InType, IdxType);</pre>
+ * @tparam ReduceLambda Binary lambda applied for reduction (eg: addition(+) for L2 norm)
+ * It must be a 'callable' supporting the following input and output:
+ * <pre>OutType (*ReduceLambda)(OutType);</pre>
+ * @tparam FinalLambda the final lambda applied before STG (eg: Sqrt for L2 norm)
+ * It must be a 'callable' supporting the following input and output:
+ * <pre>OutType (*FinalLambda)(OutType);</pre>
+ * @param dots the output reduction vector
+ * @param data the input matrix
+ * @param D number of columns
+ * @param N number of rows
+ * @param init initial value to use for the reduction
+ * @param rowMajor input matrix is row-major or not
+ * @param alongRows whether to reduce along rows or columns
+ * @param inplace reduction result added inplace or overwrites old values?
+ * @param stream cuda stream where to launch work
+ * @param main_op elementwise operation to apply before reduction
+ * @param reduce_op binary reduction operation
+ * @param final_op elementwise operation to apply before storing results
+ */
+template <typename InType, typename OutType = InType, typename IdxType = int,
+          typename MainLambda = Nop<InType, IdxType>,
+          typename ReduceLambda = Sum<OutType>,
+          typename FinalLambda = Nop<OutType>>
+void reduce(OutType *dots, const InType *data, int D, int N, OutType init,
+            bool rowMajor, bool alongRows, bool inplace = false,
+            cudaStream_t stream = 0,
+            MainLambda main_op = Nop<InType, IdxType>(),
+            ReduceLambda reduce_op = Sum<OutType>(),
+            FinalLambda final_op = Nop<OutType>()) {
+  if(rowMajor && alongRows) {
+    coalescedReduction(dots, data, D, N, init, inplace, stream,
+                       main_op, reduce_op, final_op);
+  } else if(rowMajor && !alongRows) {
+    stridedReduction(dots, data, D, N, init, inplace, stream,
+                     main_op, reduce_op, final_op);
+  } else if(!rowMajor && alongRows) {
+    stridedReduction(dots, data, N, D, init, inplace, stream,
+                     main_op, reduce_op, final_op);
+  } else {
+    coalescedReduction(dots, data, N, D, init, inplace, stream,
+                       main_op, reduce_op, final_op);
+  }
+}
+
+
+}; // end namespace LinAlg
+}; // end namespace MLCommon

--- a/ml-prims/src/linalg/reduce.h
+++ b/ml-prims/src/linalg/reduce.h
@@ -59,8 +59,8 @@ template <typename InType, typename OutType = InType, typename IdxType = int,
           typename ReduceLambda = Sum<OutType>,
           typename FinalLambda = Nop<OutType>>
 void reduce(OutType *dots, const InType *data, int D, int N, OutType init,
-            bool rowMajor, bool alongRows, bool inplace = false,
-            cudaStream_t stream = 0,
+            bool rowMajor, bool alongRows, bool inplace,
+            cudaStream_t stream,
             MainLambda main_op = Nop<InType, IdxType>(),
             ReduceLambda reduce_op = Sum<OutType>(),
             FinalLambda final_op = Nop<OutType>()) {

--- a/ml-prims/test/CMakeLists.txt
+++ b/ml-prims/test/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(mlcommon_test
   norm.cu
   permute.cu
   power.cu
+  reduce.cu
   reduce_rows_by_key.cu
   rng.cu
   rng_int.cu

--- a/ml-prims/test/coalesced_reduction.cu
+++ b/ml-prims/test/coalesced_reduction.cu
@@ -60,12 +60,18 @@ protected:
     allocate(dots_exp, rows);
     allocate(dots_act, rows);
     r.uniform(data, len, T(-1.0), T(1.0));
-    naiveCoalescedReduction(dots_exp, data, cols, rows);
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    naiveCoalescedReduction(dots_exp, data, cols, rows, stream);
 
     // Perform reduction with default inplace = false first
     coalescedReductionLaunch(dots_act, data, cols, rows);
     // Add to result with inplace = true next
     coalescedReductionLaunch(dots_act, data, cols, rows, true);
+
+    CUDA_CHECK(cudaStreamDestroy(stream));
   }
 
   void TearDown() override {

--- a/ml-prims/test/norm.cu
+++ b/ml-prims/test/norm.cu
@@ -28,6 +28,7 @@ struct NormInputs {
   int rows, cols;
   NormType type;
   bool do_sqrt;
+  bool rowMajor;
   unsigned long long int seed;
 };
 
@@ -43,7 +44,7 @@ template <typename T>
 ///// Row-wise norm test definitions
 template <typename Type>
 __global__ void naiveRowNormKernel(Type *dots, const Type *data, int D, int N,
-                                NormType type, bool do_sqrt) {
+                                   NormType type, bool do_sqrt) {
   Type acc = (Type)0;
   int rowStart = threadIdx.x + blockIdx.x * blockDim.x;
   if (rowStart < N) {
@@ -81,9 +82,9 @@ public:
     naiveRowNorm(dots_exp, data, cols, rows, params.type, params.do_sqrt);
     if (params.do_sqrt) {
       auto fin_op = [] __device__(T in) { return mySqrt(in); };
-      rowNorm(dots_act, data, cols, rows, params.type, fin_op);
+      rowNorm(dots_act, data, cols, rows, params.type, params.rowMajor, fin_op);
     } else {
-      rowNorm(dots_act, data, cols, rows, params.type);
+      rowNorm(dots_act, data, cols, rows, params.type, params.rowMajor);
     }
   }
 
@@ -140,9 +141,9 @@ public:
     naiveColNorm(dots_exp, data, cols, rows, params.type, params.do_sqrt);
     if(params.do_sqrt){
       auto fin_op = [] __device__(T in) { return mySqrt(in); };
-      colNorm(dots_act, data, cols, rows, params.type, fin_op);
+      colNorm(dots_act, data, cols, rows, params.type, params.rowMajor, fin_op);
     }else{
-      colNorm(dots_act, data, cols, rows, params.type);
+      colNorm(dots_act, data, cols, rows, params.type, params.rowMajor);
     }
   }
 
@@ -161,44 +162,42 @@ protected:
 
 ///// Row- and column-wise tests
 const std::vector<NormInputs<float>> inputsf = {
-  {0.00001f, 1024, 32, L1Norm, false, 1234ULL},
-  {0.00001f, 1024, 64, L1Norm, false, 1234ULL},
-  {0.00001f, 1024, 128, L1Norm, false, 1234ULL},
-  {0.00001f, 1024, 256, L1Norm, false, 1234ULL},
-  {0.00001f, 1024, 32, L2Norm, false, 1234ULL},
-  {0.00001f, 1024, 64, L2Norm, false, 1234ULL},
-  {0.00001f, 1024, 128, L2Norm, false, 1234ULL},
-  {0.00001f, 1024, 256, L2Norm, false, 1234ULL},
+  {0.00001f, 1024, 32, L1Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 64, L1Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 128, L1Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 256, L1Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 32, L2Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 64, L2Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 128, L2Norm, false, true, 1234ULL},
+  {0.00001f, 1024, 256, L2Norm, false, true, 1234ULL},
 
-  {0.00001f, 1024, 32, L1Norm, true, 1234ULL},
-  {0.00001f, 1024, 64, L1Norm, true, 1234ULL},
-  {0.00001f, 1024, 128, L1Norm, true, 1234ULL},
-  {0.00001f, 1024, 256, L1Norm, true, 1234ULL},
-  {0.00001f, 1024, 32, L2Norm, true, 1234ULL},
-  {0.00001f, 1024, 64, L2Norm, true, 1234ULL},
-  {0.00001f, 1024, 128, L2Norm, true, 1234ULL},
-  {0.00001f, 1024, 256, L2Norm, true, 1234ULL}
-};
+  {0.00001f, 1024, 32, L1Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 64, L1Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 128, L1Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 256, L1Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 32, L2Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 64, L2Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 128, L2Norm, true, true, 1234ULL},
+  {0.00001f, 1024, 256, L2Norm, true, true, 1234ULL}};
 
 const std::vector<NormInputs<double>> inputsd = {
-  {0.00000001, 1024, 32, L1Norm, false, 1234ULL},
-  {0.00000001, 1024, 64, L1Norm, false, 1234ULL},
-  {0.00000001, 1024, 128, L1Norm, false, 1234ULL},
-  {0.00000001, 1024, 256, L1Norm, false, 1234ULL},
-  {0.00000001, 1024, 32, L2Norm, false, 1234ULL},
-  {0.00000001, 1024, 64, L2Norm, false, 1234ULL},
-  {0.00000001, 1024, 128, L2Norm, false, 1234ULL},
-  {0.00000001, 1024, 256, L2Norm, false, 1234ULL},
+  {0.00000001, 1024, 32, L1Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 64, L1Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 128, L1Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 256, L1Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 32, L2Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 64, L2Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 128, L2Norm, false, true, 1234ULL},
+  {0.00000001, 1024, 256, L2Norm, false, true, 1234ULL},
 
-  {0.00000001, 1024, 32, L1Norm, true, 1234ULL},
-  {0.00000001, 1024, 64, L1Norm, true, 1234ULL},
-  {0.00000001, 1024, 128, L1Norm, true, 1234ULL},
-  {0.00000001, 1024, 256, L1Norm, true, 1234ULL},
-  {0.00000001, 1024, 32, L2Norm, true, 1234ULL},
-  {0.00000001, 1024, 64, L2Norm, true, 1234ULL},
-  {0.00000001, 1024, 128, L2Norm, true, 1234ULL},
-  {0.00000001, 1024, 256, L2Norm, true, 1234ULL}
-};
+  {0.00000001, 1024, 32, L1Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 64, L1Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 128, L1Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 256, L1Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 32, L2Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 64, L2Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 128, L2Norm, true, true, 1234ULL},
+  {0.00000001, 1024, 256, L2Norm, true, true, 1234ULL}};
 
 typedef RowNormTest<float> RowNormTestF;
 TEST_P(RowNormTestF, Result) {
@@ -218,44 +217,42 @@ INSTANTIATE_TEST_CASE_P(RowNormTests, RowNormTestD, ::testing::ValuesIn(inputsd)
 
 
 const std::vector<NormInputs<float>> inputscf = {
-  {0.00001f, 32,  1024, L1Norm, false, 1234ULL},
-  {0.00001f, 64,  1024, L1Norm, false, 1234ULL},
-  {0.00001f, 128, 1024, L1Norm, false, 1234ULL},
-  {0.00001f, 256, 1024, L1Norm, false, 1234ULL},
-  {0.00001f, 32,  1024, L2Norm, false, 1234ULL},
-  {0.00001f, 64,  1024, L2Norm, false, 1234ULL},
-  {0.00001f, 128, 1024, L2Norm, false, 1234ULL},
-  {0.00001f, 256, 1024, L2Norm, false, 1234ULL},
+  {0.00001f, 32,  1024, L1Norm, false, true, 1234ULL},
+  {0.00001f, 64,  1024, L1Norm, false, true, 1234ULL},
+  {0.00001f, 128, 1024, L1Norm, false, true, 1234ULL},
+  {0.00001f, 256, 1024, L1Norm, false, true, 1234ULL},
+  {0.00001f, 32,  1024, L2Norm, false, true, 1234ULL},
+  {0.00001f, 64,  1024, L2Norm, false, true, 1234ULL},
+  {0.00001f, 128, 1024, L2Norm, false, true, 1234ULL},
+  {0.00001f, 256, 1024, L2Norm, false, true, 1234ULL},
 
-  {0.00001f, 32,  1024, L1Norm, true, 1234ULL},
-  {0.00001f, 64,  1024, L1Norm, true, 1234ULL},
-  {0.00001f, 128, 1024, L1Norm, true, 1234ULL},
-  {0.00001f, 256, 1024, L1Norm, true, 1234ULL},
-  {0.00001f, 32,  1024, L2Norm, true, 1234ULL},
-  {0.00001f, 64,  1024, L2Norm, true, 1234ULL},
-  {0.00001f, 128, 1024, L2Norm, true, 1234ULL},
-  {0.00001f, 256, 1024, L2Norm, true, 1234ULL}
-};
+  {0.00001f, 32,  1024, L1Norm, true, true, 1234ULL},
+  {0.00001f, 64,  1024, L1Norm, true, true, 1234ULL},
+  {0.00001f, 128, 1024, L1Norm, true, true, 1234ULL},
+  {0.00001f, 256, 1024, L1Norm, true, true, 1234ULL},
+  {0.00001f, 32,  1024, L2Norm, true, true, 1234ULL},
+  {0.00001f, 64,  1024, L2Norm, true, true, 1234ULL},
+  {0.00001f, 128, 1024, L2Norm, true, true, 1234ULL},
+  {0.00001f, 256, 1024, L2Norm, true, true, 1234ULL}};
 
 const std::vector<NormInputs<double>> inputscd = {
-  {0.00000001, 32,  1024, L1Norm, false, 1234ULL},
-  {0.00000001, 64,  1024, L1Norm, false, 1234ULL},
-  {0.00000001, 128, 1024, L1Norm, false, 1234ULL},
-  {0.00000001, 256, 1024, L1Norm, false, 1234ULL},
-  {0.00000001, 32,  1024, L2Norm, false, 1234ULL},
-  {0.00000001, 64,  1024, L2Norm, false, 1234ULL},
-  {0.00000001, 128, 1024, L2Norm, false, 1234ULL},
-  {0.00000001, 256, 1024, L2Norm, false, 1234ULL},
+  {0.00000001, 32,  1024, L1Norm, false, true, 1234ULL},
+  {0.00000001, 64,  1024, L1Norm, false, true, 1234ULL},
+  {0.00000001, 128, 1024, L1Norm, false, true, 1234ULL},
+  {0.00000001, 256, 1024, L1Norm, false, true, 1234ULL},
+  {0.00000001, 32,  1024, L2Norm, false, true, 1234ULL},
+  {0.00000001, 64,  1024, L2Norm, false, true, 1234ULL},
+  {0.00000001, 128, 1024, L2Norm, false, true, 1234ULL},
+  {0.00000001, 256, 1024, L2Norm, false, true, 1234ULL},
 
-  {0.00000001, 32,  1024, L1Norm, true, 1234ULL},
-  {0.00000001, 64,  1024, L1Norm, true, 1234ULL},
-  {0.00000001, 128, 1024, L1Norm, true, 1234ULL},
-  {0.00000001, 256, 1024, L1Norm, true, 1234ULL},
-  {0.00000001, 32,  1024, L2Norm, true, 1234ULL},
-  {0.00000001, 64,  1024, L2Norm, true, 1234ULL},
-  {0.00000001, 128, 1024, L2Norm, true, 1234ULL},
-  {0.00000001, 256, 1024, L2Norm, true, 1234ULL}
-};
+  {0.00000001, 32,  1024, L1Norm, true, true, 1234ULL},
+  {0.00000001, 64,  1024, L1Norm, true, true, 1234ULL},
+  {0.00000001, 128, 1024, L1Norm, true, true, 1234ULL},
+  {0.00000001, 256, 1024, L1Norm, true, true, 1234ULL},
+  {0.00000001, 32,  1024, L2Norm, true, true, 1234ULL},
+  {0.00000001, 64,  1024, L2Norm, true, true, 1234ULL},
+  {0.00000001, 128, 1024, L2Norm, true, true, 1234ULL},
+  {0.00000001, 256, 1024, L2Norm, true, true, 1234ULL}};
 
 typedef ColNormTest<float> ColNormTestF;
 TEST_P(ColNormTestF, Result) {

--- a/ml-prims/test/reduce.cu
+++ b/ml-prims/test/reduce.cu
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "cuda_utils.h"
+#include "reduce.h"
+#include "linalg/reduce.h"
+#include "random/rng.h"
+#include "test_utils.h"
+
+
+namespace MLCommon {
+namespace LinAlg {
+
+template <typename T>
+struct ReduceInputs {
+  T tolerance;
+  int rows, cols;
+  bool rowMajor, alongRows;
+  unsigned long long int seed;
+};
+
+template <typename T>
+::std::ostream &operator<<(::std::ostream &os, const ReduceInputs<T> &dims) {
+  return os;
+}
+
+// Or else, we get the following compilation error
+// for an extended __device__ lambda cannot have private or protected access
+// within its class
+template <typename T>
+void reduceLaunch(T *dots, const T *data, int cols, int rows, bool rowMajor,
+                  bool alongRows, bool inplace) {
+  reduce(dots, data, cols, rows, (T)0, rowMajor, alongRows, inplace, 0,
+         [] __device__(T in, int i) { return in * in; });
+}
+
+template <typename T>
+class ReduceTest : public ::testing::TestWithParam<ReduceInputs<T>> {
+protected:
+  void SetUp() override {
+    params = ::testing::TestWithParam<ReduceInputs<T>>::GetParam();
+    Random::Rng r(params.seed);
+    int rows = params.rows, cols = params.cols;
+    int len = rows * cols;
+    outlen = params.alongRows? rows : cols;
+    allocate(data, len);
+    allocate(dots_exp, outlen);
+    allocate(dots_act, outlen);
+    r.uniform(data, len, T(-1.0), T(1.0));
+    naiveReduction(dots_exp, data, cols, rows, params.rowMajor, params.alongRows);
+
+    // Perform reduction with default inplace = false first
+    reduceLaunch(dots_act, data, cols, rows, params.rowMajor, params.alongRows,
+                 false);
+    // Add to result with inplace = true next, which shouldn't affect
+    // in the case of coalescedReduction!
+    if(!(params.rowMajor ^ params.alongRows)) {
+      reduceLaunch(dots_act, data, cols, rows, params.rowMajor, params.alongRows,
+                   true);
+    }
+  }
+
+  void TearDown() override {
+    CUDA_CHECK(cudaFree(data));
+    CUDA_CHECK(cudaFree(dots_exp));
+    CUDA_CHECK(cudaFree(dots_act));
+  }
+
+protected:
+  ReduceInputs<T> params;
+  T *data, *dots_exp, *dots_act;
+  int outlen;
+};
+
+const std::vector<ReduceInputs<float>> inputsf = {
+  {0.000002f, 1024,  32, true, true, 1234ULL},
+  {0.000002f, 1024,  64, true, true, 1234ULL},
+  {0.000002f, 1024, 128, true, true, 1234ULL},
+  {0.000002f, 1024, 256, true, true, 1234ULL},
+  {0.000002f, 1024,  32, true, false, 1234ULL},
+  {0.000002f, 1024,  64, true, false, 1234ULL},
+  {0.000002f, 1024, 128, true, false, 1234ULL},
+  {0.000002f, 1024, 256, true, false, 1234ULL},
+  {0.000002f, 1024,  32, false, true, 1234ULL},
+  {0.000002f, 1024,  64, false, true, 1234ULL},
+  {0.000002f, 1024, 128, false, true, 1234ULL},
+  {0.000002f, 1024, 256, false, true, 1234ULL},
+  {0.000002f, 1024,  32, false, false, 1234ULL},
+  {0.000002f, 1024,  64, false, false, 1234ULL},
+  {0.000002f, 1024, 128, false, false, 1234ULL},
+  {0.000002f, 1024, 256, false, false, 1234ULL}};
+
+const std::vector<ReduceInputs<double>> inputsd = {
+  {0.000000001, 1024,  32, true, true, 1234ULL},
+  {0.000000001, 1024,  64, true, true, 1234ULL},
+  {0.000000001, 1024, 128, true, true, 1234ULL},
+  {0.000000001, 1024, 256, true, true, 1234ULL},
+  {0.000000001, 1024,  32, true, false, 1234ULL},
+  {0.000000001, 1024,  64, true, false, 1234ULL},
+  {0.000000001, 1024, 128, true, false, 1234ULL},
+  {0.000000001, 1024, 256, true, false, 1234ULL},
+  {0.000000001, 1024,  32, false, true, 1234ULL},
+  {0.000000001, 1024,  64, false, true, 1234ULL},
+  {0.000000001, 1024, 128, false, true, 1234ULL},
+  {0.000000001, 1024, 256, false, true, 1234ULL},
+  {0.000000001, 1024,  32, false, false, 1234ULL},
+  {0.000000001, 1024,  64, false, false, 1234ULL},
+  {0.000000001, 1024, 128, false, false, 1234ULL},
+  {0.000000001, 1024, 256, false, false, 1234ULL}};
+
+typedef ReduceTest<float> ReduceTestF;
+TEST_P(ReduceTestF, Result) {
+  ASSERT_TRUE(devArrMatch(dots_exp, dots_act, outlen,
+                          CompareApprox<float>(params.tolerance)));
+}
+
+typedef ReduceTest<double> ReduceTestD;
+TEST_P(ReduceTestD, Result) {
+  ASSERT_TRUE(devArrMatch(dots_exp, dots_act, outlen,
+                          CompareApprox<double>(params.tolerance)));
+}
+
+INSTANTIATE_TEST_CASE_P(ReduceTests, ReduceTestF, ::testing::ValuesIn(inputsf));
+
+INSTANTIATE_TEST_CASE_P(ReduceTests, ReduceTestD, ::testing::ValuesIn(inputsd));
+
+} // end namespace LinAlg
+} // end namespace MLCommon

--- a/ml-prims/test/reduce.cu
+++ b/ml-prims/test/reduce.cu
@@ -61,7 +61,7 @@ protected:
     allocate(data, len);
     allocate(dots_exp, outlen);
     allocate(dots_act, outlen);
-    r.uniform(data, len, T(-1.0), T(1.0));
+    r.uniform(data, len, T(-1.0), T(1.0), stream);
     naiveReduction(dots_exp, data, cols, rows, params.rowMajor, params.alongRows,
                    stream);
 

--- a/ml-prims/test/reduce.h
+++ b/ml-prims/test/reduce.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuda_utils.h"
+#include <thrust/device_vector.h>
+#include <cublas_v2.h>
+#include "linalg/unary_op.h"
+#include "linalg/cublas_wrappers.h"
+
+
+namespace MLCommon {
+namespace LinAlg {
+
+template <typename Type>
+__global__ void naiveCoalescedReductionKernel(Type *dots, const Type *data,
+                                              int D, int N) {
+  Type acc = (Type)0;
+  int rowStart = threadIdx.x + blockIdx.x * blockDim.x;
+  if (rowStart < N) {
+    for (int i = 0; i < D; ++i) {
+        acc += data[rowStart * D + i] * data[rowStart * D + i];
+    }
+    dots[rowStart] = 2*acc;
+  }
+}
+
+template <typename Type>
+void naiveCoalescedReduction(Type *dots, const Type *data, int D, int N) {
+  static const int TPB = 64;
+  int nblks = ceildiv(N, TPB);
+  naiveCoalescedReductionKernel<Type><<<nblks, TPB>>>(dots, data, D, N);
+  CUDA_CHECK(cudaPeekAtLastError());
+}
+
+
+template <typename Type>
+void unaryAndGemv(Type *dots, const Type *data, int D, int N){
+    //computes a MLCommon unary op on data (squares it), then computes Ax
+    //(A input matrix and x column vector) to sum columns
+    thrust::device_vector<Type> sq(D*N);
+    unaryOp(thrust::raw_pointer_cast(sq.data()), data, D*N,
+            [] __device__(Type v) { return v*v; });
+
+    cublasHandle_t handle;
+    CUBLAS_CHECK(cublasCreate(&handle));
+    thrust::device_vector<Type> ones(N, 1); //column vector [1...1]
+    Type alpha = 1, beta = 0;
+    CUBLAS_CHECK(cublasgemv(handle, CUBLAS_OP_N, D, N,
+                            &alpha, thrust::raw_pointer_cast(sq.data()), D,
+                            thrust::raw_pointer_cast(ones.data()), 1, &beta,
+                            dots, 1));
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUBLAS_CHECK(cublasDestroy(handle));
+}
+
+template <typename Type>
+void naiveReduction(Type *dots, const Type *data, int D, int N, bool rowMajor,
+                    bool alongRows) {
+  if(rowMajor && alongRows) {
+    naiveCoalescedReduction(dots, data, D, N);
+  } else if(rowMajor && !alongRows) {
+    unaryAndGemv(dots, data, D, N);
+  } else if(!rowMajor && alongRows) {
+    unaryAndGemv(dots, data, N, D);
+  } else {
+    naiveCoalescedReduction(dots, data, N, D);
+  }
+  CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+} // end namespace LinAlg
+} // end namespace MLCommon

--- a/ml-prims/test/reduce.h
+++ b/ml-prims/test/reduce.h
@@ -25,68 +25,58 @@ namespace LinAlg {
 
 template<typename Type>
 __global__ void naiveCoalescedReductionKernel(Type *dots, const Type *data,
-		int D, int N) {
-	Type acc = (Type) 0;
-	int rowStart = threadIdx.x + blockIdx.x * blockDim.x;
-	if (rowStart < N) {
-		for (int i = 0; i < D; ++i) {
-			acc += data[rowStart * D + i] * data[rowStart * D + i];
-		}
-		dots[rowStart] = 2 * acc;
-	}
+                                              int D, int N) {
+  Type acc = (Type) 0;
+  int rowStart = threadIdx.x + blockIdx.x * blockDim.x;
+  if (rowStart < N) {
+    for (int i = 0; i < D; ++i) {
+      acc += data[rowStart * D + i] * data[rowStart * D + i];
+    }
+    dots[rowStart] = 2 * acc;
+  }
 }
 
 template<typename Type>
 void naiveCoalescedReduction(Type *dots, const Type *data, int D, int N, cudaStream_t stream) {
-	static const int TPB = 64;
-	int nblks = ceildiv(N, TPB);
-	naiveCoalescedReductionKernel<Type> <<<nblks, TPB, 0, stream>>>(dots, data, D, N);
-	CUDA_CHECK(cudaPeekAtLastError());
+  static const int TPB = 64;
+  int nblks = ceildiv(N, TPB);
+  naiveCoalescedReductionKernel<Type> <<<nblks, TPB, 0, stream>>>(dots, data, D, N);
+  CUDA_CHECK(cudaPeekAtLastError());
 }
 
 template<typename Type>
-void unaryAndGemv(Type *dots, const Type *data, int D, int N) {
-	//computes a MLCommon unary op on data (squares it), then computes Ax
-	//(A input matrix and x column vector) to sum columns
-	thrust::device_vector<Type> sq(D * N);
-	unaryOp(thrust::raw_pointer_cast(sq.data()), data, D*N,
-			[] __device__(Type v) {return v*v;});
-
-	cublasHandle_t handle;
-	CUBLAS_CHECK(cublasCreate(&handle));
-	cudaStream_t stream;
-	CUDA_CHECK(cudaStreamCreate(&stream));
-
-	thrust::device_vector<Type> ones(N, 1); //column vector [1...1]
-	Type alpha = 1, beta = 0;
-	CUBLAS_CHECK(
-			cublasgemv(handle, CUBLAS_OP_N, D, N, &alpha,
-					thrust::raw_pointer_cast(sq.data()), D,
-					thrust::raw_pointer_cast(ones.data()), 1, &beta, dots, 1,
-					stream));
-	CUDA_CHECK(cudaDeviceSynchronize());
-	CUBLAS_CHECK(cublasDestroy(handle));
-	CUDA_CHECK(cudaStreamDestroy(stream));
+void unaryAndGemv(Type *dots, const Type *data, int D, int N, cudaStream_t stream) {
+  //computes a MLCommon unary op on data (squares it), then computes Ax
+  //(A input matrix and x column vector) to sum columns
+  thrust::device_vector<Type> sq(D * N);
+  unaryOp(thrust::raw_pointer_cast(sq.data()), data, D*N,
+          [] __device__(Type v) {return v*v;});
+  cublasHandle_t handle;
+  CUBLAS_CHECK(cublasCreate(&handle));
+  thrust::device_vector<Type> ones(N, 1); //column vector [1...1]
+  Type alpha = 1, beta = 0;
+  CUBLAS_CHECK(
+      cublasgemv(handle, CUBLAS_OP_N, D, N, &alpha,
+                 thrust::raw_pointer_cast(sq.data()), D,
+                 thrust::raw_pointer_cast(ones.data()), 1, &beta, dots, 1,
+                 stream));
+  CUDA_CHECK(cudaDeviceSynchronize());
+  CUBLAS_CHECK(cublasDestroy(handle));
 }
 
 template<typename Type>
 void naiveReduction(Type *dots, const Type *data, int D, int N, bool rowMajor,
-		bool alongRows) {
-
-	cudaStream_t stream;
-	CUDA_CHECK(cudaStreamCreate(&stream));
-
-	if (rowMajor && alongRows) {
-		naiveCoalescedReduction(dots, data, D, N, stream);
-	} else if (rowMajor && !alongRows) {
-		unaryAndGemv(dots, data, D, N);
-	} else if (!rowMajor && alongRows) {
-		unaryAndGemv(dots, data, N, D);
-	} else {
-		naiveCoalescedReduction(dots, data, N, D, stream);
-	}
-	CUDA_CHECK(cudaDeviceSynchronize());
-	CUDA_CHECK(cudaStreamDestroy(stream));
+                    bool alongRows, cudaStream_t stream) {
+  if (rowMajor && alongRows) {
+    naiveCoalescedReduction(dots, data, D, N, stream);
+  } else if (rowMajor && !alongRows) {
+    unaryAndGemv(dots, data, D, N, stream);
+  } else if (!rowMajor && alongRows) {
+    unaryAndGemv(dots, data, N, D, stream);
+  } else {
+    naiveCoalescedReduction(dots, data, N, D, stream);
+  }
+  CUDA_CHECK(cudaDeviceSynchronize());
 }
 
 } // end namespace LinAlg

--- a/ml-prims/test/reduce.h
+++ b/ml-prims/test/reduce.h
@@ -20,65 +20,73 @@
 #include "linalg/unary_op.h"
 #include "linalg/cublas_wrappers.h"
 
-
 namespace MLCommon {
 namespace LinAlg {
 
-template <typename Type>
+template<typename Type>
 __global__ void naiveCoalescedReductionKernel(Type *dots, const Type *data,
-                                              int D, int N) {
-  Type acc = (Type)0;
-  int rowStart = threadIdx.x + blockIdx.x * blockDim.x;
-  if (rowStart < N) {
-    for (int i = 0; i < D; ++i) {
-        acc += data[rowStart * D + i] * data[rowStart * D + i];
-    }
-    dots[rowStart] = 2*acc;
-  }
+		int D, int N) {
+	Type acc = (Type) 0;
+	int rowStart = threadIdx.x + blockIdx.x * blockDim.x;
+	if (rowStart < N) {
+		for (int i = 0; i < D; ++i) {
+			acc += data[rowStart * D + i] * data[rowStart * D + i];
+		}
+		dots[rowStart] = 2 * acc;
+	}
 }
 
-template <typename Type>
-void naiveCoalescedReduction(Type *dots, const Type *data, int D, int N) {
-  static const int TPB = 64;
-  int nblks = ceildiv(N, TPB);
-  naiveCoalescedReductionKernel<Type><<<nblks, TPB>>>(dots, data, D, N);
-  CUDA_CHECK(cudaPeekAtLastError());
+template<typename Type>
+void naiveCoalescedReduction(Type *dots, const Type *data, int D, int N, cudaStream_t stream) {
+	static const int TPB = 64;
+	int nblks = ceildiv(N, TPB);
+	naiveCoalescedReductionKernel<Type> <<<nblks, TPB, 0, stream>>>(dots, data, D, N);
+	CUDA_CHECK(cudaPeekAtLastError());
 }
 
+template<typename Type>
+void unaryAndGemv(Type *dots, const Type *data, int D, int N) {
+	//computes a MLCommon unary op on data (squares it), then computes Ax
+	//(A input matrix and x column vector) to sum columns
+	thrust::device_vector<Type> sq(D * N);
+	unaryOp(thrust::raw_pointer_cast(sq.data()), data, D*N,
+			[] __device__(Type v) {return v*v;});
 
-template <typename Type>
-void unaryAndGemv(Type *dots, const Type *data, int D, int N){
-    //computes a MLCommon unary op on data (squares it), then computes Ax
-    //(A input matrix and x column vector) to sum columns
-    thrust::device_vector<Type> sq(D*N);
-    unaryOp(thrust::raw_pointer_cast(sq.data()), data, D*N,
-            [] __device__(Type v) { return v*v; });
+	cublasHandle_t handle;
+	CUBLAS_CHECK(cublasCreate(&handle));
+	cudaStream_t stream;
+	CUDA_CHECK(cudaStreamCreate(&stream));
 
-    cublasHandle_t handle;
-    CUBLAS_CHECK(cublasCreate(&handle));
-    thrust::device_vector<Type> ones(N, 1); //column vector [1...1]
-    Type alpha = 1, beta = 0;
-    CUBLAS_CHECK(cublasgemv(handle, CUBLAS_OP_N, D, N,
-                            &alpha, thrust::raw_pointer_cast(sq.data()), D,
-                            thrust::raw_pointer_cast(ones.data()), 1, &beta,
-                            dots, 1));
-    CUDA_CHECK(cudaDeviceSynchronize());
-    CUBLAS_CHECK(cublasDestroy(handle));
+	thrust::device_vector<Type> ones(N, 1); //column vector [1...1]
+	Type alpha = 1, beta = 0;
+	CUBLAS_CHECK(
+			cublasgemv(handle, CUBLAS_OP_N, D, N, &alpha,
+					thrust::raw_pointer_cast(sq.data()), D,
+					thrust::raw_pointer_cast(ones.data()), 1, &beta, dots, 1,
+					stream));
+	CUDA_CHECK(cudaDeviceSynchronize());
+	CUBLAS_CHECK(cublasDestroy(handle));
+	CUDA_CHECK(cudaStreamDestroy(stream));
 }
 
-template <typename Type>
+template<typename Type>
 void naiveReduction(Type *dots, const Type *data, int D, int N, bool rowMajor,
-                    bool alongRows) {
-  if(rowMajor && alongRows) {
-    naiveCoalescedReduction(dots, data, D, N);
-  } else if(rowMajor && !alongRows) {
-    unaryAndGemv(dots, data, D, N);
-  } else if(!rowMajor && alongRows) {
-    unaryAndGemv(dots, data, N, D);
-  } else {
-    naiveCoalescedReduction(dots, data, N, D);
-  }
-  CUDA_CHECK(cudaDeviceSynchronize());
+		bool alongRows) {
+
+	cudaStream_t stream;
+	CUDA_CHECK(cudaStreamCreate(&stream));
+
+	if (rowMajor && alongRows) {
+		naiveCoalescedReduction(dots, data, D, N, stream);
+	} else if (rowMajor && !alongRows) {
+		unaryAndGemv(dots, data, D, N);
+	} else if (!rowMajor && alongRows) {
+		unaryAndGemv(dots, data, N, D);
+	} else {
+		naiveCoalescedReduction(dots, data, N, D, stream);
+	}
+	CUDA_CHECK(cudaDeviceSynchronize());
+	CUDA_CHECK(cudaStreamDestroy(stream));
 }
 
 } // end namespace LinAlg

--- a/ml-prims/test/strided_reduction.cu
+++ b/ml-prims/test/strided_reduction.cu
@@ -16,12 +16,9 @@
 
 #include <gtest/gtest.h>
 #include "linalg/strided_reduction.h"
-#include "linalg/unary_op.h"
+#include "reduce.h"
 #include "random/rng.h"
 #include "test_utils.h"
-
-#include <thrust/device_vector.h>
-#include <cublas_v2.h>
 
 namespace MLCommon {
 namespace LinAlg {
@@ -37,34 +34,6 @@ template <typename T>
 void stridedReductionLaunch(T *dots, const T *data, int cols, int rows) {
   stridedReduction(dots, data, cols, rows, (T)0, false, 0,
                    [] __device__(T in, int i) { return in * in; });
-}
-
-
-template <typename T, typename GEMV_t>
-void unaryAndGemv(T *dots, const T *data, int cols, int rows, GEMV_t gemv){
-    //computes a MLCommon unary op on data (squares it), then computes Ax
-    //(A input matrix and x column vector) to sum columns
-    thrust::device_vector<T> sq(cols*rows);
-    unaryOp(thrust::raw_pointer_cast(sq.data()), data, cols*rows,
-            [] __device__(T v) { return v*v; });
-
-    cublasHandle_t handle;
-    ASSERT_TRUE(cublasCreate(&handle) == CUBLAS_STATUS_SUCCESS);
-
-    thrust::device_vector<T> ones(rows, 1); //column vector [1...1]
-    T alpha = 1, beta = 0;
-    ASSERT_TRUE(gemv(handle, CUBLAS_OP_N, cols, rows,
-                &alpha, thrust::raw_pointer_cast(sq.data()), cols,
-                thrust::raw_pointer_cast(ones.data()), 1, &beta, 
-                dots, 1) == CUBLAS_STATUS_SUCCESS);
-}
-
-void unaryAndGemv(float *dots, const float *data, int cols, int rows){
-    unaryAndGemv(dots, data, cols, rows, cublasSgemv);
-}
-
-void unaryAndGemv(double *dots, const double *data, int cols, int rows){
-    unaryAndGemv(dots, data, cols, rows, cublasDgemv);
 }
 
 
@@ -102,23 +71,13 @@ const std::vector<stridedReductionInputs<float>> inputsf = {
   {0.00001f, 1024,  32, 1234ULL},
   {0.00001f, 1024,  64, 1234ULL},
   {0.00001f, 1024, 128, 1234ULL},
-  {0.00001f, 1024, 256, 1234ULL},
-  {0.00001f, 1024,  32, 1234ULL},
-  {0.00001f, 1024,  64, 1234ULL},
-  {0.00001f, 1024, 128, 1234ULL},
-  {0.00001f, 1024, 256, 1234ULL}
-};
+  {0.00001f, 1024, 256, 1234ULL}};
 
 const std::vector<stridedReductionInputs<double>> inputsd = {
   {0.000000001, 1024,  32, 1234ULL},
   {0.000000001, 1024,  64, 1234ULL},
   {0.000000001, 1024, 128, 1234ULL},
-  {0.000000001, 1024, 256, 1234ULL},
-  {0.000000001, 1024,  32, 1234ULL},
-  {0.000000001, 1024,  64, 1234ULL},
-  {0.000000001, 1024, 128, 1234ULL},
-  {0.000000001, 1024, 256, 1234ULL}
-};
+  {0.000000001, 1024, 256, 1234ULL}};
 
 typedef stridedReductionTest<float> stridedReductionTestF;
 TEST_P(stridedReductionTestF, Result) {


### PR DESCRIPTION
Title says it all! But to make this possible, this PR also does some minor cleanups as follows:
1. Introduce a `LinAlg::reduce` method, that wraps coalesced/stridedReduction methods underneath
2. Update `LinAlg::*Norm` methods to directly use this `reduce` method.
3. Finally expose the `rowMajor` flag that can then be called by other methods. For eg: in the `cuML/src/glm/preprocess.h`

Tagging @oyilmaz-nvidia since he needs this fix.