### PR TITLE
Remove setuptools from cuml conda run dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator
 - PR #620: C++: Removed old unit-test files in ml-prims
 - PR #627: C++: Fixed dbscan crash issue filed in 613
+- PR #640: Remove setuptools from conda run dependency
 
 
 # cuML 0.7.0 (10 May 2019)

--- a/conda/recipes/cuml-cuda10/meta.yaml
+++ b/conda/recipes/cuml-cuda10/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
   run:
     - python x.x
-    - setuptools
     - cudf 0.8*
     - libcuml={{ version }}
     - libcumlMG

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
   run:
     - python x.x
-    - setuptools
     - cudf 0.8*
     - libcuml={{ version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}


### PR DESCRIPTION
This PR is for https://github.com/rapidsai/cuml/issues/639
to remove `setuptools` as a run dependency from cuml conda packages.
