### PR TITLE
[REVIEW] Implement make_regression as a prim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 - PR #1129: C++: Separate include folder for C++ API distribution
 - PR #1242: Initial implementation of FIL sparse forests
+- PR #1301: Add make_regression to generate regression datasets
 
 ## Improvements
 - PR #1170: Use git to clone subprojects instead of git submodules

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -367,6 +367,7 @@ if(BUILD_CUML_CPP_LIBRARY)
     src/comms/cuML_comms_test.cpp
     src/common/nvtx.cu
     src/datasets/make_blobs.cu
+    src/datasets/make_regression.cu
     src/dbscan/dbscan.cu
     src/decisiontree/decisiontree.cu
     src/fil/fil.cu

--- a/cpp/include/cuml/datasets/make_blobs.hpp
+++ b/cpp/include/cuml/datasets/make_blobs.hpp
@@ -22,12 +22,8 @@ namespace ML {
 namespace Datasets {
 
 /**
- * @defgroup MakeBlobs
- * @{
  * @brief GPU-equivalent of sklearn.datasets.make_blobs as documented here:
  * https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_blobs.html
- * @tparam DataT output data type
- * @tparam IdxT indexing arithmetic type
  * @param out the generated data on device (dim = n_rows x n_cols) in row-major
  * layout
  * @param labels labels for the generated data on device (dim = n_rows x 1)

--- a/cpp/include/cuml/datasets/make_regression.hpp
+++ b/cpp/include/cuml/datasets/make_regression.hpp
@@ -22,7 +22,34 @@ namespace ML {
 namespace Datasets {
 
 /**
- * @todo docs 
+ * @brief GPU-equivalent of sklearn.datasets.make_regression as documented at:
+ * https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_regression.html
+ * 
+ * @param[in]   handle          cuML handle
+ * @param[out]  out             Row-major (samples, features) matrix to store
+ *                              the problem data
+ * @param[out]  values          Row-major (samples, targets) matrix to store
+ *                              the values for the regression problem
+ * @param[in]   n_rows          Number of samples
+ * @param[in]   n_cols          Number of features
+ * @param[in]   n_informative   Number of informative features (non-zero
+ *                              coefficients)
+ * @param[out]  coef            Row-major (features, targets) matrix to store
+ *                              the coefficients used to generate the values
+ *                              for the regression problem. If nullptr is
+ *                              given, nothing will be written
+ * @param[in]   n_targets       Number of targets (generated values per sample)
+ * @param[in]   bias            A scalar that will be added to the values
+ * @param[in]   effective_rank  The approximate rank of the data matrix (used
+ *                              to create correlations in the data). -1 is the
+ *                              code to use well-conditioned data
+ * @param[in]   tail_strength   The relative importance of the fat noisy tail
+ *                              of the singular values profile if
+ *                              effective_rank is not -1
+ * @param[in]   noise           Standard deviation of the gaussian noise
+ *                              applied to the output
+ * @param[in]   shuffle         Shuffle the samples and the features
+ * @param[in]   seed            Seed for the random number generator
  */
 void make_regression(const cumlHandle& handle, float* out, float* values,
                      int64_t n_rows, int64_t n_cols, int64_t n_informative,
@@ -51,8 +78,6 @@ void make_regression(const cumlHandle& handle, double* out, double* values,
                      double bias = 0.0, int effective_rank = -1LL,
                      double tail_strength = 0.5, double noise = 0.0,
                      bool shuffle = true, uint64_t seed = 0ULL);
-
-/// @todo other variants
 
 }  // namespace Datasets
 }  // namespace ML

--- a/cpp/include/cuml/datasets/make_regression.hpp
+++ b/cpp/include/cuml/datasets/make_regression.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuml/cuml.hpp>
+
+namespace ML {
+namespace Datasets {
+
+/**
+ * @todo docs 
+ */
+void make_regression(const cumlHandle& handle, float* out, float* values,
+                     int64_t n_rows, int64_t n_cols, int64_t n_informative,
+                     int64_t n_targets = 1LL, float bias = 0.0f,
+                     int64_t effective_rank = -1LL, float tail_strength = 0.5f,
+                     float noise = 0.0f, bool shuffle = true,
+                     uint64_t seed = 0ULL);
+
+void make_regression(const cumlHandle& handle, double* out, double* values,
+                     int64_t n_rows, int64_t n_cols, int64_t n_informative,
+                     int64_t n_targets = 1LL, double bias = 0.0,
+                     int64_t effective_rank = -1LL, double tail_strength = 0.5,
+                     double noise = 0.0, bool shuffle = true,
+                     uint64_t seed = 0ULL);
+
+void make_regression(const cumlHandle& handle, float* out, float* values,
+                     int n_rows, int n_cols, int n_informative,
+                     int n_targets = 1LL, float bias = 0.0f,
+                     int effective_rank = -1LL, float tail_strength = 0.5f,
+                     float noise = 0.0f, bool shuffle = true,
+                     uint64_t seed = 0ULL);
+
+void make_regression(const cumlHandle& handle, double* out, double* values,
+                     int n_rows, int n_cols, int n_informative,
+                     int n_targets = 1LL, double bias = 0.0,
+                     int effective_rank = -1LL, double tail_strength = 0.5,
+                     double noise = 0.0, bool shuffle = true,
+                     uint64_t seed = 0ULL);
+
+/// @todo other variants
+
+}  // namespace Datasets
+}  // namespace ML

--- a/cpp/include/cuml/datasets/make_regression.hpp
+++ b/cpp/include/cuml/datasets/make_regression.hpp
@@ -26,31 +26,31 @@ namespace Datasets {
  */
 void make_regression(const cumlHandle& handle, float* out, float* values,
                      int64_t n_rows, int64_t n_cols, int64_t n_informative,
-                     int64_t n_targets = 1LL, float bias = 0.0f,
-                     int64_t effective_rank = -1LL, float tail_strength = 0.5f,
-                     float noise = 0.0f, bool shuffle = true,
-                     uint64_t seed = 0ULL);
+                     float* coef = nullptr, int64_t n_targets = 1LL,
+                     float bias = 0.0f, int64_t effective_rank = -1LL,
+                     float tail_strength = 0.5f, float noise = 0.0f,
+                     bool shuffle = true, uint64_t seed = 0ULL);
 
 void make_regression(const cumlHandle& handle, double* out, double* values,
                      int64_t n_rows, int64_t n_cols, int64_t n_informative,
-                     int64_t n_targets = 1LL, double bias = 0.0,
-                     int64_t effective_rank = -1LL, double tail_strength = 0.5,
-                     double noise = 0.0, bool shuffle = true,
-                     uint64_t seed = 0ULL);
+                     double* coef = nullptr, int64_t n_targets = 1LL,
+                     double bias = 0.0, int64_t effective_rank = -1LL,
+                     double tail_strength = 0.5, double noise = 0.0,
+                     bool shuffle = true, uint64_t seed = 0ULL);
 
 void make_regression(const cumlHandle& handle, float* out, float* values,
                      int n_rows, int n_cols, int n_informative,
-                     int n_targets = 1LL, float bias = 0.0f,
-                     int effective_rank = -1LL, float tail_strength = 0.5f,
-                     float noise = 0.0f, bool shuffle = true,
-                     uint64_t seed = 0ULL);
+                     float* coef = nullptr, int n_targets = 1LL,
+                     float bias = 0.0f, int effective_rank = -1LL,
+                     float tail_strength = 0.5f, float noise = 0.0f,
+                     bool shuffle = true, uint64_t seed = 0ULL);
 
 void make_regression(const cumlHandle& handle, double* out, double* values,
                      int n_rows, int n_cols, int n_informative,
-                     int n_targets = 1LL, double bias = 0.0,
-                     int effective_rank = -1LL, double tail_strength = 0.5,
-                     double noise = 0.0, bool shuffle = true,
-                     uint64_t seed = 0ULL);
+                     double* coef = nullptr, int n_targets = 1LL,
+                     double bias = 0.0, int effective_rank = -1LL,
+                     double tail_strength = 0.5, double noise = 0.0,
+                     bool shuffle = true, uint64_t seed = 0ULL);
 
 /// @todo other variants
 

