### PR TITLE
global_bias support in FIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - PR #911: Update headers to credit CannyLabs BH TSNE implementation
 - PR #918: Streamline CUDA_REL environment variable
 - PR #924: kmeans: updated APIs to be stateless, refactored code for mnmg support
-- PR #???: global_bias support in FIL
+- PR #950: global_bias support in FIL
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - PR #911: Update headers to credit CannyLabs BH TSNE implementation
 - PR #918: Streamline CUDA_REL environment variable
 - PR #924: kmeans: updated APIs to be stateless, refactored code for mnmg support
-
+- PR #???: global_bias support in FIL
 
 ## Bug Fixes
 

--- a/cpp/src/fil/fil.h
+++ b/cpp/src/fil/fil.h
@@ -106,6 +106,9 @@ struct forest_params_t {
   // threshold is used to for classification if output == OUTPUT_CLASS,
   // and is ignored otherwise
   float threshold;
+  // global_bias is added to the sum of tree predictions
+  // (after averaging, if it is used, but before any further transformations)
+  float global_bias;
 };
 
 /** treelite_params_t are parameters for importing treelite models */


### PR DESCRIPTION
- `global_bias` is supported in FIL
- treelite models with non-zero `global_bias` are supported