### PR TITLE
[REVIEW] Bug fix to LinAlg::reduce_rows_by_key prim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - PR #620: C++: Removed old unit-test files in ml-prims
 - PR #627: C++: Fixed dbscan crash issue filed in 613
 - PR #640: Remove setuptools from conda run dependency
-
+- PR #649: Bug fix to LinAlg::reduce_rows_by_key prim filed in issue #648
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/cpp/test/prims/reduce_rows_by_key.cu
+++ b/cpp/test/prims/reduce_rows_by_key.cu
@@ -185,5 +185,19 @@ TEST_P(ReduceRowTestManyObs, Result){
 INSTANTIATE_TEST_CASE_P(ReduceRowTests, ReduceRowTestManyObs,
                         ::testing::ValuesIn(inputsf_many_obs));
 
+// ReduceRowTestManyClusters
+// 100000 Obs, 37 cols, 2048 clusters
+const std::vector<ReduceRowsInputs<float> > inputsf_many_cluster = {
+    {0.00001f, 100000, 37, 2048, 1234ULL}
+};
+typedef ReduceRowTest<float> ReduceRowTestManyClusters;
+TEST_P(ReduceRowTestManyClusters, Result){
+    ASSERT_TRUE(devArrMatch(out_ref, out, params.cols*params.nkeys,
+                            CompareApprox<float>(params.tolerance)));
+
+}
+INSTANTIATE_TEST_CASE_P(ReduceRowTests, ReduceRowTestManyClusters,
+                        ::testing::ValuesIn(inputsf_many_cluster));
+
 } // end namespace LinAlg
 } // end namespace MLCommon


### PR DESCRIPTION
This fixes Bug #648 and adds a unit test for use-case with `nkeys > 1024`.

Tagging @LeviBarnes for review. 