### PR TITLE
Symmetrization directly from KNN indices, distances (X + X.T)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #635: Random Forest & Decision Tree Regression (Single-GPU)
 - PR #829: C++: enable nvtx ranges
 - PR #837: treelite for decision forest exchange format
+- PR #852: Symmetrization directly from KNN indices, distances (X + X.T)
 
 ## Improvements
 - PR #822: build: build.sh update to club all make targets together

--- a/cpp/src_prims/sparse/coo.h
+++ b/cpp/src_prims/sparse/coo.h
@@ -806,6 +806,181 @@ void coo_symmetrize(COO<T> *const in, COO<T> *out,
     in->n_rows, in->nnz, reduction_op);
   CUDA_CHECK(cudaPeekAtLastError());
 }
+ 
+
+// To suppress some warnings --> allow unsigned ints
+#define ceil_uint(a, b) ((a + b - 1) / b)
+#define restrict __restrict__
+
+/**
+ * @brief Find how much space needed in each row.
+ * We look through all datapoints and increment the count for each row.
+ *
+ * @param data: Input knn distances(n, k)
+ * @param indices: Input knn indices(n, k)
+ * @param n: Number of rows
+ * @param k: Number of n_neighbors
+ * @param row_sizes: Input empty row sum 1 array(n)
+ * @param row_sizes2: Input empty row sum 2 array(n) for faster reduction
+ */
+template <typename math_t> __global__ static void
+symmetric_find_size(const math_t *restrict data,
+                    const long *restrict indices,
+                    const int n, const int k,
+                    int *restrict row_sizes,
+                    int *restrict row_sizes2)
+{
+  const int j = (blockIdx.x * blockDim.x) + threadIdx.x;  // for every item in row
+  const int row = (blockIdx.y * blockDim.y) + threadIdx.y;  // for every row
+  if (row >= n || j >= k) return;
+
+  const int col = indices[row*k + j];
+  if (j % 2)  atomicAdd(&row_sizes[col], 1);
+  else        atomicAdd(&row_sizes2[col], 1);
+}
+
+
+/**
+ * @brief Reduce sum(row_sizes) + k
+ * Reduction for symmetric_find_size kernel. Allows algo to be faster.
+ *
+ * @param n: Number of rows
+ * @param k: Number of n_neighbors
+ * @param row_sizes: Input row sum 1 array(n)
+ * @param row_sizes2: Input row sum 2 array(n) for faster reduction
+ */
+__global__ static void
+reduce_find_size(const int n, const int k,
+                int *restrict row_sizes,
+                const int *restrict row_sizes2)
+{
+  const int i = (blockIdx.x * blockDim.x) + threadIdx.x;
+  if (i >= n) return;
+  row_sizes[i] += (row_sizes2[i] + k);
+}
+
+
+
+/**
+ * @brief Perform data + data.T operation.
+ * Can only run once row_sizes from the CSR matrix of data + data.T has been
+ * determined.
+ *
+ * @param edges: Input row sum array(n) after reduction
+ * @param data: Input knn distances(n, k)
+ * @param indices: Input knn indices(n, k)
+ * @param VAL: Output values for data + data.T
+ * @param COL: Output column indices for data + data.T
+ * @param ROW: Output row indices for data + data.T
+ * @param n: Number of rows
+ * @param k: Number of n_neighbors
+ */
+template <typename math_t> __global__ static void
+symmetric_sum(int *restrict edges,
+              const math_t *restrict data,
+              const long *restrict indices,
+              math_t *restrict VAL,
+              int *restrict COL,
+              int *restrict ROW,
+              const int n, const int k)
+{
+  const int j = (blockIdx.x * blockDim.x) + threadIdx.x;  // for every item in row
+  const int row = (blockIdx.y * blockDim.y) + threadIdx.y;  // for every row
+  if (row >= n || j >= k) return;
+
+  const int col = indices[row*k + j];
+  const int original = atomicAdd(&edges[row], 1);
+  const int transpose = atomicAdd(&edges[col], 1);
+
+  VAL[transpose] = VAL[original] = data[row*k + j];
+  // Notice swapped ROW, COL since transpose
+  ROW[original] = row;
+  COL[original] = col;
+
+  ROW[transpose] = col;
+  COL[transpose] = row;
+}
+
+
+
+
+/**
+ * @brief Perform data + data.T on raw KNN data.
+ * The following steps are invoked:
+ * (1) Find how much space needed in each row
+ * (2) Compute final space needed (n*k + sum(row_sizes)) == 2*n*k
+ * (3) Allocate new space
+ * (4) Prepare edges for each new row
+ * (5) Perform final data + data.T operation
+ * (6) Return summed up VAL, COL, ROW
+ *
+ * @param knn_indices: Input knn distances(n, k)
+ * @param knn_dists: Input knn indices(n, k)
+ * @param n: Number of rows
+ * @param k: Number of n_neighbors
+ * @param out: Output COO Matrix class
+ * @param stream: Input cuda stream
+ */
+template <typename math_t, int TPB_X = 32, int TPB_Y = 32> void
+from_knn_symmetrize_matrix(const long *restrict knn_indices,
+                          const math_t *restrict knn_dists,
+                          const int n, const int k, COO<math_t> *out,
+                          cudaStream_t stream)
+{   
+  // (1) Find how much space needed in each row
+  // We look through all datapoints and increment the count for each row.
+  const dim3 threadsPerBlock(TPB_X, TPB_Y);
+  const dim3 numBlocks(ceil_uint(k, threadsPerBlock.x), ceil_uint(n, threadsPerBlock.y));
+
+
+  // Notice n+1 since we can reuse these arrays for transpose_edges, original_edges in step (4)
+  int *row_sizes;
+  MLCommon::allocate(row_sizes, n, true);
+  int *row_sizes2;
+  MLCommon::allocate(row_sizes2, n, true);
+
+  symmetric_find_size<<<numBlocks, threadsPerBlock, 0, stream>>>(
+    knn_dists, knn_indices, n, k, row_sizes, row_sizes2);
+  CUDA_CHECK(cudaPeekAtLastError());
+
+  reduce_find_size<<<ceil_uint(n, 1024), 1024, 0, stream>>>(n, k, row_sizes, row_sizes2);
+  CUDA_CHECK(cudaPeekAtLastError());
+
+
+  // (2) Compute final space needed (n*k + sum(row_sizes)) == 2*n*k
+  // Notice we don't do any merging and leave the result as 2*NNZ
+  const int NNZ = 2*n*k;
+
+
+  // (3) Allocate new space
+  out->allocate(NNZ, n, n);
+
+
+  // (4) Prepare edges for each new row
+  // This mirrors CSR matrix's row Pointer, were maximum bounds for each row
+  // are calculated as the cumulative rolling sum of the previous rows.
+  // Notice reusing old row_sizes2 memory
+  int *edges = row_sizes2;
+  thrust::device_ptr<int> __edges = thrust::device_pointer_cast(edges);
+  thrust::device_ptr<int> __row_sizes = thrust::device_pointer_cast(row_sizes);
+
+  // Rolling cumulative sum
+  thrust::exclusive_scan(thrust::cuda::par.on(stream), __row_sizes, __row_sizes + n, __edges);
+  // Set last to NNZ only if CSR needed
+  // CUDA_CHECK(cudaMemcpy(edges + n, &NNZ, sizeof(int), cudaMemcpyHostToDevice));
+
+
+  // (5) Perform final data + data.T operation in tandem with memcpying
+  symmetric_sum<<<numBlocks, threadsPerBlock, 0, stream>>>(
+    edges, knn_dists, knn_indices, 
+    out->vals, out->cols, out->rows, n, k);
+  CUDA_CHECK(cudaPeekAtLastError());
+
+
+  CUDA_CHECK(cudaFree(row_sizes));
+  CUDA_CHECK(cudaFree(row_sizes2));
+}
+
 
 };  // namespace Sparse
 };  // namespace MLCommon


### PR DESCRIPTION
Performs X + X.T (will support f(X + X.T) later) directly from KNN distances / indices.
:)

In the future, will merge up all duplicate entries to make f(X + X.T) possible and allow downstream tasks to be faster in general.

Also, this code can be easily refactored for CSR output, since as of now I am discarding the Row Pointers used in CSR.