### PR TITLE
Set RF max_depth default to 16 and improve error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 - PR #932: Change default param value for RF classifier
 - PR #949: Fix dtype conversion tests for unsupported cudf dtypes
 - PR #908: Fix local build generated file ownerships
-
+- PR #983: Change RF max_depth default to 16
 
 # cuML 0.8.0 (27 June 2019)
 

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -238,7 +238,7 @@ class RandomForestClassifier(Base):
                          If features are drawn with or without replacement
     rows_sample : float (default = 1.0)
                   Ratio of dataset rows used while fitting each tree.
-    max_depth : int (default = 15)
+    max_depth : int (default = 16)
                 Maximum tree depth. Unlimited (i.e, until leaves are pure),
                 if -1. Unlimited depth is not supported with split_algo=1.
                 *Note that this default differs from scikit-learn's
@@ -269,7 +269,7 @@ class RandomForestClassifier(Base):
                  'verbose', 'rows_sample',
                  'max_leaves', 'quantile_per_tree']
 
-    def __init__(self, n_estimators=10, max_depth=15, handle=None,
+    def __init__(self, n_estimators=10, max_depth=16, handle=None,
                  max_features=1.0, n_bins=8, n_streams=4,
                  split_algo=1, split_criterion=0, min_rows_per_node=2,
                  bootstrap=True, bootstrap_features=False,
@@ -300,7 +300,7 @@ class RandomForestClassifier(Base):
                                 " more information")
 
         if max_depth < 0 and split_algo == 1:
-            raise ValueError("Must specify max_depth >0 with quantile split algo")
+            raise ValueError("Must specify max_depth >0 with split_algo=1")
 
         super(RandomForestClassifier, self).__init__(handle, verbose)
 

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -238,9 +238,11 @@ class RandomForestClassifier(Base):
                          If features are drawn with or without replacement
     rows_sample : float (default = 1.0)
                   Ratio of dataset rows used while fitting each tree.
-    max_depth : int (default = -1)
+    max_depth : int (default = 15)
                 Maximum tree depth. Unlimited (i.e, until leaves are pure),
-                if -1.
+                if -1. Unlimited depth is not supported with split_algo=1.
+                *Note that this default differs from scikit-learn's
+                random forest, which defaults to unlimited depth.*
     max_leaves : int (default = -1)
                  Maximum leaf nodes per tree. Soft constraint. Unlimited,
                  if -1.
@@ -267,7 +269,7 @@ class RandomForestClassifier(Base):
                  'verbose', 'rows_sample',
                  'max_leaves', 'quantile_per_tree']
 
-    def __init__(self, n_estimators=10, max_depth=-1, handle=None,
+    def __init__(self, n_estimators=10, max_depth=15, handle=None,
                  max_features=1.0, n_bins=8, n_streams=4,
                  split_algo=1, split_criterion=0, min_rows_per_node=2,
                  bootstrap=True, bootstrap_features=False,
@@ -296,6 +298,9 @@ class RandomForestClassifier(Base):
                                 " is not supported in cuML,"
                                 " please read the cuML documentation for"
                                 " more information")
+
+        if max_depth < 0 and split_algo == 1:
+            raise ValueError("Must specify max_depth >0 with quantile split algo")
 
         super(RandomForestClassifier, self).__init__(handle, verbose)
 

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -203,7 +203,7 @@ class RandomForestRegressor(Base):
                          If features are drawn with or without replacement
     rows_sample : float (default = 1.0)
                   Ratio of dataset rows used while fitting each tree.
-    max_depth : int (default = -1)
+    max_depth : int (default = 16)
                 Maximum tree depth. Unlimited (i.e, until leaves are pure),
                 if -1. Unlimited depth is not supported with split_algo=1.
                 *Note that this default differs from scikit-learn's
@@ -243,7 +243,7 @@ class RandomForestRegressor(Base):
                  'max_leaves', 'quantile_per_tree',
                  'accuracy_metric']
 
