### PR TITLE
[REVIEW] SVM prediction bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - PR #1116: TSNE CUDA 10.1 Bug Fixes
 - PR #1132: DBSCAN Batching Bug Fix
 - PR #1164: Fix check_dtype arg handling for input_to_dev_array
+- PR #1171: SVM prediction bug fix
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/cpp/src/svm/smosolver.h
+++ b/cpp/src/svm/smosolver.h
@@ -231,7 +231,7 @@ class SmoSolver {
   int n_small_diff;
 
   bool CheckStoppingCondition(math_t diff) {
-    // TODO improve stopping condition to detect oscillationsq, see Issue #947
+    // TODO improve stopping condition to detect oscillations, see Issue #947
     bool keep_going = true;
     if (abs(diff - diff_prev) < 0.001 * tol) {
       n_small_diff++;
@@ -239,9 +239,13 @@ class SmoSolver {
       diff_prev = diff;
       n_small_diff = 0;
     }
-    if (diff < tol || n_small_diff > 10) {
+    if (n_small_diff > 1000) {
+      if (verbose) {
+        std::cout << "SMO error: Stopping due to unchanged diff\n";
+      }
       keep_going = false;
     }
+    if (diff < tol) keep_going = false;
     // ASSERT(!isnan(diff), "SMO: NaN found during fitting")
     if (isnan(diff)) {
       std::cout << "SMO error: NaN found during fitting\n";

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -47,12 +47,14 @@ template void svcFit<double>(const cumlHandle &handle, double *input,
 template void svcPredict<float>(const cumlHandle &handle, float *input,
                                 int n_rows, int n_cols,
                                 MLCommon::Matrix::KernelParams &kernel_params,
-                                const svmModel<float> &model, float *preds);
+                                const svmModel<float> &model, float *preds,
+                                float buffer_size);
 
 template void svcPredict<double>(const cumlHandle &handle, double *input,
                                  int n_rows, int n_cols,
                                  MLCommon::Matrix::KernelParams &kernel_params,
-                                 const svmModel<double> &model, double *preds);
+                                 const svmModel<double> &model, double *preds,
+                                 double buffer_size);
 
 template void svmFreeBuffers(const cumlHandle &handle, svmModel<float> &m);
 
@@ -87,7 +89,9 @@ void SVC<math_t>::fit(math_t *input, int n_rows, int n_cols, math_t *labels) {
 template <typename math_t>
 void SVC<math_t>::predict(math_t *input, int n_rows, int n_cols,
                           math_t *preds) {
-  svcPredict(handle, input, n_rows, n_cols, kernel_params, model, preds);
+  math_t buffer_size = param.cache_size;
+  svcPredict(handle, input, n_rows, n_cols, kernel_params, model, preds,
+             buffer_size);
 }
 
 // Instantiate templates for the shared library

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -63,9 +63,9 @@ template void svmFreeBuffers(const cumlHandle &handle, svmModel<double> &m);
 template <typename math_t>
 SVC<math_t>::SVC(cumlHandle &handle, math_t C, math_t tol,
                  Matrix::KernelParams kernel_params, math_t cache_size,
-                 int max_iter, bool verbose)
+                 int max_iter, int nochange_steps, bool verbose)
   : handle(handle),
-    param(svmParameter{C, cache_size, max_iter, tol, verbose}),
+    param(svmParameter{C, cache_size, max_iter, nochange_steps, tol, verbose}),
     kernel_params(kernel_params) {
   model.n_support = 0;
   model.dual_coefs = nullptr;

--- a/cpp/src/svm/svc.hpp
+++ b/cpp/src/svm/svc.hpp
@@ -128,7 +128,8 @@ class SVC {
   SVC(cumlHandle &handle, math_t C = 1, math_t tol = 1.0e-3,
       MLCommon::Matrix::KernelParams kernel_params =
         MLCommon::Matrix::KernelParams{MLCommon::Matrix::LINEAR, 3, 1, 0},
-      math_t cache_size = 200, int max_iter = -1, bool verbose = false);
+      math_t cache_size = 200, int max_iter = -1, int nochange_steps = 1000,
+      bool verbose = false);
 
   ~SVC();
 

--- a/cpp/src/svm/svc.hpp
+++ b/cpp/src/svm/svc.hpp
@@ -71,11 +71,13 @@ void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
  * @param [in] model SVM model parameters
  * @param [out] preds device pointer to store the predicted class labels.
  *    Size [n_rows]. Should be allocated on entry.
+ * @param [in] buffer_size size of temporary buffer in MiB
  */
 template <typename math_t>
 void svcPredict(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
                 MLCommon::Matrix::KernelParams &kernel_params,
-                const svmModel<math_t> &model, math_t *preds);
+                const svmModel<math_t> &model, math_t *preds,
+                math_t buffer_size);
 
 /**
  * Deallocate device buffers in the svmModel struct.

--- a/cpp/src/svm/svc_impl.h
+++ b/cpp/src/svm/svc_impl.h
@@ -175,7 +175,7 @@ void svcPredict(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
     math_t *x_ptr = nullptr;
     int ld1 = 0;
     if (kernel_params.kernel == MLCommon::Matrix::RBF) {
-      // The RBF kernel does not support ld parameters (See issue #)
+      // The RBF kernel does not support ld parameters (See issue #1172)
       // To come around this limitation, we copy the batch into a temporary
       // buffer.
       thrust::counting_iterator<int> first(i);

--- a/cpp/src/svm/svc_impl.h
+++ b/cpp/src/svm/svc_impl.h
@@ -113,6 +113,13 @@ void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
  * We evaluate f(x_i), and then instead of taking the sign to return +/-1 labels,
  * we map it to the original labels, and return those.
  *
+ * We process the input vectors batchwise, and evaluate the full rows of kernel
+ * matrix K(x_i, x_j) for a batch (size n_batch * n_support). The maximum size
+ * of this buffer (i.e. the maximum batch_size) is controlled by the
+ * buffer_size input parameter. For models where n_support is large, increasing
+ * buffer_size might improve prediction performance.
+ *
+ *
  * @tparam math_t floating point type
  * @param handle the cuML handle
  * @param [in] input device pointer for the input data in column major format,

--- a/cpp/src/svm/svc_impl.h
+++ b/cpp/src/svm/svc_impl.h
@@ -94,7 +94,7 @@ void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
     MLCommon::Matrix::KernelFactory<math_t>::create(
       kernel_params, handle_impl.getCublasHandle());
   SmoSolver<math_t> smo(handle_impl, param.C, param.tol, kernel,
-                        param.cache_size);
+                        param.cache_size, param.nochange_steps);
   smo.verbose = param.verbose;
   smo.Solve(input, n_rows, n_cols, y.data(), &(model.dual_coefs),
             &(model.n_support), &(model.x_support), &(model.support_idx),

--- a/cpp/src/svm/svm_api.cpp
+++ b/cpp/src/svm/svm_api.cpp
@@ -129,7 +129,8 @@ cumlError_t cumlSpSvcPredict(cumlHandle_t handle, float *input, int n_rows,
                              int n_cols, cumlSvmKernelType kernel, int degree,
                              float gamma, float coef0, int n_support, float b,
                              float *dual_coefs, float *x_support, int n_classes,
-                             float *unique_labels, float *preds) {
+                             float *unique_labels, float *preds,
+                             float buffer_size) {
   MLCommon::Matrix::KernelParams kernel_param;
   kernel_param.kernel = (MLCommon::Matrix::KernelType)kernel;
   kernel_param.degree = degree;
@@ -151,7 +152,7 @@ cumlError_t cumlSpSvcPredict(cumlHandle_t handle, float *input, int n_rows,
   if (status == CUML_SUCCESS) {
     try {
       ML::SVM::svcPredict(*handle_ptr, input, n_rows, n_cols, kernel_param,
-                          model, preds);
+                          model, preds, buffer_size);
     }
     //TODO: Implement this
     //catch (const MLCommon::Exception& e)
@@ -171,7 +172,7 @@ cumlError_t cumlDpSvcPredict(cumlHandle_t handle, double *input, int n_rows,
                              double gamma, double coef0, int n_support,
                              double b, double *dual_coefs, double *x_support,
                              int n_classes, double *unique_labels,
-                             double *preds) {
+                             double *preds, double buffer_size) {
   MLCommon::Matrix::KernelParams kernel_param;
   kernel_param.kernel = (MLCommon::Matrix::KernelType)kernel;
   kernel_param.degree = degree;
@@ -193,7 +194,7 @@ cumlError_t cumlDpSvcPredict(cumlHandle_t handle, double *input, int n_rows,
   if (status == CUML_SUCCESS) {
     try {
       ML::SVM::svcPredict(*handle_ptr, input, n_rows, n_cols, kernel_param,
-                          model, preds);
+                          model, preds, buffer_size);
     }
     //TODO: Implement this
     //catch (const MLCommon::Exception& e)

--- a/cpp/src/svm/svm_api.cpp
+++ b/cpp/src/svm/svm_api.cpp
@@ -25,9 +25,9 @@
 
 cumlError_t cumlSpSvcFit(cumlHandle_t handle, float *input, int n_rows,
                          int n_cols, float *labels, float C, float cache_size,
-                         int max_iter, float tol, int verbose,
-                         cumlSvmKernelType kernel, int degree, float gamma,
-                         float coef0, int *n_support, float *b,
+                         int max_iter, int nochange_steps, float tol,
+                         int verbose, cumlSvmKernelType kernel, int degree,
+                         float gamma, float coef0, int *n_support, float *b,
                          float **dual_coefs, float **x_support,
                          int **support_idx, int *n_classes,
                          float **unique_labels) {
@@ -35,6 +35,7 @@ cumlError_t cumlSpSvcFit(cumlHandle_t handle, float *input, int n_rows,
   param.C = C;
   param.cache_size = cache_size;
   param.max_iter = max_iter;
+  param.nochange_steps = nochange_steps;
   param.tol = tol;
   param.verbose = verbose;
 
@@ -76,16 +77,17 @@ cumlError_t cumlSpSvcFit(cumlHandle_t handle, float *input, int n_rows,
 
 cumlError_t cumlDpSvcFit(cumlHandle_t handle, double *input, int n_rows,
                          int n_cols, double *labels, double C,
-                         double cache_size, int max_iter, double tol,
-                         int verbose, cumlSvmKernelType kernel, int degree,
-                         double gamma, double coef0, int *n_support, double *b,
-                         double **dual_coefs, double **x_support,
+                         double cache_size, int max_iter, int nochange_steps,
+                         double tol, int verbose, cumlSvmKernelType kernel,
+                         int degree, double gamma, double coef0, int *n_support,
+                         double *b, double **dual_coefs, double **x_support,
                          int **support_idx, int *n_classes,
                          double **unique_labels) {
   ML::SVM::svmParameter param;
   param.C = C;
   param.cache_size = cache_size;
   param.max_iter = max_iter;
+  param.nochange_steps = nochange_steps;
   param.tol = tol;
   param.verbose = verbose;
 

--- a/cpp/src/svm/svm_api.h
+++ b/cpp/src/svm/svm_api.h
@@ -39,6 +39,7 @@ extern "C" {
  * @param [in] C penalty term
  * @param [in] cache_size size of kernel cache in device memory (MiB)
  * @param [in] max_iter maximum number of outer iterations in SmoSolver
+ * @param [in] nochange_steps max number of outer iterations without change in convergence
  * @param [in] tol tolerance to stop fitting
  * @param[in] verbose Pass a 1 to print useful information as algorithm executes. To
  *     execute quietly, pass 0
@@ -61,19 +62,19 @@ extern "C" {
  */
 cumlError_t cumlSpSvcFit(cumlHandle_t handle, float *input, int n_rows,
                          int n_cols, float *labels, float C, float cache_size,
-                         int max_iter, float tol, int verbose,
-                         cumlSvmKernelType kernel, int degree, float gamma,
-                         float coef0, int *n_support, float *b,
+                         int max_iter, int nochange_steps, float tol,
+                         int verbose, cumlSvmKernelType kernel, int degree,
+                         float gamma, float coef0, int *n_support, float *b,
                          float **dual_coefs, float **x_support,
                          int **support_idx, int *n_classes,
                          float **unique_labels);
 
 cumlError_t cumlDpSvcFit(cumlHandle_t handle, double *input, int n_rows,
                          int n_cols, double *labels, double C,
-                         double cache_size, int max_iter, double tol,
-                         int verbose, cumlSvmKernelType kernel, int degree,
-                         double gamma, double coef0, int *n_support, double *b,
-                         double **dual_coefs, double **x_support,
+                         double cache_size, int max_iter, int nochange_steps,
+                         double tol, int verbose, cumlSvmKernelType kernel,
+                         int degree, double gamma, double coef0, int *n_support,
+                         double *b, double **dual_coefs, double **x_support,
                          int **support_idx, int *n_classes,
                          double **unique_labels);
 /** @} */

--- a/cpp/src/svm/svm_api.h
+++ b/cpp/src/svm/svm_api.h
@@ -59,19 +59,23 @@ extern "C" {
  * @return CUML_SUCCESS on success and other corresponding flags upon any failures.
  * @{
  */
-cumlError_t cumlSpSvcFit(
-  cumlHandle_t handle, float *input, int n_rows, int n_cols, float *labels,
-  float C, float cache_size, int max_iter, float tol, int verbose,
-  cumlSvmKernelType kernel, int degree, float gamma, float coef0,
-  int *n_support, float *b, float **dual_coefs, float **x_support,
-  int **support_idx, int *n_classes, float **unique_labels);
+cumlError_t cumlSpSvcFit(cumlHandle_t handle, float *input, int n_rows,
+                         int n_cols, float *labels, float C, float cache_size,
+                         int max_iter, float tol, int verbose,
+                         cumlSvmKernelType kernel, int degree, float gamma,
+                         float coef0, int *n_support, float *b,
+                         float **dual_coefs, float **x_support,
+                         int **support_idx, int *n_classes,
+                         float **unique_labels);
 
-cumlError_t cumlDpSvcFit(
-  cumlHandle_t handle, double *input, int n_rows, int n_cols, double *labels,
-  double C, double cache_size, int max_iter, double tol, int verbose,
-  cumlSvmKernelType kernel, int degree, double gamma, double coef0,
-  int *n_support, double *b, double **dual_coefs, double **x_support,
-  int **support_idx, int *n_classes, double **unique_labels);
+cumlError_t cumlDpSvcFit(cumlHandle_t handle, double *input, int n_rows,
+                         int n_cols, double *labels, double C,
+                         double cache_size, int max_iter, double tol,
+                         int verbose, cumlSvmKernelType kernel, int degree,
+                         double gamma, double coef0, int *n_support, double *b,
+                         double **dual_coefs, double **x_support,
+                         int **support_idx, int *n_classes,
+                         double **unique_labels);
 /** @} */
 
 /**
@@ -97,20 +101,23 @@ cumlError_t cumlDpSvcFit(
  * @param [in] unique_labels device pointer for the unique classes,
  *    size [n_classes]
  * @param [out] preds device pointer for the predictions. Size [n_rows].
+ * @param [in] buffer_size size of temporary buffer in MiB
  * @return CUML_SUCCESS on success and other corresponding flags upon any failures.
  * @{
  */
-cumlError_t cumlSpSvcPredict(
-  cumlHandle_t handle, float *input, int n_rows, int n_cols,
-  cumlSvmKernelType kernel, int degree, float gamma, float coef0,
-  int *n_support, float *b, float **dual_coefs, float **x_support,
-  int *n_classes, float **unique_labels, float *preds);
+cumlError_t cumlSpSvcPredict(cumlHandle_t handle, float *input, int n_rows,
+                             int n_cols, cumlSvmKernelType kernel, int degree,
+                             float gamma, float coef0, int *n_support, float *b,
+                             float **dual_coefs, float **x_support,
+                             int *n_classes, float **unique_labels,
+                             float *preds, float buffer_size);
 
-cumlError_t cumlDpSvcPredict(
-  cumlHandle_t handle, double *input, int n_rows, int n_cols,
-  cumlSvmKernelType kernel, int degree, double gamma, double coef0,
-  int *n_support, double *b, double **dual_coefs, double **x_support,
-  int *n_classes, double **unique_labels, double *preds);
+cumlError_t cumlDpSvcPredict(cumlHandle_t handle, double *input, int n_rows,
+                             int n_cols, cumlSvmKernelType kernel, int degree,
+                             double gamma, double coef0, int *n_support,
+                             double *b, double **dual_coefs, double **x_support,
+                             int *n_classes, double **unique_labels,
+                             double *preds, double buffer_size);
 /** @} */
 #ifdef __cplusplus
 }

--- a/cpp/src/svm/svm_parameter.h
+++ b/cpp/src/svm/svm_parameter.h
@@ -21,13 +21,13 @@ namespace SVM {
 /**
  * Numerical input parameters for an SVM.
  *
- * There are several parameters that control how long we traing. The traning
+ * There are several parameters that control how long we train. The training
  * stops if:
  * - max_iter iterations are reached. If you pass -1, then
  *   max_diff = 100 * n_rows
  * - the diff becomes less the tol
- * - the diff is changing less then 0.001*tol in nochange_steps consicutive
- *   outer iteraitions.
+ * - the diff is changing less then 0.001*tol in nochange_steps consecutive
+ *   outer iterations.
  */
 struct svmParameter {
   double C;           //!< Penalty term C

--- a/cpp/src/svm/svm_parameter.h
+++ b/cpp/src/svm/svm_parameter.h
@@ -20,16 +20,25 @@ namespace SVM {
 
 /**
  * Numerical input parameters for an SVM.
+ *
+ * There are several parameters that control how long we traing. The traning
+ * stops if:
+ * - max_iter iterations are reached. If you pass -1, then
+ *   max_diff = 100 * n_rows
+ * - the diff becomes less the tol
+ * - the diff is changing less then 0.001*tol in nochange_steps consicutive
+ *   outer iteraitions.
  */
 struct svmParameter {
-    double C;      //!< Penalty term C
-    double cache_size;  //!< kernel cache size in MiB
-    //! maximum number of outer SMO iterations. Use -1 to let the SMO solver set
-    //! a default value (100*n_rows).
-    int max_iter;
-    double tol;    //!< Tolerance used to stop fitting.
-    int verbose;  //!< Print information about traning
+  double C;           //!< Penalty term C
+  double cache_size;  //!< kernel cache size in MiB
+  //! maximum number of outer SMO iterations. Use -1 to let the SMO solver set
+  //! a default value (100*n_rows).
+  int max_iter;
+  int nochange_steps;  //<! Number of steps to continue with non-changing diff
+  double tol;          //!< Tolerance used to stop fitting.
+  int verbose;         //!< Print information about traning
 };
 
-}; // namespace SVM
-}; // namespace ML
+};  // namespace SVM
+};  // namespace ML

--- a/cpp/src_prims/matrix/kernelmatrices.h
+++ b/cpp/src_prims/matrix/kernelmatrices.h
@@ -18,8 +18,8 @@
 
 #include <cuda_utils.h>
 #include <distance/distance.h>
-#include <matrix/grammatrix.h>
 #include <linalg/gemm.h>
+#include <matrix/grammatrix.h>
 
 namespace MLCommon {
 namespace Matrix {
@@ -276,16 +276,17 @@ class RBFKernel : public GramMatrixBase<math_t> {
   * @param [out] out device buffer to store the Gram matrix in column major
   *   format, size [n1*n2]
   * @param [in] stream cuda stream
-  * @param ld1 leading dimension of x1 (usually it is n1)
-  * @param ld2 leading dimension of x2 (usually it is n2)
-  * @param ld_out leading dimension of out (usually it is n1)
+  * @param ld1 leading dimension of x1, currently only ld1 == n1 is supported
+  * @param ld2 leading dimension of x2, currently only ld2 == n2 is supported
+  * @param ld_out leading dimension of out, only ld_out == n1 is supported
   */
   void evaluate(const math_t *x1, int n1, int n_cols, const math_t *x2, int n2,
                 math_t *out, cudaStream_t stream, int ld1, int ld2,
                 int ld_out) {
-    if (ld_out != n1) {
-      std::cerr << "RBF Kernel distance does not support ld_out parameter";
-    }
+    ASSERT(ld1 == n1, "RBF Kernel distance does not support ld1 parameter");
+    ASSERT(ld2 == n2, "RBF Kernel distance does not support ld2 parameter");
+    ASSERT(ld_out == n1,
+           "RBF Kernel distance does not support ld_out parameter");
     distance(x1, n1, n_cols, x2, n2, out, stream, ld1, ld2, ld_out);
   }
 

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -307,7 +307,7 @@ class TSNE(Base):
 
     def fit(self, X):
         """Fit X into an embedded space.
-        
+
         Parameters
         -----------
         X : array-like (device or host) shape = (n_samples, n_features)
@@ -420,14 +420,14 @@ class TSNE(Base):
 
     def fit_transform(self, X):
         """Fit X into an embedded space and return that transformed output.
-        
+
         Parameters
         -----------
         X : array-like (device or host) shape = (n_samples, n_features)
             X contains a sample per row.
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
             ndarray, cuda array interface compliant array like CuPy
-        
+
         Returns
         --------
         X_new : array, shape (n_samples, n_components)

--- a/python/cuml/svm/svm.pyx
+++ b/python/cuml/svm/svm.pyx
@@ -128,7 +128,7 @@ class SVC(Base):
             Penalty parameter C
         kernel : string (default='rbf')
             Specifies the kernel function. Possible options: 'linear', 'poly',
-            'rbf', 'sigmoid', 'precomputed'
+            'rbf', 'sigmoid'. Currently precomputed kernels are not supported.
         degree : int (default=3)
             Degree of polynomial kernel function.
         gamma : float (default = 'auto')


### PR DESCRIPTION
There are a two issues with SVM prediction and one with traning, that this PR fixes:
 - RBF kernels do not handle ld parameters, which caused wrong prediction if we had more than 4096 vectors to predict.
 - For prediction we need to evaluate the kernel matrix for a batch of vectors, which needs a prediction buffer of the size n_batch * n_support. With nonlinear kernels  n_support can be similar to n_train. Using a fixed batch size can run out of memory when n_train  ~ n_support = 1M.  To fix it, the batch size is decreased to keep the prediction buffer not larger than the kernel cache. 
- During training, if the diffs do not change for many iteration, then we stop. The stopping criteria (number of steps with same diffs) was increased, because some RBF test were interrupted too early using the previous setting. 

Tests are added to safeguard against the first two problems. @cjnolet @dantegd 