### PR TITLE
[REVIEW] Re enable mlprims test for CI of PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PR #480: Replaced qn_fit() declaration with #include of file containing definition to fix linker error
 - PR #495: Update cuDF and RMM versions in GPU ci test scripts
 - PR #499: DEVELOPER_GUIDE.md: fixed links and clarified ML::detail::streamSyncer example
+- PR #506: Re enable ml-prim tests in CI
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -83,15 +83,15 @@ logger "Build cuML..."
 cd $WORKSPACE/python
 python setup.py build_ext --inplace
 
-# logger "Build ml-prims tests..."
-# mkdir -p $WORKSPACE/ml-prims/build
-# cd $WORKSPACE/ml-prims/build
-# cmake $GPU_ARCH ..
+logger "Build ml-prims tests..."
+mkdir -p $WORKSPACE/ml-prims/build
+cd $WORKSPACE/ml-prims/build
+cmake $GPU_ARCH ..
 
-# logger "Clean up make..."
-# make clean
-# logger "Make ml-prims test..."
-# make -j${PARALLEL_LEVEL}
+logger "Clean up make..."
+make clean
+logger "Make ml-prims test..."
+make -j${PARALLEL_LEVEL}
 
 
 ################################################################################
@@ -111,6 +111,6 @@ cd $WORKSPACE/python
 py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 
 
-# logger "Run ml-prims test..."
-# cd $WORKSPACE/ml-prims/build
-# GTEST_OUTPUT="xml:${WORKSPACE}/test-results/ml-prims/" ./test/mlcommon_test
+logger "Run ml-prims test..."
+cd $WORKSPACE/ml-prims/build
+GTEST_OUTPUT="xml:${WORKSPACE}/test-results/ml-prims/" ./test/mlcommon_test


### PR DESCRIPTION
During debugging of CI failing yesterday the ml-prims tests for CI of PRs were not re enabled, this PR corrects that. 