### PR TITLE
[REVIEW] Reduce cols by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PR #641: C: Separate C-wrapper library build to generate libcuml.so
 - PR #631: Add nvcategory based ordinal label encoder
 - PR #670 Add test skipping functionality to build.sh
+- PR #673: prims: reduce cols by key primitive
 
 ## Improvements
 

--- a/cpp/src_prims/linalg/reduce_cols_by_key.h
+++ b/cpp/src_prims/linalg/reduce_cols_by_key.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <cub/cub.cuh>
+#include <limits>
+#include "cuda_utils.h"
+
+namespace MLCommon {
+namespace LinAlg {
+
+///@todo: support col-major
+///@todo: specialize this to support shared-mem based atomics
+
+template <typename T, typename KeyType, typename IdxType>
+__global__ void reduce_cols_by_key_kernel(const T* data, const KeyType* keys,
+                                          T* out, IdxType nrows, IdxType ncols,
+                                          IdxType nkeys) {
+  IdxType idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if(idx >= (nrows * ncols))
+    return;
+  ///@todo: yikes! use fast-int-div!
+  IdxType colId = idx % ncols;
+  IdxType rowId = idx / ncols;
+  KeyType key = keys[colId];
+  atomicAdd(out+rowId*nkeys+key, data[idx]);
+}
+
+/**
+ * @brief Computes the sum-reduction of matrix columns for each given key
+ * @tparam T the input data type (as well as the output reduced matrix)
+ * @tparam KeyType data type of the keys
+ * @tparam IdxType indexing arithmetic type
+ * @param data the input data (dim = nrows x ncols). This is assumed to be in
+ * row-major layout
+ * @param keys keys array (len = ncols). It is assumed that each key in this
+ * array is between [0, nkeys). In case this is not true, the caller is expected
+ * to have called make_monotonic primitive to prepare such a contiguous and
+ * monotonically increasing keys array.
+ * @param out the output reduced matrix along columns (dim = nrows x nkeys).
+ * This will be assumed to be in row-major layout
+ * @param nrows number of rows in the input data
+ * @param ncols number of colums in the input data
+ * @param nkeys number of unique keys in the keys array
+ * @param stream cuda stream to launch the kernel onto
+ */
+template <typename T, typename KeyType = int, typename IdxType = int>
+void reduce_cols_by_key(const T* data, const KeyType* keys, T* out,
+                        IdxType nrows, IdxType ncols, IdxType nkeys,
+                        cudaStream_t stream) {
+  CUDA_CHECK(cudaMemsetAsync(out, 0, sizeof(T) * nrows * nkeys, stream));
+  constexpr int TPB = 256;
+  int nblks = (int)ceildiv<IdxType>(nrows * ncols, TPB);
+  reduce_cols_by_key_kernel<T, KeyType, IdxType><<<nblks, TPB, 0, stream>>>(
+    data, keys, out, nrows, ncols, nkeys);
+  CUDA_CHECK(cudaPeekAtLastError());
+}
+
+};  // end namespace LinAlg
+};  // end namespace MLCommon

