### PR TITLE
[HOTFIX][REVIEW] Numba dtype conversion output type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - PR #776: Hotfix for self.variables in RF
 - PR #777: Fix numpy input bug
 - PR #784: Fix jit of shuffle_idx python function
+- PR #793: Fix for dtype conversion utility for numba arrays without cupy installed
 
 # cuML 0.7.0 (10 May 2019)
 

--- a/python/cuml/utils/input_utils.py
+++ b/python/cuml/utils/input_utils.py
@@ -206,7 +206,8 @@ def convert_dtype(X, to_dtype=np.float32):
 
             X_df = cudf.DataFrame()
             X = X_df.from_gpu_matrix(X)
-            return convert_dtype(X, to_dtype=to_dtype)
+            X = convert_dtype(X, to_dtype=to_dtype)
+            return X.as_gpu_matrix()
 
     elif isinstance(X, cudf.DataFrame):
         dtype = np.dtype(X[X.columns[0]]._column.dtype)


### PR DESCRIPTION
Small fix so that the output of the dtype conversion coincides when the data is a numba array when CuPy is not used