### PR TITLE
[WIP] Added test suites for Dask + UCX P2P tag matching send/receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #819: Forest Inferencing Library (FIL)
 - PR #829: C++: enable nvtx ranges
 - PR #837: treelite for decision forest exchange format
+- PR #867: Additional test suites for Dask + UCX tag matching send/receive
 
 ## Improvements
 - PR #822: build: build.sh update to club all make targets together

--- a/cpp/src/comms/cuML_comms_test.cpp
+++ b/cpp/src/comms/cuML_comms_test.cpp
@@ -16,9 +16,14 @@
 
 #include "cuML_comms_test.hpp"
 
+#include <common/Timer.h>
 #include <common/cumlHandle.hpp>
 #include <common/cuml_comms_int.hpp>
 #include <common/device_buffer.hpp>
+#include <common/host_buffer.hpp>
+
+#include <algorithm>
+#include <cstring>
 #include <iostream>
 
 namespace ML {
@@ -109,6 +114,190 @@ bool test_pointToPoint_simple_send_recv(const ML::cumlHandle& h,
   }
 
   return ret;
+}
+
+bool test_p2p_send_recv(const ML::cumlHandle& h, bool checkRxData,
+                        bool srcIsDevice, bool dstIsDevice, int numP2pPeers,
+                        int* p2pDstRankOffsets, int msg_size, int num_trials) {
+  const auto& handle = h.getImpl();
+  ASSERT(handle.commsInitialized() == true, "communicator uninitialized.");
+  const auto& communicator = handle.getCommunicator();
+  const auto rank = communicator.getRank();
+  const auto comm_size = communicator.getSize();
+  const auto tag = int{0};
+
+  // check input arguments
+
+  ASSERT((numP2pPeers > 0) && (numP2pPeers < comm_size),
+         "invalid input argument: numP2pPeers=%d.", numP2pPeers);
+  for (auto i = int{0}; i < numP2pPeers; i++) {
+    auto offset = p2pDstRankOffsets[i];
+    ASSERT((offset > 0) && (offset < comm_size),
+           "invalid input argument: p2pDstRankOffsets[%d]=%d.", i, offset);
+  }
+  ASSERT(msg_size > 0, "invalid input argument: msg_size=%d.", msg_size);
+  ASSERT(num_trials > 0, "invalid input argument: num_trials=%d.", num_trials);
+
+  // update source & destination ranks
+
+  std::vector<int> v_dst_rank(numP2pPeers, -1);
+  std::vector<int> v_src_rank(numP2pPeers, -1);
+  for (auto i = int{0}; i < numP2pPeers; i++) {
+    auto offset = p2pDstRankOffsets[i];
+    v_dst_rank[i] = (rank + offset) % comm_size;
+    v_src_rank[i] = (rank + comm_size - offset) % comm_size;
+  }
+
+  // allocate tx & rx buffers (and tmp buffer if both checkRxData and
+  // dstIsDevice are true)
+
+  auto stream = h.getStream();
+
+  auto&& tx_buf_d = MLCommon::device_buffer<unsigned char>(
+    handle.getDeviceAllocator(), stream, 0);
+  auto&& rx_buf_d = MLCommon::device_buffer<unsigned char>(
+    handle.getDeviceAllocator(), stream, 0);
+
+  auto&& tx_buf_h =
+    MLCommon::host_buffer<unsigned char>(handle.getHostAllocator(), stream, 0);
+  auto&& rx_buf_h =
+    MLCommon::host_buffer<unsigned char>(handle.getHostAllocator(), stream, 0);
+
+  auto&& tmp_buf_h =
+    MLCommon::host_buffer<unsigned char>(handle.getHostAllocator(), stream, 0);
+
+  if (srcIsDevice) {
+    tx_buf_d.resize(msg_size * numP2pPeers, stream);
+  } else {
+    tx_buf_h.resize(msg_size * numP2pPeers, stream);
+  }
+
+  if (dstIsDevice) {
+    rx_buf_d.resize(msg_size * numP2pPeers, stream);
+    if (checkRxData) {
+      tmp_buf_h.resize(msg_size, stream);
+    }
+  } else {
+    rx_buf_h.resize(msg_size * numP2pPeers, stream);
+  }
+
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  auto vp_tx_buf = std::vector<unsigned char*>(numP2pPeers, nullptr);
+  if (srcIsDevice) {
+    CUDA_CHECK(cudaMemset(tx_buf_d.data(), 0x00, tx_buf_d.size()));
+    for (auto i = 0; i < numP2pPeers; i++) {
+      vp_tx_buf[i] = tx_buf_d.data() + msg_size * i;
+    }
+  } else {
+    memset(tx_buf_h.data(), 0x00, tx_buf_h.size());
+    for (auto i = 0; i < numP2pPeers; i++) {
+      vp_tx_buf[i] = tx_buf_h.data() + msg_size * i;
+    }
+  }
+
+  auto vp_rx_buf = std::vector<unsigned char*>(numP2pPeers, nullptr);
+  if (dstIsDevice) {
+    CUDA_CHECK(cudaMemset(rx_buf_d.data(), 0x00, rx_buf_d.size()));
+    for (auto i = 0; i < numP2pPeers; i++) {
+      vp_rx_buf[i] = rx_buf_d.data() + msg_size * i;
+    }
+    if (checkRxData) {
+      CUDA_CHECK(cudaMemset(tmp_buf_h.data(), 0x00, tmp_buf_h.size()));
+    }
+  } else {
+    memset(rx_buf_h.data(), 0x00, rx_buf_h.size());
+    for (auto i = 0; i < numP2pPeers; i++) {
+      vp_rx_buf[i] = rx_buf_h.data() + msg_size * i;
+    }
+  }
+
+  communicator.barrier();
+
+  auto timer = MLCommon::TimerCPU{};
+
+  // start p2p send/recieve
+
+  for (auto trial = int{0}; trial < num_trials; trial++) {
+    if (checkRxData) {
+      // update tx data
+
+      if (srcIsDevice) {
+        CUDA_CHECK(cudaMemset(tx_buf_d.data(), (rank + num_trials) & 0xff,
+                              tx_buf_d.size()));
+      } else {
+        std::memset(tx_buf_h.data(), (rank + num_trials) & 0xff,
+                    tx_buf_h.size());
+      }
+    }
+
+    // post rx & tx
+
+    auto v_request = std::vector<MLCommon::cumlCommunicator::request_t>(
+      2 * numP2pPeers);  // first half: tx, second half: rx
+
+    for (auto i = int{0}; i < numP2pPeers; i++) {
+      communicator.irecv(vp_rx_buf[i], msg_size, v_src_rank[i], tag,
+                         &(v_request[numP2pPeers + i]));
+    }
+
+    for (auto i = int{0}; i < numP2pPeers; i++) {
+      communicator.isend(vp_tx_buf[i], msg_size, v_dst_rank[i], tag,
+                         &(v_request[i]));
+    }
+
+    // wait
+
+    communicator.waitall(v_request.size(), v_request.data());
+
+    // check rx data
+
+    if (checkRxData) {
+      auto num_err_workers = int{0};
+      for (auto i = int{0}; i < numP2pPeers; i++) {
+        auto p_data = static_cast<unsigned char*>(nullptr);
+        if (dstIsDevice) {
+          p_data = tmp_buf_h.data();
+          CUDA_CHECK(cudaMemcpyAsync(p_data, vp_rx_buf[i], msg_size,
+                                     cudaMemcpyDeviceToHost, stream));
+          CUDA_CHECK(cudaStreamSynchronize(stream));
+        } else {
+          p_data = vp_rx_buf[i];
+        }
+        auto src_rank = v_src_rank[i];
+        auto num_mismatches = std::count_if(
+          p_data, p_data + msg_size, [src_rank, num_trials](unsigned char i) {
+            return (i != (src_rank + num_trials) & 0xff);
+          });
+        if (num_mismatches > 0) {
+          num_err_workers++;
+        }
+      }
+
+      // this is not good. We need host memory version of allreduce as well.
+
+      auto&& tmp_d =
+        MLCommon::device_buffer<int>(handle.getDeviceAllocator(), stream, 1);
+      CUDA_CHECK(cudaMemcpyAsync(tmp_d.data(), &num_err_workers, sizeof(int),
+                                 cudaMemcpyHostToDevice, stream));
+      communicator.allreduce(tmp_d.data(), tmp_d.data(), 1,
+                             MLCommon::cumlCommunicator::SUM, stream);
+      CUDA_CHECK(cudaMemcpyAsync(&num_err_workers, tmp_d.data(), sizeof(int),
+                                 cudaMemcpyDeviceToHost, stream));
+      CUDA_CHECK(cudaStreamSynchronize(stream));
+      if (num_err_workers > 0) {
+        return false;
+      }
+    }
+  }
+
+  communicator.barrier();
+
+  auto elapsed_time = timer.getElapsedSeconds();
+
+  std::cout << "Elapsed time: " << elapsed_time << " seconds." << std::endl;
+
+  return true;
 }
 
 };  // namespace Comms