--- a/cpp/src/datasets/make_regression.cu
+++ b/cpp/src/datasets/make_regression.cu
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <common/cumlHandle.hpp>
+#include <cuml/datasets/make_regression.hpp>
+#include "random/make_regression.h"
+
+namespace ML {
+namespace Datasets {
+
+template <typename DataT, typename IdxT>
+void make_regression_helper(const cumlHandle& handle, DataT* out, DataT* values,
+                            IdxT n_rows, IdxT n_cols, IdxT n_informative,
+                            IdxT n_targets, DataT bias, IdxT effective_rank,
+                            DataT tail_strength, DataT noise, bool shuffle,
+                            uint64_t seed) {
+  const auto& handle_impl = handle.getImpl();
+  cudaStream_t stream = handle_impl.getStream();
+  cublasHandle_t cublas_handle = handle_impl.getCublasHandle();
+  cusolverDnHandle_t cusolver_handle = handle_impl.getcusolverDnHandle();
+  auto allocator = handle_impl.getDeviceAllocator();
+
+  MLCommon::Random::make_regression(out, values, n_rows, n_cols, n_informative,
+                                    cublas_handle, cusolver_handle, allocator,
+                                    stream, n_targets, bias, effective_rank,
+                                    tail_strength, noise, shuffle, seed);
+}
+
+void make_regression(const cumlHandle& handle, float* out, float* values,
+                     int64_t n_rows, int64_t n_cols, int64_t n_informative,
+                     int64_t n_targets, float bias, int64_t effective_rank,
+                     float tail_strength, float noise, bool shuffle,
+                     uint64_t seed) {
+  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
+                         n_targets, bias, effective_rank, tail_strength, noise,
+                         shuffle, seed);
+}
+
+void make_regression(const cumlHandle& handle, double* out, double* values,
+                     int64_t n_rows, int64_t n_cols, int64_t n_informative,
+                     int64_t n_targets, double bias, int64_t effective_rank,
+                     double tail_strength, double noise, bool shuffle,
+                     uint64_t seed) {
+  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
+                         n_targets, bias, effective_rank, tail_strength, noise,
+                         shuffle, seed);
+}
+
+void make_regression(const cumlHandle& handle, float* out, float* values,
+                     int n_rows, int n_cols, int n_informative, int n_targets,
+                     float bias, int effective_rank, float tail_strength,
+                     float noise, bool shuffle, uint64_t seed) {
+  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
+                         n_targets, bias, effective_rank, tail_strength, noise,
+                         shuffle, seed);
+}
+
+void make_regression(const cumlHandle& handle, double* out, double* values,
+                     int n_rows, int n_cols, int n_informative, int n_targets,
+                     double bias, int effective_rank, double tail_strength,
+                     double noise, bool shuffle, uint64_t seed) {
+  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
+                         n_targets, bias, effective_rank, tail_strength, noise,
+                         shuffle, seed);
+}
+
+}  // namespace Datasets
+}  // namespace ML

--- a/cpp/src/datasets/make_regression.cu
+++ b/cpp/src/datasets/make_regression.cu
@@ -24,57 +24,59 @@ namespace Datasets {
 template <typename DataT, typename IdxT>
 void make_regression_helper(const cumlHandle& handle, DataT* out, DataT* values,
                             IdxT n_rows, IdxT n_cols, IdxT n_informative,
-                            IdxT n_targets, DataT bias, IdxT effective_rank,
-                            DataT tail_strength, DataT noise, bool shuffle,
-                            uint64_t seed) {
+                            DataT* coef, IdxT n_targets, DataT bias,
+                            IdxT effective_rank, DataT tail_strength,
+                            DataT noise, bool shuffle, uint64_t seed) {
   const auto& handle_impl = handle.getImpl();
   cudaStream_t stream = handle_impl.getStream();
   cublasHandle_t cublas_handle = handle_impl.getCublasHandle();
   cusolverDnHandle_t cusolver_handle = handle_impl.getcusolverDnHandle();
   auto allocator = handle_impl.getDeviceAllocator();
 
-  MLCommon::Random::make_regression(out, values, n_rows, n_cols, n_informative,
-                                    cublas_handle, cusolver_handle, allocator,
-                                    stream, n_targets, bias, effective_rank,
-                                    tail_strength, noise, shuffle, seed);
+  MLCommon::Random::make_regression(
+    out, values, n_rows, n_cols, n_informative, cublas_handle, cusolver_handle,
+    allocator, stream, coef, n_targets, bias, effective_rank, tail_strength,
+    noise, shuffle, seed);
 }
 
 void make_regression(const cumlHandle& handle, float* out, float* values,
                      int64_t n_rows, int64_t n_cols, int64_t n_informative,
-                     int64_t n_targets, float bias, int64_t effective_rank,
+                     float* coef, int64_t n_targets, float bias,
+                     int64_t effective_rank, float tail_strength, float noise,
+                     bool shuffle, uint64_t seed) {
+  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
+                         coef, n_targets, bias, effective_rank, tail_strength,
+                         noise, shuffle, seed);
+}
+
+void make_regression(const cumlHandle& handle, double* out, double* values,
+                     int64_t n_rows, int64_t n_cols, int64_t n_informative,
+                     double* coef, int64_t n_targets, double bias,
+                     int64_t effective_rank, double tail_strength, double noise,
+                     bool shuffle, uint64_t seed) {
+  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
+                         coef, n_targets, bias, effective_rank, tail_strength,
+                         noise, shuffle, seed);
+}
+
+void make_regression(const cumlHandle& handle, float* out, float* values,
+                     int n_rows, int n_cols, int n_informative, float* coef,
+                     int n_targets, float bias, int effective_rank,
                      float tail_strength, float noise, bool shuffle,
                      uint64_t seed) {
   make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
-                         n_targets, bias, effective_rank, tail_strength, noise,
-                         shuffle, seed);
+                         coef, n_targets, bias, effective_rank, tail_strength,
+                         noise, shuffle, seed);
 }
 
 void make_regression(const cumlHandle& handle, double* out, double* values,
-                     int64_t n_rows, int64_t n_cols, int64_t n_informative,
-                     int64_t n_targets, double bias, int64_t effective_rank,
+                     int n_rows, int n_cols, int n_informative, double* coef,
+                     int n_targets, double bias, int effective_rank,
                      double tail_strength, double noise, bool shuffle,
                      uint64_t seed) {
   make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
-                         n_targets, bias, effective_rank, tail_strength, noise,
-                         shuffle, seed);
-}
-
-void make_regression(const cumlHandle& handle, float* out, float* values,
-                     int n_rows, int n_cols, int n_informative, int n_targets,
-                     float bias, int effective_rank, float tail_strength,
-                     float noise, bool shuffle, uint64_t seed) {
-  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
-                         n_targets, bias, effective_rank, tail_strength, noise,
-                         shuffle, seed);
-}
-
-void make_regression(const cumlHandle& handle, double* out, double* values,
-                     int n_rows, int n_cols, int n_informative, int n_targets,
-                     double bias, int effective_rank, double tail_strength,
-                     double noise, bool shuffle, uint64_t seed) {
-  make_regression_helper(handle, out, values, n_rows, n_cols, n_informative,
-                         n_targets, bias, effective_rank, tail_strength, noise,
-                         shuffle, seed);
+                         coef, n_targets, bias, effective_rank, tail_strength,
+                         noise, shuffle, seed);
 }
 
 }  // namespace Datasets

