### PR TITLE
[WIP] Expose mem get info api

### DIFF
--- a/cuML/src/common/cumlHandle.cpp
+++ b/cuML/src/common/cumlHandle.cpp
@@ -189,6 +189,9 @@ public:
             // deallocate should not throw execeptions which is why CUDA_CHECK is not used.
         }
     }
+    virtual void getMemInfo( size_t &free, size_t &total, cudaStream_t stream ) {
+        CUDA_CHECK(cudaMemGetInfo(&free, &total));
+    }
 };
 
 class defaultHostAllocator : public hostAllocator {

--- a/cuML/src/common/rmmAllocatorAdapter.hpp
+++ b/cuML/src/common/rmmAllocatorAdapter.hpp
@@ -96,6 +96,25 @@ public:
         }
     }
 
+    /**
+     * @brief Query the underlying allocator for available memory
+     * 
+     * Such an interface is typically used to query for available memory and based
+     * on the response, budget its workspace accordingly.
+     *
+     * @param[out] free     will contain the amount of free memory (in B)
+     * @param[in] total     will contain the total amount of memory (in B)
+     * @param[in] stream    stream in which the allocations happen for the caller
+     */
+    virtual void getMemInfo( size_t &free, size_t &total, cudaStream_t stream ) {
+        if (!_rmmInitialized) {
+            CUDA_CHECK(cudaMemGetInfo(&free, &total));
+        } else {
+            auto rmmStatus = rmmGetInfo(&free, &total, stream);
+            ASSERT(RMM_SUCCESS == rmmStatus, "rmmGetInfo failed!");
+        }
+    }
+
 private:
     const bool _rmmInitialized;
 };

--- a/ml-prims/src/common/cuml_allocator.hpp
+++ b/ml-prims/src/common/cuml_allocator.hpp
@@ -56,6 +56,17 @@ public:
      * @param[in] stream    stream in which the allocation might be still in use
      */
     virtual void deallocate( void* p, std::size_t n, cudaStream_t stream ) = 0;
+    /**
+     * @brief Query the underlying allocator for available memory
+     * 
+     * Such an interface is typically used to query for available memory and based
+     * on the response, budget its workspace accordingly.
+     *
+     * @param[out] free     will contain the amount of free memory (in B)
+     * @param[in] total     will contain the total amount of memory (in B)
+     * @param[in] stream    stream in which the allocations happen for the caller
+     */
+    virtual void getMemInfo( size_t &free, size_t &total, cudaStream_t stream ) = 0;
 };
 
 /**
@@ -96,4 +107,4 @@ public:
     virtual void deallocate( void* p, std::size_t n, cudaStream_t stream ) = 0;
 };
 
-} // end namespace ML
+} // end namespace MLCommon


### PR DESCRIPTION
Following up on our discussion in PR #543, this PR proposes a change in the interface for `deviceAllocator`. The change is to add a `getMemInfo` (I'm open to suggestions for a better name) function and the underlying custom-allocator (eg: `rmmGetInfo` in case of RMM) will have to provide this functionality. If such a functionality, for whatever reasons, cannot be provided, atleast the sub-class of `deviceAllocator` which wraps this custom-allocator will have to appropriately handle it.

Tagging @jirikraus @cjnolet for discussions.

BTW, I still haven't thoroughly tested this interface, especially for the RMM side. I'll do so once we finalize on the interface level details.

NOTE: This PR is aimed for 0.8!