### PR TITLE
[REVIEW] Remove BUILD_ABI references in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #1300: Lowercase parameter versions for FIL algorithms
 - PR #1312: Update CuPy to version 6.5 and use conda-forge channel
 - PR #1314: Added options needed for ASVDb output (CUDA ver, etc.), added option to select algos
+- PR #1338: Remove BUILD_ABI references in CI scripts
 
 ## Bug Fixes
 - PR #1212: Fix cmake git cloning always running configure in subprojects

--- a/ci/cpu/libcuml/build_libcuml.sh
+++ b/ci/cpu/libcuml/build_libcuml.sh
@@ -6,9 +6,5 @@ if [ "$BUILD_LIBCUML" == '1' -o "$BUILD_CUML" == '1' ]; then
   echo "Building libcuml"
   CUDA_REL=${CUDA_VERSION%.*}
 
-  if [ "$BUILD_ABI" == "1" ]; then
-    conda build conda/recipes/libcuml --python=${PYTHON}
-  else
-    conda build conda/recipes/libcuml --python=${PYTHON}
-  fi
+  conda build conda/recipes/libcuml --python=${PYTHON}
 fi

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export BUILD_ABI=1
 export BUILD_CUML=1
 
 if [[ "$PYTHON" == "3.6" ]]; then

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -21,7 +21,6 @@ build:
   script_env:
     - CC
     - CXX
-    - BUILD_ABI
     - VERSION_SUFFIX
 
 requirements:

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -22,7 +22,6 @@ build:
     - CC
     - CXX
     - CUDAHOSTCXX
-    - BUILD_ABI
     - PARALLEL_LEVEL
     - VERSION_SUFFIX
 


### PR DESCRIPTION
Removing BUILD_ABI references in CI as we will ALWAYS build with it on. Not removing the option from CMake in case users want to build from source with it OFF.