### PR TITLE
[REVIEW] Remove unused flag and improve order of CI testing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - PR #526: Fix the issue of wrong results when fit and transform of PCA are called separately
 - PR #531: Fixing missing arguments in updateDevice() for RF
 - PR #551: Made use of ZLIB_LIBRARIES consistent between ml_test and ml_mg_test
+- PR #557: Modified CI script to run cuML tests before building mlprims and removed lapack flag
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -82,15 +82,15 @@ logger "Build cuML..."
 cd $WORKSPACE/python
 python setup.py build_ext --inplace
 
-logger "Build ml-prims tests..."
-mkdir -p $WORKSPACE/ml-prims/build
-cd $WORKSPACE/ml-prims/build
-cmake $GPU_ARCH ..
+# logger "Build ml-prims tests..."
+# mkdir -p $WORKSPACE/ml-prims/build
+# cd $WORKSPACE/ml-prims/build
+# cmake $GPU_ARCH ..
 
-logger "Clean up make..."
-make clean
-logger "Make ml-prims test..."
-make -j${PARALLEL_LEVEL}
+# logger "Clean up make..."
+# make clean
+# logger "Make ml-prims test..."
+# make -j${PARALLEL_LEVEL}
 
 
 ################################################################################
@@ -110,6 +110,6 @@ cd $WORKSPACE/python
 py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 
 
-logger "Run ml-prims test..."
-cd $WORKSPACE/ml-prims/build
-GTEST_OUTPUT="xml:${WORKSPACE}/test-results/ml-prims/" ./test/mlcommon_test
+# logger "Run ml-prims test..."
+# cd $WORKSPACE/ml-prims/build
+# GTEST_OUTPUT="xml:${WORKSPACE}/test-results/ml-prims/" ./test/mlcommon_test

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -82,16 +82,6 @@ logger "Build cuML..."
 cd $WORKSPACE/python
 python setup.py build_ext --inplace
 
-logger "Build ml-prims tests..."
-mkdir -p $WORKSPACE/ml-prims/build
-cd $WORKSPACE/ml-prims/build
-cmake $GPU_ARCH ..
-
-logger "Clean up make..."
-make clean
-logger "Make ml-prims test..."
-make -j${PARALLEL_LEVEL}
-
 
 ################################################################################
 # TEST - Run GoogleTest and py.tests for libcuml and cuML
@@ -104,11 +94,24 @@ logger "GoogleTest for libcuml..."
 cd $WORKSPACE/cuML/build
 GTEST_OUTPUT="xml:${WORKSPACE}/test-results/libcuml_cpp/" ./ml_test
 
-
 logger "Python py.test for cuML..."
 cd $WORKSPACE/python
 py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 
+
+################################################################################
+# TEST - Build and run ml-prim tests
+################################################################################
+
+logger "Build ml-prims tests..."
+mkdir -p $WORKSPACE/ml-prims/build
+cd $WORKSPACE/ml-prims/build
+cmake $GPU_ARCH ..
+
+logger "Clean up make..."
+make clean
+logger "Make ml-prims test..."
+make -j${PARALLEL_LEVEL}
 
 logger "Run ml-prims test..."
 cd $WORKSPACE/ml-prims/build

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -107,7 +107,7 @@ GTEST_OUTPUT="xml:${WORKSPACE}/test-results/libcuml_cpp/" ./ml_test
 
 logger "Python py.test for cuML..."
 cd $WORKSPACE/python
-py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
+py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v cuml/test/test_nearest_neighbors.py
 
 
 # logger "Run ml-prims test..."

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -82,15 +82,15 @@ logger "Build cuML..."
 cd $WORKSPACE/python
 python setup.py build_ext --inplace
 
-# logger "Build ml-prims tests..."
-# mkdir -p $WORKSPACE/ml-prims/build
-# cd $WORKSPACE/ml-prims/build
-# cmake $GPU_ARCH ..
+logger "Build ml-prims tests..."
+mkdir -p $WORKSPACE/ml-prims/build
+cd $WORKSPACE/ml-prims/build
+cmake $GPU_ARCH ..
 
-# logger "Clean up make..."
-# make clean
-# logger "Make ml-prims test..."
-# make -j${PARALLEL_LEVEL}
+logger "Clean up make..."
+make clean
+logger "Make ml-prims test..."
+make -j${PARALLEL_LEVEL}
 
 
 ################################################################################
@@ -107,9 +107,9 @@ GTEST_OUTPUT="xml:${WORKSPACE}/test-results/libcuml_cpp/" ./ml_test
 
 logger "Python py.test for cuML..."
 cd $WORKSPACE/python
-py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v #cuml/test/test_nearest_neighbors.py
+py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 
 
