### PR TITLE
[REVIEW] Fix get_level/trend/season for HoltWinters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ## Bug Fixes
 
+- PR #923: Fix misshapen level/trend/season HoltWinters output
 - PR #831: Update conda package dependencies to cudf 0.9
 - PR #772: Add missing cython headers to SGD and CD
 - PR #849: PCA no attribute trans_input_ transform bug fix

--- a/python/cuml/test/test_holtwinters.py
+++ b/python/cuml/test/test_holtwinters.py
@@ -170,7 +170,11 @@ def test_series_holtwinters(idx, h):
     data = np.asarray([airpassengers, co2, nybirths], dtype=np.float64)
     cu_hw = cuml_ES(data, ts_num=3)
     cu_hw.fit()
+    cu_hw.score(idx)
     cu_hw.forecast(h, idx)
+    cu_hw.get_level(idx)
+    cu_hw.get_trend(idx)
+    cu_hw.get_season(idx)
 
 
 @pytest.mark.parametrize('frequency', [7, 12])
@@ -209,3 +213,7 @@ def test_inputs_holtwinters(datatype, input_type):
     cu_hw = cuml_ES(data, ts_num=3)
     cu_hw.fit()
     cu_hw.forecast(5)
+    cu_hw.score()
+    cu_hw.get_level(0)
+    cu_hw.get_trend(1)
+    cu_hw.get_season(2)

--- a/python/cuml/test/test_holtwinters.py
+++ b/python/cuml/test/test_holtwinters.py
@@ -170,8 +170,8 @@ def test_series_holtwinters(idx, h):
     data = np.asarray([airpassengers, co2, nybirths], dtype=np.float64)
     cu_hw = cuml_ES(data, ts_num=3)
     cu_hw.fit()
-    cu_hw.score(idx)
     cu_hw.forecast(h, idx)
+    cu_hw.score(idx)
     cu_hw.get_level(idx)
     cu_hw.get_trend(idx)
     cu_hw.get_season(idx)
@@ -217,3 +217,32 @@ def test_inputs_holtwinters(datatype, input_type):
     cu_hw.get_level(0)
     cu_hw.get_trend(1)
     cu_hw.get_season(2)
+
+
+@pytest.mark.parametrize('level', [1, 3, 5, 10])
+def test_get_level(level):
+    data = np.array([level]*100, dtype=np.float64)
+    cu_hw = cuml_ES(data)
+    cu_hw.fit()
+    assert pytest.approx(cu_hw.get_level().to_array(), 1e-4) == level
+
+
+@pytest.mark.parametrize('slope', [1, 2, -2, 0.5])
+def test_get_trend(slope):
+    data = np.arange(0, 100*slope, slope, dtype=np.float64)
+    cu_hw = cuml_ES(data)
+    cu_hw.fit()
+    assert pytest.approx(cu_hw.get_trend().to_array(), 1e-4) == slope
+
+
+@pytest.mark.parametrize('freq', [1, 0.5, 5])
+def test_get_season(freq):
+    data = np.sin(np.arange(0, 100)*freq)
+    cu_hw = cuml_ES(data)
+    cu_hw.fit()
+    evens = np.arange(0, 98, 2)
+    odds = evens+1
+    seasons = cu_hw.get_season().to_array()
+    base = seasons[0]
+    assert pytest.approx(seasons[evens], 1e-4) == base
+    assert pytest.approx(seasons[odds], 1e-4) == -1*base


### PR DESCRIPTION
Bug: get_level(), get_trend(), and get_season() incorrectly return a column-major 1-dimensional array. 

This commit should reshape the array into the proper cudf.DataFrame/cudf.Series format and also adds calls for score, level, trend, and season into the test_holtwinters.py file to increase test coverage.