### PR TITLE
[REVIEW] Cache cudaDeviceProp inside cumlHandle for perf reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - PR #896: Fix typo in comms build instructions
 - PR #921: Fix build scripts using incorrect cudf version
 - PR #928: TSNE Stability Adjustments
+- PR #934: Cache cudaDeviceProp in cumlHandle for perf reasons
 
 
 # cuML 0.8.0 (27 June 2019)

--- a/cpp/src/common/cumlHandle.cpp
+++ b/cpp/src/common/cumlHandle.cpp
@@ -143,6 +143,10 @@ void cumlHandle::setStream(cudaStream_t stream) { _impl->setStream(stream); }
 
 cudaStream_t cumlHandle::getStream() const { return _impl->getStream(); }
 
+const cudaDeviceProp& cumlHandle::getDeviceProp() const {
+  return _impl->getDeviceProp();
+}
+
 void cumlHandle::setDeviceAllocator(
   std::shared_ptr<deviceAllocator> allocator) {
   _impl->setDeviceAllocator(allocator);
@@ -189,6 +193,8 @@ int cumlHandle_impl::getDevice() const { return _dev_id; }
 void cumlHandle_impl::setStream(cudaStream_t stream) { _userStream = stream; }
 
 cudaStream_t cumlHandle_impl::getStream() const { return _userStream; }
+
+const cudaDeviceProp& cumlHandle_impl::getDeviceProp() const { return prop; }
 
 void cumlHandle_impl::setDeviceAllocator(
   std::shared_ptr<deviceAllocator> allocator) {
@@ -259,13 +265,9 @@ bool cumlHandle_impl::commsInitialized() const
 void cumlHandle_impl::createResources() {
   cudaStream_t stream;
   CUDA_CHECK(cudaStreamCreate(&stream));
-
   CUBLAS_CHECK(cublasCreate(&_cublas_handle));
-
   CUSOLVER_CHECK(cusolverDnCreate(&_cusolverDn_handle));
-
   CUSPARSE_CHECK(cusparseCreate(&_cusparse_handle));
-
   _streams.push_back(stream);
   for (int i = 1; i < _num_streams; ++i) {
     cudaStream_t stream;
@@ -273,6 +275,7 @@ void cumlHandle_impl::createResources() {
     _streams.push_back(stream);
   }
   CUDA_CHECK(cudaEventCreateWithFlags(&_event, cudaEventDisableTiming));
+  CUDA_CHECK(cudaGetDeviceProperties(&prop, _dev_id));
 }
 
 void cumlHandle_impl::destroyResources() {

--- a/cpp/src/common/cumlHandle.cpp
+++ b/cpp/src/common/cumlHandle.cpp
@@ -143,8 +143,8 @@ void cumlHandle::setStream(cudaStream_t stream) { _impl->setStream(stream); }
 
 cudaStream_t cumlHandle::getStream() const { return _impl->getStream(); }
 
-const cudaDeviceProp& cumlHandle::getDeviceProp() const {
-  return _impl->getDeviceProp();
+const cudaDeviceProp& cumlHandle::getDeviceProperties() const {
+  return _impl->getDeviceProperties();
 }
 
 void cumlHandle::setDeviceAllocator(
@@ -166,10 +166,7 @@ std::shared_ptr<hostAllocator> cumlHandle::getHostAllocator() const {
 
 const cumlHandle_impl& cumlHandle::getImpl() const { return *_impl.get(); }
 
-cumlHandle_impl& cumlHandle::getImpl()
-{
-    return *_impl.get();
-}
+cumlHandle_impl& cumlHandle::getImpl() { return *_impl.get(); }
 
 using MLCommon::defaultDeviceAllocator;
 using MLCommon::defaultHostAllocator;
@@ -194,7 +191,9 @@ void cumlHandle_impl::setStream(cudaStream_t stream) { _userStream = stream; }
 
 cudaStream_t cumlHandle_impl::getStream() const { return _userStream; }
 
-const cudaDeviceProp& cumlHandle_impl::getDeviceProp() const { return prop; }
+const cudaDeviceProp& cumlHandle_impl::getDeviceProperties() const {
+  return prop;
+}
 
 void cumlHandle_impl::setDeviceAllocator(
   std::shared_ptr<deviceAllocator> allocator) {
@@ -246,20 +245,19 @@ void cumlHandle_impl::waitOnInternalStreams() const {
   }
 }
 
-void cumlHandle_impl::setCommunicator( std::shared_ptr<MLCommon::cumlCommunicator> communicator )
-{
-    _communicator = communicator;
+void cumlHandle_impl::setCommunicator(
+  std::shared_ptr<MLCommon::cumlCommunicator> communicator) {
+  _communicator = communicator;
 }
 
-const MLCommon::cumlCommunicator& cumlHandle_impl::getCommunicator() const
-{
-    ASSERT(nullptr != _communicator.get(), "ERROR: Communicator was not initialized\n");
-    return *_communicator;
+const MLCommon::cumlCommunicator& cumlHandle_impl::getCommunicator() const {
+  ASSERT(nullptr != _communicator.get(),
+         "ERROR: Communicator was not initialized\n");
+  return *_communicator;
 }
 
-bool cumlHandle_impl::commsInitialized() const
-{
-    return (nullptr != _communicator.get());
+bool cumlHandle_impl::commsInitialized() const {
+  return (nullptr != _communicator.get());
 }
 
 void cumlHandle_impl::createResources() {

--- a/cpp/src/common/cumlHandle.hpp
+++ b/cpp/src/common/cumlHandle.hpp
@@ -62,7 +62,7 @@ class cumlHandle_impl {
   const MLCommon::cumlCommunicator& getCommunicator() const;
   bool commsInitialized() const;
 
-  const cudaDeviceProp& getDeviceProp() const;
+  const cudaDeviceProp& getDeviceProperties() const;
 
  private:
   //TODO: What is the right number?

--- a/cpp/src/common/cumlHandle.hpp
+++ b/cpp/src/common/cumlHandle.hpp
@@ -62,6 +62,8 @@ class cumlHandle_impl {
   const MLCommon::cumlCommunicator& getCommunicator() const;
   bool commsInitialized() const;
 
+  const cudaDeviceProp& getDeviceProp() const;
+
  private:
   //TODO: What is the right number?
   static constexpr int _num_streams = 3;
@@ -74,6 +76,7 @@ class cumlHandle_impl {
   std::shared_ptr<hostAllocator> _hostAllocator;
   cudaStream_t _userStream;
   cudaEvent_t _event;
+  cudaDeviceProp prop;
 
   std::shared_ptr<MLCommon::cumlCommunicator> _communicator;
 

--- a/cpp/src/cuML.hpp
+++ b/cpp/src/cuML.hpp
@@ -60,7 +60,7 @@ class cumlHandle {
      */
   cudaStream_t getStream() const;
   /** Get the cached device properties of the device this handle is for */
-  const cudaDeviceProp& getDeviceProp() const;
+  const cudaDeviceProp& getDeviceProperties() const;
   /**
      * @brief sets the allocator to use for all device allocations done in cuML.
      * 
@@ -88,13 +88,14 @@ class cumlHandle {
   /**
      * @brief for internal use only.
      */
-    const cumlHandle_impl& getImpl() const;
-    /**
+  const cumlHandle_impl& getImpl() const;
+  /**
      * @brief for internal use only.
      */
-    cumlHandle_impl& getImpl();
-private:
-    std::unique_ptr<cumlHandle_impl> _impl;
+  cumlHandle_impl& getImpl();
+
+ private:
+  std::unique_ptr<cumlHandle_impl> _impl;
 };
 
 }  // end namespace ML

--- a/cpp/src/cuML.hpp
+++ b/cpp/src/cuML.hpp
@@ -59,6 +59,8 @@ class cumlHandle {
      * @returns the stream to which cuML work should be ordered.
      */
   cudaStream_t getStream() const;
+  /** Get the cached device properties of the device this handle is for */
+  const cudaDeviceProp& getDeviceProp() const;
   /**
      * @brief sets the allocator to use for all device allocations done in cuML.
      * 

--- a/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
@@ -271,8 +271,7 @@ void best_split_all_cols_classifier(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->ml_handle.getDeviceProperties().sharedMemPerBlock,
-      tempmem->stream);
+      tempmem->ml_handle.getDeviceProperties(), tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
@@ -271,7 +271,7 @@ void best_split_all_cols_classifier(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->stream);
+      tempmem->ml_handle.getDeviceProp().sharedMemPerBlock, tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
@@ -271,7 +271,8 @@ void best_split_all_cols_classifier(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->ml_handle.getDeviceProp().sharedMemPerBlock, tempmem->stream);
+      tempmem->ml_handle.getDeviceProperties().sharedMemPerBlock,
+      tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
@@ -405,7 +405,7 @@ void best_split_all_cols_regressor(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->stream);
+      tempmem->ml_handle.getDeviceProp().sharedMemPerBlock, tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
@@ -405,8 +405,7 @@ void best_split_all_cols_regressor(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->ml_handle.getDeviceProperties().sharedMemPerBlock,
-      tempmem->stream);
+      tempmem->ml_handle.getDeviceProperties(), tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
@@ -405,7 +405,8 @@ void best_split_all_cols_regressor(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->ml_handle.getDeviceProp().sharedMemPerBlock, tempmem->stream);
+      tempmem->ml_handle.getDeviceProperties().sharedMemPerBlock,
+      tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src_prims/stats/minmax.h
+++ b/cpp/src_prims/stats/minmax.h
@@ -166,6 +166,8 @@ __global__ void minmaxKernel(const T* data, const unsigned int* rowids,
  * @param globalmax final col-wise global maximum (size = ncols)
  * @param sampledcols output sampled data. Pass nullptr if you don't need this
  * @param init_val initial minimum value to be
+ * @param sharedMemPerBlk max shared mem available per block. This is being
+ * explicitly requested since querying it inside prims is not good for perf.
  * @param stream: cuda stream
  * @note This method makes the following assumptions:
  * 1. input and output matrices are assumed to be col-major
@@ -173,9 +175,9 @@ __global__ void minmaxKernel(const T* data, const unsigned int* rowids,
  *    in shared memory
  */
 template <typename T, int TPB = 512>
-void minmax(const T* data, const unsigned int* rowids,
-            const unsigned int* colids, int nrows, int ncols, int row_stride,
-            T* globalmin, T* globalmax, T* sampledcols, cudaStream_t stream) {
+void minmax(const T* data, const unsigned* rowids, const unsigned* colids,
+            int nrows, int ncols, int row_stride, T* globalmin, T* globalmax,
+            T* sampledcols, size_t sharedMemPerBlk, cudaStream_t stream) {
   using E = typename encode_traits<T>::E;
   int nblks = ceildiv(ncols, TPB);
   T init_val = std::numeric_limits<T>::max();
@@ -186,15 +188,9 @@ void minmax(const T* data, const unsigned int* rowids,
   nblks = min(nblks, 65536);
   size_t smemSize = sizeof(T) * 2 * ncols;
 
-  // Get available shared memory size.
-  cudaDeviceProp prop;
-  int dev_ID = 0;
-  CUDA_CHECK(cudaGetDevice(&dev_ID));
-  CUDA_CHECK(cudaGetDeviceProperties(&prop, dev_ID));
-  size_t max_shared_mem = prop.sharedMemPerBlock;
-
-  // Compute the batch_ncols, in [1, ncols] range, that meet the available shared memory constraints.
-  int batch_ncols = min(ncols, (int)(max_shared_mem / (sizeof(T) * 2)));
+  // Compute the batch_ncols, in [1, ncols] range, that meet the available
+  // shared memory constraints.
+  int batch_ncols = min(ncols, (int)(sharedMemPerBlk / (sizeof(T) * 2)));
   int num_batches = ceildiv(ncols, batch_ncols);
   smemSize = sizeof(T) * 2 * batch_ncols;
 

--- a/cpp/test/prims/minmax.cu
+++ b/cpp/test/prims/minmax.cu
@@ -89,6 +89,10 @@ template <typename T>
 class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
  protected:
   void SetUp() override {
+    // Get available shared memory size.
+    int dev_ID = 0;
+    CUDA_CHECK(cudaGetDevice(&dev_ID));
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev_ID));
     params = ::testing::TestWithParam<MinMaxInputs<T>>::GetParam();
     Random::Rng r(params.seed);
     int len = params.rows * params.cols;
@@ -108,7 +112,7 @@ class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
                 minmax_ref + params.cols, stream);
     minmax<T, 512>(data, nullptr, nullptr, params.rows, params.cols,
                    params.rows, minmax_act, minmax_act + params.cols, nullptr,
-                   stream);
+                   prop.sharedMemPerBlock, stream);
   }
 
   void TearDown() override {
@@ -123,6 +127,7 @@ class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
   T *data, *minmax_act, *minmax_ref;
   bool* mask;
   cudaStream_t stream;
+  cudaDeviceProp prop;
 };
 
 const std::vector<MinMaxInputs<float>> inputsf = {

--- a/cpp/test/prims/minmax.cu
+++ b/cpp/test/prims/minmax.cu
@@ -112,7 +112,7 @@ class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
                 minmax_ref + params.cols, stream);
     minmax<T, 512>(data, nullptr, nullptr, params.rows, params.cols,
                    params.rows, minmax_act, minmax_act + params.cols, nullptr,
-                   prop.sharedMemPerBlock, stream);
+                   prop, stream);
   }
 
   void TearDown() override {


### PR DESCRIPTION
Title says it all. This PR should address the perf concerns raised in issue #927.

1. `cumlHandle_impl` now has `cudaDeviceProp` of its device cached.
2. `minmax` prim explicitly requests the sharedMemPerBlock property.
3. RF algo updated to use this new interface of `minmax`.

@JohnZed and @cjnolet for review.