### PR TITLE
[REVIEW] fix conda environments version of numba = 0.45 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## Bug Fixes
 
 - PR #1016: Use correct libcumlprims version in GPU CI
-- PR #1039: Update version of numba in development conda yaml files
+- PR #1040: Update version of numba in development conda yaml files
 
 
 # cuML 0.9.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bug Fixes
 
 - PR #1016: Use correct libcumlprims version in GPU CI
+- PR #1039: Update version of numba in development conda yaml files
 
 
 # cuML 0.9.0 (Date TBD)

--- a/conda/environments/cuml_dev_cuda10.0.yml
+++ b/conda/environments/cuml_dev_cuda10.0.yml
@@ -8,7 +8,7 @@ dependencies:
 - cudatoolkit=10.0
 - libclang=8.0.0
 - cmake=3.14.5
-- numba=0.44*
+- numba=0.45*
 # - cupy>=6*
 - cudf=0.10*
 - rmm=0.10*

--- a/conda/environments/cuml_dev_cuda9.2.yml
+++ b/conda/environments/cuml_dev_cuda9.2.yml
@@ -8,7 +8,7 @@ dependencies:
 - cudatoolkit=9.2
 - libclang=8.0.0
 - cmake=3.14.5
-- numba=0.44*
+- numba=0.45*
 # - cupy>=6*
 - cudf=0.10*
 - rmm=0.10*


### PR DESCRIPTION
Currently the development conda environments specify numba to be 0.44 which makes conda to pull older cudf nightlies, this corrects that.