### PR TITLE
[REVIEW] Adding sync stream to the comms that aborts nccl comms on async error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #857: Small modifications to comms for utilizing IB w/ Dask
 - PR #851: Random forest Stateless API wrappers
 - PR #895: Pretty prints arguments!
+- PR #915: syncStream added to cumlCommunicator
 
 ## Bug Fixes
 

--- a/cpp/comms/std/src/cuML_std_comms_impl.cpp
+++ b/cpp/comms/std/src/cuML_std_comms_impl.cpp
@@ -415,12 +415,14 @@ MLCommon::cumlCommunicator::status_t cumlStdCommunicator_impl::syncStream(cudaSt
 
     if (cudaErr != cudaErrorNotReady) {
       printf("CUDA Error : cudaStreamQuery returned %d\n", cudaErr);
+      // An error occurred querying the status of the stream
       return status_t::commStatusError;
     }
 
     ncclErr = ncclCommGetAsyncError(_nccl_comm, &ncclAsyncErr);
     if (ncclErr != ncclSuccess) {
       printf("NCCL Error : ncclCommGetAsyncError returned %d\n", ncclErr);
+      // An error occurred retrieving the asynchronous error
       return status_t::commStatusError;
     }
 
@@ -430,7 +432,7 @@ MLCommon::cumlCommunicator::status_t cumlStdCommunicator_impl::syncStream(cudaSt
       ncclErr = ncclCommAbort(_nccl_comm);
       if (ncclErr != ncclSuccess)
         printf("NCCL Error : ncclCommDestroy returned %d\n", ncclErr);
-      // Caller may abort or try to re-create a new communicator.
+      // Caller may abort with an exception or try to re-create a new communicator.
       return status_t::commStatusAbort;
     }
 

--- a/cpp/comms/std/src/cuML_std_comms_impl.cpp
+++ b/cpp/comms/std/src/cuML_std_comms_impl.cpp
@@ -261,7 +261,8 @@ void cumlStdCommunicator_impl::barrier() const {
   allreduce(_sendbuff, _recvbuff, 1, MLCommon::cumlCommunicator::INT,
             MLCommon::cumlCommunicator::SUM, _stream);
 
-  cudaStreamSynchronize(_stream);
+  ASSERT(syncStream(_stream) == status_t::commStatusSuccess,
+         "ERROR: syncStream failed. This can be caused by a failed rank.");
 }
 
 void cumlStdCommunicator_impl::get_request_id(request_t *req) const {
@@ -406,7 +407,8 @@ void cumlStdCommunicator_impl::reducescatter(const void *sendbuff,
                                _nccl_comm, stream));
 }
 
