### PR TITLE
Fix typo in comms build instructions [skip ci]

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -93,7 +93,7 @@ $ ./test/prims --gtest_list_tests # ML Primitive function tests
 
 4. Build and install `libcumlcomms` (C++/CUDA library enabling multi-node multi-GPU communications), starting from the repository root folder:
 ```bash
-$ cd cpp/comms
+$ cd cpp/comms/std
 $ mkdir build && cd build
 $ cmake ..
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #849: PCA no attribute trans_input_ transform bug fix
 - PR #869: Removing incorrect information from KNN Docs
 - PR #885: libclang installation fix for GPUCI
+- PR #896: Fix typo in comms build instructions
 
 # cuML 0.8.0 (27 June 2019)
 


### PR DESCRIPTION
Attempting to set record for most trivial cuML change in history... just a small typo.