### PR TITLE
[REVIEW] Updates to README for 0.7 and adding BUILD.md build instructions back

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -36,12 +36,6 @@ If using a conda environment (recommended), then cmake can be configured appropr
 $ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 ```
 
-Additionally while using conda and a conda installed cmake, the `openblas` conda package can be explicitly specified for `blas` and `lapack`:
-
-```bash
-cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBLAS_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.a -DLAPACK_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.a
-```
-
 Note: The following warning message is dependent upon the version of cmake and the `CMAKE_INSTALL_PREFIX` used. If this warning is displayed, the build should still run succesfully. We are currently working to resolve this open issue. You can silence this warning by adding `-DCMAKE_IGNORE_PATH=$CONDA_PREFIX/lib` to your `cmake` command.
 ```
 Cannot generate a safe runtime search path for target ml_test because files
@@ -49,6 +43,12 @@ in some directories may conflict with libraries in implicit directories:
 ```
 
 The configuration script will print the BLAS found on the search path. If the version found does not match the version intended, use the flag `-DBLAS_LIBRARIES=/path/to/blas.so` with the `cmake` command to force your own version.
+
+If using conda and a conda installed cmake, the `openblas` conda package is recommended and can be explicitly specified for `blas` and `lapack`:
+
+```bash
+cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBLAS_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.so -DLAPACK_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.so
+```
 
 Additionally, to reduce compile times, you can specify a GPU compute capability to compile for, for example for Volta GPUs:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,112 @@
+# cuML Build From Source Guide
+
+## Setting Up Your Build Environment
+
+To install cuML from source, ensure the dependencies are met:
+
+1. [cuDF](https://github.com/rapidsai/cudf) (>=0.7)
+2. zlib
+3. cmake (>= 3.12.4)
+4. CUDA (>= 9.2)
+5. Cython (>= 0.29)
+6. gcc (>=5.4.0)
+7. BLAS - Any BLAS compatible with cmake's [FindBLAS](https://cmake.org/cmake/help/v3.12/module/FindBLAS.html). Note that the blas has to be installed to the same folder system as cmake, for example if using conda installed cmake, the blas implementation should also be installed in the conda environment.
+
+### Installing from Source:
+
+Once dependencies are present, follow the steps below:
+
+1. Clone the repository.
+```bash
+$ git clone --recurse-submodules https://github.com/rapidsai/cuml.git
+```
+
+2. Build and install `libcuml` (the C++/CUDA library containing the cuML algorithms), starting from the repository root folder:
+```bash
+$ cd cuML
+$ mkdir build
+$ cd build
+$ export CUDA_BIN_PATH=$CUDA_HOME # (optional env variable if cuda binary is not in the PATH. Default CUDA_HOME=/path/to/cuda/)
+$ cmake ..
+```
+
+If using a conda environment (recommended), then cmake can be configured appropriately via:
+
+```bash
+$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+```
+
+Note: The following warning message is dependent upon the version of cmake and the `CMAKE_INSTALL_PREFIX` used. If this warning is displayed, the build should still run succesfully. We are currently working to resolve this open issue. You can silence this warning by adding `-DCMAKE_IGNORE_PATH=$CONDA_PREFIX/lib` to your `cmake` command.
+```
+Cannot generate a safe runtime search path for target ml_test because files
+in some directories may conflict with libraries in implicit directories:
+```
+
+The configuration script will print the BLAS found on the search path. If the version found does not match the version intended, use the flag `-DBLAS_LIBRARIES=/path/to/blas.so` with the `cmake` command to force your own version.
+
+Additionally, to reduce compile times, you can specify a GPU compute capability to compile for, for example for Volta GPUs:
+
+```bash
+$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DGPU_ARCHS="70"
+```
+
+
+3. Build `libcuml`:
+
+```bash
+$ make -j
+$ make install
+```
+
+To run tests (optional):
+
+```bash
+$ ./ml_test
+```
+
+If you want a list of the available tests:
+```bash
+$ ./ml_test --gtest_list_tests
+```
+
+4. Build the `cuml` python package:
+
+```bash
+$ cd ../../python
+$ python setup.py build_ext --inplace
+```
+
+To run Python tests (optional):
+
+```bash
+$ py.test -v
+```
+
+If you want a list of the available tests:
+```bash
+$ py.test cuML/test --collect-only
+```
+
+5. Finally, install the Python package to your Python path:
+
+```bash
+$ python setup.py install
+```
+
+6. You can also build and run tests for the machine learning primitive header only library located in the `ml-prims` folder. From the repository root:
+
+```bash
+$ cd ml-prims
+$ mkdir build
+$ cd build
+$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DGPU_ARCHS="70" # specifying GPU_ARCH is optional, but significantly reduces compile time
+$ make -j
+```
+
+To run the ml-prim tests:
+
+```bash
+$./test/mlcommon_test
+```
+
+

--- a/BUILD.md
+++ b/BUILD.md
@@ -36,6 +36,12 @@ If using a conda environment (recommended), then cmake can be configured appropr
 $ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 ```
 
