### PR TITLE
[ENH] Ensure RegressorMixin scorer uses device arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #961: High Peformance RF; HIST algo
 - PR #1028: Dockerfile updates after dir restructure. Conda env yaml to add statsmodels as a dependency
 - PR #763: Add examples to train_test_split documentation
+- PR #1086: Ensure RegressorMixin scorer uses device arrays
 
 ## Bug Fixes
 

--- a/python/cuml/metrics/base.py
+++ b/python/cuml/metrics/base.py
@@ -15,7 +15,7 @@
 #
 
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 
 class RegressorMixin:

--- a/python/cuml/metrics/base.py
+++ b/python/cuml/metrics/base.py
@@ -17,6 +17,7 @@
 
 class RegressorMixin:
     """Mixin class for regression estimators in"""
+
     _estimator_type = "regressor"
 
     def score(self, X, y, **kwargs):
@@ -37,4 +38,5 @@ class RegressorMixin:
             R^2 of self.predict(X) wrt. y.
         """
         from cuml.metrics.regression import r2_score
+
         return r2_score(y.to_gpu_array(), self.predict(X).to_gpu_array())

--- a/python/cuml/metrics/base.py
+++ b/python/cuml/metrics/base.py
@@ -46,4 +46,4 @@ class RegressorMixin:
         X_m = input_to_dev_array(X)[0]
         y_m = input_to_dev_array(y)[0]
 
-        return r2_score(y_m, cuda.to_device(self.predict(X_m)))
+        return r2_score(y_m, rmm.to_device(self.predict(X_m)))

--- a/python/cuml/metrics/base.py
+++ b/python/cuml/metrics/base.py
@@ -15,6 +15,9 @@
 #
 
 
+from numba import cuda
+
+
 class RegressorMixin:
     """Mixin class for regression estimators in"""
 
@@ -38,5 +41,9 @@ class RegressorMixin:
             R^2 of self.predict(X) wrt. y.
         """
         from cuml.metrics.regression import r2_score
+        from cuml.utils import input_to_dev_array
 
-        return r2_score(y.to_gpu_array(), self.predict(X).to_gpu_array())
+        X_m = input_to_dev_array(X)[0]
+        y_m = input_to_dev_array(y)[0]
+
+        return r2_score(y_m, cuda.to_device(self.predict(X_m)))

--- a/python/cuml/metrics/base.py
+++ b/python/cuml/metrics/base.py
@@ -15,7 +15,7 @@
 #
 
 
-from librmm_cffi import librmm as rmm
+from numba import cuda
 
 
 class RegressorMixin:

--- a/python/cuml/metrics/base.py
+++ b/python/cuml/metrics/base.py
@@ -46,4 +46,4 @@ class RegressorMixin:
         X_m = input_to_dev_array(X)[0]
         y_m = input_to_dev_array(y)[0]
 
-        return r2_score(y_m, rmm.to_device(self.predict(X_m)))
+        return r2_score(y_m, cuda.to_device(self.predict(X_m)))


### PR DESCRIPTION
Updates the `scorer` method in `RegressorMixin` to ensure it has device arrays as inputs and intermediate results are also device arrays.

xref: https://github.com/rapidsai/cuml/issues/1085