### PR TITLE
[BUG] Pinning Distributed version to match Dask for consistent CI results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # cuML 0.10.0 (Date TBD)
 
 ## New Features
-- PR #1071: Selective eigen solver of cuSolver 
+- PR #1071: Selective eigen solver of cuSolver
 
 - PR #1073: Updating RF wrappers to use FIL for GPU accelerated prediction
 
@@ -9,7 +9,7 @@
 - PR #961: High Peformance RF; HIST algo
 - PR #1028: Dockerfile updates after dir restructure. Conda env yaml to add statsmodels as a dependency
 - PR #763: Add examples to train_test_split documentation
-- PR #1076: Paying off some UMAP / Spectral tech debt. 
+- PR #1076: Paying off some UMAP / Spectral tech debt.
 - PR #1086: Ensure RegressorMixin scorer uses device arrays
 
 ## Bug Fixes
@@ -25,6 +25,7 @@
 - PR #1072: Remove pip requirements and setup
 - PR #1074: Fix flake8 CI style check
 - PR #1088: Change straggling numba python allocations to use RMM
+- PR #    : Pinning Distributed version to match Dask for consistent CI results
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - PR #1072: Remove pip requirements and setup
 - PR #1074: Fix flake8 CI style check
 - PR #1088: Change straggling numba python allocations to use RMM
-- PR #    : Pinning Distributed version to match Dask for consistent CI results
+- PR #1106: Pinning Distributed version to match Dask for consistent CI results
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -52,6 +52,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       umap-learn \
       nccl>=2.4 \
       dask=2.3.0 \
+      distributed=2.3.0 \
       dask-ml \
       dask-cudf=${MINOR_VERSION} \
       dask-cuda=0.9 \

--- a/ci/mg/build.sh
+++ b/ci/mg/build.sh
@@ -51,6 +51,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       libclang \
       nccl>=2.4 \
       dask=2.3.0 \
+      distributed=2.3.0 \
       dask-ml \
       dask-cudf \
       dask-cuda=0.9

--- a/conda/environments/cuml_dev_cuda10.0.yml
+++ b/conda/environments/cuml_dev_cuda10.0.yml
@@ -18,6 +18,7 @@ dependencies:
 - umap-learn>=0.3.9
 - scikit-learn>=0.21
 - dask=2.3.0
+- distributed=2.3.0
 - dask-ml
 - dask-cuda=0.9*
 - dask-cudf=0.10*

--- a/conda/environments/cuml_dev_cuda9.2.yml
+++ b/conda/environments/cuml_dev_cuda9.2.yml
@@ -18,6 +18,7 @@ dependencies:
 - umap-learn>=0.3.9
 - scikit-learn>=0.21
 - dask=2.3.0
+- distributed=2.3.0
 - dask-ml
 - dask-cuda=0.9*
 - dask-cudf=0.10*


### PR DESCRIPTION
I (incorrectly) recommended not specifying `distributed` as a direct dependency thinking dask's package would automatically include it if needed. However, I recently learned that `distributed` is an _optional_ dependency of `dask`, and it must be explicitly specified if its functionality is needed.

This PR re-adds `distributed` back to the appropriate files, with the version pinned to match dask's (as @cjnolet originally had it).