--- a/cpp/src_prims/linalg/qr.h
+++ b/cpp/src_prims/linalg/qr.h
@@ -69,7 +69,7 @@ void qrGetQ(math_t *M, math_t *Q, int n_rows, int n_cols,
 }
 
 /**
- * @defgroup QR decomposition, return the Q matrix
+ * @defgroup QR decomposition, return the Q and R matrices
  * @param M: input matrix
  * @param Q: Q matrix to be returned (on GPU)
  * @param R: R matrix to be returned (on GPU)

--- a/cpp/src_prims/random/make_regression.h
+++ b/cpp/src_prims/random/make_regression.h
@@ -189,7 +189,7 @@ void make_regression(DataT* out, DataT* values, IdxT n_rows, IdxT n_cols,
   }
 
   // Generate a ground truth model with only n_informative features
-  r.uniform(_coef, n_informative * n_targets, (DataT)0.0, (DataT)100.0, stream);
+  r.uniform(_coef, n_informative * n_targets, (DataT)1.0, (DataT)100.0, stream);
   if (coef && n_informative != n_cols) {
     CUDA_CHECK(cudaMemsetAsync(
       _coef + n_informative * n_targets, 0,

--- a/cpp/src_prims/random/make_regression.h
+++ b/cpp/src_prims/random/make_regression.h
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from scikit-learn/sklearn/datasets/samples_generator.py
+// TODO: check if need to include license (BSD 3 clause)
+
+#pragma once
+
+#include <algorithm>
+#include <cuml/common/cuml_allocator.hpp>
+
+#include "linalg/add.h"
+#include "linalg/cublas_wrappers.h"
+#include "linalg/init.h"
+#include "linalg/qr.h"
+#include "linalg/transpose.h"
+#include "matrix/matrix.h"
+#include "permute.h"
+#include "rng.h"
+#include "utils.h"
+
+namespace MLCommon {
+namespace Random {
+
+template <bool square, typename DataT, typename IdxT>
+static __global__ void _singular_profile_kernel(DataT* out, IdxT n,
+                                                DataT strength, DataT coef,
+                                                IdxT rank) {
+  IdxT tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid < n) {
+    DataT sval = static_cast<DataT>(tid) / rank;
+    if (square) sval *= sval;
+    out[tid] = strength * myExp(coef * sval);
+  }
+}
+
+/*
+ * TODO: quick docs (internal auxiliary function)
+ */
+template <typename DataT, typename IdxT>
+static void _make_low_rank_matrix(DataT* out, IdxT n_rows, IdxT n_cols,
+                                  IdxT effective_rank, DataT tail_strength,
+                                  Rng& r, cublasHandle_t cublas_handle,
+                                  cusolverDnHandle_t cusolver_handle,
+                                  std::shared_ptr<deviceAllocator> allocator,
+                                  cudaStream_t stream) {
+  IdxT n = std::min(n_rows, n_cols);
+
+  // Generate random (ortho normal) vectors with QR decomposition
+  device_buffer<DataT> rd_mat_0(allocator, stream);
+  device_buffer<DataT> rd_mat_1(allocator, stream);
+  rd_mat_0.resize(n_rows * n, stream);
+  rd_mat_1.resize(n_cols * n, stream);
+  r.normal(rd_mat_0.data(), n_rows * n, (DataT)0.0, (DataT)1.0, stream);
+  r.normal(rd_mat_1.data(), n_cols * n, (DataT)0.0, (DataT)1.0, stream);
+  device_buffer<DataT> q0(allocator, stream);
+  device_buffer<DataT> q1(allocator, stream);
+  q0.resize(n_rows * n, stream);
+  q1.resize(n_cols * n, stream);
+  LinAlg::qrGetQ(rd_mat_0.data(), q0.data(), n_rows, n, cusolver_handle, stream,
+                 allocator);
+  LinAlg::qrGetQ(rd_mat_1.data(), q1.data(), n_cols, n, cusolver_handle, stream,
+                 allocator);
+
+  // Build the singular profile by assembling signal and noise components
+  device_buffer<DataT> low_rank(allocator, stream);
+  device_buffer<DataT> tail(allocator, stream);
+  device_buffer<DataT> singular(allocator, stream);
+  low_rank.resize(n, stream);
+  tail.resize(n, stream);
+  _singular_profile_kernel<true><<<ceildiv<IdxT>(n, 256), 256, 0, stream>>>(
+    low_rank.data(), n, (DataT)1.0 - tail_strength, (DataT)-1.0,
+    effective_rank);
+  CUDA_CHECK(cudaPeekAtLastError());
+  _singular_profile_kernel<false><<<ceildiv<IdxT>(n, 256), 256, 0, stream>>>(
+    tail.data(), n, tail_strength, (DataT)-0.1, effective_rank);
+  CUDA_CHECK(cudaPeekAtLastError());
+  LinAlg::add(low_rank.data(), low_rank.data(), tail.data(), n, stream);
+  singular.resize(n * n, stream);
+  CUDA_CHECK(cudaMemsetAsync(singular.data(), 0, n * sizeof(DataT), stream));
+  Matrix::initializeDiagonalMatrix(low_rank.data(), singular.data(), n, n,
+                                   stream);
+
+  // Generate the column-major matrix
+  device_buffer<DataT> temp_q0s(allocator, stream);
+  device_buffer<DataT> temp_out(allocator, stream);
+  temp_q0s.resize(n_rows * n, stream);
+  temp_out.resize(n_rows * n_cols, stream);
+  DataT alpha = 1.0, beta = 0.0;
+  LinAlg::cublasgemm(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, n_rows, n, n,
+                     &alpha, q0.data(), n_rows, singular.data(), n, &beta,
+                     temp_q0s.data(), n_rows, stream);
+  LinAlg::cublasgemm(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_T, n_rows, n_cols, n,
+                     &alpha, temp_q0s.data(), n_rows, q1.data(), n_cols, &beta,
+                     temp_out.data(), n_rows, stream);
+
+  // Transpose from column-major to row-major
+  LinAlg::transpose(temp_out.data(), out, n_rows, n_cols, cublas_handle,
+                    stream);
+}
+
+/*
+ * TODO: quick docs (internal auxiliary function)
+ */
+template <typename DataT, typename IdxT>
+static __global__ void _gather2d_kernel(DataT* out, const DataT* in,
+                                        const IdxT* perms, IdxT n_rows,
+                                        IdxT n_cols) {
+  IdxT tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const DataT* row_in = in + n_cols * perms[tid];
+  DataT* row_out = out + n_cols * tid;
+
+  if (tid < n_rows) {
+    for (IdxT i = 0; i < n_cols; i++) {
+      row_out[i] = row_in[i];
+    }
+  }
+}
+
+/**
+ * TODO: docs
+ * TODO: add support for returning coefficients?
+ */
+template <typename DataT, typename IdxT>
+void make_regression(DataT* out, DataT* values, IdxT n_rows, IdxT n_cols,
+                     IdxT n_informative, cublasHandle_t cublas_handle,
+                     cusolverDnHandle_t cusolver_handle,
+                     std::shared_ptr<deviceAllocator> allocator,
+                     cudaStream_t stream, IdxT n_targets = (IdxT)1,
+                     DataT bias = (DataT)0.0, IdxT effective_rank = (IdxT)-1,
+                     DataT tail_strength = (DataT)0.5, DataT noise = (DataT)0.0,
+                     bool shuffle = true, uint64_t seed = 0ULL,
+                     GeneratorType type = GenPhilox) {
+  n_informative = std::min(n_informative, n_cols);
+  cublasSetPointerMode(cublas_handle, CUBLAS_POINTER_MODE_HOST);
+  Rng r(seed, type);
+
+  // Use the right output buffer
+  device_buffer<DataT> tmp_out(allocator, stream);
+  device_buffer<IdxT> perms(allocator, stream);
+  device_buffer<DataT> tmp_values(allocator, stream);
+  DataT* _out;
+  DataT* _values;
+  if (shuffle) {
+    tmp_out.resize(n_rows * n_cols, stream);
+    perms.resize(n_rows, stream);
+    tmp_values.resize(n_rows * n_targets, stream);
+    _out = tmp_out.data();
+    _values = tmp_values.data();
+  } else {
+    _out = out;
+    _values = values;
+  }
+
+  if (effective_rank < 0) {
+    // Randomly generate a well conditioned input set
+    r.normal(_out, n_rows * n_cols, (DataT)0.0, (DataT)1.0, stream);
+  } else {
+    // Randomly generate a low rank, fat tail input set
+    _make_low_rank_matrix(_out, n_rows, n_cols, effective_rank, tail_strength,
+                          r, cublas_handle, cusolver_handle, allocator, stream);
+  }
+
+  // Generate a ground truth model with only n_informative features
+  device_buffer<DataT> ground_truth(allocator, stream);
+  ground_truth.resize(n_informative * n_targets, stream);
+  r.uniform(ground_truth.data(), n_informative * n_targets, (DataT)0.0,
+            (DataT)100.0, stream);
+
+  // Create a column-major matrix of output values only if it has more
+  // than 1 column
+  device_buffer<DataT> values_col(allocator, stream);
+  DataT* _values_col;
+  if (n_targets > 1) {
+    values_col.resize(n_rows * n_targets, stream);
+    _values_col = values_col.data();
+  } else {
+    _values_col = _values;
+  }
+
+  // Compute the output values
+  DataT alpha = (DataT)1.0, beta = (DataT)0.0;
+  CUBLAS_CHECK(LinAlg::cublasgemm(cublas_handle, CUBLAS_OP_T, CUBLAS_OP_T,
+                                  n_rows, n_targets, n_informative, &alpha,
+                                  _out, n_cols, ground_truth.data(), n_targets,
+                                  &beta, _values_col, n_rows, stream));
+
+  // Transpose the values from column-major to row-major if needed
+  if (n_targets > 1) {
+    LinAlg::transpose(_values_col, _values, n_rows, n_targets, cublas_handle,
+                      stream);
+  }
+
+  if (bias != 0.0) {
+    // Add bias
+    LinAlg::addScalar(_values, _values, bias, n_rows * n_targets, stream);
+  }
+
+  device_buffer<DataT> white_noise(allocator, stream);
+  if (noise != 0.0) {
+    // Add white noise
+    white_noise.resize(n_rows * n_targets, stream);
+    r.normal(white_noise.data(), n_rows * n_targets, (DataT)0.0, noise, stream);
+    LinAlg::add(_values, _values, white_noise.data(), n_rows * n_targets,
+                stream);
+  }
+
+  // Shuffle, if asked for
+  ///@todo: currently using a poor quality shuffle for better perf!
+  if (shuffle) {
+    permute<DataT, IdxT, IdxT>(perms.data(), out, _out, n_cols, n_rows, true,
+                               stream);
+    constexpr IdxT Nthreads = 256;
+    IdxT nblks = ceildiv<IdxT>(n_rows, Nthreads);
+    _gather2d_kernel<<<nblks, Nthreads, 0, stream>>>(
+      values, _values, perms.data(), n_rows, n_targets);
+    CUDA_CHECK(cudaPeekAtLastError());
+  }
+}
+
+}  // namespace Random
+}  // namespace MLCommon

