### PR TITLE
[REVIEW] Fix CompareApprox for better behavior near zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #1302: Updates for numba 0.46
 - PR #1319: Using machineName arg passed in instead of default for ASV reporting
 - PR #1326: Fix illegal memory access in make_regression (bounds issue)
+- PR #1330: Fix C++ unit test utils for better handling of differences near zero
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/cpp/test/prims/test_utils.h
+++ b/cpp/test/prims/test_utils.h
@@ -38,7 +38,7 @@ struct CompareApprox {
   bool operator()(const T &a, const T &b) const {
     T diff = abs(a - b);
     T m = std::max(abs(a), abs(b));
-    T ratio = m >= eps ? diff / m : diff;
+    T ratio = diff >= eps ? diff / m : diff;
 
     return (ratio <= eps);
   }
@@ -53,7 +53,7 @@ struct CompareApproxAbs {
   bool operator()(const T &a, const T &b) const {
     T diff = abs(abs(a) - abs(b));
     T m = std::max(abs(a), abs(b));
-    T ratio = m >= eps ? diff / m : diff;
+    T ratio = diff >= eps ? diff / m : diff;
     return (ratio <= eps);
   }
 


### PR DESCRIPTION
The idea behind this PR is an unwanted behavior around zero.

As an example, the CI failed for:
```
(actual=0.0191650390625 != expected=0.0194091796875)
```
The expected precision was `0.01`. The difference between these numbers is approximately `0.0002`. It shouldn't have failed.

With the current code the difference used is the relative difference because the values are above `0.01`, i.e `0.00244/0.01916=0.012` which is greater than `0.01`...

With the new code the difference used would be `0.0002` which is smaller than `0.01`.

To clarify:
 - if the difference is smaller than epsilon, it's ok
 - if not, check the relative difference against epsilon