### PR TITLE
[HOTFIX][REVIEW] Adding kneighbors classifier / regressor to API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PR #1431: Updated API docs
 - PR #1441: Remove unused CUDA conda labels
 - PR #1439: Match sklearn 0.22 default n_estimators for RF and fix test errors
+- PR #1461: Add kneighbors to API docs
 
 ## Bug Fixes
 - PR #1281: Making rng.h threadsafe

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -137,7 +137,7 @@ Random Forest
     :members:
 
 Forest Inferencing
--------------------------
+------------------
 
 .. autoclass:: cuml.ForestInference
     :members:
@@ -152,6 +152,18 @@ Support Vector Machines
 ------------------------
 
 .. autoclass:: cuml.svm.SVC
+    :members:
+
+Nearest Neighbors Classification
+--------------------------------
+
+.. autoclass:: cuml.neighbors.KNeighborsClassifier
+    :members:
+
+Nearest Neighbors Regression
+----------------------------
+
+.. autoclass:: cuml.neighbors.KNeighborsRegressor
     :members:
 
 Clustering
@@ -211,7 +223,19 @@ Neighbors
 Nearest Neighbors
 -----------------
 
-.. autoclass:: cuml.NearestNeighbors
+.. autoclass:: cuml.neighbors.NearestNeighbors
+    :members:
+
+Nearest Neighbors Classification
+--------------------------------
+
+.. autoclass:: cuml.neighbors.KNeighborsClassifier
+    :members:
+
+Nearest Neighbors Classification
+--------------------------------
+
+.. autoclass:: cuml.neighbors.KNeighborsRegressor
     :members:
 
 Time Series


### PR DESCRIPTION
These are 2 new algorithms in release 0.11. I noticed they were missing from the docs when creating notebooks for them. 