### PR TITLE
[REVIEW] QN Recover from numeric errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Improvements
 
+- PR #590: QN Recover from numeric errors
 - PR #482: Introduce cumlHandle for pca and tsvd
 - PR #573: Remove use of unnecessary cuDF column and series copies
 

--- a/cuML/src/glm/qn/qn_util.h
+++ b/cuML/src/glm/qn/qn_util.h
@@ -133,7 +133,7 @@ inline bool check_convergence(const LBFGSParam<T> &param, const int k, const T f
   T gnorm = nrm2(grad, dev_scalar, stream);
 
   if (verbosity > 0) {
-    printf("%04d: f(x)=%.6f conv.crit=%.6f (gnorm=%.6f, xnorm=%.6f)\n", k, fx,
+    printf("%04d: f(x)=%.8f conv.crit=%.8f (gnorm=%.8f, xnorm=%.8f)\n", k, fx,
            gnorm / std::max(T(1), xnorm), gnorm, xnorm);
   }
   // Convergence test -- gradient

--- a/cuML/test/quasi_newton.cu
+++ b/cuML/test/quasi_newton.cu
@@ -88,7 +88,7 @@ T run(const cumlHandle_impl &handle, LossFunction &loss, const SimpleMat<T> &X,
       cudaStream_t stream) {
 
   int max_iter = 100;
-  T grad_tol = 1e-8;
+  T grad_tol = 1e-16;
   int linesearch_max_iter = 50;
   int lbfgs_memory = 5;
   int num_iters = 0;


### PR DESCRIPTION
When tolerances are too tight, the algorithm might run to the point when differences between iterates become so small that we run into numerical issues.
We add recovery from this condition to the previous iterate.