### PR TITLE
[REVIEW] QN and LogisticRegression docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,13 @@
 - PR #683: Use stateless c++ API in KNN so that it can be pickled properly
 - PR #686: Use stateless c++ API in UMAP so that it can be pickled properly
 - PR #695: prims: Refactor pairwise distance
-- PR #707: Added stress test and updated documentation for RF 
+- PR #707: Added stress test and updated documentation for RF
 - PR #701: Added emacs temporary file patterns to .gitignore
 - PR #606: C++: Added tests for host_buffer and improved device_buffer and host_buffer implementation
 - PR #726: Updated RF docs and stress test
 - PR #730: Update README and RF docs for 0.8
 - PR #741: Update API docs for 0.8
+- PR #XXX: LogisticRegression and QN API docstrings
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - PR #726: Updated RF docs and stress test
 - PR #730: Update README and RF docs for 0.8
 - PR #741: Update API docs for 0.8
-- PR #XXX: LogisticRegression and QN API docstrings
+- PR #746: LogisticRegression and QN API docstrings
 
 ## Bug Fixes
 - PR #584: Added missing virtual destructor to deviceAllocator and hostAllocator

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -71,7 +71,7 @@ Random Forest
 Quasi-Newton
 ------------
 
-.. autoclass:: cuml.SGD
+.. autoclass:: cuml.QN
     :members:
 
 Clustering

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -29,6 +29,13 @@ Linear Regression
     :members:
 
 
+Logistic Regression
+-----------------
+
+.. autoclass:: cuml.LogisticRegression
+    :members:
+
+
 Ridge Regression
 ----------------
 
@@ -46,7 +53,7 @@ ElasticNet Regression
 
 .. autoclass:: cuml.ElasticNet
     :members:
-    
+
 
 Stochastic Gradient Descent
 ---------------------------
@@ -58,6 +65,13 @@ Stochastic Gradient Descent
 Random Forest
 -------------
 .. autoclass:: cuml.ensemble.RandomForestClassifier
+    :members:
+
+
+Quasi-Newton
+------------
+
+.. autoclass:: cuml.SGD
     :members:
 
 Clustering
@@ -126,4 +140,4 @@ Kalman Filter
 
 .. autoclass:: cuml.KalmanFilter
     :members:
-       
+

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -35,7 +35,7 @@ supported_solvers = ['qn', 'lbfgs', 'owl']
 class LogisticRegression(Base):
     """
     LogisticRegression is a linear model that is used to model probability of
-    occurrance of certain events, for example probability of success or fail of
+    occurrence of certain events, for example probability of success or fail of
     an event.
 
     cuML's LogisticRegression can take array-like objects, either in host as
@@ -85,7 +85,9 @@ class LogisticRegression(Base):
 
         print("Predictions:")
         print(preds)
+
     Output:
+
     .. code-block:: python
         Coefficients:
                     0.22309814
@@ -95,6 +97,7 @@ class LogisticRegression(Base):
         Predictions:
                     0    0.0
                     1    1.0
+
     Parameters
     -----------
     penalty: 'none', 'l1', 'l2', 'elasticnet' (default = 'l2')
@@ -124,12 +127,14 @@ class LogisticRegression(Base):
         depending on the condictions of the l1 regularization described
         above. Options 'lbfgs' and 'owl' are just convenience values that
         end up using the same solver following the same rules.
+
     Attributes
     -----------
-    coef_ : array, shape (n_classes, n_features)
+    coef_: device array, shape (n_classes, n_features)
         The estimated coefficients for the linear regression model.
-    intercept_ : array (n_classes, 1)
+    intercept_: device array (n_classes, 1)
         The independent term. If fit_intercept_ is False, will be 0.
+
     Notes
     ------
 
@@ -139,7 +144,7 @@ class LogisticRegression(Base):
     coefficients and predictions of the model, similar to difference when
     using different solvers in Scikit-learn.
 
-    For additional docs, see `scikitlearn's LogistRegression
+    For additional docs, see Scikit-learn's LogistRegression
     <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_.
     """
 

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -40,7 +40,7 @@ class LogisticRegression(Base):
 
     cuML's LogisticRegression can take array-like objects, either in host as
     NumPy arrays or in device (as Numba or __cuda_array_interface__ compliant).
-    It provides both two class (using sigmoid loss) and multiple class
+    It provides both single-class (using sigmoid loss) and multiple-class
     (using softmax loss) variants, depending on the input variables.
 
     Only one solver option is currently available: Quasi-Newton (QN)

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -236,8 +236,7 @@ class LogisticRegression(Base):
         self.qn = QN(loss=loss, fit_intercept=self.fit_intercept,
                      l1_strength=l1_strength, l2_strength=l2_strength,
                      max_iter=self.max_iter, tol=self.tol,
-                     verbose=self.verbose, num_classes=num_classes,
-                     handle=self.handle)
+                     verbose=self.verbose, handle=self.handle)
 
         self.qn.fit(X, y_m)
 

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -74,7 +74,7 @@ class LogisticRegression(Base):
 
         print("Coefficients:")
         print(reg.coef_.copy_to_host())
-        print("intercept:")
+        print("Intercept:")
         print(reg.intercept_.copy_to_host())
 
         X_new = cudf.DataFrame()
@@ -83,6 +83,7 @@ class LogisticRegression(Base):
 
         preds = reg.predict(X_new)
 
+        print("Predictions:")
         print(preds)
     Output:
     .. code-block:: python
