### PR TITLE
Fixed gitutils to correctly process uncommitted-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #640: Remove setuptools from conda run dependency
 - PR #646: Update link in contributing.md
 - PR #649: Bug fix to LinAlg::reduce_rows_by_key prim filed in issue #648
+- PR #666: fixes to gitutils.py to resolve both string decode and handling of uncommitted files
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/cpp/scripts/gitutils.py
+++ b/cpp/scripts/gitutils.py
@@ -50,7 +50,7 @@ def uncommittedFiles():
     ret = []
     for f in files.splitlines():
         f = f.strip(" ")
-        f = re.sub("\s+", " ", f)
+        f = re.sub("\s+", " ", f)  # noqa: W605
         tmp = f.split(" ", 1)
         # only consider staged files or uncommitted files
         # in other words, ignore untracked files

--- a/cpp/scripts/gitutils.py
+++ b/cpp/scripts/gitutils.py
@@ -15,6 +15,7 @@
 
 import subprocess
 import os
+import re
 
 
 def isFileEmpty(f):
@@ -24,7 +25,8 @@ def isFileEmpty(f):
 def __git(*opts):
     """Runs a git command and returns its output"""
     cmd = "git " + " ".join(list(opts))
-    return subprocess.check_output(cmd, shell=True)
+    ret = subprocess.check_output(cmd, shell=True)
+    return ret.decode("UTF-8")
 
 
 def __gitdiff(*opts):
@@ -44,12 +46,11 @@ def uncommittedFiles():
     Returns a list of all changed files that are not yet committed. This
     means both untracked/unstaged as well as uncommitted files too.
     """
-    files = __gitdiff("--name-only", "--cached", "--ignore-submodules")
-    ret = files.splitlines()
     files = __git("status", "-u", "-s")
+    ret = []
     for f in files.splitlines():
-        f = f.decode(encoding='UTF-8')
         f = f.strip(" ")
+        f = re.sub("\s+", " ", f)
         tmp = f.split(" ", 1)
         # only consider staged files or uncommitted files
         # in other words, ignore untracked files


### PR DESCRIPTION
On top of changes proposed in PR #664 by @canonizer, this also takes care of proper decoding of the output of the git command itself, which was noticed by @myrtw.

Tagging @dantegd for review