### PR TITLE
[HOTFIX][REVIEW] Add row major shared memory kernel back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,21 @@
 ## New Features
 
 - PR #405: Quasi-Newton GLM Solvers
-- PR #277: Added row- and column-wise weighted mean primitive
-- PR #424: Added a grid-sync struct for inter-block synchronization
-- PR #430: Adding R-Squared Score to ml primitives
-- PR #463: Added matrix gather to ml primitives
-- PR #435: Exposing cumlhandle in cython + developer guide
+- PR #277: Add row- and column-wise weighted mean primitive
+- PR #424: Add a grid-sync struct for inter-block synchronization
+- PR #430: Add R-Squared Score to ml primitives
+- PR #463: Add matrix gather to ml primitives
+- PR #435: Expose cumlhandle in cython + developer guide
 - PR #455: Remove default-stream arguement across ml-prims and cuML
 - PR #375: cuml cpp shared library renamed to libcuml++.so
-- PR #444: Added supervised training to UMAP
-- PR #460: Random Forest & Decision Trees (Single-GPU, Classification
-- PR #491: added doxygen build target for ml-prims
-- PR #505: Adding R-Squared Score to python interface
-- PR #507: Added coordinate descent for lasso and elastic-net
-- PR #511: a minmax ml-prim
+- PR #444: Add supervised training to UMAP
+- PR #460: Random Forest & Decision Trees (Single-GPU, Classification)
+- PR #491: Add doxygen build target for ml-prims
+- PR #505: Add R-Squared Score to python interface
+- PR #507: Add coordinate descent for lasso and elastic-net
+- PR #511: Add a minmax ml-prim
 - PR #520: Add local build script to mimic gpuCI
-- PR #503: Added column-wise matrix sort primitive
+- PR #503: Add column-wise matrix sort primitive
 - PR #525: Add docs build script to cuML
 - PR #528: Remove current KMeans and replace it with a new single GPU implementation built using ML primitives
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PR #527: Added notes on UMAP differences from reference implementation
 - PR #540: Use latest release version in update-version CI script
 - PR #552: Re-enable assert in kmeans tests with xfail as needed
+- PR #581: Add shared memory fast col major to row major function back with bound checks
 
 ## Bug Fixes
 

--- a/python/cuml/numba_utils.py
+++ b/python/cuml/numba_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,9 @@
 # limitations under the License.
 #
 
+import numba
+import math
+
 from numba import cuda
 from numba.cuda.cudadrv.driver import driver
 from librmm_cffi import librmm as rmm
@@ -25,7 +28,6 @@ def row_matrix(df):
         If already on the device, its stream will be used to perform the
         transpose (and to copy `row_major` to the device if necessary).
 
-    To be replaced by CUDA ml-prim in upcoming version
     """
 
     cols = [df._cols[k] for k in df._cols]
@@ -37,10 +39,28 @@ def row_matrix(df):
     row_major = rmm.device_array((nrows, ncols), dtype=dtype, order='C')
 
     tpb = driver.get_device().MAX_THREADS_PER_BLOCK
+
+    tile_width = int(math.pow(2, math.log(tpb, 2) / 2))
+    tile_height = int(tpb / tile_width)
+
+    tile_shape = (tile_height, tile_width + 1)
+
+    # one block per tile, plus one for remainders
+    blocks = int((row_major.shape[1]) / tile_height + 1), int((row_major.shape[0]) / tile_width + 1) # noqa
+    # one thread per tile element
+    threads = tile_height, tile_width
+
+    # blocks per gpu for the general kernel
     bpg = (nrows + tpb - 1) // tpb
 
+    if dtype == 'float32':
+        dt = numba.float32
+
+    else:
+        dt = numba.float64
+
     @cuda.jit
-    def kernel(_col_major, _row_major):
+    def general_kernel(_col_major, _row_major):
         tid = cuda.blockIdx.x * cuda.blockDim.x + cuda.threadIdx.x
         if tid >= nrows:
             return
@@ -50,6 +70,30 @@ def row_matrix(df):
             _row_major[tid, col_idx] = _col_major[tid, col_idx]
             _col_offset += 1
 
-    kernel[bpg, tpb](col_major, row_major)
+    @cuda.jit
+    def shared_kernel(input, output):
+
+        tile = cuda.shared.array(shape=tile_shape, dtype=dt)
+
+        tx = cuda.threadIdx.x
+        ty = cuda.threadIdx.y
+        bx = cuda.blockIdx.x * cuda.blockDim.x
+        by = cuda.blockIdx.y * cuda.blockDim.y
+        y = by + tx
+        x = bx + ty
+
+        if by + ty < input.shape[0] and bx + tx < input.shape[1]:
+            tile[ty, tx] = input[by + ty, bx + tx]
+        cuda.syncthreads()
+        if y < output.shape[0] and x < output.shape[1]:
+            output[y, x] = tile[tx, ty]
+
+    # check if we cannot call the shared memory kernel
+    if blocks[0] > 2147483647 or blocks[1] > 65535:
+        general_kernel[bpg, tpb](col_major, row_major)
+
+    else:
+        shared_kernel[blocks, threads](col_major, row_major)
+
 
     return row_major


### PR DESCRIPTION
Builds on top of #580 to finish fixes of sporadic fails, also adds the shared memory fast row major kernel back, with a check to see that the number of blocks is within cuda limits. With both of these PRs, the sporadic NN fails should be solved. 