### PR TITLE
[REVIEW] Expose cumlhandle for dbscan in python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #445: Lower dbscan memory usage by computing adjacency matrix directly
 - PR #431: Add support for fancy iterator input types to LinAlg::reduce_rows_by_key
 - PR #394: Introducing cumlHandle API to dbscan and add example
+- PR #475: exposing cumlHandle for dbscan from python-side
 
 ## Bug Fixes
 

--- a/cuML/src/dbscan/dbscan.cu
+++ b/cuML/src/dbscan/dbscan.cu
@@ -35,27 +35,9 @@ void dbscanFit(const cumlHandle& handle, double *input, int n_rows, int n_cols, 
 	dbscanFitImpl(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, handle.getStream());
 }
 
-// Following are two versions of dbscanFit, that do not take cumlHandle as
-// input arguments. The cumlHandle is created inside dbscanFit on each new call.
+}; // end namespace ML
 
-void dbscanFit(float *input, int n_rows, int n_cols, float eps, int min_pts,
-               int *labels) {
-    cumlHandle handle;
-    dbscanFitImpl(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, 0);
-    CUDA_CHECK(cudaStreamSynchronize(0));
-}
 
-void dbscanFit(double *input, int n_rows, int n_cols, double eps, int min_pts,
-               int *labels) {
-
-    cumlHandle handle;
-    dbscanFitImpl(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, 0);
-    CUDA_CHECK(cudaStreamSynchronize(0));
-}
-/** @} */
-
-};
-// end namespace ML
 extern "C" cumlError_t cumlSpDbscanFit(cumlHandle_t handle, float *input, int n_rows, int n_cols, float eps, int min_pts,
                int *labels) {
 

--- a/cuML/src/dbscan/dbscan.hpp
+++ b/cuML/src/dbscan/dbscan.hpp
@@ -25,14 +25,5 @@ void dbscanFit(const cumlHandle& handle, float *input, int n_rows, int n_cols, f
 void dbscanFit(const cumlHandle& handle, double *input, int n_rows, int n_cols, double eps, int min_pts,
 		       int *labels);
 
-// Following are two versions of dbscanFit, that do not take cumlHandle as
-// input arguments. The cumlHandle is created inside dbscanFit on each new call.
-
-void dbscanFit(float *input, int n_rows, int n_cols, float eps, int min_pts,
-               int *labels);
-
-void dbscanFit(double *input, int n_rows, int n_cols, double eps, int min_pts,
-               int *labels);
-
 }
 

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -198,6 +198,9 @@ class DBSCAN(Base):
                                <double> self.eps,
                                <int> self.min_samples,
                        <int*> labels_ptr)
+        # make sure that the `dbscanFit` is complete before the following delete
+        # call happens
+        self.handle.sync()
         del(X_m)
         return self
 

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -96,9 +96,13 @@ class DBSCAN(Base):
     -----------
     eps : float (default = 0.5)
         The maximum distance between 2 points such they reside in the same neighborhood.
+    handle : cuml.Handle
+        If it is None, a new one is created just for this class
     min_samples : int (default = 5)
         The number of samples in a neighborhood such that this group can be considered as
         an important core point (including the point itself).
+    verbose : bool
+        Whether to print debug spews
 
     Attributes
     -----------

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -30,18 +30,23 @@ from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
 
+from cuml.common.base import Base
+from cuml.common.handle cimport cumlHandle
+
 from collections import defaultdict
 
 cdef extern from "dbscan/dbscan.hpp" namespace "ML":
 
