### PR TITLE
[REVIEW] Fixing a cluster_std and centers in cuml.datasets.make_blobs and adding pytest asserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - PR #1337: Fix k-means init from preset cluster centers
 - PR #1354  Fix SVM gamma=scale implementation
 - PR #1344: Change other solver based methods to create solver object in init
+- PR #1373: Fixing a few small bugs in make_blobs and adding asserts to pytests
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/python/cuml/datasets/blobs.pyx
+++ b/python/cuml/datasets/blobs.pyx
@@ -37,9 +37,9 @@ from random import randint
 cdef extern from "cuml/datasets/make_blobs.hpp" namespace "ML::Datasets":
     cdef void make_blobs(const cumlHandle& handle,
                          float* out,
-                         long* labels,
-                         long n_rows,
-                         long n_cols,
+                         int* labels,
+                         int n_rows,
+                         int n_cols,
                          int n_clusters,
                          const float* centers,
                          const float* cluster_std,
@@ -51,10 +51,10 @@ cdef extern from "cuml/datasets/make_blobs.hpp" namespace "ML::Datasets":
 
     cdef void make_blobs(cumlHandle& handle,
                          double* out,
-                         long* labels,
-                         long n_rows,
-                         long n_cols,
-                         long n_clusters,
+                         int* labels,
+                         int n_rows,
+                         int n_cols,
+                         int n_clusters,
                          double* centers,
                          double* cluster_std,
                          double cluster_std_scalar,
@@ -148,7 +148,7 @@ def blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     out = zeros((n_samples, n_features), dtype=dtype, order='C')
     cdef uintptr_t out_ptr = get_dev_array_ptr(out)
 
-    labels = zeros(n_samples, dtype=np.int64)
+    labels = zeros(n_samples, dtype=np.int32)
     cdef uintptr_t labels_ptr = get_dev_array_ptr(labels)
 
     cdef uintptr_t centers_ptr
@@ -189,10 +189,10 @@ def blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     if dtype == np.float32:
         make_blobs(handle_[0],
                    <float*> out_ptr,
-                   <long*> labels_ptr,
-                   <long> n_samples,
-                   <long> n_features,
-                   <long> n_clusters,
+                   <int*> labels_ptr,
+                   <int> n_samples,
+                   <int> n_features,
+                   <int> n_clusters,
                    <float*> centers_ptr,
                    <float*> cluster_std_ptr,
                    <float> cluster_std,
@@ -204,10 +204,10 @@ def blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     else:
         make_blobs(handle_[0],
                    <double*> out_ptr,
-                   <long*> labels_ptr,
-                   <long> n_samples,
-                   <long> n_features,
-                   <long> n_clusters,
+                   <int*> labels_ptr,
+                   <int> n_samples,
+                   <int> n_features,
+                   <int> n_clusters,
                    <double*> centers_ptr,
                    <double*> cluster_std_ptr,
                    <double> cluster_std,

--- a/python/cuml/datasets/blobs.pyx
+++ b/python/cuml/datasets/blobs.pyx
@@ -157,18 +157,16 @@ def blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     if centers is not None:
         if isinstance(centers, int):
             n_clusters = centers
-            n_rows_centers = 1
 
         else:
             centers, centers_ptr, n_rows_centers, _, _ = \
-                input_to_dev_array(centers, convert_to_dtype=dtype,
+                input_to_dev_array(centers, order="C", convert_to_dtype=dtype,
                                    check_cols=n_features)
 
-            n_clusters = len(centers)
+            n_clusters = centers.shape[0]
 
     else:
         n_clusters = 3
-        n_rows_centers = 1
 
     cdef uintptr_t cluster_std_ptr
 
@@ -178,8 +176,8 @@ def blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     else:
         cluster_std_ary, cluster_std_ptr, _, _, _ = \
             input_to_dev_array(cluster_std, convert_to_dtype=dtype,
-                               check_cols=n_features,
-                               check_rows=n_rows_centers)
+                               check_cols=n_clusters,
+                               check_rows=1)
         cluster_std = -1.0
 
     center_box_min = center_box[0]

--- a/python/cuml/test/test_make_blobs.py
+++ b/python/cuml/test/test_make_blobs.py
@@ -107,8 +107,8 @@ centers_ary = [
 ]
 
 cluster_std_ary = [
-    np.random.uniform(size=(1, 10)),
-    np.random.uniform(size=(1, 10)),
+    np.random.uniform(low=-0.01, high=0.01, size=(1, 10)),
+    np.random.uniform(low=0.1, high=0.1, size=(1, 10)),
 ]
 
 

--- a/python/cuml/test/test_make_blobs.py
+++ b/python/cuml/test/test_make_blobs.py
@@ -106,17 +106,12 @@ centers_ary = [
     np.random.uniform(size=(10, 100))
 ]
 
-cluster_std_ary = [
-    np.random.uniform(low=-0.01, high=0.01, size=(1, 10)),
-    np.random.uniform(low=0.1, high=0.1, size=(1, 10)),
-]
-
 
 @pytest.mark.parametrize('dtype', dtype)
 @pytest.mark.parametrize('n_samples', n_samples)
 @pytest.mark.parametrize('n_features', n_features_ary)
 @pytest.mark.parametrize('centers', centers_ary)
-@pytest.mark.parametrize('cluster_std', cluster_std_ary)
+@pytest.mark.parametrize('cluster_std', cluster_std)
 @pytest.mark.parametrize('center_box', center_box)
 @pytest.mark.parametrize('shuffle', shuffle)
 @pytest.mark.parametrize('random_state', random_state)
@@ -125,7 +120,7 @@ def test_make_blobs_ary_parameters(dtype, n_samples, n_features,
                                    shuffle, random_state):
 
     centers = centers.astype(np.dtype(dtype))
-    cluster_std = cluster_std.astype(np.dtype(dtype))
+    cluster_std = np.full(shape=(1, 10), fill_value=cluster_std, dtype=dtype)
 
     if centers.shape[1] != n_features or cluster_std.shape[1] != centers.shape[0]:
         with pytest.raises(ValueError):

--- a/python/cuml/test/test_make_blobs.py
+++ b/python/cuml/test/test_make_blobs.py
@@ -17,6 +17,8 @@ import cuml
 import pytest
 import numpy as np
 
+from sklearn.metrics import adjusted_rand_score
+
 
 # Testing parameters for scalar parameter tests
 
@@ -25,23 +27,23 @@ dtype = [
     'double'
 ]
 
-n_samples = [10, 100000]
+n_samples = [100, 1000]
 
 n_features = [
     2,
     10,
-    1000
+    100
 ]
 
 centers = [
     None,
     2,
-    1000,
+    50,
 ]
 
 cluster_std = [
-    0.5,
-    2.0,
+    0.01,
+    0.1
 ]
 
 center_box = [
@@ -75,7 +77,7 @@ def test_make_blobs_scalar_parameters(dtype, n_samples, n_features, centers,
 
     out, labels = cuml.make_blobs(dtype=dtype, n_samples=n_samples,
                                   n_features=n_features, centers=centers,
-                                  cluster_std=cluster_std,
+                                  cluster_std=0.001,
                                   center_box=center_box, shuffle=shuffle,
                                   random_state=random_state)
 
@@ -96,17 +98,17 @@ def test_make_blobs_scalar_parameters(dtype, n_samples, n_features, centers,
 # Parameters for array tests
 n_features_ary = [
     2,
-    1000
+    100
 ]
 
 centers_ary = [
     np.random.uniform(size=(10, 2)),
-    np.random.uniform(size=(10, 1000))
+    np.random.uniform(size=(10, 100))
 ]
 
 cluster_std_ary = [
-    np.random.uniform(size=(1, 2)),
-    np.random.uniform(size=(1, 1000)),
+    np.random.uniform(size=(1, 10)),
+    np.random.uniform(size=(1, 10)),
 ]
 
 
@@ -125,7 +127,7 @@ def test_make_blobs_ary_parameters(dtype, n_samples, n_features,
     centers = centers.astype(np.dtype(dtype))
     cluster_std = cluster_std.astype(np.dtype(dtype))
 
-    if centers.shape[1] != n_features or cluster_std.shape[0] != n_features:
+    if centers.shape[1] != n_features or cluster_std.shape[1] != centers.shape[0]:
         with pytest.raises(ValueError):
             out, labels = \
                 cuml.make_blobs(dtype=dtype, n_samples=n_samples,
@@ -135,6 +137,7 @@ def test_make_blobs_ary_parameters(dtype, n_samples, n_features,
                                 random_state=random_state)
 
     else:
+
         out, labels = \
             cuml.make_blobs(dtype=dtype, n_samples=n_samples,
                             n_features=n_features, centers=centers,
@@ -146,5 +149,14 @@ def test_make_blobs_ary_parameters(dtype, n_samples, n_features,
         assert labels.shape == (n_samples,), "labels shape mismatch"
 
         labels_np = labels.copy_to_host()
-        assert np.unique(labels_np).shape == (len(centers),), \
+        out_np = out.copy_to_host()
+
+        assert np.unique(labels_np).shape == (centers.shape[0],), \
             "unexpected number of clusters"
+
+        # Use kmeans to verify k cluster centers
+        from sklearn.cluster import KMeans
+        model = KMeans(n_clusters=centers.shape[0])
+        model.fit(np.array(out_np))
+
+        assert adjusted_rand_score(model.labels_, labels_np)

--- a/python/cuml/test/test_make_blobs.py
+++ b/python/cuml/test/test_make_blobs.py
@@ -122,7 +122,8 @@ def test_make_blobs_ary_parameters(dtype, n_samples, n_features,
     centers = centers.astype(np.dtype(dtype))
     cluster_std = np.full(shape=(1, 10), fill_value=cluster_std, dtype=dtype)
 
-    if centers.shape[1] != n_features or cluster_std.shape[1] != centers.shape[0]:
+    if centers.shape[1] != n_features or \
+            cluster_std.shape[1] != centers.shape[0]:
         with pytest.raises(ValueError):
             out, labels = \
                 cuml.make_blobs(dtype=dtype, n_samples=n_samples,

--- a/python/cuml/test/test_mbsgd_classifier.py
+++ b/python/cuml/test/test_mbsgd_classifier.py
@@ -82,7 +82,7 @@ def test_mbsgd_classifier_default(datatype, nrows, column_info):
     X = X.astype(datatype)
     y = y.astype(datatype)
     X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.8,
-                                                        random_state=10)
+                                                        random_state=0)
 
     y_train = y_train.astype(datatype)
     y_test = y_test.astype(datatype)
@@ -99,4 +99,4 @@ def test_mbsgd_classifier_default(datatype, nrows, column_info):
 
     cu_acc = accuracy_score(cu_pred, y_test)
     skl_acc = accuracy_score(skl_pred, y_test)
-    assert cu_acc >= skl_acc - 0.02
+    assert cu_acc >= skl_acc - 0.05


### PR DESCRIPTION
I encountered this while troubleshooting some odd behavior I was seeing in #1226. There was a path through the pytest that wasn't being executed because of the conditional logic in the test. Added assert to make sure kmeans can find the blobs.