### PR TITLE
[HOTFIX] fix dbscan example build due to renaming of libcuml++.so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #443: Remove defaults channel from ci scripts
 - PR #459: Fix for runtime library path of pip package
 - PR #464: Fix for C++11 destructor warning in qn
+- PR #468: Fix dbscan example build failure
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/cuML/examples/dbscan/CMakeLists.txt
+++ b/cuML/examples/dbscan/CMakeLists.txt
@@ -17,4 +17,4 @@
 include_directories(${CUDA_INCLUDE_DIRS})
 
 add_executable(dbscan_example dbscan_example.cpp)
-target_link_libraries(dbscan_example cuml)
+target_link_libraries(dbscan_example cuml++)

--- a/cuML/examples/dbscan/CMakeLists_standalone.txt
+++ b/cuML/examples/dbscan/CMakeLists_standalone.txt
@@ -27,7 +27,7 @@ else()
     message(FATAL_ERROR "CUML_INCLUDE_DIR not specified.")
 endif(IS_DIRECTORY ${CUML_INCLUDE_DIR})
 if(IS_DIRECTORY ${CUML_LIBRARY_DIR})
-    # CUML_LIBRARY_DIR point to the director where libcuml.so lives
+    # CUML_LIBRARY_DIR point to the director where libcuml++.so lives
     link_directories(${CUML_LIBRARY_DIR})
 else()
     message(FATAL_ERROR "CUML_LIBRARY_DIR not specified.")
@@ -37,4 +37,4 @@ add_executable(dbscan_example dbscan_example.cpp)
 # Need to set linker language to CUDA to link the CUDA Runtime
 set_target_properties(dbscan_example PROPERTIES LINKER_LANGUAGE "CUDA")
 # Link cuml
-target_link_libraries(dbscan_example cuml)
+target_link_libraries(dbscan_example cuml++)


### PR DESCRIPTION
dbscan example still referred to libcuml.so, whereas now we are going to use `libcuml++.so`. This PR fixes this build issue. Tagging @dantegd or @cjnolet for review.