### PR TITLE
[REVIEW] add new benchmark support for FIL 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - PR #1286: Importing treelite models as FIL sparse forests
 - PR #1285: Fea minimum impurity decrease RF param
 - PR #1301: Add make_regression to generate regression datasets
-
+- PR #1289: Add Python benchmarking support for FIL
+ 
 ## Improvements
 - PR #1170: Use git to clone subprojects instead of git submodules
 - PR #1239: Updated the treelite version

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -28,8 +28,8 @@ import numpy as np
 
 from cuml.benchmark.bench_helper_funcs \
     import fit, fit_kneighbors, fit_transform, predict, \
-            _build_fil_classifier, _build_treelite_classifier, \
-            _treelite_fil_accuracy_score
+           _build_fil_classifier, _build_treelite_classifier, \
+           _treelite_fil_accuracy_score
 
 from cuml.utils.import_utils import has_treelite
 if has_treelite():
@@ -318,7 +318,8 @@ def all_algorithms():
             cuml.ForestInference,
             shared_args=dict(num_rounds=10, max_depth=10),
             cuml_args=dict(fil_algo="BATCH_TREE_REORG",
-                    output_class=True, threshold=0.5, storage_type="AUTO"),
+                            output_class=True,
+                            threshold=0.5, storage_type="AUTO"),
             name="FIL",
             accepts_labels=False,
             setup_cpu_func=_build_treelite_classifier,

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -27,7 +27,7 @@ import umap
 import numpy as np
 
 from cuml.benchmark.bench_helper_funcs \
-    import fit, fit_kneighbors, fit_transform, predict, _fil_classification_setup
+    import fit, fit_kneighbors, fit_transform, predict, _build_fil_classifier
 
 class AlgorithmPair:
     """
@@ -104,10 +104,10 @@ class AlgorithmPair:
         all_args = {**self.shared_args, **self.cpu_args}
         all_args = {**all_args, **override_args}
 
-        if "cpu_obj" not in all_args:
+        if "cpu_setup_result" not in all_args:
             cpu_obj = self.cpu_class(**all_args)
         else:
-            cpu_obj = all_args["cpu_obj"]
+            cpu_obj = all_args["cpu_setup_result"]
         if self.data_prep_hook:
             data = self.data_prep_hook(data)
         if self.accepts_labels:
@@ -122,10 +122,10 @@ class AlgorithmPair:
         all_args = {**self.shared_args, **self.cuml_args}
         all_args = {**all_args, **override_args}
 
-        if "cuml_obj" not in all_args:
+        if "cuml_setup_result" not in all_args:
             cuml_obj = self.cuml_class(**all_args)
         else:
-            cuml_obj = all_args["cuml_obj"]
+            cuml_obj = all_args["cuml_setup_result"]
         if self.data_prep_hook:
             data = self.data_prep_hook(data)
         if self.accepts_labels:
@@ -139,7 +139,7 @@ class AlgorithmPair:
         if self.setup_cpu_func is not None:
             all_args = {**self.shared_args, **self.cpu_args}
             all_args = {**all_args, **override_args}
-            return {"cpu_obj" : self.setup_cpu_func(self.cpu_class, data, all_args)}
+            return {"cpu_setup_result" : self.setup_cpu_func(self.cpu_class, data, all_args)}
         else:
             return {}
 
@@ -147,7 +147,7 @@ class AlgorithmPair:
         if self.setup_cuml_func is not None:
             all_args = {**self.shared_args, **self.cuml_args}
             all_args = {**all_args, **override_args}
-            return {"cuml_obj" : self.setup_cuml_func(self.cuml_class, data, all_args)}
+            return {"cuml_setup_result" : self.setup_cuml_func(self.cuml_class, data, all_args)}
         else:
             return {}
 
@@ -296,7 +296,7 @@ def all_algorithms():
             cuml_args=dict(algo="BATCH_TREE_REORG", output_class=True, threshold=0.5, num_rounds=10, max_depth=10), 
             name="FIL",
             accepts_labels=False,
-            setup_cuml_func=_fil_classification_setup,
+            setup_cuml_func=_build_fil_classifier,
             accuracy_function=metrics.accuracy_score,
             bench_func=predict,
         ), 

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -27,8 +27,9 @@ import umap
 import numpy as np
 
 from cuml.benchmark.bench_helper_funcs \
-    import fit, fit_kneighbors, fit_transform, predict, _build_fil_classifier, \
-            _build_treelite_classifier, _treelite_fil_accuracy_score
+    import fit, fit_kneighbors, fit_transform, predict, \
+        _build_fil_classifier, _build_treelite_classifier, \
+        _treelite_fil_accuracy_score
 
 from cuml.utils.import_utils import has_treelite
 if has_treelite():
@@ -60,7 +61,7 @@ class AlgorithmPair:
         accuracy_function=None,
         bench_func=fit,
         setup_cpu_func=None,
-        setup_cuml_func=None, 
+        setup_cuml_func=None,
     ):
         """
         Parameters
