### PR TITLE
[REVIEW] Change numba allocations to RMM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #990: Barnes Hut TSNE Memory Issue Fixes
 - PR #1072: Remove pip requirements and setup
 - PR #1074: Fix flake8 CI style check
+- PR #1088: Change straggling numba python allocations to use RMM
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -283,7 +283,7 @@ class KMeans(Base):
             params.init = Array
             dim_cc = self.n_clusters * self.n_cols
             self.cluster_centers_ = rmm.device_array(dim_cc,
-                                                      dtype=self.dtype)
+                                                     dtype=self.dtype)
             si = self.init
             self.cluster_centers_.copy_to_device(numba_utils.row_matrix(si))
 
@@ -535,7 +535,7 @@ class KMeans(Base):
         cdef uintptr_t cluster_centers_ptr = get_dev_array_ptr(clust_mat)
 
         preds_data = rmm.to_device(zeros(self.n_clusters*n_rows,
-                                    dtype=self.dtype))
+                                   dtype=self.dtype))
 
         cdef uintptr_t preds_ptr = get_dev_array_ptr(preds_data)
 

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -24,7 +24,7 @@ import cudf
 import numpy as np
 import warnings
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -282,7 +282,7 @@ class KMeans(Base):
                                  % (self.init.shape, self.n_clusters))
             params.init = Array
             dim_cc = self.n_clusters * self.n_cols
-            self.cluster_centers_ = cuda.device_array(dim_cc,
+            self.cluster_centers_ = rmm.device_array(dim_cc,
                                                       dtype=self.dtype)
             si = self.init
             self.cluster_centers_.copy_to_device(numba_utils.row_matrix(si))
@@ -293,7 +293,7 @@ class KMeans(Base):
                                  'does not match the number of clusters %i'
                                  % (self.init.shape, self.n_clusters))
             params.init = Array
-            self.cluster_centers_ = cuda.to_device(self.init.flatten())
+            self.cluster_centers_ = rmm.to_device(self.init.flatten())
 
         elif (self.init in ['scalable-k-means++', 'k-means||']):
             params.init = KMeansPlusPlus
@@ -338,7 +338,7 @@ class KMeans(Base):
         if (self.init in ['scalable-k-means++', 'k-means||', 'random']):
             clust_cent = zeros(self.n_clusters * self.n_cols,
                                dtype=self.dtype)
-            self.cluster_centers_ = cuda.to_device(clust_cent)
+            self.cluster_centers_ = rmm.to_device(clust_cent)
 
         c_c = self.cluster_centers_
         cdef uintptr_t cluster_centers_ptr = get_dev_array_ptr(c_c)
@@ -534,7 +534,7 @@ class KMeans(Base):
         clust_mat = numba_utils.row_matrix(self.cluster_centers_)
         cdef uintptr_t cluster_centers_ptr = get_dev_array_ptr(clust_mat)
 
