### PR TITLE
Selective eigen solver of cuSolver 

### DIFF
--- a/cpp/src_prims/linalg/cusolver_wrappers.h
+++ b/cpp/src_prims/linalg/cusolver_wrappers.h
@@ -279,61 +279,58 @@ inline cusolverStatus_t cusolverDnsyevd(cusolverDnHandle_t handle,
  * @{
 */
 template <typename T>
-cusolverStatus_t cusolverDnsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
-                                             cusolverEigRange_t range, cublasFillMode_t uplo, int n,
-                                             const T *A, int lda, T vl, T vu, int il, int iu,
-                                             int *h_meig, const T *W, int *lwork);
+cusolverStatus_t cusolverDnsyevdx_bufferSize(
+  cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+  cublasFillMode_t uplo, int n, const T *A, int lda, T vl, T vu, int il, int iu,
+  int *h_meig, const T *W, int *lwork);
 
 template <>
-inline cusolverStatus_t cusolverDnsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
-                                                    cusolverEigRange_t range, cublasFillMode_t uplo, int n,
-                                                    const float *A, int lda, float vl, float vu, int il, int iu,
-                                                    int *h_meig, const float *W, int *lwork) {
-  return cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
-                                      h_meig, W, lwork);
+inline cusolverStatus_t cusolverDnsyevdx_bufferSize(
+  cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+  cublasFillMode_t uplo, int n, const float *A, int lda, float vl, float vu,
+  int il, int iu, int *h_meig, const float *W, int *lwork) {
+  return cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl,
+                                      vu, il, iu, h_meig, W, lwork);
 }
 
 template <>
-inline cusolverStatus_t cusolverDnsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
-                                                    cusolverEigRange_t range, cublasFillMode_t uplo, int n,
-                                                    const double *A, int lda, double vl, double vu, int il, int iu,
-                                                    int *h_meig, const double *W, int *lwork) {
-  return cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
-                                      h_meig, W, lwork);
+inline cusolverStatus_t cusolverDnsyevdx_bufferSize(
+  cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+  cublasFillMode_t uplo, int n, const double *A, int lda, double vl, double vu,
+  int il, int iu, int *h_meig, const double *W, int *lwork) {
+  return cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl,
+                                      vu, il, iu, h_meig, W, lwork);
 }
-  
+
 template <typename T>
-cusolverStatus_t cusolverDnsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
-                                  cusolverEigRange_t range, cublasFillMode_t uplo, 
-                                  int n, T *A, int lda, T vl, T vu, int il, 
-                                  int iu, int *h_meig, T *W, T *work, int lwork, 
-                                  int *devInfo, cudaStream_t stream);
+cusolverStatus_t cusolverDnsyevdx(
+  cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+  cublasFillMode_t uplo, int n, T *A, int lda, T vl, T vu, int il, int iu,
+  int *h_meig, T *W, T *work, int lwork, int *devInfo, cudaStream_t stream);
 
 template <>
-inline cusolverStatus_t cusolverDnsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
-                                  cusolverEigRange_t range, cublasFillMode_t uplo, 
-                                  int n, float *A, int lda, float vl, float vu, int il, 
-                                  int iu, int *h_meig, float *W, float *work, int lwork, 
-                                  int *devInfo, cudaStream_t stream) {
+inline cusolverStatus_t cusolverDnsyevdx(
+  cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+  cublasFillMode_t uplo, int n, float *A, int lda, float vl, float vu, int il,
+  int iu, int *h_meig, float *W, float *work, int lwork, int *devInfo,
+  cudaStream_t stream) {
   CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
-  return cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, 
-                           iu, h_meig, W, work, lwork, 
-                           devInfo, stream);
+  return cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                           h_meig, W, work, lwork, devInfo);
 }
 
 template <>
-inline cusolverStatus_t cusolverDnsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
-                                  cusolverEigRange_t range, cublasFillMode_t uplo, 
-                                  int n, double *A, int lda, double vl, double vu, int il, 
-                                  int iu, int *h_meig, double *W, double *work, int lwork, 
-                                  int *devInfo, cudaStream_t stream) {
+inline cusolverStatus_t cusolverDnsyevdx(
+  cusolverDnHandle_t handle, cusolverEigMode_t jobz, cusolverEigRange_t range,
+  cublasFillMode_t uplo, int n, double *A, int lda, double vl, double vu,
+  int il, int iu, int *h_meig, double *W, double *work, int lwork, int *devInfo,
+  cudaStream_t stream) {
   CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
-  return cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, 
-                           iu, h_meig, W, work, lwork, 
-                           devInfo, stream);
+  return cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                           h_meig, W, work, lwork, devInfo);
 }
 /** @} */
