### PR TITLE
[REVIEW] Fix comms build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Bug Fixes
 - PR #1212: Fix cmake git cloning always running configure in subprojects
+- PR #1261: Fix comms build errors due to cuml++ include folder changes
 
 
 # cuML 0.10.0 (Date TBD)

--- a/cpp/comms/mpi/CMakeLists.txt
+++ b/cpp/comms/mpi/CMakeLists.txt
@@ -18,17 +18,25 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(cuML-comms-MPI LANGUAGES CXX CUDA)
 
 find_package(MPI REQUIRED)
-find_package(NCCL)
+
+if(NOT NCCL_PATH)
+  find_package(NCCL REQUIRED)
+else()
+  set(NCCL_INCLUDE_DIRS ${NCCL_PATH}/include)
+  set(NCCL_LIBRARIES ${NCCL_PATH}/lib/libnccl.so)
+  set(NCCL_FOUND ON)
+endif(NOT NCCL_PATH)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include_directories( 
-	include 
-	${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} 
-	${MPI_CXX_INCLUDE_PATH} 
-	../../src 
-	../../src_prims )
+include_directories(include
+  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+  ${MPI_CXX_INCLUDE_PATH}
+  ../../include
+  ../../src
+  ../../src_prims
+)
 
 set(MPI_COMMS_LINK_LIBRARIES ${CUML_CPP_TARGET} ${MPI_C_LIBRARIES})
 

--- a/cpp/comms/mpi/include/cuML_comms.hpp
+++ b/cpp/comms/mpi/include/cuML_comms.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <mpi.h>
-#include <cuML.hpp>
+#include <cuml/cuml.hpp>
 
 namespace ML {
 

--- a/cpp/comms/std/CMakeLists.txt
+++ b/cpp/comms/std/CMakeLists.txt
@@ -31,10 +31,11 @@ endif(NOT NCCL_PATH)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include_directories( include
-	${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
-	../../src
-	../../src_prims
+include_directories(include
+  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+  ../../include
+  ../../src
+  ../../src_prims
 )
 
 set(COMMS_LINK_LIBRARIES ${CUML_CPP_TARGET})


### PR DESCRIPTION
This PR fixes a couple of build issues in light of the recent cuml++ include folder changes. This fixes both the std and mpi comms builds. I'm a bit surprised that the cpp/comms/std build issue was not caught in our CI!

@dantegd and/or @cjnolet for review.