### PR TITLE
RF respect number of cuda streams from cuml handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## Bug Fixes
 
+- PR #1231: RF respect number of cuda streams from cuml handle
 - PR #1230: Rf bugfix memleak in regression
 - PR #1208: compile dbscan bug
 - PR #1016: Use correct libcumlprims version in GPU CI

--- a/cpp/src/common/cumlHandle.cpp
+++ b/cpp/src/common/cumlHandle.cpp
@@ -168,7 +168,9 @@ void cumlHandle::setHostAllocator(std::shared_ptr<hostAllocator> allocator) {
 std::shared_ptr<hostAllocator> cumlHandle::getHostAllocator() const {
   return _impl->getHostAllocator();
 }
-
+int cumlHandle::getNumInternalStreams() {
+  return _impl->getNumInternalStreams();
+}
 const cumlHandle_impl& cumlHandle::getImpl() const { return *_impl.get(); }
 
 cumlHandle_impl& cumlHandle::getImpl() { return *_impl.get(); }

--- a/cpp/src/cuML.hpp
+++ b/cpp/src/cuML.hpp
@@ -90,6 +90,11 @@ class cumlHandle {
      */
   std::shared_ptr<hostAllocator> getHostAllocator() const;
   /**
+  * @brief API to query Num of work streams set during handle creation.
+  * @returns num of streams in the handle.
+  */
+  int getNumInternalStreams();
+  /**
      * @brief for internal use only.
      */
   const cumlHandle_impl& getImpl() const;

--- a/python/cuml/common/handle.pxd
+++ b/python/cuml/common/handle.pxd
@@ -34,3 +34,4 @@ cdef extern from "cuML.hpp" namespace "ML" nogil:
         void setStream(cuml.common.cuda._Stream s) except +
         void setDeviceAllocator(shared_ptr[deviceAllocator] a) except +
         cuml.common.cuda._Stream getStream() except +
+        int getNumInternalStreams() except +

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -101,3 +101,7 @@ cdef class Handle:
 
     def getHandle(self):
         return self.h
+
+    def getNumInternalStreams(self):
+        cdef cumlHandle* h_ = <cumlHandle*>self.h
+        return h_.getNumInternalStreams()

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -328,7 +328,8 @@ class RandomForestClassifier(Base):
         if max_depth < 0:
             raise ValueError("Must specify max_depth >0")
 
-        handle = Handle(n_streams)
+        if handle is None:
+            handle = Handle(n_streams)
 
         super(RandomForestClassifier, self).__init__(handle, verbose)
 
@@ -355,7 +356,7 @@ class RandomForestClassifier(Base):
         self.n_bins = n_bins
         self.quantile_per_tree = quantile_per_tree
         self.n_cols = None
-        self.n_streams = n_streams
+        self.n_streams = handle.getNumInternalStreams()
         self.seed = seed
 
         cdef RandomForestMetaData[float, int] *rf_forest = \

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -308,7 +308,9 @@ class RandomForestRegressor(Base):
                                 " please read the cuML documentation for"
                                 " more information")
 
-        handle = Handle(n_streams)
+        if handle is None:
+            handle = Handle(n_streams)
+
         super(RandomForestRegressor, self).__init__(handle, verbose)
 
         if max_depth < 0:
@@ -338,7 +340,7 @@ class RandomForestRegressor(Base):
         self.n_cols = None
         self.accuracy_metric = accuracy_metric
         self.quantile_per_tree = quantile_per_tree
-        self.n_streams = n_streams
+        self.n_streams = handle.getNumInternalStreams()
         self.seed = seed
 
         cdef RandomForestMetaData[float, float] *rf_forest = \


### PR DESCRIPTION
- [BUG] cumlhandle passed into RF was not used as RF wrapper was always creating an internal handle. Now fixed. 
- Adds getInternalNumStreams() to cumlHandle.
- RF now respects no of streams in cumlHandle.
- If a handle is passed, num of streams are used from the handle.
- otherwise a handle is created internally and uses default no of streams.