### PR TITLE
[REVIEW] Update faiss to 1.6.0

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -263,7 +263,7 @@ ExternalProject_Add(cutlass
 
 ExternalProject_Add(faiss
   GIT_REPOSITORY    https://github.com/facebookresearch/faiss.git
-  GIT_TAG           656368b5eda4d376177a3355673d217fa95000b6
+  GIT_TAG           v1.6.0
   CONFIGURE_COMMAND LIBS=-pthread
                     CPPFLAGS=-w
                     LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib

--- a/cpp/src/knn/knn.hpp
+++ b/cpp/src/knn/knn.hpp
@@ -21,7 +21,7 @@
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/StandardGpuResources.h>
 
-#include <faiss/Heap.h>
+#include <faiss/utils/Heap.h>
 #include <faiss/gpu/GpuDistance.h>
 #include <faiss/gpu/GpuResources.h>
 

--- a/cpp/src_prims/selection/knn.h
+++ b/cpp/src_prims/selection/knn.h
@@ -18,7 +18,7 @@
 
 #include "cuda_utils.h"
 
-#include <faiss/Heap.h>
+#include <faiss/utils/Heap.h>
 #include <faiss/gpu/GpuDistance.h>
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/GpuResources.h>


### PR DESCRIPTION
Creating this PR to test updating git cloned projects, and to keep FAISS up to date to their latest version. Only difference in code is that `heap.h` moved to `utils/heap.h`. PR also updates the git submodule for consistency and until PR #1225 is merged