@@ -91,7 +92,7 @@ class LogisticRegression(Base):
                     0.21012752
         Intercept:
                     -0.7548761
-        Preds:
+        Predictions:
                     0    0.0
                     1    1.0
     Parameters

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -107,18 +107,18 @@ class LogisticRegression(Base):
        The training process will stop if current_loss > previous_loss - tol
     C: float (default = 1.0)
        Inverse of regularization strength; must be a positive float.
-    fit_intercept : boolean (default = True)
+    fit_intercept: boolean (default = True)
        If True, the model tries to correct for the global mean of y.
        If False, the model expects that you have centered the data.
     class_weight: None
         Custom class weighs are currently not supported.
-    max_iter : int (default = 1000)
+    max_iter: int (default = 1000)
         Maximum number of iterations taken for the solvers to converge.
     verbose: bool (optional, default False)
         Controls verbosity of logging.
-    l1_ratio : float or None, optional (default=None)
+    l1_ratio: float or None, optional (default=None)
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`
-    solver : 'qn', 'lbfgs', 'owl' (default=qn).
+    solver: 'qn', 'lbfgs', 'owl' (default=qn).
         Algorithm to use in the optimization problem. Currently only `qn` is
         supported, which automatically selects either L-BFGS or OWL-QN
         depending on the condictions of the l1 regularization described
@@ -148,9 +148,6 @@ class LogisticRegression(Base):
                  solver='qn', handle=None):
 
         super(LogisticRegression, self).__init__(handle=handle, verbose=False)
-
-        if dual:
-            raise ValueError("`dual` parameter not supported.")
 
         if class_weight:
             raise ValueError("`class_weight` not supported.")

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -103,7 +103,9 @@ cdef extern from "glm/glm.hpp" namespace "ML::GLM":
 class QN(Base):
     """
     Quasi-Newton methods are methods used to either find zeroes or local maxima
-    and minima of functions, and used by this class to optimize a cost function.
+    and minima of functions, and used by this class to optimize a cost
+    function.
+
     Two algorithms are implemented underneath cuML's QN class, and which one
     is executed depends on the following rule:
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -102,7 +102,7 @@ cdef extern from "glm/glm.hpp" namespace "ML::GLM":
 
 class QN(Base):
     """
-    Quasi-Newton methods are methods used to either find zeroes or local maxima
+    Quasi-Newton methods are used to either find zeroes or local maxima
     and minima of functions, and used by this class to optimize a cost
     function.
 
@@ -139,7 +139,7 @@ class QN(Base):
         # last position if fit_intercept=True
         print("Coefficients:")
         print(solver.coef_.copy_to_host())
-        print("intercept:")
+        print("Intercept:")
         print(solver.intercept_.copy_to_host())
 
         X_new = cudf.DataFrame()
@@ -148,8 +148,11 @@ class QN(Base):
 
         preds = solver.predict(X_new)
 
+        print("Predictions:")
         print(preds)
+
     Output:
+
     .. code-block:: python
         Coefficients:
                     10.647417
@@ -160,6 +163,7 @@ class QN(Base):
         Predictions:
                     0    0.0
                     1    1.0
+
     Parameters
     -----------
     loss: 'sigmoid', 'softmax', 'squared_loss' (default = 'squared_loss')
@@ -187,10 +191,7 @@ class QN(Base):
         O(lbfgs_memory * D) memory.
     verbose: bool (optional, default False)
         Controls verbosity of logging.
-    num_classes: int (default = 1)
-        number of outputs (C > 1, for multinomial, indicating number of
-        classes. For logistic and normal, C must be 1. For softmax C must be
-        at least 2.
+
     Attributes
     -----------
     coef_ : array, shape (n_classes, n_features)
@@ -198,6 +199,7 @@ class QN(Base):
         Note: shape is (n_classes, n_features + 1) if fit_intercept = True.
     intercept_ : array (n_classes, 1)
         The independent term. If fit_intercept_ is False, will be 0.
+
     Notes
     ------
        This class contains implementations of two popular Quasi-Newton methods:
@@ -211,7 +213,7 @@ class QN(Base):
     def __init__(self, loss='sigmoid', fit_intercept=True,
                  l1_strength=0.0, l2_strength=0.0, max_iter=1000, tol=1e-3,
                  linesearch_max_iter=50, lbfgs_memory=5, verbose=False,
-                 num_classes=1, handle=None):
+                 handle=None):
 
         super(QN, self).__init__(handle=handle, verbose=False)
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -155,7 +155,7 @@ class QN(Base):
                     -17.158297
         Intercept:
                     -17.158297
-        Preds:
+        Predictions:
                     0    0.0
                     1    1.0
     Parameters

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -191,6 +191,13 @@ class QN(Base):
         number of outputs (C > 1, for multinomial, indicating number of
         classes. For logistic and normal, C must be 1. For softmax C must be
         at least 2.
+    Attributes
+    -----------
+    coef_ : array, shape (n_classes, n_features)
+        The estimated coefficients for the linear regression model.
+        Note: shape is (n_classes, n_features + 1) if fit_intercept = True.
+    intercept_ : array (n_classes, 1)
+        The independent term. If fit_intercept_ is False, will be 0.
     Notes
     ------
        This class contains implementations of two popular Quasi-Newton methods:


### PR DESCRIPTION
PR includes docstrings for QN and Logistic, adds them to api.rst.

It also adds a small convenience function to QN to be able to print the intercept like the other classes `qn.intercept_` (since it is part of the coefficients in reality), for consistency of docstrings/printing.