### PR TITLE
[REVIEW] Random Forest support in FIL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - PR #851: Random forest Stateless API wrappers
 - PR #895: Pretty prints arguments!
 - PR #915: syncStream added to cumlCommunicator
-- PR #???: Random Forest support in FIL
+- PR #922: Random Forest support in FIL
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #851: Random forest Stateless API wrappers
 - PR #895: Pretty prints arguments!
 - PR #915: syncStream added to cumlCommunicator
+- PR #???: Random Forest support in FIL
 
 ## Bug Fixes
 

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -57,14 +57,17 @@ void dense_node_decode(const dense_node_t* n, float* output, float* thresh,
 
 __host__ __device__ float sigmoid(float x) { return 1.0f / (1.0f + expf(-x)); }
 
-__global__ void transform_k(float* preds, size_t n, bool output_class,
-                            float threshold) {
+__global__ void transform_k(float* preds, size_t n, output_t output,
+                            float inv_num_trees, float threshold) {
   size_t i = threadIdx.x + size_t(blockIdx.x) * blockDim.x;
   if (i >= n) return;
-  float out = preds[i];
-  out = sigmoid(out);
-  if (output_class) out = out > threshold ? 1.0f : 0.0f;
-  preds[i] = out;
+  float pred = preds[i];
+  if ((output & output_t::AVG) != 0) pred *= inv_num_trees;
+  if ((output & output_t::SIGMOID) != 0) pred = sigmoid(pred);
+  if ((output & output_t::THRESHOLD) != 0) {
+    pred = pred > threshold ? 1.0f : 0.0f;
+  }
+  preds[i] = pred;
 }
 
 struct forest {
@@ -154,7 +157,7 @@ struct forest {
     // Transform the output if necessary (sigmoid + thresholding if necessary).
     if (output_ != output_t::RAW) {
       transform_k<<<ceildiv(int(rows), FIL_TPB), FIL_TPB, 0, stream>>>(
-        preds, rows, output_ == output_t::CLASS, threshold_);
+        preds, rows, output_, ntrees_ > 0 ? 1.0f / ntrees_ : 1.0f, threshold_);
       CUDA_CHECK(cudaPeekAtLastError());
     }
   }
@@ -188,13 +191,12 @@ void check_params(const forest_params_t* params) {
     default:
       ASSERT(false, "aglo should be NAIVE, TREE_REORG or BATCH_TREE_REORG");
   }
-  switch (params->output) {
-    case output_t::RAW:
-    case output_t::PROB:
-    case output_t::CLASS:
-      break;
-    default:
-      ASSERT(false, "output should be RAW, PROB or CLASS");
+  // output_t::RAW == 0, and doesn't have a separate flag
+  output_t all_set =
+    output_t(output_t::AVG | output_t::SIGMOID | output_t::THRESHOLD);
+  if ((params->output & ~all_set) != 0) {
+    ASSERT(false,
+           "output should be a combination of RAW, AVG, SIGMOID and THRESHOLD");
   }
 }
 
@@ -301,15 +303,17 @@ void tl2fil(forest_params_t* params, std::vector<dense_node_t>* pnodes,
   const tl::ModelParam& param = model.param;
   ASSERT(param.sigmoid_alpha == 1.0f, "sigmoid_alpha not supported");
   ASSERT(param.global_bias == 0.0f, "bias not supported");
-  // in treelite, "random forest" means averaging the output of all trees
-  ASSERT(!model.random_forest_flag, "output averaging not supported");
-  if (param.pred_transform == "identity") {
-    ASSERT(!tl_params->output_class,
-           "class output only supported for the sigmoid transform");
-    params->output = output_t::RAW;
-  } else if (param.pred_transform == "sigmoid") {
-    params->output = tl_params->output_class ? output_t::CLASS : output_t::PROB;
-  } else {
+  params->output = output_t::RAW;
+  if (tl_params->output_class) {
+    params->output = output_t(params->output | output_t::THRESHOLD);
+  }
+  // "random forest" in treelite means tree output averaging
+  if (model.random_forest_flag) {
+    params->output = output_t(params->output | output_t::AVG);
+  }
+  if (param.pred_transform == "sigmoid") {
+    params->output = output_t(params->output | output_t::SIGMOID);
+  } else if (param.pred_transform != "identity") {
     ASSERT(false, "%s: unsupported treelite prediction transform",
            param.pred_transform.c_str());
   }

--- a/cpp/src/fil/fil.h
+++ b/cpp/src/fil/fil.h
@@ -43,14 +43,31 @@ enum algo_t {
   BATCH_TREE_REORG
 };
 
+/** 
+ * output_t are flags that define the output produced by the FIL predictor; a
+ * valid output_t values consists of the following, combined using '|' (bitwise
+ * or), which define stages, which operation in the next stage applied to the
+ * output of the previous stage:
+ * - one of RAW or AVG, indicating how to combine individual tree outputs into the forest output
+ * - optional SIGMOID for applying the sigmoid transform
+ * - optional THRESHOLD, for thresholding for classification
+ */
 enum output_t {
-  /** raw output; use for regression, or for binary classification for the value
-      before the transformation */
-  RAW,
-  /** output probability; use for binary classification for probability */
-  PROB,
-  /** output class; use for binary classification for class (0 or 1) */
-  CLASS
+  /** raw output: the sum of the tree outputs; use for GBM models for
+      regression, or for binary classification for the value before the
+      transformation; note that this value is 0, and may be omitted
+      when combined with other flags */
+  RAW = 0x0,
+  /** average output: divide the sum of the tree outputs by the number of trees 
+      before further transformations; use for random forests for regression 
+      and binary classification for the probability */
+  AVG = 0x1,
+  /** sigmoid transformation: apply 1/(1+exp(-x)) to the sum or average of tree
+      outputs; use for GBM binary classification models for probability */
+  SIGMOID = 0x10,
+  /** threshold: apply threshold to the output of the previous stage to get the
+      class (0 or 1) */
+  THRESHOLD = 0x100,
 };
 
 /** dense_node is a single tree node */


### PR DESCRIPTION
- output averaging supported
- thresholding without sigmoid supported
- note that voting for binary classification is implemented as averaging followed by thresholding