### PR TITLE
[HOTFIX][REVIEW] Add threshold to fix flaky umap test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PR #719: Adding additional checks for dtype of the data
 - PR #736: Bug fix for RF wrapper and .cu print function
 - PR #547: Fixed issue if C++ compiler is specified via CXX during configure.
+- PR #762: Apply threshold to remove flakiness of UMAP tests.
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/python/cuml/test/test_umap.py
+++ b/python/cuml/test/test_umap.py
@@ -88,8 +88,10 @@ def test_umap_fit_transform_score(nrows, n_feats):
 
         assert array_equal(score, cuml_score, 1e-2, with_sign=True)
 
+
 # Allow slight deviation from expected trust due to numerical error
 TRUST_TOLERANCE_THRESH = 0.005
+
 
 def test_supervised_umap_trustworthiness_on_iris():
     iris = datasets.load_iris()

--- a/python/cuml/test/test_umap.py
+++ b/python/cuml/test/test_umap.py
@@ -88,6 +88,8 @@ def test_umap_fit_transform_score(nrows, n_feats):
 
         assert array_equal(score, cuml_score, 1e-2, with_sign=True)
 
+# Allow slight deviation from expected trust due to numerical error
+TRUST_TOLERANCE_THRESH = 0.005
 
 def test_supervised_umap_trustworthiness_on_iris():
     iris = datasets.load_iris()
@@ -95,7 +97,7 @@ def test_supervised_umap_trustworthiness_on_iris():
     embedding = cuUMAP(n_neighbors=10, min_dist=0.01,
                        verbose=False).fit_transform(data, iris.target)
     trust = trustworthiness(iris.data, embedding, 10)
-    assert trust >= 0.97
+    assert trust >= 0.97 - TRUST_TOLERANCE_THRESH
 
 
 def test_semisupervised_umap_trustworthiness_on_iris():
@@ -107,7 +109,7 @@ def test_semisupervised_umap_trustworthiness_on_iris():
                        verbose=False).fit_transform(data, target)
 
     trust = trustworthiness(iris.data, embedding, 10)
-    assert trust >= 0.97
+    assert trust >= 0.97 - TRUST_TOLERANCE_THRESH
 
 
 def test_umap_trustworthiness_on_iris():
@@ -120,7 +122,7 @@ def test_umap_trustworthiness_on_iris():
     # We are doing a spectral embedding but not a
     # multi-component layout (which is marked experimental).
     # As a result, our score drops by 0.006.
-    assert trust >= 0.964
+    assert trust >= 0.964 - TRUST_TOLERANCE_THRESH
 
 
 @pytest.mark.parametrize('name', dataset_names)


### PR DESCRIPTION
This relaxes thresholds rather than skipping the tests completely so we'd still catch something egregious if it happens.
It relates to Issue #562 , another perhaps deeper approach to solving the flakiness.