### PR TITLE
[REVIEW] [BUG] Improve SMO error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - PR #1314: Added options needed for ASVDb output (CUDA ver, etc.), added option to select algos
 - PR #1314: Added options needed for ASVDb output (CUDA ver, etc.), added option
   to select algos
-- PR #1335: Options to print available algorithms and datasets 
+- PR #1335: Options to print available algorithms and datasets
   in the Python benchmark
 - PR #1338: Remove BUILD_ABI references in CI scripts
 - PR #1340: Updated unit tests to uses larger dataset
@@ -46,8 +46,9 @@
 - PR #1330: Fix C++ unit test utils for better handling of differences near zero
 - PR #1342: Fix to prevent memory leakage in Lasso and ElasticNet
 - PR #1337: Fix k-means init from preset cluster centers
-- PR #1354  Fix SVM gamma=scale implementation
+- PR #1354: Fix SVM gamma=scale implementation
 - PR #1344: Change other solver based methods to create solver object in init
+- PR #1361: Improve SMO error handling
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/svm/smosolver.h
+++ b/cpp/src/svm/smosolver.h
@@ -20,6 +20,8 @@
 #include <math.h>
 #include <iostream>
 #include <limits>
+#include <string>
+#include <type_traits>
 
 #include "common/cumlHandle.hpp"
 #include "kernelcache.h"
@@ -249,10 +251,15 @@ class SmoSolver {
       keep_going = false;
     }
     if (diff < tol) keep_going = false;
-    // ASSERT(!isnan(diff), "SMO: NaN found during fitting")
     if (isnan(diff)) {
-      std::cout << "SMO error: NaN found during fitting\n";
-      keep_going = false;
+      std::string txt = "SMO error: NaN found during fitting.";
+      if (std::is_same<float, math_t>::value) {
+        txt +=
+          " This might be caused by floating point overflow. In such case using"
+          " fp64 could help. Alternatively, try gamma='scale' kernel"
+          " parameter.";
+      }
+      THROW(txt.c_str());
     }
     return keep_going;
   }

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -944,5 +944,5 @@ TYPED_TEST(SmoSolverTest, MemoryLeak) {
   EXPECT_EQ(delta, 0);
 }
 
-};  // namespace SVM
-};  // namespace ML
+};  // end namespace SVM
+};  // end namespace ML

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -23,6 +23,7 @@
 #include <cub/cub.cuh>
 #include <iostream>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include "common/cumlHandle.hpp"
 #include "linalg/binary_op.h"
@@ -889,9 +890,20 @@ TYPED_TEST(SmoSolverTest, BlobPredict) {
 }
 
 TYPED_TEST(SmoSolverTest, MemoryLeak) {
-  std::vector<std::pair<blobInput, smoOutput<TypeParam>>> data{
+  // We measure that we have the same amount of free memory available on the GPU
+  // before and after we call SVM. This can help catch memory leaks, but it is
+  // not 100% sure. Small allocations might be pooled together by cudaMalloc,
+  // and some of those would be missed by this method.
+  enum class ThrowException { Yes, No };
+  std::vector<std::pair<blobInput, ThrowException>> data{
     {blobInput{1, 0.001, KernelParams{LINEAR, 3, 0.01, 0}, 1000, 1000},
-     smoOutput<TypeParam>{34, {}, 0.0681913, {}, {}, {}}}};
+     ThrowException::No},
+    {blobInput{1, 0.001, KernelParams{POLYNOMIAL, 400, 5, 10}, 1000, 1000},
+     ThrowException::Yes}};
+  // For the second set of input parameters  training will fail, some kernel
+  // function values would be 1e400 or larger, which does not fit fp64.
+  // This will lead to NaN diff in SmoSolver, which whill throw an exception
+  // to stop fitting.
   size_t free1, total, free2;
   CUDA_CHECK(cudaMemGetInfo(&free1, &total));
   auto allocator = this->handle.getDeviceAllocator();
@@ -905,15 +917,27 @@ TYPED_TEST(SmoSolverTest, MemoryLeak) {
                this->handle.getImpl().getCublasHandle(), this->stream);
 
     SVC<TypeParam> svc(this->handle, p.C, p.tol, p.kernel_params);
-    svc.fit(x.data(), p.n_rows, p.n_cols, y.data());
-    device_buffer<TypeParam> y_pred(this->handle.getDeviceAllocator(),
-                                    this->stream, p.n_rows);
-    CUDA_CHECK(cudaStreamSynchronize(this->stream));
-    CUDA_CHECK(cudaMemGetInfo(&free2, &total));
-    float delta = (free1 - free2);
-    EXPECT_GT(delta, p.n_rows * p.n_cols * 4);
-    CUDA_CHECK(cudaStreamSynchronize(this->stream));
-    svc.predict(x.data(), p.n_rows, p.n_cols, y_pred.data());
+
+    if (d.second == ThrowException::Yes) {
+      // We want to check whether we leak any memory while we unwind the stack
+      EXPECT_THROW(svc.fit(x.data(), p.n_rows, p.n_cols, y.data()),
+                   MLCommon::Exception);
+    } else {
+      svc.fit(x.data(), p.n_rows, p.n_cols, y.data());
+      device_buffer<TypeParam> y_pred(this->handle.getDeviceAllocator(),
+                                      this->stream, p.n_rows);
+      CUDA_CHECK(cudaStreamSynchronize(this->stream));
+      CUDA_CHECK(cudaMemGetInfo(&free2, &total));
+      float delta = (free1 - free2);
+      // Just to make sure that we measure any mem consumption at all:
+      // we check if we see the memory consumption of x[n_rows*n_cols].
+      // If this error is triggered, increasing the test size might help to fix
+      // it (one could additionally control the exec time by the max_iter arg to
+      // SVC).
+      EXPECT_GT(delta, p.n_rows * p.n_cols * 4);
+      CUDA_CHECK(cudaStreamSynchronize(this->stream));
+      svc.predict(x.data(), p.n_rows, p.n_cols, y_pred.data());
+    }
   }
   CUDA_CHECK(cudaMemGetInfo(&free2, &total));
   float delta = (free1 - free2);
@@ -921,4 +945,4 @@ TYPED_TEST(SmoSolverTest, MemoryLeak) {
 }
 
 };  // namespace SVM
-};  // end namespace ML
+};  // namespace ML


### PR DESCRIPTION
This PR fixes #1352.

- [x] Raise an exception if NaN is found. 
- [x] Make sure we do not leak any memory during the process (add test).
- [x] If fp32 is used, then give a hint to the user to try with fp64
- [x] Improve the post processing routines to handle n_sv = 0