### PR TITLE
[gpuCI] Auto-merge branch-0.7 to branch-0.8 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuML 0.7.0 (Date TBD)
+# cuML 0.7.0 (10 May 2019)
 
 ## New Features
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.7` that creates a PR to keep `branch-0.8` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.