--- a/cpp/src_prims/linalg/reduce_cols_by_key.h
+++ b/cpp/src_prims/linalg/reduce_cols_by_key.h
@@ -32,13 +32,12 @@ __global__ void reduce_cols_by_key_kernel(const T* data, const KeyType* keys,
                                           T* out, IdxType nrows, IdxType ncols,
                                           IdxType nkeys) {
   IdxType idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if(idx >= (nrows * ncols))
-    return;
-  ///@todo: yikes! use fast-int-div!
+  if (idx >= (nrows * ncols)) return;
+  ///@todo: yikes! use fast-int-div
   IdxType colId = idx % ncols;
   IdxType rowId = idx / ncols;
   KeyType key = keys[colId];
-  atomicAdd(out+rowId*nkeys+key, data[idx]);
+  atomicAdd(out + rowId * nkeys + key, data[idx]);
 }
 
 /**
@@ -66,8 +65,8 @@ void reduce_cols_by_key(const T* data, const KeyType* keys, T* out,
   CUDA_CHECK(cudaMemsetAsync(out, 0, sizeof(T) * nrows * nkeys, stream));
   constexpr int TPB = 256;
   int nblks = (int)ceildiv<IdxType>(nrows * ncols, TPB);
-  reduce_cols_by_key_kernel<T, KeyType, IdxType><<<nblks, TPB, 0, stream>>>(
-    data, keys, out, nrows, ncols, nkeys);
+  reduce_cols_by_key_kernel<T, KeyType, IdxType>
+    <<<nblks, TPB, 0, stream>>>(data, keys, out, nrows, ncols, nkeys);
   CUDA_CHECK(cudaPeekAtLastError());
 }
 

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -166,6 +166,7 @@ if(BUILD_PRIMS_TESTS)
       prims/power.cu
       prims/randIndex.cu
       prims/reduce.cu
+      prims/reduce_cols_by_key.cu
       prims/reduce_rows_by_key.cu
       prims/reverse.cu
       prims/rng.cu

--- a/cpp/test/prims/reduce_cols_by_key.cu
+++ b/cpp/test/prims/reduce_cols_by_key.cu
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "linalg/reduce_cols_by_key.h"
+#include "random/rng.h"
+#include "test_utils.h"
+
+namespace MLCommon {
+namespace LinAlg {
+
+template <typename T>
+void naiveReduceColsByKey(const T *in, const uint32_t *keys, T *out_ref,
+                          uint32_t nrows, uint32_t ncols, uint32_t nkeys,
+                          cudaStream_t stream) {
+  std::vector<uint32_t> h_keys(0, ncols);
+  copy(&(h_keys[0]), keys, ncols, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  std::vector<T> out(T(0), nrows*nkeys);
+  for (uint32_t i=0; i<nrows; ++i) {
+    for (uint32_t j=0; j<ncols; ++j) {
+      out[i*nkeys+h_keys[j]] += in[i*ncols+j];
+    }
+  }
+  copy(out_ref, &(out[0]), nrows*nkeys, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+}
+
+template <typename T>
+struct ReduceColsInputs {
+  T tolerance;
+  uint32_t rows;
+  uint32_t cols;
+  uint32_t nkeys;
+  unsigned long long int seed;
+};
+
+template <typename T>
+::std::ostream &operator<<(::std::ostream &os,
+                           const ReduceColsInputs<T> &dims) {
+  return os;
+}
+
+template <typename T>
+class ReduceColsTest : public ::testing::TestWithParam<ReduceColsInputs<T>> {
+ protected:
+  void SetUp() override {
+    params = ::testing::TestWithParam<ReduceColsInputs<T>>::GetParam();
+    Random::Rng r(params.seed);
+    CUDA_CHECK(cudaStreamCreate(&stream));
+    auto nrows = params.rows;
+    auto ncols = params.cols;
+    auto nkeys = params.nkeys;
+    allocate(in, nrows * ncols);
+    allocate(keys, ncols);
+    allocate(out, nrows * nkeys);
+    r.uniform(in, nrows * ncols, T(-1.0), T(1.0), stream);
+    r.uniformInt(keys, ncols, 0u, params.nkeys, stream);
+    naiveReduceColsByKey(in, keys, out_ref, nrows, ncols, nkeys, stream);
+    reduce_cols_by_key(in, keys, out, nrows, ncols, nkeys, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+  }
+
+  void TearDown() override {
+    CUDA_CHECK(cudaFree(in));
+    CUDA_CHECK(cudaFree(out_ref));
+    CUDA_CHECK(cudaFree(out));
+    CUDA_CHECK(cudaFree(keys));
+    CUDA_CHECK(cudaStreamDestroy(stream));
+  }
+
+ protected:
+  cudaStream_t stream;
+  ReduceColsInputs<T> params;
+  T *in, *out_ref, *out;
+  uint32_t *keys;
+};
+
+const std::vector<ReduceColsInputs<float>> inputsf = {
+  {0.000001f, 128, 32, 6, 1234ULL},
+  {0.000001f, 121, 63, 10, 1234ULL}};
+typedef ReduceColsTest<float> ReduceColsTestF;
+TEST_P(ReduceColsTestF, Result) {
+  ASSERT_TRUE(devArrMatch(out_ref, out, params.rows * params.nkeys,
+                          CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(ReduceColsTests, ReduceColsTestF,
+                        ::testing::ValuesIn(inputsf));
+
+const std::vector<ReduceColsInputs<double>> inputsd2 = {
+  {0.00000001, 128, 32, 6, 1234ULL},
+  {0.00000001, 121, 63, 10, 1234ULL}};
+typedef ReduceColsTest<double> ReduceColsTestD;
+TEST_P(ReduceColsTestD, Result) {
+  ASSERT_TRUE(devArrMatch(out_ref, out, params.rows * params.nkeys,
+                          CompareApprox<double>(params.tolerance)));
+}
+INSTANTIATE_TEST_CASE_P(ReduceColsTests, ReduceColsTestD,
+                        ::testing::ValuesIn(inputsd2));
+
+}  // end namespace LinAlg
+}  // end namespace MLCommon

--- a/cpp/test/prims/reduce_cols_by_key.cu
+++ b/cpp/test/prims/reduce_cols_by_key.cu
@@ -26,16 +26,18 @@ template <typename T>
 void naiveReduceColsByKey(const T *in, const uint32_t *keys, T *out_ref,
                           uint32_t nrows, uint32_t ncols, uint32_t nkeys,
                           cudaStream_t stream) {
-  std::vector<uint32_t> h_keys(0, ncols);
+  std::vector<uint32_t> h_keys(ncols, 0u);
   copy(&(h_keys[0]), keys, ncols, stream);
+  std::vector<T> h_in(nrows * ncols);
+  copy(&(h_in[0]), in, nrows * ncols, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
-  std::vector<T> out(T(0), nrows*nkeys);
-  for (uint32_t i=0; i<nrows; ++i) {
-    for (uint32_t j=0; j<ncols; ++j) {
-      out[i*nkeys+h_keys[j]] += in[i*ncols+j];
+  std::vector<T> out(nrows * nkeys, T(0));
+  for (uint32_t i = 0; i < nrows; ++i) {
+    for (uint32_t j = 0; j < ncols; ++j) {
+      out[i * nkeys + h_keys[j]] += h_in[i * ncols + j];
     }
   }
-  copy(out_ref, &(out[0]), nrows*nkeys, stream);
+  copy(out_ref, &(out[0]), nrows * nkeys, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
@@ -66,6 +68,7 @@ class ReduceColsTest : public ::testing::TestWithParam<ReduceColsInputs<T>> {
     auto nkeys = params.nkeys;
     allocate(in, nrows * ncols);
     allocate(keys, ncols);
+    allocate(out_ref, nrows * nkeys);
     allocate(out, nrows * nkeys);
     r.uniform(in, nrows * ncols, T(-1.0), T(1.0), stream);
     r.uniformInt(keys, ncols, 0u, params.nkeys, stream);
@@ -90,8 +93,7 @@ class ReduceColsTest : public ::testing::TestWithParam<ReduceColsInputs<T>> {
 };
 
 const std::vector<ReduceColsInputs<float>> inputsf = {
-  {0.000001f, 128, 32, 6, 1234ULL},
-  {0.000001f, 121, 63, 10, 1234ULL}};
+  {0.00001f, 128, 32, 6, 1234ULL}, {0.00001f, 121, 63, 10, 1234ULL}};
 typedef ReduceColsTest<float> ReduceColsTestF;
 TEST_P(ReduceColsTestF, Result) {
   ASSERT_TRUE(devArrMatch(out_ref, out, params.rows * params.nkeys,
@@ -101,8 +103,7 @@ INSTANTIATE_TEST_CASE_P(ReduceColsTests, ReduceColsTestF,
                         ::testing::ValuesIn(inputsf));
 
 const std::vector<ReduceColsInputs<double>> inputsd2 = {
-  {0.00000001, 128, 32, 6, 1234ULL},
-  {0.00000001, 121, 63, 10, 1234ULL}};
+  {0.00000001, 128, 32, 6, 1234ULL}, {0.00000001, 121, 63, 10, 1234ULL}};
 typedef ReduceColsTest<double> ReduceColsTestD;
 TEST_P(ReduceColsTestD, Result) {
   ASSERT_TRUE(devArrMatch(out_ref, out, params.rows * params.nkeys,


### PR DESCRIPTION
As opposed to `reduce_rows_by_key`, this primitive tries to reduce along columns based on the key. This will be needed for the #645 Silhouette score implementation. @cjnolet @dantegd for review and merge.

@venkywonka JFYI. Once this gets merged, it should unblock you with silhouette score.