### PR TITLE
[BUGFIX] - default argument for meanSquaredError was not at the end of parameter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PR #495: Update cuDF and RMM versions in GPU ci test scripts
 - PR #499: DEVELOPER_GUIDE.md: fixed links and clarified ML::detail::streamSyncer example
 - PR #506: Re enable ml-prim tests in CI
+- PR #508: Fix for an error with default argument in LinAlg::meanSquaredError
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/ml-prims/src/linalg/mean_squared_error.h
+++ b/ml-prims/src/linalg/mean_squared_error.h
@@ -34,7 +34,7 @@ namespace LinAlg {
  * @param stream cuda-stream where to launch this kernel
  */
 template<typename math_t, int TPB = 256>
-    void meanSquaredError(math_t* out, const math_t * A, const math_t *B, size_t len, math_t weight = 1.0, cudaStream_t stream){
+    void meanSquaredError(math_t* out, const math_t * A, const math_t *B, size_t len, math_t weight, cudaStream_t stream){
         auto sq_diff = [len, weight] __device__(const math_t a, const math_t b){
             math_t diff = a - b;
             return diff * diff * weight / len;


### PR DESCRIPTION
This fixes a minor bug in `MLCommon::LinAlg::meanSquaredError(...)` method due to default argument `weight = 1.0` not being at the end of the parameter list (before the fix it was throwing `error: default argument not at end of parameter list`).

Tagging @teju85 for review.