### PR TITLE
made the build.sh slightly more efficient by clubbing all make targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - PR #766: Expose score method based on inertia for KMeans
 
 ## Improvements
+- PR #822: build: build.sh update to club all make targets together
 
 ## Bug Fixes
 

--- a/build.sh
+++ b/build.sh
@@ -139,11 +139,19 @@ if (( ${NUMARGS} == 0 )) || hasArg libcuml || hasArg prims; then
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 fi
 
-# Build and (optionally) install libcuml + tests
+# Run all make targets at once
+MAKE_TARGETS=
 if (( ${NUMARGS} == 0 )) || hasArg libcuml; then
+    MAKE_TARGETS="${MAKE_TARGETS}cuml++ cuml ml ml_mg"
+fi
+if (( ${NUMARGS} == 0 )) || hasArg prims; then
+    MAKE_TARGETS="${MAKE_TARGETS} prims"
+fi
 
+# Build and (optionally) install libcuml + tests
+if [ "${MAKE_TARGETS}" != "" ]; then
     cd ${LIBCUML_BUILD_DIR}
-    make -j${PARALLEL_LEVEL} cuml++ cuml ml ml_mg VERBOSE=${VERBOSE} ${INSTALL_TARGET}
+    make -j${PARALLEL_LEVEL} ${MAKE_TARGETS} VERBOSE=${VERBOSE} ${INSTALL_TARGET}
 fi
 
 # Build and (optionally) install the cuml Python package
@@ -156,11 +164,4 @@ if (( ${NUMARGS} == 0 )) || hasArg cuml; then
     else
 	python setup.py build_ext --inplace --library-dir=${LIBCUML_BUILD_DIR} ${MULTIGPU}
     fi
-fi
-
-# Build the ML prims tests
-if (( ${NUMARGS} == 0 )) || hasArg prims; then
-
-    cd ${LIBCUML_BUILD_DIR}
-    make -j${PARALLEL_LEVEL} VERBOSE=${VERBOSE} prims
 fi


### PR DESCRIPTION
This is slightly faster than splitting libcuml and prims targets separate. @dantegd for review.