### PR TITLE
[REVIEW] Lower expectations on some batched matrix tests to avoid intermittent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PR #1354: Fix SVM gamma=scale implementation
 - PR #1344: Change other solver based methods to create solver object in init
 - PR #1361: Improve SMO error handling
+- PR #1384: Lower expectations on batched matrix tests to prevent CI failures
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/cpp/test/prims/batched_matrix.cu
+++ b/cpp/test/prims/batched_matrix.cu
@@ -234,10 +234,10 @@ const std::vector<BatchedMatrixInputs<double>> inputsd = {
 
 // Test parameters (op, n_batches, m, n, p, q, tolerance)
 const std::vector<BatchedMatrixInputs<float>> inputsf = {
-  {AB_op, 7, 15, 37, 37, 11, 1e-6},   {AZT_op, 5, 33, 65, 1, 1, 1e-6},
-  {ZA_op, 8, 12, 41, 1, 1, 1e-6},     {ApB_op, 4, 16, 48, 16, 48, 1e-6},
-  {AmB_op, 17, 9, 3, 9, 3, 1e-6},     {AkB_op, 5, 3, 13, 31, 8, 1e-6},
-  {AkB_op, 3, 7, 12, 31, 15, 1e-6},   {AkB_op, 2, 11, 2, 8, 46, 1e-6},
+  {AB_op, 7, 15, 37, 37, 11, 1e-3},   {AZT_op, 5, 33, 65, 1, 1, 1e-3},
+  {ZA_op, 8, 12, 41, 1, 1, 1e-3},     {ApB_op, 4, 16, 48, 16, 48, 1e-5},
+  {AmB_op, 17, 9, 3, 9, 3, 1e-5},     {AkB_op, 5, 3, 13, 31, 8, 1e-5},
+  {AkB_op, 3, 7, 12, 31, 15, 1e-5},   {AkB_op, 2, 11, 2, 8, 46, 1e-5},
   {AsolveZ_op, 6, 17, 17, 1, 1, 1e-3}};
 
 using BatchedMatrixTestD = BatchedMatrixTest<double>;


### PR DESCRIPTION
CI is failing intermittently because these tests have an expection of precision of 1e-6 for a float matrix product. That's too short. Lowering the expectations to prevent intermittent failures.