### PR TITLE
[REVIEW] Correctly handle clang-format with changed files staged for commit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #640: Remove setuptools from conda run dependency
 - PR #646: Update link in contributing.md
 - PR #649: Bug fix to LinAlg::reduce_rows_by_key prim filed in issue #648
+- PR #664: Fix clang-format handling of changes staged for commit
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/cpp/scripts/gitutils.py
+++ b/cpp/scripts/gitutils.py
@@ -44,9 +44,8 @@ def uncommittedFiles():
     Returns a list of all changed files that are not yet committed. This
     means both untracked/unstaged as well as uncommitted files too.
     """
-    files = __gitdiff("--name-only", "--cached", "--ignore-submodules")
-    ret = files.splitlines()
     files = __git("status", "-u", "-s")
+    ret = []
     for f in files.splitlines():
         f = f.decode(encoding='UTF-8')
         f = f.strip(" ")
@@ -54,7 +53,7 @@ def uncommittedFiles():
         # only consider staged files or uncommitted files
         # in other words, ignore untracked files
         if tmp[0] == "M" or tmp[0] == "A":
-            ret.append(tmp[1])
+            ret.append(tmp[1].strip(" "))
     return ret
 
 


### PR DESCRIPTION
- `git diff --cached` outputs such files with a wrong path
- as `git status` also lists them, `git diff` invocation has been removed
- cached files are listed as `M  path/to/file`' (2 spaces!) by git status;
  extra space is removed