-MLCommon::cumlCommunicator::status_t cumlStdCommunicator_impl::syncStream(cudaStream_t stream) const {
+MLCommon::cumlCommunicator::status_t cumlStdCommunicator_impl::syncStream(
+  cudaStream_t stream) const {
   cudaError_t cudaErr;
   ncclResult_t ncclErr, ncclAsyncErr;
   while (1) {

--- a/cpp/comms/std/src/cuML_std_comms_impl.cpp
+++ b/cpp/comms/std/src/cuML_std_comms_impl.cpp
@@ -416,14 +416,12 @@ MLCommon::cumlCommunicator::status_t cumlStdCommunicator_impl::syncStream(
     if (cudaErr == cudaSuccess) return status_t::commStatusSuccess;
 
     if (cudaErr != cudaErrorNotReady) {
-      printf("CUDA Error : cudaStreamQuery returned %d\n", cudaErr);
       // An error occurred querying the status of the stream
       return status_t::commStatusError;
     }
 
     ncclErr = ncclCommGetAsyncError(_nccl_comm, &ncclAsyncErr);
     if (ncclErr != ncclSuccess) {
-      printf("NCCL Error : ncclCommGetAsyncError returned %d\n", ncclErr);
       // An error occurred retrieving the asynchronous error
       return status_t::commStatusError;
     }
@@ -433,9 +431,8 @@ MLCommon::cumlCommunicator::status_t cumlStdCommunicator_impl::syncStream(
       // the communicator
       ncclErr = ncclCommAbort(_nccl_comm);
       if (ncclErr != ncclSuccess)
-        printf("NCCL Error : ncclCommDestroy returned %d\n", ncclErr);
-      // Caller may abort with an exception or try to re-create a new communicator.
-      return status_t::commStatusAbort;
+        // Caller may abort with an exception or try to re-create a new communicator.
+        return status_t::commStatusAbort;
     }
 
     // Let other threads (including NCCL threads) use the CPU.

--- a/cpp/comms/std/src/cuML_std_comms_impl.hpp
+++ b/cpp/comms/std/src/cuML_std_comms_impl.hpp
@@ -113,6 +113,8 @@ class cumlStdCommunicator_impl : public MLCommon::cumlCommunicator_iface {
                              int recvcount, datatype_t datatype, op_t op,
                              cudaStream_t stream) const;
 
+  virtual status_t syncStream(cudaStream_t stream) const;
+
  private:
   ncclComm_t _nccl_comm;
   cudaStream_t _stream;

--- a/cpp/src/common/cuML_comms_impl.cpp
+++ b/cpp/src/common/cuML_comms_impl.cpp
@@ -37,6 +37,11 @@ cumlCommunicator cumlCommunicator::commSplit(int color, int key) const {
 
 void cumlCommunicator::barrier() const { _impl->barrier(); }
 
+cumlCommunicator::status_t cumlCommunicator::syncStream(
+  cudaStream_t stream) const {
+  return _impl->syncStream(stream);
+}
+
 void cumlCommunicator::isend(const void* buf, int size, int dest, int tag,
                              request_t* request) const {
   _impl->isend(buf, size, dest, tag, request);

--- a/cpp/src/holtwinters/runner.h
+++ b/cpp/src/holtwinters/runner.h
@@ -106,13 +106,12 @@ void HoltWintersEval(const ML::cumlHandle &handle, const Dtype *ts, int n,
   if (!(!level && !trend && !season && !xhat && !error)) {
     holtwinters_eval_gpu(handle_impl, ts, n, batch_size, frequency, start_level,
                          start_trend, start_season, alpha, beta, gamma, level,
-                         trend, season, xhat, error,
-                         seasonal);
+                         trend, season, xhat, error, seasonal);
   }
 }
 
 // expose line search step size - https://github.com/rapidsai/cuml/issues/886
-// Also, precision errors arise in optimization. There's floating point instability, 
+// Also, precision errors arise in optimization. There's floating point instability,
 // and epsilon majorly influences the fitting based on precision. For a summary,
 // https://github.com/rapidsai/cuml/issues/888
 template <typename Dtype>
@@ -174,8 +173,7 @@ void HoltWintersOptim(const ML::cumlHandle &handle, const Dtype *ts, int n,
     holtwinters_optim_gpu(
       handle_impl, ts, n, batch_size, frequency, start_level, start_trend,
       start_season, alpha, optim_alpha, beta, optim_beta, gamma, optim_gamma,
-      level, trend, season, xhat, error, optim_result, seasonal,
-      optim_params_);
+      level, trend, season, xhat, error, optim_result, seasonal, optim_params_);
   }
 }
 
@@ -192,8 +190,7 @@ void HoltWintersForecast(const ML::cumlHandle &handle, Dtype *forecast, int h,
          "HW error in in line %d", __LINE__);
   ASSERT(!(season_coef && frequency < 2), "HW error in in line %d", __LINE__);
   holtwinters_forecast_gpu(handle_impl, forecast, h, batch_size, frequency,
-                           level_coef, trend_coef, season_coef,
-                           seasonal);
+                           level_coef, trend_coef, season_coef, seasonal);
 }
 
 // change optim_gamma to false here to test bug in Double Exponential Smoothing
@@ -292,7 +289,7 @@ void HoltWintersForecastHelper(const ML::cumlHandle &handle, int n,
   std::shared_ptr<MLCommon::deviceAllocator> dev_allocator =
     handle_impl.getDeviceAllocator();
 
-  bool optim_alpha = true, optim_beta = true, optim_gamma = true;
+  bool optim_beta = true, optim_gamma = true;
 
   int leveltrend_seed_len, season_seed_len, components_len;
   int leveltrend_coef_offset, season_coef_offset;

--- a/cpp/src_prims/common/cuml_comms_iface.hpp
+++ b/cpp/src_prims/common/cuml_comms_iface.hpp
@@ -32,37 +32,53 @@ namespace MLCommon {
  * cumlCommunicator_iface would be part of cuML-comms).
  */
 class cumlCommunicator_iface {
-public:
-    typedef cumlCommunicator::request_t     request_t;
-    typedef cumlCommunicator::datatype_t    datatype_t;
-    typedef cumlCommunicator::op_t          op_t;
+ public:
+  typedef cumlCommunicator::request_t request_t;
+  typedef cumlCommunicator::datatype_t datatype_t;
+  typedef cumlCommunicator::op_t op_t;
+  typedef cumlCommunicator::status_t status_t;
 
-    virtual ~cumlCommunicator_iface();
+  virtual ~cumlCommunicator_iface();
 
-    virtual int getSize() const =0;
-    virtual int getRank() const =0;
+  virtual int getSize() const = 0;
+  virtual int getRank() const = 0;
 
-    virtual std::unique_ptr<cumlCommunicator_iface> commSplit( int color, int key ) const =0;
+  virtual std::unique_ptr<cumlCommunicator_iface> commSplit(int color,
+                                                            int key) const = 0;
 
-    virtual void barrier() const =0;
+  virtual void barrier() const = 0;
 
-    virtual void isend(const void *buf, int size, int dest, int tag, request_t *request) const =0;
+  virtual status_t syncStream(cudaStream_t stream) const = 0;
 
-    virtual void irecv(void *buf, int size, int source, int tag, request_t *request) const =0;
+  virtual void isend(const void* buf, int size, int dest, int tag,
+                     request_t* request) const = 0;
 
-    virtual void waitall(int count, request_t array_of_requests[]) const =0;
+  virtual void irecv(void* buf, int size, int source, int tag,
+                     request_t* request) const = 0;
 
-    virtual void allreduce(const void* sendbuff, void* recvbuff, int count, datatype_t datatype, op_t op, cudaStream_t stream) const =0;
+  virtual void waitall(int count, request_t array_of_requests[]) const = 0;
 
-    virtual void bcast(void* buff, int count, datatype_t datatype, int root, cudaStream_t stream) const =0;
+  virtual void allreduce(const void* sendbuff, void* recvbuff, int count,
+                         datatype_t datatype, op_t op,
+                         cudaStream_t stream) const = 0;
 
-    virtual void reduce(const void* sendbuff, void* recvbuff, int count, datatype_t datatype, op_t op, int root, cudaStream_t stream) const =0;
+  virtual void bcast(void* buff, int count, datatype_t datatype, int root,
+                     cudaStream_t stream) const = 0;
 
-    virtual void allgather(const void* sendbuff, void* recvbuff, int sendcount, datatype_t datatype, cudaStream_t stream) const =0;
+  virtual void reduce(const void* sendbuff, void* recvbuff, int count,
+                      datatype_t datatype, op_t op, int root,
+                      cudaStream_t stream) const = 0;
 
-    virtual void allgatherv(const void *sendbuf, void *recvbuf, const int recvcounts[], const int displs[], datatype_t datatype, cudaStream_t stream) const =0;
+  virtual void allgather(const void* sendbuff, void* recvbuff, int sendcount,
+                         datatype_t datatype, cudaStream_t stream) const = 0;
 
-    virtual void reducescatter(const void* sendbuff, void* recvbuff, int recvcount, datatype_t datatype, op_t op, cudaStream_t stream) const =0;
+  virtual void allgatherv(const void* sendbuf, void* recvbuf,
+                          const int recvcounts[], const int displs[],
+                          datatype_t datatype, cudaStream_t stream) const = 0;
+
+  virtual void reducescatter(const void* sendbuff, void* recvbuff,
+                             int recvcount, datatype_t datatype, op_t op,
+                             cudaStream_t stream) const = 0;
 };
 
-} // end namespace ML
+}  // namespace MLCommon