-  
+
 /**
  * @defgroup svd cusolver svd operations
  * @{

--- a/cpp/src_prims/linalg/cusolver_wrappers.h
+++ b/cpp/src_prims/linalg/cusolver_wrappers.h
@@ -275,6 +275,66 @@ inline cusolverStatus_t cusolverDnsyevd(cusolverDnHandle_t handle,
 /** @} */
 
 /**
+ * @defgroup syevdx cusolver syevdx operations
+ * @{
+*/
+template <typename T>
+cusolverStatus_t cusolverDnsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
+                                             cusolverEigRange_t range, cublasFillMode_t uplo, int n,
+                                             const T *A, int lda, T vl, T vu, int il, int iu,
+                                             int *h_meig, const T *W, int *lwork);
+
+template <>
+inline cusolverStatus_t cusolverDnsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
+                                                    cusolverEigRange_t range, cublasFillMode_t uplo, int n,
+                                                    const float *A, int lda, float vl, float vu, int il, int iu,
+                                                    int *h_meig, const float *W, int *lwork) {
+  return cusolverDnSsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                                      h_meig, W, lwork);
+}
+
+template <>
+inline cusolverStatus_t cusolverDnsyevdx_bufferSize(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
+                                                    cusolverEigRange_t range, cublasFillMode_t uplo, int n,
+                                                    const double *A, int lda, double vl, double vu, int il, int iu,
+                                                    int *h_meig, const double *W, int *lwork) {
+  return cusolverDnDsyevdx_bufferSize(handle, jobz, range, uplo, n, A, lda, vl, vu, il, iu,
+                                      h_meig, W, lwork);
+}
+  
+template <typename T>
+cusolverStatus_t cusolverDnsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
+                                  cusolverEigRange_t range, cublasFillMode_t uplo, 
+                                  int n, T *A, int lda, T vl, T vu, int il, 
+                                  int iu, int *h_meig, T *W, T *work, int lwork, 
+                                  int *devInfo, cudaStream_t stream);
+
+template <>
+inline cusolverStatus_t cusolverDnsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
+                                  cusolverEigRange_t range, cublasFillMode_t uplo, 
+                                  int n, float *A, int lda, float vl, float vu, int il, 
+                                  int iu, int *h_meig, float *W, float *work, int lwork, 
+                                  int *devInfo, cudaStream_t stream) {
+  CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
+  return cusolverDnSsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, 
+                           iu, h_meig, W, work, lwork, 
+                           devInfo, stream);
+}
+
+template <>
+inline cusolverStatus_t cusolverDnsyevdx(cusolverDnHandle_t handle, cusolverEigMode_t jobz, 
+                                  cusolverEigRange_t range, cublasFillMode_t uplo, 
+                                  int n, double *A, int lda, double vl, double vu, int il, 
+                                  int iu, int *h_meig, double *W, double *work, int lwork, 
+                                  int *devInfo, cudaStream_t stream) {
+  CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
+  return cusolverDnDsyevdx(handle, jobz, range, uplo, n, A, lda, vl, vu, il, 
+                           iu, h_meig, W, work, lwork, 
+                           devInfo, stream);
+}
+/** @} */
+  
+/**
  * @defgroup svd cusolver svd operations
  * @{
  */

--- a/cpp/src_prims/linalg/cusolver_wrappers.h
+++ b/cpp/src_prims/linalg/cusolver_wrappers.h
@@ -274,6 +274,7 @@ inline cusolverStatus_t cusolverDnsyevd(cusolverDnHandle_t handle,
 }
 /** @} */
 
+#if CUDART_VERSION >= 10010
 /**
  * @defgroup syevdx cusolver syevdx operations
  * @{
@@ -330,6 +331,7 @@ inline cusolverStatus_t cusolverDnsyevdx(
                            h_meig, W, work, lwork, devInfo);
 }
 /** @} */
