### PR TITLE
[REVIEW] Allow benchmarks to run multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #1258: Documenting new MPI communicator for multi-node multi-GPU testing
 - PR #1345: Removing deprecated should_downcast argument
 - PR #1362: device_buffer in UMAP + Sparse prims
+- PR #1357: Run benchmarks multiple times for CI
 
 ## Bug Fixes
 - PR #1281: Making rng.h threadsafe

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -25,18 +25,24 @@ import cuml.metrics
 import cuml.decomposition
 from cuml.utils.import_utils import has_umap
 import numpy as np
-if has_umap():
-    import umap
 
-from cuml.benchmark.bench_helper_funcs \
-    import fit, fit_kneighbors, fit_transform, predict, \
-    _build_fil_classifier, _build_treelite_classifier, \
-    _treelite_fil_accuracy_score
-
+from cuml.benchmark.bench_helper_funcs import (
+    fit,
+    fit_kneighbors,
+    fit_transform,
+    predict,
+    _build_fil_classifier,
+    _build_treelite_classifier,
+    _treelite_fil_accuracy_score,
+)
 from cuml.utils.import_utils import has_treelite
+
 if has_treelite():
     import treelite
     import treelite.runtime
+
+if has_umap():
+    import umap
 
 
 class AlgorithmPair:
@@ -151,8 +157,11 @@ class AlgorithmPair:
         if self.setup_cpu_func is not None:
             all_args = {**self.shared_args, **self.cpu_args}
             all_args = {**all_args, **override_args}
-            return {"cpu_setup_result":
-                    self.setup_cpu_func(self.cpu_class, data, all_args)}
+            return {
+                "cpu_setup_result": self.setup_cpu_func(
+                    self.cpu_class, data, all_args
+                )
+            }
         else:
             return {}
 
@@ -160,8 +169,11 @@ class AlgorithmPair:
         if self.setup_cuml_func is not None:
             all_args = {**self.shared_args, **self.cuml_args}
             all_args = {**all_args, **override_args}
-            return {"cuml_setup_result":
-                    self.setup_cuml_func(self.cuml_class, data, all_args)}
+            return {
+                "cuml_setup_result": self.setup_cuml_func(
+                    self.cuml_class, data, all_args
+                )
+            }
         else:
             return {}
 
@@ -174,6 +186,7 @@ def _labels_to_int_hook(data):
 def _treelite_format_hook(data):
     """Helper function converting data into treelite format"""
     from cuml.utils.import_utils import has_treelite
+
     if has_treelite():
         import treelite
         import treelite.runtime
@@ -184,7 +197,7 @@ def _treelite_format_hook(data):
 
 def all_algorithms():
     """Returns all defined AlgorithmPair objects"""
