### PR TITLE
[HOTFIX][REVIEW] Fix jit shuffle function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - PR #768: Fixing memory bug from stateless refactor
 - PR #776: Hotfix for self.variables in RF
 - PR #777: Fix numpy input bug
+- PR #784: Fix jit of shuffle_idx python function
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -21,7 +21,7 @@ import numpy as np
 
 @jit
 def _shuffle_idx(idx: np.ndarray):
-    """ Shuffle indices in place which will be used as indices to split a
+    """ Shuffle idx in place which will be used as indices to split a
     dataframe of size len(np.ndarray)
     """
     # TODO this is the bottleneck and should be a gpu operation,

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -21,8 +21,8 @@ import numpy as np
 
 @jit
 def _shuffle_idx(idx: np.ndarray):
-    """ Return indices which will be used as indices to split a dataframe of
-    size len(np.ndarray)
+    """ Shuffle indices in place which will be used as indices to split a
+    dataframe of size len(np.ndarray)
     """
     # TODO this is the bottleneck and should be a gpu operation,
     # when possible replace with the mlprim mentioned in cuml #659

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -20,8 +20,9 @@ import numpy as np
 
 
 @jit
-def _shuffle_idx(idx: np.ndarray) -> np.ndarray:
-    """ Return indices which represent a randomly shuffled version of `df`
+def _shuffle_idx(idx: np.ndarray):
+    """ Return indices which will be used as indices to split a dataframe of
+    size len(np.ndarray)
     """
     # TODO this is the bottleneck and should be a gpu operation,
     # when possible replace with the mlprim mentioned in cuml #659
@@ -95,7 +96,7 @@ def train_test_split(
 
     # Replace Numpy/cuDF here when issue mentioned above is solved!
     if shuffle:
-        idxs = cudf.utils.cudautils.arange(len(X)).copy_to_host()
+        idxs = np.arange(len(X))
         _shuffle_idx(idxs)
         X = X.iloc[idxs].reset_index(drop=True)
         y = y.iloc[idxs].reset_index(drop=True)

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -18,7 +18,7 @@ import cudf
 from cuml.preprocessing.model_selection import train_test_split
 
 
-@pytest.mark.parametrize("n_rows", [100, 100000])
+@pytest.mark.parametrize("n_rows", [100, 10000])
 @pytest.mark.parametrize("train_size", [0.0, 0.1, 0.5, 0.75, 1.0])
 def test_split(n_rows, train_size):
     X = cudf.DataFrame({"x": range(n_rows)})
@@ -41,7 +41,7 @@ def test_split(n_rows, train_size):
     assert all(y_reconstructed == y)
 
 
-@pytest.mark.parametrize("n_rows", [100, 100000])
+@pytest.mark.parametrize("n_rows", [100, 10000])
 def test_split_column(n_rows):
     data = cudf.DataFrame(
         {


### PR DESCRIPTION
Shuffle idx was a jitted function that was allocating memory which was causing issues, replacing with using shuffle removes the numba dtype error in tests and also should solve the issue ```*** Error in `/conda/envs/gdf/bin/python': corrupted double-linked list: 0x0000561c52741a20 ***``` that was causing core dumps in CI pytests.