### PR TITLE
[REVIEW] Update API docs for 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - PR #1362: device_buffer in UMAP + Sparse prims
 - PR #1357: Run benchmarks multiple times for CI
 - PR #1382: ARIMA optimization: move functions to C++ side
+- PR #1431: Updated API docs
 
 ## Bug Fixes
 - PR #1281: Making rng.h threadsafe

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -248,10 +248,16 @@ Random Forest
     :members:
 
 
-Principal Component Analysis
------------------------------
+Dimensionality Reduction
+------------------------
 
 .. autoclass:: cuml.dask.decomposition.PCA
+    :members:
+
+Truncated SVD
+--------------
+
+.. autoclass:: cuml.dask.decomposition.TruncatedSVD
     :members:
 
 Nearest Neighbors

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -248,9 +248,15 @@ Random Forest
     :members:
 
 
-Dimensionality Reduction
-------------------------
+Nearest Neighbors
+-----------------
 
+.. autoclass:: cuml.dask.neighbors.NearestNeighbors
+    :members:
+
+
+Principal Component Analysis
+-----------------------------
 .. autoclass:: cuml.dask.decomposition.PCA
     :members:
 
@@ -258,10 +264,4 @@ Truncated SVD
 --------------
 
 .. autoclass:: cuml.dask.decomposition.TruncatedSVD
-    :members:
-
-Nearest Neighbors
------------------
-
-.. autoclass:: cuml.dask.neighbors.NearestNeighbors
     :members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -229,6 +229,13 @@ Kalman Filter
 .. autoclass:: cuml.KalmanFilter
     :members:
 
+ARIMA
+-----
+
+.. autoclass:: cuml.tsa.ARIMAModel
+    :members:
+
+
 Multi-Node, Multi-GPU Algorithms
 ================================
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,10 +19,17 @@ Label Encoding
  .. autoclass:: cuml.preprocessing.LabelEncoder
     :members:
 
-Dataset Generation
-------------------
+Dataset Generation (Single-GPU)
+-------------------------------
 
   .. automethod:: cuml.datasets.make_blobs
+
+
+Dataset Generation (Dask)
+-------------------------
+  .. automodule:: cuml.dask.datasets.blobs
+     :members:
+
 
 Metrics
 ---------
@@ -62,6 +69,13 @@ Utilities for I/O and Numba
   .. automodule:: cuml.utils.numba_utils
     :members:
 
+Utilities for Dask and Multi-GPU Preprocessing
+-----------------------------------------------
+
+  .. automodule:: cuml.dask.common.utils
+     :members:
+  
+
 Regression and Classification
 =============================
 
@@ -72,7 +86,7 @@ Linear Regression
     :members:
 
 Logistic Regression
------------------
+-------------------
 
 .. autoclass:: cuml.LogisticRegression
     :members:
@@ -96,13 +110,13 @@ ElasticNet Regression
     :members:
 
 Mini Batch SGD Classifier 
----------------------
+-------------------------
 
 .. autoclass:: cuml.MBSGDClassifier
     :members:
 
 Mini Batch SGD Regressor
----------------------
+------------------------
 
 .. autoclass:: cuml.MBSGDRegressor
     :members:
@@ -231,4 +245,17 @@ Random Forest
     :members:
 
 .. autoclass:: cuml.dask.ensemble.RandomForestRegressor
+    :members:
+
+
+Principal Component Analysis
+-----------------------------
+
+.. autoclass:: cuml.dask.decomposition.PCA
+    :members:
+
+Nearest Neighbors
+-----------------
+
+.. autoclass:: cuml.dask.neighbors.NearestNeighbors
     :members:

