### PR TITLE
[REVIEW] Using proper set of workers to destroy nccl comms

### DIFF
--- a/python/cuml/test/dask/test_kmeans.py
+++ b/python/cuml/test/dask/test_kmeans.py
@@ -42,6 +42,9 @@ def test_end_to_end(nrows, ncols, nclusters, n_parts, client=None):
                                    random_state=10)
 
     wait(X_cudf)
+    wait(X_df)
+
+    print(str(X_df))
 
     cumlModel = cumlKMeans(verbose=0, init="k-means||", n_clusters=nclusters,
                            random_state=10)


### PR DESCRIPTION
0.9 released the first version of the comms, which allows the initialization of a subset of the available workers in a Dask cluster. The subset of workers passed into the constructor was not being stored on the instance and all workers were being used to destroy the NCCL comms. 

This PR fixes this issue, however, it has exposed what seems to be a recent version conflict in the dask-ml packages, causing a strange error in the kmeans test that appears to be numba/numpy related. 