### PR TITLE
[REVIEW] [HOTFIX] Fix RF docs formatting and minor edits [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - PR #1007: Throws a well defined error when mutigpu is not enabled
 - PR #1018: Hint location of nccl in build.sh for CI
 - PR #1022: Using random_state to make K-Means MNMG tests deterministic
+- PR #1034: Fix typos and formatting issues in RF docs
 
 # cuML 0.8.0 (27 June 2019)
 

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -34,7 +34,7 @@ class RandomForestClassifier:
     Currently, this API makes the following assumptions:
      * The set of Dask workers used between instantiation, fit,
        and predict are all consistent
-     * Training data is comes in the form of cuDF dataframes,
+     * Training data comes in the form of cuDF dataframes,
        distributed so that each worker has at least one partition.
 
     Future versions of the API will support more flexible data

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -178,18 +178,15 @@ class RandomForestClassifier(Base):
     histogram-based algorithms to determine splits, rather than an exact
     count. You can tune the size of the histograms with the n_bins parameter.
 
-    **Known Limitations**: This is an initial preview release of the cuML
-    Random Forest code. It contains a number of known
-    limitations:
+    **Known Limitations**: This is an initial release of the cuML
+    Random Forest code. It contains a few known limitations:
 
        * Inference/prediction takes place on the CPU. A GPU-based inference
-         solution is planned for a near-future release release.
+         solution based on the forest inference library is planned for a
+         near-future release.
 
        * Instances of RandomForestClassifier cannot be pickled currently.
 
-    The code is under heavy development, so users who need these features may
-    wish to pull from nightly builds of cuML. (See https://rapids.ai/start.html
-    for instructions to download nightly packages via conda.)
 
     Examples
     ---------
@@ -222,12 +219,14 @@ class RandomForestClassifier(Base):
     handle : cuml.Handle
              If it is None, a new one is created just for this class.
     split_criterion: The criterion used to split nodes.
-                     0 for GINI, 1 for ENTROPY, 4 for CRITERION_END.
+                     0 for GINI, 1 for ENTROPY
                      2 and 3 not valid for classification
                      (default = 0)
     split_algo : 0 for HIST and 1 for GLOBAL_QUANTILE
                  (default = 1)
                  the algorithm to determine how nodes are split in the tree.
+                 HIST curently uses a slower tree-building algorithm
+                 so GLOBAL_QUANTILE is recommended for most cases.
     bootstrap : boolean (default = True)
                 Control bootstrapping.
                 If set, each tree in the forest is built

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -160,7 +160,17 @@ class RandomForestRegressor(Base):
     used in scikit-learn. By default, the cuML Random Forest uses a
     histogram-based algorithms to determine splits, rather than an exact
     count. You can tune the size of the histograms with the n_bins parameter.
-    The instances of RandomForestRegressor cannot be pickled currently.
+
+    **Known Limitations**: This is an initial release of the cuML
+    Random Forest code. It contains a few known limitations:
+
+       * Inference/prediction takes place on the CPU. A GPU-based inference
+         solution based on the forest inference library is planned for a
+         near-future release.
+
+       * Instances of RandomForestRegressor cannot be pickled currently.
+
+
     Examples
     ---------
     .. code-block:: python
@@ -186,12 +196,14 @@ class RandomForestRegressor(Base):
     handle : cuml.Handle
              If it is None, a new one is created just for this class.
     split_algo : int (default = 1)
-                 0 for HIST, 1 for GLOBAL_QUANTILE and 2 for SPLIT_ALGO_END
+                 0 for HIST, 1 for GLOBAL_QUANTILE
                  The type of algorithm to be used to create the trees.
+                 HIST curently uses a slower tree-building algorithm
+                 so GLOBAL_QUANTILE is recommended for most cases.
     split_criterion: int (default = 2)
                      The criterion used to split nodes.
                      0 for GINI, 1 for ENTROPY,
-                     2 for MSE, 3 for MAE and 4 for CRITERION_END.
+                     2 for MSE, or 3 for MAE
                      0 and 1 not valid for regression
     bootstrap : boolean (default = True)
                 Control bootstrapping.

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -170,7 +170,6 @@ class RandomForestRegressor(Base):
 
        * Instances of RandomForestRegressor cannot be pickled currently.
 
-
     Examples
     ---------
     .. code-block:: python


### PR DESCRIPTION
@robocopnixon  pointed out that the example docs for RandomForestRegressor were not formatted properly. When I went to fix them, I noticed a few other small documentation glitches.