@@ -148,7 +149,8 @@ class AlgorithmPair:
         if self.setup_cpu_func is not None:
             all_args = {**self.shared_args, **self.cpu_args}
             all_args = {**all_args, **override_args}
-            return {"cpu_setup_result" : self.setup_cpu_func(self.cpu_class, data, all_args)}
+            return {"cpu_setup_result": \
+                self.setup_cpu_func(self.cpu_class, data, all_args)}
         else:
             return {}
 
@@ -156,7 +158,8 @@ class AlgorithmPair:
         if self.setup_cuml_func is not None:
             all_args = {**self.shared_args, **self.cuml_args}
             all_args = {**all_args, **override_args}
-            return {"cuml_setup_result" : self.setup_cuml_func(self.cuml_class, data, all_args)}
+            return {"cuml_setup_result": \
+                self.setup_cuml_func(self.cuml_class, data, all_args)}
         else:
             return {}
 
@@ -173,7 +176,7 @@ def _treelite_format_hook(data):
         import treelite
         import treelite.runtime
     else:
-        raise ImportError("No treelite package found which is required for benchmarking FIL")
+        raise ImportError("No treelite package found")
     return treelite.runtime.Batch.from_npy2d(data[0]), data[1]
 
 
@@ -302,7 +305,7 @@ def all_algorithms():
             accuracy_function=cuml.metrics.trustworthiness,
         ),
         AlgorithmPair(
-            None, 
+            None,
             cuml.linear_model.MBSGDClassifier,
             shared_args={},
             cuml_args=dict(eta0=0.005, epochs=100),
@@ -311,10 +314,11 @@ def all_algorithms():
             accuracy_function=cuml.metrics.accuracy_score,
         ),
         AlgorithmPair(
-            treelite if has_treelite() else None, 
+            treelite if has_treelite() else None,
             cuml.ForestInference,
             shared_args=dict(num_rounds=10, max_depth=10),
-            cuml_args=dict(fil_algo="BATCH_TREE_REORG", output_class=True, threshold=0.5, storage_type="AUTO"), 
+            cuml_args=dict(fil_algo="BATCH_TREE_REORG", 
+                output_class=True, threshold=0.5, storage_type="AUTO"),
             name="FIL",
             accepts_labels=False,
             setup_cpu_func=_build_treelite_classifier,
@@ -322,7 +326,7 @@ def all_algorithms():
             cpu_data_prep_hook=_treelite_format_hook,
             accuracy_function=_treelite_fil_accuracy_score,
             bench_func=predict,
-        ), 
+        ),
     ]
 
 

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -27,7 +27,7 @@ import umap
 import numpy as np
 
 from cuml.benchmark.bench_helper_funcs \
-    import fit, fit_kneighbors, fit_transform, predict, _fil_classification_set_up
+    import fit, fit_kneighbors, fit_transform, predict, _fil_classification_setup
 
 class AlgorithmPair:
     """
@@ -92,56 +92,64 @@ class AlgorithmPair:
         self.cpu_args = cpu_args
         self.data_prep_hook = data_prep_hook
         self.accuracy_function = accuracy_function
-        self.cpu_obj = None 
-        self.cuml_obj = None 
 
     def __str__(self):
         return "AlgoPair:%s" % (self.name)
 
-    def run_cpu(self, data):
+    def run_cpu(self, data, **override_args):
         """Runs the cpu-based algorithm's fit method on specified data"""
