### PR TITLE
[Review] Implement nvcategory based label encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 - PR #515: Added Random Projection feature
 - PR #504: Contingency matrix ml-prim
+- PR #631: Add nvcategory based ordinal label encoder
 
 ## Improvements
 

--- a/python/cuml/__init__.py
+++ b/python/cuml/__init__.py
@@ -44,6 +44,8 @@ from cuml.manifold.umap import UMAP
 
 from cuml.random_projection.random_projection import GaussianRandomProjection, SparseRandomProjection, johnson_lindenstrauss_min_dim
 
+from cuml.preprocessing.LabelEncoder import LabelEncoder
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -6,6 +6,9 @@ import numpy as np
 
 
 def _enforce_str(y: cudf.Series) -> cudf.Series:
+    """
+    Ensure that nvcategory is being given strings
+    """
     if y.dtype != "object":
         return y.astype("str")
     return y
@@ -22,13 +25,87 @@ class Base(object):
 
 
 class LabelEncoder(Base):
+    """
+    An nvcategory based implementation of ordinal label encoding
+
+    Examples
+    --------
+    Converting a categorical implementation to a numerical one
+
+    .. code-block:: python
+        from cudf import DataFrame, Series
+
+        data = DataFrame({'category': ['a', 'b', 'c', 'd']})
+
+        # There are two functionally equivalent ways to do this
+        le = LabelEncoder()
+        le.fit(data.category)  # le = le.fit(data.category) also works
+        encoded = le.transform(data.category)
+
+        print(encoded)
+
+        # This method is preferred
+        le = LabelEncoder()
+        encoded = le.fit_transform(data.category)
+
+        print(encoded)
+
+        # We can assign this to a new column
+        data = data.assign(encoded=encoded)
+        print(data.head())
+
+        # We can also encode more data
+        test_data = Series(['c', 'a'])
+        encoded = le.transform(test_data)
+        print(encoded)
+
+    Output:
+
+    .. code-block:: python
+        0    0
+        1    1
+        2    2
+        3    3
+        dtype: int64
+
+        0    0
+        1    1
+        2    2
+        3    3
+        dtype: int32
+
+        category  encoded
+        0         a        0
+        1         b        1
+        2         c        2
+        3         d        3
+
+        0    2
+        1    0
+        dtype: int64
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._cats: nvcategory.nvcategory = None
         self._dtype = None
 
     def fit(self, y: cudf.Series) -> "LabelEncoder":
+        """
+        Fit a LabelEncoder (nvcategory) instance to a set of categories
+
+        Parameters
+        ---------
+        y : cudf.Series
+            Series containing the categories to be encoded. It's elements
+            may or may not be unique
+
+        Returns
+        -------
+        self : LabelEncoder
+            A fitted instance of itself to allow method chaining
+        """
         self._dtype = y.dtype
+
         y = _enforce_str(y)
 
         self._cats = nvcategory.from_strings(y.data)
@@ -36,6 +113,29 @@ class LabelEncoder(Base):
         return self
 
     def transform(self, y: cudf.Series) -> cudf.Series:
+        """
+        Transform an input into its categorical keys.
+
+        This is intended for use with small inputs relative to the size of the
+        dataset. For fitting and transforming an entire dataset, prefer
+        `fit_transform`.
+
+        Parameters
+        ----------
+        y : cudf.Series
+            Input keys to be transformed. Its values should match the
+            categories given to `fit`
+
+        Returns
+        ------
+        encoded : cudf.Series
+            The ordinally encoded input series
+
+        Raises
+        ------
+        KeyError
+            if a category appears that was not seen in `fit`
+        """
         self.check_is_fitted()
         y = _enforce_str(y)
         encoded = cudf.Series(
@@ -48,9 +148,20 @@ class LabelEncoder(Base):
         return encoded
 
     def fit_transform(self, y: cudf.Series) -> cudf.Series:
+        """
+        Simultaneously fit and transform an input
+
+        This is functionally equivalent to (but faster than)
+        `LabelEncoder().fit(y).transform(y)`
+        """
         self._dtype = y.dtype
+
+        # Convert y to nvstrings series, if it isn't one
         y = _enforce_str(y)
+
+        # Bottleneck is here, despite everything being done on the device
         self._cats = nvcategory.from_strings(y.data)
+
         self._fitted = True
         arr: librmm.device_array = librmm.device_array(
             y.data.size(), dtype=np.int32
@@ -58,5 +169,5 @@ class LabelEncoder(Base):
         self._cats.values(devptr=arr.device_ctypes_pointer.value)
         return cudf.Series(arr)
 
-    def inverse_transform(self, y: cudf.Series):
+    def inverse_transform(self, y: cudf.Series) -> cudf.Series:
         raise NotImplementedError

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -1,0 +1,62 @@
+import cudf
+import nvcategory
+
+from librmm_cffi import librmm
+import numpy as np
+
+
+def _enforce_str(y: cudf.Series) -> cudf.Series:
+    if y.dtype != "object":
+        return y.astype("str")
+    return y
+
+
+# FIXME I didn't have cuml built. this would be cuml.common.Base
+class Base(object):
+    def __init__(self, *args, **kwargs):
+        self._fitted = False
+
+    def check_is_fitted(self):
+        if not self._fitted:
+            raise TypeError("Model must first be .fit()")
+
+
+class LabelEncoder(Base):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cats: nvcategory.nvcategory = None
+        self._dtype = None
+
+    def fit(self, y: cudf.Series) -> "LabelEncoder":
+        self._dtype = y.dtype
+        y = _enforce_str(y)
+
+        self._cats = nvcategory.from_strings(y.data)
+        self._fitted = True
+        return self
+
+    def transform(self, y: cudf.Series) -> cudf.Series:
+        self.check_is_fitted()
+        y = _enforce_str(y)
+        encoded = cudf.Series(
+            nvcategory.from_strings(y.data)
+            .set_keys(self._cats.keys())
+            .values()
+        )
+        if -1 in encoded:
+            raise KeyError("Attempted to encode unseen key")
+        return encoded
+
+    def fit_transform(self, y: cudf.Series) -> cudf.Series:
+        self._dtype = y.dtype
+        y = _enforce_str(y)
+        self._cats = nvcategory.from_strings(y.data)
+        self._fitted = True
+        arr: librmm.device_array = librmm.device_array(
+            y.data.size(), dtype=np.int32
+        )
+        self._cats.values(devptr=arr.device_ctypes_pointer.value)
+        return cudf.Series(arr)
+
+    def inverse_transform(self, y: cudf.Series):
+        raise NotImplementedError

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -14,17 +14,7 @@ def _enforce_str(y: cudf.Series) -> cudf.Series:
     return y
 
 
-# FIXME I didn't have cuml built. this would be cuml.common.Base
-class Base(object):
-    def __init__(self, *args, **kwargs):
-        self._fitted = False
-
-    def check_is_fitted(self):
-        if not self._fitted:
-            raise TypeError("Model must first be .fit()")
-
-
-class LabelEncoder(Base):
+class LabelEncoder(object):
     """
     An nvcategory based implementation of ordinal label encoding
 
