### PR TITLE
[HOTFIX][REVIEW] Fixing nearest neighbors destructor for the non-pickleable knn version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - PR #759: Configure Sphinx to render params correctly
 - PR #762: Apply threshold to remove flakiness of UMAP tests.
 - PR #768: Fixing memory bug from stateless refactor
+- PR #782: Nearest neighbors checking properly whether memory should be freed
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -204,12 +204,18 @@ class NearestNeighbors(Base):
         self.n_neighbors = n_neighbors
         self._should_downcast = should_downcast
         self.n_indices = 0
+        self.X_m = None
+
 
     def __del__(self):
+
+        # Explicitly free these since they were allocated
+        # on the heap. 
         if self.n_indices > 0:
             free(<int*><size_t>self.sizes)
             free(<float**><size_t>self.input)
             self.n_indices = 0
+
 
     def fit(self, X):
         """

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -206,16 +206,14 @@ class NearestNeighbors(Base):
         self.n_indices = 0
         self.X_m = None
 
-
     def __del__(self):
 
         # Explicitly free these since they were allocated
-        # on the heap. 
+        # on the heap.
         if self.n_indices > 0:
             free(<int*><size_t>self.sizes)
             free(<float**><size_t>self.input)
             self.n_indices = 0
-
 
     def fit(self, X):
         """

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -204,7 +204,6 @@ class NearestNeighbors(Base):
         self.n_neighbors = n_neighbors
         self._should_downcast = should_downcast
         self.n_indices = 0
-        self.X_m = None
 
     def __del__(self):
 

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -84,6 +84,30 @@ def test_knn(input_type, should_downcast, nrows, n_feats, k):
         assert I_cuml_arr.all() == I_sk.all()
 
 
+
+def test_knn_fit_twice():
+    """
+    Test that fitting a model twice does not fail.
+    This is necessary since the NearestNeighbors class
+    needs to free Cython allocated heap memory when
+    fit() is called more than once.
+    """
+
+    n_samples = 50
+    n_feats = 50
+    k = 5
+
+    X, y = make_blobs(n_samples=n_samples,
+                      n_features=n_feats, random_state=0)
+
+    knn_cu = cuKNN()
+    knn_cu.fit(X)
+    knn_cu.fit(X)
+
+    knn_cu.kneighbors(X, k)
+
+
+
 @pytest.mark.parametrize('input_type', ['ndarray'])
 @pytest.mark.parametrize('nrows', [unit_param(20), quality_param(5000),
                          stress_param(500000)])

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -84,7 +84,6 @@ def test_knn(input_type, should_downcast, nrows, n_feats, k):
         assert I_cuml_arr.all() == I_sk.all()
 
 
-
 def test_knn_fit_twice():
     """
     Test that fitting a model twice does not fail.
@@ -107,7 +106,6 @@ def test_knn_fit_twice():
     knn_cu.kneighbors(X, k)
 
     del knn_cu
-
 
 
 @pytest.mark.parametrize('input_type', ['ndarray'])

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -106,6 +106,8 @@ def test_knn_fit_twice():
 
     knn_cu.kneighbors(X, k)
 
+    del knn_cu
+
 
 
 @pytest.mark.parametrize('input_type', ['ndarray'])

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -186,6 +186,7 @@ def test_decomposition_pickle_xfail(tmpdir, datatype, model, nrows, ncols):
 @pytest.mark.parametrize('nrows', [unit_param(20)])
 @pytest.mark.parametrize('ncols', [unit_param(3)])
 @pytest.mark.parametrize('k', [unit_param(3)])
+@pytest.mark.skip(reason="This feature will be in a future version")
 def test_neighbors_pickle(tmpdir, datatype, model, nrows, ncols, k):
     X_train, _, X_test = make_dataset(datatype, nrows, ncols)
 


### PR DESCRIPTION
The previous destructor works in the pickleable version introduced in 0.9, but will not work in the current version. 