### PR TITLE
[WIP] Generic copy interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #394: Introducing cumlHandle API to dbscan and add example
 - PR #475: exposing cumlHandle for dbscan from python-side
 - PR #395: Edited the CONTRIBUTING.md file
+- PR #512: generic copy method for copying buffers between device/host
 
 ## Bug Fixes
 

--- a/cuML/src/dbscan/adjgraph/naive.h
+++ b/cuML/src/dbscan/adjgraph/naive.h
@@ -34,8 +34,8 @@ void launcher(const ML::cumlHandle_impl& handle, Pack<Type> data, int batchSize,
     MLCommon::host_buffer<bool> host_core_pts(handle.getHostAllocator(), stream, batchSize);
     MLCommon::host_buffer<bool> host_adj(handle.getHostAllocator(), stream, batchSize*N);
     MLCommon::host_buffer<Type> host_ex_scan(handle.getHostAllocator(), stream, batchSize);
-    MLCommon::updateHostAsync(host_adj.data(), data.adj, batchSize*N, stream);
-    MLCommon::updateHostAsync(host_vd.data(), data.vd, batchSize+1, stream);
+    MLCommon::updateHost(host_adj.data(), data.adj, batchSize*N, stream);
+    MLCommon::updateHost(host_vd.data(), data.vd, batchSize+1, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     size_t adjgraph_size = size_t(host_vd[batchSize]);
     MLCommon::host_buffer<Type> host_adj_graph(handle.getHostAllocator(), stream, adjgraph_size);
@@ -52,9 +52,9 @@ void launcher(const ML::cumlHandle_impl& handle, Pack<Type> data, int batchSize,
     host_ex_scan[0] = Type(0);
     for(int i=1; i<batchSize; i++) 
         host_ex_scan[i] = host_ex_scan[i-1] + host_vd[i-1];
-    MLCommon::updateDeviceAsync(data.adj_graph, host_adj_graph.data(), adjgraph_size, stream);
-    MLCommon::updateDeviceAsync(data.core_pts, host_core_pts.data(), batchSize, stream);
-    MLCommon::updateDeviceAsync(data.ex_scan, host_ex_scan.data(), batchSize, stream);
+    MLCommon::updateDevice(data.adj_graph, host_adj_graph.data(), adjgraph_size, stream);
+    MLCommon::updateDevice(data.core_pts, host_core_pts.data(), batchSize, stream);
+    MLCommon::updateDevice(data.ex_scan, host_ex_scan.data(), batchSize, stream);
 }
 } // End Naive
 } // End AdjGraph