-    return [
+    algorithms = [
         AlgorithmPair(
             sklearn.cluster.KMeans,
             cuml.cluster.KMeans,
@@ -223,7 +236,7 @@ def all_algorithms():
             cuml_args={},
             name="NearestNeighbors",
             accepts_labels=False,
-            bench_func=fit_kneighbors
+            bench_func=fit_kneighbors,
         ),
         AlgorithmPair(
             sklearn.cluster.DBSCAN,
@@ -311,9 +324,12 @@ def all_algorithms():
             treelite if has_treelite() else None,
             cuml.ForestInference,
             shared_args=dict(num_rounds=10, max_depth=10),
-            cuml_args=dict(fil_algo="BATCH_TREE_REORG",
-                           output_class=True,
-                           threshold=0.5, storage_type="AUTO"),
+            cuml_args=dict(
+                fil_algo="BATCH_TREE_REORG",
+                output_class=True,
+                threshold=0.5,
+                storage_type="AUTO",
+            ),
             name="FIL",
             accepts_labels=False,
             setup_cpu_func=_build_treelite_classifier,
@@ -337,7 +353,6 @@ def all_algorithms():
         )
 
     return algorithms
-
 
 
 def algorithm_by_name(name):

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -23,8 +23,10 @@ import sklearn.random_projection
 from sklearn import metrics
 import cuml.metrics
 import cuml.decomposition
-import umap
+from cuml.utils.import_utils import has_umap
 import numpy as np
+if has_umap():
+    import umap
 
 from cuml.benchmark.bench_helper_funcs \
     import fit, fit_kneighbors, fit_transform, predict, \
@@ -266,7 +268,7 @@ def all_algorithms():
         AlgorithmPair(
             sklearn.linear_model.LogisticRegression,
             cuml.linear_model.LogisticRegression,
-            shared_args={},
+            shared_args=dict(solver="lbfgs"),
             name="LogisticRegression",
             accepts_labels=True,
             accuracy_function=metrics.accuracy_score,
@@ -297,14 +299,6 @@ def all_algorithms():
             accepts_labels=False,
         ),
         AlgorithmPair(
-            umap.UMAP,
-            cuml.manifold.UMAP,
-            shared_args=dict(n_neighbors=5, n_epochs=500),
-            name="UMAP",
-            accepts_labels=False,
-            accuracy_function=cuml.metrics.trustworthiness,
-        ),
-        AlgorithmPair(
             None,
             cuml.linear_model.MBSGDClassifier,
             shared_args={},
@@ -329,6 +323,21 @@ def all_algorithms():
             bench_func=predict,
         ),
     ]
+
+    if has_umap():
+        algorithms.append(
+            AlgorithmPair(
+                umap.UMAP,
+                cuml.manifold.UMAP,
+                shared_args=dict(n_neighbors=5, n_epochs=500),
+                name="UMAP",
+                accepts_labels=False,
+                accuracy_function=cuml.metrics.trustworthiness,
+            )
+        )
+
+    return algorithms
+
 
 
 def algorithm_by_name(name):

--- a/python/cuml/benchmark/ci_benchmark.py
+++ b/python/cuml/benchmark/ci_benchmark.py
@@ -185,6 +185,7 @@ if __name__ == '__main__':
                         help='The OS type to include in reports')
     parser.add_argument('--report_machine_name', type=str, default="",
                         help='The machine name to include in reports')
+    parser.add_argument('--n-reps', type=int, default=3)
 
     args = parser.parse_args()
     invalidAlgoNames = (set(args.algo) - allAlgoNames)
@@ -193,7 +194,7 @@ if __name__ == '__main__':
 
     bench_to_run = bench_config[args.benchmark]
 
-    default_args = dict(run_cpu=False)
+    default_args = dict(run_cpu=False, n_reps=args.n_reps)
     all_results = []
     for cfg_in in bench_to_run:
         if (args.algo is None) or ("ALL" in args.algo) or \

--- a/python/cuml/benchmark/ci_benchmark.py
+++ b/python/cuml/benchmark/ci_benchmark.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
                         help='The OS type to include in reports')
     parser.add_argument('--report_machine_name', type=str, default="",
                         help='The machine name to include in reports')
-    parser.add_argument('--n-reps', type=int, default=3)
+    parser.add_argument('--n_reps', type=int, default=3)
 
     args = parser.parse_args()
     invalidAlgoNames = (set(args.algo) - allAlgoNames)

--- a/python/cuml/benchmark/run_benchmarks.py
+++ b/python/cuml/benchmark/run_benchmarks.py
@@ -147,6 +147,10 @@ if __name__ == '__main__':
         nargs='*',
         help='List of algorithms to run, or omit to run all',
     )
+    parser.add_argument(
+        '--n-reps',
+        type=int,
+        default=1)
     args = parser.parse_args()
 
     bench_rows = np.logspace(
@@ -186,7 +190,8 @@ if __name__ == '__main__':
         param_override_list=param_override_list,
         cuml_param_override_list=cuml_param_override_list,
         run_cpu=(not args.skip_cpu),
-        raise_on_error=args.raise_on_error
+        raise_on_error=args.raise_on_error,
+        n_reps=args.n_reps
     )
 
     if args.csv:

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -20,6 +20,7 @@ import time
 import numpy as np
 import pandas as pd
 
+
 class BenchmarkTimer:
     """Provides a context manager that runs a code block `reps` times
     and records results to the instance variable `timings`. Use like:
@@ -29,6 +30,7 @@ class BenchmarkTimer:
        ... do something ...
     print(np.min(timer.timings))
     """
