### PR TITLE
[REVIEW] Improve error checking for mnmg rf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #1186: Using LocalCUDACluster Pytest fixture
 - PR #1173: Docs: Barnes Hut TSNE documentation
 - PR #1176: Use new RMM API based on Cython
+- PR #1247: Improved MNMG RF error checking
 
 ## Bug Fixes
 

--- a/python/cuml/dask/common/__init__.py
+++ b/python/cuml/dask/common/__init__.py
@@ -21,3 +21,5 @@ from cuml.dask.common.comms_utils import inject_comms_on_handle, \
     inject_comms_on_handle_coll_only, is_ucx_enabled
 
 from cuml.dask.common.dask_df_utils import get_meta, to_dask_cudf, to_dask_df, extract_ddf_partitions
+
+from cuml.dask.common.utils import raise_exception_from_futures

--- a/python/cuml/dask/common/utils.py
+++ b/python/cuml/dask/common/utils.py
@@ -121,3 +121,12 @@ def persist_across_workers(client, objects, workers=None):
     if workers is None:
         workers = client.has_what().keys()  # Default to all workers
     return client.persist(objects, workers={o: workers for o in objects})
+
+
+def raise_exception_from_futures(futures):
+    """Raises a RuntimeError if any of the futures indicates an exception"""
+    errs = [f.exception() for f in futures if f.exception()]
+    if errs:
+        raise RuntimeError("%d of %d worker jobs failed: %s" % (
+            len(errs), len(futures), ", ".join(map(str, errs))
+            ))

--- a/python/cuml/test/dask/test_dask_utils.py
+++ b/python/cuml/test/dask/test_dask_utils.py
@@ -18,8 +18,10 @@ import pytest
 from dask.distributed import Client, wait
 from cuml.dask.common import raise_exception_from_futures
 
+
 def _raise_exception():
     raise ValueError("intentional exception")
+
 
 def test_dask_exceptions(cluster):
     c = Client(cluster)

--- a/python/cuml/test/dask/test_dask_utils.py
+++ b/python/cuml/test/dask/test_dask_utils.py
@@ -1,0 +1,33 @@
+
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+from dask.distributed import Client, wait
+from cuml.dask.common import raise_exception_from_futures
+
+def _raise_exception():
+    raise ValueError("intentional exception")
+
+def test_dask_exceptions(cluster):
+    c = Client(cluster)
+    try:
+        fut = c.submit(_raise_exception)
+        wait(fut)
+
+        with pytest.raises(RuntimeError):
+            raise_exception_from_futures([fut])
+    finally:
+        c.close()

--- a/python/cuml/test/dask/test_random_forest.py
+++ b/python/cuml/test/dask/test_random_forest.py
@@ -90,13 +90,11 @@ def test_rf_classification_dask(partitions_per_worker, cluster):
 def test_rf_throws_exceptions(cluster):
     c = Client(cluster)
     try:
-        cu_rf_params = { 'n_estimators': 10, 'max_depth': 8 }
+        cu_rf_params = {'n_estimators': 10, 'max_depth': 8}
         cu_rf_mg = cuRFR_mg(**cu_rf_params)
         X_train, y_train = make_regression(n_samples=100, n_features=20,
                                            n_informative=10, random_state=123)
         X_train = X_train.astype(np.float32)
-
-        workers = c.has_what().keys()
 
         X_train_df, y_train_df = _prep_training_data(c, X_train, y_train, 1)
 


### PR DESCRIPTION
Addresses issue #1243 by adding a utility to more easily report errors when `wait`ing on asynchronous Dask results.

Added a simple test and tried out my demo_dask script included in the issue to confirm that it prints a nice error (albeit a very long one with the whole c++ backtrace).