--- a/cuML/src/dbscan/labelling/algo1.h
+++ b/cuML/src/dbscan/labelling/algo1.h
@@ -55,8 +55,8 @@ void bfs(const ML::cumlHandle_impl& handle, int id, Pack<Type> data, Type *host_
     memset(host_xa.data(), false, sizeof(bool)*N);
     memset(host_fa.data(), false, sizeof(bool)*N);
     host_fa[id] = true;
-    MLCommon::updateDeviceAsync(data.xa, host_xa.data(), N, stream);
-    MLCommon::updateDeviceAsync(data.fa, host_fa.data(), N, stream);
+    MLCommon::updateDevice(data.xa, host_xa.data(), N, stream);
+    MLCommon::updateDevice(data.fa, host_fa.data(), N, stream);
     int countFa = 1;
     dim3 blocks(ceildiv(batchSize, TPB_X), 1, 1);
     dim3 threads(TPB_X, 1, 1);
@@ -66,7 +66,7 @@ void bfs(const ML::cumlHandle_impl& handle, int id, Pack<Type> data, Type *host_
         auto execution_policy = thrust::cuda::par(alloc).on(stream);
         countFa = count(execution_policy, data.fa, data.fa + N, true);
     }
-    MLCommon::updateHostAsync(host_xa.data(), data.xa, N, stream);
+    MLCommon::updateHost(host_xa.data(), data.xa, N, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     for(int i=0; i<N; i++) {
         if(host_xa[i]) {
@@ -86,15 +86,15 @@ void identifyCluster(const ML::cumlHandle_impl& handle, Pack<Type> data, int sta
     MLCommon::host_buffer<Type> host_ex_scan(handle.getHostAllocator(), stream, batchSize);
     MLCommon::host_buffer<Type> host_db_cluster(handle.getHostAllocator(), stream, N);
 
-    MLCommon::updateHostAsync(host_core_pts.data(), data.core_pts, batchSize, stream);
-    MLCommon::updateHostAsync(host_vd.data(), data.vd, batchSize+1, stream);
+    MLCommon::updateHost(host_core_pts.data(), data.core_pts, batchSize, stream);
+    MLCommon::updateHost(host_vd.data(), data.vd, batchSize+1, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     size_t adjgraph_size = size_t(host_vd[batchSize]);
     MLCommon::host_buffer<Type> host_adj_graph(handle.getHostAllocator(), stream, adjgraph_size);
-    MLCommon::updateHostAsync(host_ex_scan.data(), data.ex_scan, batchSize, stream);
-    MLCommon::updateHostAsync(host_adj_graph.data(), data.adj_graph, adjgraph_size, stream);
-    MLCommon::updateHostAsync(host_visited.data(), data.visited, N, stream);
-    MLCommon::updateHostAsync(host_db_cluster.data(), data.db_cluster, N, stream);
+    MLCommon::updateHost(host_ex_scan.data(), data.ex_scan, batchSize, stream);
+    MLCommon::updateHost(host_adj_graph.data(), data.adj_graph, adjgraph_size, stream);
+    MLCommon::updateHost(host_visited.data(), data.visited, N, stream);
+    MLCommon::updateHost(host_db_cluster.data(), data.db_cluster, N, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
     for(int i=0; i<batchSize; i++) {
@@ -107,8 +107,8 @@ void identifyCluster(const ML::cumlHandle_impl& handle, Pack<Type> data, int sta
             cluster++;
         }
     }
-    MLCommon::updateDeviceAsync(data.visited, host_visited.data(), N, stream);
-    MLCommon::updateDeviceAsync(data.db_cluster, host_db_cluster.data(), N, stream);
+    MLCommon::updateDevice(data.visited, host_visited.data(), N, stream);
+    MLCommon::updateDevice(data.db_cluster, host_db_cluster.data(), N, stream);
 }
 
 template <typename Type>

--- a/cuML/src/dbscan/labelling/algo2.h
+++ b/cuML/src/dbscan/labelling/algo2.h
@@ -132,12 +132,12 @@ void label(const ML::cumlHandle_impl& handle, Pack<Type> data, int startVertexId
         CUDA_CHECK( cudaMemsetAsync(data.m, false, sizeof(bool), stream) ); 
         label_device<Type, TPB_X><<<blocks, threads, 0, stream>>>(data, startVertexId, batchSize);
         //** swapping F1 and F2
-        MLCommon::updateHostAsync(host_fa.data(), data.fa, N, stream);
-        MLCommon::updateHostAsync(host_xa.data(), data.xa, N, stream);
-        MLCommon::updateDeviceAsync(data.fa, host_xa.data(), N, stream);
-        MLCommon::updateDeviceAsync(data.xa, host_fa.data(), N, stream);
+        MLCommon::updateHost(host_fa.data(), data.fa, N, stream);
+        MLCommon::updateHost(host_xa.data(), data.xa, N, stream);
+        MLCommon::updateDevice(data.fa, host_xa.data(), N, stream);
+        MLCommon::updateDevice(data.xa, host_fa.data(), N, stream);
         //** Updating m *
-        MLCommon::updateHostAsync(&host_m, data.m, 1, stream);
+        MLCommon::updateHost(&host_m, data.m, 1, stream);
         CUDA_CHECK(cudaStreamSynchronize(stream));
     } while(host_m);
 }
@@ -162,14 +162,14 @@ void relabel(const ML::cumlHandle_impl& handle, Pack<Type> data, cudaStream_t st
     MLCommon::host_buffer<Type> host_db_cluster(handle.getHostAllocator(), stream, N);
     MLCommon::host_buffer<Type> host_map_id(handle.getHostAllocator(), stream, N);
     memset(host_map_id.data(), 0, N*sizeof(Type));
-    MLCommon::updateHostAsync(host_db_cluster.data(), data.db_cluster, N, stream);
+    MLCommon::updateHost(host_db_cluster.data(), data.db_cluster, N, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     sort(host, host_db_cluster.data(), host_db_cluster.data() + N);
     Type *uid = unique(host, host_db_cluster.data(), host_db_cluster.data() + N, equal_to<Type>());
     Type num_clusters = uid - host_db_cluster.data();
     for(int i=0; i<num_clusters; i++)
         host_map_id[i] = host_db_cluster[i];
-    MLCommon::updateDeviceAsync(data.map_id, host_map_id.data(), N, stream);
+    MLCommon::updateDevice(data.map_id, host_map_id.data(), N, stream);
     map_label<Type,TPB_X><<<blocks, threads, 0, stream>>>(data, MAX_LABEL);
 }
 

--- a/cuML/src/dbscan/labelling/naive.h
+++ b/cuML/src/dbscan/labelling/naive.h
@@ -68,16 +68,16 @@ void launcher(const ML::cumlHandle_impl& handle, Pack<Type> data, int startVerte
     data.resetArray(stream);
     /** this line not in resetArray function because it interferes with algo2 */
     //CUDA_CHECK(cudaMemsetAsync(data.db_cluster, 0, sizeof(Type)*N, stream));
-    MLCommon::updateHostAsync(host_core_pts.data(), data.core_pts, N, stream);
-    MLCommon::updateHostAsync(host_vd.data(), data.vd, N+1, stream);
+    MLCommon::updateHost(host_core_pts.data(), data.core_pts, N, stream);
+    MLCommon::updateHost(host_vd.data(), data.vd, N+1, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
     size_t adjgraph_size = size_t(host_vd[N]);
     MLCommon::host_buffer<Type> host_adj_graph(handle.getHostAllocator(), stream, adjgraph_size);
-    MLCommon::updateHostAsync(host_ex_scan.data(), data.ex_scan, N, stream);
-    MLCommon::updateHostAsync(host_adj_graph.data(), data.adj_graph, adjgraph_size, stream);
-    MLCommon::updateHostAsync(host_xa.data(), data.xa, N, stream);
-    MLCommon::updateHostAsync(host_visited.data(), data.visited, N, stream);
-    MLCommon::updateHostAsync(host_db_cluster.data(), data.db_cluster, N, stream);
+    MLCommon::updateHost(host_ex_scan.data(), data.ex_scan, N, stream);
+    MLCommon::updateHost(host_adj_graph.data(), data.adj_graph, adjgraph_size, stream);
+    MLCommon::updateHost(host_xa.data(), data.xa, N, stream);
+    MLCommon::updateHost(host_visited.data(), data.visited, N, stream);
+    MLCommon::updateHost(host_db_cluster.data(), data.db_cluster, N, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
     Type cluster = Type(1);
@@ -90,8 +90,8 @@ void launcher(const ML::cumlHandle_impl& handle, Pack<Type> data, int startVerte
             cluster++; 
 	}
    } 
-    MLCommon::updateDeviceAsync(data.visited, host_visited.data(), N, stream);
-    MLCommon::updateDeviceAsync(data.db_cluster, host_db_cluster.data(), N, stream);
+    MLCommon::updateDevice(data.visited, host_visited.data(), N, stream);
+    MLCommon::updateDevice(data.db_cluster, host_db_cluster.data(), N, stream);
 }
 } // End Naive
 } // End Label

--- a/cuML/src/dbscan/runner.h
+++ b/cuML/src/dbscan/runner.h
@@ -93,8 +93,8 @@ size_t run(const ML::cumlHandle_impl& handle, Type_f* x, Type N, Type D, Type_f 
             continue;
 		VertexDeg::run(handle, adj, vd, x, eps, N, D, algoVd,
 				startVertexId, nPoints, stream);
-		MLCommon::updateHostAsync(&curradjlen, vd + nPoints, 1, stream);
-        CUDA_CHECK(cudaStreamSynchronize(stream));
+		MLCommon::updateHost(&curradjlen, vd + nPoints, 1, stream);
+                CUDA_CHECK(cudaStreamSynchronize(stream));
 
 		// Running AdjGraph
 		// TODO -: To come up with a mechanism as to reduce and reuse adjgraph mallocs

--- a/cuML/src/glm/preprocess.h
+++ b/cuML/src/glm/preprocess.h
@@ -82,7 +82,8 @@ void postProcessData(math_t *input, int n_rows, int n_cols, math_t *labels, math
 		    CUBLAS_OP_N, CUBLAS_OP_N, cublas_handle, stream);
 
 	LinAlg::subtract(d_intercept, mu_labels, d_intercept, 1, stream);
-	updateHost(intercept, d_intercept, 1);
+	updateHost(intercept, d_intercept, 1, stream);
+        CUDA_CHECK(cudaStreamSynchronize(stream));
 	if (d_intercept != NULL)
 		cudaFree(d_intercept);
 

--- a/cuML/src/glm/qn/simple_mat.h
+++ b/cuML/src/glm/qn/simple_mat.h
@@ -194,7 +194,8 @@ template <typename T> struct SimpleVec : SimpleMat<T> {
 
   inline T operator[](int pos) const {
     T tmp;
-    MLCommon::updateHost(&tmp, &this->data[pos], 1);
+    MLCommon::updateHost(&tmp, &this->data[pos], 1, 0);
+    CUDA_CHECK(cudaStreamSynchronize(0));
     return tmp;
   }
 };
@@ -229,7 +230,8 @@ inline T dot(const SimpleVec<T> &u, const SimpleVec<T> &v, T *tmp_dev,
   auto f = [] __device__(const T x, const T y) { return x * y; };
   MLCommon::LinAlg::mapThenSumReduce(tmp_dev, u.len, f, stream, u.data, v.data);
   T tmp_host;
-  MLCommon::updateHost(&tmp_host, tmp_dev, 1);
+  MLCommon::updateHost(&tmp_host, tmp_dev, 1, 0);
+  CUDA_CHECK(cudaStreamSynchronize(0));
   return tmp_host;
 }
 
@@ -249,14 +251,16 @@ inline T nrm1(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream = 0){
   MLCommon::LinAlg::rowNorm(tmp_dev, u.data,  u.len, 1, MLCommon::LinAlg::L1Norm,
                             true, stream, MLCommon::Nop<T>());
   T tmp_host;
-  MLCommon::updateHost(&tmp_host, tmp_dev, 1);
+  MLCommon::updateHost(&tmp_host, tmp_dev, 1, 0);
+  CUDA_CHECK(cudaStreamSynchronize(0));
   return tmp_host;
 }
 
 template <typename T>
 std::ostream &operator<<(std::ostream &os, const SimpleVec<T> &v) {
   std::vector<T> out(v.len);
-  MLCommon::updateHost(&out[0], v.data, v.len);
+  MLCommon::updateHost(&out[0], v.data, v.len, 0);
+  CUDA_CHECK(cudaStreamSynchronize(0));
   int it = 0;
   for (; it < v.len - 1;) {
     os << out[it] << " ";
@@ -270,7 +274,8 @@ template <typename T>
 std::ostream &operator<<(std::ostream &os, const SimpleMat<T> &mat) {
   os << "ord=" << (mat.ord == COL_MAJOR ? "CM" : "RM") << "\n";
   std::vector<T> out(mat.len);
-  MLCommon::updateHost(&out[0], mat.data, mat.len);
+  MLCommon::updateHost(&out[0], mat.data, mat.len, 0);
+  CUDA_CHECK(cudaStreamSynchronize(0));
   if (mat.ord == COL_MAJOR) {
     for (int r = 0; r < mat.m; r++) {
       int idx = r;

--- a/cuML/src/glm/ridge.h
+++ b/cuML/src/glm/ridge.h
@@ -48,7 +48,7 @@ void ridgeSolve(math_t *S, math_t *V, math_t *U, int n_rows, int n_cols,
 
 	Matrix::setSmallValuesZero(S, n_cols, stream, thres);
 	allocate(S_nnz, n_cols, true);
-	copy(S_nnz, S, n_cols);
+	copy(S_nnz, S, n_cols, stream);
 	Matrix::power(S_nnz, n_cols, stream);
 	LinAlg::addScalar(S_nnz, S_nnz, alpha[0], n_cols, stream);
 	Matrix::matrixVectorBinaryDivSkipZero(S, S_nnz, 1, n_cols, false, true, stream, true);

--- a/cuML/src/kalman_filter/lkf.h
+++ b/cuML/src/kalman_filter/lkf.h
@@ -141,7 +141,8 @@ void update_x(Variables<T>& var, cublasHandle_t handle, cusolverDnHandle_t handl
                                            (const int *)var.piv, var.z, var.dim_z, var.info,
                                            stream));
             int info_h;
-            updateHost(&info_h, var.info, 1);
+            updateHost(&info_h, var.info, 1, stream);
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             ASSERT(info_h == 0,
                    "kf::linear: implicit kalman gain"
                    " {Y = [inv(B)*(z - H*x)]}, info returned val=%d",
@@ -214,7 +215,8 @@ void update_P(Variables<T>& var, cublasHandle_t handle, cusolverDnHandle_t handl
                                            (const int *)var.piv, var.placeHolder1,
                                            var.dim_z, var.info, stream));
             int info_h;
-            updateHost(&info_h, var.info, 1);
+            updateHost(&info_h, var.info, 1, stream);
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             ASSERT(info_h == 0,
                    "kf::linear: implicit kalman gain with short form, finding "
                    "[inv(B)*H] info returned val=%d", info_h);
@@ -251,7 +253,8 @@ void find_kalman_gain(Variables<T>& var, cublasHandle_t handle, cusolverDnHandle
         CUSOLVER_CHECK(cusolverDngetrf(handle_sol, var.dim_z, var.dim_z, var.R_cpy, var.dim_z,
                                        var.workspace_lu, var.piv, var.info, stream));
         int info_h;
-        updateHost(&info_h, var.info, 1);
+        updateHost(&info_h, var.info, 1, stream);
+            CUDA_CHECK(cudaStreamSynchronize(stream));
         ASSERT(info_h == 0, "kf::linear: LU decomp, info returned val=%d",
                info_h);
         if (var.solver < ShortFormImplicit) {
@@ -264,7 +267,8 @@ void find_kalman_gain(Variables<T>& var, cublasHandle_t handle, cusolverDnHandle
                                            (const int *)var.piv, var.placeHolder0,
                                            var.dim_z, var.info, stream));
             int info_h;
-            updateHost(&info_h, var.info, 1);
+            updateHost(&info_h, var.info, 1, stream);
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             ASSERT(info_h == 0,
                    "kf::linear: Explicit var.kalman gain, inverse "
                    "returned val=%d", info_h);

--- a/cuML/src/knn/knn.cu
+++ b/cuML/src/knn/knn.cu
@@ -250,7 +250,7 @@ namespace ML {
 
             float *ptr_d;
             MLCommon::allocate(ptr_d, size_t(length)*size_t(D));
-            MLCommon::updateDevice(ptr_d, ptr+(size_t(chunk_size)*i), size_t(length)*size_t(D));
+            MLCommon::updateDevice(ptr_d, ptr+(size_t(chunk_size)*i), size_t(length)*size_t(D), 0);
 
             kNNParams p;
             p.N = length;

--- a/cuML/src/solver/sgd.h
+++ b/cuML/src/solver/sgd.h
@@ -130,7 +130,7 @@ void sgdFit(math_t *input,
 			if (cbs == 0)
 				break;
 
-			updateDevice(indices, &rand_indices[j], cbs);
+			updateDevice(indices, &rand_indices[j], cbs, stream);
 			Matrix::copyRows(input, n_rows, n_cols, input_batch, indices, cbs, stream);
 			Matrix::copyRows(labels, n_rows, 1, labels_batch, indices, cbs, stream);
 
@@ -170,7 +170,8 @@ void sgdFit(math_t *input,
 						penalty, alpha, l1_ratio, cublas_handle, stream);
 			}
 
-			updateHost(&curr_loss_value, loss_value, 1);
+			updateHost(&curr_loss_value, loss_value, 1, stream);
+                        CUDA_CHECK(cudaStreamSynchronize(stream));
 
 			if (i > 0) {
                 if (curr_loss_value > (prev_loss_value - tol)) {

--- a/cuML/src/tsvd/tsvd.h
+++ b/cuML/src/tsvd/tsvd.h
@@ -244,7 +244,8 @@ void tsvdFitTransform(math_t *input, math_t *trans_input, math_t *components,
 	Stats::sum(total_vars, vars, 1, prms.n_cols, false, stream);
 
 	math_t total_vars_h;
-	updateHost(&total_vars_h, total_vars, 1);
+	updateHost(&total_vars_h, total_vars, 1, stream);
+        CUDA_CHECK(cudaStreamSynchronize(stream));
 	math_t scalar = math_t(1) / total_vars_h;
 
 	LinAlg::scalarMultiply(explained_var_ratio, explained_var, scalar,

--- a/cuML/src/umap/fuzzy_simpl_set/naive.h
+++ b/cuML/src/umap/fuzzy_simpl_set/naive.h
@@ -451,9 +451,9 @@ namespace UMAPAlgo {
                 if(params->verbose)
                     std::cout << "cur_coo_len=" << n_compressed_nonzeros << std::endl;
 
-                MLCommon::copy(rrows, crows, n_compressed_nonzeros);
-                MLCommon::copy(rcols, ccols, n_compressed_nonzeros);
-                MLCommon::copy(rvals, cvals, n_compressed_nonzeros);
+                MLCommon::copy(rrows, crows, n_compressed_nonzeros, stream);
+                MLCommon::copy(rcols, ccols, n_compressed_nonzeros, stream);
+                MLCommon::copy(rvals, cvals, n_compressed_nonzeros, stream);
 
                 CUDA_CHECK(cudaFree(rhos));
                 CUDA_CHECK(cudaFree(sigmas));

--- a/cuML/src/umap/fuzzy_simpl_set/naive.h
+++ b/cuML/src/umap/fuzzy_simpl_set/naive.h
@@ -336,7 +336,8 @@ namespace UMAPAlgo {
                 CUDA_CHECK(cudaPeekAtLastError());
 
                 T *dist_means_host = (T*) malloc(params->n_neighbors * sizeof(T));
-                MLCommon::updateHost(dist_means_host, dist_means_dev,params->n_neighbors);
+                MLCommon::updateHost(dist_means_host, dist_means_dev,params->n_neighbors, stream);
+                CUDA_CHECK(cudaStreamSynchronize(stream));
 
                 float sum = 0.0;
                 for (int i = 0; i < params->n_neighbors; i++)
@@ -428,7 +429,8 @@ namespace UMAPAlgo {
                 CUDA_CHECK(cudaPeekAtLastError());
 
                 int n_compressed_nonzeros = 0;
-                MLCommon::updateHost(&n_compressed_nonzeros, rnnz + n, 1);
+                MLCommon::updateHost(&n_compressed_nonzeros, rnnz + n, 1, stream);
+                CUDA_CHECK(cudaStreamSynchronize(stream));
 
                 /**
                  * Remove resulting zeros from COO

--- a/cuML/src/umap/optimize.h
+++ b/cuML/src/umap/optimize.h
@@ -93,8 +93,8 @@ namespace UMAPAlgo {
              */
             T *a_deriv;
             MLCommon::allocate(a_deriv, n_rows);
-            MLCommon::copy(a_deriv, input, n_rows);
-            map_kernel<T, TPB_X><<<grid, blk>>>(a_deriv, a_deriv, n_rows, coef,
+            MLCommon::copy(a_deriv, input, n_rows, stream);
+            map_kernel<T, TPB_X><<<grid, blk, 0, stream>>>(a_deriv, a_deriv, n_rows, coef,
                     []__device__ __host__ (T x, T a, T b) {
                         return -(pow(x, 2.0*b)) /
                                 pow((1.0 + a * pow(x, 2.0 * b)), 2.0);
@@ -109,8 +109,8 @@ namespace UMAPAlgo {
              */
             T *b_deriv;
             MLCommon::allocate(b_deriv, n_rows);
-            MLCommon::copy(b_deriv, input, n_rows);
-            map_kernel<T, TPB_X><<<grid, blk>>>(b_deriv, b_deriv, n_rows, coef,
+            MLCommon::copy(b_deriv, input, n_rows, stream);
+            map_kernel<T, TPB_X><<<grid, blk, 0, stream>>>(b_deriv, b_deriv, n_rows, coef,
                     []__device__ __host__ (T x, T a, T b) {
                         return -(2.0 * a * pow(x, 2.0 * b) * log(x))
                                 / pow(1 + a * pow(x, 2.0 * b), 2.0);

--- a/cuML/src/umap/runner.h
+++ b/cuML/src/umap/runner.h
@@ -261,8 +261,8 @@ namespace UMAPAlgo {
         CUDA_CHECK(cudaPeekAtLastError());
 
         if(params->verbose) {
-            std::cout << MLCommon::arr2Str(sigmas, n, "sigmas") << std::endl;
-            std::cout << MLCommon::arr2Str(rhos, n, "rhos") << std::endl;
+            std::cout << MLCommon::arr2Str(sigmas, n, "sigmas", stream) << std::endl;
+            std::cout << MLCommon::arr2Str(rhos, n, "rhos", stream) << std::endl;
         }
 
         int *ia, *ex_scan;

--- a/cuML/src/umap/simpl_set_embed/algo.h
+++ b/cuML/src/umap/simpl_set_embed/algo.h
@@ -259,11 +259,11 @@ namespace UMAPAlgo {
 
 	            T *epoch_of_next_negative_sample;
                 MLCommon::allocate(epoch_of_next_negative_sample, nnz);
-                MLCommon::copy(epoch_of_next_negative_sample, epochs_per_negative_sample, nnz);
+                MLCommon::copy(epoch_of_next_negative_sample, epochs_per_negative_sample, nnz, stream);
 
 	            T *epoch_of_next_sample;
                 MLCommon::allocate(epoch_of_next_sample, nnz);
-                MLCommon::copy(epoch_of_next_sample, epochs_per_sample, nnz);
+                MLCommon::copy(epoch_of_next_sample, epochs_per_sample, nnz, stream);
 
                 dim3 grid(MLCommon::ceildiv(nnz, TPB_X), 1, 1);
                 dim3 blk(TPB_X, 1, 1);

--- a/cuML/test/dbscan_test.cu
+++ b/cuML/test/dbscan_test.cu
@@ -46,6 +46,8 @@ template<typename T>
 class DbscanTest: public ::testing::TestWithParam<DbscanInputs<T> > {
 protected:
 	void basicTest() {
+		cudaStream_t stream;
+		CUDA_CHECK( cudaStreamCreate(&stream) );
 
 		params = ::testing::TestWithParam<DbscanInputs<T>>::GetParam();
 		Random::Rng r(params.seed);
@@ -55,19 +57,17 @@ protected:
 
 		std::vector<T> data_h = { 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 8.0, 7.0, 8.0, 8.0, 25.0, 80.0 };
 		data_h.resize(len);
-		updateDevice(data, data_h.data(), len);
+		updateDevice(data, data_h.data(), len, stream);
 
 		allocate(labels, params.n_row);
 		allocate(labels_ref, params.n_row);
 		std::vector<int> labels_ref_h = { 0, 0, 0, 1, 1, -1 };
 		labels_ref_h.resize(len);
-		updateDevice(labels_ref, labels_ref_h.data(), params.n_row);
+		updateDevice(labels_ref, labels_ref_h.data(), params.n_row, stream);
 
 		T eps = 3.0;
 		int min_pts = 2;
 		cumlHandle handle;
-		cudaStream_t stream;
-		CUDA_CHECK( cudaStreamCreate(&stream) );
 		handle.setStream(stream);
 		dbscanFit(handle, data, params.n_row, params.n_col, eps, min_pts, labels);
 		CUDA_CHECK( cudaStreamSynchronize(stream) );

--- a/cuML/test/kmeans_test.cu
+++ b/cuML/test/kmeans_test.cu
@@ -52,16 +52,16 @@ protected:
         // make testdata on host
         std::vector<T> h_srcdata = {1.0,1.0,3.0,4.0, 1.0,2.0,2.0,3.0};
         h_srcdata.resize(n * m);
-        updateDevice(d_srcdata, h_srcdata.data(), m*n);
+        updateDevice(d_srcdata, h_srcdata.data(), m*n, stream);
 
         // make and assign reference output
         std::vector<int> h_labels_ref_fit = {1, 1, 0, 0};
         h_labels_ref_fit.resize(m);
-        updateDevice(labels_ref_fit, h_labels_ref_fit.data(), m);
+        updateDevice(labels_ref_fit, h_labels_ref_fit.data(), m, stream);
 
         std::vector<T> h_centroids_ref = {3.5,2.5, 1.0,1.5};
         h_centroids_ref.resize(k * n);
-        updateDevice(centroids_ref, h_centroids_ref.data(), k * n);
+        updateDevice(centroids_ref, h_centroids_ref.data(), k * n, stream);
 
         // The actual kmeans api calls
         // fit
@@ -71,7 +71,8 @@ protected:
     }
 
  	void SetUp() override {
-		basicTest();
+            CUDA_CHECK(cudaStreamCreate(&stream));
+            basicTest();
 	}
 
 	void TearDown() override {
@@ -80,7 +81,7 @@ protected:
 		CUDA_CHECK(cudaFree(pred_centroids));
 		CUDA_CHECK(cudaFree(labels_ref_fit));
 		CUDA_CHECK(cudaFree(centroids_ref));
-
+                CUDA_CHECK(cudaStreamDestroy(stream));
 	}
 
 protected:
@@ -95,6 +96,7 @@ protected:
     char ord = 'c'; // here c means col order, NOT C (vs F) order
     int max_iterations = 300;
     int init_from_data = 0;
+    cudaStream_t stream;
 };
 
 const std::vector<KmeansInputs<float> > inputsf2 = {

--- a/cuML/test/knn_test.cu
+++ b/cuML/test/knn_test.cu
@@ -52,15 +52,15 @@ protected:
         // make testdata on host
         std::vector<T> h_train_inputs = {1.0, 50.0, 51.0};
         h_train_inputs.resize(n);
-        updateDevice(d_train_inputs, h_train_inputs.data(), n*d);
+        updateDevice(d_train_inputs, h_train_inputs.data(), n*d, 0);
 
         std::vector<T> h_res_D = { 0.0, 2401.0, 2500.0, 0.0, 1.0, 2401.0, 0.0, 1.0, 2500.0 };
         h_res_D.resize(n*n);
-        updateDevice(d_ref_D, h_res_D.data(), n*n);
+        updateDevice(d_ref_D, h_res_D.data(), n*n, 0);
 
         std::vector<long> h_res_I = { 0, 1, 2, 1, 2, 0, 2, 1, 0 };
         h_res_I.resize(n*n);
-        updateDevice<long>(d_ref_I, h_res_I.data(), n*n);
+        updateDevice<long>(d_ref_I, h_res_I.data(), n*n, 0);
 
         kNNParams params[1];
         params[0] = { d_train_inputs, n };

--- a/cuML/test/ols.cu
+++ b/cuML/test/ols.cu
@@ -70,39 +70,39 @@ protected:
 
 		std::vector<T> data_h = {1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0, 3.0};
 		data_h.resize(len);
-		updateDevice(data, data_h.data(), len);
+		updateDevice(data, data_h.data(), len, stream);
 
 		std::vector<T> labels_h = {6.0, 8.0, 9.0, 11.0};
 		labels_h.resize(params.n_row);
-		updateDevice(labels, labels_h.data(), params.n_row);
+		updateDevice(labels, labels_h.data(), params.n_row, stream);
 
 		std::vector<T> coef_ref_h = {2.090908, 2.5454557};
 		coef_ref_h.resize(params.n_col);
-		updateDevice(coef_ref, coef_ref_h.data(), params.n_col);
+		updateDevice(coef_ref, coef_ref_h.data(), params.n_col, stream);
 
 		std::vector<T> coef2_ref_h = {1.000001 , 1.9999998};
 		coef2_ref_h.resize(params.n_col);
-		updateDevice(coef2_ref, coef2_ref_h.data(), params.n_col);
+		updateDevice(coef2_ref, coef2_ref_h.data(), params.n_col, stream);
 
 		std::vector<T> coef3_ref_h = {0.99999 , 2.00000};
 		coef3_ref_h.resize(params.n_col);
-		updateDevice(coef3_ref, coef3_ref_h.data(), params.n_col);
+		updateDevice(coef3_ref, coef3_ref_h.data(), params.n_col, stream);
 
 		std::vector<T> pred_data_h = {3.0, 2.0, 5.0, 5.0};
 		pred_data_h.resize(len2);
-		updateDevice(pred_data, pred_data_h.data(), len2);
+		updateDevice(pred_data, pred_data_h.data(), len2, stream);
 
 		std::vector<T> pred_ref_h = {19.0, 16.9090};
 		pred_ref_h.resize(params.n_row_2);
-		updateDevice(pred_ref, pred_ref_h.data(), params.n_row_2);
+		updateDevice(pred_ref, pred_ref_h.data(), params.n_row_2, stream);
 
 		std::vector<T> pred2_ref_h = {16.0, 15.0};
 		pred2_ref_h.resize(params.n_row_2);
-		updateDevice(pred2_ref, pred2_ref_h.data(), params.n_row_2);
+		updateDevice(pred2_ref, pred2_ref_h.data(), params.n_row_2, stream);
 
 		std::vector<T> pred3_ref_h = {16.0, 15.0};
 		pred3_ref_h.resize(params.n_row_2);
-		updateDevice(pred3_ref, pred3_ref_h.data(), params.n_row_2);
+		updateDevice(pred3_ref, pred3_ref_h.data(), params.n_row_2, stream);
 
 		intercept = T(0);
 
@@ -112,8 +112,8 @@ protected:
 		olsPredict(pred_data, params.n_row_2, params.n_col, coef, intercept,
 				pred, cublas_handle, stream);
 
-		updateDevice(data, data_h.data(), len);
-		updateDevice(labels, labels_h.data(), params.n_row);
+		updateDevice(data, data_h.data(), len, stream);
+		updateDevice(labels, labels_h.data(), params.n_row, stream);
 
 		intercept2 = T(0);
 		olsFit(data, params.n_row, params.n_col, labels, coef2, &intercept2,
@@ -122,8 +122,8 @@ protected:
 		olsPredict(pred_data, params.n_row_2, params.n_col, coef2, intercept2,
 				pred2, cublas_handle, stream);
 
-		updateDevice(data, data_h.data(), len);
-		updateDevice(labels, labels_h.data(), params.n_row);
+		updateDevice(data, data_h.data(), len, stream);
+		updateDevice(labels, labels_h.data(), params.n_row, stream);
 
 		intercept3 = T(0);
 		olsFit(data, params.n_row, params.n_col, labels, coef3, &intercept3,
@@ -158,15 +158,15 @@ protected:
 
 		std::vector<T> data_h = {1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0, 3.0};
 		data_h.resize(len);
-		updateDevice(data_sc, data_h.data(), len);
+		updateDevice(data_sc, data_h.data(), len, stream);
 
 		std::vector<T> labels_h = {6.0, 8.0, 9.0, 11.0, -1.0, 2.0, -3.6, 3.3};
 		labels_h.resize(len);
-		updateDevice(labels_sc, labels_h.data(), len);
+		updateDevice(labels_sc, labels_h.data(), len, stream);
 
 		std::vector<T> coef_sc_ref_h = {-0.29285714};
 		coef_sc_ref_h.resize(1);
-		updateDevice(coef_sc_ref, coef_sc_ref_h.data(), 1);
+		updateDevice(coef_sc_ref, coef_sc_ref_h.data(), 1, stream);
 
 		T intercept_sc = T(0);
 

--- a/cuML/test/pca_test.cu
+++ b/cuML/test/pca_test.cu
@@ -70,11 +70,11 @@ protected:
 
 		std::vector<T> data_h = { 1.0, 2.0, 5.0, 4.0, 2.0, 1.0 };
 		data_h.resize(len);
-		updateDevice(data, data_h.data(), len);
+		updateDevice(data, data_h.data(), len, stream);
 
 		std::vector<T> trans_data_ref_h = { -2.3231, -0.3517, 2.6748, -0.3979, 0.6571, -0.2592 };
 		trans_data_ref_h.resize(len);
-		updateDevice(trans_data_ref, trans_data_ref_h.data(), len);
+		updateDevice(trans_data_ref, trans_data_ref_h.data(), len, stream);
 
 		int len_comp = params.n_col * params.n_col;
 		allocate(components, len_comp);
@@ -92,8 +92,8 @@ protected:
 		allocate(components_ref, len_comp);
 		allocate(explained_vars_ref, params.n_col);
 
-		updateDevice(components_ref, components_ref_h.data(), len_comp);
-		updateDevice(explained_vars_ref, explained_vars_ref_h.data(), params.n_col);
+		updateDevice(components_ref, components_ref_h.data(), len_comp, stream);
+		updateDevice(explained_vars_ref, explained_vars_ref_h.data(), params.n_col, stream);
 
 		paramsPCA prms;
 		prms.n_cols = params.n_col;

--- a/cuML/test/ridge.cu
+++ b/cuML/test/ridge.cu
@@ -70,31 +70,31 @@ protected:
 		T alpha = params.alpha;
 
 		T data_h[len] = { 0.0, 0.0, 1.0, 0.0, 0.0, 1.0 };
-		updateDevice(data, data_h, len);
+		updateDevice(data, data_h, len, stream);
 
 		T labels_h[params.n_row] = { 0.0, 0.1, 1.0 };
-		updateDevice(labels, labels_h, params.n_row);
+		updateDevice(labels, labels_h, params.n_row, stream);
 
 		T coef_ref_h[params.n_col] = { 0.39999998, 0.4 };
-		updateDevice(coef_ref, coef_ref_h, params.n_col);
+		updateDevice(coef_ref, coef_ref_h, params.n_col, stream);
 
 		T coef2_ref_h[params.n_col] = { 0.3454546, 0.34545454 };
-		updateDevice(coef2_ref, coef2_ref_h, params.n_col);
+		updateDevice(coef2_ref, coef2_ref_h, params.n_col, stream);
 
 		T coef3_ref_h[params.n_col] = { 0.3799999, 0.38000008 };
-		updateDevice(coef3_ref, coef3_ref_h, params.n_col);
+		updateDevice(coef3_ref, coef3_ref_h, params.n_col, stream);
 
 		T pred_data_h[len2] = { 0.5, 2.0, 0.2, 1.0 };
-		updateDevice(pred_data, pred_data_h, len2);
+		updateDevice(pred_data, pred_data_h, len2, stream);
 
 		T pred_ref_h[params.n_row_2] = { 0.28, 1.1999999 };
-		updateDevice(pred_ref, pred_ref_h, params.n_row_2);
+		updateDevice(pred_ref, pred_ref_h, params.n_row_2, stream);
 
 		T pred2_ref_h[params.n_row_2] = { 0.37818184, 1.1727273 };
-		updateDevice(pred2_ref, pred2_ref_h, params.n_row_2);
+		updateDevice(pred2_ref, pred2_ref_h, params.n_row_2, stream);
 
 		T pred3_ref_h[params.n_row_2] = { 0.37933332, 1.2533332 };
-		updateDevice(pred3_ref, pred3_ref_h, params.n_row_2);
+		updateDevice(pred3_ref, pred3_ref_h, params.n_row_2, stream);
 
 		intercept = T(0);
 
@@ -105,8 +105,8 @@ protected:
 		ridgePredict(pred_data, params.n_row_2, params.n_col, coef, intercept,
 				pred, cublas_handle, stream);
 
-		updateDevice(data, data_h, len);
-		updateDevice(labels, labels_h, params.n_row);
+		updateDevice(data, data_h, len, stream);
+		updateDevice(labels, labels_h, params.n_row, stream);
 
 		intercept2 = T(0);
 		ridgeFit(data, params.n_row, params.n_col, labels, &alpha, 1, coef2,
@@ -116,8 +116,8 @@ protected:
 		ridgePredict(pred_data, params.n_row_2, params.n_col, coef2, intercept2,
 				pred2, cublas_handle, stream);
 
-		updateDevice(data, data_h, len);
-		updateDevice(labels, labels_h, params.n_row);
+		updateDevice(data, data_h, len, stream);
+		updateDevice(labels, labels_h, params.n_row, stream);
 
 		intercept3 = T(0);
 		ridgeFit(data, params.n_row, params.n_col, labels, &alpha, 1, coef3,
@@ -153,15 +153,15 @@ protected:
 
 		std::vector<T> data_h = {1.0, 1.0, 2.0, 2.0, 1.0, 2.0};
 		data_h.resize(len);
-		updateDevice(data_sc, data_h.data(), len);
+		updateDevice(data_sc, data_h.data(), len, stream);
 
 		std::vector<T> labels_h = {6.0, 8.0, 9.0, 11.0, -1.0, 2.0};
 		labels_h.resize(len);
-		updateDevice(labels_sc, labels_h.data(), len);
+		updateDevice(labels_sc, labels_h.data(), len, stream);
 
 		std::vector<T> coef_sc_ref_h = {1.8};
 		coef_sc_ref_h.resize(1);
-		updateDevice(coef_sc_ref, coef_sc_ref_h.data(), 1);
+		updateDevice(coef_sc_ref, coef_sc_ref_h.data(), 1, stream);
 
 		T intercept_sc = T(0);
 		T alpha_sc = T(1.0);

--- a/cuML/test/sgd.cu
+++ b/cuML/test/sgd.cu
@@ -46,16 +46,16 @@ protected:
 		allocate(coef2_ref, params.n_col);
 
 		T data_h[len] = { 1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0, 3.0 };
-		updateDevice(data, data_h, len);
+		updateDevice(data, data_h, len, stream);
 
 		T labels_h[params.n_row] = { 6.0, 8.0, 9.0, 11.0 };
-		updateDevice(labels, labels_h, params.n_row);
+		updateDevice(labels, labels_h, params.n_row, stream);
 
 		T coef_ref_h[params.n_col] = { 2.087, 2.5454557 };
-		updateDevice(coef_ref, coef_ref_h, params.n_col);
+		updateDevice(coef_ref, coef_ref_h, params.n_col, stream);
 
 		T coef2_ref_h[params.n_col] = { 1.000001, 1.9999998 };
-		updateDevice(coef2_ref, coef2_ref_h, params.n_col);
+		updateDevice(coef2_ref, coef2_ref_h, params.n_col, stream);
 
 		bool fit_intercept = false;
 		intercept = T(0);
@@ -112,17 +112,17 @@ protected:
 
 		T data_h[len] = { 0.1, -2.1, 5.4, 5.4, -1.5, -2.15, 2.65, 2.65, 3.25,
 				-0.15, -7.35, -7.35 };
-		updateDevice(data_logreg, data_h, len);
+		updateDevice(data_logreg, data_h, len, stream);
 
 		T data_test_h[len] = { 0.3, 1.1, 2.1, -10.1, 0.5, 2.5, -3.55, -20.5,
 				-1.3, 3.0, -5.0, 15.0 };
-		updateDevice(data_logreg_test, data_test_h, len);
+		updateDevice(data_logreg_test, data_test_h, len, stream);
 
 		T labels_logreg_h[params.n_row2] = { 0.0, 1.0, 1.0, 0.0 };
-		updateDevice(labels_logreg, labels_logreg_h, params.n_row2);
+		updateDevice(labels_logreg, labels_logreg_h, params.n_row2, stream);
 
 		T pred_log_ref_h[params.n_row2] = { 1.0, 0.0, 1.0, 1.0 };
-		updateDevice(pred_log_ref, pred_log_ref_h, params.n_row2);
+		updateDevice(pred_log_ref, pred_log_ref_h, params.n_row2, stream);
 
 		bool fit_intercept = true;
 		T intercept_class = T(0);
@@ -177,17 +177,17 @@ protected:
 
 		T data_h[len] = { 0.1, -2.1, 5.4, 5.4, -1.5, -2.15, 2.65, 2.65, 3.25,
 				-0.15, -7.35, -7.35 };
-		updateDevice(data_svmreg, data_h, len);
+		updateDevice(data_svmreg, data_h, len, stream);
 
 		T data_test_h[len] = { 0.3, 1.1, 2.1, -10.1, 0.5, 2.5, -3.55, -20.5,
 				-1.3, 3.0, -5.0, 15.0 };
-		updateDevice(data_svmreg_test, data_test_h, len);
+		updateDevice(data_svmreg_test, data_test_h, len, stream);
 
 		T labels_svmreg_h[params.n_row2] = { 0.0, 1.0, 1.0, 0.0 };
-		updateDevice(labels_svmreg, labels_svmreg_h, params.n_row2);
+		updateDevice(labels_svmreg, labels_svmreg_h, params.n_row2, stream);
 
 		T pred_svm_ref_h[params.n_row2] = { 1.0, 0.0, 1.0, 1.0 };
-		updateDevice(pred_svm_ref, pred_svm_ref_h, params.n_row2);
+		updateDevice(pred_svm_ref, pred_svm_ref_h, params.n_row2, stream);
 
 		bool fit_intercept = true;
 		T intercept_class = T(0);

--- a/cuML/test/tsvd_test.cu
+++ b/cuML/test/tsvd_test.cu
@@ -65,7 +65,7 @@ protected:
 
 		std::vector<T> data_h = { 1.0, 2.0, 4.0, 2.0, 4.0, 5.0, 5.0, 4.0, 2.0, 1.0, 6.0, 4.0 };
 		data_h.resize(len);
-		updateDevice(data, data_h.data(), len);
+		updateDevice(data, data_h.data(), len, stream);
 
 		int len_comp = params.n_col * params.n_col;
 		allocate(components, len_comp);
@@ -76,7 +76,7 @@ protected:
 		components_ref_h.resize(len_comp);
 
 		allocate(components_ref, len_comp);
-		updateDevice(components_ref, components_ref_h.data(), len_comp);
+		updateDevice(components_ref, components_ref_h.data(), len_comp, stream);
 
 		paramsTSVD prms;
 		prms.n_cols = params.n_col;

--- a/cuML/test/umap_test.cu
+++ b/cuML/test/umap_test.cu
@@ -56,7 +56,7 @@ protected:
     float* X_d;
 
 		MLCommon::allocate(X_d, n*d);
-		MLCommon::updateDevice(X_d, X.data(), n*d);
+		MLCommon::updateDevice(X_d, X.data(), n*d, stream);
 
 		MLCommon::allocate(embeddings, n*umap_params->n_components);
 

--- a/cuML/test_mg/knn_test.cu
+++ b/cuML/test_mg/knn_test.cu
@@ -56,16 +56,16 @@ protected:
         std::vector<T> h_train_inputs = {1.0, 50.0, 51.0};
         h_train_inputs.resize(n);
 
-        updateDevice(d_train_inputs_dev1, h_train_inputs.data(), n*d);
-        updateDevice(d_train_inputs_dev2, h_train_inputs.data(), n*d);
+        updateDevice(d_train_inputs_dev1, h_train_inputs.data(), n*d, 0);
+        updateDevice(d_train_inputs_dev2, h_train_inputs.data(), n*d, 0);
 
         std::vector<T> h_res_D = { 0.0, 0.0, 2401.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0 };
         h_res_D.resize(n*n);
-        updateDevice(d_ref_D, h_res_D.data(), n*n);
+        updateDevice(d_ref_D, h_res_D.data(), n*n, 0);
 
         std::vector<long> h_res_I = { 0, 3, 1, 1, 4, 2, 2, 5, 1 };
         h_res_I.resize(n*n);
-        updateDevice<long>(d_ref_I, h_res_I.data(), n*n);
+        updateDevice<long>(d_ref_I, h_res_I.data(), n*n, 0);
 
         params[0] = { d_train_inputs_dev1, n };
         params[1] = { d_train_inputs_dev2, n };

--- a/ml-prims/src/cuda_utils.h
+++ b/ml-prims/src/cuda_utils.h
@@ -84,12 +84,13 @@ DI void forEach(int num, L lambda) {
 }
 
 template<typename T>
-std::string arr2Str(const T *arr, int size, std::string name) {
+std::string arr2Str(const T *arr, int size, std::string name, cudaStream_t stream) {
 
     std::stringstream ss;
 
     T* arr_h = (T*)malloc(size * sizeof(T));
-    updateHost(arr_h, arr, size);
+    updateHost(arr_h, arr, size, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     ss << name << " = [ ";
     for(int i = 0; i < size; i++) {

--- a/ml-prims/src/linalg/eig.h
+++ b/ml-prims/src/linalg/eig.h
@@ -58,7 +58,8 @@ void eigDC(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
   CUDA_CHECK(cudaGetLastError());
 
   int dev_info;
-  updateHost(&dev_info, d_dev_info, 1);
+  updateHost(&dev_info, d_dev_info, 1, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   ASSERT(dev_info == 0,
          "eig.h: eigensolver couldn't converge to a solution. "
          "This usually occurs when some of the features do not vary enough.");

--- a/ml-prims/src/linalg/svd.h
+++ b/ml-prims/src/linalg/svd.h
@@ -88,7 +88,8 @@ void svdQR(T *in, int n_rows, int n_cols, T *sing_vals, T *left_sing_vecs,
   CUDA_CHECK(cudaGetLastError());
 
   int dev_info;
-  updateHost(&dev_info, devInfo, 1);
+  updateHost(&dev_info, devInfo, 1, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   ASSERT(dev_info == 0,
          "svd.h: svd couldn't converge to a solution. "
          "This usually occurs when some of the features do not vary enough.");

--- a/ml-prims/src/random/mvg.h
+++ b/ml-prims/src/random/mvg.h
@@ -185,7 +185,8 @@ public: // functions
                                              dim, eig, workspace_decomp, Lwork,
                                              info, cudaStream));
     }
-    updateHost(&info_h, info, 1);
+    updateHost(&info_h, info, 1, cudaStream);
+    CUDA_CHECK(cudaStreamSynchronize(cudaStream));
     ASSERT(info_h == 0, "mvg: error in syevj/syevd/potrf, info=%d | expected=0",
            info_h);
     T mean = 0.0, stddv = 1.0;
@@ -214,7 +215,8 @@ public: // functions
       CUDA_CHECK(cudaPeekAtLastError());
 
       // checking if any eigen vals were negative
-      updateHost(&info_h, info, 1);
+      updateHost(&info_h, info, 1, cudaStream);
+      CUDA_CHECK(cudaStreamSynchronize(cudaStream));
       ASSERT(info_h == 0, "mvg: Cov matrix has %dth Eigenval negative", info_h);
 
       // Got Q = eigvect*eigvals.sqrt in P, Q*X in X below

--- a/ml-prims/src/sparse/coo.h
+++ b/ml-prims/src/sparse/coo.h
@@ -138,7 +138,7 @@ namespace MLCommon {
             cudaDeviceSynchronize();
 
 
-            copy(vals, vals_sorted, nnz);
+            copy(vals, vals_sorted, nnz, stream);
 
             cudaFree(d_P);
             cudaFree(vals_sorted);

--- a/ml-prims/src/utils.h
+++ b/ml-prims/src/utils.h
@@ -111,6 +111,20 @@ private:
 /// (Ref: https://github.com/rapidsai/cuml/issues/229)
 
 /**
+ * @brief Generic copy method for all kinds of transfers
+ * @tparam Type data type
+ * @param dst destination pointer
+ * @param src source pointer
+ * @param len lenth of the src/dst buffers in terms of number of elements
+ * @param stream cuda stream
+ */
+template <typename Type>
+void copy(Type *dst, Type *src, size_t len, cudaStream_t stream) {
+    CUDA_CHECK(cudaMemcpyAsync(dst, src, len * sizeof(Type),
+                               cudaMemcpyDefault, stream));
+}
+
+/**
  * @defgroup Copy Copy methods
  * @{
  */
@@ -144,13 +158,6 @@ void updateHostAsync(Type *hPtr, const Type *dPtr, size_t len,
                      cudaStream_t stream) {
   CUDA_CHECK(cudaMemcpyAsync(hPtr, dPtr, len * sizeof(Type),
                              cudaMemcpyDeviceToHost, stream));
-}
-
-/** performs a device to device copy */
-template <typename Type>
-void copy(Type* dPtr1, const Type* dPtr2, size_t len) {
-  CUDA_CHECK(cudaMemcpy(dPtr1, dPtr2, len*sizeof(Type),
-                        cudaMemcpyDeviceToDevice));
 }
 /** @} */
 

--- a/ml-prims/src/utils.h
+++ b/ml-prims/src/utils.h
@@ -119,45 +119,29 @@ private:
  * @param stream cuda stream
  */
 template <typename Type>
-void copy(Type *dst, Type *src, size_t len, cudaStream_t stream) {
+void copy(Type *dst, const Type *src, size_t len, cudaStream_t stream) {
     CUDA_CHECK(cudaMemcpyAsync(dst, src, len * sizeof(Type),
                                cudaMemcpyDefault, stream));
 }
 
 /**
  * @defgroup Copy Copy methods
+ * These are here along with the generic 'copy' method in order to improve
+ * code readability using explicitly specified function names
  * @{
  */
 /** performs a host to device copy */
 template <typename Type>
 void updateDevice(Type *dPtr, const Type *hPtr, size_t len,
-                  cudaStream_t stream = 0) {
-  CUDA_CHECK(cudaMemcpy(dPtr, hPtr, len * sizeof(Type),
-                        cudaMemcpyHostToDevice));
-}
-
-/** performs an sync host to device copy */
-template <typename Type>
-void updateDeviceAsync(Type *dPtr, const Type *hPtr, size_t len,
-                       cudaStream_t stream) {
-  CUDA_CHECK(cudaMemcpyAsync(dPtr, hPtr, len * sizeof(Type),
-                             cudaMemcpyHostToDevice, stream));
+                  cudaStream_t stream) {
+  copy(dPtr, hPtr, len, stream);
 }
 
 /** performs a device to host copy */
 template <typename Type>
 void updateHost(Type *hPtr, const Type *dPtr, size_t len,
-                cudaStream_t stream = 0) {
-  CUDA_CHECK(cudaMemcpy(hPtr, dPtr, len * sizeof(Type),
-                        cudaMemcpyDeviceToHost));
-}
-
-/** performs an async device to host copy */
-template <typename Type>
-void updateHostAsync(Type *hPtr, const Type *dPtr, size_t len,
-                     cudaStream_t stream) {
-  CUDA_CHECK(cudaMemcpyAsync(hPtr, dPtr, len * sizeof(Type),
-                             cudaMemcpyDeviceToHost, stream));
+                cudaStream_t stream) {
+  copy(hPtr, dPtr, len, stream);
 }
 /** @} */
 

--- a/ml-prims/test/coo.cu
+++ b/ml-prims/test/coo.cu
@@ -66,10 +66,10 @@ TEST_P(COOSort, Result) {
     allocate(in_cols, params.nnz);
     allocate(verify, params.nnz);
 
-    updateDevice(in_rows, in_rows_h, params.nnz);
+    updateDevice(in_rows, in_rows_h, params.nnz, stream);
 
-    updateDevice(in_cols, in_cols_h, params.nnz);
-    updateDevice(verify, verify_h, params.nnz);
+    updateDevice(in_cols, in_cols_h, params.nnz, stream);
+    updateDevice(verify, verify_h, params.nnz, stream);
 
     coo_sort(params.m, params.n, params.nnz, in_rows, in_cols, in_vals);
 
@@ -96,13 +96,14 @@ TEST_P(COORemoveZeros, Result) {
     r.uniform(in_vals, params.nnz, float(-1.0), float(1.0), stream);
 
     float *vals_h = (float*)malloc(params.nnz * sizeof(float));
-    updateHost(vals_h, in_vals, params.nnz);
+    updateHost(vals_h, in_vals, params.nnz, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     vals_h[0] = 0;
     vals_h[2] = 0;
     vals_h[3] = 0;
 
-    updateDevice(in_vals, vals_h, params.nnz);
+    updateDevice(in_vals, vals_h, params.nnz, stream);
 
     int out_rows_ref_h[2]  = { 3, 0 };
     int out_cols_ref_h[2] =  { 1, 4 };
@@ -120,14 +121,14 @@ TEST_P(COORemoveZeros, Result) {
     allocate(out_vals_ref, 2);
     allocate(out_cols_ref, 2);
 
-    updateDevice(out_rows_ref, *&out_rows_ref_h, 2);
-    updateDevice(out_cols_ref, *&out_cols_ref_h, 2);
-    updateDevice(out_vals_ref, out_vals_ref_h, 2);
+    updateDevice(out_rows_ref, *&out_rows_ref_h, 2, stream);
+    updateDevice(out_cols_ref, *&out_cols_ref_h, 2, stream);
+    updateDevice(out_vals_ref, out_vals_ref_h, 2, stream);
 
     int *cnnz, cnnz_h[5] = { 0, 1, 0, 0, 1 };
     allocate(cnnz, 5);
 
-    updateDevice(cnnz, *&cnnz_h, 5);
+    updateDevice(cnnz, *&cnnz_h, 5, stream);
 
     int *in_rows_h = (int*)malloc(params.nnz * sizeof(int));
     int *in_cols_h = (int*)malloc(params.nnz * sizeof(int));
@@ -140,8 +141,8 @@ TEST_P(COORemoveZeros, Result) {
     allocate(in_rows, params.nnz);
     allocate(in_cols, params.nnz);
 
-    updateDevice(in_rows, in_rows_h, params.nnz);
-    updateDevice(in_cols, in_cols_h, params.nnz);
+    updateDevice(in_rows, in_rows_h, params.nnz, stream);
+    updateDevice(in_cols, in_cols_h, params.nnz, stream);
 
     coo_remove_zeros<16, float>(params.nnz, in_rows, in_cols, in_vals, out_rows, out_cols, out_vals, cnnz, 5);
 
@@ -178,8 +179,8 @@ TEST_P(COORowCount, Result) {
     allocate(verify, 5, true);
     allocate(results, 5, true);
 
-    updateDevice(in_rows, *&in_rows_h, 5);
-    updateDevice(verify, *&verify_h, 5);
+    updateDevice(in_rows, *&in_rows_h, 5, 0);
+    updateDevice(verify, *&verify_h, 5, 0);
 
     dim3 grid(ceildiv(5, 32), 1, 1);
     dim3 blk(32, 1, 1);
@@ -207,9 +208,9 @@ TEST_P(COORowCountNonzero, Result) {
     allocate(results, 5, true);
     allocate(in_vals, 5, true);
 
-    updateDevice(in_rows, *&in_rows_h, 5);
-    updateDevice(verify, *&verify_h, 5);
-    updateDevice(in_vals, *&in_vals_h, 5);
+    updateDevice(in_rows, *&in_rows_h, 5, 0);
+    updateDevice(verify, *&verify_h, 5, 0);
+    updateDevice(in_vals, *&in_vals_h, 5, 0);
 
     dim3 grid(ceildiv(5, 32), 1, 1);
     dim3 blk(32, 1, 1);

--- a/ml-prims/test/cov.cu
+++ b/ml-prims/test/cov.cu
@@ -65,8 +65,8 @@ protected:
     allocate(cov_cm_ref, 4);
     allocate(mean_cm, 2);
 
-    updateDevice(data_cm, data_h, 6);
-    updateDevice(cov_cm_ref, cov_cm_ref_h, 4);
+    updateDevice(data_cm, data_h, 6, stream);
+    updateDevice(cov_cm_ref, cov_cm_ref_h, 4, stream);
 
     mean(mean_cm, data_cm, 2, 3, true, false, stream);
     cov(cov_cm, data_cm, mean_cm, 2, 3, true, false, true, handle, stream);

--- a/ml-prims/test/csr.cu
+++ b/ml-prims/test/csr.cu
@@ -55,9 +55,9 @@ TEST_P(CSRRowNormalizeL1, Result) {
     allocate(ex_scan, 4);
     allocate(result, 10, true);
 
-    updateDevice(ex_scan, *&ex_scan_h, 4);
-    updateDevice(in_vals, *&in_vals_h, 10);
-    updateDevice(verify, *&verify_h, 10);
+    updateDevice(ex_scan, *&ex_scan_h, 4, 0);
+    updateDevice(in_vals, *&in_vals_h, 10, 0);
+    updateDevice(verify, *&verify_h, 10, 0);
 
     dim3 grid(ceildiv(10, 32), 1, 1);
     dim3 blk(32, 1, 1);

--- a/ml-prims/test/decoupled_lookback.cu
+++ b/ml-prims/test/decoupled_lookback.cu
@@ -71,9 +71,10 @@ protected:
 
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatchCustom(const T *actual, size_t size,
-                                             L eq_compare) {
+                                             L eq_compare, cudaStream_t stream = 0) {
   std::vector<T> act_h(size);
-  updateHost<T>(&(act_h[0]), actual, size);
+  updateHost<T>(&(act_h[0]), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i(0); i < size; ++i) {
     auto act = act_h[i];
     auto expected = (T)i;

--- a/ml-prims/test/eig.cu
+++ b/ml-prims/test/eig.cu
@@ -56,7 +56,7 @@ protected:
     T cov_matrix_h[] = {1.0,  0.9, 0.81, 0.729, 0.9,   1.0,  0.9, 0.81,
                         0.81, 0.9, 1.0,  0.9,   0.729, 0.81, 0.9, 1.0};
     ASSERT(len == 16, "This test only works with 4x4 matrices!");
-    updateDevice(cov_matrix, cov_matrix_h, len);
+    updateDevice(cov_matrix, cov_matrix_h, len, stream);
 
     allocate(eig_vectors, len);
     allocate(eig_vals, params.n_col);
@@ -72,8 +72,8 @@ protected:
     allocate(eig_vectors_ref, len);
     allocate(eig_vals_ref, params.n_col);
 
-    updateDevice(eig_vectors_ref, eig_vectors_ref_h, len);
-    updateDevice(eig_vals_ref, eig_vals_ref_h, params.n_col);
+    updateDevice(eig_vectors_ref, eig_vectors_ref_h, len, stream);
+    updateDevice(eig_vals_ref, eig_vals_ref_h, params.n_col, stream);
 
     eigDC(cov_matrix, params.n_row, params.n_col, eig_vectors, eig_vals,
           cusolverH, stream, mgr);

--- a/ml-prims/test/gather.cu
+++ b/ml-prims/test/gather.cu
@@ -114,7 +114,7 @@ protected:
 
     // launch gather on the host and copy the results to device
     naiveGather(h_in, ncols, nrows, h_map, map_length, h_out);
-    updateDevice(d_out_exp, h_out, map_length * ncols);
+    updateDevice(d_out_exp, h_out, map_length * ncols, stream);
 
     // launch device version of the kernel
     gatherLaunch(d_in, ncols, nrows, d_map, map_length, d_out_act, stream);

--- a/ml-prims/test/gemm.cu
+++ b/ml-prims/test/gemm.cu
@@ -52,7 +52,8 @@ TEST(Gemm, Gemm_128x128x8) {
   gemm<float, float, float, cutlass::Shape<8, 128, 128>>(
     CUBLAS_OP_N, CUBLAS_OP_N, M, N, K, 1.f, B, N, A, K, 1.f, C, N, D, stream);
   float *hD = new float[M * N];
-  updateHost<float>(hD, D, M * N);
+  updateHost<float>(hD, D, M * N, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (int i = 0; i < M * N; ++i) {
     ASSERT_FLOAT_EQ(0.5f * K + 2.f, hD[i]) << " @hD[" << i << "]";
   }

--- a/ml-prims/test/hinge.cu
+++ b/ml-prims/test/hinge.cu
@@ -54,37 +54,37 @@ protected:
         allocate(coef, params.n_cols);
 
         T h_in[len] = {0.1, 0.35, -0.9, -1.4, 2.0, 3.1};
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         T h_labels[n_rows] = {0.3, 2.0, -1.1};
-        updateDevice(labels, h_labels, n_rows);
+        updateDevice(labels, h_labels, n_rows, stream);
 
         T h_coef[n_cols] = {0.35, -0.24};
-        updateDevice(coef, h_coef, n_cols);
+        updateDevice(coef, h_coef, n_cols, stream);
 
         T h_out_ref[1] = {2.6037};
-        updateDevice(out_ref, h_out_ref, 1);
+        updateDevice(out_ref, h_out_ref, 1, stream);
 
         T h_out_lasso_ref[1] = {2.9577};
-        updateDevice(out_lasso_ref, h_out_lasso_ref, 1);
+        updateDevice(out_lasso_ref, h_out_lasso_ref, 1, stream);
 
         T h_out_ridge_ref[1] = {2.71176};
-        updateDevice(out_ridge_ref, h_out_ridge_ref, 1);
+        updateDevice(out_ridge_ref, h_out_ridge_ref, 1, stream);
 
         T h_out_elasticnet_ref[1] = {2.83473};
-        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1);
+        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1, stream);
 
         T h_out_grad_ref[n_cols] = {-0.24333, -1.1933};
-        updateDevice(out_grad_ref, h_out_grad_ref, n_cols);
+        updateDevice(out_grad_ref, h_out_grad_ref, n_cols, stream);
 
         T h_out_lasso_grad_ref[n_cols] = {0.3566, -1.7933};
-        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, n_cols);
+        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, n_cols, stream);
 
         T h_out_ridge_grad_ref[n_cols] = {0.1766, -1.4813};
-        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, n_cols);
+        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, n_cols, stream);
 
         T h_out_elasticnet_grad_ref[n_cols] = {0.2666, -1.63733};
-        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, n_cols);
+        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, n_cols, stream);
 
         T alpha = 0.6;
         T l1_ratio = 0.5;
@@ -92,22 +92,22 @@ protected:
         hingeLoss(in, params.n_rows, params.n_cols, labels, coef, out, penalty::NONE,
                     alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         hingeLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_grad, penalty::NONE,
                         alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         hingeLoss(in, params.n_rows, params.n_cols, labels, coef, out_lasso, penalty::L1,
                     alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         hingeLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_lasso_grad, penalty::L1,
                         alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         hingeLoss(in, params.n_rows, params.n_cols, labels, coef, out_ridge, penalty::L2,
                     alpha, l1_ratio, cublas_handle, stream);
@@ -115,7 +115,7 @@ protected:
         hingeLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_ridge_grad, penalty::L2,
                         alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         hingeLoss(in, params.n_rows, params.n_cols, labels, coef, out_elasticnet, penalty::ELASTICNET,
                     alpha, l1_ratio, cublas_handle, stream);
@@ -123,7 +123,7 @@ protected:
         hingeLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_elasticnet_grad, penalty::ELASTICNET,
                         alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         CUBLAS_CHECK(cublasDestroy(cublas_handle));
         CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/kselection.cu
+++ b/ml-prims/test/kselection.cu
@@ -46,7 +46,7 @@ void sortTest(TypeK *key) {
   CUDA_CHECK(cudaMalloc((void **)&dkey, sizeof(TypeK) * TPB * N));
   sortTestKernel<TypeV, TypeK, N, TPB, Greater><<<1, TPB>>>(dkey);
   CUDA_CHECK(cudaPeekAtLastError());
-  updateHost<TypeK>(key, dkey, TPB * N);
+  updateHost<TypeK>(key, dkey, TPB * N, 0);
   CUDA_CHECK(cudaFree(dkey));
 }
 
@@ -77,7 +77,7 @@ template <typename TypeV, typename TypeK, bool Greater>
   for (int rIndex = 0; rIndex < rows; rIndex++) {
     // input data
     TypeV *h_arr = new TypeV[N];
-    updateHost(h_arr, d_arr + rIndex * N, N);
+    updateHost(h_arr, d_arr + rIndex * N, N, 0);
     KVPair<TypeV, TypeK> *topk = new KVPair<TypeV, TypeK>[N];
     for (int j = 0; j < N; j++) {
       topk[j].val = h_arr[j];
@@ -85,9 +85,9 @@ template <typename TypeV, typename TypeK, bool Greater>
     }
     // result reference
     TypeV *h_outv = new TypeV[k];
-    updateHost(h_outv, d_outv + rIndex * k, k);
+    updateHost(h_outv, d_outv + rIndex * k, k, 0);
     TypeK *h_outk = new TypeK[k];
-    updateHost(h_outk, d_outk + rIndex * k, k);
+    updateHost(h_outk, d_outk + rIndex * k, k, 0);
     // calculate the result
     partSortKVPair<TypeV, TypeK, Greater>(topk, N, k);
 

--- a/ml-prims/test/linearReg.cu
+++ b/ml-prims/test/linearReg.cu
@@ -54,37 +54,37 @@ protected:
         allocate(coef, params.n_cols);
 
         T h_in[len] = {0.1, 0.35, -0.9, -1.4, 2.0, 3.1};
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         T h_labels[n_rows] = {0.3, 2.0, -1.1};
-        updateDevice(labels, h_labels, n_rows);
+        updateDevice(labels, h_labels, n_rows, stream);
 
         T h_coef[n_cols] = {0.35, -0.24};
-        updateDevice(coef, h_coef, n_cols);
+        updateDevice(coef, h_coef, n_cols, stream);
 
         T h_out_ref[1] = {1.854842};
-        updateDevice(out_ref, h_out_ref, 1);
+        updateDevice(out_ref, h_out_ref, 1, stream);
 
         T h_out_lasso_ref[1] = {2.2088};
-        updateDevice(out_lasso_ref, h_out_lasso_ref, 1);
+        updateDevice(out_lasso_ref, h_out_lasso_ref, 1, stream);
 
         T h_out_ridge_ref[1] = {1.9629};
-        updateDevice(out_ridge_ref, h_out_ridge_ref, 1);
+        updateDevice(out_ridge_ref, h_out_ridge_ref, 1, stream);
 
         T h_out_elasticnet_ref[1] = {2.0858};
-        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1);
+        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1, stream);
 
         T h_out_grad_ref[n_cols] = {-0.56995, -3.12486};
-        updateDevice(out_grad_ref, h_out_grad_ref, n_cols);
+        updateDevice(out_grad_ref, h_out_grad_ref, n_cols, stream);
 
         T h_out_lasso_grad_ref[n_cols] = {0.03005, -3.724866};
-        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, n_cols);
+        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, n_cols, stream);
 
         T h_out_ridge_grad_ref[n_cols] = {-0.14995, -3.412866};
-        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, n_cols);
+        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, n_cols, stream);
 
         T h_out_elasticnet_grad_ref[n_cols] = {-0.05995, -3.568866};
-        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, n_cols);
+        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, n_cols, stream);
 
         T alpha = 0.6;
         T l1_ratio = 0.5;
@@ -92,22 +92,22 @@ protected:
         linearRegLoss(in, params.n_rows, params.n_cols, labels, coef, out, penalty::NONE,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         linearRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_grad, penalty::NONE,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         linearRegLoss(in, params.n_rows, params.n_cols, labels, coef, out_lasso, penalty::L1,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         linearRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_lasso_grad, penalty::L1,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         linearRegLoss(in, params.n_rows, params.n_cols, labels, coef, out_ridge, penalty::L2,
                                       alpha, l1_ratio, cublas_handle, stream);
@@ -115,7 +115,7 @@ protected:
         linearRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_ridge_grad, penalty::L2,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         linearRegLoss(in, params.n_rows, params.n_cols, labels, coef, out_elasticnet, penalty::ELASTICNET,
                                       alpha, l1_ratio, cublas_handle, stream);
@@ -123,7 +123,7 @@ protected:
         linearRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_elasticnet_grad, penalty::ELASTICNET,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         CUBLAS_CHECK(cublasDestroy(cublas_handle));
         CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/log.cu
+++ b/ml-prims/test/log.cu
@@ -30,12 +30,12 @@ protected:
 
         allocate(data, len);
         T data_h[params.len] = { 2.1, 4.5, 0.34, 10.0 };
-        updateDevice(data, data_h, len);
+        updateDevice(data, data_h, len, stream);
 
         allocate(result, len);
         allocate(result_ref, len);
         T result_ref_h[params.len] = { 0.74193734, 1.5040774, -1.07880966, 2.30258509 };
-        updateDevice(result_ref, result_ref_h, len);
+        updateDevice(result_ref, result_ref_h, len, stream);
 
         f_log(result, data, T(1), len, stream);
         CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/logisticReg.cu
+++ b/ml-prims/test/logisticReg.cu
@@ -53,37 +53,37 @@ protected:
         allocate(coef, params.n_cols);
 
         T h_in[len] = {0.1, 0.35, -0.9, -1.4, 2.0, 3.1};
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         T h_labels[n_rows] = {0.3, 2.0, -1.1};
-        updateDevice(labels, h_labels, n_rows);
+        updateDevice(labels, h_labels, n_rows, stream);
 
         T h_coef[n_cols] = {0.35, -0.24};
-        updateDevice(coef, h_coef, n_cols);
+        updateDevice(coef, h_coef, n_cols, stream);
 
         T h_out_ref[1] = {0.38752545};
-        updateDevice(out_ref, h_out_ref, 1);
+        updateDevice(out_ref, h_out_ref, 1, stream);
 
         T h_out_lasso_ref[1] = {0.74152};
-        updateDevice(out_lasso_ref, h_out_lasso_ref, 1);
+        updateDevice(out_lasso_ref, h_out_lasso_ref, 1, stream);
 
         T h_out_ridge_ref[1] = {0.4955854};
-        updateDevice(out_ridge_ref, h_out_ridge_ref, 1);
+        updateDevice(out_ridge_ref, h_out_ridge_ref, 1, stream);
 
         T h_out_elasticnet_ref[1] = {0.618555};
-        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1);
+        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1, stream);
 
         T h_out_grad_ref[n_cols] = {-0.58284, 0.207666};
-        updateDevice(out_grad_ref, h_out_grad_ref, n_cols);
+        updateDevice(out_grad_ref, h_out_grad_ref, n_cols, stream);
 
         T h_out_lasso_grad_ref[n_cols] = {0.0171, -0.39233};
-        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, n_cols);
+        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, n_cols, stream);
 
         T h_out_ridge_grad_ref[n_cols] = {-0.16284, -0.080333};
-        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, n_cols);
+        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, n_cols, stream);
 
         T h_out_elasticnet_grad_ref[n_cols] = {-0.07284, -0.23633};
-        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, n_cols);
+        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, n_cols, stream);
 
         T alpha = 0.6;
         T l1_ratio = 0.5;
@@ -91,22 +91,22 @@ protected:
         logisticRegLoss(in, params.n_rows, params.n_cols, labels, coef, out, penalty::NONE,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         logisticRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_grad, penalty::NONE,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         logisticRegLoss(in, params.n_rows, params.n_cols, labels, coef, out_lasso, penalty::L1,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         logisticRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_lasso_grad, penalty::L1,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         logisticRegLoss(in, params.n_rows, params.n_cols, labels, coef, out_ridge, penalty::L2,
                                       alpha, l1_ratio, cublas_handle, stream);
@@ -114,7 +114,7 @@ protected:
         logisticRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_ridge_grad, penalty::L2,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         logisticRegLoss(in, params.n_rows, params.n_cols, labels, coef, out_elasticnet, penalty::ELASTICNET,
                                       alpha, l1_ratio, cublas_handle, stream);
@@ -122,7 +122,7 @@ protected:
         logisticRegLossGrads(in, params.n_rows, params.n_cols, labels, coef, out_elasticnet_grad, penalty::ELASTICNET,
                                       alpha, l1_ratio, cublas_handle, stream);
 
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         CUBLAS_CHECK(cublasDestroy(cublas_handle));
         CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/math.cu
+++ b/ml-prims/test/math.cu
@@ -128,11 +128,11 @@ protected:
 
     allocate(in_ratio, 4);
     T in_ratio_h[4] = {1.0, 2.0, 2.0, 3.0};
-    updateDevice(in_ratio, in_ratio_h, 4);
+    updateDevice(in_ratio, in_ratio_h, 4, stream);
 
     allocate(out_ratio_ref, 4);
     T out_ratio_ref_h[4] = {0.125, 0.25, 0.25, 0.375};
-    updateDevice(out_ratio_ref, out_ratio_ref_h, 4);
+    updateDevice(out_ratio_ref, out_ratio_ref_h, 4, stream);
 
     r.uniform(in_power, len, T(-1.0), T(1.0), stream);
     r.uniform(in_sqrt, len, T(0.0), T(1.0), stream);
@@ -157,8 +157,8 @@ protected:
     // default threshold is 1e-15
     std::vector<T> in_recip_h = {0.1, 0.01, -0.01, 0.1e-16};
     std::vector<T> in_recip_ref_h = {10.0, 100.0, -100.0, 0.0};
-    updateDevice(in_recip, in_recip_h.data(), 4);
-    updateDevice(in_recip_ref, in_recip_ref_h.data(), 4);
+    updateDevice(in_recip, in_recip_h.data(), 4, stream);
+    updateDevice(in_recip_ref, in_recip_ref_h.data(), 4, stream);
     T recip_scalar = T(1.0);
 
     // this `reciprocal()` has to go first bc next one modifies its input
@@ -171,8 +171,8 @@ protected:
     allocate(in_smallzero, 4);
     allocate(out_smallzero, 4);
     allocate(out_smallzero_ref, 4);
-    updateDevice(in_smallzero, in_small_val_zero_h.data(), 4);
-    updateDevice(out_smallzero_ref, in_small_val_zero_ref_h.data(), 4);
+    updateDevice(in_smallzero, in_small_val_zero_h.data(), 4, stream);
+    updateDevice(out_smallzero_ref, in_small_val_zero_ref_h.data(), 4, stream);
     setSmallValuesZero(out_smallzero, in_smallzero, 4, stream);
     setSmallValuesZero(in_smallzero, 4, stream);
     CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/metrics.cu
+++ b/ml-prims/test/metrics.cu
@@ -48,8 +48,8 @@ TEST(MetricsTestHighScore, Result) {
     float *d_y_hat;
     MLCommon::allocate(d_y_hat, 5);
 
-    MLCommon::updateDevice(d_y_hat, y_hat, 5);
-    MLCommon::updateDevice(d_y, y, 5);
+    MLCommon::updateDevice(d_y_hat, y_hat, 5, stream);
+    MLCommon::updateDevice(d_y, y, 5, stream);
 
     float result = MLCommon::Metrics::r2_score(d_y, d_y_hat, 5, stream);
     ASSERT_TRUE(result == 0.98f);
@@ -70,8 +70,8 @@ TEST(MetricsTestLowScore, Result) {
     float *d_y_hat;
     MLCommon::allocate(d_y_hat, 5);
 
-    MLCommon::updateDevice(d_y_hat, y_hat, 5);
-    MLCommon::updateDevice(d_y, y, 5);
+    MLCommon::updateDevice(d_y_hat, y_hat, 5, stream);
+    MLCommon::updateDevice(d_y, y, 5, stream);
 
     float result = MLCommon::Metrics::r2_score(d_y, d_y_hat, 5, stream);
 

--- a/ml-prims/test/mvg.cu
+++ b/ml-prims/test/mvg.cu
@@ -126,8 +126,8 @@ protected:
     }
 
     // porting inputs to gpu
-    updateDevice(P_d, P, dim * dim);
-    updateDevice(x_d, x, dim);
+    updateDevice(P_d, P, dim * dim, stream);
+    updateDevice(x_d, x, dim, stream);
 
     // initilizing the mvg
     mvg = new MultiVarGaussian<T>(dim, method);
@@ -165,7 +165,7 @@ protected:
                                     Rand_cov, dim, stream));
 
     // restoring cov provided into P_d
-    updateDevice(P_d, P, dim * dim);
+    updateDevice(P_d, P, dim * dim, stream);
   }
 
   void TearDown() override {

--- a/ml-prims/test/penalty.cu
+++ b/ml-prims/test/penalty.cu
@@ -38,25 +38,25 @@ protected:
         allocate(out_elasticnet_grad_ref, len);
 
         T h_in[len] = {0.1, 0.35, -0.9, -1.4};
-        updateDevice(in, h_in, len);
+        updateDevice(in, h_in, len, stream);
 
         T h_out_lasso_ref[1] = {1.65};
-        updateDevice(out_lasso_ref, h_out_lasso_ref, 1);
+        updateDevice(out_lasso_ref, h_out_lasso_ref, 1, stream);
 
         T h_out_ridge_ref[1] = {1.741499};
-        updateDevice(out_ridge_ref, h_out_ridge_ref, 1);
+        updateDevice(out_ridge_ref, h_out_ridge_ref, 1, stream);
 
         T h_out_elasticnet_ref[1] = {1.695749};
-        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1);
+        updateDevice(out_elasticnet_ref, h_out_elasticnet_ref, 1, stream);
 
         T h_out_lasso_grad_ref[len] = {0.6, 0.6, -0.6, -0.6};
-        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, len);
+        updateDevice(out_lasso_grad_ref, h_out_lasso_grad_ref, len, stream);
 
         T h_out_ridge_grad_ref[len] = {0.12, 0.42, -1.08, -1.68};
-        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, len);
+        updateDevice(out_ridge_grad_ref, h_out_ridge_grad_ref, len, stream);
 
         T h_out_elasticnet_grad_ref[len] = {0.36, 0.51, -0.84, -1.14};
-        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, len);
+        updateDevice(out_elasticnet_grad_ref, h_out_elasticnet_grad_ref, len, stream);
 
         T alpha = 0.6;
         T l1_ratio = 0.5;

--- a/ml-prims/test/permute.cu
+++ b/ml-prims/test/permute.cu
@@ -85,9 +85,11 @@ protected:
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatchRange(const T *actual, size_t size,
                                             T start, L eq_compare,
-                                            bool doSort = true) {
+                                            bool doSort = true,
+                                            cudaStream_t stream = 0) {
   std::vector<T> act_h(size);
-  updateHost<T>(&(act_h[0]), actual, size);
+  updateHost<T>(&(act_h[0]), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   if(doSort)
     std::sort(act_h.begin(), act_h.end());
   for (size_t i(0); i < size; ++i) {
@@ -104,12 +106,14 @@ template <typename T, typename L>
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatchShuffle(const int *perms, const T *out,
                                               const T *in, int D, int N,
-                                              bool rowMajor, L eq_compare) {
+                                              bool rowMajor, L eq_compare,
+                                              cudaStream_t stream = 0) {
   std::vector<int> h_perms(N);
-  updateHost<int>(&(h_perms[0]), perms, N);
+  updateHost<int>(&(h_perms[0]), perms, N, stream);
   std::vector<T> h_out(N * D), h_in(N * D);
-  updateHost<T>(&(h_out[0]), out, N * D);
-  updateHost<T>(&(h_in[0]), in, N * D);
+  updateHost<T>(&(h_out[0]), out, N * D, stream);
+  updateHost<T>(&(h_in[0]), in, N * D, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (int i = 0; i < N; ++i) {
       for (int j = 0; j < D; ++j) {
           int outPos = rowMajor? i * D + j : j * N + i;

--- a/ml-prims/test/rng.cu
+++ b/ml-prims/test/rng.cu
@@ -118,7 +118,8 @@ protected:
     static const int threads = 128;
     meanKernel<T, threads><<<ceildiv(params.len, threads), threads, 0, stream>>>(
       stats, data, params.len);
-    updateHost<T>(h_stats, stats, 2);
+    updateHost<T>(h_stats, stats, 2, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
     h_stats[0] /= params.len;
     h_stats[1] = (h_stats[1] / params.len) - (h_stats[0] * h_stats[0]);
     CUDA_CHECK(cudaStreamDestroy(stream));
@@ -395,8 +396,9 @@ INSTANTIATE_TEST_CASE_P(RngTests, RngTestD, ::testing::ValuesIn(inputsd));
                       false, stream);
       std::vector<float> h_mean_result(num_experiments);
       std::vector<float> h_std_result(num_experiments);
-      updateHost(h_mean_result.data(), mean_result, num_experiments);
-      updateHost(h_std_result.data(), std_result, num_experiments);
+      updateHost(h_mean_result.data(), mean_result, num_experiments, stream);
+      updateHost(h_std_result.data(), std_result, num_experiments, stream);
+      CUDA_CHECK(cudaStreamSynchronize(stream));
       auto d_mean = quick_mean(h_mean_result);
 
       // std-dev of mean; also known as mean error

--- a/ml-prims/test/rng_int.cu
+++ b/ml-prims/test/rng_int.cu
@@ -83,7 +83,8 @@ protected:
     static const int threads = 128;
     meanKernel<T, threads><<<ceildiv(params.len, threads), threads, 0, stream>>>(
       stats, data, params.len);
-    updateHost<float>(h_stats, stats, 2);
+    updateHost<float>(h_stats, stats, 2, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
     h_stats[0] /= params.len;
     h_stats[1] = (h_stats[1] / params.len) - (h_stats[0] * h_stats[0]);
     CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/rsvd.cu
+++ b/ml-prims/test/rsvd.cu
@@ -64,7 +64,7 @@ protected:
       ASSERT(m == 3, "This test only supports mxn=3x2!");
       ASSERT(m * n == 6, "This test only supports mxn=3x2!");
       T data_h[] = {1.0, 4.0, 2.0, 2.0, 5.0, 1.0};
-      updateDevice(A, data_h, m * n);
+      updateDevice(A, data_h, m * n, stream);
 
       T left_eig_vectors_ref_h[] = {-0.308219, -0.906133, -0.289695};
       T right_eig_vectors_ref_h[] = {-0.638636, -0.769509};
@@ -74,9 +74,9 @@ protected:
       allocate(right_eig_vectors_ref, n * 1);
       allocate(sing_vals_ref, 1);
 
-      updateDevice(left_eig_vectors_ref, left_eig_vectors_ref_h, m * 1);
-      updateDevice(right_eig_vectors_ref, right_eig_vectors_ref_h, n * 1);
-      updateDevice(sing_vals_ref, sing_vals_ref_h, 1);
+      updateDevice(left_eig_vectors_ref, left_eig_vectors_ref_h, m * 1, stream);
+      updateDevice(right_eig_vectors_ref, right_eig_vectors_ref_h, n * 1, stream);
+      updateDevice(sing_vals_ref, sing_vals_ref_h, 1, stream);
 
     } else { // Other normal tests
       r.normal(A, m * n, mu, sigma, stream);
@@ -84,7 +84,7 @@ protected:
     A_backup_cpu = (T *)malloc(
       sizeof(T) * m *
       n); // Backup A matrix as svdJacobi will destroy the content of A
-    updateHost(A_backup_cpu, A, m * n);
+    updateHost(A_backup_cpu, A, m * n, stream);
 
     auto mgr = makeDefaultAllocator();
     // RSVD tests
@@ -105,7 +105,7 @@ protected:
                     true, true, eig_svd_tol, max_sweeps, cusolverH, cublasH,
                     stream, mgr);
     }
-    updateDevice(A, A_backup_cpu, m * n);
+    updateDevice(A, A_backup_cpu, m * n, stream);
 
     free(A_backup_cpu);
   }

--- a/ml-prims/test/sigmoid.cu
+++ b/ml-prims/test/sigmoid.cu
@@ -30,12 +30,12 @@ protected:
 
         allocate(data, len);
         T data_h[params.len] = { 2.1, -4.5, -0.34, 10.0 };
-        updateDevice(data, data_h, len);
+        updateDevice(data, data_h, len, stream);
 
         allocate(result, len);
         allocate(result_ref, len);
         T result_ref_h[params.len] = { 0.89090318, 0.01098694, 0.41580948, 0.9999546 };
-        updateDevice(result_ref, result_ref_h, len);
+        updateDevice(result_ref, result_ref_h, len, stream);
 
         sigmoid(result, data, len, stream);
         CUDA_CHECK(cudaStreamDestroy(stream));

--- a/ml-prims/test/sum.cu
+++ b/ml-prims/test/sum.cu
@@ -51,7 +51,7 @@ protected:
       data_h[i] = T(1);
     }
 
-    updateDevice(data, data_h, len);
+    updateDevice(data, data_h, len, stream);
 
     allocate(sum_act, cols);
     sum(sum_act, data, cols, rows, false, stream);

--- a/ml-prims/test/svd.cu
+++ b/ml-prims/test/svd.cu
@@ -57,7 +57,7 @@ protected:
     ASSERT(params.n_row == 3, "This test only supports nrows=3!");
     ASSERT(params.len == 6, "This test only supports len=6!");
     T data_h[] = {1.0, 4.0, 2.0, 2.0, 5.0, 1.0};
-    updateDevice(data, data_h, len);
+    updateDevice(data, data_h, len, stream);
 
     int left_evl = params.n_row * params.n_col;
     int right_evl = params.n_col * params.n_col;
@@ -81,9 +81,9 @@ protected:
     allocate(right_eig_vectors_ref, right_evl);
     allocate(sing_vals_ref, params.n_col);
 
-    updateDevice(left_eig_vectors_ref, left_eig_vectors_ref_h, left_evl);
-    updateDevice(right_eig_vectors_ref, right_eig_vectors_ref_h, right_evl);
-    updateDevice(sing_vals_ref, sing_vals_ref_h, params.n_col);
+    updateDevice(left_eig_vectors_ref, left_eig_vectors_ref_h, left_evl, stream);
+    updateDevice(right_eig_vectors_ref, right_eig_vectors_ref_h, right_evl, stream);
+    updateDevice(sing_vals_ref, sing_vals_ref_h, params.n_col, stream);
 
     auto mgr = makeDefaultAllocator();
     svdQR(data, params.n_row, params.n_col, sing_vals_qr, left_eig_vectors_qr,

--- a/ml-prims/test/test_utils.h
+++ b/ml-prims/test/test_utils.h
@@ -71,16 +71,19 @@ private:
  * @param expected expected value(s)
  * @param actual actual values
  * @param eq_compare the comparator
+ * @param stream cuda stream
  * @return the testing assertion to be later used by ASSERT_TRUE/EXPECT_TRUE
  * @{
  */
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatch(const T *expected, const T *actual,
-                                       size_t size, L eq_compare) {
+                                       size_t size, L eq_compare,
+                                       cudaStream_t stream = 0) {
   std::shared_ptr<T> exp_h(new T[size]);
   std::shared_ptr<T> act_h(new T[size]);
-  updateHost<T>(exp_h.get(), expected, size);
-  updateHost<T>(act_h.get(), actual, size);
+  updateHost<T>(exp_h.get(), expected, size, stream);
+  updateHost<T>(act_h.get(), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i(0); i < size; ++i) {
     auto exp = exp_h.get()[i];
     auto act = act_h.get()[i];
@@ -94,9 +97,10 @@ template <typename T, typename L>
 
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatch(T expected, const T *actual, size_t size,
-                                       L eq_compare) {
+                                       L eq_compare, cudaStream_t stream = 0) {
   std::shared_ptr<T> act_h(new T[size]);
-  updateHost<T>(act_h.get(), actual, size);
+  updateHost<T>(act_h.get(), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i(0); i < size; ++i) {
     auto act = act_h.get()[i];
     if (!eq_compare(expected, act)) {
@@ -109,12 +113,14 @@ template <typename T, typename L>
 
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatch(const T *expected, const T *actual,
-                                       size_t rows, size_t cols, L eq_compare) {
+                                       size_t rows, size_t cols, L eq_compare,
+                                       cudaStream_t stream = 0) {
   size_t size = rows * cols;
   std::shared_ptr<T> exp_h(new T[size]);
   std::shared_ptr<T> act_h(new T[size]);
-  updateHost<T>(exp_h.get(), expected, size);
-  updateHost<T>(act_h.get(), actual, size);
+  updateHost<T>(exp_h.get(), expected, size, stream);
+  updateHost<T>(act_h.get(), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i(0); i < rows; ++i) {
     for (size_t j(0); j < cols; ++j) {
       auto idx = i * cols + j; // row major assumption!
@@ -132,10 +138,11 @@ template <typename T, typename L>
 
 template <typename T, typename L>
 ::testing::AssertionResult devArrMatch(T expected, const T *actual, size_t rows,
-                                       size_t cols, L eq_compare) {
+                                       size_t cols, L eq_compare, cudaStream_t stream = 0) {
   size_t size = rows * cols;
   std::shared_ptr<T> act_h(new T[size]);
-  updateHost<T>(act_h.get(), actual, size);
+  updateHost<T>(act_h.get(), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i(0); i < rows; ++i) {
     for (size_t j(0); j < cols; ++j) {
       auto idx = i * cols + j; // row major assumption!
@@ -158,15 +165,17 @@ template <typename T, typename L>
  * @param expected expected value along diagonal
  * @param actual actual matrix
  * @param eq_compare the comparator
+ * @param stream cuda stream
  * @return the testing assertion to be later used by ASSERT_TRUE/EXPECT_TRUE
  */
 template <typename T, typename L>
 ::testing::AssertionResult diagonalMatch(T expected, const T *actual,
                                          size_t rows, size_t cols,
-                                         L eq_compare) {
+                                         L eq_compare, cudaStream_t stream = 0) {
   size_t size = rows * cols;
   std::shared_ptr<T> act_h(new T[size]);
-  updateHost<T>(act_h.get(), actual, size);
+  updateHost<T>(act_h.get(), actual, size, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i(0); i < rows; ++i) {
     for (size_t j(0); j < cols; ++j) {
       if (i != j)

--- a/ml-prims/test/transpose.cu
+++ b/ml-prims/test/transpose.cu
@@ -51,11 +51,11 @@ protected:
     allocate(data, len);
     ASSERT(params.len == 9, "This test works only with len=9!");
     T data_h[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
-    updateDevice(data, data_h, len);
+    updateDevice(data, data_h, len, stream);
 
     allocate(data_trans_ref, len);
     T data_ref_h[] = {1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0};
-    updateDevice(data_trans_ref, data_ref_h, len);
+    updateDevice(data_trans_ref, data_ref_h, len, stream);
 
     allocate(data_trans, len);
 


### PR DESCRIPTION
This PR:
1. Creates a generic `MLCommon::copy` method which uses the `cudaMemcpyDefault` flag for auto-recognition of direction from the pointers themselves
2. Removes the update*Async methods and enables the corresponding update* methods to be the async methods itself. That way, there'll no more be the usage of cudaMemcpy calls on default stream.