+
     def __init__(self, reps=1):
         self.reps = reps
         self.timings = []
@@ -40,16 +42,18 @@ class BenchmarkTimer:
             t1 = time.time()
             self.timings.append(t1 - t0)
 
+
 class SpeedupComparisonRunner:
     """Wrapper to run an algorithm with multiple dataset sizes
     and compute speedup of cuml relative to sklearn baseline."""
 
     def __init__(
-            self, bench_rows,
-            bench_dims,
-            dataset_name='blobs',
-            input_type='numpy',
-            n_reps=1
+        self,
+        bench_rows,
+        bench_dims,
+        dataset_name="blobs",
+        input_type="numpy",
+        n_reps=1,
     ):
         self.bench_rows = bench_rows
         self.bench_dims = bench_dims
@@ -79,28 +83,29 @@ class SpeedupComparisonRunner:
         cuml_timer = BenchmarkTimer(self.n_reps)
         for rep in cuml_timer.benchmark_runs():
             algo_pair.run_cuml(
-                data, **param_overrides, **cuml_param_overrides, **setup_overrides
+                data,
+                **param_overrides,
+                **cuml_param_overrides,
+                **setup_overrides
             )
-        cu_elapsed = np.min(timer.timings)
+        cu_elapsed = np.min(cuml_timer.timings)
 
         if run_cpu and algo_pair.cpu_class is not None:
-            setup_overrides = algo_pair.set_up_cpu(
-                data, **param_overrides
-            )
+            setup_overrides = algo_pair.set_up_cpu(data, **param_overrides)
 
             cpu_timer = BenchmarkTimer(self.n_reps)
             for rep in cpu_timer.benchmark_runs():
-                algo_pair.run_cpu(
-                    data, **param_overrides, **setup_overrides
-                )
+                algo_pair.run_cpu(data, **param_overrides, **setup_overrides)
             cpu_elapsed = np.min(cpu_timer.timings)
         else:
             cpu_elapsed = 0.0
 
         speedup = cpu_elapsed / float(cu_elapsed)
         if verbose:
-            print("%s Speedup (n_samples=%s, n_features=%s) = %s" %
-                  (algo_pair.name, n_samples, n_features, speedup))
+            print(
+                "%s Speedup (n_samples=%s, n_features=%s) = %s"
+                % (algo_pair.name, n_samples, n_features, speedup)
+            )
 
         return dict(
             cu_time=cu_elapsed,
@@ -136,7 +141,7 @@ class SpeedupComparisonRunner:
                             cuml_param_overrides,
                             cpu_param_overrides,
                             run_cpu,
-                            verbose
+                            verbose,
                         )
                     )
                 except Exception as e:
@@ -159,12 +164,14 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
         self,
         bench_rows,
         bench_dims,
-        dataset_name='blobs',
-        input_type='numpy',
+        dataset_name="blobs",
+        input_type="numpy",
         test_fraction=0.10,
-        n_reps=1
+        n_reps=1,
     ):
