### PR TITLE
Improved performance of FIL sparse trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PR #1408: Updated pickle tests to delete the pre-pickled model to prevent pointer leakage
 - PR #1357: Run benchmarks multiple times for CI
 - PR #1382: ARIMA optimization: move functions to C++ side
+- PR #1445: Improved performance of FIL sparse trees
 
 ## Bug Fixes
 - PR #1281: Making rng.h threadsafe

--- a/cpp/include/cuml/fil/fil.h
+++ b/cpp/include/cuml/fil/fil.h
@@ -91,6 +91,8 @@ struct sparse_node_t {
   float val;
   int bits;
   int left_idx;
+  // pad the size to 16 bytes to match sparse_node
+  // (in cpp/src/fil/common.cuh)
   int dummy;
 };
 

--- a/cpp/include/cuml/fil/fil.h
+++ b/cpp/include/cuml/fil/fil.h
@@ -91,6 +91,7 @@ struct sparse_node_t {
   float val;
   int bits;
   int left_idx;
+  int dummy;
 };
 
 /** dense_node_init initializes node from paramters */

--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -103,6 +103,7 @@ struct dense_storage {
 /** sparse_node is a single node in a sparse forest */
 struct alignas(16) sparse_node : base_node {
   int left_idx;
+  // pad the size to 16 bytes to match sparse_node_t (in fil.h)
   int dummy;
   __host__ __device__ sparse_node() : left_idx(0), base_node() {}
   sparse_node(sparse_node_t node)

--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -101,8 +101,9 @@ struct dense_storage {
 };
 
 /** sparse_node is a single node in a sparse forest */
-struct sparse_node : base_node {
+struct alignas(16) sparse_node : base_node {
   int left_idx;
+  int dummy;
   __host__ __device__ sparse_node() : left_idx(0), base_node() {}
   sparse_node(sparse_node_t node)
     : base_node(dense_node_t{node.val, node.bits}), left_idx(node.left_idx) {}


### PR DESCRIPTION
- aligned `sparse_node` to 16 bytes