### PR TITLE
[REVIEW] Fix memory leaks in ARIMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PR #1354: Fix SVM gamma=scale implementation
 - PR #1344: Change other solver based methods to create solver object in init
 - PR #1361: Improve SMO error handling
+- PR #1380: Fix memory leaks in ARIMA
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/cpp/src/arima/batched_arima.cu
+++ b/cpp/src/arima/batched_arima.cu
@@ -125,6 +125,9 @@ void forecast(cumlHandle& handle, int num_steps, int p, int d, int q,
         }
       });
   }
+
+  alloc->deallocate(d_y_, (p + num_steps) * batch_size, stream);
+  alloc->deallocate(d_vs_, (q + num_steps) * batch_size, stream);
 }
 
 void predict_in_sample(cumlHandle& handle, double* d_y, int num_batches,
@@ -174,6 +177,10 @@ void predict_in_sample(cumlHandle& handle, double* d_y, int num_batches,
                      counting + num_batches, [=] __device__(int bid) {
                        d_y_p[bid * nobs + (nobs - 1)] = d_y_fc[bid];
                      });
+    handle.getDeviceAllocator()->deallocate(
+      d_y_diff, sizeof(double) * num_batches * (nobs - 1), handle.getStream());
+    handle.getDeviceAllocator()->deallocate(
+      d_y_fc, sizeof(double) * num_batches, handle.getStream());
   }
 }
 


### PR DESCRIPTION
ARIMA is missing a few `deallocate`, which causes a RMM memory error on large datasets.

*Wondering why I found this literally 2 minutes after we finally merged ARIMA*