-    cdef void dbscanFit(float *input,
+    cdef void dbscanFit(cumlHandle& handle,
+                   float *input,
                    int n_rows,
                    int n_cols,
                    float eps,
                    int min_pts,
                    int *labels)
 
-    cdef void dbscanFit(double *input,
+    cdef void dbscanFit(cumlHandle& handle,
+                   double *input,
                    int n_rows,
                    int n_cols,
                    double eps,
@@ -49,7 +54,7 @@ cdef extern from "dbscan/dbscan.hpp" namespace "ML":
                    int *labels)
 
 
-class DBSCAN:
+class DBSCAN(Base):
     """
     DBSCAN is a very powerful yet fast clustering technique that finds clusters where
     data is concentrated. This allows DBSCAN to generalize to many problems if the
@@ -117,7 +122,8 @@ class DBSCAN:
     For additional docs, see `scikitlearn's DBSCAN <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html>`_.
     """
 
-    def __init__(self, eps=0.5, min_samples=5):
+    def __init__(self, eps=0.5, handle=None, min_samples=5, verbose=False):
+        super(DBSCAN, self).__init__(handle, verbose)
         self.eps = eps
         self.min_samples = min_samples
         self.labels_ = None
@@ -168,18 +174,21 @@ class DBSCAN:
 
         input_ptr = self._get_ctype_ptr(X_m)
 
+        cdef cumlHandle* handle_ = <cumlHandle*><size_t>self.handle.getHandle()
         self.labels_ = cudf.Series(np.zeros(self.n_rows, dtype=np.int32))
         self.labels_array = self.labels_._column._data.to_gpu_array()
         cdef uintptr_t labels_ptr = self._get_ctype_ptr(self.labels_array)
         if self.gdf_datatype.type == np.float32:
-            dbscanFit(<float*>input_ptr,
+            dbscanFit(handle_[0],
+                      <float*>input_ptr,
                                <int> self.n_rows,
                                <int> self.n_cols,
                                <float> self.eps,
                                <int> self.min_samples,
                        <int*> labels_ptr)
         else:
-            dbscanFit(<double*>input_ptr,
+            dbscanFit(handle_[0],
+                      <double*>input_ptr,
                                <int> self.n_rows,
                                <int> self.n_cols,
                                <double> self.eps,
@@ -205,40 +214,5 @@ class DBSCAN:
         self.fit(X)
         return self.labels_
 
-    def get_params(self, deep=True):
-        """
-        Sklearn style return parameter state
-
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        params = dict()
-        variables = [ 'eps','min_samples']
-        for key in variables:
-            var_value = getattr(self,key,None)
-            params[key] = var_value
-        return params
-
-
-
-    def set_params(self, **params):
-        """
-        Sklearn style set parameter state to dictionary of params.
-
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        if not params:
-            return self
-        current_params = {"eps": self.eps,"min_samples":self.min_samples}
-        for key, value in params.items():
-            if key not in current_params:
-                raise ValueError('Invalid parameter for estimator')
-            else:
-                setattr(self, key, value)
-                current_params[key] = value
-        return self
- 
- 
+    def get_param_names(self):
+        return ["eps", "min_samples"]

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -60,6 +60,8 @@ class Base:
         algo.fit(...)
         result = algo.predict(...)
         # final sync of all gpu-work launched inside this object
+        # this is same as `cuml.cuda.Stream.sync()` call, but safer in case
+        # the default stream inside the `cumlHandle` is being used
         base.handle.sync()
         del base  # optional!
     """
@@ -75,13 +77,7 @@ class Base:
         verbose : bool
                 Whether to print debug spews
         """
-        if handle is None:
-            self.handle = cuml.common.handle.Handle()
-            # TODO: This will not be needed once PR #477 gets through
-            self.stream = cuml.common.cuda.Stream()
-            self.handle.setStream(self.stream)
-        else:
-            self.handle = handle
+        self.handle = cuml.common.handle.Handle() if handle is None else handle
         self.verbose = verbose
 
 

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -59,8 +59,8 @@ class Base:
         algo = MyAlgo(handle=handle)
         algo.fit(...)
         result = algo.predict(...)
-        # final synchronization of all work launched/dependent on this stream
-        stream.sync()
+        # final sync of all gpu-work launched inside this object
+        base.sync()
         del base  # optional!
     """
 
@@ -93,6 +93,7 @@ class Base:
         """
         return []
 
+
     def get_params(self, deep=True):
         """
         Returns a dict of all params owned by this class. If the child class has
@@ -124,3 +125,10 @@ class Base:
             else:
                 setattr(self, key, value)
         return self
+
+
+    def sync(self):
+        """
+        Issues a sync on the stream set for the underlying handle
+        """
+        self.handle.sync()

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -60,7 +60,7 @@ class Base:
         algo.fit(...)
         result = algo.predict(...)
         # final sync of all gpu-work launched inside this object
-        base.sync()
+        base.handle.sync()
         del base  # optional!
     """
 
@@ -77,6 +77,7 @@ class Base:
         """
         if handle is None:
             self.handle = cuml.common.handle.Handle()
+            # TODO: This will not be needed once PR #477 gets through
             self.stream = cuml.common.cuda.Stream()
             self.handle.setStream(self.stream)
         else:
@@ -125,10 +126,3 @@ class Base:
             else:
                 setattr(self, key, value)
         return self
-
-
-    def sync(self):
-        """
-        Issues a sync on the stream set for the underlying handle
-        """
-        self.handle.sync()

--- a/python/cuml/common/handle.pxd
+++ b/python/cuml/common/handle.pxd
@@ -32,3 +32,4 @@ cdef extern from "cuML.hpp" namespace "ML" nogil:
         cumlHandle() except +
         void setStream(cuml.common.cuda._Stream s)
         void setDeviceAllocator(shared_ptr[deviceAllocator] a)
+        cuml.common.cuda._Stream getStream()

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -20,8 +20,9 @@
 # cython: language_level = 3
 
 
+import cuml
 from libcpp.memory cimport shared_ptr
-from cuml.common.cuda cimport _Stream
+from cuml.common.cuda cimport _Stream, _Error, cudaStreamSynchronize
 
 
 cdef extern from "common/rmmAllocatorAdapter.hpp" namespace "ML" nogil:
@@ -48,8 +49,8 @@ cdef class Handle:
 
         # call ML algos here
 
-        # final synchronization of all work launched/dependent on this stream
-        stream.sync()
+        # final sync of all work launched in the stream of this handle
+        handle.sync()
         del handle  # optional!
     """
 
@@ -81,6 +82,16 @@ cdef class Handle:
         cdef shared_ptr[deviceAllocator] rmmAlloc = shared_ptr[deviceAllocator](new rmmAllocatorAdapter())
         cdef cumlHandle* h_ = <cumlHandle*>self.h
         h_.setDeviceAllocator(rmmAlloc)
+
+    def sync(self):
+        """
+        Issues a sync on the stream set for this handle.
+        """
+        cdef cumlHandle* h_ = <cumlHandle*>self.h
+        cdef _Stream stream = h_.getStream()
+        cdef _Error e = cudaStreamSynchronize(stream)
+        if e != 0:
+            raise cuml.cuda.CudaRuntimeError("Stream sync")
 
     def getHandle(self):
         return self.h

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -50,6 +50,8 @@ cdef class Handle:
         # call ML algos here
 
         # final sync of all work launched in the stream of this handle
+        # this is same as `cuml.cuda.Stream.sync()` call, but safer in case
+        # the default stream inside the `cumlHandle` is being used
         handle.sync()
         del handle  # optional!
     """

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -86,6 +86,9 @@ cdef class Handle:
     def sync(self):
         """
         Issues a sync on the stream set for this handle.
+
+        Once we make `cuml.cuda.Stream` as a mandatory option for creating `cuml.Handle`,
+        this should go away!
         """
         cdef cumlHandle* h_ = <cumlHandle*>self.h
         cdef _Stream stream = h_.getStream()

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -18,7 +18,7 @@ import cuml
 
 def test_base_class_usage():
     base = cuml.Base()
-    base.sync()
+    base.handle.sync()
     base_params = base.get_param_names()
     assert base_params == []
     del base
@@ -29,5 +29,5 @@ def test_base_class_usage_with_handle():
     stream = cuml.cuda.Stream()
     handle.setStream(stream)
     base = cuml.Base(handle=handle)
-    base.sync()
+    base.handle.sync()
     del base

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -18,7 +18,7 @@ import cuml
 
 def test_base_class_usage():
     base = cuml.Base()
-    base.stream.sync()
+    base.sync()
     base_params = base.get_param_names()
     assert base_params == []
     del base
@@ -29,5 +29,5 @@ def test_base_class_usage_with_handle():
     stream = cuml.cuda.Stream()
     handle.setStream(stream)
     base = cuml.Base(handle=handle)
-    stream.sync()
+    base.sync()
     del base

--- a/python/cuml/test/test_dbscan.py
+++ b/python/cuml/test/test_dbscan.py
@@ -51,8 +51,7 @@ def test_dbscan_predict(datatype, input_type, use_handle):
 
     for i in range(X.shape[0]):
         assert cu_labels[i] == sk_labels[i]
-    if stream is not None:
-        stream.sync()
+    cudbscan.sync()
 
 
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])
@@ -74,8 +73,7 @@ def test_dbscan_predict_numpy(datatype, use_handle):
     print(X.shape[0])
     for i in range(X.shape[0]):
         assert cu_labels[i] == sk_labels[i]
-    if stream is not None:
-        stream.sync()
+    cudbscan.sync()
 
 
 def test_dbscan_predict_multiple_streams():
@@ -143,5 +141,4 @@ def test_dbscan_sklearn_comparison(name, use_handle):
     assert(sk_n_clusters == cu_n_clusters)
 
     clusters_equal(sk_y_pred, cu_y_pred, sk_n_clusters)
-    if stream is not None:
-        stream.sync()
+    cuml_dbscan.sync()

--- a/python/cuml/test/test_dbscan.py
+++ b/python/cuml/test/test_dbscan.py
@@ -97,6 +97,8 @@ def test_dbscan_predict_multiple_streams():
     for i in range(X.shape[0]):
         assert cu_labels1[i] == sk_labels[i]
         assert cu_labels2[i] == sk_labels[i]
+    cudbscan1.sync()
+    cudbscan2.sync()
 
 
 @pytest.mark.parametrize("name", [

--- a/python/cuml/test/test_dbscan.py
+++ b/python/cuml/test/test_dbscan.py
@@ -48,10 +48,10 @@ def test_dbscan_predict(datatype, input_type, use_handle):
         cu_labels = cudbscan.fit_predict(gdf)
     else:
         cu_labels = cudbscan.fit_predict(X)
+    cudbscan.handle.sync()
 
     for i in range(X.shape[0]):
         assert cu_labels[i] == sk_labels[i]
-    cudbscan.sync()
 
 
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])
@@ -71,9 +71,9 @@ def test_dbscan_predict_numpy(datatype, use_handle):
     skdbscan = skDBSCAN(eps=3, min_samples=2)
     sk_labels = skdbscan.fit_predict(X)
     print(X.shape[0])
+    cudbscan.handle.sync()
     for i in range(X.shape[0]):
         assert cu_labels[i] == sk_labels[i]
-    cudbscan.sync()
 
 
 def test_dbscan_predict_multiple_streams():
@@ -94,11 +94,11 @@ def test_dbscan_predict_multiple_streams():
     cudbscan2 = cuDBSCAN(handle=handle2, eps=3, min_samples=2)
     cu_labels1 = cudbscan1.fit_predict(gdf)
     cu_labels2 = cudbscan2.fit_predict(gdf)
+    cudbscan1.handle.sync()
+    cudbscan2.handle.sync()
     for i in range(X.shape[0]):
         assert cu_labels1[i] == sk_labels[i]
         assert cu_labels2[i] == sk_labels[i]
-    cudbscan1.sync()
-    cudbscan2.sync()
 
 
 @pytest.mark.parametrize("name", [
@@ -140,7 +140,8 @@ def test_dbscan_sklearn_comparison(name, use_handle):
     cu_y_pred, cu_n_clusters = fit_predict(clustering_algorithms[1][1],
                                            clustering_algorithms[1][0], X)
 
+    cuml_dbscan.handle.sync()
+
     assert(sk_n_clusters == cu_n_clusters)
 
     clusters_equal(sk_y_pred, cu_y_pred, sk_n_clusters)
-    cuml_dbscan.sync()

--- a/python/cuml/test/test_dbscan.py
+++ b/python/cuml/test/test_dbscan.py
@@ -15,6 +15,7 @@
 
 import pytest
 from cuml import DBSCAN as cuDBSCAN
+from cuml.test.utils import get_handle
 from sklearn.cluster import DBSCAN as skDBSCAN
 import cudf
 import numpy as np
@@ -29,14 +30,16 @@ dataset_names = ['noisy_moons', 'varied', 'aniso', 'blobs', 'noisy_circles',
 
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])
 @pytest.mark.parametrize('input_type', ['dataframe', 'ndarray'])
-def test_dbscan_predict(datatype, input_type):
+@pytest.mark.parametrize('use_handle', [True, False])
+def test_dbscan_predict(datatype, input_type, use_handle):
 
     X = np.array([[1, 2], [2, 2], [2, 3], [8, 7], [8, 8], [25, 80]],
                  dtype=datatype)
     skdbscan = skDBSCAN(eps=3, min_samples=2)
     sk_labels = skdbscan.fit_predict(X)
 
-    cudbscan = cuDBSCAN(eps=3, min_samples=2)
+    handle, stream = get_handle(use_handle)
+    cudbscan = cuDBSCAN(handle=handle, eps=3, min_samples=2)
 
     if input_type == 'dataframe':
         gdf = cudf.DataFrame()
@@ -48,10 +51,13 @@ def test_dbscan_predict(datatype, input_type):
 
     for i in range(X.shape[0]):
         assert cu_labels[i] == sk_labels[i]
+    if stream is not None:
+        stream.sync()
 
 
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])
-def test_dbscan_predict_numpy(datatype):
+@pytest.mark.parametrize('use_handle', [True, False])
+def test_dbscan_predict_numpy(datatype, use_handle):
     gdf = cudf.DataFrame()
     gdf['0'] = np.asarray([1, 2, 2, 8, 8, 25], dtype=datatype)
     gdf['1'] = np.asarray([2, 2, 3, 7, 8, 80], dtype=datatype)
@@ -60,22 +66,48 @@ def test_dbscan_predict_numpy(datatype):
                  dtype=datatype)
 
     print("Calling fit_predict")
-    cudbscan = cuDBSCAN(eps=3, min_samples=2)
+    handle, stream = get_handle(use_handle)
+    cudbscan = cuDBSCAN(handle=handle, eps=3, min_samples=2)
     cu_labels = cudbscan.fit_predict(gdf)
     skdbscan = skDBSCAN(eps=3, min_samples=2)
     sk_labels = skdbscan.fit_predict(X)
     print(X.shape[0])
     for i in range(X.shape[0]):
         assert cu_labels[i] == sk_labels[i]
+    if stream is not None:
+        stream.sync()
+
+
+def test_dbscan_predict_multiple_streams():
+    datatype = np.float32
+    gdf = cudf.DataFrame()
+    gdf['0'] = np.asarray([1, 2, 2, 8, 8, 25], dtype=datatype)
+    gdf['1'] = np.asarray([2, 2, 3, 7, 8, 80], dtype=datatype)
+
+    X = np.array([[1, 2], [2, 2], [2, 3], [8, 7], [8, 8], [25, 80]],
+                 dtype=datatype)
+
+    skdbscan = skDBSCAN(eps=3, min_samples=2)
+    sk_labels = skdbscan.fit_predict(X)
+
+    handle1, stream1 = get_handle(True)
+    handle2, stream2 = get_handle(True)
+    cudbscan1 = cuDBSCAN(handle=handle1, eps=3, min_samples=2)
+    cudbscan2 = cuDBSCAN(handle=handle2, eps=3, min_samples=2)
+    cu_labels1 = cudbscan1.fit_predict(gdf)
+    cu_labels2 = cudbscan2.fit_predict(gdf)
+    for i in range(X.shape[0]):
+        assert cu_labels1[i] == sk_labels[i]
+        assert cu_labels2[i] == sk_labels[i]
 
 
 @pytest.mark.parametrize("name", [
                                  'noisy_moons',
                                  'blobs',
                                  'no_structure'])
+@pytest.mark.parametrize('use_handle', [True, False])
 @pytest.mark.stress
-def test_dbscan_sklearn_comparison(name):
-
+def test_dbscan_sklearn_comparison(name, use_handle):
     # Skipping datasets of known discrepancies in PR83 while they are corrected
     default_base = {'quantile': .3,
                     'eps': .3,
@@ -90,7 +122,8 @@ def test_dbscan_sklearn_comparison(name):
     params.update(pat[1])
 
     dbscan = skDBSCAN(eps=params['eps'], min_samples=5)
-    cuml_dbscan = cuDBSCAN(eps=params['eps'], min_samples=5)
+    handle, stream = get_handle(use_handle)
+    cuml_dbscan = cuDBSCAN(handle=handle, eps=params['eps'], min_samples=5)
 
     X, y = pat[0]
 
@@ -110,3 +143,5 @@ def test_dbscan_sklearn_comparison(name):
     assert(sk_n_clusters == cu_n_clusters)
 
     clusters_equal(sk_y_pred, cu_y_pred, sk_n_clusters)
+    if stream is not None:
+        stream.sync()

--- a/python/cuml/test/utils.py
+++ b/python/cuml/test/utils.py
@@ -22,6 +22,7 @@ from numba import cuda
 from sklearn import datasets
 
 import cudf
+import cuml
 
 
 def array_equal(a, b, tol=1e-4, with_sign=True):
@@ -123,3 +124,12 @@ def normalize_clusters(a0, b0, n_clusters):
 def clusters_equal(a0, b0, n_clusters):
     a, b = normalize_clusters(a0, b0, n_clusters)
     return array_equal(a, b)
+
+
+def get_handle(use_handle):
+    if not use_handle:
+        return None, None
+    h = cuml.Handle()
+    s = cuml.cuda.Stream()
+    h.setStream(s)
+    return h, s


### PR DESCRIPTION
As per [this] comment in PR #331 , this PR exposes cumlHandle for dbscan in cython. This shows an end-usage of the cumlHandle changes in PR #435 and also exposes @vinaydes's C++ cumlHandle changes for dbscan in the cython world.

Tagging @vinaydes @jirikraus @dantegd @cjnolet for the review.

@dantegd this PR also contains a testcase showing the launch of 2 dbscan-fit calls using 2 different cumlHandle's, as per your suggestion in the original PR #331 .