-        if self.cpu_obj is None:
-            raise ValueError("No CPU object for %s" % self.name)
-
-        if self.data_prep_hook:
-            data = self.data_prep_hook(data)
-        if self.accepts_labels:
-            self.bench_func(self.cpu_obj, data[0], data[1])
-        else:
-            self.bench_func(self.cpu_obj, data[0])
-
-        return self.cpu_obj
-
-    def run_cuml(self, data):
-        """Runs the cuml-based algorithm's fit method on specified data"""
-
-        if self.data_prep_hook:
-            data = self.data_prep_hook(data)
-        if self.accepts_labels:
-            self.bench_func(self.cuml_obj, data[0], data[1])
-        else:
-            self.bench_func(self.cuml_obj, data[0])
-
-        return self.cuml_obj
-
-    def setup_cpu(self, data, **override_args):
         if self.cpu_class is None:
             raise ValueError("No CPU implementation for %s" % self.name)
 
         all_args = {**self.shared_args, **self.cpu_args}
         all_args = {**all_args, **override_args}
-        if self.setup_cpu_func is not None:
-            self.cpu_obj = self.setup_cpu_func(self.cpu_class, data, all_args)
-        else:
-            self.cpu_obj = self.cpu_class(**all_args)
 
-    def setup_cuml(self, data, **override_args):
+        if "cpu_obj" not in all_args:
+            cpu_obj = self.cpu_class(**all_args)
+        else:
+            cpu_obj = all_args["cpu_obj"]
+        if self.data_prep_hook:
+            data = self.data_prep_hook(data)
+        if self.accepts_labels:
+            self.bench_func(cpu_obj, data[0], data[1])
+        else:
+            self.bench_func(cpu_obj, data[0])
+
+        return cpu_obj
+
+    def run_cuml(self, data, **override_args):
+        """Runs the cuml-based algorithm's fit method on specified data"""
         all_args = {**self.shared_args, **self.cuml_args}
         all_args = {**all_args, **override_args}
-        if self.setup_cuml_func is not None:
-            self.cuml_obj = self.setup_cuml_func(self.cuml_class, data, all_args)
+
+        if "cuml_obj" not in all_args:
+            cuml_obj = self.cuml_class(**all_args)
         else:
-            self.cuml_obj = self.cuml_class(**all_args)
+            cuml_obj = all_args["cuml_obj"]
+        if self.data_prep_hook:
+            data = self.data_prep_hook(data)
+        if self.accepts_labels:
+            self.bench_func(cuml_obj, data[0], data[1])
+        else:
+            self.bench_func(cuml_obj, data[0])
+
+        return cuml_obj
+
+    def setup_cpu(self, data, **override_args):
+        if self.setup_cpu_func is not None:
+            all_args = {**self.shared_args, **self.cpu_args}
+            all_args = {**all_args, **override_args}
+            return {"cpu_obj" : self.setup_cpu_func(self.cpu_class, data, all_args)}
+        else:
+            return {}
+
+    def setup_cuml(self, data, **override_args):
+        if self.setup_cuml_func is not None:
+            all_args = {**self.shared_args, **self.cuml_args}
+            all_args = {**all_args, **override_args}
+            return {"cuml_obj" : self.setup_cuml_func(self.cuml_class, data, all_args)}
+        else:
+            return {}
 
 
 def _labels_to_int_hook(data):
@@ -288,7 +296,7 @@ def all_algorithms():
             cuml_args=dict(algo="BATCH_TREE_REORG", output_class=True, threshold=0.5, num_rounds=10, max_depth=10), 
             name="FIL",
             accepts_labels=False,
-            setup_cuml_func=_fil_classification_set_up,
+            setup_cuml_func=_fil_classification_setup,
             accuracy_function=metrics.accuracy_score,
             bench_func=predict,
         ), 

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -29,6 +29,12 @@ import numpy as np
 from cuml.benchmark.bench_helper_funcs \
     import fit, fit_kneighbors, fit_transform, predict, _build_fil_classifier, _build_treelite_classifier
 
