### PR TITLE
Auto-detection of GPU archs to be compiled against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #618: CI: Enable copyright header checks
 - PR #622: Updated to use 0.8 dependencies
 - PR #626: Added build.sh script, updated CI scripts and documentation
+- PR #633: build: Auto-detection of GPU_ARCHS during cmake
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/conda/recipes/libcuml/build.sh
+++ b/conda/recipes/libcuml/build.sh
@@ -10,4 +10,4 @@ printenv
 # Cleanup local git
 git clean -xdf
 
-./build.sh clean libcuml -v
+./build.sh clean libcuml -v --allgpuarch

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -155,7 +155,7 @@ if("${GPU_ARCHS}" STREQUAL "")
   evaluate_gpu_archs(GPU_ARCHS)
 endif()
 
-if(GPU_ACHS EQUAL ALL)
+if("${GPU_ACHS}" STREQUAL "ALL")
   set(GPU_ARCHS "60")
   if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
     set(GPU_ARCHS "${GPU_ARCHS};70")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -61,7 +61,7 @@ set(BLAS_LIBRARIES "" CACHE STRING
     "Location of BLAS library")
 
 set(GPU_ARCHS "" CACHE STRING
-  "List of GPU architectures (semicolon-separated) to be compiled for. Pass a value of 'ALL' if you want to compile for all supported GPU architectures.")
+  "List of GPU architectures (semicolon-separated) to be compiled for. Pass 'ALL' if you want to compile for all supported GPU architectures. Empty string means to auto-detect the GPUs on the current system")
 
 set(CMAKE_IGNORE_PATH "${CMAKE_INSTALL_DIR}/lib" CACHE STRING
   "Ignore any libs added implicitly from the CMAKE_INSTALL_DIR")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -61,7 +61,9 @@ set(BLAS_LIBRARIES "" CACHE STRING
     "Location of BLAS library")
 
 set(GPU_ARCHS "" CACHE STRING
-  "List of GPU architectures (semicolon-separated) to be compiled for")
+  "List of GPU architectures (semicolon-separated) to be compiled for."
+  " Pass a value of 'ALL' if you want to compile for all supported GPU "
+  "architectures.")
 
 set(CMAKE_IGNORE_PATH "${CMAKE_INSTALL_DIR}/lib" CACHE STRING
   "Ignore any libs added implicitly from the CMAKE_INSTALL_DIR")
@@ -151,6 +153,11 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 if(NOT "${GPU_ARCHS}")
+  include(cmake/EvalGpuArchs.cmake)
+  evaluate_gpu_archs(GPU_ARCHS)
+endif()
+
+if(GPU_ACHS EQUAL ALL)
   set(GPU_ARCHS "60")
   if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
     set(GPU_ARCHS "${GPU_ARCHS};70")
@@ -159,6 +166,7 @@ if(NOT "${GPU_ARCHS}")
     set(GPU_ARCHS "${GPU_ARCHS};75")
   endif()
 endif()
+message("GPU_ARCHS = ${GPU_ARCHS}")
 
 foreach(arch ${GPU_ARCHS})
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${arch},code=sm_${arch}")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -61,9 +61,7 @@ set(BLAS_LIBRARIES "" CACHE STRING
     "Location of BLAS library")
 
 set(GPU_ARCHS "" CACHE STRING
-  "List of GPU architectures (semicolon-separated) to be compiled for."
-  " Pass a value of 'ALL' if you want to compile for all supported GPU "
-  "architectures.")
+  "List of GPU architectures (semicolon-separated) to be compiled for. Pass a value of 'ALL' if you want to compile for all supported GPU architectures.")
 
 set(CMAKE_IGNORE_PATH "${CMAKE_INSTALL_DIR}/lib" CACHE STRING
   "Ignore any libs added implicitly from the CMAKE_INSTALL_DIR")
@@ -152,7 +150,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 endif()
 
