### PR TITLE
FIX Remove unused CUDA conda labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PR #1408: Updated pickle tests to delete the pre-pickled model to prevent pointer leakage
 - PR #1357: Run benchmarks multiple times for CI
 - PR #1382: ARIMA optimization: move functions to C++ side
+- PR #1441: Remove unused CUDA conda labels
 
 ## Bug Fixes
 - PR #1281: Making rng.h threadsafe

--- a/ci/cpu/cuml/upload-anaconda.sh
+++ b/ci/cpu/cuml/upload-anaconda.sh
@@ -11,7 +11,7 @@ if [ "$BUILD_CUML" == "1" ]; then
 
   SOURCE_BRANCH=master
 
-  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}

--- a/ci/cpu/cuml/upload-anaconda.sh
+++ b/ci/cpu/cuml/upload-anaconda.sh
@@ -7,7 +7,7 @@ set -e
 if [ "$BUILD_CUML" == "1" ]; then
   CUDA_REL=${CUDA_VERSION%.*}
 
-  export UPLOADFILE=`conda build conda/recipes/cuml -c conda-forge -c numba -c conda-forge/label/rc_ucx -c rapidsai/label/cuda${CUDA_REL} -c nvidia/label/cuda${CUDA_REL} -c pytorch -c defaults --python=${PYTHON} --output`
+  export UPLOADFILE=`conda build conda/recipes/cuml -c conda-forge -c numba -c conda-forge/label/rc_ucx -c rapidsai -c nvidia -c pytorch -c defaults --python=${PYTHON} --output`
 
   SOURCE_BRANCH=master
 

--- a/ci/cpu/libcuml/upload-anaconda.sh
+++ b/ci/cpu/libcuml/upload-anaconda.sh
@@ -7,11 +7,11 @@ set -e
 if [ "$BUILD_LIBCUML" == "1" ]; then
   CUDA_REL=${CUDA_VERSION%.*}
 
-  export UPLOADFILE=`conda build conda/recipes/libcuml -c conda-forge -c numba -c conda-forge/label/rc_ucx -c nvidia/label/cuda${CUDA_REL} -c rapidsai/label/cuda${CUDA_REL} -c pytorch -c defaults --python=${PYTHON} --output`
+  export UPLOADFILE=`conda build conda/recipes/libcuml -c conda-forge -c numba -c conda-forge/label/rc_ucx -c nvidia -c rapidsai -c pytorch -c defaults --python=${PYTHON} --output`
 
   SOURCE_BRANCH=master
 
-  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -41,7 +41,7 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install -c rapidsai/label/cuda$CUDA_REL -c rapidsai-nightly/label/cuda$CUDA_REL -c conda-forge \
+conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge \
     cudf=$CUDF_VERSION rmm=$RMM_VERSION cudatoolkit=$CUDA_REL
 
 pip install numpydoc sphinx sphinx-rtd-theme sphinxcontrib-websupport


### PR DESCRIPTION
We no longer rely on these labels for version matching and use `cudatoolkit` package to do so.