### PR TITLE
use cudaDeviceGetAttribute instead of relying on cudaDeviceProp for knowing shared-mem per block value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PR #773: Significant improvements to input checking of all classes and common input API for Python
 - PR #957: Adding docs to RF & KMeans MNMG. Small fixes for release
 - PR #965: Making dask-ml a hard dependency
+- PR #973: Use cudaDeviceGetAttribute instead of relying on cudaDeviceProp object being passed
 
 ## Bug Fixes
 

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -244,9 +244,7 @@ void DecisionTreeBase<T, L>::plant(
   feature_selector.resize((int)(colper * dinfo.Ncols));
 
   if (split_algo == SPLIT_ALGO::HIST) {
-    cudaDeviceProp prop;
-    CUDA_CHECK(cudaGetDeviceProperties(&prop, handle.getDevice()));
-    max_shared_mem = prop.sharedMemPerBlock;
+    max_shared_mem = MLCommon::getSharedMemPerBlock();
     shmem_used += 2 * sizeof(T);
 
     if (typeid(L) == typeid(int)) {  // Classification

--- a/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_classifier.cuh
@@ -271,7 +271,7 @@ void best_split_all_cols_classifier(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->ml_handle.getDeviceProperties(), tempmem->stream);
+      tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
+++ b/cpp/src/decisiontree/kernels/evaluate_regressor.cuh
@@ -405,7 +405,7 @@ void best_split_all_cols_regressor(
     MLCommon::Stats::minmax<T, threads>(
       data, rowids, d_colids, nrows, ncols, rowoffset, &d_globalminmax[0],
       &d_globalminmax[colselector.size()], tempmem->temp_data->data(),
-      tempmem->ml_handle.getDeviceProperties(), tempmem->stream);
+      tempmem->stream);
   } else if (split_algo ==
              ML::SPLIT_ALGO::
                GLOBAL_QUANTILE) {  // Global quantiles; just col condenser

--- a/cpp/src/decisiontree/memory.cuh
+++ b/cpp/src/decisiontree/memory.cuh
@@ -29,10 +29,8 @@ TemporaryMemory<T, L>::TemporaryMemory(const ML::cumlHandle_impl& handle, int N,
   stream = ml_handle.getStream();
   splitalgo = split_algo;
 
-  cudaDeviceProp prop;
-  CUDA_CHECK(cudaGetDeviceProperties(&prop, ml_handle.getDevice()));
   max_shared_mem = MLCommon::getSharedMemPerBlock();
-  num_sms = prop.multiProcessorCount;
+  num_sms = MLCommon::getMultiProcessorCount();
 
   if (splitalgo == ML::SPLIT_ALGO::GLOBAL_QUANTILE) {
     LevelMemAllocator(N, Ncols, n_unique, n_bins, depth);

--- a/cpp/src/decisiontree/memory.cuh
+++ b/cpp/src/decisiontree/memory.cuh
@@ -31,7 +31,7 @@ TemporaryMemory<T, L>::TemporaryMemory(const ML::cumlHandle_impl& handle, int N,
 
   cudaDeviceProp prop;
   CUDA_CHECK(cudaGetDeviceProperties(&prop, ml_handle.getDevice()));
-  max_shared_mem = prop.sharedMemPerBlock;
+  max_shared_mem = MLCommon::getSharedMemPerBlock();
   num_sms = prop.multiProcessorCount;
 
   if (splitalgo == ML::SPLIT_ALGO::GLOBAL_QUANTILE) {

--- a/cpp/src/holtwinters/internal/hw_eval.h
+++ b/cpp/src/holtwinters/internal/hw_eval.h
@@ -168,19 +168,11 @@ void holtwinters_eval_gpu(const ML::cumlHandle_impl &handle, const Dtype *ts,
   int total_blocks = GET_NUM_BLOCKS(batch_size);
   int threads_per_block = GET_THREADS_PER_BLOCK(batch_size);
 
-  // Get shared memory size
-  int device;
-  CUDA_CHECK(cudaGetDevice(&device));
-  struct cudaDeviceProp prop;
-  memset(&prop, 0, sizeof(cudaDeviceProp));
-  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
-
   // How much sm needed for shared kernel
   size_t sm_needed = sizeof(Dtype) * threads_per_block * frequency;
   bool is_additive = seasonal == ML::SeasonalType::ADDITIVE;
 
-  if (sm_needed >
-      prop.sharedMemPerBlock) {
+  if (sm_needed > MLCommon::getSharedMemPerBlock()) {
     MLCommon::device_buffer<Dtype> pseason(dev_allocator, stream,
                                            batch_size * frequency);
     holtwinters_eval_gpu_global_kernel<Dtype>

--- a/cpp/src/holtwinters/internal/hw_optim.h
+++ b/cpp/src/holtwinters/internal/hw_optim.h
@@ -428,23 +428,13 @@ void holtwinters_optim_gpu(
   int total_blocks = (batch_size - 1) / 128 + 1;
   int threads_per_block = 128;
 
-  // Get shared memory size //
-  int device;
-  CUDA_CHECK(cudaGetDevice(&device));
-  struct cudaDeviceProp prop;
-  memset(&prop, 0, sizeof(cudaDeviceProp));
-  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
-
   // How much sm needed for shared kernel
   size_t sm_needed = sizeof(Dtype) * threads_per_block * frequency;
   bool is_additive = seasonal == ML::SeasonalType::ADDITIVE;
   bool single_param =
     (optim_alpha + optim_beta + optim_gamma > 1) ? false : true;
 
-  if (
-    sm_needed >
-    prop
-      .sharedMemPerBlock) {  // Global memory // 
+  if (sm_needed > MLCommon::getSharedMemPerBlock()) {  // Global memory //
     MLCommon::device_buffer<Dtype> pseason(dev_allocator, stream,
                                            batch_size * frequency);
     holtwinters_optim_gpu_global_kernel<Dtype>

--- a/cpp/src/tsne/barnes_hut.h
+++ b/cpp/src/tsne/barnes_hut.h
@@ -58,9 +58,7 @@ void Barnes_Hut(float *VAL, const int *COL, const int *ROW, const int NNZ,
 
   // Get device properites
   //---------------------------------------------------
-  cudaDeviceProp deviceProp;
-  cudaGetDeviceProperties(&deviceProp, 0);
-  int blocks = deviceProp.multiProcessorCount;
+  int blocks = MLCommon::getMultiProcessorCount();
 
   int nnodes = n * 2;
   if (nnodes < 1024 * blocks) nnodes = 1024 * blocks;

--- a/cpp/src_prims/random/rng.h
+++ b/cpp/src_prims/random/rng.h
@@ -178,11 +178,7 @@ class Rng {
     offset = 0;
     // simple heuristic to make sure all SMs will be occupied properly
     // and also not too many initialization calls will be made by each thread
-    int dev;
-    CUDA_CHECK(cudaGetDevice(&dev));
-    cudaDeviceProp props;
-    CUDA_CHECK(cudaGetDeviceProperties(&props, dev));
-    nBlocks = 4 * props.multiProcessorCount;
+    nBlocks = 4 * getMultiProcessorCount();
   }
 
   /**

--- a/cpp/src_prims/stats/minmax.h
+++ b/cpp/src_prims/stats/minmax.h
@@ -177,7 +177,7 @@ __global__ void minmaxKernel(const T* data, const unsigned int* rowids,
 template <typename T, int TPB = 512>
 void minmax(const T* data, const unsigned* rowids, const unsigned* colids,
             int nrows, int ncols, int row_stride, T* globalmin, T* globalmax,
-            T* sampledcols, const cudaDeviceProp& prop, cudaStream_t stream) {
+            T* sampledcols, cudaStream_t stream) {
   using E = typename encode_traits<T>::E;
   int nblks = ceildiv(ncols, TPB);
   T init_val = std::numeric_limits<T>::max();
@@ -190,7 +190,8 @@ void minmax(const T* data, const unsigned* rowids, const unsigned* colids,
 
   // Compute the batch_ncols, in [1, ncols] range, that meet the available
   // shared memory constraints.
-  int batch_ncols = min(ncols, (int)(prop.sharedMemPerBlock / (sizeof(T) * 2)));
+  auto smemPerBlk = getSharedMemPerBlock();
+  int batch_ncols = min(ncols, (int)(smemPerBlk / (sizeof(T) * 2)));
   int num_batches = ceildiv(ncols, batch_ncols);
   smemSize = sizeof(T) * 2 * batch_ncols;
 

--- a/cpp/src_prims/utils.h
+++ b/cpp/src_prims/utils.h
@@ -128,6 +128,15 @@ inline int getSharedMemPerBlock() {
                                     cudaDevAttrMaxSharedMemoryPerBlock, devId));
   return smemPerBlk;
 }
+/** helper method to get multi-processor count parameter */
+inline int getMultiProcessorCount() {
+  int devId;
+  CUDA_CHECK(cudaGetDevice(&devId));
+  int mpCount;
+  CUDA_CHECK(
+    cudaDeviceGetAttribute(&mpCount, cudaDevAttrMultiProcessorCount, devId));
+  return mpCount;
+}
 
 /**
  * @brief Generic copy method for all kinds of transfers

--- a/cpp/src_prims/utils.h
+++ b/cpp/src_prims/utils.h
@@ -120,7 +120,7 @@ class Exception : public std::exception {
   } while (0)
 
 /** helper method to get max usable shared mem per block parameter */
-int getSharedMemPerBlock() {
+inline int getSharedMemPerBlock() {
   int devId;
   CUDA_CHECK(cudaGetDevice(&devId));
   int smemPerBlk;

--- a/cpp/src_prims/utils.h
+++ b/cpp/src_prims/utils.h
@@ -119,6 +119,16 @@ class Exception : public std::exception {
     }                                                                          \
   } while (0)
 
+/** helper method to get max usable shared mem per block parameter */
+int getSharedMemPerBlock() {
+  int devId;
+  CUDA_CHECK(cudaGetDevice(&devId));
+  int smemPerBlk;
+  CUDA_CHECK(cudaDeviceGetAttribute(&smemPerBlk,
+                                    cudaDevAttrMaxSharedMemoryPerBlock, devId));
+  return smemPerBlk;
+}
+
 /**
  * @brief Generic copy method for all kinds of transfers
  * @tparam Type data type

--- a/cpp/test/prims/minmax.cu
+++ b/cpp/test/prims/minmax.cu
@@ -89,10 +89,6 @@ template <typename T>
 class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
  protected:
   void SetUp() override {
-    // Get available shared memory size.
-    int dev_ID = 0;
-    CUDA_CHECK(cudaGetDevice(&dev_ID));
-    CUDA_CHECK(cudaGetDeviceProperties(&prop, dev_ID));
     params = ::testing::TestWithParam<MinMaxInputs<T>>::GetParam();
     Random::Rng r(params.seed);
     int len = params.rows * params.cols;
@@ -112,7 +108,7 @@ class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
                 minmax_ref + params.cols, stream);
     minmax<T, 512>(data, nullptr, nullptr, params.rows, params.cols,
                    params.rows, minmax_act, minmax_act + params.cols, nullptr,
-                   prop, stream);
+                   stream);
   }
 
   void TearDown() override {
@@ -127,7 +123,6 @@ class MinMaxTest : public ::testing::TestWithParam<MinMaxInputs<T>> {
   T *data, *minmax_act, *minmax_ref;
   bool* mask;
   cudaStream_t stream;
-  cudaDeviceProp prop;
 };
 
 const std::vector<MinMaxInputs<float>> inputsf = {

--- a/wiki/cpp/DEVELOPER_GUIDE.md
+++ b/wiki/cpp/DEVELOPER_GUIDE.md
@@ -4,6 +4,9 @@ This document summarizes rules and best practices for contributions to the cuML 
 ## General
 Please start by reading [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
+## Performance
+1. In performance critical sections of the code, favor `cudaDeviceGetAttribute` over `cudaDeviceGetProperties`. See PR [#973](https://github.com/rapidsai/cuml/pull/973) for more details.
+
 ## Thread safety
 cuML is thread safe so its functions can be called from multiple host threads if they use different handles.
 


### PR DESCRIPTION
In PR #934, `minmax` prim was updated to request `cudaDeviceProp` as an argument. @harrism rightly pointed out that we could just use `cudaDeviceGetAttribute`, if all we are interested in is knowing the shared-mem per block. In fact, this also simplifies our interface, as we don't have to pass `cudaDeviceProp` as an arg to such prims.

This PR updates the `minmax` to use `cudaDeviceGetAttribute` for querying for shared memory.

Question for you @JohnZed: I also had introduced `cumlHandle::getDeviceProperties` in the above PR. Should we keep it or remove it?