### PR TITLE
[REVIEW] fix to xfail pytest in unsupported cudf dtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 - PR #918: Streamline CUDA_REL environment variable
 - PR #924: kmeans: updated APIs to be stateless, refactored code for mnmg support
 
-
 ## Bug Fixes
 
 - PR #923: Fix misshapen level/trend/season HoltWinters output
@@ -55,6 +54,7 @@
 - PR #921: Fix build scripts using incorrect cudf version
 - PR #928: TSNE Stability Adjustments
 - PR #932: Change default param value for RF classifier
+- PR #949: Fix dtype conversion tests for unsupported cudf dtypes
 
 
 # cuML 0.8.0 (27 June 2019)

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -22,7 +22,7 @@ import numpy as np
 from numba import cuda
 from copy import deepcopy
 
-from cuml.utils import input_to_dev_array
+from cuml.utils import input_to_dev_array, has_cupy
 
 from cuml.utils.input_utils import convert_dtype
 
@@ -75,6 +75,14 @@ def test_convert_inputs(from_dtype, to_dtype, input_type, num_rows, num_cols):
 
     if from_dtype == np.float16 and input_type != 'numpy':
         pytest.xfail("float16 not yet supported by numba/cuDF.from_gpu_matrix")
+
+    if from_dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
+        if input_type == 'dataframe':
+            pytest.xfail("unsigned int types not yet supported by \
+                         cuDF")
+        elif not has_cupy():
+            pytest.xfail("unsigned int types not yet supported by \
+                         cuDF and cuPy is not installed.")
 
     input_data, real_data = get_input(input_type, num_rows, num_cols,
                                       from_dtype, out_dtype=to_dtype)


### PR DESCRIPTION
Small fix now that cudf is correctly not accepting unsupported data types (before it would silently convert them without failing). Needed for 0.9. 