### PR TITLE
Update API docs for new 0.8 modules and docstring fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - PR #606: C++: Added tests for host_buffer and improved device_buffer and host_buffer implementation
 - PR #726: Updated RF docs and stress test
 - PR #730: Update README and RF docs for 0.8
+- PR #741: Update API docs for 0.8
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ repo](https://github.com/rapidsai/notebooks-extended).
 | --- | --- | --- |
 | **Clustering** |  Density-Based Spatial Clustering of Applications with Noise (DBSCAN) | |
 |  | K-Means | |
-|  | K-Nearest Neighbors (KNN) | Multi-GPU with [dask-cuml](http://github.com/rapidsai/dask-cuml) <br> Uses [Faiss](https://github.com/facebookresearch/faiss) |
 | **Dimensionality Reduction** | Principal Components Analysis (PCA) | |
 | | Truncated Singular Value Decomposition (tSVD) | Multi-GPU version available (CUDA 10 only) |
 | | Uniform Manifold Approximation and Projection (UMAP) | |
@@ -63,6 +62,7 @@ repo](https://github.com/rapidsai/notebooks-extended).
 | | Logistic Regression | |
 | | Stochastic Gradient Descent (SGD), Coordinate Descent (CD), and Quasi-Newton (QN) (including L-BFGS and OWL-QN) solvers for linear models  | |
 | **Nonlinear Models for Regression or Classification** | Random Forest (RF) Classification | Initial preview version in cuML 0.8 | 
+|  | K-Nearest Neighbors (KNN) | Multi-GPU with [dask-cuml](http://github.com/rapidsai/dask-cuml) <br> Uses [Faiss](https://github.com/facebookresearch/faiss) |
 | **Time Series** | Linear Kalman Filter | |
 ---
 

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -1,0 +1,31 @@
+name: rapids_dev
+channels:
+- nvidia
+- conda-forge
+- rapidsai
+dependencies:
+- cudatoolkit=10.0
+- clangdev
+- cmake>=3.12
+- python>=3.7,<3.8
+- numba>=0.40
+- pandas>=0.23.4
+- pyarrow=0.12.0
+- boost
+- cffi>=1.10.0   
+- distributed>=1.23.0
+- cython>=0.29,<0.30
+- pytest
+# required for building rapids project docs
+- sphinx
+- sphinx_rtd_theme
+- sphinxcontrib-websupport
+- nbsphinx
+- numpydoc
+- ipython
+- recommonmark
+- pandoc=<2.0.0
+- pip
+- pip:
+  - sphinx-markdown-tables
+  - cmake_setuptools

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - cudatoolkit=10.0
 - clangdev
-- cmake>=3.12
+- cmake>=3.13
 - python>=3.7,<3.8
 - numba>=0.40
 - pandas>=0.23.4

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,25 +1,66 @@
+~~~~~~~~~~~~~~~~~~~
 cuML API Reference
-====================
+~~~~~~~~~~~~~~~~~~~
+
+
+
+Preprocessing
+==============
+
+Model Selection and Data Splitting
+----------------------------------
+
+ .. automodule:: cuml.preprocessing.model_selection
+    :members:
+
+Label Encoding
+--------------
+
+ .. autoclass:: cuml.preprocessing.LabelEncoder
+    :members:
+
+Regression and Classification
+=============================
 
 Linear Regression
-------------------
+-----------------
 
 .. autoclass:: cuml.LinearRegression
     :members:
 
 
 Ridge Regression
------------------
+----------------
 
 .. autoclass:: cuml.Ridge
     :members:
 
+Lasso Regression
+----------------
+
+.. autoclass:: cuml.Lasso
+    :members:
+
+ElasticNet Regression
+---------------------
+
+.. autoclass:: cuml.ElasticNet
+    :members:
+    
 
 Stochastic Gradient Descent
-----------------------------
+---------------------------
 
 .. autoclass:: cuml.SGD
     :members:
+
+Random Forest
+-------------
+.. autoclass:: cuml.ensemble.RandomForestClassifier
+    :members:
+
+Clustering
+==========
 
 
 Nearest Neighbors
@@ -42,13 +83,8 @@ DBSCAN
 .. autoclass:: cuml.DBSCAN
     :members:
 
-
-Kalman Filter
--------------
-
-.. autoclass:: cuml.KalmanFilter
-    :members:
-
+Dimensionality Reduction
+========================
 
 Principal Component Analysis
 -----------------------------
@@ -69,3 +105,14 @@ UMAP
 
 .. autoclass:: cuml.UMAP
     :members:
+
+
+Time Series
+============
+
+Kalman Filter
+-------------
+
+.. autoclass:: cuml.KalmanFilter
+    :members:
+       

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -54,11 +54,6 @@ Stochastic Gradient Descent
 .. autoclass:: cuml.SGD
     :members:
 
-Nearest Neighbors
------------------
-
-.. autoclass:: cuml.NearestNeighbors
-    :members:
 
 Random Forest
 -------------
@@ -102,6 +97,24 @@ UMAP
 -------------
 
 .. autoclass:: cuml.UMAP
+    :members:
+
+Random Projections
+------------------
+
+.. autoclass:: cuml.random_projection.GaussianRandomProjection
+    :members:
+
+.. autoclass:: cuml.random_projection.SparseRandomProjection
+    :members:
+
+Neighbors
+==========
+
+Nearest Neighbors
+-----------------
+
+.. autoclass:: cuml.NearestNeighbors
     :members:
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -54,6 +54,12 @@ Stochastic Gradient Descent
 .. autoclass:: cuml.SGD
     :members:
 
+Nearest Neighbors
+-----------------
+
+.. autoclass:: cuml.NearestNeighbors
+    :members:
+
 Random Forest
 -------------
 .. autoclass:: cuml.ensemble.RandomForestClassifier
@@ -61,14 +67,6 @@ Random Forest
 
 Clustering
 ==========
-
-
-Nearest Neighbors
---------------------
-
-.. autoclass:: cuml.NearestNeighbors
-    :members:
-
 
 K-Means Clustering
 --------------------
@@ -83,8 +81,8 @@ DBSCAN
 .. autoclass:: cuml.DBSCAN
     :members:
 
-Dimensionality Reduction
-========================
+Dimensionality Reduction and Manifold Learning
+==============================================
 
 Principal Component Analysis
 -----------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 Welcome to cuML's documentation!
 =================================
 
-cuML is a suite of fast GPU accelerated machine learning algorithms
+cuML is a suite of fast, GPU-accelerated machine learning algorithms
 designed for data science and analytical tasks. Our API mirrors Sklearn's,
 and we provide practitioners with the easy fit-predict-transform paradigm
 without ever having to program on a GPU.
@@ -13,7 +13,7 @@ in the GPU, and compute tasks can be performed on it directly.
 cuML is fully open source, and the RAPIDS team welcomes new and seasoned
 contributors, users and hobbyists! Thank you for your wonderful support!
 
-An installation requirement for cuML is that your system must be linux-like.
+An installation requirement for cuML is that your system must be Linux-like.
 Support for Windows is possible in the near future.
 
 

--- a/python/cuml/ensemble/randomforest.pyx
+++ b/python/cuml/ensemble/randomforest.pyx
@@ -377,13 +377,13 @@ class RandomForestClassifier(Base):
             print("Predicted labels : ", cuml_predict)
 
     Output:
-    .. code-block:: python
+
+    .. code-block:: none
 
             Predicted labels :  [0 1 0 1 0 1 0 1 0 1]
 
     Parameters
     -----------
-
     n_estimators : int (default = 10)
                    number of trees in the forest.
     handle : cuml.Handle

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -116,7 +116,7 @@ class LinearRegression(Base):
         X_new['col2'] = np.array([5,5], dtype = np.float32)
         preds = lr.predict(X_new)
 
-        print("Preds:")
+        print("Predictions:")
         print(preds)
 
     Output:
@@ -131,7 +131,7 @@ class LinearRegression(Base):
         Intercept:
                     3.0
 
-        Preds:
+        Predictions:
 
                     0 15.999999
                     1 14.999999

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -108,7 +108,7 @@ class LinearRegression(Base):
         reg = lr.fit(X,y)
         print("Coefficients:")
         print(reg.coef_)
-        print("intercept:")
+        print("Intercept:")
         print(reg.intercept_)
 
         X_new = cudf.DataFrame()
@@ -116,6 +116,7 @@ class LinearRegression(Base):
         X_new['col2'] = np.array([5,5], dtype = np.float32)
         preds = lr.predict(X_new)
 
+        print("Preds:")
         print(preds)
 
     Output:

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -105,7 +105,7 @@ class Ridge(Base, RegressorMixin):
         from cuml import Ridge
         from cuml.linear_model import Ridge
 
-        alpha = np.array([1.0])
+        alpha = np.array([1e-5])
         ridge = Ridge(alpha = alpha, fit_intercept = True, normalize = False,
                       solver = "eig")
 
@@ -115,10 +115,10 @@ class Ridge(Base, RegressorMixin):
 
         y = cudf.Series( np.array([6.0, 8.0, 9.0, 11.0], dtype = np.float32) )
 
-        result_ridge = ridge.fit(X_cudf, y_cudf)
+        result_ridge = ridge.fit(X, y)
         print("Coefficients:")
         print(result_ridge.coef_)
-        print("intercept:")
+        print("Intercept:")
         print(result_ridge.intercept_)
 
         X_new = cudf.DataFrame()
@@ -126,6 +126,7 @@ class Ridge(Base, RegressorMixin):
         X_new['col2'] = np.array([5,5], dtype = np.float32)
         preds = result_ridge.predict(X_new)
 
+        print("Predictions:")
         print(preds)
 
     Output:
@@ -407,3 +408,4 @@ class Ridge(Base, RegressorMixin):
         if 'solver' in params.keys():
             self.algo = self._get_algorithm_int(self.solver)
         return self
+

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -408,4 +408,3 @@ class Ridge(Base, RegressorMixin):
         if 'solver' in params.keys():
             self.algo = self._get_algorithm_int(self.solver)
         return self
-


### PR DESCRIPTION
This addresses Issue #738 
We had several new algorithms not included in the API docs. This adds them in and makes a few docstring fixes.
It does not address incorrect parameter type formatting, which is more pervasive. That needs a bulk change sometime or a sphinx-level fix.