### PR TITLE
[REVIEW] --num-rows benchmark command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@
   in the Python benchmark
 - PR #1338: Remove BUILD_ABI references in CI scripts
 - PR #1340: Updated unit tests to uses larger dataset
-- PR #1351: Build treelite temporarily for GPU CI testing of FIL Scikit-learn model importing
+- PR #1351: Build treelite temporarily for GPU CI testing of FIL Scikit-learn
+  model importing
+- PR #1368: --num-rows benchmark command line argument
 
 ## Bug Fixes
 - PR #1281: Making rng.h threadsafe

--- a/python/cuml/benchmark/run_benchmarks.py
+++ b/python/cuml/benchmark/run_benchmarks.py
@@ -104,6 +104,13 @@ if __name__ == '__main__':
         default=2,
         help='Number of different sizes to test',
     )
+    parser.add_argument(
+        '--num-rows',
+        type=int,
+        default=None,
+        metavar='N',
+        help='Shortcut for --min-rows N --max-rows N --num-sizes 1'
+    )
     parser.add_argument('--num-features', type=int, default=-1)
     parser.add_argument(
         '--quiet', '-q', action='store_false', dest='verbose', default=True
@@ -176,7 +183,11 @@ if __name__ == '__main__':
         num=args.num_sizes,
         dtype=np.int32,
     )
+
     bench_dims = args.input_dimensions
+
+    if args.num_rows is not None:
+        bench_rows = [args.num_rows]
 
     if args.num_features > 0:
         bench_dims = [args.num_features]


### PR DESCRIPTION
`--num-rows N` is a shortcut for `--min-rows N --max-rows N --num-sizes 1`