--- a/cpp/src_prims/common/cuml_comms_int.hpp
+++ b/cpp/src_prims/common/cuml_comms_int.hpp
@@ -46,9 +46,11 @@ class cumlCommunicator {
   /**
    * The resulting status of distributed stream synchronization
    */
-  enum status_t { commStatusSuccess, // Synchronization successful
-                  commStatusError,   // An error occured querying sync status
-                  commStatusAbort }; // A failure occured in sync, queued operations aborted
+  enum status_t {
+    commStatusSuccess,  // Synchronization successful
+    commStatusError,    // An error occured querying sync status
+    commStatusAbort
+  };  // A failure occured in sync, queued operations aborted
 
   template <typename T>
   datatype_t getDataType() const;
@@ -83,12 +85,12 @@ class cumlCommunicator {
   void barrier() const;
 
   /**
-   * Synchronization all ranks for the current stream. This allows difference cumlCommunicator
+   * Synchronization of all ranks for the current stream. This allows different cumlCommunicator
    * implementations to provide custom handling of asynchronous errors, such as the failure of
    * ranks during collective communication operations.
    *
-   * In the case where status of commStatusAbort is returned, the underlying comms implementation
-   * may need to be re-initialized.
+   * In the case where commStatusAbort is returned, the underlying comms implementation may need
+   * to be re-initialized.
    *
    * A status of commStatusError should be thrown if an error occurs when querying the stream
    * sync status of the underlying communicator.


### PR DESCRIPTION
This PR adds a `syncStream` method to the `cumlCommunicator` that can abort a NCCL comm in the case an unrecoverable asynchronous error occurs. This enables applications to fail gracefully in the face of such async errors (eg. a rank/Dask worker fails) rather than blocking indefinitely, causing the need for workers to be restarted. 

This PR closes #913. Refer to that issue for more details. 