### PR TITLE
Refactor FIL to prepare for sparse trees

### DIFF
--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -100,43 +100,6 @@ struct dense_storage {
   int node_pitch_ = 0;
 };
 
-/** sparse_node is a single node in a sparse forest */
-struct sparse_node : base_node {
-  int left_idx;
-  __host__ __device__ sparse_node() : left_idx(0), base_node() {}
-  sparse_node(sparse_node_t node)
-    : base_node(dense_node_t{node.val, node.bits}), left_idx(node.left_idx) {}
-  sparse_node(float output, float thresh, int fid, bool def_left, bool is_leaf,
-              int left_index)
-    : base_node(output, thresh, fid, def_left, is_leaf), left_idx(left_index) {}
-  __host__ __device__ int left_index() const { return left_idx; }
-  /** index of the left child, where curr is the index of the current node */
-  __host__ __device__ int left(int curr) const { return left_idx; }
-};
-
-/** sparse_tree is a sparse tree */
-struct sparse_tree {
-  __host__ __device__ sparse_tree(sparse_node* nodes) : nodes_(nodes) {}
-  __host__ __device__ const sparse_node& operator[](int i) const {
-    return nodes_[i];
-  }
-  sparse_node* nodes_ = nullptr;
-};
-
-/** sparse_storage stores the forest as a collection of sparse nodes */
-struct sparse_storage {
-  int* trees_ = nullptr;
-  sparse_node* nodes_ = nullptr;
-  int num_trees_ = 0;
-  __host__ __device__ sparse_storage(int* trees, sparse_node* nodes,
-                                     int num_trees)
-    : trees_(trees), nodes_(nodes), num_trees_(num_trees) {}
-  __host__ __device__ int num_trees() const { return num_trees_; }
-  __host__ __device__ sparse_tree operator[](int i) const {
-    return sparse_tree(&nodes_[trees_[i]]);
-  }
-};
-
 // predict_params are parameters for prediction
 struct predict_params {
   // Model parameters.

--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -33,16 +33,16 @@ __host__ __device__ __forceinline__ int tree_num_nodes(int depth) {
   return (1 << (depth + 1)) - 1;
 }
 
-__host__ __device__ __forceinline__ int forest_num_nodes(int ntrees,
+__host__ __device__ __forceinline__ int forest_num_nodes(int num_trees,
                                                          int depth) {
-  return ntrees * tree_num_nodes(depth);
+  return num_trees * tree_num_nodes(depth);
 }
 
 // FIL_TPB is the number of threads per block to use with FIL kernels
 const int FIL_TPB = 256;
 
-/** node is a single tree node. */
-struct __align__(8) dense_node {
+/** base_node contains common implementation details for dense and sparse nodes */
+struct base_node {
   static const int FID_MASK = (1 << 30) - 1;
   static const int DEF_LEFT_MASK = 1 << 30;
   static const int IS_LEAF_MASK = 1 << 31;
@@ -53,39 +53,109 @@ struct __align__(8) dense_node {
   __host__ __device__ int fid() const { return bits & FID_MASK; }
   __host__ __device__ bool def_left() const { return bits & DEF_LEFT_MASK; }
   __host__ __device__ bool is_leaf() const { return bits & IS_LEAF_MASK; }
-  __host__ __device__ dense_node() : val(0.0f), bits(0) {}
-  dense_node(dense_node_t n) : val(n.val), bits(n.bits) {}
-  dense_node(float output, float thresh, int fid, bool def_left, bool is_leaf)
+  __host__ __device__ base_node() : val(0.0f), bits(0) {}
+  base_node(dense_node_t node) : val(node.val), bits(node.bits) {}
+  base_node(float output, float thresh, int fid, bool def_left, bool is_leaf)
     : val(is_leaf ? output : thresh),
       bits((fid & FID_MASK) | (def_left ? DEF_LEFT_MASK : 0) |
            (is_leaf ? IS_LEAF_MASK : 0)) {}
 };
 
+/** dense_node is a single node of a dense forest */
+struct alignas(8) dense_node : base_node {
+  __host__ __device__ dense_node() : base_node() {}
+  dense_node(dense_node_t node) : base_node(node) {}
+  dense_node(float output, float thresh, int fid, bool def_left, bool is_leaf)
+    : base_node(output, thresh, fid, def_left, is_leaf) {}
+  /** index of the left child, where curr is the index of the current node */
+  __host__ __device__ int left(int curr) const { return 2 * curr + 1; }
+};
+
+/** dense_tree represents a dense tree */
+struct dense_tree {
+  __host__ __device__ dense_tree(dense_node* nodes, int node_pitch)
+    : nodes_(nodes), node_pitch_(node_pitch) {}
+  __host__ __device__ const dense_node& operator[](int i) const {
+    return nodes_[i * node_pitch_];
+  }
+  dense_node* nodes_ = nullptr;
+  int node_pitch_ = 0;
+};
+
+/** dense_storage stores the forest as a collection of dense nodes */
+struct dense_storage {
+  __host__ __device__ dense_storage(dense_node* nodes, int num_trees,
+                                    int tree_stride, int node_pitch)
+    : nodes_(nodes),
+      num_trees_(num_trees),
+      tree_stride_(tree_stride),
+      node_pitch_(node_pitch) {}
+  __host__ __device__ int num_trees() const { return num_trees_; }
+  __host__ __device__ dense_tree operator[](int i) const {
+    return dense_tree(nodes_ + i * tree_stride_, node_pitch_);
+  }
+  dense_node* nodes_ = nullptr;
+  int num_trees_ = 0;
+  int tree_stride_ = 0;
+  int node_pitch_ = 0;
+};
+
+/** sparse_node is a single node in a sparse forest */
+struct sparse_node : base_node {
+  int left_idx;
+  __host__ __device__ sparse_node() : left_idx(0), base_node() {}
+  sparse_node(sparse_node_t node)
+    : base_node(dense_node_t{node.val, node.bits}), left_idx(node.left_idx) {}
+  sparse_node(float output, float thresh, int fid, bool def_left, bool is_leaf,
+              int left_index)
+    : base_node(output, thresh, fid, def_left, is_leaf), left_idx(left_index) {}
+  __host__ __device__ int left_index() const { return left_idx; }
+  /** index of the left child, where curr is the index of the current node */
+  __host__ __device__ int left(int curr) const { return left_idx; }
+};
+
+/** sparse_tree is a sparse tree */
+struct sparse_tree {
+  __host__ __device__ sparse_tree(sparse_node* nodes) : nodes_(nodes) {}
+  __host__ __device__ const sparse_node& operator[](int i) const {
+    return nodes_[i];
+  }
+  sparse_node* nodes_ = nullptr;
+};
+
+/** sparse_storage stores the forest as a collection of sparse nodes */
+struct sparse_storage {
+  int* trees_ = nullptr;
+  sparse_node* nodes_ = nullptr;
+  int num_trees_ = 0;
+  __host__ __device__ sparse_storage(int* trees, sparse_node* nodes,
+                                     int num_trees)
+    : trees_(trees), nodes_(nodes), num_trees_(num_trees) {}
+  __host__ __device__ int num_trees() const { return num_trees_; }
+  __host__ __device__ sparse_tree operator[](int i) const {
+    return sparse_tree(&nodes_[trees_[i]]);
+  }
+};
+
 // predict_params are parameters for prediction
 struct predict_params {
-  // Forest parameters.
-  const dense_node* nodes;
-  int ntrees;
-  int depth;
-  int cols;
+  // Model parameters.
+  int num_cols;
   algo_t algo;
-
-  // Parameters filled and used only by infer().
-  int pitch;
-  int tree_stride;
-  int max_items;
+  int max_items;  // only set and used by infer()
 
   // Data parameters.
   float* preds;
   const float* data;
-  size_t rows;
+  size_t num_rows;
 
   // Other parameters.
   int max_shm;
 };
 
 // infer() calls the inference kernel with the parameters on the stream
-void infer(predict_params ps, cudaStream_t stream);
+template <typename storage_type>
+void infer(storage_type forest, predict_params params, cudaStream_t stream);
 
 }  // namespace fil
 }  // namespace ML

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -51,6 +51,27 @@ void dense_node_decode(const dense_node_t* n, float* output, float* thresh,
   *is_leaf = dn.is_leaf();
 }
 
+void sparse_node_init(sparse_node_t* node, float output, float thresh, int fid,
+                      bool def_left, bool is_leaf, int left_index) {
+  sparse_node n(output, thresh, fid, def_left, is_leaf, left_index);
+  node->bits = n.bits;
+  node->val = n.val;
+  node->left_idx = n.left_idx;
+}
+
+/** sparse_node_decode extracts individual members from node */
+void sparse_node_decode(const sparse_node_t* node, float* output, float* thresh,
+                        int* fid, bool* def_left, bool* is_leaf,
+                        int* left_index) {
+  sparse_node n(*node);
+  *output = n.output();
+  *thresh = n.thresh();
+  *fid = n.fid();
+  *def_left = n.def_left();
+  *is_leaf = n.is_leaf();
+  *left_index = n.left_index();
+}
+
 __host__ __device__ float sigmoid(float x) { return 1.0f / (1.0f + expf(-x)); }
 
 /** performs additional transformations on the array of forest predictions
@@ -73,26 +94,6 @@ __global__ void transform_k(float* preds, size_t n, output_t output,
 }
 
 struct forest {
-  forest()
-    : depth_(0),
-      ntrees_(0),
-      cols_(0),
-      algo_(algo_t::NAIVE),
-      output_(output_t::RAW),
-      threshold_(0.5),
-      global_bias_(0) {}
-
-  void transform_trees(const dense_node_t* nodes) {
-    // populate node information
-    for (int i = 0, gid = 0; i < ntrees_; ++i) {
-      for (int j = 0, nid = 0; j <= depth_; ++j) {
-        for (int k = 0; k < 1 << j; ++k, ++nid, ++gid) {
-          h_nodes_[nid * ntrees_ + i] = dense_node(nodes[gid]);
-        }
-      }
-    }
-  }
-
   void init_max_shm() {
     int max_shm_std = 48 * 1024;  // 48 KiB
     int device = 0;
@@ -104,80 +105,155 @@ struct forest {
     max_shm_ = std::min(max_shm_, max_shm_std);
   }
 
-  void init(const cumlHandle& h, const forest_params_t* params) {
+  void init_common(const forest_params_t* params) {
     depth_ = params->depth;
-    ntrees_ = params->ntrees;
-    cols_ = params->cols;
+    num_trees_ = params->num_trees;
+    num_cols_ = params->num_cols;
     algo_ = params->algo;
     output_ = params->output;
     threshold_ = params->threshold;
     global_bias_ = params->global_bias;
     init_max_shm();
-
-    int nnodes = forest_num_nodes(ntrees_, depth_);
-    nodes_ = (dense_node*)h.getDeviceAllocator()->allocate(
-      sizeof(dense_node) * nnodes, h.getStream());
-    h_nodes_.resize(nnodes);
-    if (algo_ == algo_t::NAIVE) {
-      std::copy(params->nodes, params->nodes + nnodes, h_nodes_.begin());
-    } else {
-      transform_trees(params->nodes);
-    }
-    CUDA_CHECK(cudaMemcpy(nodes_, h_nodes_.data(), nnodes * sizeof(dense_node),
-                          cudaMemcpyHostToDevice));
-    h_nodes_.clear();
-    h_nodes_.shrink_to_fit();
   }
 
+  virtual void infer(predict_params params, cudaStream_t stream) = 0;
+
   void predict(const cumlHandle& h, float* preds, const float* data,
-               size_t rows) {
+               size_t num_rows) {
     // Initialize prediction parameters.
-    predict_params ps;
-    ps.nodes = nodes_;
-    ps.ntrees = ntrees_;
-    ps.depth = depth_;
-    ps.cols = cols_;
-    ps.algo = algo_;
-    ps.preds = preds;
-    ps.data = data;
-    ps.rows = rows;
-    ps.max_shm = max_shm_;
+    predict_params params;
+    params.num_cols = num_cols_;
+    params.algo = algo_;
+    params.preds = preds;
+    params.data = data;
+    params.num_rows = num_rows;
+    params.max_shm = max_shm_;
 
     // Predict using the forest.
     cudaStream_t stream = h.getStream();
-    infer(ps, stream);
+    infer(params, stream);
 
     // Transform the output if necessary.
     if (output_ != output_t::RAW || global_bias_ != 0.0f) {
-      transform_k<<<ceildiv(int(rows), FIL_TPB), FIL_TPB, 0, stream>>>(
-        preds, rows, output_, ntrees_ > 0 ? (1.0f / ntrees_) : 1.0f, threshold_,
-        global_bias_);
+      transform_k<<<ceildiv(int(num_rows), FIL_TPB), FIL_TPB, 0, stream>>>(
+        preds, num_rows, output_, num_trees_ > 0 ? (1.0f / num_trees_) : 1.0f,
+        threshold_, global_bias_);
       CUDA_CHECK(cudaPeekAtLastError());
     }
   }
 
-  void free(const cumlHandle& h) {
-    int num_nodes = forest_num_nodes(ntrees_, depth_);
+  virtual void free(const cumlHandle& h) = 0;
+  virtual ~forest() {}
+
+  int num_trees_ = 0;
+  int depth_ = 0;
+  int num_cols_ = 0;
+  algo_t algo_ = algo_t::NAIVE;
+  int max_shm_ = 0;
+  output_t output_ = output_t::RAW;
+  float threshold_ = 0.5;
+  float global_bias_ = 0;
+};
+
+struct dense_forest : forest {
+  void transform_trees(const dense_node_t* nodes) {
+    // populate node information
+    for (int i = 0, gid = 0; i < num_trees_; ++i) {
+      for (int j = 0, nid = 0; j <= depth_; ++j) {
+        for (int k = 0; k < 1 << j; ++k, ++nid, ++gid) {
+          h_nodes_[nid * num_trees_ + i] = dense_node(nodes[gid]);
+        }
+      }
+    }
+  }
+
+  void init(const cumlHandle& h, const dense_node_t* nodes,
+            const forest_params_t* params) {
+    init_common(params);
+
+    int num_nodes = forest_num_nodes(num_trees_, depth_);
+    nodes_ = (dense_node*)h.getDeviceAllocator()->allocate(
+      sizeof(dense_node) * num_nodes, h.getStream());
+    h_nodes_.resize(num_nodes);
+    if (algo_ == algo_t::NAIVE) {
+      std::copy(nodes, nodes + num_nodes, h_nodes_.begin());
+    } else {
+      transform_trees(nodes);
+    }
+    CUDA_CHECK(cudaMemcpyAsync(nodes_, h_nodes_.data(),
+                               num_nodes * sizeof(dense_node),
+                               cudaMemcpyHostToDevice, h.getStream()));
+    // copy must be finished before freeing the host data
+    CUDA_CHECK(cudaStreamSynchronize(h.getStream()));
+    h_nodes_.clear();
+    h_nodes_.shrink_to_fit();
+  }
+
+  virtual void infer(predict_params params, cudaStream_t stream) override {
+    dense_storage forest(nodes_, num_trees_,
+                         algo_ == algo_t::NAIVE ? tree_num_nodes(depth_) : 1,
+                         algo_ == algo_t::NAIVE ? 1 : num_trees_);
+    fil::infer(forest, params, stream);
+  }
+
+  virtual void free(const cumlHandle& h) override {
+    int num_nodes = forest_num_nodes(num_trees_, depth_);
     h.getDeviceAllocator()->deallocate(nodes_, sizeof(dense_node) * num_nodes,
                                        h.getStream());
   }
 
-  int ntrees_;
-  int depth_;
-  int cols_;
-  algo_t algo_;
-  int max_shm_;
-  output_t output_;
-  float threshold_;
-  float global_bias_;
   dense_node* nodes_ = nullptr;
   thrust::host_vector<dense_node> h_nodes_;
 };
 
-void check_params(const forest_params_t* params) {
-  ASSERT(params->depth >= 0, "depth must be non-negative");
-  ASSERT(params->ntrees >= 0, "ntrees must be non-negative");
-  ASSERT(params->cols >= 0, "cols must be non-negative");
+struct sparse_forest : forest {
+  void init(const cumlHandle& h, const int* trees, const sparse_node_t* nodes,
+            const forest_params_t* params) {
+    init_common(params);
+    depth_ = 0;  // a placeholder value
+    num_nodes_ = params->num_nodes;
+
+    // trees
+    trees_ = (int*)h.getDeviceAllocator()->allocate(sizeof(int) * num_trees_,
+                                                    h.getStream());
+    CUDA_CHECK(cudaMemcpyAsync(trees_, trees, sizeof(int) * num_trees_,
+                               cudaMemcpyHostToDevice, h.getStream()));
+
+    // nodes
+    nodes_ = (sparse_node*)h.getDeviceAllocator()->allocate(
+      sizeof(sparse_node) * num_nodes_, h.getStream());
+    CUDA_CHECK(cudaMemcpyAsync(nodes_, nodes, sizeof(sparse_node) * num_nodes_,
+                               cudaMemcpyHostToDevice, h.getStream()));
+  }
+
+  virtual void infer(predict_params params, cudaStream_t stream) override {
+    sparse_storage forest(trees_, nodes_, num_trees_);
+    fil::infer(forest, params, stream);
+  }
+
+  void free(const cumlHandle& h) override {
+    h.getDeviceAllocator()->deallocate(trees_, sizeof(int) * num_trees_,
+                                       h.getStream());
+    h.getDeviceAllocator()->deallocate(nodes_, sizeof(sparse_node) * num_nodes_,
+                                       h.getStream());
+  }
+
+  int num_nodes_ = 0;
+  int* trees_ = nullptr;
+  sparse_node* nodes_ = nullptr;
+};
+
+void check_params(const forest_params_t* params, bool dense) {
+  if (dense) {
+    ASSERT(params->depth >= 0, "depth must be non-negative for dense forests");
+  } else {
+    ASSERT(params->num_nodes >= 0,
+           "num_nodes must be non-negative for sparse forests");
+    ASSERT(params->algo == algo_t::NAIVE,
+           "only NAIVE algorithm is supported for sparse forests");
+  }
+  ASSERT(params->num_trees >= 0, "num_trees must be non-negative");
+  ASSERT(params->num_cols >= 0, "num_cols must be non-negative");
   switch (params->algo) {
     case algo_t::NAIVE:
     case algo_t::TREE_REORG:
@@ -292,7 +368,7 @@ void tl2fil(forest_params_t* params, std::vector<dense_node_t>* pnodes,
   params->threshold = tl_params->threshold;
 
   // fill in forest-dependent params
-  params->cols = model.num_feature;
+  params->num_cols = model.num_feature;
   ASSERT(model.num_output_group == 1,
          "multi-class classification not supported");
   const tl::ModelParam& param = model.param;
@@ -312,26 +388,33 @@ void tl2fil(forest_params_t* params, std::vector<dense_node_t>* pnodes,
     ASSERT(false, "%s: unsupported treelite prediction transform",
            param.pred_transform.c_str());
   }
-  params->ntrees = model.trees.size();
+  params->num_trees = model.trees.size();
 
   int depth = 0;
   for (const auto& tree : model.trees) depth = std::max(depth, max_depth(tree));
   params->depth = depth;
 
   // convert the nodes
-  int num_nodes = forest_num_nodes(params->ntrees, params->depth);
+  int num_nodes = forest_num_nodes(params->num_trees, params->depth);
   pnodes->resize(num_nodes, dense_node_t{0, 0});
   for (int i = 0; i < model.trees.size(); ++i) {
     tree2fil(pnodes, i * tree_num_nodes(params->depth), model.trees[i]);
   }
-  params->nodes = pnodes->data();
 }
 
-void init_dense(const cumlHandle& h, forest_t* pf,
+void init_dense(const cumlHandle& h, forest_t* pf, const dense_node_t* nodes,
                 const forest_params_t* params) {
-  check_params(params);
-  forest* f = new forest;
-  f->init(h, params);
+  check_params(params, true);
+  dense_forest* f = new dense_forest;
+  f->init(h, nodes, params);
+  *pf = f;
+}
+
+void init_sparse(const cumlHandle& h, forest_t* pf, const int* trees,
+                 const sparse_node_t* nodes, const forest_params_t* params) {
+  check_params(params, false);
+  sparse_forest* f = new sparse_forest;
+  f->init(h, trees, nodes, params);
   *pf = f;
 }
 
@@ -340,7 +423,7 @@ void from_treelite(const cumlHandle& handle, forest_t* pforest,
   forest_params_t params;
   std::vector<dense_node_t> nodes;
   tl2fil(&params, &nodes, *(tl::Model*)model, tl_params);
-  init_dense(handle, pforest, &params);
+  init_dense(handle, pforest, nodes.data(), &params);
   // sync is necessary as nodes is used in init_dense(),
   // but destructed at the end of this function
   CUDA_CHECK(cudaStreamSynchronize(handle.getStream()));
@@ -352,8 +435,8 @@ void free(const cumlHandle& h, forest_t f) {
 }
 
 void predict(const cumlHandle& h, forest_t f, float* preds, const float* data,
-             size_t n) {
-  f->predict(h, preds, data, n);
+             size_t num_rows) {
+  f->predict(h, preds, data, num_rows);
 }
 
 }  // namespace fil

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -51,27 +51,6 @@ void dense_node_decode(const dense_node_t* n, float* output, float* thresh,
   *is_leaf = dn.is_leaf();
 }
 
-void sparse_node_init(sparse_node_t* node, float output, float thresh, int fid,
-                      bool def_left, bool is_leaf, int left_index) {
-  sparse_node n(output, thresh, fid, def_left, is_leaf, left_index);
-  node->bits = n.bits;
-  node->val = n.val;
-  node->left_idx = n.left_idx;
-}
-
-/** sparse_node_decode extracts individual members from node */
-void sparse_node_decode(const sparse_node_t* node, float* output, float* thresh,
-                        int* fid, bool* def_left, bool* is_leaf,
-                        int* left_index) {
-  sparse_node n(*node);
-  *output = n.output();
-  *thresh = n.thresh();
-  *fid = n.fid();
-  *def_left = n.def_left();
-  *is_leaf = n.is_leaf();
-  *left_index = n.left_index();
-}
-
 __host__ __device__ float sigmoid(float x) { return 1.0f / (1.0f + expf(-x)); }
 
 /** performs additional transformations on the array of forest predictions
@@ -206,52 +185,8 @@ struct dense_forest : forest {
   thrust::host_vector<dense_node> h_nodes_;
 };
 
-struct sparse_forest : forest {
-  void init(const cumlHandle& h, const int* trees, const sparse_node_t* nodes,
-            const forest_params_t* params) {
-    init_common(params);
-    depth_ = 0;  // a placeholder value
-    num_nodes_ = params->num_nodes;
-
-    // trees
-    trees_ = (int*)h.getDeviceAllocator()->allocate(sizeof(int) * num_trees_,
-                                                    h.getStream());
-    CUDA_CHECK(cudaMemcpyAsync(trees_, trees, sizeof(int) * num_trees_,
-                               cudaMemcpyHostToDevice, h.getStream()));
-
-    // nodes
-    nodes_ = (sparse_node*)h.getDeviceAllocator()->allocate(
-      sizeof(sparse_node) * num_nodes_, h.getStream());
-    CUDA_CHECK(cudaMemcpyAsync(nodes_, nodes, sizeof(sparse_node) * num_nodes_,
-                               cudaMemcpyHostToDevice, h.getStream()));
-  }
-
-  virtual void infer(predict_params params, cudaStream_t stream) override {
-    sparse_storage forest(trees_, nodes_, num_trees_);
-    fil::infer(forest, params, stream);
-  }
-
-  void free(const cumlHandle& h) override {
-    h.getDeviceAllocator()->deallocate(trees_, sizeof(int) * num_trees_,
-                                       h.getStream());
-    h.getDeviceAllocator()->deallocate(nodes_, sizeof(sparse_node) * num_nodes_,
-                                       h.getStream());
-  }
-
-  int num_nodes_ = 0;
-  int* trees_ = nullptr;
-  sparse_node* nodes_ = nullptr;
-};
-
-void check_params(const forest_params_t* params, bool dense) {
-  if (dense) {
-    ASSERT(params->depth >= 0, "depth must be non-negative for dense forests");
-  } else {
-    ASSERT(params->num_nodes >= 0,
-           "num_nodes must be non-negative for sparse forests");
-    ASSERT(params->algo == algo_t::NAIVE,
-           "only NAIVE algorithm is supported for sparse forests");
-  }
+void check_params(const forest_params_t* params) {
+  ASSERT(params->depth >= 0, "depth must be non-negative for dense forests");
   ASSERT(params->num_trees >= 0, "num_trees must be non-negative");
   ASSERT(params->num_cols >= 0, "num_cols must be non-negative");
   switch (params->algo) {
@@ -404,17 +339,9 @@ void tl2fil(forest_params_t* params, std::vector<dense_node_t>* pnodes,
 
 void init_dense(const cumlHandle& h, forest_t* pf, const dense_node_t* nodes,
                 const forest_params_t* params) {
-  check_params(params, true);
+  check_params(params);
   dense_forest* f = new dense_forest;
   f->init(h, nodes, params);
-  *pf = f;
-}
-
-void init_sparse(const cumlHandle& h, forest_t* pf, const int* trees,
-                 const sparse_node_t* nodes, const forest_params_t* params) {
-  check_params(params, false);
-  sparse_forest* f = new sparse_forest;
-  f->init(h, trees, nodes, params);
   *pf = f;
 }
 

--- a/cpp/src/fil/fil.h
+++ b/cpp/src/fil/fil.h
@@ -76,13 +76,6 @@ struct dense_node_t {
   int bits;
 };
 
-/** sparse_node_t is a node in a sparsely-stored forest */
-struct sparse_node_t {
-  float val;
-  int bits;
-  int left_idx;
-};
-
 /** dense_node_init initializes node from paramters */
 void dense_node_init(dense_node_t* n, float output, float thresh, int fid,
                      bool def_left, bool is_leaf);
@@ -91,15 +84,6 @@ void dense_node_init(dense_node_t* n, float output, float thresh, int fid,
 void dense_node_decode(const dense_node_t* node, float* output, float* thresh,
                        int* fid, bool* def_left, bool* is_leaf);
 
-/** sparse_node_init initializes node from parameters */
-void sparse_node_init(sparse_node_t* node, float output, float thresh, int fid,
-                      bool def_left, bool is_leaf, int left_index);
-
-/** sparse_node_decode extracts individual members from node */
-void sparse_node_decode(const sparse_node_t* node, float* output, float* thresh,
-                        int* fid, bool* def_left, bool* is_leaf,
-                        int* left_index);
-
 struct forest;
 
 /** forest_t is the predictor handle */
@@ -107,9 +91,7 @@ typedef forest* forest_t;
 
 /** forest_params_t are the trees to initialize the predictor */
 struct forest_params_t {
-  // total number of nodes; ignored for dense forests
-  int num_nodes;
-  // maximum depth; ignored for sparse forests
+  // maximum depth
   int depth;
   // ntrees is the number of trees
   int num_trees;
@@ -149,16 +131,6 @@ struct treelite_params_t {
  */
 void init_dense(const cumlHandle& h, forest_t* pf, const dense_node_t* nodes,
                 const forest_params_t* params);
-
-/** init_sparse uses params, trees and nodes to initialize the sparse forest stored in pf
- *  @param h cuML handle used by this function
- *  @param pf pointer to where to store the newly created forest
- *  @param trees indices of tree roots in the nodes arrray, of length params->ntrees
- *  @param nodes nodes for the forest, of length params->num_nodes
- *  @param params pointer to parameters used to initialize the forest
- */
-void init_sparse(const cumlHandle& h, forest_t* pf, const int* trees,
-                 const sparse_node_t* nodes, const forest_params_t* params);
 
 /** from_treelite uses a treelite model to initialize the forest
  * @param handle cuML handle used by this function

--- a/cpp/src/fil/fil.h
+++ b/cpp/src/fil/fil.h
@@ -70,19 +70,35 @@ enum output_t {
   THRESHOLD = 0x100,
 };
 
-/** dense_node is a single tree node */
+/** dense_node_t is a node in a densely-stored forest */
 struct dense_node_t {
   float val;
   int bits;
 };
 
-/** dense_node_init initializes n from paramters */
+/** sparse_node_t is a node in a sparsely-stored forest */
+struct sparse_node_t {
+  float val;
+  int bits;
+  int left_idx;
+};
+
+/** dense_node_init initializes node from paramters */
 void dense_node_init(dense_node_t* n, float output, float thresh, int fid,
                      bool def_left, bool is_leaf);
 
-/** dense_node_decode extracts individual members from n */
-void dense_node_decode(const dense_node_t* n, float* output, float* thresh,
+/** dense_node_decode extracts individual members from node */
+void dense_node_decode(const dense_node_t* node, float* output, float* thresh,
                        int* fid, bool* def_left, bool* is_leaf);
+
+/** sparse_node_init initializes node from parameters */
+void sparse_node_init(sparse_node_t* node, float output, float thresh, int fid,
+                      bool def_left, bool is_leaf, int left_index);
+
+/** sparse_node_decode extracts individual members from node */
+void sparse_node_decode(const sparse_node_t* node, float* output, float* thresh,
+                        int* fid, bool* def_left, bool* is_leaf,
+                        int* left_index);
 
 struct forest;
 
@@ -91,15 +107,16 @@ typedef forest* forest_t;
 
 /** forest_params_t are the trees to initialize the predictor */
 struct forest_params_t {
-  // nodes of trees, of length (2**(depth + 1) - 1) * ntrees
-  const dense_node_t* nodes;
-  // depth of each tree
+  // total number of nodes; ignored for dense forests
+  int num_nodes;
+  // maximum depth; ignored for sparse forests
   int depth;
   // ntrees is the number of trees
-  int ntrees;
-  // cols is the number of columns in the data
-  int cols;
-  // algo is the inference algorithm
+  int num_trees;
+  // num_cols is the number of columns in the data
+  int num_cols;
+  // algo is the inference algorithm;
+  // sparse forests do not distinguish between NAIVE and TREE_REORG
   algo_t algo;
   // output is the desired output type
   output_t output;
@@ -123,13 +140,25 @@ struct treelite_params_t {
   float threshold;
 };
 
-/** init_dense uses params to initialize the forest stored in pf
+/** init_dense uses params and nodes to initialize the dense forest stored in pf
  *  @param h cuML handle used by this function
  *  @param pf pointer to where to store the newly created forest
+ *  @param nodes nodes for the forest, of length
+      (2**(params->depth + 1) - 1) * params->ntrees
  *  @param params pointer to parameters used to initialize the forest
  */
-void init_dense(const cumlHandle& h, forest_t* pf,
+void init_dense(const cumlHandle& h, forest_t* pf, const dense_node_t* nodes,
                 const forest_params_t* params);
+
+/** init_sparse uses params, trees and nodes to initialize the sparse forest stored in pf
+ *  @param h cuML handle used by this function
+ *  @param pf pointer to where to store the newly created forest
+ *  @param trees indices of tree roots in the nodes arrray, of length params->ntrees
+ *  @param nodes nodes for the forest, of length params->num_nodes
+ *  @param params pointer to parameters used to initialize the forest
+ */
+void init_sparse(const cumlHandle& h, forest_t* pf, const int* trees,
+                 const sparse_node_t* nodes, const forest_params_t* params);
 
 /** from_treelite uses a treelite model to initialize the forest
  * @param handle cuML handle used by this function
@@ -153,10 +182,10 @@ void free(const cumlHandle& h, forest_t f);
  *  @param preds array of size n in GPU memory to store predictions into
  *  @param data array of size n * cols (cols is the number of columns 
  *      for the forest f) from which to predict
- *  @param n number of data rows
+ *  @param num_rows number of data rows
  */
 void predict(const cumlHandle& h, forest_t f, float* preds, const float* data,
-             size_t n);
+             size_t num_rows);
 
 }  // namespace fil
 }  // namespace ML

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -142,8 +142,6 @@ void infer(storage_type forest, predict_params params, cudaStream_t stream) {
 
 template void infer<dense_storage>(dense_storage forest, predict_params params,
                                    cudaStream_t stream);
-template void infer<sparse_storage>(sparse_storage forest,
-                                    predict_params params, cudaStream_t stream);
 
 }  // namespace fil
 }  // namespace ML

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -37,9 +37,8 @@ struct vec {
   }
 };
 
-template <int NITEMS>
-__device__ __forceinline__ void infer_one_tree(const dense_node* root,
-                                               float* sdata, int pitch,
+template <int NITEMS, typename tree_type>
+__device__ __forceinline__ void infer_one_tree(tree_type tree, float* sdata,
                                                int cols, vec<NITEMS>& out) {
   int curr[NITEMS];
   int mask = (1 << NITEMS) - 1;  // all active
@@ -48,99 +47,103 @@ __device__ __forceinline__ void infer_one_tree(const dense_node* root,
 #pragma unroll
     for (int j = 0; j < NITEMS; ++j) {
       if ((mask >> j) & 1 == 0) continue;
-      dense_node n = root[curr[j] * pitch];
+      auto n = tree[curr[j]];
       if (n.is_leaf()) {
         mask &= ~(1 << j);
         continue;
       }
       float val = sdata[j * cols + n.fid()];
       bool cond = isnan(val) ? !n.def_left() : val >= n.thresh();
-      curr[j] = (curr[j] << 1) + 1 + cond;
+      curr[j] = n.left(curr[j]) + cond;
     }
   } while (mask != 0);
 #pragma unroll
-  for (int j = 0; j < NITEMS; ++j)
-    out[j] += root[curr[j] * pitch].output();
+  for (int j = 0; j < NITEMS; ++j) out[j] += tree[curr[j]].output();
 }
 
-__device__ __forceinline__ void infer_one_tree(const dense_node* root,
-                                               float* sdata, int pitch,
+template <typename tree_type>
+__device__ __forceinline__ void infer_one_tree(tree_type tree, float* sdata,
                                                int cols, vec<1>& out) {
   int curr = 0;
   for (;;) {
-    dense_node n = root[curr * pitch];
+    auto n = tree[curr];
     if (n.is_leaf()) break;
     float val = sdata[n.fid()];
     bool cond = isnan(val) ? !n.def_left() : val >= n.thresh();
-    curr = (curr << 1) + 1 + cond;
+    curr = n.left(curr) + cond;
   }
-  out[0] = root[curr * pitch].output();
+  out[0] = tree[curr].output();
 }
 
-template <int NITEMS>
-__global__ void infer_k(predict_params ps) {
+template <int NITEMS, typename storage_type>
+__global__ void infer_k(storage_type forest, predict_params params) {
   // cache the row for all threads to reuse
   extern __shared__ char smem[];
   float* sdata = (float*)smem;
   size_t rid = blockIdx.x * NITEMS;
   for (int j = 0; j < NITEMS; ++j) {
-    for (int i = threadIdx.x; i < ps.cols; i += blockDim.x) {
+    for (int i = threadIdx.x; i < params.num_cols; i += blockDim.x) {
       size_t row = rid + j;
-      sdata[j * ps.cols + i] =
-        row < ps.rows ? ps.data[row * ps.cols + i] : 0.0f;
+      sdata[j * params.num_cols + i] =
+        row < params.num_rows ? params.data[row * params.num_cols + i] : 0.0f;
     }
   }
   __syncthreads();
+
   // one block works on a single row and the whole forest
   vec<NITEMS> out;
   for (int i = 0; i < NITEMS; ++i) out[i] = 0.0f;
-  for (int j = threadIdx.x; j < ps.ntrees; j += blockDim.x) {
-    infer_one_tree<NITEMS>(ps.nodes + j * ps.tree_stride, sdata, ps.pitch,
-                           ps.cols, out);
+  for (int j = threadIdx.x; j < forest.num_trees(); j += blockDim.x) {
+    infer_one_tree<NITEMS>(forest[j], sdata, params.num_cols, out);
   }
-  typedef cub::BlockReduce<vec<NITEMS>, FIL_TPB> BlockReduce;
+  using BlockReduce = cub::BlockReduce<vec<NITEMS>, FIL_TPB>;
   __shared__ typename BlockReduce::TempStorage tmp_storage;
   out = BlockReduce(tmp_storage).Sum(out);
   if (threadIdx.x == 0) {
     for (int i = 0; i < NITEMS; ++i) {
       int idx = blockIdx.x * NITEMS + i;
-      if (idx < ps.rows) ps.preds[idx] = out[i];
+      if (idx < params.num_rows) params.preds[idx] = out[i];
     }
   }
 }
 
-void infer(predict_params ps, cudaStream_t stream) {
+template <typename storage_type>
+void infer(storage_type forest, predict_params params, cudaStream_t stream) {
   const int MAX_BATCH_ITEMS = 4;
-  ps.max_items = ps.algo == algo_t::BATCH_TREE_REORG ? MAX_BATCH_ITEMS : 1;
-  ps.pitch = ps.algo == algo_t::NAIVE ? 1 : ps.ntrees;
-  ps.tree_stride = ps.algo == algo_t::NAIVE ? tree_num_nodes(ps.depth) : 1;
-  int num_items = ps.max_shm / (sizeof(float) * ps.cols);
+  params.max_items =
+    params.algo == algo_t::BATCH_TREE_REORG ? MAX_BATCH_ITEMS : 1;
+  int num_items = params.max_shm / (sizeof(float) * params.num_cols);
   if (num_items == 0) {
-    int max_cols = ps.max_shm / sizeof(float);
-    ASSERT(false, "p.cols == %d: too many features, only %d allowed", ps.cols,
-           max_cols);
+    int max_cols = params.max_shm / sizeof(float);
+    ASSERT(false, "p.num_cols == %d: too many features, only %d allowed",
+           params.num_cols, max_cols);
   }
-  num_items = std::min(num_items, ps.max_items);
-  int nblks = ceildiv(int(ps.rows), num_items);
-  int shm_sz = num_items * sizeof(float) * ps.cols;
+  num_items = std::min(num_items, params.max_items);
+  int num_blocks = ceildiv(int(params.num_rows), num_items);
+  int shm_sz = num_items * sizeof(float) * params.num_cols;
   switch (num_items) {
     case 1:
-      infer_k<1><<<nblks, FIL_TPB, shm_sz, stream>>>(ps);
+      infer_k<1><<<num_blocks, FIL_TPB, shm_sz, stream>>>(forest, params);
       break;
     case 2:
-      infer_k<2><<<nblks, FIL_TPB, shm_sz, stream>>>(ps);
+      infer_k<2><<<num_blocks, FIL_TPB, shm_sz, stream>>>(forest, params);
       break;
     case 3:
-      infer_k<3><<<nblks, FIL_TPB, shm_sz, stream>>>(ps);
+      infer_k<3><<<num_blocks, FIL_TPB, shm_sz, stream>>>(forest, params);
       break;
     case 4:
-      infer_k<4><<<nblks, FIL_TPB, shm_sz, stream>>>(ps);
+      infer_k<4><<<num_blocks, FIL_TPB, shm_sz, stream>>>(forest, params);
       break;
     default:
       ASSERT(false, "internal error: nitems > 4");
   }
   CUDA_CHECK(cudaPeekAtLastError());
 }
+
+template void infer<dense_storage>(dense_storage forest, predict_params params,
+                                   cudaStream_t stream);
+template void infer<sparse_storage>(sparse_storage forest,
+                                    predict_params params, cudaStream_t stream);
 
 }  // namespace fil
 }  // namespace ML

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -39,8 +39,8 @@ namespace tlf = treelite::frontend;
 
 struct FilTestParams {
   // input data parameters
-  int rows;
-  int cols;
+  int num_rows;
+  int num_cols;
   float nan_prob;
   // forest parameters
   int depth;
@@ -59,7 +59,7 @@ struct FilTestParams {
 };
 
 std::ostream& operator<<(std::ostream& os, const FilTestParams& ps) {
-  os << "rows = " << ps.rows << ", cols = " << ps.cols
+  os << "num_rows = " << ps.num_rows << ", num_cols = " << ps.num_cols
      << ", nan_prob = " << ps.nan_prob << ", depth = " << ps.depth
      << ", num_trees = " << ps.num_trees << ", leaf_prob = " << ps.leaf_prob
      << ", output = " << ps.output << ", threshold = " << ps.threshold
@@ -119,7 +119,7 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
     Random::Rng r(ps.seed);
     r.uniform(weights_d, num_nodes, -1.0f, 1.0f, stream);
     r.uniform(thresholds_d, num_nodes, -1.0f, 1.0f, stream);
-    r.uniformInt(fids_d, num_nodes, 0, ps.cols, stream);
+    r.uniformInt(fids_d, num_nodes, 0, ps.num_cols, stream);
     r.bernoulli(def_lefts_d, num_nodes, 0.5f, stream);
     r.bernoulli(is_leafs_d, num_nodes, 1.0f - ps.leaf_prob, stream);
 
@@ -165,7 +165,7 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
 
   void generate_data() {
     // allocate arrays
-    size_t num_data = ps.rows * ps.cols;
+    size_t num_data = ps.num_rows * ps.num_cols;
     allocate(data_d, num_data);
     bool* mask_d = nullptr;
     allocate(mask_d, num_data);
@@ -190,12 +190,12 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
 
   void predict_on_cpu() {
     // predict on host
-    std::vector<float> want_preds_h(ps.rows);
+    std::vector<float> want_preds_h(ps.num_rows);
     int num_nodes = tree_num_nodes();
-    for (int i = 0; i < ps.rows; ++i) {
+    for (int i = 0; i < ps.num_rows; ++i) {
       float pred = 0.0f;
       for (int j = 0; j < ps.num_trees; ++j) {
-        pred += infer_one_tree(&nodes[j * num_nodes], &data_h[i * ps.cols]);
+        pred += infer_one_tree(&nodes[j * num_nodes], &data_h[i * ps.num_cols]);
       }
       if ((ps.output & fil::output_t::AVG) != 0) pred = pred / ps.num_trees;
       pred += ps.global_bias;
@@ -207,8 +207,8 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
     }
 
     // copy to GPU
-    allocate(want_preds_d, ps.rows);
-    updateDevice(want_preds_d, want_preds_h.data(), ps.rows, stream);
+    allocate(want_preds_d, ps.num_rows);
+    updateDevice(want_preds_d, want_preds_h.data(), ps.num_rows, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
   }
 
@@ -219,8 +219,8 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
     init_forest(&forest);
 
     // predict
-    allocate(preds_d, ps.rows);
-    fil::predict(handle, forest, preds_d, data_d, ps.rows);
+    allocate(preds_d, ps.num_rows);
+    fil::predict(handle, forest, preds_d, data_d, ps.num_rows);
     CUDA_CHECK(cudaStreamSynchronize(stream));
 
     // cleanup
@@ -228,7 +228,7 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
   }
 
   void compare() {
-    ASSERT_TRUE(devArrMatch(want_preds_d, preds_d, ps.rows,
+    ASSERT_TRUE(devArrMatch(want_preds_d, preds_d, ps.num_rows,
                             CompareApprox<float>(ps.tolerance), stream));
   }
 
@@ -269,21 +269,78 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
   FilTestParams ps;
 };
 
-class PredictFilTest : public BaseFilTest {
+class PredictDenseFilTest : public BaseFilTest {
  protected:
   void init_forest(fil::forest_t* pforest) override {
     // init FIL model
     fil::forest_params_t fil_ps;
-    fil_ps.nodes = nodes.data();
     fil_ps.depth = ps.depth;
-    fil_ps.ntrees = ps.num_trees;
-    fil_ps.cols = ps.cols;
+    fil_ps.num_trees = ps.num_trees;
+    fil_ps.num_cols = ps.num_cols;
     fil_ps.algo = ps.algo;
     fil_ps.output = ps.output;
     fil_ps.threshold = ps.threshold;
     fil_ps.global_bias = ps.global_bias;
-    fil::init_dense(handle, pforest, &fil_ps);
+    fil::init_dense(handle, pforest, nodes.data(), &fil_ps);
   }
+};
+
+class PredictSparseFilTest : public BaseFilTest {
+ protected:
+  void dense2sparse_node(const fil::dense_node_t* dense_root, int i_dense,
+                         int i_sparse_root, int i_sparse) {
+    float output, threshold;
+    int feature;
+    bool def_left, is_leaf;
+    dense_node_decode(&dense_root[i_dense], &output, &threshold, &feature,
+                      &def_left, &is_leaf);
+    if (is_leaf) {
+      // leaf sparse node
+      sparse_node_init(&sparse_nodes[i_sparse], output, threshold, feature,
+                       def_left, is_leaf, 0);
+      return;
+    }
+    // inner sparse node
+    // reserve space for children
+    int left_index = sparse_nodes.size();
+    sparse_nodes.push_back(fil::sparse_node_t());
+    sparse_nodes.push_back(fil::sparse_node_t());
+    sparse_node_init(&sparse_nodes[i_sparse], output, threshold, feature,
+                     def_left, is_leaf, left_index - i_sparse_root);
+    dense2sparse_node(dense_root, 2 * i_dense + 1, i_sparse_root, left_index);
+    dense2sparse_node(dense_root, 2 * i_dense + 2, i_sparse_root,
+                      left_index + 1);
+  }
+
+  void dense2sparse_tree(const fil::dense_node_t* dense_root) {
+    int i_sparse_root = sparse_nodes.size();
+    sparse_nodes.push_back(fil::sparse_node_t());
+    dense2sparse_node(dense_root, 0, i_sparse_root, i_sparse_root);
+    trees.push_back(i_sparse_root);
+  }
+
+  void dense2sparse() {
+    for (int tree = 0; tree < ps.num_trees; ++tree) {
+      dense2sparse_tree(&nodes[tree * tree_num_nodes()]);
+    }
+  }
+
+  void init_forest(fil::forest_t* pforest) override {
+    // init FIL model
+    fil::forest_params_t fil_params;
+    fil_params.num_trees = ps.num_trees;
+    fil_params.num_cols = ps.num_cols;
+    fil_params.algo = ps.algo;
+    fil_params.output = ps.output;
+    fil_params.threshold = ps.threshold;
+    fil_params.global_bias = ps.global_bias;
+    dense2sparse();
+    fil_params.num_nodes = sparse_nodes.size();
+    fil::init_sparse(handle, pforest, trees.data(), sparse_nodes.data(),
+                     &fil_params);
+  }
+  std::vector<fil::sparse_node_t> sparse_nodes;
+  std::vector<int> trees;
 };
 
 class TreeliteFilTest : public BaseFilTest {
@@ -336,7 +393,7 @@ class TreeliteFilTest : public BaseFilTest {
   void init_forest(fil::forest_t* pforest) override {
     bool random_forest_flag = (ps.output & fil::output_t::AVG) != 0;
     std::unique_ptr<tlf::ModelBuilder> model_builder(
-      new tlf::ModelBuilder(ps.cols, 1, random_forest_flag));
+      new tlf::ModelBuilder(ps.num_cols, 1, random_forest_flag));
 
     // prediction transform
     if ((ps.output & fil::output_t::SIGMOID) != 0) {
@@ -377,7 +434,7 @@ class TreeliteFilTest : public BaseFilTest {
 
 // rows, cols, nan_prob, depth, num_trees, leaf_prob, output, threshold,
 // global_bias, algo, seed, tolerance
-std::vector<FilTestParams> predict_inputs = {
+std::vector<FilTestParams> predict_dense_inputs = {
   {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0, fil::algo_t::NAIVE,
    42, 2e-3f},
   {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0,
@@ -425,10 +482,41 @@ std::vector<FilTestParams> predict_inputs = {
    fil::algo_t::TREE_REORG, 42, 2e-3f},
 };
 
-TEST_P(PredictFilTest, Predict) { compare(); }
+TEST_P(PredictDenseFilTest, Predict) { compare(); }
 
-INSTANTIATE_TEST_CASE_P(FilTests, PredictFilTest,
-                        testing::ValuesIn(predict_inputs));
+INSTANTIATE_TEST_CASE_P(FilTests, PredictDenseFilTest,
+                        testing::ValuesIn(predict_dense_inputs));
+
+// rows, cols, nan_prob, depth, num_trees, leaf_prob, output, threshold,
+// global_bias, algo, seed, tolerance
+std::vector<FilTestParams> predict_sparse_inputs = {
+  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0, fil::algo_t::NAIVE,
+   42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::SIGMOID, 0, 0,
+   fil::algo_t::NAIVE, 42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05,
+   fil::output_t(fil::output_t::SIGMOID | fil::output_t::THRESHOLD), 0, 0,
+   fil::algo_t::NAIVE, 42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::AVG, 0, 0, fil::algo_t::NAIVE,
+   42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05,
+   fil::output_t(fil::output_t::AVG | fil::output_t::THRESHOLD), 0, 0.5,
+   fil::algo_t::NAIVE, 42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0.5, fil::algo_t::NAIVE,
+   42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::SIGMOID, 0, 0.5,
+   fil::algo_t::NAIVE, 42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::AVG, 0, 0.5, fil::algo_t::NAIVE,
+   42, 2e-3f},
+  {20000, 50, 0.05, 8, 50, 0.05,
+   fil::output_t(fil::output_t::AVG | fil::output_t::THRESHOLD), 1.0, 0.5,
+   fil::algo_t::NAIVE, 42, 2e-3f},
+};
+
+TEST_P(PredictSparseFilTest, Predict) { compare(); }
+
+INSTANTIATE_TEST_CASE_P(FilTests, PredictSparseFilTest,
+                        testing::ValuesIn(predict_sparse_inputs));
 
 std::vector<FilTestParams> import_inputs = {
   {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0, fil::algo_t::NAIVE,

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -285,64 +285,6 @@ class PredictDenseFilTest : public BaseFilTest {
   }
 };
 
-class PredictSparseFilTest : public BaseFilTest {
- protected:
-  void dense2sparse_node(const fil::dense_node_t* dense_root, int i_dense,
-                         int i_sparse_root, int i_sparse) {
-    float output, threshold;
-    int feature;
-    bool def_left, is_leaf;
-    dense_node_decode(&dense_root[i_dense], &output, &threshold, &feature,
-                      &def_left, &is_leaf);
-    if (is_leaf) {
-      // leaf sparse node
-      sparse_node_init(&sparse_nodes[i_sparse], output, threshold, feature,
-                       def_left, is_leaf, 0);
-      return;
-    }
-    // inner sparse node
-    // reserve space for children
-    int left_index = sparse_nodes.size();
-    sparse_nodes.push_back(fil::sparse_node_t());
-    sparse_nodes.push_back(fil::sparse_node_t());
-    sparse_node_init(&sparse_nodes[i_sparse], output, threshold, feature,
-                     def_left, is_leaf, left_index - i_sparse_root);
-    dense2sparse_node(dense_root, 2 * i_dense + 1, i_sparse_root, left_index);
-    dense2sparse_node(dense_root, 2 * i_dense + 2, i_sparse_root,
-                      left_index + 1);
-  }
-
-  void dense2sparse_tree(const fil::dense_node_t* dense_root) {
-    int i_sparse_root = sparse_nodes.size();
-    sparse_nodes.push_back(fil::sparse_node_t());
-    dense2sparse_node(dense_root, 0, i_sparse_root, i_sparse_root);
-    trees.push_back(i_sparse_root);
-  }
-
-  void dense2sparse() {
-    for (int tree = 0; tree < ps.num_trees; ++tree) {
-      dense2sparse_tree(&nodes[tree * tree_num_nodes()]);
-    }
-  }
-
-  void init_forest(fil::forest_t* pforest) override {
-    // init FIL model
-    fil::forest_params_t fil_params;
-    fil_params.num_trees = ps.num_trees;
-    fil_params.num_cols = ps.num_cols;
-    fil_params.algo = ps.algo;
-    fil_params.output = ps.output;
-    fil_params.threshold = ps.threshold;
-    fil_params.global_bias = ps.global_bias;
-    dense2sparse();
-    fil_params.num_nodes = sparse_nodes.size();
-    fil::init_sparse(handle, pforest, trees.data(), sparse_nodes.data(),
-                     &fil_params);
-  }
-  std::vector<fil::sparse_node_t> sparse_nodes;
-  std::vector<int> trees;
-};
-
 class TreeliteFilTest : public BaseFilTest {
  protected:
   /** adds nodes[node] of tree starting at index root to builder 
@@ -486,37 +428,6 @@ TEST_P(PredictDenseFilTest, Predict) { compare(); }
 
 INSTANTIATE_TEST_CASE_P(FilTests, PredictDenseFilTest,
                         testing::ValuesIn(predict_dense_inputs));
-
-// rows, cols, nan_prob, depth, num_trees, leaf_prob, output, threshold,
-// global_bias, algo, seed, tolerance
-std::vector<FilTestParams> predict_sparse_inputs = {
-  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0, fil::algo_t::NAIVE,
-   42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::SIGMOID, 0, 0,
-   fil::algo_t::NAIVE, 42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05,
-   fil::output_t(fil::output_t::SIGMOID | fil::output_t::THRESHOLD), 0, 0,
-   fil::algo_t::NAIVE, 42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::AVG, 0, 0, fil::algo_t::NAIVE,
-   42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05,
-   fil::output_t(fil::output_t::AVG | fil::output_t::THRESHOLD), 0, 0.5,
-   fil::algo_t::NAIVE, 42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0.5, fil::algo_t::NAIVE,
-   42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::SIGMOID, 0, 0.5,
-   fil::algo_t::NAIVE, 42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::AVG, 0, 0.5, fil::algo_t::NAIVE,
-   42, 2e-3f},
-  {20000, 50, 0.05, 8, 50, 0.05,
-   fil::output_t(fil::output_t::AVG | fil::output_t::THRESHOLD), 1.0, 0.5,
-   fil::algo_t::NAIVE, 42, 2e-3f},
-};
-
-TEST_P(PredictSparseFilTest, Predict) { compare(); }
-
-INSTANTIATE_TEST_CASE_P(FilTests, PredictSparseFilTest,
-                        testing::ValuesIn(predict_sparse_inputs));
 
 std::vector<FilTestParams> import_inputs = {
   {20000, 50, 0.05, 8, 50, 0.05, fil::output_t::RAW, 0, 0, fil::algo_t::NAIVE,


### PR DESCRIPTION
- move dense functionality into a separate class
- abstract away dense/sparse forest differences into the storage, tree and node structs
- inference code works in terms of those abstractions
