### PR TITLE
[gpuCI] Auto-merge branch-0.10 to branch-0.11 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuML 0.10.0 (Date TBD)
+# cuML 0.10.0 (Oct 16 2019)
 
 ## New Features
 - PR #1148: C++ benchmark tool for c++/CUDA code inside cuML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuML 0.10.0 (Oct 16 2019)
+# cuML 0.10.0 (16 Oct 2019)
 
 ## New Features
 - PR #1148: C++ benchmark tool for c++/CUDA code inside cuML


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.10` that creates a PR to keep `branch-0.11` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.