+from cuml.utils.import_utils import has_treelite
+if has_treelite():
+    import treelite
+    import treelite.runtime
+
+
 class AlgorithmPair:
     """
     Wraps a cuML algorithm and (optionally) a cpu-based algorithm
@@ -292,7 +298,7 @@ def all_algorithms():
             accuracy_function=cuml.metrics.trustworthiness,
         ),
         AlgorithmPair(
-            None,
+            None, 
             cuml.linear_model.MBSGDClassifier,
             shared_args={},
             cuml_args=dict(eta0=0.005, epochs=100),
@@ -301,10 +307,10 @@ def all_algorithms():
             accuracy_function=cuml.metrics.accuracy_score,
         ),
         AlgorithmPair(
-            treelite, 
+            treelite if has_treelite() else None, 
             cuml.ForestInference,
-            shared_args={},
-            cuml_args=dict(fil_algo="BATCH_TREE_REORG", output_class=True, threshold=0.5, num_rounds=10, max_depth=10), 
+            shared_args=dict(num_rounds=10, max_depth=10),
+            cuml_args=dict(fil_algo="BATCH_TREE_REORG", output_class=True, threshold=0.5), 
             name="FIL",
             accepts_labels=False,
             setup_cpu_func=_build_treelite_classifier,

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -28,8 +28,8 @@ import numpy as np
 
 from cuml.benchmark.bench_helper_funcs \
     import fit, fit_kneighbors, fit_transform, predict, \
-        _build_fil_classifier, _build_treelite_classifier, \
-        _treelite_fil_accuracy_score
+            _build_fil_classifier, _build_treelite_classifier, \
+            _treelite_fil_accuracy_score
 
 from cuml.utils.import_utils import has_treelite
 if has_treelite():
@@ -149,8 +149,8 @@ class AlgorithmPair:
         if self.setup_cpu_func is not None:
             all_args = {**self.shared_args, **self.cpu_args}
             all_args = {**all_args, **override_args}
-            return {"cpu_setup_result": \
-                self.setup_cpu_func(self.cpu_class, data, all_args)}
+            return {"cpu_setup_result":
+                    self.setup_cpu_func(self.cpu_class, data, all_args)}
         else:
             return {}
 
@@ -158,8 +158,8 @@ class AlgorithmPair:
         if self.setup_cuml_func is not None:
             all_args = {**self.shared_args, **self.cuml_args}
             all_args = {**all_args, **override_args}
-            return {"cuml_setup_result": \
-                self.setup_cuml_func(self.cuml_class, data, all_args)}
+            return {"cuml_setup_result":
+                    self.setup_cuml_func(self.cuml_class, data, all_args)}
         else:
             return {}
 
@@ -317,8 +317,8 @@ def all_algorithms():
             treelite if has_treelite() else None,
             cuml.ForestInference,
             shared_args=dict(num_rounds=10, max_depth=10),
-            cuml_args=dict(fil_algo="BATCH_TREE_REORG", 
-                output_class=True, threshold=0.5, storage_type="AUTO"),
+            cuml_args=dict(fil_algo="BATCH_TREE_REORG",
+                    output_class=True, threshold=0.5, storage_type="AUTO"),
             name="FIL",
             accepts_labels=False,
             setup_cpu_func=_build_treelite_classifier,

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -28,8 +28,8 @@ import numpy as np
 
 from cuml.benchmark.bench_helper_funcs \
     import fit, fit_kneighbors, fit_transform, predict, \
-           _build_fil_classifier, _build_treelite_classifier, \
-           _treelite_fil_accuracy_score
+    _build_fil_classifier, _build_treelite_classifier, \
+    _treelite_fil_accuracy_score
 
 from cuml.utils.import_utils import has_treelite
 if has_treelite():
@@ -318,8 +318,8 @@ def all_algorithms():
             cuml.ForestInference,
             shared_args=dict(num_rounds=10, max_depth=10),
             cuml_args=dict(fil_algo="BATCH_TREE_REORG",
-                            output_class=True,
-                            threshold=0.5, storage_type="AUTO"),
+                           output_class=True,
+                           threshold=0.5, storage_type="AUTO"),
             name="FIL",
             accepts_labels=False,
             setup_cpu_func=_build_treelite_classifier,

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import os
+import tempfile
 
 def fit_kneighbors(m, x):
     m.fit(x)
@@ -28,37 +29,30 @@ def fit_transform(m, x):
     m.fit_transform(x)
 
 
-def predict(m, x, y=None):
-    m.predict(x) if y is None else m.predict(x, y)
+def predict(m, x):
+    m.predict(x)
 
 
-def _fil_classification_setup(m, data, arg={}):
+def _build_fil_classifier(m, data, arg={}):
+    """Setup function for FIL classification benchmarking"""
     from cuml.utils.import_utils import has_xgboost
     if has_xgboost():
         import xgboost as xgb
     else:
         raise ImportError("No XGBoost package found which is required for benchmarking FIL")
-    import os 
-
-    tmp_path = "./fil_models"
-    if not os.path.exists(tmp_path):
-        os.makedirs(tmp_path)
 
     # use maximum 1e6 rows to train the model 
     train_size = min(data[0].shape[0], 1000000)
     dtrain = xgb.DMatrix(data[0][:train_size, :], label=data[1][:train_size])
     params = {"silent": 1, "eval_metric": "error", "objective": "binary:logistic"}
     params.update(arg)
-
     max_depth = arg["max_depth"]
     num_rounds = arg["num_rounds"]
     n_features = data[0].shape[1]
-    model_name = "xgb_" + str(max_depth) + "_" + str(num_rounds) + "_" + str(n_features) + "_" + str(train_size) + ".model"
-    model_path = os.path.join(tmp_path, model_name)
 
-    from pathlib import Path
-    if Path(model_path).is_file():
-        return m.load(model_path, algo=arg["algo"], output_class=arg["output_class"], threshold=arg["threshold"])
+    tmpdir = tempfile.mkdtemp()
+    model_name = f"xgb_{max_depth}_{num_rounds}_{n_features}_{train_size}.model"
+    model_path = os.path.join(tmpdir, model_name)
 
     bst = xgb.train(params, dtrain, num_rounds)
     bst.save_model(model_path)

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -32,7 +32,7 @@ def predict(m, x, y=None):
     m.predict(x) if y is None else m.predict(x, y)
 
 
-def _fil_classification_set_up(m, data, arg={}):
+def _fil_classification_setup(m, data, arg={}):
     from cuml.utils.import_utils import has_xgboost
     if has_xgboost():
         import xgboost as xgb
@@ -40,8 +40,8 @@ def _fil_classification_set_up(m, data, arg={}):
         raise ImportError("No XGBoost package found which is required for benchmarking FIL")
     import os 
 
-    # use maximum 10000 rows to train the model 
-    train_size = min(data[0].shape[0], 10000)
+    # use maximum 1e6 rows to train the model 
+    train_size = min(data[0].shape[0], 1000000)
     dtrain = xgb.DMatrix(data[0][:train_size, :], label=data[1][:train_size])
     params = {"silent": 1, "eval_metric": "error", "objective": "binary:logistic"}
     params.update(arg)

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -26,3 +26,27 @@ def fit(m, x, y=None):
 
 def fit_transform(m, x):
     m.fit_transform(x)
+
+
+def predict(m, x, y=None):
+    m.predict(x) if y is None else m.predict(x, y)
+
+
+def fil_classification_set_up(m, data, arg={}):
+    from cuml.utils.import_utils import has_xgboost
+    if has_xgboost():
+        import xgboost as xgb
+    else:
+        raise ImportError("No XGBoost package found which is required for benchmarking FIL")
+    import os 
+
+    dtrain = xgb.DMatrix(data[0], label=data[1])
+    params = {"silent": 1, "eval_metric": "error", "objective": "binary:logistic"}
+    params.update(arg)
+    tmp_path = "./"
+    model_path = os.path.join(tmp_path, 'xgb_class.model')
+    bst = xgb.train(params, dtrain, arg["num_rounds"])
+    bst.save_model(model_path)
+
+    obj = m.load(model_path, algo=arg["algo"], output_class=arg["output_class"], threshold=arg["threshold"])
+    return obj

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -40,14 +40,26 @@ def _fil_classification_setup(m, data, arg={}):
         raise ImportError("No XGBoost package found which is required for benchmarking FIL")
     import os 
 
+    tmp_path = "./fil_models"
+    if not os.path.exists(tmp_path):
+        os.makedirs(tmp_path)
+
     # use maximum 1e6 rows to train the model 
     train_size = min(data[0].shape[0], 1000000)
     dtrain = xgb.DMatrix(data[0][:train_size, :], label=data[1][:train_size])
     params = {"silent": 1, "eval_metric": "error", "objective": "binary:logistic"}
     params.update(arg)
-    tmp_path = "./"
-    model_path = os.path.join(tmp_path, 'xgb_class.model')
-    bst = xgb.train(params, dtrain, arg["num_rounds"])
-    bst.save_model(model_path)
 
+    max_depth = arg["max_depth"]
+    num_rounds = arg["num_rounds"]
+    n_features = data[0].shape[1]
+    model_name = "xgb_" + str(max_depth) + "_" + str(num_rounds) + "_" + str(n_features) + "_" + str(train_size) + ".model"
+    model_path = os.path.join(tmp_path, model_name)
+
+    from pathlib import Path
+    if Path(model_path).is_file():
+        return m.load(model_path, algo=arg["algo"], output_class=arg["output_class"], threshold=arg["threshold"])
+
+    bst = xgb.train(params, dtrain, num_rounds)
+    bst.save_model(model_path)
     return m.load(model_path, algo=arg["algo"], output_class=arg["output_class"], threshold=arg["threshold"])

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -56,4 +56,37 @@ def _build_fil_classifier(m, data, arg={}):
 
     bst = xgb.train(params, dtrain, num_rounds)
     bst.save_model(model_path)
-    return m.load(model_path, algo=arg["algo"], output_class=arg["output_class"], threshold=arg["threshold"])
+    print(arg["fil_algo"])
+    return m.load(model_path, algo=arg["fil_algo"], output_class=arg["output_class"], threshold=arg["threshold"])
+
+
+def _build_treelite_classifier(m, data, arg={}):
+    """Setup function for treelite classification benchmarking"""
+    from cuml.utils.import_utils import has_treelite, has_xgboost
+    if has_treelite():
+        import treelite
+        import treelite.runtime
+    else:
+        raise ImportError("No treelite package found which is required for benchmarking FIL")
+    if has_xgboost():
+        import xgboost as xgb
+    else:
+        raise ImportError("No XGBoost package found which is required for benchmarking FIL")
+
+    # use maximum 1e6 rows to train the model 
+    train_size = min(data[0].shape[0], 1000000)
+    dtrain = xgb.DMatrix(data[0][:train_size, :], label=data[1][:train_size])
+    params = {"silent": 1, "eval_metric": "error", "objective": "binary:logistic"}
+    params.update(arg)
+    max_depth = arg["max_depth"]
+    num_rounds = arg["num_rounds"]
+    n_features = data[0].shape[1]
+
+    tmpdir = tempfile.mkdtemp()
+    model_name = f"xgb_{max_depth}_{num_rounds}_{n_features}_{train_size}.model"
+    model_path = os.path.join(tmpdir, model_name)
+
+    bst = xgb.train(params, dtrain, num_rounds)
+    tl_model = treelite.Model.from_xgboost(bst)
+    tl_model.export_lib(toolchain="gcc", libpath=model_path+"treelite.so", params={'parallel_comp': 40}, verbose=False)
+    return treelite.runtime.Predictor(model_path+"treelite.so", verbose=False)

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -43,8 +43,8 @@ def _build_fil_classifier(m, data, arg={}):
     else:
         raise ImportError("No XGBoost package found")
 
-    # use maximum 1e6 rows to train the model
-    train_size = min(data[0].shape[0], 1000000)
+    # use maximum 1e5 rows to train the model
+    train_size = min(data[0].shape[0], 100000)
     dtrain = xgb.DMatrix(data[0][:train_size, :], label=data[1][:train_size])
     params = {
         "silent": 1, "eval_metric": "error", "objective": "binary:logistic"
@@ -79,8 +79,8 @@ def _build_treelite_classifier(m, data, arg={}):
     else:
         raise ImportError("No XGBoost package found")
 
-    # use maximum 1e6 rows to train the model
-    train_size = min(data[0].shape[0], 1000000)
+    # use maximum 1e5 rows to train the model
+    train_size = min(data[0].shape[0], 100000)
     dtrain = xgb.DMatrix(data[0][:train_size, :], label=data[1][:train_size])
     params = {
         "silent": 1, "eval_metric": "error", "objective": "binary:logistic"

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -61,9 +61,9 @@ def _build_fil_classifier(m, data, arg={}):
     bst = xgb.train(params, dtrain, num_rounds)
     bst.save_model(model_path)
     return m.load(model_path, algo=arg["fil_algo"],
-                    output_class=arg["output_class"],
-                    threshold=arg["threshold"],
-                    storage_type=arg["storage_type"])
+                  output_class=arg["output_class"],
+                  threshold=arg["threshold"],
+                  storage_type=arg["storage_type"])
 
 
 def _build_treelite_classifier(m, data, arg={}):

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 import cuml
 
+
 def fit_kneighbors(m, x):
     m.fit(x)
     m.kneighbors(x)
@@ -59,10 +60,10 @@ def _build_fil_classifier(m, data, arg={}):
 
     bst = xgb.train(params, dtrain, num_rounds)
     bst.save_model(model_path)
-    return m.load(model_path, algo=arg["fil_algo"], 
-        output_class=arg["output_class"],
-        threshold=arg["threshold"], 
-        storage_type=arg["storage_type"])
+    return m.load(model_path, algo=arg["fil_algo"],
+                    output_class=arg["output_class"],
+                    threshold=arg["threshold"],
+                    storage_type=arg["storage_type"])
 
 
 def _build_treelite_classifier(m, data, arg={}):
@@ -96,7 +97,7 @@ def _build_treelite_classifier(m, data, arg={}):
     bst = xgb.train(params, dtrain, num_rounds)
     tl_model = treelite.Model.from_xgboost(bst)
     tl_model.export_lib(
-        toolchain="gcc", libpath=model_path+"treelite.so", \
+        toolchain="gcc", libpath=model_path+"treelite.so",
         params={'parallel_comp': 40}, verbose=False
     )
     return treelite.runtime.Predictor(model_path+"treelite.so", verbose=False)

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -255,14 +255,10 @@ def run_variations(
                     raise_on_error=raise_on_error,
                 )
                 for r in results:
-                    if "algo" in r:
-                        algo_name = algo.name + "_" + r["algo"]
-                    else:
-                        algo_name = algo.name
                     all_results.append(
-                        {**r, 'algo': algo_name, 'input': input_type}
+                        {'algo': algo.name, 'input': input_type, **r}
                     )
-
+                    
     print("Finished all benchmark runs")
     results_df = pd.DataFrame.from_records(all_results)
     print(results_df)

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -47,18 +47,26 @@ class SpeedupComparisonRunner:
         data = datagen.gen_data(
             self.dataset_name, self.input_type, n_samples, n_features
         )
-        
-        setup_overrides = algo_pair.setup_cuml(data, **param_overrides, **cuml_param_overrides)
+
+        setup_overrides = algo_pair.setup_cuml(
+            data, **param_overrides, **cuml_param_overrides
+        )
         
         cu_start = time.time()
-        algo_pair.run_cuml(data, **param_overrides, **cuml_param_overrides, **setup_overrides)
+        algo_pair.run_cuml(
+            data, **param_overrides, **cuml_param_overrides, **setup_overrides
+        )
         cu_elapsed = time.time() - cu_start
 
         if run_cpu and algo_pair.cpu_class is not None:
-            setup_overrides = algo_pair.set_up_cpu(data, **param_overrides)
+            setup_overrides = algo_pair.set_up_cpu(
+                data, **param_overrides
+            )
 
             cpu_start = time.time()
-            algo_pair.run_cpu(data, **param_overrides, **setup_overrides)
+            algo_pair.run_cpu(
+                data, **param_overrides, **setup_overrides
+            )
             cpu_elapsed = time.time() - cpu_start
         else:
             cpu_elapsed = 0.0
@@ -160,7 +168,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             data, **{**param_overrides, **cuml_param_overrides, **setup_override}
         )
         cu_elapsed = time.time() - cu_start
-        
+
         if algo_pair.accuracy_function:
             if algo_pair.cuml_data_prep_hook is not None:
                 X_test, y_test = algo_pair.cuml_data_prep_hook(data[2:])
@@ -182,9 +190,11 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             setup_override = algo_pair.setup_cpu(data, **param_overrides)
 
             cpu_start = time.time()
-            cpu_model = algo_pair.run_cpu(data, **param_overrides, **setup_override)
+            cpu_model = algo_pair.run_cpu(
+                data, **param_overrides, **setup_override
+            )
             cpu_elapsed = time.time() - cpu_start
-        
+
             if algo_pair.accuracy_function:
                 if algo_pair.cpu_data_prep_hook is not None:
                     X_test, y_test = algo_pair.cpu_data_prep_hook(data[2:])
@@ -267,7 +277,7 @@ def run_variations(
                     all_results.append(
                         {'algo': algo.name, 'input': input_type, **r}
                     )
-                    
+
     print("Finished all benchmark runs")
     results_df = pd.DataFrame.from_records(all_results)
     print(results_df)

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -150,8 +150,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             n_features,
             test_fraction=self.test_fraction,
         )
-        X_test, y_test = data[2:]
-
+        
         setup_override = algo_pair.setup_cuml(
             data, **{**param_overrides, **cuml_param_overrides}
         )
@@ -161,7 +160,13 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             data, **{**param_overrides, **cuml_param_overrides, **setup_override}
         )
         cu_elapsed = time.time() - cu_start
+        
         if algo_pair.accuracy_function:
+            if algo_pair.cuml_data_prep_hook is not None:
+                X_test, y_test = algo_pair.cuml_data_prep_hook(data[2:])
+            else:
+                X_test, y_test = data[2:]
+
             if hasattr(cuml_model, 'predict'):
                 y_pred_cuml = cuml_model.predict(X_test)
             else:
@@ -179,8 +184,12 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             cpu_start = time.time()
             cpu_model = algo_pair.run_cpu(data, **param_overrides, **setup_override)
             cpu_elapsed = time.time() - cpu_start
-
+        
             if algo_pair.accuracy_function:
+                if algo_pair.cpu_data_prep_hook is not None:
+                    X_test, y_test = algo_pair.cpu_data_prep_hook(data[2:])
+                else:
+                    X_test, y_test = data[2:]
                 if hasattr(cpu_model, 'predict'):
                     y_pred_cpu = cpu_model.predict(X_test)
                 else:

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -165,7 +165,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
 
         cu_start = time.time()
         cuml_model = algo_pair.run_cuml(
-            data, 
+            data,
             **{**param_overrides, **cuml_param_overrides, **setup_override}
         )
         cu_elapsed = time.time() - cu_start

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -51,7 +51,7 @@ class SpeedupComparisonRunner:
         setup_overrides = algo_pair.setup_cuml(
             data, **param_overrides, **cuml_param_overrides
         )
-        
+
         cu_start = time.time()
         algo_pair.run_cuml(
             data, **param_overrides, **cuml_param_overrides, **setup_overrides
@@ -158,14 +158,15 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             n_features,
             test_fraction=self.test_fraction,
         )
-        
+
         setup_override = algo_pair.setup_cuml(
             data, **{**param_overrides, **cuml_param_overrides}
         )
 
         cu_start = time.time()
         cuml_model = algo_pair.run_cuml(
-            data, **{**param_overrides, **cuml_param_overrides, **setup_override}
+            data, 
+            **{**param_overrides, **cuml_param_overrides, **setup_override}
         )
         cu_elapsed = time.time() - cu_start
 


### PR DESCRIPTION
- Adding Python benchmarking code for FIL (new version)
- Adding `setup_cpu` and `setup_cuml` methods so user can define the set up method for cpu and cuml algorithms separately. The setup methods are done outside the timer. 