@@ -84,10 +74,15 @@ class LabelEncoder(Base):
         1    0
         dtype: int64
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._cats: nvcategory.nvcategory = None
         self._dtype = None
+
+    def _check_is_fitted(self):
+        if not self._fitted:
+            raise TypeError("Model must first be .fit()")
 
     def fit(self, y: cudf.Series) -> "LabelEncoder":
         """
@@ -136,7 +131,7 @@ class LabelEncoder(Base):
         KeyError
             if a category appears that was not seen in `fit`
         """
-        self.check_is_fitted()
+        self._check_is_fitted()
         y = _enforce_str(y)
         encoded = cudf.Series(
             nvcategory.from_strings(y.data)

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import cudf
 import nvcategory
 

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -76,9 +76,9 @@ class LabelEncoder(object):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self._cats: nvcategory.nvcategory = None
         self._dtype = None
+        self._fitted: bool = False
 
     def _check_is_fitted(self):
         if not self._fitted:

--- a/python/cuml/preprocessing/__init__.py
+++ b/python/cuml/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+from cuml.preprocessing.LabelEncoder import LabelEncoder

--- a/python/cuml/preprocessing/__init__.py
+++ b/python/cuml/preprocessing/__init__.py
@@ -1,1 +1,17 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from cuml.preprocessing.LabelEncoder import LabelEncoder

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from cuml.preprocessing.LabelEncoder import LabelEncoder
-from cudf.tests import utils as cudf_utils
 import cudf
 from cuml.test import utils
 import pytest
@@ -34,7 +33,7 @@ def test_labelencoder_fit_transform(length, cardinality):
     encoded = LabelEncoder().fit_transform(df)
 
     df_arr = _df_to_similarity_mat(df)
-    encoded_arr = _df_to_similarity_mat(df)
+    encoded_arr = _df_to_similarity_mat(encoded)
     assert ((encoded_arr == encoded_arr.T) == (df_arr == df_arr.T)).all()
 
 
@@ -47,7 +46,7 @@ def test_labelencoder_transform(length, cardinality):
     le = LabelEncoder().fit(df)
     assert le._fitted
 
-    subset = df.iloc[0 : df.shape[0] // 2]
+    subset = df.iloc[0:df.shape[0] // 2]
     encoded = le.transform(subset)
 
     subset_arr = _df_to_similarity_mat(subset)

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -33,8 +33,6 @@ def test_labelencoder_fit_transform(length, cardinality):
     df = cudf.Series(np.random.choice(cardinality, (length,)))
     encoded = LabelEncoder().fit_transform(df)
 
-    # df_arr = utils.to_nparray(df)
-    # encoded_arr = utils.to_nparray(encoded)
     df_arr = _df_to_similarity_mat(df)
     encoded_arr = _df_to_similarity_mat(df)
     assert ((encoded_arr == encoded_arr.T) == (df_arr == df_arr.T)).all()

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cuml.preprocessing.LabelEncoder import LabelEncoder
+from cudf.tests import utils as cudf_utils
+import cudf
+from cuml.test import utils
+import pytest
+import numpy as np
+
+
+def _df_to_similarity_mat(df):
+    arr = utils.to_nparray(df).reshape(1, -1)
+    return np.pad(arr, [(arr.shape[1] - 1, 0), (0, 0)], "edge")
+
+
+@pytest.mark.parametrize("length", [10, 100, 1000])
+@pytest.mark.parametrize("cardinality", [5, 10, 50])
+def test_labelencoder_fit_transform(length, cardinality):
+    """ Try encoding the entire df
+    """
+    df = cudf.Series(np.random.choice(cardinality, (length,)))
+    encoded = LabelEncoder().fit_transform(df)
+
+    # df_arr = utils.to_nparray(df)
+    # encoded_arr = utils.to_nparray(encoded)
+    df_arr = _df_to_similarity_mat(df)
+    encoded_arr = _df_to_similarity_mat(df)
+    assert ((encoded_arr == encoded_arr.T) == (df_arr == df_arr.T)).all()
+
+
+@pytest.mark.parametrize("length", [10, 100, 1000])
+@pytest.mark.parametrize("cardinality", [5, 10, 50])
+def test_labelencoder_transform(length, cardinality):
+    """ Try fitting and then encoding a small subset of the df
+    """
+    df = cudf.Series(np.random.choice(cardinality, (length,)))
+    le = LabelEncoder().fit(df)
+    assert le._fitted
+
+    subset = df.iloc[0 : df.shape[0] // 2]
+    encoded = le.transform(subset)
+
+    subset_arr = _df_to_similarity_mat(subset)
+    encoded_arr = _df_to_similarity_mat(encoded)
+    assert (
+        (encoded_arr == encoded_arr.T) == (subset_arr == subset_arr.T)
+    ).all()
+
+
+def test_labelencoder_unseen():
+    """ Try encoding a value that was not present during fitting
+    """
+    df = cudf.Series(np.random.choice(10, (10,)))
+    le = LabelEncoder().fit(df)
+    assert le._fitted
+
+    with pytest.raises(KeyError):
+        le.transform(cudf.Series([-1]))
+
+
+def test_labelencoder_unfitted():
+    """ Try calling `.transform()` without fitting first
+    """
+    df = cudf.Series(np.random.choice(10, (10,)))
+    le = LabelEncoder()
+    assert not le._fitted
+
+    with pytest.raises(TypeError):
+        le.transform(df)


### PR DESCRIPTION
Categorical to numeric label encoding is a common preprocessing step. Currently, `cudf.DataFrame.label_encoding` exists but relies on host side categorization. This PR proposes an implementation that would live in `cuml` which uses `nvcategory` and `nvstrings`.

In practice, this performs up to 290x better on long (~`10^7` rows) dataframes