### PR TITLE
[REVIEW]  cumlHandle_t from a struct to an int handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Improvements
 
+- PR #467: Added validity check on cumlHandle_t
 - PR #440: README updates
 - PR #295: Improve build-time and the interface e.g., enable bool-OutType, for distance()
 - PR #390: Update docs version

--- a/cuML/src/common/cumlHandle.cpp
+++ b/cuML/src/common/cumlHandle.cpp
@@ -366,4 +366,85 @@ void cumlHandle_impl::destroyResources()
     }
 }
 
+HandleMap handleMap;
+
+std::pair<cumlHandle_t, cumlError_t> HandleMap::createAndInsertHandle()
+{
+    cumlError_t status = CUML_SUCCESS;
+	  cumlHandle_t chosen_handle;
+    try
+    {
+        auto handle_ptr = new ML::cumlHandle();
+        bool inserted;
+        {
+            std::lock_guard<std::mutex> guard(_mapMutex);
+            cumlHandle_t initial_next = _nextHandle;
+            do {
+                // try to insert using next free handle identifier
+                chosen_handle = _nextHandle;
+                inserted = _handleMap.insert({ chosen_handle, handle_ptr}).second;
+                _nextHandle += 1;
+            } while(!inserted && _nextHandle != initial_next);
+        }
+        if (!inserted) {
+            // no free handle identifier available
+            chosen_handle = INVALID_HANDLE;
+            status = CUML_ERROR_UNKNOWN;
+        }
+    }
+    //TODO: Implement this
+    //catch (const MLCommon::Exception& e)
+    //{
+    //    //log e.what()?
+    //    status =  e.getErrorCode();
+    //}
+    catch (...)
+    {
+        status = CUML_ERROR_UNKNOWN;
+        chosen_handle = CUML_ERROR_UNKNOWN;
+    }
+    return std::pair<cumlHandle_t, cumlError_t>(chosen_handle, status);
+}
+
+std::pair<cumlHandle*, cumlError_t> HandleMap::lookupHandlePointer(cumlHandle_t handle) const
+{
+    std::lock_guard<std::mutex> guard(_mapMutex);
+    auto it = _handleMap.find(handle);
+    if (it == _handleMap.end()) {
+        return std::pair<cumlHandle*, cumlError_t>(nullptr, CUML_INVALID_HANDLE);
+    } else {
+        return std::pair<cumlHandle*, cumlError_t>(it->second, CUML_SUCCESS);
+    }
+}
+
+cumlError_t HandleMap::removeAndDestroyHandle(cumlHandle_t handle)
+{
+    ML::cumlHandle *handle_ptr;
+    {
+        std::lock_guard<std::mutex> guard(_mapMutex);
+        auto it = _handleMap.find(handle);
+        if (it == _handleMap.end()) {
+            return CUML_INVALID_HANDLE;
+        }
+        handle_ptr = it->second;
+        _handleMap.erase(it);
+    }
+    cumlError_t status = CUML_SUCCESS;
+    try
+    {
+        delete handle_ptr;
+    }
+    //TODO: Implement this
+    //catch (const MLCommon::Exception& e)
+    //{
+    //    //log e.what()?
+    //    status =  e.getErrorCode();
+    //}
+    catch (...)
+    {
+        status = CUML_ERROR_UNKNOWN;
+    }
+    return status;
+}
+
 } // end namespace ML

--- a/cuML/src/common/cumlHandle.hpp
+++ b/cuML/src/common/cumlHandle.hpp
@@ -16,12 +16,16 @@
 
 #pragma once
 
+#include <mutex>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <cublas_v2.h>
 #include <cusolverDn.h>
 #include <cusparse.h>
 
+#include "../cuML_api.h"
 #include "../cuML.hpp"
 
 namespace ML {
@@ -67,6 +71,49 @@ private:
     void createResources();
     void destroyResources();
 };