-    def __init__(self, n_estimators=10, max_depth=15, handle=None,
+    def __init__(self, n_estimators=10, max_depth=16, handle=None,
                  max_features='auto', n_bins=8, n_streams=4,
                  split_algo=1, split_criterion=2,
                  bootstrap=True, bootstrap_features=False,
@@ -276,7 +276,7 @@ class RandomForestRegressor(Base):
         super(RandomForestRegressor, self).__init__(handle, verbose)
 
         if max_depth < 0 and split_algo == 1:
-            raise ValueError("Must specify max_depth >0 with quantile split algo")
+            raise ValueError("Must specify max_depth >0 with split_algo=1")
 
         self.split_algo = split_algo
         criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -205,7 +205,9 @@ class RandomForestRegressor(Base):
                   Ratio of dataset rows used while fitting each tree.
     max_depth : int (default = -1)
                 Maximum tree depth. Unlimited (i.e, until leaves are pure),
-                if -1.
+                if -1. Unlimited depth is not supported with split_algo=1.
+                *Note that this default differs from scikit-learn's
+                random forest, which defaults to unlimited depth.*
     max_leaves : int (default = -1)
                  Maximum leaf nodes per tree. Soft constraint. Unlimited,
                  if -1.
@@ -241,7 +243,7 @@ class RandomForestRegressor(Base):
                  'max_leaves', 'quantile_per_tree',
                  'accuracy_metric']
 
-    def __init__(self, n_estimators=10, max_depth=-1, handle=None,
+    def __init__(self, n_estimators=10, max_depth=15, handle=None,
                  max_features='auto', n_bins=8, n_streams=4,
                  split_algo=1, split_criterion=2,
                  bootstrap=True, bootstrap_features=False,
@@ -272,6 +274,9 @@ class RandomForestRegressor(Base):
                                 " please read the cuML documentation for"
                                 " more information")
         super(RandomForestRegressor, self).__init__(handle, verbose)
+
+        if max_depth < 0 and split_algo == 1:
+            raise ValueError("Must specify max_depth >0 with quantile split algo")
 
         self.split_algo = split_algo
         criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -48,7 +48,7 @@ def stress_param(*args, **kwargs):
                          stress_param(100)])
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])
 @pytest.mark.parametrize('split_algo', [0, 1])
-@pytest.mark.parametrize('max_depth', [-1, 1, 15])
+@pytest.mark.parametrize('max_depth', [-1, 1, 16])
 def test_rf_classification(datatype, split_algo,
                            n_info, nrows, ncols, max_depth):
     use_handle = True
@@ -80,7 +80,8 @@ def test_rf_classification(datatype, split_algo,
     if nrows < 500000:
         # sklearn random forest classification model
         # initialization, fit and predict
-        sk_model = skrfc(n_estimators=40, max_depth=None,
+        sk_model = skrfc(n_estimators=40,
+                         max_depth=(max_depth if max_depth > 0 else None),
                          min_samples_split=2, max_features=1.0,
                          random_state=10)
         sk_model.fit(X_train, y_train)
@@ -131,7 +132,7 @@ def test_rf_regression(datatype, use_handle, split_algo,
                        n_bins=8, split_algo=split_algo, split_criterion=2,
                        min_rows_per_node=2,
                        n_estimators=50, handle=handle, max_leaves=-1,
-                       max_depth=50, accuracy_metric='mse')
+                       max_depth=25, accuracy_metric='mse')
     cuml_model.fit(X_train, y_train)
     cu_mse = cuml_model.score(X_test, y_test)
     if mode != 'stress':


### PR DESCRIPTION
The default max_depth of -1 is incompatible with the new default split_algo (quantile). This change adds a clearer error message and also changes default max_depth to 16. This is a deviation from sklearn's defaults. However, the only way to get greater max_depth than 32 currently is to use the old HIST approach, which is extremely slow for these depths and will be replaced with another layer-wise approach in 0.10 anyways. 16 seems like a reasonable point that tends to deliver good accuracy in past experiments (actually, even shallower is fine for very many use cases) while still being fairly fast. 