--- a/cpp/src/comms/cuML_comms_test.hpp
+++ b/cpp/src/comms/cuML_comms_test.hpp
@@ -37,5 +37,25 @@ bool test_collective_allreduce(const ML::cumlHandle& handle);
 bool test_pointToPoint_simple_send_recv(const ML::cumlHandle& handle,
                                         int n_trials);
 
+/**
+ * @brief Point-to-point tag matching send/receive test. Each rank send data to
+ * numP2pPeers and recieve data from numP2pPeers.
+ * @param[in] handle cumlHandle instance with initialized cumlCommunicator.
+ * @param[in] checkRxData if set to true, perform correctness test for received
+ * data. Set to false to measure send/receive performance.
+ * @param[in] srcIsDevice if true source (send) data are placed in device
+ * memory. If false, source data are placed in host memory.
+ * @param[in] dstIsDevice if true, destination (receive) data are placed in
+ * device memory. If false, destination data are placed in host memory.
+ * @param[in] numP2pPeers number of peer ranks to send/receive data.
+ * @param[in] p2pDstRankOffsets pointer to the array storing destination
+ * rank offsets (array size: numP2pPeers).
+ * @param[in] msgSize message size.
+ * @param[in] numTrials number of iterations to pass messages.
+ */
+bool test_p2p_send_recv(const ML::cumlHandle& handle, bool checkRxData,
+                        bool srcIsDevice, bool dstIsDevice, int numP2pPeers,
+                        int* p2pDstRankOffsets, int msgSize, int numTrials);
+
 };  // namespace Comms
 };  // end namespace ML

