### PR TITLE
[REVIEW] Adding dask-ml to dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PR #918: Streamline CUDA_REL environment variable
 - PR #924: kmeans: updated APIs to be stateless, refactored code for mnmg support
 - PR #950: global_bias support in FIL
+- PR #965: Making dask-ml a hard dependency
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -52,6 +52,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       nccl>=2.4 \
       dask \
       distributed \
+      dask-ml \
       dask-cudf=${MINOR_VERSION} \
       dask-cuda=${MINOR_VERSION} \
       statsmodels \

--- a/ci/mg/build.sh
+++ b/ci/mg/build.sh
@@ -52,6 +52,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       nccl>=2.4 \
       dask \
       distributed \
+      dask-ml \
       dask-cudf \
       dask-cuda
 

--- a/conda/environments/cuml_dev_cuda10.0.yml
+++ b/conda/environments/cuml_dev_cuda10.0.yml
@@ -19,5 +19,6 @@ dependencies:
 - scikit-learn>=0.21
 - dask
 - distributed
+- dask-ml
 - dask-cuda=0.8*
 - dask-cudf=0.8*

--- a/conda/environments/cuml_dev_cuda9.2.yml
+++ b/conda/environments/cuml_dev_cuda9.2.yml
@@ -19,5 +19,6 @@ dependencies:
 - scikit-learn>=0.21
 - dask
 - distributed
+- dask-ml
 - dask-cuda=0.8*
 - dask-cudf=0.8*

--- a/python/cuml/dask/cluster/__init__.py
+++ b/python/cuml/dask/cluster/__init__.py
@@ -1,0 +1,1 @@
+from cuml.dask.cluster.kmeans import KMeans

--- a/python/cuml/test/dask/__init__.py
+++ b/python/cuml/test/dask/__init__.py
@@ -13,3 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from cuml.test.dask.utils import dask_make_blobs


### PR DESCRIPTION
Dask-ML is needed both for our cuml.dask KMeans integration tests, but also for our new kmeans MNMG notebook.

Because of this, we need to make sure it is installed w/ cuML so that users aren't surprised.