### PR TITLE
[REVIEW] Add notes on unsupported UMAP features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #475: exposing cumlHandle for dbscan from python-side
 - PR #395: Edited the CONTRIBUTING.md file
 - PR #512: generic copy method for copying buffers between device/host
+- PR #527: Added notes on UMAP differences from reference implementation
 
 ## Bug Fixes
 

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -152,14 +152,21 @@ cdef class UMAP:
 
     Notes
     -----
-    This UMAP module is heavily based on Leland McInnes' umap.py package.
+    This module is heavily based on Leland McInnes' reference UMAP package.
     However, there are a number of differences and features that are not yet
     implemented in cuml.umap:
-      * Supervised training (planned for implementation soon)
       * Specifying the random seed
-      * Specifying a custom distance metric (cuml.umap always uses euclidean
-        distance)
+      * Using a non-euclidean distance metric (support for a fixed set
+        of non-euclidean metrics is planned for an upcoming release).
+      * Using a pre-computed pairwise distance matrix (under consideration
+        for future releases)
       * Manual initialization of initial embedding positions
+
+    In addition to these missing features, you should expect to see
+    the final embeddings differing between cuml.umap and the reference
+    UMAP. In particular, the reference UMAP uses an approximate kNN
+    algorithm for large data sizes while cuml.umap always uses exact
+    kNN.
 
     References
     ----------

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -149,6 +149,24 @@ cdef class UMAP:
         ``spread``.
     verbose: bool (optional, default False)
         Controls verbosity of logging.
+
+    Notes
+    -----
+    This UMAP module is heavily based on Leland McInnes' umap.py package.
+    However, there are a number of differences and features that are not yet
+    implemented in cuml.umap:
+      * Supervised training (planned for implementation soon)
+      * Specifying the random seed
+      * Specifying a custom distance metric (cuml.umap always uses euclidean
+        distance)
+      * Manual initialization of initial embedding positions
+
+    References
+    ----------
+    * Leland McInnes, John Healy, James Melville
+      UMAP: Uniform Manifold Approximation and Projection for Dimension Reduction
+      https://arxiv.org/abs/1802.03426
+
     """
 
     cpdef UMAPParams *umap_params


### PR DESCRIPTION
This change expands the docstrings for the UMAP constructor to explain some of the features missing relative to the reference python UMAP implementation. (Inspired by this blog post which mentioned some challenges with these missing features: https://medium.com/the-artificial-impostor/umap-on-rapids-15x-speedup-f4eabfbdd978)

Closes issue #442 