+#endif
 
 /**
  * @defgroup svd cusolver svd operations

--- a/cpp/src_prims/linalg/eig.h
+++ b/cpp/src_prims/linalg/eig.h
@@ -67,6 +67,49 @@ void eigDC(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
          "This usually occurs when some of the features do not vary enough.");
 }
 
+
+/**
+ * @defgroup eig decomp with divide and conquer method for the column-major
+ * symmetric matrices
+ * @param in the input buffer (symmetric matrix that has real eig values and
+ * vectors.
+ * @param n_rows: number of rows of the input
+ * @param n_cols: number of cols of the input
+ * @param eig_vectors: eigenvectors
+ * @param eig_vals: eigen values
+ * @param cusolverH cusolver handle
+ * @param stream cuda stream
+ * @param allocator device allocator for temporary buffers during computation
+ * @{
+ */
+template <typename math_t>
+void eigSelDC(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
+           math_t *eig_vals, cusolverDnHandle_t cusolverH, cudaStream_t stream,
+           std::shared_ptr<deviceAllocator> allocator) {
+  int lwork;
+  CUSOLVER_CHECK(cusolverDnsyevd_bufferSize(cusolverH, CUSOLVER_EIG_MODE_VECTOR,
+                                            CUBLAS_FILL_MODE_UPPER, n_rows, in,
+                                            n_cols, eig_vals, &lwork));
+
+  device_buffer<math_t> d_work(allocator, stream, lwork);
+  device_buffer<int> d_dev_info(allocator, stream, 1);
+
+  MLCommon::Matrix::copy(in, eig_vectors, n_rows, n_cols, stream);
+
+  CUSOLVER_CHECK(cusolverDnsyevd(cusolverH, CUSOLVER_EIG_MODE_VECTOR,
+                                 CUBLAS_FILL_MODE_UPPER, n_rows, eig_vectors,
+                                 n_cols, eig_vals, d_work.data(), lwork,
+                                 d_dev_info.data(), stream));
+  CUDA_CHECK(cudaGetLastError());
+
+  int dev_info;
+  updateHost(&dev_info, d_dev_info.data(), 1, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  ASSERT(dev_info == 0,
+         "eig.h: eigensolver couldn't converge to a solution. "
+         "This usually occurs when some of the features do not vary enough.");
+}
+
 /**
  * @defgroup overloaded function for eig decomp with Jacobi method for the
  * column-major symmetric matrices (in parameter)

--- a/cpp/src_prims/linalg/eig.h
+++ b/cpp/src_prims/linalg/eig.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cuda_runtime_api.h>
 #include "common/cuml_allocator.hpp"
 #include "common/device_buffer.hpp"
 #include "cuda_utils.h"
@@ -68,6 +69,8 @@ void eigDC(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
 }
 
 enum EigVecMemUsage { OVERWRITE_INPUT, COPY_INPUT };
+
+#if CUDART_VERSION >= 10010
 
 /**
  * @defgroup eig decomp with divide and conquer method for the column-major
@@ -135,6 +138,8 @@ void eigSelDC(math_t *in, int n_rows, int n_cols, int n_eig_vals,
                             n_eig_vals, stream);
   }
 }
+
+#endif
 
 /**
  * @defgroup overloaded function for eig decomp with Jacobi method for the

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -151,6 +151,7 @@ if(BUILD_PRIMS_TESTS)
       prims/dist_l1.cu
       prims/divide.cu
       prims/eig.cu
+      prims/eig_sel.cu
       prims/eltwise.cu
       prims/eltwise2d.cu
       prims/entropy.cu

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -126,7 +126,7 @@ const std::vector<EigSelInputs<float>> inputsf2 = {
 const std::vector<EigSelInputs<double>> inputsd2 = {
   {0.001, 4 * 4, 4, 4, 1234ULL, 256}};
 
-typedef EigTSelTest<float> EigSelTestValF;
+typedef EigSelTest<float> EigSelTestValF;
 TEST_P(EigSelTestValF, Result) {
   ASSERT_TRUE(devArrMatch(eig_vals_ref, eig_vals, params.n_col,
                           CompareApproxAbs<float>(params.tolerance)));

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -126,7 +126,7 @@ const std::vector<EigSelInputs<float>> inputsf2 = {
 const std::vector<EigSelInputs<double>> inputsd2 = {
   {0.001, 4 * 4, 4, 4, 1234ULL, 256}};
 
-typedef EigTSelest<float> EigSelTestValF;
+typedef EigTSelTest<float> EigSelTestValF;
 TEST_P(EigSelTestValF, Result) {
   ASSERT_TRUE(devArrMatch(eig_vals_ref, eig_vals, params.n_col,
                           CompareApproxAbs<float>(params.tolerance)));

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "cuda_utils.h"
+#include "linalg/eig.h"
+#include "random/rng.h"
+#include "test_utils.h"
+
+namespace MLCommon {
+namespace LinAlg {
+
+template <typename T>
+struct EigSelInputs {
+  T tolerance;
+  int len;
+  int n_row;
+  int n_col;
+  unsigned long long int seed;
+  int n;
+};
+
+template <typename T>
+::std::ostream &operator<<(::std::ostream &os, const EigSelInputs<T> &dims) {
+  return os;
+}
+
+template <typename T>
+class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
+ protected:
+  void SetUp() override {
+    CUSOLVER_CHECK(cusolverDnCreate(&cusolverH));
+    CUDA_CHECK(cudaStreamCreate(&stream));
+    std::shared_ptr<deviceAllocator> allocator(new defaultDeviceAllocator);
+
+    params = ::testing::TestWithParam<EigSelInputs<T>>::GetParam();
+    Random::Rng r(params.seed);
+    int len = params.len;
+
+    allocate(cov_matrix, len);
+    T cov_matrix_h[] = {1.0,  0.9, 0.81, 0.729, 0.9,   1.0,  0.9, 0.81,
+                        0.81, 0.9, 1.0,  0.9,   0.729, 0.81, 0.9, 1.0};
+    ASSERT(len == 16, "This test only works with 4x4 matrices!");
+    updateDevice(cov_matrix, cov_matrix_h, len, stream);
+
+    allocate(eig_vectors, len);
+    allocate(eig_vals, params.n_col);
+    allocate(eig_vectors_jacobi, len);
+    allocate(eig_vals_jacobi, params.n_col);
+
+    T eig_vectors_ref_h[] = {0.2790, -0.6498, 0.6498, -0.2789, -0.5123, 0.4874,
+                             0.4874, -0.5123, 0.6498, 0.2789,  -0.2789, -0.6498,
+                             0.4874, 0.5123,  0.5123, 0.4874};
+    T eig_vals_ref_h[] = {0.0614, 0.1024, 0.3096, 3.5266};
+
+    allocate(eig_vectors_ref, len);
+    allocate(eig_vals_ref, params.n_col);
+
+    updateDevice(eig_vectors_ref, eig_vectors_ref_h, len, stream);
+    updateDevice(eig_vals_ref, eig_vals_ref_h, params.n_col, stream);
+
+    eigDC(cov_matrix, params.n_row, params.n_col, eig_vectors, eig_vals,
+          cusolverH, stream, allocator);
+
+    T tol = 1.e-7;
+    int sweeps = 15;
+    eigJacobi(cov_matrix, params.n_row, params.n_col, eig_vectors_jacobi,
+              eig_vals_jacobi, tol, sweeps, cusolverH, stream, allocator);
+
+    // test code for comparing two methods
+    len = params.n * params.n;
+    allocate(cov_matrix_large, len);
+    allocate(eig_vectors_large, len);
+    allocate(eig_vectors_jacobi_large, len);
+    allocate(eig_vals_large, params.n);
+    allocate(eig_vals_jacobi_large, params.n);
+
+    r.uniform(cov_matrix_large, len, T(-1.0), T(1.0), stream);
+
+    eigDC(cov_matrix_large, params.n, params.n, eig_vectors_large,
+          eig_vals_large, cusolverH, stream, allocator);
+    eigJacobi(cov_matrix_large, params.n, params.n, eig_vectors_jacobi_large,
+              eig_vals_jacobi_large, tol, sweeps, cusolverH, stream, allocator);
+  }
+
+  void TearDown() override {
+    CUDA_CHECK(cudaFree(cov_matrix));
+    CUDA_CHECK(cudaFree(eig_vectors));
+    CUDA_CHECK(cudaFree(eig_vectors_jacobi));
+    CUDA_CHECK(cudaFree(eig_vals));
+    CUDA_CHECK(cudaFree(eig_vals_jacobi));
+    CUDA_CHECK(cudaFree(eig_vectors_ref));
+    CUDA_CHECK(cudaFree(eig_vals_ref));
+    CUSOLVER_CHECK(cusolverDnDestroy(cusolverH));
+    CUDA_CHECK(cudaStreamDestroy(stream));
+  }
+
+ protected:
+  EigSelInputs<T> params;
+  T *cov_matrix, *eig_vectors, *eig_vectors_jacobi, *eig_vectors_ref, *eig_vals,
+    *eig_vals_jacobi, *eig_vals_ref;
+
+  T *cov_matrix_large, *eig_vectors_large, *eig_vectors_jacobi_large,
+    *eig_vals_large, *eig_vals_jacobi_large;
+
+  cusolverDnHandle_t cusolverH = NULL;
+  cudaStream_t stream;
+};
+
+const std::vector<EigSelInputs<float>> inputsf2 = {
+  {0.001f, 4 * 4, 4, 4, 1234ULL, 256}};
+
+const std::vector<EigSelInputs<double>> inputsd2 = {
+  {0.001, 4 * 4, 4, 4, 1234ULL, 256}};
+
+typedef EigTSelest<float> EigSelTestValF;
+TEST_P(EigSelTestValF, Result) {
+  ASSERT_TRUE(devArrMatch(eig_vals_ref, eig_vals, params.n_col,
+                          CompareApproxAbs<float>(params.tolerance)));
+}
+
+typedef EigSelTest<double> EigSelTestValD;
+TEST_P(EigSelTestValD, Result) {
+  ASSERT_TRUE(devArrMatch(eig_vals_ref, eig_vals, params.n_col,
+                          CompareApproxAbs<double>(params.tolerance)));
+}
+
+typedef EigSelTest<float> EigSelTestVecF;
+TEST_P(EigSelTestVecF, Result) {
+  ASSERT_TRUE(devArrMatch(eig_vectors_ref, eig_vectors, params.len,
+                          CompareApproxAbs<float>(params.tolerance)));
+}
+
+typedef EigSelTest<double> EigSelTestVecD;
+TEST_P(EigSelTestVecD, Result) {
+  ASSERT_TRUE(devArrMatch(eig_vectors_ref, eig_vectors, params.len,
+                          CompareApproxAbs<double>(params.tolerance)));
+}
+
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestValF, ::testing::ValuesIn(inputsf2));
+
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestValD, ::testing::ValuesIn(inputsd2));
+
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecF, ::testing::ValuesIn(inputsf2));
+
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecD, ::testing::ValuesIn(inputsd2));
+
+}  // end namespace LinAlg
+}  // end namespace MLCommon

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -45,7 +45,7 @@ class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
     CUSOLVER_CHECK(cusolverDnCreate(&cusolverH));
     CUDA_CHECK(cudaStreamCreate(&stream));
     std::shared_ptr<deviceAllocator> allocator(new defaultDeviceAllocator);
-
+    params = ::testing::TestWithParam<EigInputs<T>>::GetParam();
     int len = params.len;
 
     allocate(cov_matrix, len);
@@ -68,7 +68,7 @@ class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
     updateDevice(eig_vectors_ref, eig_vectors_ref_h, len, stream);
     updateDevice(eig_vals_ref, eig_vals_ref_h, params.n_col, stream);
 
-    eigDC(cov_matrix, params.n_row, params.n_col, eig_vectors, eig_vals,
+    eigSelDC(cov_matrix, params.n_row, params.n_col, params.n_col, eig_vectors, eig_vals,
           cusolverH, stream, allocator);
   }
 

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -54,22 +54,21 @@ class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
     ASSERT(len == 16, "This test only works with 4x4 matrices!");
     updateDevice(cov_matrix, cov_matrix_h, len, stream);
 
-    allocate(eig_vectors, len);
+    allocate(eig_vectors, 12);
     allocate(eig_vals, params.n_col);
 
-    T eig_vectors_ref_h[] = {0.2790, -0.6498, 0.6498, -0.2789, -0.5123, 0.4874,
-                             0.4874, -0.5123, 0.6498, 0.2789,  -0.2789, -0.6498,
-                             0.4874, 0.5123,  0.5123, 0.4874};
-    T eig_vals_ref_h[] = {0.0614, 0.1024, 0.3096, 3.5266};
+    T eig_vectors_ref_h[] = {-0.5123, 0.4874,  0.4874, -0.5123, 0.6498, 0.2789,
+                             -0.2789, -0.6498, 0.4874, 0.5123,  0.5123, 0.4874};
+    T eig_vals_ref_h[] = {0.1024, 0.3096, 3.5266, 3.5266};
 
-    allocate(eig_vectors_ref, len);
+    allocate(eig_vectors_ref, 12);
     allocate(eig_vals_ref, params.n_col);
 
-    updateDevice(eig_vectors_ref, eig_vectors_ref_h, len, stream);
-    updateDevice(eig_vals_ref, eig_vals_ref_h, params.n_col, stream);
+    updateDevice(eig_vectors_ref, eig_vectors_ref_h, 12, stream);
+    updateDevice(eig_vals_ref, eig_vals_ref_h, 4, stream);
 
-    eigSelDC(cov_matrix, params.n_row, params.n_col, params.n_col, eig_vectors,
-             eig_vals, cusolverH, stream, allocator);
+    eigSelDC(cov_matrix, params.n_row, params.n_col, 3, eig_vectors, eig_vals,
+             EigVecMemUsage::OVERWRITE_INPUT, cusolverH, stream, allocator);
   }
 
   void TearDown() override {
@@ -110,13 +109,13 @@ TEST_P(EigSelTestValD, Result) {
 
 typedef EigSelTest<float> EigSelTestVecF;
 TEST_P(EigSelTestVecF, Result) {
-  ASSERT_TRUE(devArrMatch(eig_vectors_ref, eig_vectors, params.len,
+  ASSERT_TRUE(devArrMatch(eig_vectors_ref, eig_vectors, 12,
                           CompareApproxAbs<float>(params.tolerance)));
 }
 
 typedef EigSelTest<double> EigSelTestVecD;
 TEST_P(EigSelTestVecD, Result) {
-  ASSERT_TRUE(devArrMatch(eig_vectors_ref, eig_vectors, params.len,
+  ASSERT_TRUE(devArrMatch(eig_vectors_ref, eig_vectors, 12,
                           CompareApproxAbs<double>(params.tolerance)));
 }
 

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -45,7 +45,7 @@ class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
     CUSOLVER_CHECK(cusolverDnCreate(&cusolverH));
     CUDA_CHECK(cudaStreamCreate(&stream));
     std::shared_ptr<deviceAllocator> allocator(new defaultDeviceAllocator);
-    params = ::testing::TestWithParam<EigInputs<T>>::GetParam();
+    params = ::testing::TestWithParam<EigSelInputs<T>>::GetParam();
     int len = params.len;
 
     allocate(cov_matrix, len);
@@ -68,8 +68,8 @@ class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
     updateDevice(eig_vectors_ref, eig_vectors_ref_h, len, stream);
     updateDevice(eig_vals_ref, eig_vals_ref_h, params.n_col, stream);
 
-    eigSelDC(cov_matrix, params.n_row, params.n_col, params.n_col, eig_vectors, eig_vals,
-          cusolverH, stream, allocator);
+    eigSelDC(cov_matrix, params.n_row, params.n_col, params.n_col, eig_vectors,
+             eig_vals, cusolverH, stream, allocator);
   }
 
   void TearDown() override {
@@ -84,8 +84,7 @@ class EigSelTest : public ::testing::TestWithParam<EigSelInputs<T>> {
 
  protected:
   EigSelInputs<T> params;
-  T *cov_matrix, *eig_vectors, *eig_vectors_ref, *eig_vals,
-    *eig_vals_ref;
+  T *cov_matrix, *eig_vectors, *eig_vectors_ref, *eig_vals, *eig_vals_ref;
 
   cusolverDnHandle_t cusolverH = NULL;
   cudaStream_t stream;
@@ -121,13 +120,17 @@ TEST_P(EigSelTestVecD, Result) {
                           CompareApproxAbs<double>(params.tolerance)));
 }
 
-INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestValF, ::testing::ValuesIn(inputsf2));
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestValF,
+                        ::testing::ValuesIn(inputsf2));
 
-INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestValD, ::testing::ValuesIn(inputsd2));
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestValD,
+                        ::testing::ValuesIn(inputsd2));
 
-INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecF, ::testing::ValuesIn(inputsf2));
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecF,
+                        ::testing::ValuesIn(inputsf2));
 
-INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecD, ::testing::ValuesIn(inputsd2));
+INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecD,
+                        ::testing::ValuesIn(inputsd2));
 
 }  // end namespace LinAlg
 }  // end namespace MLCommon

--- a/cpp/test/prims/eig_sel.cu
+++ b/cpp/test/prims/eig_sel.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if CUDART_VERSION >= 10010
+
 #include <gtest/gtest.h>
 #include "cuda_utils.h"
 #include "linalg/eig.h"
@@ -133,3 +135,5 @@ INSTANTIATE_TEST_CASE_P(EigSelTest, EigSelTestVecD,
 
 }  // end namespace LinAlg
 }  // end namespace MLCommon
+
+#endif


### PR DESCRIPTION
Selective eigen solver of cuSolver is added to prims to use it in PCA and tSVD.