-        super().__init__(bench_rows, bench_dims, dataset_name, input_type, n_reps)
+        super().__init__(
+            bench_rows, bench_dims, dataset_name, input_type, n_reps
+        )
         self.test_fraction = test_fraction
 
     def _run_one_size(
@@ -176,7 +183,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
         cuml_param_overrides={},
         cpu_param_overrides={},
         run_cpu=True,
-        verbose=False
+        verbose=False,
     ):
         data = datagen.gen_data(
             self.dataset_name,
@@ -204,7 +211,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             else:
                 X_test, y_test = data[2:]
 
-            if hasattr(cuml_model, 'predict'):
+            if hasattr(cuml_model, "predict"):
                 y_pred_cuml = cuml_model.predict(X_test)
             else:
                 y_pred_cuml = cuml_model.transform(X_test)
@@ -230,7 +237,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
                     X_test, y_test = algo_pair.cpu_data_prep_hook(data[2:])
                 else:
                     X_test, y_test = data[2:]
-                if hasattr(cpu_model, 'predict'):
+                if hasattr(cpu_model, "predict"):
                     y_pred_cpu = cpu_model.predict(X_test)
                 else:
                     y_pred_cpu = cpu_model.transform(X_test)
@@ -263,7 +270,7 @@ def run_variations(
     input_type="numpy",
     run_cpu=True,
     raise_on_error=False,
-    n_reps=1
+    n_reps=1,
 ):
     """
     Runs each algo in `algos` once per
@@ -306,7 +313,7 @@ def run_variations(
                 )
                 for r in results:
                     all_results.append(
-                        {'algo': algo.name, 'input': input_type, **r}
+                        {"algo": algo.name, "input": input_type, **r}
                     )
 
     print("Finished all benchmark runs")

--- a/python/cuml/test/test_benchmark.py
+++ b/python/cuml/test/test_benchmark.py
@@ -66,6 +66,27 @@ def test_run_variations():
     assert (res.n_samples == 100).sum() == 2
     assert (res.n_features == 20).sum() == 2
 
+def test_multi_reps():
+    class CountingAlgo:
+        tot_reps = 0
+        def fit(self, X, y):
+            CountingAlgo.tot_reps += 1
+
+    pair = algorithms.AlgorithmPair(
+        CountingAlgo,
+        CountingAlgo,
+        shared_args={},
+        name="Counting",
+    )
+
+    runner = AccuracyComparisonRunner(
+        [20], [5], dataset_name='zeros', test_fraction=0.20, n_reps=4
+    )
+    runner.run(pair)
+
+    # Double the n_reps since it is used in cpu and cuml versions
+    assert CountingAlgo.tot_reps == 8
+
 
 def test_accuracy_runner():
     # Set up data that should deliver accuracy of 0.20 if all goes right

--- a/python/cuml/test/test_benchmark.py
+++ b/python/cuml/test/test_benchmark.py
@@ -66,9 +66,11 @@ def test_run_variations():
     assert (res.n_samples == 100).sum() == 2
     assert (res.n_features == 20).sum() == 2
 
+
 def test_multi_reps():
     class CountingAlgo:
         tot_reps = 0
+
         def fit(self, X, y):
             CountingAlgo.tot_reps += 1
 

--- a/python/cuml/utils/cupy_utils.py
+++ b/python/cuml/utils/cupy_utils.py
@@ -65,7 +65,6 @@ def checked_cupy_unique(x):
     if has_cupy():
         import cupy as cp  # noqa: E402
         unique = checked_cupy_fn(cp.unique, x)
-
     else:
         warnings.warn("Using NumPy for number of class detection,"
                       "install CuPy for faster processing.")
@@ -74,6 +73,5 @@ def checked_cupy_unique(x):
         else:
             unique = np.unique(x.copy_to_host())
 
-        unique = cp.asarray(unique)
 
     return unique

--- a/python/cuml/utils/cupy_utils.py
+++ b/python/cuml/utils/cupy_utils.py
@@ -73,5 +73,4 @@ def checked_cupy_unique(x):
         else:
             unique = np.unique(x.copy_to_host())
 
-
     return unique

--- a/python/cuml/utils/import_utils.py
+++ b/python/cuml/utils/import_utils.py
@@ -45,6 +45,7 @@ def has_ucp():
     except ImportError:
         return False
 
+
 def has_umap():
     try:
         import umap  # NOQA

--- a/python/cuml/utils/import_utils.py
+++ b/python/cuml/utils/import_utils.py
@@ -45,6 +45,13 @@ def has_ucp():
     except ImportError:
         return False
 
+def has_umap():
+    try:
+        import umap  # NOQA
+        return True
+    except ImportError:
+        return False
+
 
 def has_treelite():
     try:


### PR DESCRIPTION
This allows you to run a cuml benchmark multiple times and report the min time to stabilize results. By default, the big command line UI uses 1 rep (current default) but CI defaults to 3. Honestly, 5 reps might be better for very short runs, but I think part of the answer there is to use larger datasets to not have such short, highly-variable benchmark runs.

I also added a missing algo (SVM) and allowed it to work if you don't have umap installed. Changing the solver in logistic to be explictly lbfgs removes an annoying warning message.