### PR TITLE
[REVIEW]updated the documentation for ridge regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #1224: Refactored FIL to prepare for sparse trees
 - PR #1249: Include libcuml.so C API in installed targets
 - PR #1259: Conda dev environment updates and use libcumlprims current version in CI
+- PR #1271: Updated the Ridge regression documentation
 
 ## Bug Fixes
 - PR #1212: Fix cmake git cloning always running configure in subprojects

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -89,9 +89,11 @@ class Ridge(Base, RegressorMixin):
     the conditioning of the problem.
 
     cuML's Ridge an array-like object or cuDF DataFrame, and provides 3
-    algorithms: SVD, Eig and CD to fit a linear model. SVD is more stable,
-    but Eig (default) is much faster. CD uses Coordinate Descent and can be
-    faster when data is large.
+    algorithms: SVD, Eig and CD to fit a linear model. In general SVD uses 
+    significantly more memory and is slower than Eig. If using CUDA 10.1, 
+    the memory difference is even bigger than in the other supported CUDA
+    versions. However, SVD is more stable than Eig (default). CD uses
+    Coordinate Descent and can be faster when data is large.  
 
     Examples
     ---------

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -89,11 +89,11 @@ class Ridge(Base, RegressorMixin):
     the conditioning of the problem.
 
     cuML's Ridge an array-like object or cuDF DataFrame, and provides 3
-    algorithms: SVD, Eig and CD to fit a linear model. In general SVD uses 
-    significantly more memory and is slower than Eig. If using CUDA 10.1, 
+    algorithms: SVD, Eig and CD to fit a linear model. In general SVD uses
+    significantly more memory and is slower than Eig. If using CUDA 10.1,
     the memory difference is even bigger than in the other supported CUDA
     versions. However, SVD is more stable than Eig (default). CD uses
-    Coordinate Descent and can be faster when data is large.  
+    Coordinate Descent and can be faster when data is large.
 
     Examples
     ---------


### PR DESCRIPTION
Updated the Ridge documentation to mention that 'svd' uses more memory than 'eig' and the difference in memory is bigger in CUDA 10.1