--- a/python/cuml/dask/common/__init__.py
+++ b/python/cuml/dask/common/__init__.py
@@ -18,6 +18,7 @@ from cuml.dask.common.comms import CommsContext, worker_state, default_comms
 
 from cuml.dask.common.comms_utils import inject_comms_on_handle, \
     perform_test_comms_allreduce, perform_test_comms_send_recv, \
+    perform_test_comms_p2p_send_recv, \
     inject_comms_on_handle_coll_only, is_ucx_enabled
 
 from cuml.dask.common.dask_df_utils import get_meta, to_dask_cudf, extract_ddf_partitions

--- a/python/cuml/dask/common/comms_utils.pyx
+++ b/python/cuml/dask/common/comms_utils.pyx
@@ -105,16 +105,16 @@ def perform_test_comms_p2p_send_recv(handle,
     cdef const cumlHandle* h = <cumlHandle*><size_t>handle.getHandle()
     cdef int *offsets = <int*> malloc(len(p2p_dst_rank_offsets)*sizeof(int))
     for i in range(len(p2p_dst_rank_offsets)):
-      offsets[i] = <int>p2p_dst_rank_offsets[i]
+        offsets[i] = <int>p2p_dst_rank_offsets[i]
 
     ret = test_p2p_send_recv(deref(h),
-                              <bool>check_rx_data,
-                              <bool>src_is_device,
-                              <bool>dst_is_device,
-                              <int>num_p2p_peers,
-                              offsets,
-                              <int>msg_size,
-                              <int>n_trials)
+                             <bool>check_rx_data,
+                             <bool>src_is_device,
+                             <bool>dst_is_device,
+                             <int>num_p2p_peers,
+                             offsets,
+                             <int>msg_size,
+                             <int>n_trials)
     free(offsets)
 
     return ret


### PR DESCRIPTION
Only lightly tested with a known Device to Device performance issue (this is currently blocked on UCX updates).

This PR builds on top of https://github.com/rapidsai/cuml/pull/812 and add additional tests for P2P tag matching send receive.

Additional tests consider H(ost)->H, D(evice)->D, H->D, and D->H data transfers with varying message sizes.