### PR TITLE
CMake: Added option to skip clang format

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -151,3 +151,4 @@ cuML's cmake has the following configurable flags available:
 | GPU_ARCHS |  List of GPU architectures, semicolon-separated | 60;70;75  | List of GPU architectures that all artifacts are compiled for.  |
 | KERNEL_INFO | [ON, OFF]  | OFF  | Enable/disable kernel resource usage info in nvcc. |
 | LINE_INFO | [ON, OFF]  | OFF  | Enable/disable lineinfo in nvcc.  |
+| SKIP_CLANG_FORMAT | [ON, OFF]  | OFF  | Enable/disable style check with clang-format.  |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #707: Added stress test and updated documentation for RF 
 - PR #701: Added emacs temporary file patterns to .gitignore
 - PR #606: C++: Added tests for host_buffer and improved device_buffer and host_buffer implementation
+- PR #725: CMake: Added option to skip clang format
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -108,9 +108,12 @@ else()
 endif()
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-find_package(ClangFormat 8.0.0 EXACT REQUIRED)
-# TODO: enable this when we are ready!
-#find_package(ClangTidy 8.0.0 EXACT REQUIRED)
+if (NOT SKIP_CLANG_FORMAT OR NOT ${SKIP_CLANG_FORMAT})
+  find_package(ClangFormat 8.0.0 EXACT REQUIRED)
+  # TODO: enable this when we are ready!
+  #find_package(ClangTidy 8.0.0 EXACT REQUIRED)
+endif(NOT SKIP_CLANG_FORMAT OR NOT ${SKIP_CLANG_FORMAT})
+
 
 ###################################################################################################
 # - External Dependencies--------------------------------------------------------------------------
@@ -200,9 +203,11 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 ###################################################################################################
 # - clang-format targets --------------------------------------------------------------------------
 
-add_clang_format(
-  DSTDIR ${PROJECT_BINARY_DIR}/clang-format
-  SRCDIR ${PROJECT_SOURCE_DIR})
+if(ClangFormat_FOUND)
+  add_clang_format(
+    DSTDIR ${PROJECT_BINARY_DIR}/clang-format
+    SRCDIR ${PROJECT_SOURCE_DIR})
+endif(ClangFormat_FOUND)
 
 ###################################################################################################
 # - FAISS Build  ----------------------------------------------------------------------------------
@@ -322,7 +327,9 @@ if(BUILD_CUML_CPP_LIBRARY)
   endif(OPENMP_FOUND)
 
   target_link_libraries(${CUML_CPP_TARGET} ${CUML_LINK_LIBRARIES})
-  add_dependencies(${CUML_CPP_TARGET} ${ClangFormat_TARGET})
+  if (ClangFormat_FOUND)
+    add_dependencies(${CUML_CPP_TARGET} ${ClangFormat_TARGET})
+  endif (ClangFormat_FOUND)
 
 endif(BUILD_CUML_CPP_LIBRARY)
 

--- a/cpp/examples/dbscan/CMakeLists.txt
+++ b/cpp/examples/dbscan/CMakeLists.txt
@@ -17,5 +17,7 @@
 include_directories(${CUDA_INCLUDE_DIRS})
 
 add_executable(dbscan_example dbscan_example.cpp)
-add_dependencies(dbscan_example ${ClangFormat_TARGET})
+if(ClangFormat_FOUND)
+  add_dependencies(dbscan_example ${ClangFormat_TARGET})
+endif(ClangFormat_FOUND)
 target_link_libraries(dbscan_example cuml++)

--- a/cpp/examples/kmeans/CMakeLists.txt
+++ b/cpp/examples/kmeans/CMakeLists.txt
@@ -16,5 +16,7 @@
 
 include_directories(${CUDA_INCLUDE_DIRS})
 add_executable(kmeans_example kmeans_example.cpp)
-add_dependencies(kmeans_example ${ClangFormat_TARGET})
+if(ClangFormat_FOUND)
+  add_dependencies(kmeans_example ${ClangFormat_TARGET})
+endif(ClangFormat_FOUND)
 target_link_libraries(kmeans_example cuml++)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -62,7 +62,9 @@ if(BUILD_CUML_TESTS)
       sg/umap_test.cu
       )
 
-    add_dependencies(ml ${ClangFormat_TARGET})
+    if(ClangFormat_FOUND)
+      add_dependencies(ml ${ClangFormat_TARGET})
+    endif(ClangFormat_FOUND)
 
     target_link_libraries(ml
       ${GTEST_LIBNAME}
@@ -97,7 +99,9 @@ if(BUILD_CUML_MG_TESTS)
       mg/test_ml_mg_utils.cu
       )
 
-    add_dependencies(ml_mg ${ClangFormat_TARGET})
+    if(ClangFormat_FOUND)
+      add_dependencies(ml_mg ${ClangFormat_TARGET})
+    endif(ClangFormat_FOUND)
 
     target_link_libraries(ml_mg
       ${GTEST_LIBNAME}
@@ -193,7 +197,9 @@ if(BUILD_PRIMS_TESTS)
       prims/weighted_mean.cu
       )
 
-    add_dependencies(prims ${ClangFormat_TARGET})
+    if(ClangFormat_FOUND)
+      add_dependencies(prims ${ClangFormat_TARGET})
+    endif(ClangFormat_FOUND)
 
     target_link_libraries(prims
       ${GTEST_LIBNAME}


### PR DESCRIPTION
To avoid a dependency to `clang-format` to build cuML on build only hosts this PR adds the CMake option `SKIP_CLANG_FORMAT` to skip code formatting with `clang-format`.