+Additionally while using conda and a conda installed cmake, the `openblas` conda package can be explicitly specified for `blas` and `lapack`:
+
+```bash
+cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBLAS_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.a -DLAPACK_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.a
+```
+
 Note: The following warning message is dependent upon the version of cmake and the `CMAKE_INSTALL_PREFIX` used. If this warning is displayed, the build should still run succesfully. We are currently working to resolve this open issue. You can silence this warning by adding `-DCMAKE_IGNORE_PATH=$CONDA_PREFIX/lib` to your `cmake` command.
 ```
 Cannot generate a safe runtime search path for target ml_test because files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## New Features
 
 - PR #405: Quasi-Newton GLM Solvers
-
-## New Features
-
 - PR #277: Added row- and column-wise weighted mean primitive
 - PR #424: Added a grid-sync struct for inter-block synchronization
 - PR #430: Adding R-Squared Score to ml primitives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #499: DEVELOPER_GUIDE.md: fixed links and clarified ML::detail::streamSyncer example
 - PR #506: Re enable ml-prim tests in CI
 - PR #508: Fix for an error with default argument in LinAlg::meanSquaredError
+- PR #519: README.md Updates and adding BUILD.md back
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/README.md
+++ b/README.md
@@ -39,26 +39,21 @@ For additional examples, browse our complete [API documentation](https://docs.ra
 | Algorithm | Scale | Notes |
 | --- | --- | --- |
 | Truncated Singular Value Decomposition (tSVD) | Single GPU | Multi-GPU available in conda cuda10 package |
-| Linear Regression (OLS) | Single GPU | Multi-GPU available in conda cuda10 package <br> Multi-Node with [dask-cuml](http://github.com/rapidsai/dask-cuml) |
+| Linear Regression (OLS) | Single GPU | Multi-GPU available in conda cuda10 package and [dask-cuml](http://github.com/rapidsai/dask-cuml) |
 | Principal Component Analysis (PCA) | Single GPU |
 | Density-Based Spatial Clustering of Applications with Noise (DBSCAN) | Single GPU |
-| K-Means Clustering | Multi-GPU |
-| K-Nearest Neighbors (KNN) | Multi-GPU | Multi-Node with [dask-cuml](http://github.com/rapidsai/dask-cuml) <br> Uses [Faiss](https://github.com/facebookresearch/faiss) |
+| K-Means Clustering | Single-GPU |
+| K-Nearest Neighbors (KNN) | Multi-GPU with [dask-cuml](http://github.com/rapidsai/dask-cuml) <br> Uses [Faiss](https://github.com/facebookresearch/faiss) |
 | Ridge Regression | Single-GPU |
-| Kalman Filter | Single-GPU |
+| Linear Kalman Filter | Single-GPU |
 | UMAP | Single-GPU |
 | Stochastic Gradient Descent | Single-GPU | for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties |
+| Coordinate Descent | Single-GPU | |
+| Limited-memory BFGS | Single-GPU | |
 
 ---
 
-Algorithms in progress:
-
-- More Kalman Filter versions
-- Lasso
-- Elastic-Net
-- Logistic Regression
-
-More ML algorithms in cuML and more ML primitives in ml-prims are being worked on. Goals for future versions include more algorithms and multi-gpu versions of the algorithms and primitives.
+More ML algorithms in cuML and more ML primitives in ml-prims are being worked on, among them t-sne, decision trees, random forests and others. Goals for future versions include more multi-gpu versions of the algorithms and primitives.
 
 ## Installation
 
@@ -70,23 +65,11 @@ sudo apt install libopenblas-base libomp-dev
 #### Conda
 cuML can be installed using the `rapidsai` conda channel:
 ```bash
