### PR TITLE
[Review] Improve fix for SMO solvers potential crash on Turing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #1199: Replaced sprintf() with snprintf() in THROW()
 - PR #1205: Update dask-cuda in yml envs
 - PR #1211: Fixing Dask k-means transform bug and adding test
+- PR #1236: Improve fix for SMO solvers potential crash on Turing
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/cpp/src/svm/smoblocksolve.h
+++ b/cpp/src/svm/smoblocksolve.h
@@ -126,10 +126,10 @@ namespace SVM {
  * @param [in] max_iter maximum number of iterations
  */
 template <typename math_t, int WSIZE>
-__global__ void SmoBlockSolve(math_t *y_array, int n_rows, math_t *alpha,
-                              int n_ws, math_t *delta_alpha, math_t *f_array,
-                              math_t *kernel, int *ws_idx, math_t C, math_t eps,
-                              math_t *return_buff, int max_iter = 10000) {
+__global__ __launch_bounds__(WSIZE) void SmoBlockSolve(
+  math_t *y_array, int n_rows, math_t *alpha, int n_ws, math_t *delta_alpha,
+  math_t *f_array, math_t *kernel, int *ws_idx, math_t C, math_t eps,
+  math_t *return_buff, int max_iter = 10000) {
   typedef MLCommon::Selection::KVPair<math_t, int> Pair;
   typedef cub::BlockReduce<Pair, WSIZE> BlockReduce;
   typedef cub::BlockReduce<math_t, WSIZE> BlockReduceFloat;

--- a/cpp/src/svm/smosolver.h
+++ b/cpp/src/svm/smosolver.h
@@ -85,7 +85,7 @@ class SmoSolver {
       delta_alpha(handle.getDeviceAllocator(), stream),
       f(handle.getDeviceAllocator(), stream) {}
 
-#define SMO_WS_SIZE 512
+#define SMO_WS_SIZE 1024
   /**
    * Solve the quadratic optimization problem.
    *


### PR DESCRIPTION
For performance reasons we aim to use 1024 threads/block in the SmoBlockSolve kernel. Considering the 64k limit on the number of registers, we have a limit of 64 registers per thread for this particular kernel. 

The register usage depends on the target architecture and the CUDA version. When the code is compiled using CUDA 10.1 for Turing, then we go above 64 register/thread, therefore the code fails to launch for 1024 threads. 

The previous fix for the problem (PR #1204) is a good workaround. Unfortunately, the corresponding test was not modified: https://github.com/rapidsai/cuml/blob/70d7bff009d101b1fe11ef15acc08390e3e45f8d/cpp/test/sg/svc_test.cu#L358 It is expected that the svc_test will fail on Turing with CUDA 10.1 (false positive: the cuML library is correctly fixed by PR #1204).

This PR propose an alternative fix for the problem. We use [launch_bounds](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#launch-bounds) to inform the compiler about the maximum number of threads we expect to use for the kernel. As a result the compiler will keep register usage within limits.

This way we can keep 1024 threads/block for the SmoBlockSolve kernel, and svc_test does not need modification.

Tagging @teju85 and @JohnZed for review.