+
+/**
+ * Map from integral cumlHandle_t identifiers to cumlHandle pointer protected
+ * by a mutex for thread-safe access.
+ */
+class HandleMap {
+public:
+    /**
+     * @brief Creates new handle object with associated handle ID and insert into map.
+     *
+     * @return std::pair with handle and error code. If error code is not CUML_SUCCESS
+     *                   the handle is INVALID_HANDLE.
+     */
+    std::pair<cumlHandle_t, cumlError_t> createAndInsertHandle();
+
+    /**
+     * @brief Lookup pointer to handle object for handle ID in map.
+     *
+     * @return std::pair with handle and error code. If error code is not CUML_SUCCESS
+     *                   the handle is INVALID_HANDLE. Error code CUML_INAVLID_HANDLE
+     *                   is returned if the provided `handle` is invald.
+     */
+    std::pair<cumlHandle*, cumlError_t> lookupHandlePointer(cumlHandle_t handle) const;
+
+    /**
+     * @brief Remove handle from map and destroy associated handle object.
+     *
+     * @return cumlError_t CUML_SUCCESS or CUML_INVALID_HANDLE.
+     *                   Error code CUML_INAVLID_HANDLE is returned if the provided
+     *                   `handle` is invald.
+     */
+    cumlError_t removeAndDestroyHandle(cumlHandle_t handle);
+
+    static const cumlHandle_t INVALID_HANDLE = -1;            //!< sentinel value for invalid ID
+
+private:
+    std::unordered_map<cumlHandle_t, cumlHandle*> _handleMap; //!< map from ID to pointer
+    mutable std::mutex _mapMutex;                             //!< mutex protecting the map
+    cumlHandle_t _nextHandle;                                 //!< value of next handle ID
+};
+
+/// Static handle map instance (see cumlHandle.cpp)
+extern HandleMap handleMap;
 
 namespace detail {
 

--- a/cuML/src/common/cuml_api.cpp
+++ b/cuML/src/common/cuml_api.cpp
@@ -16,8 +16,6 @@
 #include "cuML_api.h"
 
 #include <functional>
-#include <mutex>
-#include <unordered_map>
 
 #include "cumlHandle.hpp"
 

--- a/cuML/src/cuML_api.h
+++ b/cuML/src/cuML_api.h
@@ -24,12 +24,9 @@
 extern "C" {
 #endif
 
-typedef struct
-{
-    void* ptr;
-} cumlHandle_t;
+typedef int cumlHandle_t;
 
-enum cumlError_t { CUML_SUCCESS, CUML_ERROR_UNKOWN };
+enum cumlError_t { CUML_SUCCESS, CUML_ERROR_UNKNOWN, CUML_INVALID_HANDLE };
 
 typedef cudaError_t (*cuml_allocate)(void** p,size_t n, cudaStream_t stream);
 typedef cudaError_t (*cuml_deallocate)(void* p, size_t n, cudaStream_t stream);

--- a/cuML/src/dbscan/dbscan.cu
+++ b/cuML/src/dbscan/dbscan.cu
@@ -58,22 +58,24 @@ void dbscanFit(double *input, int n_rows, int n_cols, double eps, int min_pts,
 // end namespace ML
 extern "C" cumlError_t cumlSpDbscanFit(cumlHandle_t handle, float *input, int n_rows, int n_cols, float eps, int min_pts,
                int *labels) {
-
-    cumlError_t status = CUML_SUCCESS;
-    try
-    {
-        dbscanFit(*reinterpret_cast<ML::cumlHandle*>(handle.ptr), input,
-         n_rows, n_cols, eps, min_pts, labels);
-    }
-    //TODO: Implement this
-    //catch (const MLCommon::Exception& e)
-    //{
-    //    //log e.what()?
-    //    status =  e.getErrorCode();
-    //}
-    catch (...)
-    {
-        status = CUML_ERROR_UNKOWN;
+    cumlError_t status;
+    ML::cumlHandle *handle_ptr;
+    std::tie(handle_ptr, status) = ML::handleMap.lookupHandlePointer(handle);
+    if (status == CUML_SUCCESS) {
+        try
+        {
+            dbscanFit(*handle_ptr, input, n_rows, n_cols, eps, min_pts, labels);
+        }
+        //TODO: Implement this
+        //catch (const MLCommon::Exception& e)
+        //{
+        //    //log e.what()?
+        //    status =  e.getErrorCode();
+        //}
+        catch (...)
+        {
+            status = CUML_ERROR_UNKNOWN;
+        }
     }
     return status;
 
@@ -81,21 +83,24 @@ extern "C" cumlError_t cumlSpDbscanFit(cumlHandle_t handle, float *input, int n_
 
 extern "C" cumlError_t cumlDpDbscanFit(cumlHandle_t handle, double *input, int n_rows, int n_cols, double eps, int min_pts,
                int *labels) {
-    cumlError_t status = CUML_SUCCESS;
-    try
-    {
-        dbscanFit(*reinterpret_cast<ML::cumlHandle*>(handle.ptr), input,
-         n_rows, n_cols, eps, min_pts, labels);
-    }
-    //TODO: Implement this
-    //catch (const MLCommon::Exception& e)
-    //{
-    //    //log e.what()?
-    //    status =  e.getErrorCode();
-    //}
-    catch (...)
-    {
-        status = CUML_ERROR_UNKOWN;
+    cumlError_t status;
+    ML::cumlHandle *handle_ptr;
+    std::tie(handle_ptr, status) = ML::handleMap.lookupHandlePointer(handle);
+    if (status == CUML_SUCCESS) {
+        try
+        {
+            dbscanFit(*handle_ptr, input, n_rows, n_cols, eps, min_pts, labels);
+        }
+        //TODO: Implement this
+        //catch (const MLCommon::Exception& e)
+        //{
+        //    //log e.what()?
+        //    status =  e.getErrorCode();
+        //}
+        catch (...)
+        {
+            status = CUML_ERROR_UNKNOWN;
+        }
     }
     return status;
 }

--- a/cuML/test/handle_test.cu
+++ b/cuML/test/handle_test.cu
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "cuML_api.h"
+
+TEST(HandleTest, CreateHandleAndDestroy)
+{
+  cumlHandle_t handle;
+  cumlError_t status = cumlCreate(&handle);
+  EXPECT_EQ(CUML_SUCCESS, status);
+
+  status = cumlDestroy(handle);
+  EXPECT_EQ(CUML_SUCCESS, status);
+}
+
+TEST(HandleTest, DoubleDestoryFails)
+{
+  cumlHandle_t handle;
+  cumlError_t status = cumlCreate(&handle);
+  EXPECT_EQ(CUML_SUCCESS, status);
+
+  status = cumlDestroy(handle);
+  EXPECT_EQ(CUML_SUCCESS, status);
+  // handle is destroyed
+  status = cumlDestroy(handle);
+  EXPECT_EQ(CUML_INVALID_HANDLE, status);
+}
+
+TEST(HandleTest, SetStream)
+{
+  cumlHandle_t handle;
+  cumlError_t status = cumlCreate(&handle);
+  EXPECT_EQ(CUML_SUCCESS, status);
+
+  status = cumlSetStream(handle, 0);
+  EXPECT_EQ(CUML_SUCCESS, status);
+
+  status = cumlDestroy(handle);
+  EXPECT_EQ(CUML_SUCCESS, status);
+}
+
+TEST(HandleTest, SetStreamInvalidHandle)
+{
+  cumlHandle_t handle = 12346;
+  EXPECT_EQ(CUML_INVALID_HANDLE, cumlSetStream(handle, 0));
+}


### PR DESCRIPTION
PR for Issue #436

- `cuMLHandle_t` is a type-alias to int rather than a struct containing a pointer. 
- `cuml_api.cpp` contains a `std::unordered_map<cuMLHandle_t, cumlHandle>*`
- API function check handle's validity when looking up the `cumlHandle*` from `cuMLHandle_t`.
- Map is protected by a mutex (thread-safety)
- New error type `CUML_INVALID_HANDLE` and fixed a typo in existing `CUML_ERROR_UNKOWN`.
- Added unit test.