### PR TITLE
Using machineName arg passed in instead of default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #1267: Update build.sh for recent change of building comms in main CMakeLists
 - PR #1278: Removed incorrect overloaded instance of eigJacobi
 - PR #1302: Updates for numba 0.46
+- PR #1319: Using machineName arg passed in instead of default for ASV reporting
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/python/cuml/benchmark/ci_benchmark.py
+++ b/python/cuml/benchmark/ci_benchmark.py
@@ -52,7 +52,7 @@ def report_asv(results_df, output_dir,
     (commitHash, commitTime) = asvdb.utils.getCommitInfo()
 
     b_info = asvdb.BenchmarkInfo(
-        machineName=uname.machine,
+        machineName=machineName or uname.machine,
         cudaVer=cudaVer or "unknown",
         osType=osType or "%s %s" % (uname.system,
                                     uname.release),


### PR DESCRIPTION
Minor fix so ASV output includes machine name as passed in from the Jenkins job, instead of always using the default.