### PR TITLE
[REVIEW] Disable optimization in distance prims on CUDA 10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #1205: Update dask-cuda in yml envs
 - PR #1211: Fixing Dask k-means transform bug and adding test
 - PR #1236: Improve fix for SMO solvers potential crash on Turing
+- PR #1251: Disable compiler optimization for CUDA 10.1 for distance prims
 
 # cuML 0.9.0 (21 Aug 2019)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -107,7 +107,7 @@ GTEST_OUTPUT="xml:${WORKSPACE}/test-results/libcuml_cpp/" ./test/ml
 
 logger "Python pytest for cuml..."
 cd $WORKSPACE/python
-pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v --ignore=cuml/test/test_trustworthiness.py
+pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v
 
 ################################################################################
 # TEST - Run GoogleTest for ml-prims

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -116,7 +116,7 @@ fi
 
 # Run the generated build script in a container
 docker pull "${DOCKER_IMAGE}"
-docker run --runtime=nvidia --rm -it -e NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES}" \
+docker run --gpus 1 --rm -it -e NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES}" \
        --user "$(id -u)":"$(id -g)" \
        -v "${REPO_PATH}:${REPO_PATH_IN_CONTAINER}" \
        -v "${CPP_CONTAINER_BUILD_DIR}:${CPP_BUILD_DIR_IN_CONTAINER}" \

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -116,7 +116,7 @@ fi
 
 # Run the generated build script in a container
 docker pull "${DOCKER_IMAGE}"
-docker run --gpus 1 --rm -it -e NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES}" \
+docker run --runtime=nvidia --rm -it -e NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES}" \
        --user "$(id -u)":"$(id -g)" \
        -v "${REPO_PATH}:${REPO_PATH_IN_CONTAINER}" \
        -v "${CPP_CONTAINER_BUILD_DIR}:${CPP_BUILD_DIR_IN_CONTAINER}" \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -230,6 +230,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   endif(NOT CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
+set(CMAKE_CUDA_FLAGS
+  "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=unrecognized_gcc_pragma")
+
 ###################################################################################################
 # - clang-format targets --------------------------------------------------------------------------
 

--- a/cpp/src_prims/distance/distance.h
+++ b/cpp/src_prims/distance/distance.h
@@ -23,6 +23,13 @@
 #include "distance/euclidean.h"
 #include "distance/l1.h"
 
+#if CUDART_VERSION >= 10010
+// With optimization enabled, CUDA 10.1 generates segfaults for distance
+// prims, so disable optimization until another workaround is found
+#pragma GCC push_options
+#pragma GCC optimize("O0")
+#endif
+
 namespace MLCommon {
 namespace Distance {
 
@@ -373,6 +380,10 @@ size_t epsilon_neighborhood(const T *a, const T *b, bool *adj, Index_ m,
                               OutputTile_>(a, b, adj, m, n, k, eps, workspace,
                                            worksize, stream, lambda);
 }
+
+#if CUDART_VERSION >= 10010
+#pragma GCC pop_options
+#endif
 
 };  // end namespace Distance
 };  // end namespace MLCommon

--- a/cpp/src_prims/distance/distance.h
+++ b/cpp/src_prims/distance/distance.h
@@ -24,13 +24,6 @@
 #include "distance/euclidean.h"
 #include "distance/l1.h"
 
-#if CUDART_VERSION >= 10010
-// With optimization enabled, CUDA 10.1 generates segfaults for distance
-// prims, so disable optimization until another workaround is found
-#pragma GCC push_options
-#pragma GCC optimize("O0")
-#endif
-
 namespace MLCommon {
 namespace Distance {
 
@@ -393,10 +386,6 @@ size_t epsilon_neighborhood(const T *a, const T *b, bool *adj, Index_ m,
                               OutputTile_>(a, b, adj, m, n, k, eps, workspace,
                                            worksize, stream, lambda);
 }
-
-#if CUDART_VERSION >= 10010
-#pragma GCC pop_options
-#endif
 
 };  // end namespace Distance
 };  // end namespace MLCommon

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_CUML_TESTS)
       sg/sgd.cu
       sg/spectral_test.cu
       sg/svc_test.cu
+      sg/trustworthiness_test.cu
       sg/tsne_test.cu
       sg/tsvd_test.cu
       sg/umap_test.cu

--- a/cpp/test/sg/trustworthiness_test.cu
+++ b/cpp/test/sg/trustworthiness_test.cu
@@ -421,8 +421,9 @@ class TrustworthinessScoreTest : public ::testing::Test {
     updateDevice(d_X_embedded, X_embedded.data(), X_embedded.size(), stream);
 
     // euclidean test
-    score = trustworthiness_score<float, EucUnexpandedL2Sqrt>(
-      h, d_X, d_X_embedded, 50, 30, 8, 5);
+    score =
+      trustworthiness_score<float, MLCommon::Distance::EucUnexpandedL2Sqrt>(
+        h, d_X, d_X_embedded, 50, 30, 8, 5);
 
     d_alloc->deallocate(d_X, X.size() * sizeof(float), stream);
     d_alloc->deallocate(d_X_embedded, X_embedded.size() * sizeof(float),


### PR DESCRIPTION
This experimental approach stops crashes locally for me on CUDA 10.1 on Turing / ubuntu 18.04 (gcc 7.4.0). It only disables host-side (GCC) optimization, but that _appears_ to be enough. It is definitely unsatisfying, but I want to see it it allows CI to pass as well. I brought the python trustworthiness test back to life as well.