-# logger "Run ml-prims test..."
-# cd $WORKSPACE/ml-prims/build
-# GTEST_OUTPUT="xml:${WORKSPACE}/test-results/ml-prims/" ./test/mlcommon_test
+logger "Run ml-prims test..."
+cd $WORKSPACE/ml-prims/build
+GTEST_OUTPUT="xml:${WORKSPACE}/test-results/ml-prims/" ./test/mlcommon_test

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -107,7 +107,7 @@ GTEST_OUTPUT="xml:${WORKSPACE}/test-results/libcuml_cpp/" ./ml_test
 
 logger "Python py.test for cuML..."
 cd $WORKSPACE/python
-py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v cuml/test/test_nearest_neighbors.py
+py.test --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v #cuml/test/test_nearest_neighbors.py
 
 
 # logger "Run ml-prims test..."

--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -235,8 +235,7 @@ set(CUML_LINK_LIBRARIES
   ${CUDA_nvgraph_LIBRARY}
   ${ZLIB_LIBRARIES}
   gpufaisslib
-  faisslib
-  ${BLAS_LIBRARIES})
+  faisslib)
 
 if(OPENMP_FOUND)
   set(CUML_LINK_LIBRARIES ${CUML_LINK_LIBRARIES} OpenMP::OpenMP_CXX pthread)
@@ -260,7 +259,6 @@ target_link_libraries(ml_test
   ${CUDA_cusparse_LIBRARY}
   ${CUDA_nvgraph_LIBRARY}
   faisslib
-  ${BLAS_LIBRARIES}
   ${CUML_CPP_TARGET}
   pthread
   ${ZLIB_LIBRARIES})
@@ -281,7 +279,6 @@ target_link_libraries(ml_mg_test
   ${CUDA_nvgraph_LIBRARY}
   gpufaisslib
   faisslib
-  ${BLAS_LIBRARIES}
   ${CUML_CPP_TARGET}
   pthread
   ${ZLIB_LIBRARIES})

