### PR TITLE
[REVIEW] Replaced qn_fit() declaration with #include of file containing definition to fix linker error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #468: Fix dbscan example build failure
 - PR #470: Fix resource leakage in Kalman filter python wrapper
 - PR #473: Fix gather ml-prim test for change in rng uniform API
+- PR #480: Replaced qn_fit() declaration with #include of file containing definition to fix linker error
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/cuML/test/quasi_newton.cu
+++ b/cuML/test/quasi_newton.cu
@@ -6,15 +6,10 @@
 #include <linalg/transpose.h>
 #include <vector>
 #include <glm/glm_c.h>
+#include <glm/qn/qn.h>
 
 namespace ML {
 namespace GLM {
-
-template <typename T, typename LossFunction>
-int qn_fit(LossFunction &loss, T *Xptr, T *yptr, T *zptr, int N, bool has_bias,
-           T l1, T l2, int max_iter, T grad_tol, int linesearch_max_iter,
-           int lbfgs_memory, int verbosity, T *w0, T *fx, int *num_iters,
-           STORAGE_ORDER ordX, cudaStream_t stream);
 
 using namespace MLCommon;
 


### PR DESCRIPTION
Replaced `qn_fit()` declaration with #include of file containing definition to fix linker error.

The presence of the `qn_fit()` declaration allowed the test to compile, but the linker could not succeed without the definition. This only happened when building for release, which adds the `-O3` optimization flag - debug builds link with only the declaration (may need further investigation?)