-        preds_data = cuda.to_device(zeros(self.n_clusters*n_rows,
+        preds_data = rmm.to_device(zeros(self.n_clusters*n_rows,
                                     dtype=self.dtype))
 
         cdef uintptr_t preds_ptr = get_dev_array_ptr(preds_data)

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -24,7 +24,7 @@ import cudf
 import numpy as np
 import warnings
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -118,7 +118,7 @@ class KMeansMG(KMeans):
         if (self.init in ['scalable-k-means++', 'k-means||', 'random']):
             clust_cent = zeros(self.n_clusters * self.n_cols,
                                dtype=self.dtype)
-            self.cluster_centers_ = cuda.to_device(clust_cent)
+            self.cluster_centers_ = rmm.to_device(clust_cent)
 
         cdef uintptr_t cluster_centers_ptr = \
             get_dev_array_ptr(self.cluster_centers_)

--- a/python/cuml/dask/neighbors/nearest_neighbors.py
+++ b/python/cuml/dask/neighbors/nearest_neighbors.py
@@ -24,7 +24,7 @@ import logging
 import random
 
 from cuml.utils import numba_utils
-
+from librmm_cffi import librmm as rmm
 
 from dask import delayed
 from collections import defaultdict
@@ -229,9 +229,9 @@ def input_to_device_arrays(X, params):
     shape = X_mat.shape[0]*params["k"]
 
     # Create output numba arrays.
-    I_ndarr = numba.cuda.to_device(np.zeros(shape, dtype=np.int64, order="C"))
-    D_ndarr = numba.cuda.to_device(np.zeros(shape, dtype=np.float32,
-                                            order="C"))
+    I_ndarr = rmm.to_device(np.zeros(shape, dtype=np.int64, order="C"))
+    D_ndarr = rmm.to_device(np.zeros(shape, dtype=np.float32,
+                                     order="C"))
 
     # Return canonical device id as string
     return [(X_mat, I_ndarr, D_ndarr)], dev, (start_idx, stop_idx)

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -23,7 +23,7 @@ import ctypes
 import cudf
 import numpy as np
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -314,10 +314,10 @@ class PCA(Base):
 
     def _initialize_arrays(self, n_components, n_rows, n_cols):
 
-        self.trans_input_ = cuda.to_device(zeros(n_rows*n_components,
-                                                 dtype=self.dtype))
-        self.components_ary = cuda.to_device(zeros(n_components*n_cols,
-                                                   dtype=self.dtype))
+        self.trans_input_ = rmm.to_device(zeros(n_rows*n_components,
+                                                dtype=self.dtype))
+        self.components_ary = rmm.to_device(zeros(n_components*n_cols,
+                                                  dtype=self.dtype))
         self.explained_variance_ = cudf.Series(zeros(n_components,
                                                dtype=self.dtype))
         self.explained_variance_ratio_ = cudf.Series(zeros(n_components,
@@ -489,8 +489,8 @@ class PCA(Base):
         params.n_cols = self.n_cols
         params.whiten = self.whiten
 
-        input_data = cuda.to_device(zeros(params.n_rows*params.n_cols,
-                                          dtype=dtype.type))
+        input_data = rmm.to_device(zeros(params.n_rows*params.n_cols,
+                                         dtype=dtype.type))
 
         cdef uintptr_t input_ptr = input_data.device_ctypes_pointer.value
 
@@ -572,8 +572,8 @@ class PCA(Base):
         params.whiten = self.whiten
 
         t_input_data = \
-            cuda.to_device(zeros(params.n_rows*params.n_components,
-                                 dtype=dtype.type))
+            rmm.to_device(zeros(params.n_rows*params.n_components,
+                                dtype=dtype.type))
 
         cdef uintptr_t trans_input_ptr = get_dev_array_ptr(t_input_data)
         cdef uintptr_t components_ptr = get_dev_array_ptr(self.components_ary)

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -272,7 +272,7 @@ class TruncatedSVD(Base):
        X : array-like (device or host) shape = (n_samples, n_features)
            Dense matrix (floats or doubles) of shape (n_samples, n_features).
            Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-           ndarray, rmm.array interface compliant array like CuPy
+           ndarray, cuda array interface compliant array like CuPy
 
         """
         cdef uintptr_t input_ptr
@@ -348,7 +348,7 @@ class TruncatedSVD(Base):
         X : array-like (device or host) shape = (n_samples, n_features)
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-            ndarray, rmm.array interface compliant array like CuPy
+            ndarray, cuda array interface compliant array like CuPy
 
         Returns
         ----------
@@ -376,7 +376,7 @@ class TruncatedSVD(Base):
         X : array-like (device or host) shape = (n_samples, n_features)
            Dense matrix (floats or doubles) of shape (n_samples, n_features).
            Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-           ndarray, rmm.array interface compliant array like CuPy
+           ndarray, cuda array interface compliant array like CuPy
 
         convert_dtype : bool, optional (default = False)
             When set to True, the inverse_transform method will automatically
@@ -442,7 +442,7 @@ class TruncatedSVD(Base):
         X : array-like (device or host) shape = (n_samples, n_features)
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-            ndarray, rmm.array interface compliant array like CuPy
+            ndarray, cuda array interface compliant array like CuPy
 
         convert_dtype : bool, optional (default = False)
             When set to True, the transform method will automatically

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -23,8 +23,7 @@ import ctypes
 import cudf
 import numpy as np
 
-from numba import cuda
-
+from librmm_cffi import librmm as rmm
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 
@@ -251,10 +250,10 @@ class TruncatedSVD(Base):
 
     def _initialize_arrays(self, n_components, n_rows, n_cols):
 
-        self.trans_input_ = cuda.to_device(zeros(n_rows*n_components,
-                                                 dtype=self.dtype))
-        self.components_ary = cuda.to_device(zeros(n_components*n_cols,
-                                                   dtype=self.dtype))
+        self.trans_input_ = rmm.to_device(zeros(n_rows*n_components,
+                                                dtype=self.dtype))
+        self.components_ary = rmm.to_device(zeros(n_components*n_cols,
+                                                  dtype=self.dtype))
         self.explained_variance_ = cudf.Series(zeros(n_components,
                                                      dtype=self.dtype))
         self.explained_variance_ratio_ = cudf.Series(zeros(n_components,
@@ -273,7 +272,7 @@ class TruncatedSVD(Base):
        X : array-like (device or host) shape = (n_samples, n_features)
            Dense matrix (floats or doubles) of shape (n_samples, n_features).
            Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-           ndarray, cuda array interface compliant array like CuPy
+           ndarray, rmm.array interface compliant array like CuPy
 
         """
         cdef uintptr_t input_ptr
@@ -349,7 +348,7 @@ class TruncatedSVD(Base):
         X : array-like (device or host) shape = (n_samples, n_features)
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-            ndarray, cuda array interface compliant array like CuPy
+            ndarray, rmm.array interface compliant array like CuPy
 
         Returns
         ----------
@@ -377,7 +376,7 @@ class TruncatedSVD(Base):
         X : array-like (device or host) shape = (n_samples, n_features)
            Dense matrix (floats or doubles) of shape (n_samples, n_features).
            Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-           ndarray, cuda array interface compliant array like CuPy
+           ndarray, rmm.array interface compliant array like CuPy
 
         convert_dtype : bool, optional (default = False)
             When set to True, the inverse_transform method will automatically
@@ -402,8 +401,8 @@ class TruncatedSVD(Base):
         params.n_rows = n_rows
         params.n_cols = self.n_cols
 
-        input_data = cuda.to_device(zeros(params.n_rows*params.n_cols,
-                                          dtype=dtype.type))
+        input_data = rmm.to_device(zeros(params.n_rows*params.n_cols,
+                                         dtype=dtype.type))
 
         cdef uintptr_t input_ptr = input_data.device_ctypes_pointer.value
         cdef uintptr_t components_ptr = get_dev_array_ptr(self.components_ary)
@@ -443,7 +442,7 @@ class TruncatedSVD(Base):
         X : array-like (device or host) shape = (n_samples, n_features)
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-            ndarray, cuda array interface compliant array like CuPy
+            ndarray, rmm.array interface compliant array like CuPy
 
         convert_dtype : bool, optional (default = False)
             When set to True, the transform method will automatically
@@ -469,8 +468,8 @@ class TruncatedSVD(Base):
         params.n_cols = self.n_cols
 
         t_input_data = \
-            cuda.to_device(zeros(params.n_rows*params.n_components,
-                                 dtype=dtype.type))
+            rmm.to_device(zeros(params.n_rows*params.n_components,
+                                dtype=dtype.type))
 
         cdef uintptr_t trans_input_ptr = get_dev_array_ptr(t_input_data)
         cdef uintptr_t components_ptr = get_dev_array_ptr(self.components_ary)

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -26,7 +26,7 @@ import math
 import numpy as np
 import warnings
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -197,9 +197,9 @@ cdef class ForestInference_impl():
             <cumlHandle*><size_t>self.handle.getHandle()
 
         if preds is None:
-            preds = cuda.device_array(n_rows, dtype=np.float32)
+            preds = rmm.device_array(n_rows, dtype=np.float32)
         elif (not isinstance(preds, cudf.Series) and
-              not cuda.is_cuda_array(preds)):
+              not rmm.is_cuda_array(preds)):
             raise ValueError("Invalid type for output preds,"
                              " need GPU array")
 

--- a/python/cuml/filter/kalman_filter.pyx
+++ b/python/cuml/filter/kalman_filter.pyx
@@ -24,6 +24,7 @@ import numpy as np
 
 from numba import cuda
 from cuml.utils import numba_utils
+from librmm_cffi import librmm as rmm
 
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -138,7 +139,7 @@ class KalmanFilter(Base):
     .. code::
 
         while some_condition_is_true:
-            z = numba.cuda.to_device(np.array([i])
+            z = numba.rmm.to_device(np.array([i])
             f.predict()
             f.update(z)
 
@@ -215,15 +216,15 @@ class KalmanFilter(Base):
         R = np.eye(dim_z, dtype=self.dtype)
         z = np.array([[0]*dim_z], dtype=self.dtype).T
 
-        self.F = cuda.to_device(Phi)
-        self.x = cuda.to_device(x_up)
-        self.x_prev = cuda.to_device(x_est)
-        self.P = cuda.to_device(P_up)
-        self.P_prev = cuda.to_device(P_est)
-        self.Q = cuda.to_device(Q)
-        self.H = cuda.to_device(H)
-        self.R = cuda.to_device(R)
-        self.z = cuda.to_device(z)
+        self.F = rmm.to_device(Phi)
+        self.x = rmm.to_device(x_up)
+        self.x_prev = rmm.to_device(x_est)
+        self.P = rmm.to_device(P_up)
+        self.P_prev = rmm.to_device(P_est)
+        self.Q = rmm.to_device(Q)
+        self.H = rmm.to_device(H)
+        self.R = rmm.to_device(R)
+        self.z = rmm.to_device(z)
 
         self.dim_x = dim_x
         self.dim_z = dim_z
@@ -261,7 +262,7 @@ class KalmanFilter(Base):
                                                     <float*> _R_ptr,
                                                     <float*> _H_ptr)
 
-        self.workspace = cuda.to_device(zeros(workspace_size,
+        self.workspace = rmm.to_device(zeros(workspace_size,
                                               dtype=self.dtype))
         self._workspace_size = workspace_size
 
@@ -435,7 +436,7 @@ class KalmanFilter(Base):
             z_ptr = self._get_column_ptr(z)
 
         elif isinstance(z, np.ndarray):
-            z_dev = cuda.to_device(z)
+            z_dev = rmm.to_device(z)
             z_ptr = z.device_ctypes_pointer.value
 
         elif cuda.devicearray.is_cuda_ndarray(z):
@@ -525,7 +526,7 @@ class KalmanFilter(Base):
 
             elif (isinstance(value, np.ndarray) or
                   cuda.devicearray.is_cuda_ndarray(value)):
-                val = cuda.to_device(value)
+                val = rmm.to_device(value)
 
             super(KalmanFilter, self).__setattr__(name, val)
 

--- a/python/cuml/filter/kalman_filter.pyx
+++ b/python/cuml/filter/kalman_filter.pyx
@@ -263,7 +263,7 @@ class KalmanFilter(Base):
                                                     <float*> _H_ptr)
 
         self.workspace = rmm.to_device(zeros(workspace_size,
-                                              dtype=self.dtype))
+                                             dtype=self.dtype))
         self._workspace_size = workspace_size
 
     def _get_algorithm_c_name(self, algorithm):

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -32,7 +32,7 @@ from cuml.common.base import Base
 from cuml.common.handle cimport cumlHandle
 
 from cuml.utils import input_to_dev_array as to_cuda
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -340,7 +340,7 @@ class TSNE(Base):
             self.perplexity = n
 
         # Prepare output embeddings
-        Y = cuda.device_array(
+        Y = rmm.device_array(
             (n, self.n_components),
             order="F",
             dtype=np.float32)

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -31,7 +31,7 @@ from cuml.common.handle cimport cumlHandle
 from cuml.utils import get_cudf_column_ptr, get_dev_array_ptr, \
     input_to_dev_array, zeros, row_matrix
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -396,7 +396,7 @@ class UMAP(Base):
         self.raw_data = X_ctype
         self.raw_data_rows = n_rows
 
-        self.arr_embed = cuda.to_device(zeros((self.X_m.shape[0],
+        self.arr_embed = rmm.to_device(zeros((self.X_m.shape[0],
                                                umap_params.n_components),
                                               order="C", dtype=np.float32))
         self.embeddings = \
@@ -506,7 +506,7 @@ class UMAP(Base):
 
         cdef UMAPParams * umap_params = \
             <UMAPParams*> < size_t > self.umap_params
-        embedding = cuda.to_device(zeros((X_m.shape[0],
+        embedding = rmm.to_device(zeros((X_m.shape[0],
                                           umap_params.n_components),
                                          order="C", dtype=np.float32))
         cdef uintptr_t xformed_ptr = embedding.device_ctypes_pointer.value

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -397,8 +397,8 @@ class UMAP(Base):
         self.raw_data_rows = n_rows
 
         self.arr_embed = rmm.to_device(zeros((self.X_m.shape[0],
-                                               umap_params.n_components),
-                                              order="C", dtype=np.float32))
+                                              umap_params.n_components),
+                                             order="C", dtype=np.float32))
         self.embeddings = \
             self.arr_embed.device_ctypes_pointer.value
 
@@ -507,8 +507,8 @@ class UMAP(Base):
         cdef UMAPParams * umap_params = \
             <UMAPParams*> < size_t > self.umap_params
         embedding = rmm.to_device(zeros((X_m.shape[0],
-                                          umap_params.n_components),
-                                         order="C", dtype=np.float32))
+                                         umap_params.n_components),
+                                        order="C", dtype=np.float32))
         cdef uintptr_t xformed_ptr = embedding.device_ctypes_pointer.value
 
         cdef cumlHandle * handle_ = \

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -42,6 +42,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
 
 from numba import cuda
+from librmm_cffi import librmm as rmm
 
 cimport cuml.common.handle
 cimport cuml.common.cuda
@@ -444,8 +445,8 @@ class NearestNeighbors(Base):
 
         # Need to establish result matrices for indices (Nxk)
         # and for distances (Nxk)
-        I_ndarr = cuda.to_device(zeros(N*k, dtype=np.int64, order="C"))
-        D_ndarr = cuda.to_device(zeros(N*k, dtype=np.float32, order="C"))
+        I_ndarr = rmm.to_device(zeros(N*k, dtype=np.int64, order="C"))
+        D_ndarr = rmm.to_device(zeros(N*k, dtype=np.float32, order="C"))
 
         cdef uintptr_t I_ptr = get_dev_array_ptr(I_ndarr)
         cdef uintptr_t D_ptr = get_dev_array_ptr(D_ndarr)

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -22,7 +22,7 @@
 import cudf
 import numpy as np
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool
@@ -234,7 +234,7 @@ cdef class BaseRandomProjection():
                                convert_to_dtype=(self.dtype if convert_dtype
                                                  else None))
 
-        X_new = cuda.device_array((n_samples, self.params.n_components),
+        X_new = rmm.device_array((n_samples, self.params.n_components),
                                   dtype=self.dtype,
                                   order='F')
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -235,8 +235,8 @@ cdef class BaseRandomProjection():
                                                  else None))
 
         X_new = rmm.device_array((n_samples, self.params.n_components),
-                                  dtype=self.dtype,
-                                  order='F')
+                                 dtype=self.dtype,
+                                 order='F')
 
         cdef uintptr_t output_ptr = get_dev_array_ptr(X_new)
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -23,7 +23,7 @@ import cudf
 import numpy as np
 import warnings
 
-from numba import cuda
+from librmm_cffi import librmm as rmm
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
@@ -292,7 +292,7 @@ class QN(Base):
         else:
             coef_size = (self.n_cols, self.num_classes)
 
-        self.coef_ = cuda.to_device(zeros(coef_size, dtype=self.dtype))
+        self.coef_ = rmm.to_device(zeros(coef_size, dtype=self.dtype))
 
         cdef uintptr_t coef_ptr = get_dev_array_ptr(self.coef_)
 
@@ -384,7 +384,7 @@ class QN(Base):
                                                  else None),
                                check_cols=self.n_cols)
 
-        preds = cuda.to_device(zeros(n_rows, dtype=self.dtype))
+        preds = rmm.to_device(zeros(n_rows, dtype=self.dtype))
 
         cdef uintptr_t coef_ptr = get_dev_array_ptr(self.coef_)
         cdef uintptr_t pred_ptr = get_dev_array_ptr(preds)


### PR DESCRIPTION
Changing the straggling python allocations (`cuda.to_device` mainly) to use RMM instead of numba directly