### PR TITLE
Updated to use 0.8 dependencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@
 
 To install cuML from source, ensure the dependencies are met:
 
-1. [cuDF](https://github.com/rapidsai/cudf) (>=0.7)
+1. [cuDF](https://github.com/rapidsai/cudf) (>=0.8)
 2. zlib
 3. cmake (>= 3.12.4)
 4. CUDA (>= 9.2)
@@ -123,6 +123,3 @@ cuML's cmake has the following configurable flags available:
 | GPU_ARCHS |  List of GPU architectures, semicolon-separated | 60;70;75  | List of GPU architectures that all artifacts are compiled for.  |
 | KERNEL_INFO | [ON, OFF]  | OFF  | Enable/disable kernel resource usage info in nvcc. |
 | LINE_INFO | [ON, OFF]  | OFF  | Enable/disable lineinfo in nvcc.  |
-
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #596: Introduce cumlHandle for ols and ridge
 - PR #579: Introduce cumlHandle for cd and sgd, and propagate C++ errors in cython level for cd and sgd
 - PR #604: Adding cumlHandle to kNN, spectral methods, and UMAP
+- PR #622: Updated to use 0.8 dependencies
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -15,9 +15,9 @@ export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
 export PARALLEL_LEVEL=4
 
 # Set versions of packages needed to be grabbed
-export CUDF_VERSION=0.7.*
-export NVSTRINGS_VERSION=0.7.*
-export RMM_VERSION=0.7.*
+export CUDF_VERSION=0.8.*
+export NVSTRINGS_VERSION=0.8.*
+export RMM_VERSION=0.8.*
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -14,8 +14,8 @@ function logger() {
 export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
 export PARALLEL_LEVEL=4
 export CUDA_REL=${CUDA_VERSION%.*}
-export CUDF_VERSION=0.7.*
-export RMM_VERSION=0.7.*
+export CUDF_VERSION=0.8.*
+export RMM_VERSION=0.8.*
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -16,9 +16,9 @@ export PARALLEL_LEVEL=4
 export CUDA_REL=${CUDA_VERSION%.*}
 
 # Set versions of packages needed to be grabbed
-export CUDF_VERSION=0.7.*
-export NVSTRINGS_VERSION=0.7.*
-export RMM_VERSION=0.7.*
+export CUDF_VERSION=0.8.*
+export NVSTRINGS_VERSION=0.8.*
+export RMM_VERSION=0.8.*
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE

--- a/conda/recipes/cuml-cuda10/meta.yaml
+++ b/conda/recipes/cuml-cuda10/meta.yaml
@@ -28,14 +28,14 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.12.4
-    - cudf 0.7*
+    - cudf 0.8*
     - libcuml={{ version }}
     - libcumlMG
     - cudatoolkit {{ cuda_version }}.*
   run:
     - python x.x
     - setuptools
-    - cudf 0.7*
+    - cudf 0.8*
     - libcuml={{ version }}
     - libcumlMG
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,13 +28,13 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.12.4
-    - cudf 0.7*
+    - cudf 0.8*
     - libcuml={{ version }}
     - cudatoolkit {{ cuda_version }}.*
   run:
     - python x.x
     - setuptools
-    - cudf 0.7*
+    - cudf 0.8*
     - libcuml={{ version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -27,11 +27,11 @@ build:
 requirements:
   build:
     - cmake>=3.12.4
-    - cudf 0.7*
+    - cudf 0.8*
     - cudatoolkit {{ cuda_version }}.*
     - lapack
   run:
-    - cudf 0.7*
+    - cudf 0.8*
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 about:


### PR DESCRIPTION
Updated scripts and `meta.yaml` files to use 0.8 dependencies.
Tested using `ci/local/build.sh` where cuml was successfully built and all unit tests passed.