### PR TITLE
[REVIEW] Stylesheet workaround for doc params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PR #719: Adding additional checks for dtype of the data
 - PR #736: Bug fix for RF wrapper and .cu print function
 - PR #547: Fixed issue if C++ compiler is specified via CXX during configure.
+- PR #759: Configure Sphinx to render params correctly
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/docs/source/_static/params.css
+++ b/docs/source/_static/params.css
@@ -1,0 +1,9 @@
+/* Mirrors the change in:
+ *   https://github.com/sphinx-doc/sphinx/pull/5976
+ * which is not showing up in our theme.
+ */
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'numpydoc',
 ]
 
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -177,3 +178,6 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 # Config numpydoc
 numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False
+
+def setup(app):
+    app.add_stylesheet('params.css')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,5 +179,6 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False
 
+
 def setup(app):
     app.add_stylesheet('params.css')


### PR DESCRIPTION
This change fixes the missing ":" in parameters in our API docs. Some themes in sphinx have applied this workaround but for some reason that escapes me it's not showing up in our theme or related ones.