### PR TITLE
[WIP] Add more RF c++ tests (some failing)

### DIFF
--- a/cpp/src_prims/utils.h
+++ b/cpp/src_prims/utils.h
@@ -205,6 +205,24 @@ void myPrintHostVector(const char* variableName, const T* hostMem,
   out << "];\n";
 }
 
+template <class T, class OutStream>
+void myPrintHostMatrix(const char* variableName, const T* hostMem,
+                       size_t n_rows, size_t n_cols, bool row_major,
+                       OutStream& out) {
+  out << variableName << "=[";
+  for (size_t i = 0; i < n_rows; i++) {
+    for (size_t j = 0; j < n_cols; j++) {
+      if (row_major) {
+        out << hostMem[i * n_cols + j];
+      } else {
+        out << hostMem[j * n_rows + i];
+      }
+      out << ",  ";
+    }
+  }
+  out << "];\n";
+}
+
 template <class T>
 void myPrintHostVector(const char* variableName, const T* hostMem,
                        size_t componentsCount) {

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -47,6 +47,7 @@ if(BUILD_CUML_TESTS)
     add_executable(ml
       sg/cd_test.cu
       sg/dbscan_test.cu
+      sg/generators_test.cu
       sg/handle_test.cu
       sg/kmeans_test.cu
       sg/knn_test.cu

--- a/cpp/test/prims/data_generators.h
+++ b/cpp/test/prims/data_generators.h
@@ -1,0 +1,134 @@
+#include "ml_utils.h"
+#include <random>
+
+namespace ML {
+
+typedef enum {
+  MAX,
+  SUM
+} AggregationType;
+
+/*
+ * Fills in data and labels with an easy-to-predict classification dataset.
+ * Both vectors will be resized to hold datasets of size nrows * ncols.
+ * Data will be laid out in row-major format.
+ * The labels are computed as max(...) or sum(all_informative_cols), scaled to
+ * map to n_classes integer outputs.
+ */
+template <typename T>
+void makeClassificationDataHost(std::vector<T>& data, std::vector<int>& labels,
+                                unsigned n_samples, unsigned n_features, unsigned n_classes,
+                                unsigned n_informative = 2, unsigned n_redundant = 2,
+                                int rand_seed = 42, AggregationType agg_type = MAX
+                                ) {
+  ASSERT(n_informative + n_redundant <= n_features,
+         "informative + redundant cannot exceed cols");
+  data.resize(n_samples * n_features);
+  labels.resize(n_samples);
+  
+  srand(rand_seed);
+  T agg_relevant_vals = 10.0 + n_classes;  // Data pattern respects this max
+  if (agg_type == SUM) {
+    agg_relevant_vals *= n_informative;
+  }
+
+  // first NI columns are informative, next NR are identical, rest are junk
+  for (int i = 0; i < n_samples; i++) {
+    T max_relevant_row = agg_type == MAX ? -1e6 : 0.0;
+    
+    for (int j = 0; j < n_features; j++) {
+      if (j < n_informative) {
+        // Totally arbitrary data pattern that spreads out a bit
+        // This differs from sklearn's random pattern
+        T val = 10.0 * ((i + 1) / (float)n_samples) + ((i + j) % n_classes);
+        if (agg_type == MAX) {
+          max_relevant_row = max(max_relevant_row, val);
+        } else if (agg_type == SUM) {
+          max_relevant_row += val;
+        }
+        data[(j * n_samples) + i] = val;
+      } else if (j < n_informative + n_redundant) {
+        // Trivial combination of two adjacent informatives
+        unsigned col1 = j % n_informative, col2 = (j+1) % n_informative;
+        data[(j * n_samples) + i] = data[(col1 * n_samples) + i] +
+                                 data[(col2 * n_samples) + i];
+      } else {
+        // Totally junk data (irrelevant distractors)
+        data[(j * n_samples) + i] = 10.0 * ((rand() / (float)RAND_MAX) - 0.5);
+      }
+    }
+
+    labels[i] = (int)n_classes * (max_relevant_row / agg_relevant_vals);
+  }
+}
+
+template <typename T>
+void tranposeHostMatrix(std::vector<T> in,
+                        std::vector<T> out,
+                        unsigned n_rows,
+                        unsigned n_cols) {
+  for (unsigned i = 0; i < n_rows; i++) {
+    for (unsigned j = 0; j < n_cols; j++) {
+        out[i * n_cols + j] = in[j * n_rows + i];
+      }
+    }
+}
+
+/**
+ * Returns an X, y pair constructed from an underlying linear model:
+ *   y = X*coef + bias + epsilon
+ *
+ * Where epsilon is a normal random variate with standard deviation
+ * of 'noise_sd'.
+ *
+ * The 'coef' vector is randomly generated from a gaussian, but only
+ * the first n_informative elements have nonzero values, so the remainder
+ * of the columns are uninformative for y.
+ *
+ * Inspired by sklearn.datasets.make_regression, but the approach is
+ * NOT identical.
+ */
+template <typename T>
+ void makeRegressionDataHost(std::vector<T>& X,
+                             std::vector<T>& y,
+                             std::vector<T>& coeff,
+                             unsigned n_samples,
+                             unsigned n_features,
+                             unsigned n_informative,
+                             T noise_sd = 0.0,
+                             T bias = 0.0,
+                             int rand_seed = 42) {
+  
+  std::default_random_engine rng(rand_seed);
+  std::normal_distribution<float> data_distribution(0.0,3.0);
+  std::normal_distribution<float> eps_distribution(0.0,noise_sd);  
+
+  ASSERT(n_informative <= n_features,
+         "informative may not exceed total features");
+  X.resize(n_features * n_samples);
+  y.resize(n_samples);
+  coeff.resize(n_features);
+  
+  for (int i = 0; i < n_features; i++) {
+    if (i < n_informative) {
+      coeff[i] = data_distribution(rng);
+    } else {
+      coeff[i] = 0.0;
+    }
+  }
+  for (int i = 0; i < n_samples; i++) {
+    for (int j = 0; j < n_features; j++) {
+      X[j + i*n_features] = data_distribution(rng);
+    }
+    // OH HIGH K&R, FORGIVETH ME FOR MANUALLY WRITTING
+    // SGEMV IN AN UN-OPTIMIZE LOOP!
+    T tmp = bias;
+    for (int j = 0; j < n_features; j++) {
+      tmp += X[j + i*n_features]*coeff[j] + bias;
+    }
+    tmp += eps_distribution(rng); // epsilon
+    y[i] = tmp;
+  }
+}
+
+}

--- a/cpp/test/sg/generators_test.cu
+++ b/cpp/test/sg/generators_test.cu
@@ -1,0 +1,64 @@
+#include <cuda_utils.h>
+#include <gtest/gtest.h>
+#include <test_utils.h>
+#include "ml_utils.h"
+#include <random/rng.h>
+#include <data_generators.h>
+
+namespace ML {
+
+using namespace MLCommon;
+
+void test_function() {
+  int random_state = 100;
+  auto rng = Random::Rng(random_state);
+
+  int n = 20;
+  std::vector<float> x(n);
+  cudaStream_t stream;
+  CUDA_CHECK(cudaStreamCreate(&stream));
+ 
+  rng.normal(x.data(), n, 0.0f, 1.0f, stream);
+  
+  CUDA_CHECK(cudaStreamDestroy(stream));
+  for (int i = 0; i < n; i++) {
+    std::cout << x[i] << ", ";
+  }
+    
+  std::cout << "Demo" << std::endl;
+}
+
+void demo_class() {
+  std::vector<float> data;
+  std::vector<int> labels;
+  
+  makeClassificationDataHost(data, labels,
+                             1000, 5, 3,
+                             2, 2);
+  
+}
+
+void demo_reg() {
+  std::vector<float> X, y, coeff;
+  
+  makeRegressionDataHost(X, y, coeff,
+                         100, 10, 5,
+                         0.0f);
+  myPrintHostVector("y", y.data(), y.size());
+  myPrintHostMatrix("X", X.data(), 100, 10,
+                    true, std::cout);
+}
+
+
+TEST(demo_rng, demo_reg) {
+  demo_reg();
+  ASSERT_EQ(1, 1);
+}
+
+
+// TEST(demo_rng, demo2) {
+//   demo_class();
+//   ASSERT_EQ(1, 1);
+// }
+
+}

--- a/cpp/test/sg/rf_test.cu
+++ b/cpp/test/sg/rf_test.cu
@@ -39,7 +39,59 @@ struct RfInputs {
   int n_bins;
   int split_algo;
   int min_rows_per_node;
+  bool cross_validate;
 };
+
+static const bool VERBOSE_TEST = false;
+
+/*
+ * Fills in data and labels with an easy-to-predict classification dataset.
+ * Both vectors will be resized to hold datasets of size nrows * ncols.
+ * Data will be laid out in row-major format.
+ * The dataset contains some relevant data, some repeated data, and some
+ * irrelevant data.
+ * The labels are computed as max(all_relevant_cols), scaled to
+ * map to nclasses integer outputs.
+ */
+template <typename T>
+void makeClassificationDataHost(std::vector<T>& data, std::vector<int>& labels,
+                                int nrows, int ncols, int nclasses) {
+  data.resize(nrows * ncols);
+  labels.resize(nrows * ncols);
+
+  const int N_INFORMATIVE = 4;
+  const int N_REPEATED = 4;
+  const T MAX_RELEVANT_VAL = 10.0 + nclasses;  // Data pattern respects this max
+
+  // first NI columns are informative, next NR are identical, rest are junk
+  for (int i = 0; i < nrows; i++) {
+    T max_relevant_row = -1e6;
+
+    for (int j = 0; j < ncols; j++) {
+      if (j < N_INFORMATIVE) {
+        // Totally arbitrary data pattern that spreads out a bit
+        T val = 10.0 * ((i + 1) / (float)nrows) + ((i + j) % nclasses);
+        max_relevant_row = max(max_relevant_row, val);
+        data[(j * nrows) + i] = val;
+      } else if (j < N_INFORMATIVE + N_REPEATED) {
+        data[(j * nrows) + i] = data[((j - N_INFORMATIVE) * nrows) + i];
+      } else {
+        // Totally junk data (irrelevant distractors)
+        data[(j * nrows) + i] = j + ((j + i) % 2) * -1;
+      }
+    }
+
+    labels[i] = (int)nclasses * (max_relevant_row / MAX_RELEVANT_VAL);
+  }
+
+  if (VERBOSE_TEST) {
+    std::cout << "Labels: " << std::endl;
+    for (int i = 0; i < nrows; i++) {
+      std::cout << labels[i] << ", " << std::endl;
+    }
+    std::cout << "Done with labels" << std::endl;
+  }
+}
 
 template <typename T>
 ::std::ostream& operator<<(::std::ostream& os, const RfInputs<T>& dims) {
@@ -69,14 +121,12 @@ class RfTest : public ::testing::TestWithParam<RfInputs<T>> {
     cudaStream_t stream;
     CUDA_CHECK(cudaStreamCreate(&stream));
 
-    // Populate data (assume Col major)
-    std::vector<T> data_h = {30.0, 1.0, 2.0, 0.0, 10.0, 20.0, 10.0, 40.0};
-    data_h.resize(data_len);
-    updateDevice(data, data_h.data(), data_len, stream);
+    std::vector<T> data_h;
 
-    // Populate labels
-    labels_h = {0, 1, 0, 4};
-    labels_h.resize(params.n_rows);
+    // Create the dataset and transfer it to device
+    makeClassificationDataHost(data_h, labels_h, params.n_rows, params.n_cols,
+                               5);
+    updateDevice(data, data_h.data(), data_len, stream);
     preprocess_labels(params.n_rows, labels_h, labels_map);
     updateDevice(labels, labels_h.data(), params.n_rows, stream);
 
@@ -93,15 +143,33 @@ class RfTest : public ::testing::TestWithParam<RfInputs<T>> {
 
     // Inference data: same as train, but row major
     int inference_data_len = params.n_inference_rows * params.n_cols;
-    inference_data_h = {30.0, 10.0, 1.0, 20.0, 2.0, 10.0, 0.0, 40.0};
     inference_data_h.resize(inference_data_len);
+    for (int i = 0; i < params.n_inference_rows; i++) {
+      for (int j = 0; j < params.n_cols; j++) {
+        inference_data_h[i * params.n_cols + j] = data_h[j * params.n_rows + i];
+      }
+    }
 
     // Predict and compare against known labels
     predicted_labels.resize(params.n_inference_rows);
-    RF_metrics tmp = cross_validate(
-      handle, rf_classifier, inference_data_h.data(), labels_h.data(),
-      params.n_inference_rows, params.n_cols, predicted_labels.data(), false);
-    accuracy = tmp.accuracy;
+
+    if (!params.cross_validate) {
+      rf_classifier->predict(handle, inference_data_h.data(),
+                             params.n_inference_rows, params.n_cols,
+                             predicted_labels.data(), VERBOSE_TEST);
+
+      int num_correct;
+      for (int i = 0; i < params.n_inference_rows; i++) {
+        num_correct += (predicted_labels[i] == labels_h[i]);
+      }
+      accuracy = num_correct / params.n_inference_rows;
+    } else {
+      RF_metrics tmp =
+        cross_validate(handle, rf_classifier, inference_data_h.data(),
+                       labels_h.data(), params.n_inference_rows, params.n_cols,
+                       predicted_labels.data(), VERBOSE_TEST);
+      accuracy = tmp.accuracy;
+    }
   }
 
   void SetUp() override { basicTest(); }
@@ -109,6 +177,7 @@ class RfTest : public ::testing::TestWithParam<RfInputs<T>> {
   void TearDown() override {
     accuracy = -1.0f;  // reset accuracy
     postprocess_labels(params.n_rows, labels_h, labels_map);
+
     inference_data_h.clear();
     labels_h.clear();
     labels_map.clear();
@@ -134,48 +203,86 @@ class RfTest : public ::testing::TestWithParam<RfInputs<T>> {
   std::vector<int> predicted_labels;
 };
 
-const std::vector<RfInputs<float>> inputsf2 = {
-  {4, 2, 1, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST,
-   2},  // single tree forest, bootstrap false, unlimited depth, 4 bins
-  {4, 2, 1, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST,
-   2},  // single tree forest, bootstrap false, depth of 8, 4 bins
-  {4, 2, 10, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST,
-   2},  //forest with 10 trees, all trees should produce identical predictions (no bootstrapping or column subsampling)
-  {4, 2, 10, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST,
-   2},  //forest with 10 trees, with bootstrap and column subsampling enabled, 3 bins
+const std::vector<RfInputs<float>> float_input_params = {
+  {4, 2, 1, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // single tree forest, bootstrap false, unlimited depth, 4 bins
+  {4, 2, 1, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   true},  // same but with cross-validation
+  {50000, 200, 250, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // larger data more trees, bootstrap false, unlimited depth,4 bins
+  {5003, 11, 11, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // Odd numbers
+  {10, 680, 10, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // Short and wide (if you set width to 700, it will crash)
+  {4, 2, 1, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // single tree forest, bootstrap false, depth of 8, 4 bins
+  {4, 2, 1, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 1,
+   false},  // same but min_rows_per_node=1 --> fails
+  {4, 2, 10, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  //forest with 10 trees, all trees should produce identical predictions (no bootstrapping or column subsampling)
+  {4, 2, 10, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2,
+   false},  // forest with 10 trees, with bootstrap and column subsampling enabled, 3 bins
+  {50000, 200, 250, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2,
+   false},  // Large forest with bootstrap and subsampling
+  {50000, 200, 250, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2,
+   true},  // Same but with cross-validation
   {4, 2, 10, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2}  //forest with 10 trees, with bootstrap and column subsampling enabled, 3 bins, different split algorithm
+   2,
+   false}  // with bootstrap and column subsampling enabled, 3 bins, different split algorithm
 };
 
-const std::vector<RfInputs<double>> inputsd2 = {  // Same as inputsf2
-  {4, 2, 1, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2},
-  {4, 2, 1, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 2},
-  {4, 2, 10, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 2},
-  {4, 2, 10, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2},
+const std::vector<RfInputs<double>> double_input_params = {
+  // Same as float_input_params
+  {4, 2, 1, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // single tree forest, bootstrap false, unlimited depth, 4 bins
+  {4, 2, 1, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   true},  // same but with cross-validation
+  {50000, 200, 250, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // larger data more trees, bootstrap false, unlimited depth,4 bins
+  {5003, 11, 11, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // Odd numbers
+  {10, 680, 10, 1.0f, 1.0f, 4, -1, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // Short and wide (if you set width to 700, it will crash)
+  {4, 2, 1, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  // single tree forest, bootstrap false, depth of 8, 4 bins
+  {4, 2, 1, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 1,
+   false},  // same but min_rows_per_node=1 --> fails
+  {4, 2, 10, 1.0f, 1.0f, 4, 8, -1, false, false, 4, SPLIT_ALGO::HIST, 2,
+   false},  //forest with 10 trees, all trees should produce identical predictions (no bootstrapping or column subsampling)
+  {4, 2, 10, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2,
+   false},  // forest with 10 trees, with bootstrap and column subsampling enabled, 3 bins
+  {50000, 200, 250, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2,
+   false},  // Large forest with bootstrap and subsampling
+  {50000, 200, 250, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::HIST, 2,
+   true},  // Same but with cross-validation
   {4, 2, 10, 0.8f, 0.8f, 4, 8, -1, true, false, 3, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2}};
+   2,
+   false}  // with bootstrap and column subsampling enabled, 3 bins, different split algorithm
+};
 
 typedef RfTest<float> RfTestF;
 TEST_P(RfTestF, Fit) {
   //rf_classifier->print_rf_detailed(); // Prints all trees in the forest. Leaf nodes use the remapped values from labels_map.
   if (!params.bootstrap && (params.max_features == 1.0f)) {
-    ASSERT_TRUE(accuracy == 1.0f);
+    ASSERT_GE(accuracy, 1.0f);
   } else {
-    ASSERT_TRUE(accuracy >= 0.75f);  // Empirically derived accuracy range
+    ASSERT_GE(accuracy, 0.75f);  // Empirically derived accuracy range
   }
 }
 
 typedef RfTest<double> RfTestD;
 TEST_P(RfTestD, Fit) {
   if (!params.bootstrap && (params.max_features == 1.0f)) {
-    ASSERT_TRUE(accuracy == 1.0f);
+    ASSERT_GE(accuracy, 1.0f);
   } else {
-    ASSERT_TRUE(accuracy >= 0.75f);
+    ASSERT_GE(accuracy, 0.75f);
   }
 }
 
-INSTANTIATE_TEST_CASE_P(RfTests, RfTestF, ::testing::ValuesIn(inputsf2));
+INSTANTIATE_TEST_CASE_P(RfTests, RfTestF,
+                        ::testing::ValuesIn(float_input_params));
 
-INSTANTIATE_TEST_CASE_P(RfTests, RfTestD, ::testing::ValuesIn(inputsd2));
+INSTANTIATE_TEST_CASE_P(RfTests, RfTestD,
+                        ::testing::ValuesIn(double_input_params));
 
 }  // end namespace ML


### PR DESCRIPTION
(Still WIP - but feedback welcome!)

Dante and Saloni asked about adding a few more C++ tests for RF. This adds a non-random data generator to make it easier to generate large datasets.
It also adds some larger tests. It lets you test without doing cross-validation, which some folks requested to simplify the inference path.

On my P6000, tests start failing once I hit 700 columns. See stacktrace below.
The other oddity (maybe not real issue) is that if I set min_rows_per_node to 1, accuracy drops to 0. We should test against scikit learn here.

Large numbers of rows seem to work well!

Stacktrace from "short and wide" example:
```
C++ exception with description "Exception occured! file=/home/jzedlewski/code/rapidsai/cuml/cpp/src/decisiontree/decisiontree.cu line=229: Shared memory per block limit 49152 , requested 56000 

Obtained 14 stack frames
#0 in test/ml(_ZN8MLCommon9Exception16collectCallStackEv+0x3b) [0x4f37bb]
#1 in /home/jzedlewski/code/rapidsai/cuml/cpp/build/libcuml++.so(_ZN2ML12DecisionTree22DecisionTreeClassifierIdE5plantERKNS_15cumlHandle_implEPdiiPiPjiiiifiiib+0xc7a) [0x7f5e967df73a]
#2 in /home/jzedlewski/code/rapidsai/cuml/cpp/build/libcuml++.so(_ZN2ML12DecisionTree22DecisionTreeClassifierIdE3fitERKNS_10cumlHandleEPdiiPiPjiiNS0_18DecisionTreeParamsE+0xd5) [0x7f5e967df865]
#3 in /home/jzedlewski/code/rapidsai/cuml/cpp/build/libcuml++.so(_ZN2ML12rfClassifierIdE3fitERKNS_10cumlHandleEPdiiPii+0x2ed) [0x7f5e968e61cd]
#4 in test/ml() [0x60a8b8]
```