### PR TITLE
[ORPHAN] Fix Distances Seg Faults [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #1319: Using machineName arg passed in instead of default for ASV reporting
 - PR #1326: Fix illegal memory access in make_regression (bounds issue)
 - PR #1330: Fix C++ unit test utils for better handling of differences near zero
+- PR #1341: Fix Distances Seg Faults
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/cpp/src_prims/distance/distance.h
+++ b/cpp/src_prims/distance/distance.h
@@ -161,13 +161,6 @@ size_t getWorkspaceSize(const InType *x, const InType *y, Index_ m, Index_ n,
   return worksize;
 }
 
-#if CUDART_VERSION >= 10010
-// With optimization enabled, CUDA 10.1 generates segfaults for distance
-// prims, so disable optimization until another workaround is found
-// #pragma GCC push_options
-#pragma GCC optimize("O0")
-#endif
-
 /**
  * @brief Evaluate pairwise distances with the user epilogue lamba allowed
  * @tparam DistanceType which distance to evaluate
@@ -242,11 +235,6 @@ void distance(const InType *x, const InType *y, OutType *dist, Index_ m,
                                              isRowMajor);
   CUDA_CHECK(cudaPeekAtLastError());
 }
-
-#if CUDART_VERSION >= 10010
-// Undo special optimization options set earlier
-#pragma GCC reset_options
-#endif
 
 /**
  * @defgroup PairwiseDistance

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -171,10 +171,10 @@ void euclideanAlgo2(Index_ m, Index_ n, Index_ k, const InType *pA,
     gemm_n = n;
   }
 
-  float k = rand() / 2;
+  float adder = rand() / 2;
   const float add = rand();
 
-  pass_function3(k, [add] __host__ __device__ (float x) {return x + add;}, stream);
+  pass_function3(adder, [add] __host__ __device__ (float x) {return x + add;}, stream);
 
   // LinAlg::gemm<InType, AccType, EffOutType, OutputTile_, AccumulatorsPerThread_,
   //              MainLoopFunctor_, Index_, GemmConfig_, EpilogueFunctor_,

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -70,7 +70,7 @@ void pass_function1(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() / 2;
   fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
-  // op(a);
+  op(a);
 }
 
 template <typename Lambda>
@@ -86,7 +86,8 @@ void pass_function3(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 10;
   fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
-  pass_function2(a, op, stream);
+  // pass_function2(a, op, stream);
+  op(a);
 }
 
 /**

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -70,7 +70,7 @@ void pass_function1(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() / 2;
   fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
-  op(a);
+  // op(a);
 }
 
 template <typename Lambda>
@@ -86,7 +86,7 @@ void pass_function3(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 10;
   fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
-  // pass_function2(a, op, stream);
+  pass_function2(a, op, stream);
 }
 
 /**

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -150,7 +150,7 @@ void euclideanAlgo2(Index_ m, Index_ n, Index_ k, const InType *pA,
                GemmEpilogueTraits_, GemmEpilogue_>(
     transa, transb, gemm_m, gemm_n, k, (EffOutType)1, aPtr, lda, bPtr, ldb,
     (EffOutType)0, nullptr, ldd, pDCast,
-    [enable_sqrt] (typename EpilogueFunctor_::Params & p) {
+    [enable_sqrt] (EpiParams & p) {
       return p.initializeExtra(nullptr, nullptr, enable_sqrt);
     },
     fin_op, stream);

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -78,7 +78,8 @@ void pass_function2(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 3;
   fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
-  pass_function1(a, op, stream);
+  // pass_function1(a, op, stream);
+  op(a);
 }
 
 template <typename Lambda>
@@ -86,8 +87,7 @@ void pass_function3(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 10;
   fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
-  // pass_function2(a, op, stream);
-  op(a);
+  pass_function2(a, op, stream);
 }
 
 /**

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -86,7 +86,7 @@ void pass_function3(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 10;
   fprintf(stderr, "%d+%f->%d[%s]\n", stream, a, __LINE__, __FILE__);
-  pass_function2(a, op, stream);
+  // pass_function2(a, op, stream);
 }
 
 /**

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -69,7 +69,7 @@ template <typename Lambda>
 void pass_function1(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() / 2;
-  fprintf(stderr, "%d+%f->%d[%s]\n", stream, a, __LINE__, __FILE__);
+  fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
   op(a);
 }
 
@@ -77,7 +77,7 @@ template <typename Lambda>
 void pass_function2(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 3;
-  fprintf(stderr, "%d+%f->%d[%s]\n", stream, a, __LINE__, __FILE__);
+  fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
   pass_function1(a, op, stream);
 }
 
@@ -85,7 +85,7 @@ template <typename Lambda>
 void pass_function3(float a, Lambda op, cudaStream_t stream)
 {
   a += (float)rand() + 10;
-  fprintf(stderr, "%d+%f->%d[%s]\n", stream, a, __LINE__, __FILE__);
+  fprintf(stderr, "%d+%f->(((%d)))[%s]\n", stream, a, __LINE__, __FILE__);
   // pass_function2(a, op, stream);
 }
 

--- a/cpp/src_prims/distance/euclidean.h
+++ b/cpp/src_prims/distance/euclidean.h
@@ -150,9 +150,8 @@ void euclideanAlgo2(Index_ m, Index_ n, Index_ k, const InType *pA,
                GemmEpilogueTraits_, GemmEpilogue_>(
     transa, transb, gemm_m, gemm_n, k, (EffOutType)1, aPtr, lda, bPtr, ldb,
     (EffOutType)0, nullptr, ldd, pDCast,
-    [enable_sqrt] HD(EpiParams & p) {
-      int err = p.initializeExtra(nullptr, nullptr, enable_sqrt);
-      return err;
+    [enable_sqrt] (typename EpilogueFunctor_::Params & p) {
+      return p.initializeExtra(nullptr, nullptr, enable_sqrt);
     },
     fin_op, stream);
 }


### PR DESCRIPTION
I possibly might have fixed the distance seg faults.
It's possible that NVCC for CUDA 10.1 on GCC 7.2 is accidentally not compiling `__host__` and `__device__` functions properly in tandem.
Instead, compiling only as `__host__` seems to solve the issue.

Likewise `typename EpilogueFunctor_::Params &p` should be used instead of `Params & p`. So, it's easier for the compiler to directly use the stuff, and instantiating then referencing it is causing issues.