### PR TITLE
[REVIEW] [bugfix] Reduce SMO solver workspace size to fix Turing crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - PR #1162: DASK RF random seed bug fix
 - PR #1164: Fix check_dtype arg handling for input_to_dev_array
 - PR #1177: Update dask and distributed to 2.5
+- PR #1204: Fix SVM crash on Turing
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/cpp/src/svm/smosolver.h
+++ b/cpp/src/svm/smosolver.h
@@ -84,7 +84,7 @@ class SmoSolver {
       delta_alpha(handle.getDeviceAllocator(), stream),
       f(handle.getDeviceAllocator(), stream) {}
 
-#define SMO_WS_SIZE 1024
+#define SMO_WS_SIZE 512
   /**
    * Solve the quadratic optimization problem.
    *


### PR DESCRIPTION
SVM tests and SVM python code fail on my RTX8000 with the message:

```
Exception occured! file=/home/jzedlewski/code/rapidsai/cuml/cpp/src/svm/smosolver.h line=141: FAIL: call='cudaPeekAtLastError()'. Reason:too many resources requested for launch
```

It appears that the smo solver workspace is too large on this GPU. Reducing this constant fixes the issue.