-conda install -c nvidia -c rapidsai -c conda-forge -c pytorch -c defaults cuml
-```
-
-#### Pip
-cuML can also be installed using pip. Select the package based on your version of CUDA.
-
-
-```bash
-# cuda 9.2
-pip install cuml-cuda92
-
-# cuda 10.0
-pip install cuml-cuda100
+conda install -c nvidia -c rapidsai -c conda-forge cuml
 ```
 
 ## Build/Install from Source
-See build [instructions](CONTRIBUTING.md#setting-up-your-build-environment).
+See the build [guide](BUILD.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,17 @@ For additional examples, browse our complete [API documentation](https://docs.ra
 
 | Algorithm | Scale | Notes |
 | --- | --- | --- |
-| Truncated Singular Value Decomposition (tSVD) | Single GPU | Multi-GPU available in conda cuda10 package |
 | Linear Regression (OLS) | Single GPU | Multi-GPU available in conda cuda10 package and [dask-cuml](http://github.com/rapidsai/dask-cuml) |
-| Principal Component Analysis (PCA) | Single GPU |
+| Stochastic Gradient Descent | Single-GPU | for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties |
+| Coordinate Descent | Single-GPU | |
+| Ridge Regression | Single-GPU |
+| UMAP | Single-GPU |
 | Density-Based Spatial Clustering of Applications with Noise (DBSCAN) | Single GPU |
 | K-Means Clustering | Single-GPU |
 | K-Nearest Neighbors (KNN) | Multi-GPU with [dask-cuml](http://github.com/rapidsai/dask-cuml) <br> Uses [Faiss](https://github.com/facebookresearch/faiss) |
-| Ridge Regression | Single-GPU |
+| Principal Component Analysis (PCA) | Single GPU |
+| Truncated Singular Value Decomposition (tSVD) | Single GPU | Multi-GPU available in conda cuda10 package |
 | Linear Kalman Filter | Single-GPU |
-| UMAP | Single-GPU |
-| Stochastic Gradient Descent | Single-GPU | for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties |
-| Coordinate Descent | Single-GPU | |
-| Limited-memory BFGS | Single-GPU | |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,25 +38,25 @@ For additional examples, browse our complete [API documentation](https://docs.ra
 
 | Algorithm | Scale | Notes |
 | --- | --- | --- |
-| Linear Regression (OLS) | Single GPU | Multi-GPU available in conda cuda10 package and [dask-cuml](http://github.com/rapidsai/dask-cuml) |
-| Stochastic Gradient Descent | Single-GPU | for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties |
 | Coordinate Descent | Single-GPU | |
-| Ridge Regression | Single-GPU |
-| UMAP | Single-GPU |
 | Density-Based Spatial Clustering of Applications with Noise (DBSCAN) | Single GPU |
 | K-Means Clustering | Single-GPU |
 | K-Nearest Neighbors (KNN) | Multi-GPU with [dask-cuml](http://github.com/rapidsai/dask-cuml) <br> Uses [Faiss](https://github.com/facebookresearch/faiss) |
-| Principal Component Analysis (PCA) | Single GPU |
-| Truncated Singular Value Decomposition (tSVD) | Single GPU | Multi-GPU available in conda cuda10 package |
 | Linear Kalman Filter | Single-GPU |
+| Linear Regression (OLS) | Single GPU | Multi-GPU available in conda cuda10 package and [dask-cuml](http://github.com/rapidsai/dask-cuml) |
+| Principal Component Analysis (PCA) | Single GPU |
+| Ridge Regression | Single-GPU |
+| Stochastic Gradient Descent | Single-GPU | for linear regression, logistic regression, and linear svm with L1, L2, and elastic-net penalties |
+| Truncated Singular Value Decomposition (tSVD) | Single GPU | Multi-GPU available in conda cuda10 package |
+| UMAP | Single-GPU |
 
 ---
 
-More ML algorithms in cuML and more ML primitives in ml-prims are being worked on, among them t-sne, decision trees, random forests and others. Goals for future versions include more multi-gpu versions of the algorithms and primitives.
+More ML algorithms in cuML and more ML primitives in ml-prims are being worked on, among them: t-sne, random forests, spectral embedding, spectral clustering, random projections, support vector machine and others. Goals for future versions include more multi-gpu versions of the algorithms and primitives.
 
 ## Installation
 
-1. Install NVIDIA drivers with CUDA 9.2 or 10.0 
+1. Install NVIDIA drivers with CUDA 9.2 or 10.0
 2. Ensure `libomp` and `libopenblas` are installed, for example via apt:
 ```bash
 sudo apt install libopenblas-base libomp-dev


### PR DESCRIPTION
Updated `README.md` for status of things for version 0.7. Also added back `BUILD.md` since `CONTRIBUTING.md` is already a large document, and it was counter intuitive to have the build from source instructions there.