### PR TITLE
[gpuCI] Auto-merge branch-0.7 to branch-0.8 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PR #543: Exposing dbscan batch size through cython API and fixing broken batching
 - PR #551: Made use of ZLIB_LIBRARIES consistent between ml_test and ml_mg_test
 - PR #557: Modified CI script to run cuML tests before building mlprims and removed lapack flag
+- PR #577: Use find libz in prims cmake
 
 # cuML 0.6.0 (22 Mar 2019)
 

--- a/ml-prims/CMakeLists.txt
+++ b/ml-prims/CMakeLists.txt
@@ -26,6 +26,13 @@ find_package(OpenMP REQUIRED)
 #find_package(ClangFormat REQUIRED)
 #find_package(ClangTidy REQUIRED)
 
+find_package(ZLIB REQUIRED)
+if(ZLIB_FOUND)
+  message(STATUS "ZLib found in ${ZLIB_INCLUDE_DIRS}")
+else()
+  message(FATAL_ERROR "ZLib not found, please check your settings.")
+endif(ZLIB_FOUND)
+
 # Submodules
 set(GTEST_DIR ${PROJECT_SOURCE_DIR}/external/googletest CACHE STRING
   "Path to the googletest repo")
@@ -87,7 +94,7 @@ set(MLPRIMS_LIBS
   ${CUDA_cusolver_LIBRARY}
   ${CUDA_cusparse_LIBRARY}
   pthread
-  z)
+  ${ZLIB_LIBRARIES})
 
 include_directories(src
   ${CUTLASS_DIR}


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.7` that creates a PR to keep `branch-0.8` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.