### PR TITLE
[REVIEW] Replaced sprintf() with snprintf() in THROW() to avoid buffer overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - PR #1162: DASK RF random seed bug fix
 - PR #1164: Fix check_dtype arg handling for input_to_dev_array
 - PR #1177: Update dask and distributed to 2.5
+- PR #1199: Replaced sprintf() with snprintf() in THROW()
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/cpp/src_prims/utils.h
+++ b/cpp/src_prims/utils.h
@@ -79,16 +79,16 @@ class Exception : public std::exception {
 };
 
 /** macro to throw a runtime error */
-#define THROW(fmt, ...)                                                    \
-  do {                                                                     \
-    std::string msg;                                                       \
-    char errMsg[2048];                                                     \
-    std::sprintf(errMsg, "Exception occured! file=%s line=%d: ", __FILE__, \
-                 __LINE__);                                                \
-    msg += errMsg;                                                         \
-    std::sprintf(errMsg, fmt, ##__VA_ARGS__);                              \
-    msg += errMsg;                                                         \
-    throw MLCommon::Exception(msg);                                        \
+#define THROW(fmt, ...)                                                        \
+  do {                                                                         \
+    std::string msg;                                                           \
+    char errMsg[2048];                                                         \
+    std::snprintf(errMsg, sizeof(errMsg),                                      \
+                  "Exception occured! file=%s line=%d: ", __FILE__, __LINE__); \
+    msg += errMsg;                                                             \
+    std::snprintf(errMsg, sizeof(errMsg), fmt, ##__VA_ARGS__);                 \
+    msg += errMsg;                                                             \
+    throw MLCommon::Exception(msg);                                            \
   } while (0)
 
 /** macro to check for a conditional and assert on failure */


### PR DESCRIPTION
Replaced `sprintf()` with `snprintf()` in `THROW()` to avoid buffer overflows.