### PR TITLE
[REVIEW] Removed incorrect overloaded instance of eigJacobi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #1212: Fix cmake git cloning always running configure in subprojects
 - PR #1261: Fix comms build errors due to cuml++ include folder changes
 - PR #1267: Update build.sh for recent change of building comms in main CMakeLists
+- PR #1278: Removed incorrect overloaded instance of eigJacobi
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/tsvd/tsvd.h
+++ b/cpp/src/tsvd/tsvd.h
@@ -89,8 +89,8 @@ void calEig(const cumlHandle_impl &handle, math_t *in, math_t *components,
 
   if (prms.algorithm == solver::COV_EIG_JACOBI) {
     LinAlg::eigJacobi(in, prms.n_cols, prms.n_cols, components, explained_var,
-                      (math_t)prms.tol, prms.n_iterations, cusolver_handle,
-                      stream, allocator);
+                      cusolver_handle, stream, allocator,(math_t)prms.tol,
+                      prms.n_iterations);
   } else {
     LinAlg::eigDC(in, prms.n_cols, prms.n_cols, components, explained_var,
                   cusolver_handle, stream, allocator);

--- a/cpp/src_prims/linalg/eig.h
+++ b/cpp/src_prims/linalg/eig.h
@@ -148,25 +148,6 @@ void eigSelDC(math_t *in, int n_rows, int n_cols, int n_eig_vals,
  * @param n_cols: number of cols of the input
  * @param eig_vectors: eigenvectors
  * @param eig_vals: eigen values
- * @{
- */
-template <typename math_t>
-void eigJacobi(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
-               math_t *eig_vals, cusolverDnHandle_t cusolverH,
-               cudaStream_t stream) {
-  math_t tol = 1.e-7;
-  int sweeps = 15;
-  eigJacobi(in, eig_vectors, eig_vals, tol, sweeps, n_rows, n_cols, cusolverH,
-            stream);
-}
-
-/**
- * @defgroup overloaded function for eig decomp with Jacobi method for the
- * column-major symmetric matrices (in parameter)
- * @param n_rows: number of rows of the input
- * @param n_cols: number of cols of the input
- * @param eig_vectors: eigenvectors
- * @param eig_vals: eigen values
  * @param tol: error tolerance for the jacobi method. Algorithm stops when the
  * error is below tol
  * @param sweeps: number of sweeps in the Jacobi algorithm. The more the better
@@ -177,9 +158,9 @@ void eigJacobi(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
  */
 template <typename math_t>
 void eigJacobi(const math_t *in, int n_rows, int n_cols, math_t *eig_vectors,
-               math_t *eig_vals, math_t tol, int sweeps,
-               cusolverDnHandle_t cusolverH, cudaStream_t stream,
-               std::shared_ptr<deviceAllocator> allocator) {
+               math_t *eig_vals, cusolverDnHandle_t cusolverH,
+               cudaStream_t stream, std::shared_ptr<deviceAllocator> allocator,
+               math_t tol = 1.e-7, int sweeps = 15) {
   syevjInfo_t syevj_params = nullptr;
   CUSOLVER_CHECK(cusolverDnCreateSyevjInfo(&syevj_params));
   CUSOLVER_CHECK(cusolverDnXsyevjSetTolerance(syevj_params, tol));

--- a/cpp/src_prims/linalg/rsvd.h
+++ b/cpp/src_prims/linalg/rsvd.h
@@ -182,8 +182,8 @@ void rsvdFixedRank(math_t *M, int n_rows, int n_cols, math_t *&S_vec,
       cudaMemsetAsync(Uhat_dup.data(), 0, sizeof(math_t) * l * l, stream));
     Matrix::copyUpperTriangular(BBt.data(), Uhat_dup.data(), l, l, stream);
     if (use_jacobi)
-      eigJacobi(Uhat_dup.data(), l, l, Uhat.data(), S_vec_tmp.data(), tol,
-                max_sweeps, cusolverH, stream, allocator);
+      eigJacobi(Uhat_dup.data(), l, l, Uhat.data(), S_vec_tmp.data(), cusolverH,
+                stream, allocator, tol, max_sweeps);
     else
       eigDC(Uhat_dup.data(), l, l, Uhat.data(), S_vec_tmp.data(), cusolverH,
             stream, allocator);

--- a/cpp/test/prims/eig.cu
+++ b/cpp/test/prims/eig.cu
@@ -78,7 +78,7 @@ class EigTest : public ::testing::TestWithParam<EigInputs<T>> {
     T tol = 1.e-7;
     int sweeps = 15;
     eigJacobi(cov_matrix, params.n_row, params.n_col, eig_vectors_jacobi,
-              eig_vals_jacobi, tol, sweeps, cusolverH, stream, allocator);
+              eig_vals_jacobi, cusolverH, stream, allocator, tol, sweeps);
 
     // test code for comparing two methods
     len = params.n * params.n;
@@ -93,7 +93,7 @@ class EigTest : public ::testing::TestWithParam<EigInputs<T>> {
     eigDC(cov_matrix_large, params.n, params.n, eig_vectors_large,
           eig_vals_large, cusolverH, stream, allocator);
     eigJacobi(cov_matrix_large, params.n, params.n, eig_vectors_jacobi_large,
-              eig_vals_jacobi_large, tol, sweeps, cusolverH, stream, allocator);
+              eig_vals_jacobi_large, cusolverH, stream, allocator, tol, sweeps);
   }
 
   void TearDown() override {


### PR DESCRIPTION
Jacobi based Eigen Prim had a overloaded instance of `eigJacobi()` which passed most arguments to actual `eigJacobi()`, as it is except `tolerance` and `sweeps`. However the order of arguments passed was incorrect and also a compulsorily argument (device allocator) was not passed. I have removed the overloaded instance and provided default value to `tolerance` and `sweeps`. Corresponding change in code elsewhere is also included. 