### PR TITLE
[REVIEW] Added build.sh script, updated CI scripts and documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -106,6 +106,32 @@ $ pytest cuML/test --collect-only
 $ python setup.py install
 ```
 
+#### `build.sh`
+
+As a convenience, a `build.sh` script is provided which can be used to execute the same build commands above.  Note that the libraries will be installed to the location set in `$INSTALL_PREFIX` if set (i.e. `export INSTALL_PREFIX=/install/path`), otherwise to `$CONDA_PREFIX`.
+```bash
+$ ./build.sh                           # build the cuML libraries, tests, and python package, then
+                                       # install them to $INSTALL_PREFIX if set, otherwise $CONDA_PREFIX
+```
+
+To build individual components, specify them as arguments to `build.sh`
+```bash
+$ ./build.sh libcuml                   # build and install the cuML C++ library
+$ ./build.sh cuml                      # build and install the cuML python package
+$ ./build.sh prims                     # build the ML prims tests
+```
+
+Other `build.sh` options:
+```bash
+$ ./build.sh clean                     # remove any prior build artifacts and configuration (start over)
+$ ./build.sh libcuml -v                # build and install libcuml with verbose output
+$ ./build.sh libcuml -g                # build and install libcuml for debug
+$ PARALLEL_LEVEL=4 ./build.sh libcuml  # build and install libcuml limiting parallel build jobs to 4 (make -j4)
+$ ./build.sh libcuml -n                # build libcuml but do not install
+$ ./build.sh prims --buildAllGPUArch   # build the ML prims tests for all supported GPU architectures
+$ ./build.sh cuml --multigpu           # build the cuml python package with multi-GPU support (requires libcumlMG and CUDA >= 10.0)
+```
+
 ### Custom Build Options
 
 cuML's cmake has the following configurable flags available:

--- a/BUILD.md
+++ b/BUILD.md
@@ -128,7 +128,7 @@ $ ./build.sh libcuml -v                # build and install libcuml with verbose 
 $ ./build.sh libcuml -g                # build and install libcuml for debug
 $ PARALLEL_LEVEL=4 ./build.sh libcuml  # build and install libcuml limiting parallel build jobs to 4 (make -j4)
 $ ./build.sh libcuml -n                # build libcuml but do not install
-$ ./build.sh prims --buildAllGPUArch   # build the ML prims tests for all supported GPU architectures
+$ ./build.sh prims --allgpuarch        # build the ML prims tests for all supported GPU architectures
 $ ./build.sh cuml --multigpu           # build the cuml python package with multi-GPU support (requires libcumlMG and CUDA >= 10.0)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #604: Adding cumlHandle to kNN, spectral methods, and UMAP
 - PR #618: CI: Enable copyright header checks
 - PR #622: Updated to use 0.8 dependencies
+- PR #626: Added build.sh script, updated CI scripts and documentation
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/build.sh
+++ b/build.sh
@@ -18,25 +18,27 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libcuml cuml prims -v -g -n --buildAllGPUArch --multigpu -h --help"
+VALIDARGS="clean libcuml cuml prims -v -g -n --allgpuarch --multigpu -h --help"
 HELP="$0 [<target> ...] [<flag> ...]
  where <target> is:
-   clean             - remove all existing build artifacts and configuration (start over)
-   libcuml           - build the cuml C++ code only
-   cuml              - build the cuml Python package
-   prims             - build the ML prims tests
+   clean         - remove all existing build artifacts and configuration (start over)
+   libcuml       - build the cuml C++ code only
+   cuml          - build the cuml Python package
+   prims         - build the ML prims tests
  and <flag> is:
-   -v                - verbose build mode
-   -g                - build for debug
-   -n                - no install step
-   --buildAllGPUArch - build for all supported GPU architectures
-   --multigpu        - Build cuml with multigpu support (requires libcumlMG and CUDA >=10.0)
-   -h                - print this text
+   -v            - verbose build mode
+   -g            - build for debug
+   -n            - no install step
+   --allgpuarch  - build for all supported GPU architectures
+   --multigpu    - Build cuml with multigpu support (requires libcumlMG and CUDA >=10.0)
+   -h            - print this text
 
  default action (no args) is to build and install 'libcuml', 'cuml', and 'prims' targets only for the detected GPU arch
 "
 LIBCUML_BUILD_DIR=${REPODIR}/cpp/build
 CUML_BUILD_DIR=${REPODIR}/python/build
+# TODO: consider adding the faiss build dir to clean, possibly only done with a
+# new "deep-clean" target.
 BUILD_DIRS="${LIBCUML_BUILD_DIR} ${CUML_BUILD_DIR}"
 
 # Set defaults for vars modified by flags to this script
@@ -82,7 +84,7 @@ fi
 if hasArg -n; then
     INSTALL_TARGET=""
 fi
-if hasArg --buildAllGPUArch; then
+if hasArg --allgpuarch; then
     BUILD_ALL_GPU_ARCH=1
 fi
 if hasArg --multigpu; then
@@ -116,6 +118,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libcuml || hasArg prims; then
 
     # Configure the build for the GPU type of this machine, or all (GPU_ARCH="")
     # if it cannot be detected.
+    # TODO: add additional detected GPU archs
     if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
         if (( ${HAS_NVIDIA_SMI} )); then
             GPU="$(nvidia-smi | awk '{print $4}' | sed '8!d')"
@@ -131,7 +134,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libcuml || hasArg prims; then
             fi
         else
             echo "nvidia-smi was not found on PATH and is needed for detecting the GPU arch"
-            echo "Ensure nvidia-smi is on PATH or use --buildAllGPUArch"
+            echo "Ensure nvidia-smi is on PATH or use --allgpuarch"
             exit 1
         fi
     else

--- a/build.sh
+++ b/build.sh
@@ -18,17 +18,19 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libcuml cuml -v -g -n -h"
+VALIDARGS="clean libcuml cuml prims -v -g -n --buildAllGPUArch -h"
 HELP="$0 [clean] [libcuml] [cuml] [-v] [-g] [-n] [-h]
-   clean   - remove all existing build artifacts and configuration (start over)
-   libcuml - build the cuml C++ code only
-   cuml    - build the cuml Python package
-   -v      - verbose build mode
-   -g      - build for debug
-   -n      - no install step
-   -h      - print this text
+   clean             - remove all existing build artifacts and configuration (start over)
+   libcuml           - build the cuml C++ code only
+   cuml              - build the cuml Python package
+   prims             - build the ML prims tests
+   -v                - verbose build mode
+   -g                - build for debug
+   -n                - no install step
+   --buildAllGPUArch - build for all supported GPU architectures
+   -h                - print this text
 
-   default action (no args) is to build and install 'libcuml' then 'cuml' targets
+   default action (no args) is to build and install 'libcuml', 'cuml', and 'prims' targets only for the detected GPU arch
 "
 LIBCUML_BUILD_DIR=${REPODIR}/cpp/build
 CUML_BUILD_DIR=${REPODIR}/python/build
@@ -38,13 +40,14 @@ BUILD_DIRS="${LIBCUML_BUILD_DIR} ${CUML_BUILD_DIR}"
 VERBOSE=""
 BUILD_TYPE=Release
 INSTALL_TARGET=install
+BUILD_ALL_GPU_ARCH=0
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
 #         CONDA_PREFIX, but there is no fallback from there!
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX}}}
-PYTHON=${PYTHON:=python}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:=""}
+BUILD_ABI=${BUILD_ABI:=ON}
 
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
@@ -75,6 +78,16 @@ fi
 if hasArg -n; then
     INSTALL_TARGET=""
 fi
+if hasArg --buildAllGPUArch; then
+    BUILD_ALL_GPU_ARCH=1
+fi
+
+# Various build options use nvidia-smi for querying the system
+HAS_NVIDIA_SMI=1
+which nvidia-smi > /dev/null
+if (( $? != 0 )); then
+    HAS_NVIDIA_SMI=0
+fi
 
 # If clean given, run it prior to any other steps
 if hasArg clean; then
@@ -91,28 +104,77 @@ if hasArg clean; then
 fi
 
 ################################################################################
-# Configure, build, and install libcuml
-if (( ${NUMARGS} == 0 )) || hasArg libcuml; then
+# Configure for building
+if (( ${NUMARGS} == 0 )) || hasArg libcuml || hasArg prims; then
+
+    # Configure the build for the GPU type of this machine, or all (GPU_ARCH="")
+    # if it cannot be detected.
+    if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
+        if (( ${HAS_NVIDIA_SMI} )); then
+            GPU="$(nvidia-smi | awk '{print $4}' | sed '8!d')"
+            if [[ $GPU == *"P100"* ]]; then
+                GPU_ARCH="-DGPU_ARCHS=\"60\""
+                echo "Building for Pascal..."
+            elif [[ $GPU == *"V100"* ]]; then
+                GPU_ARCH="-DGPU_ARCHS=\"70\""
+                echo "Building for Volta..."
+            elif [[ $GPU == *"T4"* ]]; then
+                GPU_ARCH="-DGPU_ARCHS=\"75\""
+                echo "Building for Turing..."
+            fi
+        else
+            echo "nvidia-smi was not found on PATH and is needed for detecting the GPU arch"
+            echo "Ensure nvidia-smi is on PATH or use --buildAllGPUArch"
+            exit 1
+        fi
+    else
+        GPU_ARCH=""
+        echo "Building for *ALL* GPU architectures..."
+    fi
 
     mkdir -p ${LIBCUML_BUILD_DIR}
     cd ${LIBCUML_BUILD_DIR}
 
     cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+          -DCMAKE_CXX11_ABI=${BUILD_ABI} \
           -DBLAS_LIBRARIES=${INSTALL_PREFIX}/lib/libopenblas.so \
           -DLAPACK_LIBRARIES=${INSTALL_PREFIX}/lib/libopenblas.so \
-          -DCMAKE_CXX11_ABI=ON \
+          ${GPU_ARCH} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-    make -j${PARALLEL_LEVEL} VERBOSE=${VERBOSE} ${INSTALL_TARGET}
 fi
 
-# Build and install the cuml Python package
+# Build and (optionally) install libcuml + tests
+if (( ${NUMARGS} == 0 )) || hasArg libcuml; then
+
+    cd ${LIBCUML_BUILD_DIR}
+    make -j${PARALLEL_LEVEL} cuml++ ml ml_mg VERBOSE=${VERBOSE} ${INSTALL_TARGET}
+fi
+
+# Build and (optionally) install the cuml Python package
 if (( ${NUMARGS} == 0 )) || hasArg cuml; then
+
+    # Set the multigpu option based on CUDA version: version 9.2 will disable
+    # multigpu, all others assume it should be enabled.
+    MULTIGPU_OPTION=--multigpu
+    if (( ${HAS_NVIDIA_SMI} )); then
+        CUDA_VERSION=$(nvidia-smi -q|grep "CUDA Version"|awk '{print $NF}')
+        if [[ ${CUDA_VERSION} == "9.2" ]]; then
+            MULTIGPU_OPTION=""
+        fi
+    fi
 
     cd ${REPODIR}/python
     if [[ ${INSTALL_TARGET} != "" ]]; then
-	${PYTHON} setup.py build_ext --inplace ${MULTIGPU_OPTION}
-	${PYTHON} setup.py install --single-version-externally-managed --record=record.txt ${MULTIGPU_OPTION}
+	python setup.py build_ext --inplace ${MULTIGPU_OPTION}
+	python setup.py install --single-version-externally-managed --record=record.txt ${MULTIGPU_OPTION}
     else
-	${PYTHON} setup.py build_ext --inplace --library-dir=${LIBCUML_BUILD_DIR} ${MULTIGPU_OPTION}
+	python setup.py build_ext --inplace --library-dir=${LIBCUML_BUILD_DIR} ${MULTIGPU_OPTION}
     fi
+fi
+
+# Build the ML prims tests
+if (( ${NUMARGS} == 0 )) || hasArg prims; then
+
+    cd ${LIBCUML_BUILD_DIR}
+    make -j${PARALLEL_LEVEL} VERBOSE=${VERBOSE} prims
 fi

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -60,25 +60,7 @@ cd $WORKSPACE
 git submodule update --init --recursive
 
 logger "Build libcuml..."
-mkdir -p $WORKSPACE/cuML/build
-cd $WORKSPACE/cuML/build
-logger "Run cmake libcuml..."
-cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_CXX11_ABI=ON ..
-
-logger "Clean up make..."
-make clean
-
-logger "Make libcuml..."
-make -j${PARALLEL_LEVEL}
-
-logger "Install libcuml..."
-make -j${PARALLEL_LEVEL} install
-
-
-logger "Build cuML..."
-cd $WORKSPACE/python
-python setup.py build_ext --inplace
-python setup.py install
+$WORKSPACE/build.sh clean libcuml cuml
 
 ################################################################################
 # BUILD - Build docs

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -76,5 +76,5 @@ pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 ################################################################################
 
 logger "Run ml-prims test..."
-cd $WORKSPACE/cpp/build_prims
+cd $WORKSPACE/cpp/build
 GTEST_OUTPUT="xml:${WORKSPACE}/test-results/prims/" ./test/prims

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -44,44 +44,12 @@ $CC --version
 $CXX --version
 conda list
 
-logger "Check GPU running the tests..."
-GPU="$(nvidia-smi | awk '{print $4}' | sed '8!d')"
-echo "Running tests on $GPU"
-
-if [[ $GPU == *"P100"* ]]; then
-  logger "Building for Pascal..."
-  GPU_ARCH="-DGPU_ARCHS=\"60\""
-elif [[ $GPU == *"V100"* ]]; then
-  logger "Building for Volta..."
-  GPU_ARCH=GPU_ARCH="-DGPU_ARCHS=\"70\""
-elif [[ $GPU == *"T4"* ]]; then
-  logger "Building for Turing..."
-  GPU_ARCH=GPU_ARCH="-DGPU_ARCHS=\"75\""
-fi
-
 ################################################################################
-# BUILD - Build libcuml and cuML from source
+# BUILD - Build libcuml, cuML, and prims from source
 ################################################################################
 
 logger "Build libcuml..."
-mkdir -p $WORKSPACE/cpp/build
-cd $WORKSPACE/cpp/build
-logger "Run cmake libcuml..."
-cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_CXX11_ABI=ON -DBLAS_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.a $GPU_ARCH -DBUILD_PRIMS_TESTS=OFF ..
-
-logger "Clean up make..."
-make clean
-
-logger "Make libcuml++ and algorithm tests..."
-make -j${PARALLEL_LEVEL} cuml++ ml ml_mg
-
-logger "Install libcuml++..."
-make -j${PARALLEL_LEVEL} install
-
-logger "Build cuml python package..."
-cd $WORKSPACE/python
-python setup.py build_ext --inplace
-
+$WORKSPACE/build.sh clean libcuml cuml prims -v
 
 ################################################################################
 # TEST - Run GoogleTest and py.tests for libcuml and cuML
@@ -103,20 +71,9 @@ logger "Python pytest for cuml..."
 cd $WORKSPACE/python
 pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 
-
 ################################################################################
-# TEST - Build and run ml-prim tests
+# TEST - Run GoogleTest for ml-prims
 ################################################################################
-
-logger "Build ml-prims tests..."
-mkdir -p $WORKSPACE/cpp/build_prims
-cd $WORKSPACE/cpp/build_prims
-cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_CXX11_ABI=ON -DBLAS_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.a $GPU_ARCH -DBUILD_CUML_CPP_LIBRARY=OFF ..
-
-logger "Clean up make..."
-make clean
-logger "Make ml-prims test..."
-make -j${PARALLEL_LEVEL} prims
 
 logger "Run ml-prims test..."
 cd $WORKSPACE/cpp/build_prims

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -96,7 +96,7 @@ chmod ugo+x ${CPP_CONTAINER_BUILD_DIR}/build.sh
 # Run the generated build script in a container
 docker pull ${DOCKER_IMAGE}
 docker run --runtime=nvidia --rm -it -e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES} \
-       --user $(id -u) \
+       --user $(id -u):$(id -g) \
        -v ${REPO_PATH}:${REPO_PATH_IN_CONTAINER} \
        -v ${CPP_CONTAINER_BUILD_DIR}:${CPP_BUILD_DIR_IN_CONTAINER} \
        -v ${PYTHON_CONTAINER_BUILD_DIR}:${PYTHON_BUILD_DIR_IN_CONTAINER} \

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -96,7 +96,7 @@ chmod ugo+x ${CPP_CONTAINER_BUILD_DIR}/build.sh
 # Run the generated build script in a container
 docker pull ${DOCKER_IMAGE}
 docker run --runtime=nvidia --rm -it -e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES} \
-       --user $(id -u):$(id -g) \
+       --user $(id -u) \
        -v ${REPO_PATH}:${REPO_PATH_IN_CONTAINER} \
        -v ${CPP_CONTAINER_BUILD_DIR}:${CPP_BUILD_DIR_IN_CONTAINER} \
        -v ${PYTHON_CONTAINER_BUILD_DIR}:${PYTHON_BUILD_DIR_IN_CONTAINER} \

--- a/conda/recipes/cuml-cuda10/build.sh
+++ b/conda/recipes/cuml-cuda10/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-cd python
-$PYTHON setup.py build_ext --inplace --multigpu
-$PYTHON setup.py install --multigpu
+
+# This assumes the script is executed from the root of the repo directory
+./build.sh cuml

--- a/conda/recipes/cuml-cuda10/build.sh
+++ b/conda/recipes/cuml-cuda10/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh cuml
+./build.sh cuml --multigpu

--- a/conda/recipes/cuml/build.sh
+++ b/conda/recipes/cuml/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cd python
-$PYTHON setup.py build_ext --inplace
-$PYTHON setup.py install
+
+# This assumes the script is executed from the root of the repo directory
+./build.sh cuml
 $PYTHON -c 'import cuml'

--- a/conda/recipes/libcuml/build.sh
+++ b/conda/recipes/libcuml/build.sh
@@ -1,5 +1,3 @@
-CMAKE_COMMON_VARIABLES=" -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX11_ABI=$BUILD_ABI"
-
 
 if [ -n "$MACOSX_DEPLOYMENT_TARGET" ]; then
     # C++11 requires 10.9
@@ -11,12 +9,5 @@ fi
 printenv
 # Cleanup local git
 git clean -xdf
-# Change directory for build process
-cd cpp
-# Use CMake-based build procedure
-mkdir build
-cd build
-# configure
-cmake $CMAKE_COMMON_VARIABLES ..
-# build
-make -j${PARALLEL_LEVEL} cuml++ VERBOSE=1 install
+
+./build.sh clean libcuml -v


### PR DESCRIPTION
This PR adds a new top-level script named build.sh that allows a contributor to build from source using the same commands and options the CI system, container builds, doc builds, nightly unit test runs, and (eventually) ASV build & test iterations use. The relevant CI scripts have been updated to call this script and all related documentation should be updated as well.

This PR allows a maintainer to update the common build steps in one place while also simplifying the build process for all contributors and other build-related operations.

The changes were tested using the gpuCI container via the `ci/local/build.sh` testing script, where cuml branch-0.8 was successfully built and tested without errors.