### PR TITLE
[Review] [Bugfix] SVM gamma='scale' implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - PR #1285: Fea minimum impurity decrease RF param
 - PR #1301: Add make_regression to generate regression datasets
 - PR #1289: Add Python benchmarking support for FIL
- 
+
 ## Improvements
 - PR #1170: Use git to clone subprojects instead of git submodules
 - PR #1239: Updated the treelite version
@@ -36,8 +36,9 @@
 - PR #1319: Using machineName arg passed in instead of default for ASV reporting
 - PR #1326: Fix illegal memory access in make_regression (bounds issue)
 - PR #1330: Fix C++ unit test utils for better handling of differences near zero
-- PR #1342: Fix to prevent memory leakage in Lasso and ElasticNet 
+- PR #1342: Fix to prevent memory leakage in Lasso and ElasticNet
 - PR #1337: Fix k-means init from preset cluster centers
+- PR #1354  Fix SVM gamma=scale implementation
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/python/cuml/svm/svm.pyx
+++ b/python/cuml/svm/svm.pyx
@@ -131,8 +131,11 @@ class SVC(Base):
             'rbf', 'sigmoid'. Currently precomputed kernels are not supported.
         degree : int (default=3)
             Degree of polynomial kernel function.
-        gamma : float (default = 'auto')
-            Coefficient for rbf, poly, and sigmoid kernels.
+        gamma : float or string (default = 'auto')
+            Coefficient for rbf, poly, and sigmoid kernels. You can specify the
+            numeric value, or use one of the following options:
+            - 'auto': gamma will be set to 1 / n_features
+            - 'scale': gamma will be se to 1 / (n_features * X.var())
         coef0 : float (default = 0.0)
             Independent term in kernel function, only signifficant for poly and
             sigmoid
@@ -260,8 +263,8 @@ class SVC(Base):
             if self.gamma == 'auto':
                 return 1 / self.n_cols
             elif self.gamma == 'scale':
-                x_std = X.std()
-                return 1 / (self.n_cols * x_std)
+                x_var = X.var()
+                return 1 / (self.n_cols * x_var)
             else:
                 raise ValueError("Not implemented gamma option: " + self.gamma)
         else:

--- a/python/cuml/svm/svm.pyx
+++ b/python/cuml/svm/svm.pyx
@@ -20,6 +20,7 @@
 
 import ctypes
 import cudf
+import cupy
 import numpy as np
 
 from numba import cuda
@@ -263,7 +264,7 @@ class SVC(Base):
             if self.gamma == 'auto':
                 return 1 / self.n_cols
             elif self.gamma == 'scale':
-                x_var = X.var()
+                x_var = cupy.asarray(X).var()
                 return 1 / (self.n_cols * x_var)
             else:
                 raise ValueError("Not implemented gamma option: " + self.gamma)
@@ -419,7 +420,7 @@ class SVC(Base):
         self._dealloc()  # delete any previously fitted model
         self._coef_ = None
 
-        cdef KernelParams _kernel_params = self._get_kernel_params(X)
+        cdef KernelParams _kernel_params = self._get_kernel_params(X_m)
         cdef svmParameter param = self._get_svm_params()
         cdef svmModel[float] *model_f
         cdef svmModel[double] *model_d


### PR DESCRIPTION
This fixes #1353, by setting the scaling factor to `1/(n_features * X.var())`. 

The current implementation only works for numpy input data.