--- a/python/cuml/dask/datasets/blobs.py
+++ b/python/cuml/dask/datasets/blobs.py
@@ -77,21 +77,35 @@ def make_blobs(nrows, ncols, centers=8, n_parts=None, cluster_std=1.0,
     For more information on Scikit-learn's `make_blobs:
     <https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_blobs.html>`_.
 
-    :param nrows : number of rows
-    :param ncols : number of features
-    :param n_centers : number of centers to generate
-    :param n_parts : number of partitions to generate (this can be greater
-    than the number of workers)
-    :param cluster_std : how far can each generated point deviate from its
-    closest centroid?
-    :param center_box : the bounding box which constrains all the centroids
-    :param random_state : sets random seed
-    :param verbose : enables / disables verbose printing.
-    :param dtype : (default = np.float32) datatype to generate
-    :param output : (default = 'dataframe') whether to generate dask array or
-    dask dataframe output. Default will be array soon.
+    Parameters
+    ----------
 
-    :return: (dask.Dataframe for X, dask.Series for labels)
+    nrows : int
+        number of rows
+    ncols : int
+        number of features
+    n_centers : int
+        number of centers to generate
+    n_parts : int
+        number of partitions to generate (this can be greater
+        than the number of workers)
+    cluster_std : float
+         standard deviation of points around centroid
+    center_box : tuple (int, int, int, int)
+         the bounding box which constrains all the centroids
+    random_state : float
+         sets random seed
+    verbose : bool
+         enables / disables verbose printing.
+    dtype : dtype (default = np.float32)
+         datatype to generate
+    output : str (default = 'dataframe')
+         whether to generate dask array or
+         dask dataframe output. Default will be array in the future.
+
+    Returns
+    -------
+         (dask.Dataframe for X, dask.Series for labels)
     """
 
     client = default_client()

--- a/python/cuml/dask/datasets/blobs.py
+++ b/python/cuml/dask/datasets/blobs.py
@@ -84,18 +84,18 @@ def make_blobs(nrows, ncols, centers=8, n_parts=None, cluster_std=1.0,
         number of rows
     ncols : int
         number of features
-    n_centers : int
+    n_centers : int (default = 8)
         number of centers to generate
-    n_parts : int
+    n_parts : int (default = None)
         number of partitions to generate (this can be greater
         than the number of workers)
-    cluster_std : float
+    cluster_std : float (default = 1.0)
          standard deviation of points around centroid
-    center_box : tuple (int, int, int, int)
+    center_box : tuple (int, int) (default = (-10, 10))
          the bounding box which constrains all the centroids
-    random_state : float
-         sets random seed
-    verbose : bool
+    random_state : int (default = None)
+         sets random seed (or use None to reinitialize each time)
+    verbose : bool (default = False)
          enables / disables verbose printing.
     dtype : dtype (default = np.float32)
          datatype to generate

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -204,6 +204,14 @@ class RandomForestClassifier(Base):
     histogram-based algorithms to determine splits, rather than an exact
     count. You can tune the size of the histograms with the n_bins parameter.
 
+    **Known Limitations**: This is an early release of the cuML
+    Random Forest code. It contains a few known limitations:
+
+       * GPU-based inference is only supported if the model was trained
+         with 32-bit (float32) datatypes
+       * Very deep / very wide models may exhaust available GPU memory.
+         Future versions of cuML will provide an alternative algorithm to
+         reduce memory consumption.
 
     Examples
     ---------

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -208,7 +208,8 @@ class RandomForestClassifier(Base):
     Random Forest code. It contains a few known limitations:
 
        * GPU-based inference is only supported if the model was trained
-         with 32-bit (float32) datatypes
+         with 32-bit (float32) datatypes. CPU-based inference may be used
+         in this case as a slower fallback.
        * Very deep / very wide models may exhaust available GPU memory.
          Future versions of cuML will provide an alternative algorithm to
          reduce memory consumption.

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -182,10 +182,18 @@ class RandomForestRegressor(Base):
     histogram-based algorithm to determine splits, rather than an exact
     count. You can tune the size of the histograms with the n_bins parameter.
 
-    **Known Limitations**: This is an initial release of the cuML
+    **Known Limitations**: This is an early release of the cuML
     Random Forest code. It contains a few known limitations:
 
+<<<<<<< HEAD
        * Instances of RandomForestRegressor cannot be fully pickled currently.
+=======
+       * GPU-based inference is only supported if the model was trained
+         with 32-bit (float32) datatypes
+       * Very deep / very wide models may exhaust available GPU memory.
+         Future versions of cuML will provide an alternative algorithm to
+         reduce memory consumption.
+>>>>>>> Doc improvements for 0.11
 
     Examples
     ---------

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -185,15 +185,12 @@ class RandomForestRegressor(Base):
     **Known Limitations**: This is an early release of the cuML
     Random Forest code. It contains a few known limitations:
 
-<<<<<<< HEAD
-       * Instances of RandomForestRegressor cannot be fully pickled currently.
-=======
        * GPU-based inference is only supported if the model was trained
-         with 32-bit (float32) datatypes
+         with 32-bit (float32) datatypes CPU-based inference may be used
+         in this case as a slower fallback.
        * Very deep / very wide models may exhaust available GPU memory.
          Future versions of cuML will provide an alternative algorithm to
          reduce memory consumption.
->>>>>>> Doc improvements for 0.11
 
     Examples
     ---------

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -323,8 +323,9 @@ class LinearRegression(Base):
             When set to True, the predict method will, when necessary, convert
             the input to the data type which was used to train the model. This
             will increase memory used for the method.
+
         Returns
-        ----------
+        -------
         y: cuDF DataFrame
            Dense vector (floats or doubles) of shape (n_samples, 1)
 

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -51,6 +51,7 @@ class LogisticRegression(Base):
     regularization
     - Limited Memory BFGS (L-BFGS) otherwise.
 
+
     Note that, just like in Scikit-learn, the bias will not be regularized.
 
     Examples
@@ -89,6 +90,7 @@ class LogisticRegression(Base):
     Output:
 
     .. code-block:: python
+
         Coefficients:
                     0.22309814
                     0.21012752

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -30,6 +30,7 @@ class MBSGDClassifier:
     Examples
     ---------
     .. code-block:: python
+
         import numpy as np
         import cudf
         from cuml.linear_model import MBSGDClassifier as cumlMBSGDClassifier
@@ -52,8 +53,11 @@ class MBSGDClassifier:
         print(" cuML intercept : ", cu_mbsgd_classifier.intercept_)
         print(" cuML coef : ", cu_mbsgd_classifier.coef_)
         print("cuML predictions : ", cu_pred)
+
     Output:
+
     .. code-block:: python
+
         cuML intercept :  0.7150013446807861
         cuML coef :  0    0.27320495
                     1     0.1875956

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -30,6 +30,7 @@ class MBSGDRegressor:
     Examples
     ---------
     .. code-block:: python
+
         import numpy as np
         import cudf
         from cuml.linear_model import MBSGDRegressor as cumlMBSGDRegressor

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -43,6 +43,7 @@ class LabelEncoder(object):
     Converting a categorical implementation to a numerical one
 
     .. code-block:: python
+
         from cudf import DataFrame, Series
 
         data = DataFrame({'category': ['a', 'b', 'c', 'd']})
@@ -79,6 +80,7 @@ class LabelEncoder(object):
     Output:
 
     .. code-block:: python
+
         0    0
         1    1
         2    2
@@ -124,7 +126,7 @@ class LabelEncoder(object):
         Fit a LabelEncoder (nvcategory) instance to a set of categories
 
         Parameters
-        ---------
+        ----------
         y : cudf.Series
             Series containing the categories to be encoded. It's elements
             may or may not be unique
@@ -157,7 +159,7 @@ class LabelEncoder(object):
             categories given to `fit`
 
         Returns
-        ------
+        -------
         encoded : cudf.Series
             The ordinally encoded input series
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -156,6 +156,7 @@ class QN(Base):
     Output:
 
     .. code-block:: python
+
         Coefficients:
                     10.647417
                     0.3267412

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -128,6 +128,7 @@ class SGD(Base):
     Examples
     ---------
     .. code-block:: python
+
         import numpy as np
         import cudf
         from cuml.solvers import SGD as cumlSGD
@@ -146,7 +147,8 @@ class SGD(Base):
         print(" cuML intercept : ", cu_sgd.intercept_)
         print(" cuML coef : ", cu_sgd.coef_)
         print("cuML predictions : ", cu_pred)
-    Output:
+
+    *Output*:
     .. code-block:: python
 
         cuML intercept :  0.004561662673950195
@@ -441,6 +443,7 @@ class SGD(Base):
     def predictClass(self, X, convert_dtype=False):
         """
         Predicts the y for X.
+
         Parameters
         ----------
         X : array-like (device or host) shape = (n_samples, n_features)
@@ -452,9 +455,10 @@ class SGD(Base):
             When set to True, the predictClass method will automatically
             convert the input to the data type which was used to train the
             model. This will increase memory used for the method.
+
         Returns
         ----------
-        y: cuDF DataFrame
+        y : cuDF DataFrame
            Dense vector (floats or doubles) of shape (n_samples, 1)
         """
 

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -95,19 +95,15 @@ class ExponentialSmoothing(Base):
     other minor ways:
 
         * .__init__() : Cannot pass trend component or damped trend component
-
         * .__init__() : this version can take additional parameter eps,
                         start_periods, ts_num, and handle
-
         * .score() : returns SSE rather than gradient logL
                      https://github.com/rapidsai/cuml/issues/876
-
         * this version provides get_level(), get_trend(), get_season()
 
     Examples
     ---------
     .. code-block:: python
-
 
             from cuml import ExponentialSmoothing
             import cudf
@@ -127,7 +123,7 @@ class ExponentialSmoothing(Base):
 
     Output:
 
-    .. code-block:: none
+    .. code-block:: python
 
             Forecasted points :
             0    4.000143766093652

--- a/python/cuml/utils/input_utils.py
+++ b/python/cuml/utils/input_utils.py
@@ -77,23 +77,18 @@ def input_to_dev_array(X, order='F', deepcopy=False,
 
     Acceptable input formats:
 
-    * cuDF Dataframe - returns a deep copy always
-
+    * cuDF Dataframe - returns a deep copy always.
     * cuDF Series - returns by reference or a deep copy depending on
-        `deepcopy`
-
+        `deepcopy`.
     * Numpy array - returns a copy in device always
-
     * cuda array interface compliant array (like Cupy) - returns a
-        reference unless `deepcopy`=True
-
+        reference unless `deepcopy`=True.
     * numba device array - returns a reference unless deepcopy=True
 
     Parameters
-        ----------
+    ----------
 
-    X:
-        cuDF.DataFrame, cuDF.Series, numba array, NumPy array or any
+    X : cuDF.DataFrame, cuDF.Series, numba array, NumPy array or any
         cuda_array_interface compliant array like CuPy or pytorch.
 
     order: string (default: 'F')


### PR DESCRIPTION
This change adds several new algorithms (MNMG) to API docs. It also adds some missing utilities.

I cleaned up doc formatting issues as I found them. In particular, if you have `code-block` with no blank line, Sphinx will swallow the whole block, ouch, so I fixed those.

There are still a few formatting oddities we've had forever that are not solved - especially how sphinx will format some elements of an unordered list differently from others. (See the acceptable input formats in input_to_dev_array here for an example: https://rapidsai.github.io/projects/cuml/en/0.11.0/api.html#cuml.utils.input_utils.input_to_dev_array). Those still need further work, but I think this change can stand without them.

Closes Issue #1402 