--- a/cuML/CMakeLists.txt
+++ b/cuML/CMakeLists.txt
@@ -172,7 +172,7 @@ endif(NOT CMAKE_CXX11_ABI)
 include (ExternalProject)
 ExternalProject_Add(faiss
   SOURCE_DIR ${FAISS_DIR}
-  CONFIGURE_COMMAND LIBS=-pthread CPPFLAGS=-w LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib ${FAISS_DIR}/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/faiss --with-blas=${BLAS_LIBRARIES} --with-lapack=${LAPACK_LIBRARIES} --with-cuda=${CUDA_TOOLKIT_ROOT_DIR} --quiet
+  CONFIGURE_COMMAND LIBS=-pthread CPPFLAGS=-w LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib ${FAISS_DIR}/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/faiss --with-blas=${BLAS_LIBRARIES} --with-cuda=${CUDA_TOOLKIT_ROOT_DIR} --quiet
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/faiss/
   BUILD_COMMAND $(MAKE)
   INSTALL_COMMAND $(MAKE) -s install > /dev/null || $(MAKE) && cd gpu && $(MAKE) -s install > /dev/null || $(MAKE)

--- a/python/cuml/test/test_kmeans.py
+++ b/python/cuml/test/test_kmeans.py
@@ -24,9 +24,7 @@ from sklearn.preprocessing import StandardScaler
 
 from cuml.test.utils import fit_predict, get_pattern, clusters_equal
 
-dataset_names = ['blobs', 'noisy_circles'] + \
-                [pytest.param(ds, marks=pytest.mark.xfail)
-                 for ds in ['noisy_moons', 'varied', 'aniso']]
+dataset_names = ['noisy_moons', 'varied', 'aniso', 'blobs', 'noisy_circles']
 
 
 @pytest.mark.parametrize('name', dataset_names)

--- a/python/cuml/test/test_kmeans.py
+++ b/python/cuml/test/test_kmeans.py
@@ -69,4 +69,4 @@ def test_kmeans_sklearn_comparison(name):
         assert (np.sum(sk_y_pred) - np.sum(cu_y_pred))/len(sk_y_pred) < 1e-10
 
     else:
-        assert clusters_equal(sk_y_pred, cu_y_pred, params['n_clusters'])
+        clusters_equal(sk_y_pred, cu_y_pred, params['n_clusters'])

--- a/python/cuml/test/test_kmeans.py
+++ b/python/cuml/test/test_kmeans.py
@@ -24,7 +24,9 @@ from sklearn.preprocessing import StandardScaler
 
 from cuml.test.utils import fit_predict, get_pattern, clusters_equal
 
-dataset_names = ['noisy_moons', 'varied', 'aniso', 'blobs', 'noisy_circles']
+dataset_names = ['blobs', 'noisy_circles'] + \
+                [pytest.param(ds, marks=pytest.mark.xfail)
+                 for ds in ['noisy_moons', 'varied', 'aniso']]
 
 
 @pytest.mark.parametrize('name', dataset_names)
@@ -67,4 +69,4 @@ def test_kmeans_sklearn_comparison(name):
         assert (np.sum(sk_y_pred) - np.sum(cu_y_pred))/len(sk_y_pred) < 1e-10
 
     else:
-        clusters_equal(sk_y_pred, cu_y_pred, params['n_clusters'])
+        assert clusters_equal(sk_y_pred, cu_y_pred, params['n_clusters'])

--- a/python/cuml/test/test_umap.py
+++ b/python/cuml/test/test_umap.py
@@ -29,7 +29,7 @@ from sklearn.metrics import adjusted_rand_score
 def test_blobs_cluster():
     data, labels = datasets.make_blobs(
         n_samples=500, n_features=10, centers=5)
-    embedding = UMAP().fit_transform(data)
+    embedding = UMAP(verbose=True).fit_transform(data)
     score = adjusted_rand_score(labels,
                                 KMeans(5).fit_predict(embedding))
     assert score == 1.0
@@ -54,7 +54,7 @@ def test_umap_transform_on_iris():
 def test_supervised_umap_trustworthiness_on_iris():
     iris = datasets.load_iris()
     data = iris.data
-    embedding = UMAP(n_neighbors=10, min_dist=0.01).fit_transform(
+    embedding = UMAP(n_neighbors=10, min_dist=0.01, verbose=True).fit_transform(
         data, iris.target
     )
     trust = trustworthiness(iris.data, embedding, 10)
@@ -66,7 +66,7 @@ def test_semisupervised_umap_trustworthiness_on_iris():
     data = iris.data
     target = iris.target.copy()
     target[25:75] = -1
-    embedding = UMAP(n_neighbors=10, min_dist=0.01).fit_transform(
+    embedding = UMAP(n_neighbors=10, min_dist=0.01, verbose=True).fit_transform(
         data, target
     )
     trust = trustworthiness(iris.data, embedding, 10)
@@ -76,7 +76,7 @@ def test_semisupervised_umap_trustworthiness_on_iris():
 def test_umap_trustworthiness_on_iris():
     iris = datasets.load_iris()
     data = iris.data
-    embedding = UMAP(n_neighbors=10, min_dist=0.01).fit_transform(data)
+    embedding = UMAP(n_neighbors=10, min_dist=0.01, verbose=True).fit_transform(data)
     trust = trustworthiness(iris.data, embedding, 10)
 
     # We are doing a spectral embedding but not a
@@ -106,7 +106,7 @@ def test_umap_data_formats(input_type, should_downcast):
     X = digits["data"].astype(dtype)
 
     umap = UMAP(n_neighbors=3, n_components=2,
-                should_downcast=should_downcast)
+                should_downcast=should_downcast, verbose=True)
 
     if input_type == 'dataframe':
         X = cudf.DataFrame.from_pandas(pd.DataFrame(X))
@@ -125,7 +125,7 @@ def test_umap_downcast_fails(input_type):
     X = np.array([[1.0, 1.0], [50.0, 1.0], [51.0, 1.0]], dtype=np.float64)
 
     # Test fit() fails with double precision when should_downcast set to False
-    umap = UMAP(should_downcast=False)
+    umap = UMAP(should_downcast=False, verbose=True)
     if input_type == 'dataframe':
         X = cudf.DataFrame.from_pandas(pd.DataFrame(X))
 

--- a/python/cuml/test/test_umap.py
+++ b/python/cuml/test/test_umap.py
@@ -54,9 +54,8 @@ def test_umap_transform_on_iris():
 def test_supervised_umap_trustworthiness_on_iris():
     iris = datasets.load_iris()
     data = iris.data
-    embedding = UMAP(n_neighbors=10, min_dist=0.01, verbose=True).fit_transform(
-        data, iris.target
-    )
+    embedding = UMAP(n_neighbors=10, min_dist=0.01,
+                     verbose=True).fit_transform(data, iris.target)
     trust = trustworthiness(iris.data, embedding, 10)
     assert trust >= 0.97
 
@@ -66,9 +65,8 @@ def test_semisupervised_umap_trustworthiness_on_iris():
     data = iris.data
     target = iris.target.copy()
     target[25:75] = -1
-    embedding = UMAP(n_neighbors=10, min_dist=0.01, verbose=True).fit_transform(
-        data, target
-    )
+    embedding = UMAP(n_neighbors=10, min_dist=0.01,
+                     verbose=True).fit_transform(data, target)
     trust = trustworthiness(iris.data, embedding, 10)
     assert trust >= 0.97
 
@@ -76,7 +74,8 @@ def test_semisupervised_umap_trustworthiness_on_iris():
 def test_umap_trustworthiness_on_iris():
     iris = datasets.load_iris()
     data = iris.data
-    embedding = UMAP(n_neighbors=10, min_dist=0.01, verbose=True).fit_transform(data)
+    embedding = UMAP(n_neighbors=10, min_dist=0.01,
+                     verbose=True).fit_transform(data)
     trust = trustworthiness(iris.data, embedding, 10)
 
     # We are doing a spectral embedding but not a


### PR DESCRIPTION
PR removes the unnecessary lapack flag, and makes it so that the cuML tests are run before building the mlprim tests, so that failures can be detected 10+ minutes earlier. 