### PR TITLE
[REVIEW] Fixed template parameters in bernoulli() implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #646: Update link in contributing.md
 - PR #649: Bug fix to LinAlg::reduce_rows_by_key prim filed in issue #648
 - PR #666: fixes to gitutils.py to resolve both string decode and handling of uncommitted files
+- PR #676: Fix template parameters in `bernoulli()` implementation.
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/cpp/src_prims/random/rng.h
+++ b/cpp/src_prims/random/rng.h
@@ -273,7 +273,7 @@ class Rng {
    */
   template <typename Type, typename LenType = int>
   void bernoulli(bool *ptr, LenType len, Type prob, cudaStream_t stream) {
-    randImpl(
+    randImpl<bool, Type>(
       offset, ptr, len,
       [=] __device__(Type val, LenType idx) { return val > prob; }, NumThreads,
       nBlocks, type, stream);


### PR DESCRIPTION
- by default for `randImpl()`, `MathType = OutType`
- for `bernoulli()`, `OutType = bool`, not usable as `MathType`
- explicitly specified `MathType = Type` (`float` or `double`)
- added test for `bernoulli()`