--- a/cpp/src_prims/random/make_regression.h
+++ b/cpp/src_prims/random/make_regression.h
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-// Adapted from scikit-learn/sklearn/datasets/samples_generator.py
-// TODO: check if need to include license (BSD 3 clause)
+/* Adapted from scikit-learn
+ * https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/datasets/_samples_generator.py
+ */
 
 #pragma once
 
@@ -35,6 +36,7 @@
 namespace MLCommon {
 namespace Random {
 
+/* Internal auxiliary function to help build the singular profile */
 template <bool square, typename DataT, typename IdxT>
 static __global__ void _singular_profile_kernel(DataT* out, IdxT n,
                                                 DataT strength, DataT coef,
@@ -47,9 +49,7 @@ static __global__ void _singular_profile_kernel(DataT* out, IdxT n,
   }
 }
 
-/*
- * TODO: quick docs (internal auxiliary function)
- */
+/* Internal auxiliary function to generate a low-rank matrix */
 template <typename DataT, typename IdxT>
 static void _make_low_rank_matrix(DataT* out, IdxT n_rows, IdxT n_cols,
                                   IdxT effective_rank, DataT tail_strength,
@@ -112,9 +112,8 @@ static void _make_low_rank_matrix(DataT* out, IdxT n_rows, IdxT n_cols,
                     stream);
 }
 
-/*
- * TODO: quick docs (internal auxiliary function)
- */
+/* Internal auxiliary function to permute rows in the given matrix according
+ * to a given permutation vector */
 template <typename DataT, typename IdxT>
 static __global__ void _gather2d_kernel(DataT* out, const DataT* in,
                                         const IdxT* perms, IdxT n_rows,
@@ -131,8 +130,41 @@ static __global__ void _gather2d_kernel(DataT* out, const DataT* in,
 }
 
 /**
- * TODO: docs
- * TODO: add support for returning coefficients?
+ * @brief GPU-equivalent of sklearn.datasets.make_regression as documented at:
+ * https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_regression.html
+ * 
+ * @tparam  DataT  Scalar type
+ * @tparam  IdxT   Index type
+ * 
+ * @param[out]  out             Row-major (samples, features) matrix to store
+ *                              the problem data
+ * @param[out]  values          Row-major (samples, targets) matrix to store
+ *                              the values for the regression problem
+ * @param[in]   n_rows          Number of samples
+ * @param[in]   n_cols          Number of features
+ * @param[in]   n_informative   Number of informative features (non-zero
+ *                              coefficients)
+ * @param[in]   cublas_handle   cuBLAS handle
+ * @param[in]   cusolver_handle cuSOLVER handle
+ * @param[in]   allocator       Device memory allocator
+ * @param[in]   stream          CUDA stream
+ * @param[out]  coef            Row-major (features, targets) matrix to store
+ *                              the coefficients used to generate the values
+ *                              for the regression problem. If nullptr is
+ *                              given, nothing will be written
+ * @param[in]   n_targets       Number of targets (generated values per sample)
+ * @param[in]   bias            A scalar that will be added to the values
+ * @param[in]   effective_rank  The approximate rank of the data matrix (used
+ *                              to create correlations in the data). -1 is the
+ *                              code to use well-conditioned data
+ * @param[in]   tail_strength   The relative importance of the fat noisy tail
+ *                              of the singular values profile if
+ *                              effective_rank is not -1
+ * @param[in]   noise           Standard deviation of the gaussian noise
+ *                              applied to the output
+ * @param[in]   shuffle         Shuffle the samples and the features
+ * @param[in]   seed            Seed for the random number generator
+ * @param[in]   type            Random generator type
  */
 template <typename DataT, typename IdxT>
 void make_regression(DataT* out, DataT* values, IdxT n_rows, IdxT n_cols,

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -214,6 +214,7 @@ if(BUILD_PRIMS_TESTS)
       prims/log.cu
       prims/logisticReg.cu
       prims/make_blobs.cu
+      prims/make_regression.cu
       prims/map_then_reduce.cu
       prims/math.cu
       prims/matrix.cu

--- a/cpp/test/prims/make_regression.cu
+++ b/cpp/test/prims/make_regression.cu
@@ -15,8 +15,13 @@
  */
 
 #include <gtest/gtest.h>
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
 
 #include "cuda_utils.h"
+#include "linalg/cublas_wrappers.h"
+#include "linalg/subtract.h"
+#include "linalg/transpose.h"
 #include "random/make_regression.h"
 #include "test_utils.h"
 
@@ -38,38 +43,64 @@ class MakeRegressionTest
   : public ::testing::TestWithParam<MakeRegressionInputs<T>> {
  protected:
   void SetUp() override {
-    params = ::testing::TestWithParam<MakeBlobsInputs<T>>::GetParam();
+    params = ::testing::TestWithParam<MakeRegressionInputs<T>>::GetParam();
+
+    // Noise must be zero to compare the actual and expected values
     T noise = (T)0.0, tail_strength = (T)0.5;
 
     allocator.reset(new defaultDeviceAllocator);
     CUBLAS_CHECK(cublasCreate(&cublas_handle));
-    CUSOLVER_CHECK(cusolverDnCreate(&cusolverH));
+    CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     allocate(data, params.n_samples * params.n_features);
-    allocate(values, params.n_samples * params.n_targets);
+    allocate(values_ret, params.n_samples * params.n_targets);
+    allocate(values_prod, params.n_samples * params.n_targets);
+    allocate(values_cm, params.n_samples * params.n_targets);
+    allocate(coef, params.n_features * params.n_targets);
 
     // Create the regression problem
-    make_regression(data, values, params.n_samples, params.n_features,
+    make_regression(data, values_ret, params.n_samples, params.n_features,
                     params.n_informative, cublas_handle, cusolver_handle,
-                    allocator, stream, params.n_targets, params.bias,
-                    params.effective_rank, tail_strength, noise,
-                    params.shuffle, params.seed, params.gtype);
-    
-    // TODO: option to return coeff so we can test the feature correctly
+                    allocator, stream, coef, params.n_targets, params.bias,
+                    params.effective_rank, tail_strength, noise, params.shuffle,
+                    params.seed, params.gtype);
+
+    // Calculate the values from the data and coefficients (column-major)
+    T alpha = (T)1.0, beta = (T)0.0;
+    CUBLAS_CHECK(LinAlg::cublasgemm(
+      cublas_handle, CUBLAS_OP_T, CUBLAS_OP_T, params.n_samples,
+      params.n_targets, params.n_features, &alpha, data, params.n_features,
+      coef, params.n_targets, &beta, values_cm, params.n_samples, stream));
+
+    // Transpose the values to row-major
+    LinAlg::transpose(values_cm, values_prod, params.n_samples,
+                      params.n_targets, cublas_handle, stream);
+
+    // Add the bias
+    LinAlg::addScalar(values_prod, values_prod, params.bias,
+                           params.n_samples * params.n_targets, stream);
+
+    // Count the number of zeroes in the coefficients
+    thrust::device_ptr<T> __coef = thrust::device_pointer_cast(coef);
+    zero_count = thrust::count(
+      __coef, __coef + params.n_features * params.n_targets, (T)0.0);
   }
 
   void TearDown() override {
     CUDA_CHECK(cudaFree(data));
-    CUDA_CHECK(cudaFree(values));
+    CUDA_CHECK(cudaFree(values_ret));
+    CUDA_CHECK(cudaFree(values_prod));
+    CUDA_CHECK(cudaFree(values_cm));
     CUBLAS_CHECK(cublasDestroy(cublas_handle));
-    CUSOLVER_CHECK(cusolverDnDestroy(cusolverH));
+    CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
     CUDA_CHECK(cudaStreamDestroy(stream));
   }
 
  protected:
   MakeRegressionInputs<T> params;
-  T *data, *values;
+  T *data, *values_ret, *values_prod, *values_cm, *coef;
+  int zero_count;
   std::shared_ptr<deviceAllocator> allocator;
   cudaStream_t stream;
   cublasHandle_t cublas_handle;
@@ -77,16 +108,36 @@ class MakeRegressionTest
 };
 
 typedef MakeRegressionTest<float> MakeRegressionTestF;
-const std::vector<MakeRegressionInputs<float>> inputsf_t = {};
+const std::vector<MakeRegressionInputs<float>> inputsf_t = {
+  {0.01f, 256, 32, 16, 1, -1, 0.f, true, GenPhilox, 1234ULL},
+  {0.01f, 1000, 100, 47, 4, 65, 4.2f, true, GenPhilox, 1234ULL},
+  {0.01f, 20000, 500, 450, 13, -1, -3.f, false, GenPhilox, 1234ULL}};
 
-TEST_P(MakeRegressionTestF, Result) {}
+TEST_P(MakeRegressionTestF, Result) {
+  ASSERT_TRUE(
+    match(params.n_targets * (params.n_features - params.n_informative),
+          zero_count, Compare<int>()));
+  ASSERT_TRUE(devArrMatch(values_ret, values_prod, params.n_samples,
+                          params.n_targets,
+                          CompareApprox<float>(params.tolerance), stream));
+}
 INSTANTIATE_TEST_CASE_P(MakeRegressionTests, MakeRegressionTestF,
                         ::testing::ValuesIn(inputsf_t));
 
 typedef MakeRegressionTest<double> MakeRegressionTestD;
-const std::vector<MakeRegressionInputs<double>> inputsd_t = {};
+const std::vector<MakeRegressionInputs<double>> inputsd_t = {
+  {0.01, 256, 32, 16, 1, -1, 0.0, true, GenPhilox, 1234ULL},
+  {0.01, 1000, 100, 47, 4, 65, 4.2, true, GenPhilox, 1234ULL},
+  {0.01, 20000, 500, 450, 13, -1, -3.0, false, GenPhilox, 1234ULL}};
 
-TEST_P(MakeRegressionTestD, Result) {}
+TEST_P(MakeRegressionTestD, Result) {
+  ASSERT_TRUE(
+    match(params.n_targets * (params.n_features - params.n_informative),
+          zero_count, Compare<int>()));
+  ASSERT_TRUE(devArrMatch(values_ret, values_prod, params.n_samples,
+                          params.n_targets,
+                          CompareApprox<double>(params.tolerance), stream));
+}
 INSTANTIATE_TEST_CASE_P(MakeRegressionTests, MakeRegressionTestD,
                         ::testing::ValuesIn(inputsd_t));
 

--- a/cpp/test/prims/make_regression.cu
+++ b/cpp/test/prims/make_regression.cu
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "cuda_utils.h"
+#include "random/make_regression.h"
+#include "test_utils.h"
+
+namespace MLCommon {
+namespace Random {
+
+template <typename T>
+struct MakeRegressionInputs {
+  T tolerance;
+  int n_samples, n_features, n_informative, n_targets, effective_rank;
+  T bias;
+  bool shuffle;
+  GeneratorType gtype;
+  uint64_t seed;
+};
+
+template <typename T>
+class MakeRegressionTest
+  : public ::testing::TestWithParam<MakeRegressionInputs<T>> {
+ protected:
+  void SetUp() override {
+    params = ::testing::TestWithParam<MakeBlobsInputs<T>>::GetParam();
+    T noise = (T)0.0, tail_strength = (T)0.5;
+
+    allocator.reset(new defaultDeviceAllocator);
+    CUBLAS_CHECK(cublasCreate(&cublas_handle));
+    CUSOLVER_CHECK(cusolverDnCreate(&cusolverH));
+    CUDA_CHECK(cudaStreamCreate(&stream));
+
+    allocate(data, params.n_samples * params.n_features);
+    allocate(values, params.n_samples * params.n_targets);
+
+    // Create the regression problem
+    make_regression(data, values, params.n_samples, params.n_features,
+                    params.n_informative, cublas_handle, cusolver_handle,
+                    allocator, stream, params.n_targets, params.bias,
+                    params.effective_rank, tail_strength, noise,
+                    params.shuffle, params.seed, params.gtype);
+    
+    // TODO: option to return coeff so we can test the feature correctly
+  }
+
+  void TearDown() override {
+    CUDA_CHECK(cudaFree(data));
+    CUDA_CHECK(cudaFree(values));
+    CUBLAS_CHECK(cublasDestroy(cublas_handle));
+    CUSOLVER_CHECK(cusolverDnDestroy(cusolverH));
+    CUDA_CHECK(cudaStreamDestroy(stream));
+  }
+
+ protected:
+  MakeRegressionInputs<T> params;
+  T *data, *values;
+  std::shared_ptr<deviceAllocator> allocator;
+  cudaStream_t stream;
+  cublasHandle_t cublas_handle;
+  cusolverDnHandle_t cusolver_handle;
+};
+
+typedef MakeRegressionTest<float> MakeRegressionTestF;
+const std::vector<MakeRegressionInputs<float>> inputsf_t = {};
+
+TEST_P(MakeRegressionTestF, Result) {}
+INSTANTIATE_TEST_CASE_P(MakeRegressionTests, MakeRegressionTestF,
+                        ::testing::ValuesIn(inputsf_t));
+
+typedef MakeRegressionTest<double> MakeRegressionTestD;
+const std::vector<MakeRegressionInputs<double>> inputsd_t = {};
+
+TEST_P(MakeRegressionTestD, Result) {}
+INSTANTIATE_TEST_CASE_P(MakeRegressionTests, MakeRegressionTestD,
+                        ::testing::ValuesIn(inputsd_t));
+
+}  // end namespace Random
+}  // end namespace MLCommon

--- a/python/cuml/__init__.py
+++ b/python/cuml/__init__.py
@@ -22,6 +22,7 @@ from cuml.cluster.dbscan import DBSCAN
 from cuml.cluster.kmeans import KMeans
 
 from cuml.datasets.blobs import blobs as make_blobs
+from cuml.datasets.regression import make_regression
 
 from cuml.decomposition.pca import PCA
 from cuml.decomposition.tsvd import TruncatedSVD

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -139,13 +139,13 @@ def make_regression(n_samples=100, n_features=2, n_informative=2, n_targets=1,
 
     Returns
     -------
-    out : array of shape [n_samples, n_features]
+    out : device array of shape [n_samples, n_features]
         The input samples.
 
-    values : array of shape [n_samples, n_targets]
+    values : device array of shape [n_samples, n_targets]
         The output values.
 
-    coef : array of shape [n_features, n_targets], optional
+    coef : device array of shape [n_features, n_targets], optional
         The coefficient of the underlying linear model. It is returned only if
         coef is True.
     """

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -71,12 +71,13 @@ inp_to_dtype = {
     np.float64: np.float64
 }
 
+
 def make_regression(n_samples=100, n_features=2, n_informative=2, n_targets=1,
                     bias=0.0, effective_rank=None, tail_strength=0.5,
                     noise=0.0, shuffle=True, coef=False, random_state=None,
                     dtype='single', handle=None):
     """Generate a random regression problem.
-    
+
     See https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_regression.html
 
     Example
@@ -148,7 +149,7 @@ def make_regression(n_samples=100, n_features=2, n_informative=2, n_targets=1,
     coef : device array of shape [n_features, n_targets], optional
         The coefficient of the underlying linear model. It is returned only if
         coef is True.
-    """
+    """  # noqa
 
     if dtype not in ['single', 'float', 'double', np.float32, np.float64]:
         raise TypeError("dtype must be either 'float' or 'double'")

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -75,7 +75,80 @@ def make_regression(n_samples=100, n_features=2, n_informative=2, n_targets=1,
                     bias=0.0, effective_rank=None, tail_strength=0.5,
                     noise=0.0, shuffle=True, coef=False, random_state=None,
                     dtype='single', handle=None):
-    """TODO: docs"""
+    """Generate a random regression problem.
+    
+    See https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_regression.html
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        from cuml.datasets.regression import make_regression
+        from cuml.linear_model import LinearRegression
+
+        # Create regression problem
+        data, values = make_regression(n_samples=200, n_features=12,
+                                       n_informative=7, bias=-4.2, noise=0.3)
+
+        # Perform a linear regression on this problem
+        lr = LinearRegression(fit_intercept = True, normalize = False,
+                              algorithm = "eig")
+        reg = lr.fit(data, values)
+        print(reg.coef_)
+
+    Parameters
+    ----------
+    n_samples : int, optional (default=100)
+        The number of samples.
+    n_features : int, optional (default=2)
+        The number of features.
+    n_informative : int, optional (default=2)
+        The number of informative features, i.e., the number of features used
+        to build the linear model used to generate the output.
+    n_targets : int, optional (default=1)
+        The number of regression targets, i.e., the dimension of the y output
+        vector associated with a sample. By default, the output is a scalar.
+    bias : float, optional (default=0.0)
+        The bias term in the underlying linear model.
+    effective_rank : int or None, optional (default=None)
+        if not None:
+            The approximate number of singular vectors required to explain most
+            of the input data by linear combinations. Using this kind of
+            singular spectrum in the input allows the generator to reproduce
+            the correlations often observed in practice.
+        if None:
+            The input set is well conditioned, centered and gaussian with
+            unit variance.
+    tail_strength : float between 0.0 and 1.0, optional (default=0.5)
+        The relative importance of the fat noisy tail of the singular values
+        profile if `effective_rank` is not None.
+    noise : float, optional (default=0.0)
+        The standard deviation of the gaussian noise applied to the output.
+    shuffle : boolean, optional (default=True)
+        Shuffle the samples and the features.
+    coef : boolean, optional (default=False)
+        If True, the coefficients of the underlying linear model are returned.
+    random_state : int, RandomState instance or None (default)
+        Seed for the random number generator for dataset creation.
+    dtype: string or numpy dtype (default: 'single')
+        Type of the data. Possible values: float32, float64, 'single', 'float'
+        or 'double'.
+    handle: cuml.Handle
+        If it is None, a new one is created just for this function call
+
+    Returns
+    -------
+    out : array of shape [n_samples, n_features]
+        The input samples.
+
+    values : array of shape [n_samples, n_targets]
+        The output values.
+
+    coef : array of shape [n_features, n_targets], optional
+        The coefficient of the underlying linear model. It is returned only if
+        coef is True.
+    """
 
     if dtype not in ['single', 'float', 'double', np.float32, np.float64]:
         raise TypeError("dtype must be either 'float' or 'double'")

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+import cuml
+import numpy as np
+
+from cuml.common.handle cimport cumlHandle
+from cuml.utils import get_dev_array_ptr, zeros
+
+from libcpp cimport bool
+from libc.stdint cimport uint64_t, uintptr_t
+
+from random import randint
+
+cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML":
+    void cpp_make_regression "ML::Datasets::make_regression" (
+        const cumlHandle& handle,
+        float* out,
+        float* values,
+        long n_rows,
+        long n_cols,
+        long n_informative,
+        long n_targets,
+        float bias,
+        long effective_rank,
+        float tail_strength,
+        float noise,
+        bool shuffle,
+        uint64_t seed)
+
+    void cpp_make_regression "ML::Datasets::make_regression" (
+        const cumlHandle& handle,
+        double* out,
+        double* values,
+        long n_rows,
+        long n_cols,
+        long n_informative,
+        long n_targets,
+        double bias,
+        long effective_rank,
+        double tail_strength,
+        double noise,
+        bool shuffle,
+        uint64_t seed)
+
+inp_to_dtype = {
+    'single': np.float32,
+    'float': np.float32,
+    'double': np.float64,
+    np.float32: np.float32,
+    np.float64: np.float64
+}
+
+def make_regression(n_samples=100, n_features=2, n_informative=2, n_targets=1,
+                    bias=0.0, effective_rank=None, tail_strength=0.5,
+                    noise=0.0, shuffle=True, random_state=None, dtype='single',
+                    handle=None):
+    """TODO: docs"""
+
+    if dtype not in ['single', 'float', 'double', np.float32, np.float64]:
+        raise TypeError("dtype must be either 'float' or 'double'")
+    else:
+        dtype = inp_to_dtype[dtype]
+
+    if effective_rank is None:
+        effective_rank = -1
+
+    handle = cuml.common.handle.Handle() if handle is None else handle
+    cdef cumlHandle* handle_ = <cumlHandle*><size_t>handle.getHandle()
+
+    out = zeros((n_samples, n_features), dtype=dtype, order='C')
+    cdef uintptr_t out_ptr = get_dev_array_ptr(out)
+
+    values = zeros((n_samples, n_targets), dtype=dtype, order='C')
+    cdef uintptr_t values_ptr = get_dev_array_ptr(values)
+
+    if random_state is None:
+        random_state = randint(0, 1e18)
+
+    if dtype == np.float32:
+        cpp_make_regression(handle_[0], <float*> out_ptr,
+                            <float*> values_ptr, <long> n_samples,
+                            <long> n_features, <long> n_informative,
+                            <long> n_targets, <float> bias,
+                            <long> effective_rank, <float> tail_strength,
+                            <float> noise, <bool> shuffle,
+                            <uint64_t> random_state)
+
+    else:
+        cpp_make_regression(handle_[0], <double*> out_ptr,
+                            <double*> values_ptr, <long> n_samples,
+                            <long> n_features, <long> n_informative,
+                            <long> n_targets, <double> bias,
+                            <long> effective_rank, <double> tail_strength,
+                            <double> noise, <bool> shuffle,
+                            <uint64_t> random_state)
+
+    return out, values

--- a/python/cuml/test/test_make_blobs.py
+++ b/python/cuml/test/test_make_blobs.py
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 
 
-# Testing parameters for scalar paramter tests
+# Testing parameters for scalar parameter tests
 
 dtype = [
     'single',
@@ -93,7 +93,7 @@ def test_make_blobs_scalar_parameters(dtype, n_samples, n_features, centers,
             "unexpected number of clusters"
 
 
-# parameters for array tests
+# Parameters for array tests
 n_features_ary = [
     2,
     1000

--- a/python/cuml/test/test_make_regression.py
+++ b/python/cuml/test/test_make_regression.py
@@ -19,7 +19,6 @@
 
 import cuml
 import pytest
-import numpy as np
 
 
 # Testing parameters
@@ -58,7 +57,8 @@ def test_make_blobs_scalar_parameters(dtype, n_samples, n_features,
                                   n_targets=n_targets, bias=bias,
                                   effective_rank=effective_rank, noise=noise,
                                   shuffle=shuffle,
-                                  coef=coef, random_state=random_state, dtype=dtype)
+                                  coef=coef, random_state=random_state,
+                                  dtype=dtype)
 
     if coef:
         out, values, coefs = result
@@ -67,6 +67,6 @@ def test_make_blobs_scalar_parameters(dtype, n_samples, n_features,
 
     assert out.shape == (n_samples, n_features), "out shape mismatch"
     assert values.shape == (n_samples, n_targets), "values shape mismatch"
-    
+
     if coef:
         assert coefs.shape == (n_features, n_targets), "coefs shape mismatch"

--- a/python/cuml/test/test_make_regression.py
+++ b/python/cuml/test/test_make_regression.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 #
 
-# Note: this isn't a very strict test, the goal is to test the Cython
-# interface and cover all the parameters
+# Note: this isn't a strict test, the goal is to test the Cython interface
+# and cover all the parameters.
+# See the C++ test for an actual correction test
 
 import cuml
 import pytest

--- a/python/cuml/test/test_make_regression.py
+++ b/python/cuml/test/test_make_regression.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Note: this isn't a very strict test, the goal is to test the Cython
+# interface and cover all the parameters
+
+import cuml
+import pytest
+import numpy as np
+
+
+# Testing parameters
+
+dtype = ['single', 'double']
+n_samples = [100, 100000]
+n_features = [10, 100]
+n_informative = [5, 7]
+n_targets = [1, 3]
+shuffle = [True, False]
+effective_rank = [None, 6]
+random_state = [None, 1234]
+bias = [-4.0]
+noise = [3.5]
+
+
+@pytest.mark.parametrize('dtype', dtype)
+@pytest.mark.parametrize('n_samples', n_samples)
+@pytest.mark.parametrize('n_features', n_features)
+@pytest.mark.parametrize('n_informative', n_informative)
+@pytest.mark.parametrize('n_targets', n_targets)
+@pytest.mark.parametrize('shuffle', shuffle)
+@pytest.mark.parametrize('effective_rank', effective_rank)
+@pytest.mark.parametrize('random_state', random_state)
+@pytest.mark.parametrize('bias', bias)
+@pytest.mark.parametrize('noise', noise)
+def test_make_blobs_scalar_parameters(dtype, n_samples, n_features,
+                                      n_informative, n_targets, shuffle,
+                                      effective_rank, random_state, bias,
+                                      noise):
+
+    out, values = cuml.make_regression(n_samples=n_samples,
+                                       n_features=n_features,
+                                       n_informative=n_informative,
+                                       n_targets=n_targets, bias=bias,
+                                       effective_rank=effective_rank,
+                                       noise=noise, shuffle=shuffle,
+                                       random_state=random_state, dtype=dtype)
+
+    # we can use cupy in the future
+    labels_np = values.copy_to_host()
+
+    assert out.shape == (n_samples, n_features), "out shape mismatch"
+    assert values.shape == (n_samples, n_targets), "values shape mismatch"

--- a/python/cuml/test/test_make_regression.py
+++ b/python/cuml/test/test_make_regression.py
@@ -26,9 +26,10 @@ import numpy as np
 dtype = ['single', 'double']
 n_samples = [100, 100000]
 n_features = [10, 100]
-n_informative = [5, 7]
+n_informative = [7]
 n_targets = [1, 3]
 shuffle = [True, False]
+coef = [True, False]
 effective_rank = [None, 6]
 random_state = [None, 1234]
 bias = [-4.0]
@@ -41,25 +42,30 @@ noise = [3.5]
 @pytest.mark.parametrize('n_informative', n_informative)
 @pytest.mark.parametrize('n_targets', n_targets)
 @pytest.mark.parametrize('shuffle', shuffle)
+@pytest.mark.parametrize('coef', coef)
 @pytest.mark.parametrize('effective_rank', effective_rank)
 @pytest.mark.parametrize('random_state', random_state)
 @pytest.mark.parametrize('bias', bias)
 @pytest.mark.parametrize('noise', noise)
 def test_make_blobs_scalar_parameters(dtype, n_samples, n_features,
-                                      n_informative, n_targets, shuffle,
+                                      n_informative, n_targets, shuffle, coef,
                                       effective_rank, random_state, bias,
                                       noise):
 
-    out, values = cuml.make_regression(n_samples=n_samples,
-                                       n_features=n_features,
-                                       n_informative=n_informative,
-                                       n_targets=n_targets, bias=bias,
-                                       effective_rank=effective_rank,
-                                       noise=noise, shuffle=shuffle,
-                                       random_state=random_state, dtype=dtype)
+    result = cuml.make_regression(n_samples=n_samples, n_features=n_features,
+                                  n_informative=n_informative,
+                                  n_targets=n_targets, bias=bias,
+                                  effective_rank=effective_rank, noise=noise,
+                                  shuffle=shuffle,
+                                  coef=coef, random_state=random_state, dtype=dtype)
 
-    # we can use cupy in the future
-    labels_np = values.copy_to_host()
+    if coef:
+        out, values, coefs = result
+    else:
+        out, values = result
 
     assert out.shape == (n_samples, n_features), "out shape mismatch"
     assert values.shape == (n_samples, n_targets), "values shape mismatch"
+    
+    if coef:
+        assert coefs.shape == (n_features, n_targets), "coefs shape mismatch"


### PR DESCRIPTION
See https://github.com/rapidsai/cuml/issues/1125

This PR creates a GPU version of SKL's [`make_regression`](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_regression.html), available as a prim and in the C++ library and Python module. This function will be used to implement the benchmark requested in https://github.com/rapidsai/cuml/issues/1126 (though this function is more generic than what's needed for the benchmark).

Notes:
 - The stricter unit test is the C++ one, the Python test simply covers all the parameters' possible values but doesn't do real testing (simply checking that the output as the expected form)
- The Python API matches exactly SKL's API
- The algorithm used to generate the dataset is also the same as SKL's