### PR TITLE
[REVIEW] add an empty marker kernel useful during tracing process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PR #857: Small modifications to comms for utilizing IB w/ Dask
 - PR #851: Random forest Stateless API wrappers
 - PR #895: Pretty prints arguments!
+- PR #920: Add an empty marker kernel for tracing purposes
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -61,6 +61,7 @@ option(KERNEL_INFO "Enable kernel resource usage info" OFF)
 option(LINE_INFO "Enable lineinfo in nvcc" OFF)
 
 option(NVTX "Enable nvtx markers" OFF)
+option(EMPTY_MARKER_KERNEL "Enable empty marker kernel after nvtxRangePop" ON)
 
 set(BLAS_LIBRARIES "" CACHE STRING
     "Location of BLAS library")
@@ -178,6 +179,9 @@ endif(KERNEL_INFO)
 if(NVTX)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DNVTX_ENABLED")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNVTX_ENABLED")
+  if(EMPTY_MARKER_KERNEL)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DENABLE_EMPTY_MARKER_KERNEL")
+  endif(EMPTY_MARKER_KERNEL)
 endif(NVTX)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -335,7 +339,7 @@ if(BUILD_CUML_CPP_LIBRARY)
     src/common/cuml_api.cpp
     src/common/cuML_comms_impl.cpp
     src/comms/cuML_comms_test.cpp
-    src/common/nvtx.cpp
+    src/common/nvtx.cu
     src/datasets/make_blobs.cu
     src/dbscan/dbscan.cu
     src/decisiontree/decisiontree.cu

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -147,7 +147,17 @@ void PUSH_RANGE(const char *name) {
   nvtxRangePushEx(&eventAttrib);
 }
 
-void POP_RANGE() { nvtxRangePop(); }
+#ifdef ENABLE_EMPTY_MARKER_KERNEL
+__global__ void emptyMarkerKernel() {
+}
+#endif // ENABLE_EMPTY_MARKER_KERNEL
+
+void POP_RANGE() {
+  nvtxRangePop();
+#ifdef ENABLE_EMPTY_MARKER_KERNEL
+  emptyMarkerKernel<<<1,1>>>();
+#endif
+}
 
 #else  // NVTX_ENABLED
 


### PR DESCRIPTION
@cjnolet and @dantegd to review.

Guys, since this is not used by most of the dev's, I did not want to document the cmake option introduced in this PR in our BUILD.md.