-if(NOT "${GPU_ARCHS}")
+if("${GPU_ARCHS}" STREQUAL "")
   include(cmake/EvalGpuArchs.cmake)
   evaluate_gpu_archs(GPU_ARCHS)
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -155,7 +155,7 @@ if("${GPU_ARCHS}" STREQUAL "")
   evaluate_gpu_archs(GPU_ARCHS)
 endif()
 
-if("${GPU_ACHS}" STREQUAL "ALL")
+if("${GPU_ARCHS}" STREQUAL "ALL")
   set(GPU_ARCHS "60")
   if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
     set(GPU_ARCHS "${GPU_ARCHS};70")

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -36,7 +36,7 @@ Current cmake offers the following configuration options:
 | BUILD_CUML_EXAMPLES | [ON, OFF]  | ON  | Enable/disable building cuML C++ API usage examples.  |
 | CMAKE_CXX11_ABI | [ON, OFF]  | ON  | Enable/disable the GLIBCXX11 ABI  |
 | DISABLE_OPENMP | [ON, OFF]  | OFF  | Set to `ON` to disable OpenMP  |
-| GPU_ARCHS |  List of GPU architectures, semicolon-separated | 60;70;75  | List of GPU architectures that all artifacts are compiled for.  |
+| GPU_ARCHS |  List of GPU architectures, semicolon-separated | Empty  | List of GPU architectures that all artifacts are compiled for. Passing ALL means compiling for all currently supported GPU architectures: 60;70;75. If you don't pass this flag, then the build system will try to look for the GPU card installed on the system and compiles only for that.  |
 | KERNEL_INFO | [ON, OFF]  | OFF  | Enable/disable kernel resource usage info in nvcc. |
 | LINE_INFO | [ON, OFF]  | OFF  | Enable/disable lineinfo in nvcc.  |
 

--- a/cpp/cmake/EvalGpuArchs.cmake
+++ b/cpp/cmake/EvalGpuArchs.cmake
@@ -1,0 +1,60 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function(evaluate_gpu_archs gpu_archs)
+  set(eval_file ${PROJECT_BINARY_DIR}/eval_gpu_archs.cu)
+  set(eval_exe ${PROJECT_BINARY_DIR}/eval_gpu_archs)
+  file(WRITE ${eval_file}
+    "
+#include <cstdio>
+#include <set>
+#include <string>
+using namespace std;
+int main(int argc, char** argv) {
+  set<string> archs;
+  int nDevices;
+  if((cudaGetDeviceCount(&nDevices) == cudaSuccess) && (nDevices > 0)) {
+    for(int dev=0;dev<nDevices;++dev) {
+      char buff[32];
+      cudaDeviceProp prop;
+      if(cudaGetDeviceProperties(&prop, dev) != cudaSuccess) continue;
+      sprintf(buff, \"%d%d\", prop.major, prop.minor);
+      archs.insert(buff);
+    }
+  }
+  if(archs.empty()) {
+    printf(\"ALL\");
+  } else {
+    bool first = true;
+    for(const auto& arch : archs) {
+      printf(first? \"%s\" : \";%s\", arch.c_str());
+      first = false;
+    }
+  }
+  printf(\"\\n\");
+  return 0;
+}
+")
+  execute_process(
+    COMMAND ${CUDA_NVCC_EXECUTABLE}
+      -std=c++11
+      -o ${eval_exe}
+      --run
+      ${eval_file}
+    OUTPUT_VARIABLE __gpu_archs
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  message("Auto detection of gpu-archs: ${__gpu_archs}")
+  set(${gpu_archs} ${__gpu_archs} PARENT_SCOPE)
+endfunction(evaluate_gpu_archs)


### PR DESCRIPTION
A simple application of `execute_process` method in cmake to detect the GPU-archs to be compiled against. The flowchart for deciding `GPU_ARCHS` cmake variable is now as follows:
1. If `GPU_ARCHS` variable is not set, use the `execute_process` approach to figure out the GPU archs
2. If `GPU_ARCHS == ALL`, then compile for all the supported architectures
3. If specific GPU architectures have been passed to `GPU_ARCHS`, then compile only for those archs.

@rlratzel @dantegd for review