### PR TITLE
Made use of ZLIB_LIBRARIES consistent between ml_test and ml_mg_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - PR #519: README.md Updates and adding BUILD.md back
 - PR #526: Fix the issue of wrong results when fit and transform of PCA are called separately
 - PR #531: Fixing missing arguments in updateDevice() for RF
+- PR #551: Made use of ZLIB_LIBRARIES consistent between ml_test and ml_mg_test
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -263,7 +263,7 @@ target_link_libraries(ml_test
   ${BLAS_LIBRARIES}
   ${CUML_CPP_TARGET}
   pthread
-  z)
+  ${ZLIB_LIBRARIES})
 
 ###################################################################################################
 # - build test executable -------------------------------------------------------------------------


### PR DESCRIPTION
Made use of ZLIB_LIBRARIES consistent between ml_test and ml_mg_test. This fixes linker errors by using the ZLIB cmake found instead of adding -lz and looking for it on the default (system) lib search path.