### PR TITLE
Fix check_dtype arg handling for input_to_dev_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #1106: Pinning Distributed version to match Dask for consistent CI results
 - PR #1116: TSNE CUDA 10.1 Bug Fixes
 - PR #1132: DBSCAN Batching Bug Fix
+- PR #1164: Fix check_dtype arg handling for input_to_dev_array
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -111,6 +111,10 @@ def test_dtype_check(dtype, check_dtype, input_type):
             _, _, _, _, got_dtype = \
                 input_to_dev_array(input_data, check_dtype=check_dtype)
 
+    with pytest.raises(ValueError):
+        _, _, _, _, got_dtype = \
+            input_to_dev_array(input_data, check_dtype='float32')
+
 
 @pytest.mark.parametrize('num_rows', [1, 100])
 @pytest.mark.parametrize('num_cols', [1, 100])

--- a/python/cuml/utils/input_utils.py
+++ b/python/cuml/utils/input_utils.py
@@ -174,16 +174,24 @@ def input_to_dev_array(X, order='F', deepcopy=False,
     dtype = X_m.dtype
 
     if check_dtype:
-        if isinstance(check_dtype, type):
+        if isinstance(check_dtype, type) or isinstance(check_dtype, np.dtype):
             if dtype != check_dtype:
                 del X_m
                 raise TypeError("Expected " + str(check_dtype) + "input but" +
                                 " got " + str(dtype) + " instead.")
-        elif isinstance(check_dtype, Collection):
+        elif isinstance(check_dtype, Collection) and \
+                not isinstance(check_dtype, str):
+            # The 'not isinstance(check_dtype, string)' condition is needed,
+            # because the 'float32' string is a Collection, but in this
+            # branch we only want to process collections like
+            # [np.float32, np.float64].
             if dtype not in check_dtype:
                 del X_m
                 raise TypeError("Expected input to be of type in " +
                                 str(check_dtype) + " but got " + str(dtype))
+        else:
+            raise ValueError("Expected a type as check_dtype arg, but got " +
+                             str(check_dtype))
 
     n_rows = X_m.shape[0]
     if len(X_m.shape) > 1:


### PR DESCRIPTION
Fix handling `check_dtype=np.dtype(np.float32)` arg. Additionally test if unexpected check_type args throw error. @dantegd 