### PR TITLE
[REVIEW] Fix for dbscan crash filed in issue #613

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator
 - PR #620: C++: Removed old unit-test files in ml-prims
+- PR #627: C++: Fixed dbscan crash issue filed in 613
 
 
 # cuML 0.7.0 (10 May 2019)

--- a/cpp/src/dbscan/adjgraph/algo.h
+++ b/cpp/src/dbscan/adjgraph/algo.h
@@ -40,9 +40,9 @@ static const int TPB_X = 256;
  * Takes vertex degree array (vd) and CSR row_ind array (ex_scan) to produce the
  * CSR row_ind_ptr array (adj_graph) and filters into a core_pts array based on min_pts.
  */
-template <typename Type>
-void launcher(const ML::cumlHandle_impl& handle, Pack<Type> data, Type batchSize, cudaStream_t stream) {
-
+template <typename Type, typename Index_ = int>
+void launcher(const ML::cumlHandle_impl& handle, Pack<Type, Index_> data, Index_ batchSize,
+              cudaStream_t stream) {
     device_ptr<int> dev_vd = device_pointer_cast(data.vd); 
     device_ptr<Type> dev_ex_scan = device_pointer_cast(data.ex_scan);
 

--- a/cpp/src/dbscan/adjgraph/pack.h
+++ b/cpp/src/dbscan/adjgraph/pack.h
@@ -19,7 +19,7 @@
 namespace Dbscan {
 namespace AdjGraph {
 
-template <typename Type>
+template <typename Type, typename Index_ = int>
 struct Pack {
     /**
      * vertex degree array
@@ -39,7 +39,7 @@ struct Pack {
     /** array to store whether a vertex is core poType or not */
     bool *core_pts;
     /** number of poTypes in the dataset */
-    Type N;
+    Index_ N;
     /** Minpts for classifying core pts */
     Type minPts;
 };

--- a/cpp/src/dbscan/adjgraph/runner.h
+++ b/cpp/src/dbscan/adjgraph/runner.h
@@ -24,16 +24,16 @@
 namespace Dbscan {
 namespace AdjGraph {
 
-template <typename Type>
-void run(const ML::cumlHandle_impl& handle, bool* adj, int* vd, Type* adj_graph, Type adjnnz, Type* ex_scan, Type N,
-         Type minpts, bool* core_pts, int algo, Type batchSize, cudaStream_t stream) {
-    Pack<Type> data = {vd, adj, adj_graph, adjnnz, ex_scan, core_pts, N, minpts};
+template <typename Type, typename Index_ = int>
+void run(const ML::cumlHandle_impl& handle, bool* adj, int* vd, Type* adj_graph, Type adjnnz, Type* ex_scan,
+         Index_ N, Type minpts, bool* core_pts, int algo, Index_ batchSize, cudaStream_t stream) {
+    Pack<Type, Index_> data = {vd, adj, adj_graph, adjnnz, ex_scan, core_pts, N, minpts};
     switch(algo) {
     case 0:
-        Naive::launcher<Type>(handle, data, batchSize, stream);
+        Naive::launcher<Type, Index_>(handle, data, batchSize, stream);
         break;
     case 1:
-        Algo::launcher<Type>(handle, data, batchSize, stream);
+        Algo::launcher<Type, Index_>(handle, data, batchSize, stream);
         break;
     default:
         ASSERT(false, "Incorrect algo passed! '%d'", algo);

--- a/cpp/src/dbscan/dbscan.cu
+++ b/cpp/src/dbscan/dbscan.cu
@@ -24,14 +24,17 @@ namespace ML {
 
 using namespace Dbscan;
 
+// @todo
+// In the below 2 calls, the Index type has been hard-coded to `int64_t`
+// We should pick the right Index type based on the input dimensions.
 void dbscanFit(const cumlHandle& handle, float *input, int n_rows, int n_cols, float eps, int min_pts,
 		       int *labels, size_t max_bytes_per_batch = 0, bool verbose) {
-	dbscanFitImpl(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, max_bytes_per_batch, handle.getStream(), verbose);
+    dbscanFitImpl<float, int64_t>(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, max_bytes_per_batch, handle.getStream(), verbose);
 }
 
 void dbscanFit(const cumlHandle& handle, double *input, int n_rows, int n_cols, double eps, int min_pts,
 		       int *labels, size_t max_bytes_per_batch = 0, bool verbose) {
-	dbscanFitImpl(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, max_bytes_per_batch, handle.getStream(), verbose);
+    dbscanFitImpl<double, int64_t>(handle.getImpl(), input, n_rows, n_cols, eps, min_pts, labels, max_bytes_per_batch, handle.getStream(), verbose);
 }
 
 }; // end namespace ML

--- a/cpp/src/dbscan/dbscan.h
+++ b/cpp/src/dbscan/dbscan.h
@@ -24,7 +24,7 @@ namespace ML {
 using namespace Dbscan;
 
 // Default max mem set to a reasonable value for a 16gb card.
-static const size_t DEFAULT_MAX_MEM_BYTES = 8e9;
+static const size_t DEFAULT_MAX_MEM_BYTES = 13e9;
 
 template<typename T, typename Index_ = int>
 Index_ computeBatchCount(Index_ n_rows, size_t max_bytes_per_batch) {

--- a/cpp/src/dbscan/dbscan.h
+++ b/cpp/src/dbscan/dbscan.h
@@ -24,7 +24,7 @@ namespace ML {
 using namespace Dbscan;
 
 // Default max mem set to a reasonable value for a 16gb card.
-static const size_t DEFAULT_MAX_MEM_BYTES = 13e9;
+static const size_t DEFAULT_MAX_MEM_BYTES = 8e9;
 
 template<typename T, typename Index_ = int>
 Index_ computeBatchCount(Index_ n_rows, size_t max_bytes_per_batch) {

--- a/cpp/src/dbscan/dbscan.h
+++ b/cpp/src/dbscan/dbscan.h
@@ -26,10 +26,9 @@ using namespace Dbscan;
 // Default max mem set to a reasonable value for a 16gb card.
 static const size_t DEFAULT_MAX_MEM_BYTES = 13e9;
 
-template<typename T>
-int computeBatchCount(int n_rows, size_t max_bytes_per_batch) {
-
-    int n_batches = 1;
+template<typename T, typename Index_ = int>
+Index_ computeBatchCount(Index_ n_rows, size_t max_bytes_per_batch) {
+    Index_ n_batches = 1;
     // There seems to be a weird overflow bug with cutlass gemm kernels
     // hence, artifically limiting to a smaller batchsize!
     ///TODO: in future, when we bump up the underlying cutlass version, this should go away
@@ -43,9 +42,9 @@ int computeBatchCount(int n_rows, size_t max_bytes_per_batch) {
     return n_batches;
 }
 
-template<typename T>
+template<typename T, typename Index_ = int>
 void dbscanFitImpl(const ML::cumlHandle_impl& handle, T *input,
-        int n_rows, int n_cols,
+        Index_ n_rows, Index_ n_cols,
         T eps, int min_pts,
         int *labels,
         size_t max_bytes_per_batch,
@@ -59,7 +58,7 @@ void dbscanFitImpl(const ML::cumlHandle_impl& handle, T *input,
         // @todo: Query device for remaining memory
         max_bytes_per_batch = DEFAULT_MAX_MEM_BYTES;
 
-    int n_batches = computeBatchCount<T>(n_rows, max_bytes_per_batch);
+    Index_ n_batches = computeBatchCount<T, Index_>(n_rows, max_bytes_per_batch);
 
     if(verbose) {
         size_t batchSize = ceildiv<size_t>(n_rows, n_batches);

--- a/cpp/src/dbscan/runner.h
+++ b/cpp/src/dbscan/runner.h
@@ -106,7 +106,6 @@ size_t run(const ML::cumlHandle_impl& handle, Type_f* x, Index_ N, Index_ D, Typ
     MLCommon::Sparse::WeakCCState<Type> state(xa, fa, m);
 
 	for (int i = 0; i < nBatches; i++) {
-            std::cout << "Running batch id = " << i << "\n";
 		MLCommon::device_buffer<Type> adj_graph(handle.getDeviceAllocator(), stream);
 		Type startVertexId = i * batchSize;
         int nPoints = min(N-startVertexId, batchSize);

--- a/cpp/src/dbscan/vertexdeg/algo.h
+++ b/cpp/src/dbscan/vertexdeg/algo.h
@@ -33,15 +33,16 @@ namespace Algo {
 /**
  * Calculates the vertex degree array and the epsilon neighborhood adjacency matrix for the batch.
  */
-template <typename value_t>
-void launcher(const ML::cumlHandle_impl& handle, Pack<value_t> data, int startVertexId, int batchSize, cudaStream_t stream) {
+template <typename value_t, typename index_t = int>
+void launcher(const ML::cumlHandle_impl& handle, Pack<value_t, index_t> data,
+              index_t startVertexId, index_t batchSize, cudaStream_t stream) {
     data.resetArray(stream, batchSize+1);
 
-    int m = data.N;
-    int n = min(data.N - startVertexId, batchSize);
-    int k = data.D;
+    index_t m = data.N;
+    index_t n = min(data.N - startVertexId, batchSize);
+    index_t k = data.D;
 
-    int* vd = data.vd;
+    index_t* vd = data.vd;
 
     value_t eps2 = data.eps * data.eps;
 
@@ -50,22 +51,24 @@ void launcher(const ML::cumlHandle_impl& handle, Pack<value_t> data, int startVe
 
     constexpr auto distance_type = MLCommon::Distance::DistanceType::EucUnexpandedL2;
 
-    workspaceSize =  MLCommon::Distance::getWorkspaceSize<distance_type, value_t, value_t, bool>
+    workspaceSize =  MLCommon::Distance::getWorkspaceSize<distance_type, value_t, value_t,
+                                                          bool, index_t>
             (data.x, data.x+startVertexId*k, m, n, k);
 
     if (workspaceSize != 0)
         workspace.resize(workspaceSize, stream);
 
-    MLCommon::Distance::epsilon_neighborhood<distance_type, value_t>
+    auto fused_op =  [vd, n] __device__ (index_t global_c_idx, bool in_neigh) {
+                         // fused construction of vertex degree
+                         index_t batch_vertex = global_c_idx - (n * (global_c_idx / n));
+                         atomicAdd(vd+batch_vertex, in_neigh);
+                         atomicAdd(vd+n, in_neigh);
+                     };
+
+    MLCommon::Distance::epsilon_neighborhood<distance_type, value_t,
+                                             decltype(fused_op), index_t>
         (data.x, data.x+startVertexId*k, data.adj, m, n, k, eps2,
-         (void*)workspace.data(), workspaceSize, stream,
-         [vd, n] __device__ (int global_c_idx, bool in_neigh) {
-             // fused construction of vertex degree
-             int batch_vertex = global_c_idx - (n * (global_c_idx / n));
-             atomicAdd(vd+batch_vertex, in_neigh);
-             atomicAdd(vd+n, in_neigh);
-         }
-	);
+         (void*)workspace.data(), workspaceSize, stream, fused_op);
 
     CUDA_CHECK(cudaPeekAtLastError());
 }

--- a/cpp/src/dbscan/vertexdeg/algo.h
+++ b/cpp/src/dbscan/vertexdeg/algo.h
@@ -42,7 +42,7 @@ void launcher(const ML::cumlHandle_impl& handle, Pack<value_t, index_t> data,
     index_t n = min(data.N - startVertexId, batchSize);
     index_t k = data.D;
 
-    index_t* vd = data.vd;
+    int* vd = data.vd;
 
     value_t eps2 = data.eps * data.eps;
 

--- a/cpp/src/dbscan/vertexdeg/naive.h
+++ b/cpp/src/dbscan/vertexdeg/naive.h
@@ -38,22 +38,23 @@ static const int TPB_Y = 8;
  * @param N number of rows
  * @param D number of columns
  */
-template <typename Type>
-__global__ void vertex_degree_kernel(Pack<Type> data, int startVertexId, int batchSize) {
+template <typename Type, typename Index_ = int>
+__global__ void vertex_degree_kernel(Pack<Type, Index_> data, Index_ startVertexId,
+                                     Index_ batchSize) {
     const Type Zero = (Type)0;
-    int row = (blockIdx.y * TPB_Y) + threadIdx.y;
-    int col = (blockIdx.x * TPB_X) + threadIdx.x;
-    int N = data.N;
+    Index_ row = (blockIdx.y * TPB_Y) + threadIdx.y;
+    Index_ col = (blockIdx.x * TPB_X) + threadIdx.x;
+    Index_ N = data.N;
     if((row >= batchSize) || (col >= N))
         return;
     Type eps = data.eps;
     Type eps2 = eps * eps;
     Type sum = Zero;
-    int D = data.D;
+    Index_ D = data.D;
     Type *x = data.x;
     bool *adj = data.adj;
-    int *vd = data.vd;
-    for(int d=0;d<D;++d) {
+    Index_ *vd = data.vd;
+    for(Index_ d=0;d<D;++d) {
         Type a = __ldg(x+(row+startVertexId)*D+d);
         Type b = __ldg(x+col*D+d);
         Type diff = a - b;
@@ -65,9 +66,9 @@ __global__ void vertex_degree_kernel(Pack<Type> data, int startVertexId, int bat
     atomicAdd(vd+batchSize, res);
 }
 
-template <typename Type>
-void launcher(Pack<Type> data, int startVertexId, int batchSize, cudaStream_t stream) {
-    dim3 grid(ceildiv(data.N, TPB_X), ceildiv(batchSize, TPB_Y), 1);
+template <typename Type, typename Index_ = int>
+void launcher(Pack<Type, Index_> data, Index_ startVertexId, Index_ batchSize, cudaStream_t stream) {
+    dim3 grid(ceildiv(data.N, (Index_)TPB_X), ceildiv(batchSize, (Index_)TPB_Y), 1);
     dim3 blk(TPB_X, TPB_Y, 1);
     data.resetArray(stream, batchSize+1);
     vertex_degree_kernel<<<grid, blk, 0, stream>>>(data, startVertexId, batchSize);

--- a/cpp/src/dbscan/vertexdeg/naive.h
+++ b/cpp/src/dbscan/vertexdeg/naive.h
@@ -53,7 +53,7 @@ __global__ void vertex_degree_kernel(Pack<Type, Index_> data, Index_ startVertex
     Index_ D = data.D;
     Type *x = data.x;
     bool *adj = data.adj;
-    Index_ *vd = data.vd;
+    int *vd = data.vd;
     for(Index_ d=0;d<D;++d) {
         Type a = __ldg(x+(row+startVertexId)*D+d);
         Type b = __ldg(x+col*D+d);

--- a/cpp/src/dbscan/vertexdeg/pack.h
+++ b/cpp/src/dbscan/vertexdeg/pack.h
@@ -26,7 +26,7 @@ struct Pack {
      * Last position is the sum of all elements in this array (excluding it)
      * Hence, its length is one more than the number of points
      */
-    Index_ *vd;
+    int *vd;
     /** the adjacency matrix */
     bool *adj;
     /** input dataset */
@@ -43,7 +43,7 @@ struct Pack {
      * @param stream cuda stream where to perform this operation
      */
     void resetArray(cudaStream_t stream, Index_ vdlen) {
-        CUDA_CHECK(cudaMemsetAsync(vd, 0, sizeof(Index_)*vdlen, stream));
+        CUDA_CHECK(cudaMemsetAsync(vd, 0, sizeof(int)*vdlen, stream));
     }
 };
 

--- a/cpp/src/dbscan/vertexdeg/pack.h
+++ b/cpp/src/dbscan/vertexdeg/pack.h
@@ -19,14 +19,14 @@
 namespace Dbscan {
 namespace VertexDeg {
 
-template <typename Type>
+template <typename Type, typename Index_>
 struct Pack {
     /**
      * vertex degree array
      * Last position is the sum of all elements in this array (excluding it)
      * Hence, its length is one more than the number of points
      */
-    int *vd;
+    Index_ *vd;
     /** the adjacency matrix */
     bool *adj;
     /** input dataset */
@@ -34,16 +34,16 @@ struct Pack {
     /** epsilon neighborhood thresholding param */
     Type eps;
     /** number of points in the dataset */
-    int N;
+    Index_ N;
     /** dataset dimensionality */
-    int D;
+    Index_ D;
 
     /**
      * @brief reset the output array before calling the actual kernel
      * @param stream cuda stream where to perform this operation
      */
-    void resetArray(cudaStream_t stream, int vdlen) {
-        CUDA_CHECK(cudaMemsetAsync(vd, 0, sizeof(int)*vdlen, stream));
+    void resetArray(cudaStream_t stream, Index_ vdlen) {
+        CUDA_CHECK(cudaMemsetAsync(vd, 0, sizeof(Index_)*vdlen, stream));
     }
 };
 

--- a/cpp/src/dbscan/vertexdeg/runner.h
+++ b/cpp/src/dbscan/vertexdeg/runner.h
@@ -25,25 +25,21 @@ namespace Dbscan {
 namespace VertexDeg {
 
 
-template <typename Type>
-void run(const ML::cumlHandle_impl& handle, bool* adj, int* vd, Type* x, Type eps, int N, int D,
-         int algo, int startVertexId, int batchSize, cudaStream_t stream) {
-         Pack<Type> data = {vd, adj, x, eps, N, D};
-
+template <typename Type, typename Index_ = int>
+void run(const ML::cumlHandle_impl& handle, bool* adj, Index_* vd, Type* x, Type eps,
+         Index_ N, Index_ D,
+         int algo, Index_ startVertexId, Index_ batchSize, cudaStream_t stream) {
+    Pack<Type, Index_> data = {vd, adj, x, eps, N, D};
     switch(algo) {
-
     case 0:
-       Naive::launcher(data, startVertexId, batchSize, stream);
+        Naive::launcher<Type, Index_>(data, startVertexId, batchSize, stream);
     	break;
-
     case 1:
-       Algo::launcher<Type>(handle, data, startVertexId, batchSize, stream);
+        Algo::launcher<Type, Index_>(handle, data, startVertexId, batchSize, stream);
     	break;
-
     default:
         ASSERT(false, "Incorrect algo passed! '%d'", algo);
     }
-
 }
 
 } // namespace VertexDeg

--- a/cpp/src/dbscan/vertexdeg/runner.h
+++ b/cpp/src/dbscan/vertexdeg/runner.h
@@ -25,17 +25,17 @@ namespace Dbscan {
 namespace VertexDeg {
 
 
-template <typename Type, typename Index_ = int>
-void run(const ML::cumlHandle_impl& handle, bool* adj, Index_* vd, Type* x, Type eps,
+template <typename Type_f, typename Index_ = int>
+void run(const ML::cumlHandle_impl& handle, bool* adj, int* vd, Type_f* x, Type_f eps,
          Index_ N, Index_ D,
          int algo, Index_ startVertexId, Index_ batchSize, cudaStream_t stream) {
-    Pack<Type, Index_> data = {vd, adj, x, eps, N, D};
+    Pack<Type_f, Index_> data = {vd, adj, x, eps, N, D};
     switch(algo) {
     case 0:
-        Naive::launcher<Type, Index_>(data, startVertexId, batchSize, stream);
+        Naive::launcher<Type_f, Index_>(data, startVertexId, batchSize, stream);
     	break;
     case 1:
-        Algo::launcher<Type, Index_>(handle, data, startVertexId, batchSize, stream);
+        Algo::launcher<Type_f, Index_>(handle, data, startVertexId, batchSize, stream);
     	break;
     default:
         ASSERT(false, "Incorrect algo passed! '%d'", algo);

--- a/cpp/src_prims/distance/algo1.h
+++ b/cpp/src_prims/distance/algo1.h
@@ -44,6 +44,7 @@ namespace Distance {
  * @tparam OutputTile_ output tile size for the thread block
  * @tparam FragmentMultiplyAdd_ cutlass-fragment-level multiply & add
  * @tparam FinalLambda user-defined epilogue lamba
+ * @tparam Index_ index type
  * @param NormLambda the final L2 norm lambda
  * @param m number of rows of A and C/D
  * @param n number of columns of B and C/D
@@ -61,8 +62,8 @@ namespace Distance {
  */
 template <typename InType, typename AccType, typename OutType,
           typename OutputTile_, typename FragmentMultiplyAdd_,
-          typename FinalLambda, typename NormLambda>
-void distanceAlgo1(int m, int n, int k, InType const *pA, InType const *pB,
+          typename FinalLambda, typename NormLambda, typename Index_ = int>
+void distanceAlgo1(Index_ m, Index_ n, Index_ k, InType const *pA, InType const *pB,
                    OutType *pD, bool enable_sqrt, AccType *workspace,
                    size_t worksize, FinalLambda fin_op, NormLambda norm_op,
                    cudaStream_t stream) {
@@ -92,7 +93,6 @@ void distanceAlgo1(int m, int n, int k, InType const *pA, InType const *pB,
   typedef cutlass::gemm::ThreadMultiplyAdd<
     AccumulatorsPerThread_, cutlass::Shape<1, 4, 8>, InType, InType, AccType>
     MainLoopFunctor_;
-  typedef int Index_;
   typedef LinAlg::CustomGemmConfig<InType, AccType, EffOutType, OutputTile_,
                                    AccumulatorsPerThread_, MainLoopFunctor_>
     GemmConfig_;

--- a/cpp/src_prims/distance/cosine.h
+++ b/cpp/src_prims/distance/cosine.h
@@ -30,6 +30,7 @@ namespace Distance {
  * @tparam OType output data-type (for C and D matrices)
  * @tparam OutputTile_ output tile size for the thread block
  * @tparam FinalLambda user-defined epilogue lamba
+ * @tparam Index_ Index type
  * @param m number of rows of A and C/D
  * @param n number of columns of B and C/D
  * @param k number of cols of A and rows of B
@@ -44,14 +45,15 @@ namespace Distance {
  * @{
  */
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-void cosineAlgo1(int m, int n, int k, InType const *pA, InType const *pB,
+          typename OutputTile_, typename FinalLambda, typename Index_ = int>
+void cosineAlgo1(Index_ m, Index_ n, Index_ k, InType const *pA, InType const *pB,
                  OutType *pD, AccType *workspace, size_t worksize,
                  FinalLambda fin_op, cudaStream_t stream) {
   typedef ExpandedDistanceFragmentMultiplyAdd<CosFusedDistance>
     FragmentMultiplyAdd_;
   auto norm_op = [] __device__(AccType in) { return mySqrt(in); };
-  distanceAlgo1<InType, AccType, OutType, OutputTile_, FragmentMultiplyAdd_>(
+  distanceAlgo1<InType, AccType, OutType, OutputTile_, FragmentMultiplyAdd_,
+                FinalLambda, decltype(norm_op), Index_>(
     m, n, k, pA, pB, pD, false, workspace, worksize, fin_op, norm_op, stream);
 }
 

--- a/cpp/src_prims/distance/distance.h
+++ b/cpp/src_prims/distance/distance.h
@@ -45,77 +45,79 @@ enum DistanceType {
 
 namespace {
 template <DistanceType distanceType, typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
+          typename OutputTile_, typename FinalLambda, typename Index_>
 struct DistanceImpl {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {}
 };
 
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-struct DistanceImpl<EucExpandedL2, InType, AccType, OutType, OutputTile_, FinalLambda> {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_>
+struct DistanceImpl<EucExpandedL2, InType, AccType, OutType, OutputTile_, FinalLambda, Index_> {
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {
-    euclideanAlgo1<InType, AccType, OutType, OutputTile_>(
+    euclideanAlgo1<InType, AccType, OutType, OutputTile_, FinalLambda, Index_>(
       m, n, k, x, y, dist, false, (AccType *)workspace, worksize, fin_op,
       stream);
   }
 };
 
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-struct DistanceImpl<EucExpandedL2Sqrt, InType, AccType, OutType, OutputTile_, FinalLambda> {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_>
+struct DistanceImpl<EucExpandedL2Sqrt, InType, AccType, OutType, OutputTile_, FinalLambda, Index_> {
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {
-    euclideanAlgo1<InType, AccType, OutType, OutputTile_>(
+    euclideanAlgo1<InType, AccType, OutType, OutputTile_, FinalLambda, Index_>(
       m, n, k, x, y, dist, true, (AccType *)workspace, worksize, fin_op,
       stream);
   }
 };
 
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-struct DistanceImpl<EucExpandedCosine, InType, AccType, OutType, OutputTile_, FinalLambda> {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_>
+struct DistanceImpl<EucExpandedCosine, InType, AccType, OutType, OutputTile_, FinalLambda, Index_> {
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {
-    cosineAlgo1<InType, AccType, OutType, OutputTile_>(
+    cosineAlgo1<InType, AccType, OutType, OutputTile_, FinalLambda, Index_>(
       m, n, k, x, y, dist, (AccType *)workspace, worksize, fin_op, stream);
   }
 };
 
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-struct DistanceImpl<EucUnexpandedL2, InType, AccType, OutType, OutputTile_, FinalLambda> {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_>
+struct DistanceImpl<EucUnexpandedL2, InType, AccType, OutType, OutputTile_, FinalLambda, Index_> {
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {
-    euclideanAlgo2<InType, AccType, OutType, OutputTile_>(
+    euclideanAlgo2<InType, AccType, OutType, OutputTile_, FinalLambda, Index_>(
       m, n, k, x, y, dist, false, fin_op, stream);
   }
 };
 
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-struct DistanceImpl<EucUnexpandedL2Sqrt, InType, AccType, OutType, OutputTile_, FinalLambda> {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_>
+struct DistanceImpl<EucUnexpandedL2Sqrt, InType, AccType, OutType, OutputTile_, FinalLambda,
+                    Index_> {
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {
-    euclideanAlgo2<InType, AccType, OutType, OutputTile_>(
+    euclideanAlgo2<InType, AccType, OutType, OutputTile_, FinalLambda, Index_>(
       m, n, k, x, y, dist, true, fin_op, stream);
   }
 };
 
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-struct DistanceImpl<EucUnexpandedL1, InType, AccType, OutType, OutputTile_, FinalLambda> {
-  void run(InType *x, InType *y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_>
+struct DistanceImpl<EucUnexpandedL1, InType, AccType, OutType, OutputTile_,
+                    FinalLambda, Index_> {
+  void run(InType *x, InType *y, OutType *dist, Index_ m, Index_ n, Index_ k,
                 void *workspace, size_t worksize,
                 FinalLambda fin_op, cudaStream_t stream) {
-    l1Impl<InType, AccType, OutType, OutputTile_>(
+    l1Impl<InType, AccType, OutType, OutputTile_, FinalLambda, Index_>(
       m, n, k, x, y, dist, fin_op, stream);
   }
 };
@@ -128,6 +130,7 @@ struct DistanceImpl<EucUnexpandedL1, InType, AccType, OutType, OutputTile_, Fina
  * @tparam InType input argument type
  * @tparam AccType accumulation type
  * @tparam OutType output type
+ * @tparam Index_ Index type
  * @param x first set of points
  * @param y second set of points
  * @param m number of points in x
@@ -136,8 +139,9 @@ struct DistanceImpl<EucUnexpandedL1, InType, AccType, OutType, OutputTile_, Fina
  *
  * @note If the specifed distanceType doesn't need the workspace at all, it returns 0.
  */
-template <DistanceType distanceType, typename InType, typename AccType, typename OutType>
-size_t getWorkspaceSize(InType* x, InType* y, int m, int n, int k) {
+template <DistanceType distanceType, typename InType, typename AccType, typename OutType,
+          typename Index_ = int>
+size_t getWorkspaceSize(InType* x, InType* y, Index_ m, Index_ n, Index_ k) {
   size_t worksize = 0;
   constexpr bool is_allocated = distanceType <= EucExpandedCosine;
   if(is_allocated) {
@@ -156,6 +160,7 @@ size_t getWorkspaceSize(InType* x, InType* y, int m, int n, int k) {
  * @tparam AccType accumulation type
  * @tparam OutType output type
  * @tparam FinalLambda user-defined epilogue lamba
+ * @tparam Index_ Index type
  * @param x first set of points
  * @param y second set of points
  * @param dist output distance matrix
@@ -172,13 +177,12 @@ size_t getWorkspaceSize(InType* x, InType* y, int m, int n, int k) {
  * as follows:  <pre>OutType fin_op(AccType in, int g_idx);</pre>. If one needs
  * any other parameters, feel free to pass them via closure.
  */
-
 template <DistanceType distanceType,typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
-void distance(InType* const x, InType* const y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename FinalLambda, typename Index_ = int>
+void distance(InType* const x, InType* const y, OutType *dist, Index_ m, Index_ n, Index_ k,
               void *workspace, size_t worksize,
               FinalLambda fin_op, cudaStream_t stream) {
-  DistanceImpl<distanceType, InType, AccType, OutType, OutputTile_, FinalLambda> distImpl;
+  DistanceImpl<distanceType, InType, AccType, OutType, OutputTile_, FinalLambda, Index_> distImpl;
   distImpl.run(x, y, dist, m, n, k, workspace, worksize, fin_op, stream);
   CUDA_CHECK(cudaPeekAtLastError());
 }
@@ -189,6 +193,7 @@ void distance(InType* const x, InType* const y, OutType *dist, int m, int n, int
  * @tparam InType input argument type
  * @tparam AccType accumulation type
  * @tparam OutType output type
+ * @tparam Index_ Index type
  * @param x first set of points
  * @param y second set of points
  * @param dist output distance matrix
@@ -203,13 +208,13 @@ void distance(InType* const x, InType* const y, OutType *dist, int m, int n, int
  *  worksize, the number of bytes of workspace required
  */
 template <DistanceType distanceType, typename InType, typename AccType, typename OutType,
-          typename OutputTile_>
-void distance(InType* const x, InType* const y, OutType *dist, int m, int n, int k,
+          typename OutputTile_, typename Index_ = int>
+void distance(InType* const x, InType* const y, OutType *dist, Index_ m, Index_ n, Index_ k,
               void *workspace,
               size_t worksize, cudaStream_t stream) {
   auto default_fin_op =
-      [] __device__(AccType d_val, int g_d_idx) { return d_val; };
-  distance<distanceType, InType, AccType, OutType, OutputTile_>(
+      [] __device__(AccType d_val, Index_ g_d_idx) { return d_val; };
+  distance<distanceType, InType, AccType, OutType, OutputTile_, decltype(default_fin_op), Index_>(
     x, y, dist, m, n, k, workspace, worksize, default_fin_op, stream);
 
   CUDA_CHECK(cudaPeekAtLastError());
@@ -221,7 +226,9 @@ void distance(InType* const x, InType* const y, OutType *dist, int m, int n, int
  * filtering the final distance by some epsilon.
  * @tparam distanceType: distance metric to compute between a and b matrices
  * @tparam T: the type of input matrices a and b
- * @tparam Lambda:
+ * @tparam Lambda Lambda function
+ * @tparam Index_ Index type
+ * @tparam OutputTile_ output tile size per thread
  * @param a: row-major input matrix a
  * @param b: row-major input matrix b
  * @param adj: a boolean output adjacency matrix
@@ -238,18 +245,20 @@ void distance(InType* const x, InType* const y, OutType *dist, int m, int n, int
  *                  and a boolean denoting whether or not the inputs are part of
  *                  the epsilon neighborhood.
  */
-template<DistanceType distanceType, typename T,
-                                    typename OutputTile_= OutputTile_t,
-                                    typename Lambda = auto (int, bool)->void >
-size_t epsilon_neighborhood(T* const a, T* const b, bool *adj, int m, int n, int k, T eps,
-            void *workspace, size_t worksize, cudaStream_t stream, Lambda fused_op) {
-    auto epsilon_op = [n, eps, fused_op] __device__ (T val, int global_c_idx) {
+template <DistanceType distanceType, typename T,
+          typename Lambda, typename Index_ = int,
+          typename OutputTile_= OutputTile_t>
+size_t epsilon_neighborhood(T* const a, T* const b, bool *adj,
+                            Index_ m, Index_ n, Index_ k, T eps,
+                            void *workspace, size_t worksize, cudaStream_t stream,
+                            Lambda fused_op) {
+    auto epsilon_op = [n, eps, fused_op] __device__ (T val, Index_ global_c_idx) {
         bool acc = val <= eps;
         fused_op(global_c_idx, acc);
         return acc;
     };
 
-    distance<distanceType, T, T, bool, OutputTile_>
+    distance<distanceType, T, T, bool, OutputTile_, decltype(epsilon_op), Index_>
             (a, b, adj, m, n, k, (void*)workspace, worksize, epsilon_op, stream);
 
     return worksize;
@@ -260,7 +269,8 @@ size_t epsilon_neighborhood(T* const a, T* const b, bool *adj, int m, int n, int
  * filtering the final distance by some epsilon.
  * @tparam distanceType: distance metric to compute between a and b matrices
  * @tparam T: the type of input matrices a and b
- * @tparam Lambda:
+ * @tparam Index_ Index type
+ * @tparam OutputTile_ output tile size per thread
  * @param a: row-major input matrix a
  * @param b: row-major input matrix b
  * @param adj: a boolean output adjacency matrix
@@ -275,13 +285,14 @@ size_t epsilon_neighborhood(T* const a, T* const b, bool *adj, int m, int n, int
  * @param stream cuda stream
  */
 template<DistanceType distanceType, typename T,
-                                    typename OutputTile_= OutputTile_t>
-size_t epsilon_neighborhood(T* const a, T* const b, bool *adj, int m, int n, int k, T eps,
-            void *workspace, size_t worksize, cudaStream_t stream) {
-    return epsilon_neighborhood<distanceType, T, OutputTile_>(
-        a, b, adj, m, n, k, eps, workspace, worksize, stream,
-        [] __device__ (int c_idx, bool acc) {}
-    );
+         typename Index_ = int,
+         typename OutputTile_= OutputTile_t>
+size_t epsilon_neighborhood(T* const a, T* const b, bool *adj,
+                            Index_ m, Index_ n, Index_ k, T eps,
+                            void *workspace, size_t worksize, cudaStream_t stream) {
+    auto lambda = [] __device__ (Index_ c_idx, bool acc) {};
+    return epsilon_neighborhood<distanceType, T, decltype(lambda), Index_, OutputTile_>(
+        a, b, adj, m, n, k, eps, workspace, worksize, stream, lambda);
 }
 
 

--- a/cpp/src_prims/distance/l1.h
+++ b/cpp/src_prims/distance/l1.h
@@ -32,6 +32,7 @@ namespace Distance {
  * @tparam OutType output data-type (for C and D matrices)
  * @tparam OutputTile_ output tile size for the thread block
  * @tparam FinalLambda user-defined epilogue lamba
+ * @tparam Index_ Index type
  * @param m number of rows of A and C/D
  * @param n number of columns of B and C/D
  * @param k number of cols of A and rows of B
@@ -43,7 +44,7 @@ namespace Distance {
  * @{
  */
 template <typename InType, typename AccType, typename OutType,
-          typename OutputTile_, typename FinalLambda>
+          typename OutputTile_, typename FinalLambda, typename Index_ = int>
 void l1Impl(int m, int n, int k, InType const *pA, InType const *pB,
             OutType *pD, FinalLambda fin_op, cudaStream_t stream) {
   typedef std::is_same<OutType, bool> is_bool;
@@ -54,7 +55,6 @@ void l1Impl(int m, int n, int k, InType const *pA, InType const *pB,
   typedef LinAlg::ThreadL1NormAdd<
     AccumulatorsPerThread_, cutlass::Shape<1, 4, 8>, InType, InType, AccType>
     MainLoopFunctor_;
-  typedef int Index_;
   typedef LinAlg::CustomGemmConfig<InType, AccType, EffOutType, OutputTile_,
                                    AccumulatorsPerThread_, MainLoopFunctor_>
     GemmConfig_;

--- a/cpp/src_prims/linalg/cutlass_wrappers.h
+++ b/cpp/src_prims/linalg/cutlass_wrappers.h
@@ -541,9 +541,9 @@ template <
     GemmConfig_, EpilogueFunctor_, Index_>,
   typename GemmEpilogue_ = CustomGemmEpilogue<GemmEpilogueTraits_>,
   typename Lambda, typename FinalLambda>
-void gemmLauncher(cublasOperation_t transA, cublasOperation_t transB, int m,
-                  int n, int k, OType alpha, IType const *A, int lda,
-                  IType const *B, int ldb, OType beta, OType const *C, int ldc,
+void gemmLauncher(cublasOperation_t transA, cublasOperation_t transB, Index_ m,
+                  Index_ n, Index_ k, OType alpha, IType const *A, Index_ lda,
+                  IType const *B, Index_ ldb, OType beta, OType const *C, Index_ ldc,
                   OType *D, Lambda op, FinalLambda fin_op,
                   cudaStream_t stream) {
   typedef CustomGemmTraits<IType, AccType, OType, kLayoutA, kLayoutB,
@@ -577,9 +577,9 @@ template <
     GemmConfig_, EpilogueFunctor_, Index_>,
   typename GemmEpilogue_ = cutlass::gemm::GemmEpilogue<GemmEpilogueTraits_>,
   typename Lambda>
-void gemmLauncher(cublasOperation_t transA, cublasOperation_t transB, int m,
-                  int n, int k, OType alpha, IType const *A, int lda,
-                  IType const *B, int ldb, OType beta, OType const *C, int ldc,
+void gemmLauncher(cublasOperation_t transA, cublasOperation_t transB, Index_ m,
+                  Index_ n, Index_ k, OType alpha, IType const *A, Index_ lda,
+                  IType const *B, Index_ ldb, OType beta, OType const *C, Index_ ldc,
                   OType *D, Lambda op, cudaStream_t stream) {
   typedef CustomGemmTraits<IType, AccType, OType, kLayoutA, kLayoutB,
                            OutputTile_, AccumulatorsPerThread_,
@@ -651,9 +651,9 @@ template <
     GemmConfig_, EpilogueFunctor_, Index_>,
   typename GemmEpilogue_ = CustomGemmEpilogue<GemmEpilogueTraits_>,
   typename Lambda, typename FinalLambda>
-void baseGemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
-              int k, OType alpha, IType const *A, int lda, IType const *B,
-              int ldb, OType beta, OType const *C, int ldc, OType *D, Lambda op,
+void baseGemm(cublasOperation_t transA, cublasOperation_t transB, Index_ m, Index_ n,
+              Index_ k, OType alpha, IType const *A, Index_ lda, IType const *B,
+              Index_ ldb, OType beta, OType const *C, Index_ ldc, OType *D, Lambda op,
               FinalLambda fin_op, cudaStream_t stream) {
   if (transA == CUBLAS_OP_N && transB == CUBLAS_OP_N) {
     gemmLauncher<IType, AccType, OType, cutlass::MatrixLayout::kColumnMajor,
@@ -704,9 +704,9 @@ template <
     GemmConfig_, EpilogueFunctor_, Index_>,
   typename GemmEpilogue_ = cutlass::gemm::GemmEpilogue<GemmEpilogueTraits_>,
   typename Lambda>
-void baseGemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
-              int k, OType alpha, IType const *A, int lda, IType const *B,
-              int ldb, OType beta, OType const *C, int ldc, OType *D, Lambda op,
+void baseGemm(cublasOperation_t transA, cublasOperation_t transB, Index_ m, Index_ n,
+              Index_ k, OType alpha, IType const *A, Index_ lda, IType const *B,
+              Index_ ldb, OType beta, OType const *C, Index_ ldc, OType *D, Lambda op,
               cudaStream_t stream) {
   if (transA == CUBLAS_OP_N && transB == CUBLAS_OP_N) {
     gemmLauncher<IType, AccType, OType, cutlass::MatrixLayout::kColumnMajor,

--- a/cpp/src_prims/linalg/cutlass_wrappers.h
+++ b/cpp/src_prims/linalg/cutlass_wrappers.h
@@ -364,8 +364,8 @@ struct CustomGemm : public BaseClass {
                      cudaStream_t stream) {
     // Setup the grid.
     dim3 grid;
-    grid.x = ceildiv(params.m, Traits::OutputTile::kW);
-    grid.y = ceildiv(params.n, Traits::OutputTile::kH);
+    grid.x = ceildiv<int>(params.m, Traits::OutputTile::kW);
+    grid.y = ceildiv<int>(params.n, Traits::OutputTile::kH);
     // The number of threads.
     dim3 block;
     block.x = BaseClass::kThreads;

--- a/cpp/src_prims/linalg/row_gemm.h
+++ b/cpp/src_prims/linalg/row_gemm.h
@@ -74,9 +74,9 @@ template <
     GemmConfig_, EpilogueFunctor_, Index_>,
   typename GemmEpilogue_ = CustomGemmEpilogue<GemmEpilogueTraits_>,
   typename Lambda, typename FinalLambda>
-void row_gemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
-              int k, OType alpha, IType const *A, int lda, IType const *B,
-              int ldb, OType beta, OType const *C, int ldc, OType *D, Lambda op,
+void row_gemm(cublasOperation_t transA, cublasOperation_t transB, Index_ m, Index_ n,
+              Index_ k, OType alpha, IType const *A, Index_ lda, IType const *B,
+              Index_ ldb, OType beta, OType const *C, Index_ ldc, OType *D, Lambda op,
               FinalLambda fin_op, cudaStream_t stream) {
   gemm<IType, AccType, OType, OutputTile_, AccumulatorsPerThread_,
        MainLoopFunctor_, Index_, GemmConfig_, EpilogueFunctor_,
@@ -94,6 +94,7 @@ void row_gemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
  * @tparam OType output data-type (for C and D matrices)
  * @tparam OutputTile_ output tile size for the thread block
  * @tparam AccumulatorsPerThread_ number of accumulators per thread
+ * @tparam Index_ index type
  * @tparam EpilogueFunctor_ custom epilogue functor
  * @param transA cublas transpose op for A
  * @param transB cublas transpose op for B
@@ -116,13 +117,14 @@ template <
   typename AccumulatorsPerThread_ = cutlass::Shape<8, 8, 8>,
   typename MainLoopFunctor_ = cutlass::gemm::ThreadMultiplyAdd<
     AccumulatorsPerThread_, cutlass::Shape<1, 4, 8>, IType, IType, AccType>,
+  typename Index_ = int,
   typename EpilogueFunctor_ = LinearScaling<OType>>
-void row_gemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
-              int k, OType alpha, IType const *A, int lda, IType const *B,
-              int ldb, OType beta, OType const *C, int ldc, OType *D,
+void row_gemm(cublasOperation_t transA, cublasOperation_t transB, Index_ m, Index_ n,
+              Index_ k, OType alpha, IType const *A, Index_ lda, IType const *B,
+              Index_ ldb, OType beta, OType const *C, Index_ ldc, OType *D,
               cudaStream_t stream) {
   gemm<IType, AccType, OType, OutputTile_, AccumulatorsPerThread_,
-       MainLoopFunctor_, EpilogueFunctor_>(
+       MainLoopFunctor_, Index_, EpilogueFunctor_>(
     transB, transA, n, m, k, alpha, B, ldb, A, lda, beta, C, ldc, D, stream);
 }
 
@@ -135,6 +137,7 @@ void row_gemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
  * @tparam OType output data-type (for C and D matrices)
  * @tparam OutputTile_ output tile size for the thread block
  * @tparam AccumulatorsPerThread_ number of accumulators per thread
+ * @tparam Index_ index type
  * @tparam EpilogueFunctor_ custom epilogue functor
  * @param transA cublas transpose op for A
  * @param transB cublas transpose op for B
@@ -154,13 +157,14 @@ template <
   typename AccumulatorsPerThread_ = cutlass::Shape<8, 8, 8>,
   typename MainLoopFunctor_ = cutlass::gemm::ThreadMultiplyAdd<
     AccumulatorsPerThread_, cutlass::Shape<1, 4, 8>, IType, IType, AccType>,
+  typename Index_ = int,
   typename EpilogueFunctor_ = cutlass::gemm::LinearScaling<OType>>
-void row_gemm(cublasOperation_t transA, cublasOperation_t transB, int m, int n,
-              int k, OType alpha, IType const *A, IType const *B, OType beta,
+void row_gemm(cublasOperation_t transA, cublasOperation_t transB, Index_ m, Index_ n,
+              Index_ k, OType alpha, IType const *A, IType const *B, OType beta,
               OType const *C, OType *D, cudaStream_t stream) {
-  int lda = (transA == CUBLAS_OP_N) ? k : m;
-  int ldb = (transB == CUBLAS_OP_N) ? n : k;
-  int ldc = n; // output is always row-major!
+  Index_ lda = (transA == CUBLAS_OP_N) ? k : m;
+  Index_ ldb = (transB == CUBLAS_OP_N) ? n : k;
+  Index_ ldc = n; // output is always row-major!
   row_gemm<IType, AccType, OType, OutputTile_, AccumulatorsPerThread_,
            MainLoopFunctor_, EpilogueFunctor_>(
     transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, D, stream);


### PR DESCRIPTION
It was mainly due to the integer overflow during indexing arithmetic. Thus, had to update all the way from cutlass_wrappers to the dbscan code to expose an `Index` template param to choose between 32b/64b indexing. This should fix issue #613 

@JohnZed and @cjnolet for review.