### PR TITLE
[HOTFIX][REVIEW][BUG] Properly freeing memory in nearest neighbors python class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - PR #547: Fixed issue if C++ compiler is specified via CXX during configure.
 - PR #759: Configure Sphinx to render params correctly
 - PR #762: Apply threshold to remove flakiness of UMAP tests.
+- PR #768: Fixing memory bug from stateless refactor
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -346,6 +346,7 @@ class UMAP(Base):
                 < float*>embed_raw)
 
         del X_m
+        return self
 
     def fit_transform(self, X, y=None):
         """Fit X into an embedded space and return that transformed

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -309,6 +309,8 @@ class NearestNeighbors(Base):
             self.sizes = <size_t>sizes_arr
             self.input = <size_t>input_arr
 
+        return self 
+
     def _fit_mg(self, n_dims, alloc_info):
         """
         Fits a model using multiple GPUs. This method takes in a list of dict

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -309,7 +309,7 @@ class NearestNeighbors(Base):
             self.sizes = <size_t>sizes_arr
             self.input = <size_t>input_arr
 
-        return self 
+        return self
 
     def _fit_mg(self, n_dims, alloc_info):
         """

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -203,6 +203,13 @@ class NearestNeighbors(Base):
         self.devices = devices
         self.n_neighbors = n_neighbors
         self._should_downcast = should_downcast
+        self.sizes = None
+        self.inputs = None
+
+    def __del__(self):
+        if self.sizes is not None:
+            free(<int*><size_t>self.sizes)
+            free(<float**><size_t>self.inputs)
 
     def fit(self, X):
         """


### PR DESCRIPTION
This was an oversight in switching NearestNeighbors from a pure Cython class to a Python class. The `__dealloc__` function was removed with the Cython code and a corresponding `__del__` was never restored.  