### PR TITLE
[REVIEW] Updates to clang format workflow to make it more usable and robust

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,7 +11,7 @@ To install cuML from source, ensure the following dependencies are met:
 5. Cython (>= 0.29)
 6. gcc (>=5.4.0)
 7. BLAS - Any BLAS compatible with cmake's [FindBLAS](https://cmake.org/cmake/help/v3.14/module/FindBLAS.html). Note that the blas has to be installed to the same folder system as cmake, for example if using conda installed cmake, the blas implementation should also be installed in the conda environment.
-8. clang-format (= 8.0.0) - enforces uniform C++ coding style; required to build cuML from source. The RAPIDS conda channel provides a package. If not using conda, install using your OS package manager.
+8. clang-format (= 8.0.0) - enforces uniform C++ coding style; required for developers. The RAPIDS conda channel provides a package. If not using conda, install using your OS package manager.
 9. NCCL (>=2.4)
 10. UCX [optional] (>= 1.7) - enables point-to-point messaging in the cuML standard communicator. This is necessary for many multi-node multi-GPU cuML algorithms to function.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -11,7 +11,7 @@ To install cuML from source, ensure the following dependencies are met:
 5. Cython (>= 0.29)
 6. gcc (>=5.4.0)
 7. BLAS - Any BLAS compatible with cmake's [FindBLAS](https://cmake.org/cmake/help/v3.14/module/FindBLAS.html). Note that the blas has to be installed to the same folder system as cmake, for example if using conda installed cmake, the blas implementation should also be installed in the conda environment.
-8. clang-format (= 8.0.0) - enforces uniform C++ coding style; required for developers. The RAPIDS conda channel provides a package. If not using conda, install using your OS package manager.
+8. clang-format (= 8.0.0) - enforces uniform C++ coding style; required for developers. The RAPIDS conda channel provides a package (`conda install -c rapidsai libclang`). If not using conda, install using your OS package manager.
 9. NCCL (>=2.4)
 10. UCX [optional] (>= 1.7) - enables point-to-point messaging in the cuML standard communicator. This is necessary for many multi-node multi-GPU cuML algorithms to function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #1468: C++: updates to clang format flow to make it more usable among devs
 
 ## Bug Fixes
 

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -66,18 +66,7 @@ fi
 
 # Check for a consistent code format
 # TODO: keep adding more dirs when we add more source folders in cuml
-FORMAT=`python cpp/scripts/run-clang-format.py \
-               cpp/bench \
-               cpp/comms/mpi/include \
-               cpp/comms/mpi/src \
-               cpp/comms/std/include \
-               cpp/comms/std/src \
-               cpp/include \
-               cpp/examples \
-               cpp/src \
-               cpp/src_prims \
-               cpp/test \
-               2>&1`
+FORMAT=`python cpp/scripts/run-clang-format.py 2>&1`
 FORMAT_RETVAL=$?
 if [ "$RETVAL" = "0" ]; then
   RETVAL=$FORMAT_RETVAL

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -64,4 +64,32 @@ else
   echo -e "\n\n>>>> PASSED: #include check\n\n"
 fi
 
+# Check for a consistent code format
+# TODO: keep adding more dirs when we add more source folders in cuml
+FORMAT=`python cpp/scripts/run-clang-format.py \
+               cpp/bench \
+               cpp/comms/mpi/include \
+               cpp/comms/mpi/src \
+               cpp/comms/std/include \
+               cpp/comms/std/src \
+               cpp/include \
+               cpp/examples \
+               cpp/src \
+               cpp/src_prims \
+               cpp/test \
+               2>&1`
+FORMAT_RETVAL=$?
+if [ "$RETVAL" = "0" ]; then
+  RETVAL=$FORMAT_RETVAL
+fi
+
+# Output results if failure otherwise show pass
+if [ "$FORMAT_RETVAL" != "0" ]; then
+  echo -e "\n\n>>>> FAILED: clang format check; begin output\n\n"
+  echo -e "$FORMAT"
+  echo -e "\n\n>>>> FAILED: clang format check; end output\n\n"
+else
+  echo -e "\n\n>>>> PASSED: clang format check\n\n"
+fi
+
 exit $RETVAL

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -44,6 +44,10 @@ env
 logger "Activate conda env..."
 source activate gdf
 
+# installing libclang separately so it doesn't get installed from conda-forge
+conda install -c rapidsai \
+      libclang=8.0.0
+
 logger "Check versions..."
 python --version
 gcc --version

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -44,10 +44,6 @@ env
 logger "Activate conda env..."
 source activate gdf
 
-# installing libclang separately so it doesn't get installed from conda-forge
-conda install -c rapidsai \
-      libclang=8.0.0
-
 logger "Check versions..."
 python --version
 gcc --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -65,7 +65,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
 
 # installing libclang separately so it doesn't get installed from conda-forge
 conda install -c rapidsai \
-      libclang
+      libclang=8.0.0
 
 logger "Check versions..."
 python --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -62,11 +62,6 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       "statsmodels" \
       "xgboost=0.90.rapidsdev1"
 
-
-# installing libclang separately so it doesn't get installed from conda-forge
-conda install -c rapidsai \
-      libclang=8.0.0
-
 logger "Check versions..."
 python --version
 $CC --version

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -128,9 +128,6 @@ set(Protobuf_USE_STATIC_LIBS ON)
 find_package(Protobuf REQUIRED)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-find_package(ClangFormat 8.0.0 EXACT REQUIRED)
-# TODO: enable this when we are ready!
-#find_package(ClangTidy 8.0.0 EXACT REQUIRED)
 
 ##############################################################################
 # - External Dependencies-----------------------------------------------------
@@ -240,13 +237,6 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 
 set(CMAKE_CUDA_FLAGS
   "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=unrecognized_gcc_pragma")
-
-##############################################################################
-# - clang-format targets -----------------------------------------------------
-
-add_clang_format(
-  DSTDIR ${PROJECT_BINARY_DIR}/clang-format
-  SRCDIR ${PROJECT_SOURCE_DIR})
 
 ##############################################################################
 # - Cloning header only libraries---------------------------------------------
@@ -423,8 +413,6 @@ if(BUILD_CUML_CPP_LIBRARY)
   endif(NVTX)
 
   target_link_libraries(${CUML_CPP_TARGET} ${CUML_LINK_LIBRARIES})
-  add_dependencies(${CUML_CPP_TARGET} ${ClangFormat_TARGET})
-
 endif(BUILD_CUML_CPP_LIBRARY)
 
 ##############################################################################
@@ -456,7 +444,7 @@ endif(BUILD_CUML_TESTS OR BUILD_CUML_MG_TESTS OR BUILD_PRIMS_TESTS)
 # - build comms ------------------------------------------------------------------------
 
 if(BUILD_CUML_STD_COMMS)
-	add_subdirectory(comms/std)
+  add_subdirectory(comms/std)
 endif(BUILD_CUML_STD_COMMS)
 
 if(BUILD_CUML_MPI_COMMS)

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -62,5 +62,4 @@ add_executable(${CUML_SG_BENCH_TARGET}
   sg/rf_regressor.cu
   )
 
-add_dependencies(${CUML_SG_BENCH_TARGET} ${ClangFormat_TARGET})
 target_link_libraries(${CUML_SG_BENCH_TARGET} ${ML_BENCH_LINK_LIBRARIES})

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -50,7 +50,6 @@ if(BUILD_CUML_BENCH)
     ${CUML_CPP_TARGET}
     benchmarklib
     )
-
   # (please keep the filenames in alphabetical order)
   add_executable(${CUML_SG_BENCH_TARGET}
     sg/dbscan.cu
@@ -59,8 +58,6 @@ if(BUILD_CUML_BENCH)
     sg/rf_classifier.cu
     sg/rf_regressor.cu
     )
-
-  add_dependencies(${CUML_SG_BENCH_TARGET} ${ClangFormat_TARGET})
   target_link_libraries(${CUML_SG_BENCH_TARGET} ${ML_BENCH_LINK_LIBRARIES})
   target_include_directories(${CUML_SG_BENCH_TARGET}
     PRIVATE ${GBENCH_DIR}/include)

--- a/cpp/comms/mpi/include/cuML_comms.hpp
+++ b/cpp/comms/mpi/include/cuML_comms.hpp
@@ -23,4 +23,4 @@ namespace ML {
 
 void initialize_mpi_comms(cumlHandle& handle, MPI_Comm comm);
 
-} // end namespace ML
+}  // end namespace ML

--- a/cpp/comms/mpi/src/cuML_comms_mpi_impl.cpp
+++ b/cpp/comms/mpi/src/cuML_comms_mpi_impl.cpp
@@ -16,350 +16,355 @@
 
 #include "cuML_comms_mpi_impl.hpp"
 
-#include <memory>
 #include <cstdio>
+#include <memory>
 
-#include <cuML_comms.hpp>
 #include <common/cumlHandle.hpp>
+#include <cuML_comms.hpp>
 
 #include <utils.h>
 
-#define MPI_CHECK(call)                                                             \
-  do {                                                                              \
-    int status = call;                                                              \
-    if ( MPI_SUCCESS != status ) {                                                  \
-        int mpi_error_string_lenght = 0;                                            \
-        char mpi_error_string[MPI_MAX_ERROR_STRING];                                \
-        MPI_Error_string(status, mpi_error_string, &mpi_error_string_lenght);       \
-        ASSERT(MPI_SUCCESS == status, "ERROR: MPI call='%s'. Reason:%s\n", #call,   \
-            mpi_error_string);                                                      \
-    }                                                                               \
+#define MPI_CHECK(call)                                                     \
+  do {                                                                      \
+    int status = call;                                                      \
+    if (MPI_SUCCESS != status) {                                            \
+      int mpi_error_string_lenght = 0;                                      \
+      char mpi_error_string[MPI_MAX_ERROR_STRING];                          \
+      MPI_Error_string(status, mpi_error_string, &mpi_error_string_lenght); \
+      ASSERT(MPI_SUCCESS == status, "ERROR: MPI call='%s'. Reason:%s\n",    \
+             #call, mpi_error_string);                                      \
+    }                                                                       \
   } while (0)
 
 //@todo adapt logging infrastructure for MPI_CHECK_NO_THROW once available:
 //https://github.com/rapidsai/cuml/issues/100
-#define MPI_CHECK_NO_THROW(call)                                            \
-  do {                                                                      \
-    int status = call;                                                      \
-    if ( MPI_SUCCESS != status ) {                                          \
-      int mpi_error_string_lenght = 0;                                      \
-      char mpi_error_string[MPI_MAX_ERROR_STRING];                          \
-      MPI_Error_string(status, mpi_error_string, &mpi_error_string_lenght); \
-      std::fprintf(stderr,                                                  \
-          "ERROR: MPI call='%s' at file=%s line=%d failed with %s ",        \
-          #call, __FILE__, __LINE__, mpi_error_string );                    \
-    }                                                                       \
-  } while(0)
+#define MPI_CHECK_NO_THROW(call)                                              \
+  do {                                                                        \
+    int status = call;                                                        \
+    if (MPI_SUCCESS != status) {                                              \
+      int mpi_error_string_lenght = 0;                                        \
+      char mpi_error_string[MPI_MAX_ERROR_STRING];                            \
+      MPI_Error_string(status, mpi_error_string, &mpi_error_string_lenght);   \
+      std::fprintf(stderr,                                                    \
+                   "ERROR: MPI call='%s' at file=%s line=%d failed with %s ", \
+                   #call, __FILE__, __LINE__, mpi_error_string);              \
+    }                                                                         \
+  } while (0)
 
-#define NCCL_CHECK(call)                                                        \
-  do {                                                                          \
-    ncclResult_t status = call;                                                 \
-    ASSERT(ncclSuccess == status, "ERROR: NCCL call='%s'. Reason:%s\n", #call,  \
-        ncclGetErrorString(status));                                            \
-  } while(0)
+#define NCCL_CHECK(call)                                                       \
+  do {                                                                         \
+    ncclResult_t status = call;                                                \
+    ASSERT(ncclSuccess == status, "ERROR: NCCL call='%s'. Reason:%s\n", #call, \
+           ncclGetErrorString(status));                                        \
+  } while (0)
 
 //@todo adapt logging infrastructure for NCCL_CHECK_NO_THROW once available:
 //https://github.com/rapidsai/cuml/issues/100
-#define NCCL_CHECK_NO_THROW(call)                                       \
-  do {                                                                  \
-    ncclResult_t status = call;                                         \
-    if ( ncclSuccess != status ) {                                      \
-      std::fprintf(stderr,                                              \
-          "ERROR: NCCL call='%s' at file=%s line=%d failed with %s ",   \
-          #call, __FILE__, __LINE__, ncclGetErrorString(status) );      \
-    }                                                                   \
-  } while(0)
+#define NCCL_CHECK_NO_THROW(call)                                              \
+  do {                                                                         \
+    ncclResult_t status = call;                                                \
+    if (ncclSuccess != status) {                                               \
+      std::fprintf(stderr,                                                     \
+                   "ERROR: NCCL call='%s' at file=%s line=%d failed with %s ", \
+                   #call, __FILE__, __LINE__, ncclGetErrorString(status));     \
+    }                                                                          \
+  } while (0)
 
 namespace ML {
 
 namespace {
-    size_t getDatatypeSize( const cumlMPICommunicator_impl::datatype_t datatype )
-    {
-        switch ( datatype )
-        {
-            case MLCommon::cumlCommunicator::CHAR:
-                return sizeof(char);
-            case MLCommon::cumlCommunicator::UINT8:
-                return sizeof(unsigned char);
-            case MLCommon::cumlCommunicator::INT:
-                return sizeof(int);
-            case MLCommon::cumlCommunicator::UINT:
-                return sizeof(unsigned int);
-            case MLCommon::cumlCommunicator::INT64:
-                return sizeof(long long int);
-            case MLCommon::cumlCommunicator::UINT64:
-                return sizeof(unsigned long long int);
-            case MLCommon::cumlCommunicator::FLOAT:
-                return sizeof(float);
-            case MLCommon::cumlCommunicator::DOUBLE:
-                return sizeof(double);
-        }
-    }
+size_t getDatatypeSize(const cumlMPICommunicator_impl::datatype_t datatype) {
+  switch (datatype) {
+    case MLCommon::cumlCommunicator::CHAR:
+      return sizeof(char);
+    case MLCommon::cumlCommunicator::UINT8:
+      return sizeof(unsigned char);
+    case MLCommon::cumlCommunicator::INT:
+      return sizeof(int);
+    case MLCommon::cumlCommunicator::UINT:
+      return sizeof(unsigned int);
+    case MLCommon::cumlCommunicator::INT64:
+      return sizeof(long long int);
+    case MLCommon::cumlCommunicator::UINT64:
+      return sizeof(unsigned long long int);
+    case MLCommon::cumlCommunicator::FLOAT:
+      return sizeof(float);
+    case MLCommon::cumlCommunicator::DOUBLE:
+      return sizeof(double);
+  }
+}
 
-    MPI_Datatype getMPIDatatype( const cumlMPICommunicator_impl::datatype_t datatype )
-    {
-        switch ( datatype )
-        {
-            case MLCommon::cumlCommunicator::CHAR:
-                return MPI_CHAR;
-            case MLCommon::cumlCommunicator::UINT8:
-                return MPI_UNSIGNED_CHAR;
-            case MLCommon::cumlCommunicator::INT:
-                return MPI_INT;
-            case MLCommon::cumlCommunicator::UINT:
-                return MPI_UNSIGNED;
-            case MLCommon::cumlCommunicator::INT64:
-                return MPI_LONG_LONG;
-            case MLCommon::cumlCommunicator::UINT64:
-                return MPI_UNSIGNED_LONG_LONG;
-            case MLCommon::cumlCommunicator::FLOAT:
-                return MPI_FLOAT;
-            case MLCommon::cumlCommunicator::DOUBLE:
-                return MPI_DOUBLE;
-        }
-    }
+MPI_Datatype getMPIDatatype(
+  const cumlMPICommunicator_impl::datatype_t datatype) {
+  switch (datatype) {
+    case MLCommon::cumlCommunicator::CHAR:
+      return MPI_CHAR;
+    case MLCommon::cumlCommunicator::UINT8:
+      return MPI_UNSIGNED_CHAR;
+    case MLCommon::cumlCommunicator::INT:
+      return MPI_INT;
+    case MLCommon::cumlCommunicator::UINT:
+      return MPI_UNSIGNED;
+    case MLCommon::cumlCommunicator::INT64:
+      return MPI_LONG_LONG;
+    case MLCommon::cumlCommunicator::UINT64:
+      return MPI_UNSIGNED_LONG_LONG;
+    case MLCommon::cumlCommunicator::FLOAT:
+      return MPI_FLOAT;
+    case MLCommon::cumlCommunicator::DOUBLE:
+      return MPI_DOUBLE;
+  }
+}
 
-    MPI_Op getMPIOp( const cumlMPICommunicator_impl::op_t op )
-    {
-        switch ( op )
-        {
-            case MLCommon::cumlCommunicator::SUM:
-                return MPI_SUM;
-            case MLCommon::cumlCommunicator::PROD:
-                return MPI_PROD;
-            case MLCommon::cumlCommunicator::MIN:
-                return MPI_MIN;
-            case MLCommon::cumlCommunicator::MAX:
-                return MPI_MAX;
-        }
-    }
+MPI_Op getMPIOp(const cumlMPICommunicator_impl::op_t op) {
+  switch (op) {
+    case MLCommon::cumlCommunicator::SUM:
+      return MPI_SUM;
+    case MLCommon::cumlCommunicator::PROD:
+      return MPI_PROD;
+    case MLCommon::cumlCommunicator::MIN:
+      return MPI_MIN;
+    case MLCommon::cumlCommunicator::MAX:
+      return MPI_MAX;
+  }
+}
 
 #ifdef HAVE_NCCL
-    ncclDataType_t getNCCLDatatype( const cumlMPICommunicator_impl::datatype_t datatype )
-    {
-        switch ( datatype )
-        {
-            case MLCommon::cumlCommunicator::CHAR:
-                return ncclChar;
-            case MLCommon::cumlCommunicator::UINT8:
-                return ncclUint8;
-            case MLCommon::cumlCommunicator::INT:
-                return ncclInt;
-            case MLCommon::cumlCommunicator::UINT:
-                return ncclUint32;
-            case MLCommon::cumlCommunicator::INT64:
-                return ncclInt64;
-            case MLCommon::cumlCommunicator::UINT64:
-                return ncclUint64;
-            case MLCommon::cumlCommunicator::FLOAT:
-                return ncclFloat;
-            case MLCommon::cumlCommunicator::DOUBLE:
-                return ncclDouble;
-        }
-    }
+ncclDataType_t getNCCLDatatype(
+  const cumlMPICommunicator_impl::datatype_t datatype) {
+  switch (datatype) {
+    case MLCommon::cumlCommunicator::CHAR:
+      return ncclChar;
+    case MLCommon::cumlCommunicator::UINT8:
+      return ncclUint8;
+    case MLCommon::cumlCommunicator::INT:
+      return ncclInt;
+    case MLCommon::cumlCommunicator::UINT:
+      return ncclUint32;
+    case MLCommon::cumlCommunicator::INT64:
+      return ncclInt64;
+    case MLCommon::cumlCommunicator::UINT64:
+      return ncclUint64;
+    case MLCommon::cumlCommunicator::FLOAT:
+      return ncclFloat;
+    case MLCommon::cumlCommunicator::DOUBLE:
+      return ncclDouble;
+  }
+}
 
-    ncclRedOp_t getNCCLOp( const cumlMPICommunicator_impl::op_t op )
-    {
-        switch ( op )
-        {
-            case MLCommon::cumlCommunicator::SUM:
-                return ncclSum;
-            case MLCommon::cumlCommunicator::PROD:
-                return ncclProd;
-            case MLCommon::cumlCommunicator::MIN:
-                return ncclMin;
-            case MLCommon::cumlCommunicator::MAX:
-                return ncclMax;
-        }
-    }
+ncclRedOp_t getNCCLOp(const cumlMPICommunicator_impl::op_t op) {
+  switch (op) {
+    case MLCommon::cumlCommunicator::SUM:
+      return ncclSum;
+    case MLCommon::cumlCommunicator::PROD:
+      return ncclProd;
+    case MLCommon::cumlCommunicator::MIN:
+      return ncclMin;
+    case MLCommon::cumlCommunicator::MAX:
+      return ncclMax;
+  }
+}
+#endif
+}  // namespace
+
+void initialize_mpi_comms(cumlHandle& handle, MPI_Comm comm) {
+  auto communicator = std::make_shared<MLCommon::cumlCommunicator>(
+    std::unique_ptr<MLCommon::cumlCommunicator_iface>(
+      new cumlMPICommunicator_impl(comm)));
+  handle.getImpl().setCommunicator(communicator);
+}
+
+cumlMPICommunicator_impl::cumlMPICommunicator_impl(MPI_Comm comm,
+                                                   const bool owns_mpi_comm)
+  : _owns_mpi_comm(owns_mpi_comm),
+    _mpi_comm(comm),
+    _size(0),
+    _rank(1),
+    _next_request_id(0) {
+  int mpi_is_initialized = 0;
+  MPI_CHECK(MPI_Initialized(&mpi_is_initialized));
+  ASSERT(mpi_is_initialized, "ERROR: MPI is not initialized!");
+  MPI_CHECK(MPI_Comm_size(_mpi_comm, &_size));
+  MPI_CHECK(MPI_Comm_rank(_mpi_comm, &_rank));
+#ifdef HAVE_NCCL
+  //get NCCL unique ID at rank 0 and broadcast it to all others
+  ncclUniqueId id;
+  if (0 == _rank) NCCL_CHECK(ncclGetUniqueId(&id));
+  MPI_CHECK(MPI_Bcast((void*)&id, sizeof(id), MPI_BYTE, 0, _mpi_comm));
+
+  //initializing NCCL
+  NCCL_CHECK(ncclCommInitRank(&_nccl_comm, _size, id, _rank));
 #endif
 }
 
-void initialize_mpi_comms(cumlHandle& handle, MPI_Comm comm)
-{
-    auto communicator = std::make_shared<MLCommon::cumlCommunicator>( 
-         std::unique_ptr<MLCommon::cumlCommunicator_iface>( new cumlMPICommunicator_impl(comm) ) );
-    handle.getImpl().setCommunicator( communicator );
-}
-
-cumlMPICommunicator_impl::cumlMPICommunicator_impl(MPI_Comm comm, const bool owns_mpi_comm)
-    : _owns_mpi_comm(owns_mpi_comm), _mpi_comm(comm), _size(0), _rank(1), _next_request_id(0)
-{
-    int mpi_is_initialized = 0;
-    MPI_CHECK( MPI_Initialized(&mpi_is_initialized) );
-    ASSERT( mpi_is_initialized, "ERROR: MPI is not initialized!" );
-    MPI_CHECK( MPI_Comm_size( _mpi_comm, &_size ) );
-    MPI_CHECK( MPI_Comm_rank( _mpi_comm, &_rank ) );
+cumlMPICommunicator_impl::~cumlMPICommunicator_impl() {
 #ifdef HAVE_NCCL
-    //get NCCL unique ID at rank 0 and broadcast it to all others
-    ncclUniqueId id;
-    if ( 0 == _rank ) NCCL_CHECK(ncclGetUniqueId(&id));
-    MPI_CHECK(MPI_Bcast((void *)&id, sizeof(id), MPI_BYTE, 0, _mpi_comm));
-
-    //initializing NCCL
-    NCCL_CHECK(ncclCommInitRank(&_nccl_comm, _size, id, _rank));
+  //finalizing NCCL
+  NCCL_CHECK_NO_THROW(ncclCommDestroy(_nccl_comm));
 #endif
+  if (_owns_mpi_comm) {
+    MPI_CHECK_NO_THROW(MPI_Comm_free(&_mpi_comm));
+  }
 }
 
-cumlMPICommunicator_impl::~cumlMPICommunicator_impl()
-{
+int cumlMPICommunicator_impl::getSize() const { return _size; }
+
+int cumlMPICommunicator_impl::getRank() const { return _rank; }
+
+std::unique_ptr<MLCommon::cumlCommunicator_iface>
+cumlMPICommunicator_impl::commSplit(int color, int key) const {
+  MPI_Comm new_comm;
+  MPI_CHECK(MPI_Comm_split(_mpi_comm, color, key, &new_comm));
+  return std::unique_ptr<MLCommon::cumlCommunicator_iface>(
+    new cumlMPICommunicator_impl(new_comm, true));
+}
+
+void cumlMPICommunicator_impl::barrier() const {
+  MPI_CHECK(MPI_Barrier(_mpi_comm));
+}
+
+void cumlMPICommunicator_impl::isend(const void* buf, int size, int dest,
+                                     int tag, request_t* request) const {
+  MPI_Request mpi_req;
+  request_t req_id;
+  if (_free_requests.empty()) {
+    req_id = _next_request_id++;
+  } else {
+    auto it = _free_requests.begin();
+    req_id = *it;
+    _free_requests.erase(it);
+  }
+  MPI_CHECK(MPI_Isend(buf, size, MPI_BYTE, dest, tag, _mpi_comm, &mpi_req));
+  _requests_in_flight.insert(std::make_pair(req_id, mpi_req));
+  *request = req_id;
+}
+
+void cumlMPICommunicator_impl::irecv(void* buf, int size, int source, int tag,
+                                     request_t* request) const {
+  if (source == CUML_ANY_SOURCE) source = MPI_ANY_SOURCE;
+
+  MPI_Request mpi_req;
+  request_t req_id;
+  if (_free_requests.empty()) {
+    req_id = _next_request_id++;
+  } else {
+    auto it = _free_requests.begin();
+    req_id = *it;
+    _free_requests.erase(it);
+  }
+
+  MPI_CHECK(MPI_Irecv(buf, size, MPI_BYTE, source, tag, _mpi_comm, &mpi_req));
+  _requests_in_flight.insert(std::make_pair(req_id, mpi_req));
+  *request = req_id;
+}
+
+void cumlMPICommunicator_impl::waitall(int count,
+                                       request_t array_of_requests[]) const {
+  std::vector<MPI_Request> requests;
+  requests.reserve(count);
+  for (int i = 0; i < count; ++i) {
+    auto req_it = _requests_in_flight.find(array_of_requests[i]);
+    ASSERT(_requests_in_flight.end() != req_it,
+           "ERROR: waitall on invalid request: %d", array_of_requests[i]);
+    requests.push_back(req_it->second);
+    _free_requests.insert(req_it->first);
+    _requests_in_flight.erase(req_it);
+  }
+  MPI_CHECK(MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE));
+}
+
+void cumlMPICommunicator_impl::allreduce(const void* sendbuff, void* recvbuff,
+                                         int count, datatype_t datatype,
+                                         op_t op, cudaStream_t stream) const {
 #ifdef HAVE_NCCL
-    //finalizing NCCL
-    NCCL_CHECK_NO_THROW( ncclCommDestroy(_nccl_comm) );
-#endif
-    if (_owns_mpi_comm)
-    {
-        MPI_CHECK_NO_THROW(MPI_Comm_free(&_mpi_comm));
-    }
-}
-
-int cumlMPICommunicator_impl::getSize() const
-{
-    return _size;
-}
-
-int cumlMPICommunicator_impl::getRank() const
-{
-    return _rank;
-}
-
-std::unique_ptr<MLCommon::cumlCommunicator_iface> cumlMPICommunicator_impl::commSplit( int color, int key ) const
-{
-    MPI_Comm new_comm;
-    MPI_CHECK( MPI_Comm_split(_mpi_comm, color, key, &new_comm) );
-    return std::unique_ptr<MLCommon::cumlCommunicator_iface>(new cumlMPICommunicator_impl(new_comm,true));
-}
-
-void cumlMPICommunicator_impl::barrier() const
-{
-    MPI_CHECK( MPI_Barrier( _mpi_comm ) );
-}
-
-void cumlMPICommunicator_impl::isend(const void *buf, int size, int dest, int tag, request_t *request) const
-{
-    MPI_Request mpi_req;
-    request_t req_id;
-    if ( _free_requests.empty() )
-    {
-        req_id = _next_request_id++;
-    }
-    else
-    {
-        auto it = _free_requests.begin();
-        req_id = *it;
-        _free_requests.erase(it);
-    }
-    MPI_CHECK( MPI_Isend(buf, size, MPI_BYTE, dest, tag, _mpi_comm, &mpi_req) );
-    _requests_in_flight.insert( std::make_pair( req_id, mpi_req ) );
-    *request = req_id;
-}
-
-void cumlMPICommunicator_impl::irecv(void *buf, int size, int source, int tag, request_t *request) const
-{
-    if(source == CUML_ANY_SOURCE)
-      source = MPI_ANY_SOURCE;
-
-    MPI_Request mpi_req;
-    request_t req_id;
-    if ( _free_requests.empty() )
-    {
-        req_id = _next_request_id++;
-    }
-    else
-    {
-        auto it = _free_requests.begin();
-        req_id = *it;
-        _free_requests.erase(it);
-    }
-
-    MPI_CHECK( MPI_Irecv(buf, size, MPI_BYTE, source, tag, _mpi_comm, &mpi_req) );
-    _requests_in_flight.insert( std::make_pair( req_id, mpi_req ) );
-    *request = req_id;
-}
-
-void cumlMPICommunicator_impl::waitall(int count, request_t array_of_requests[]) const
-{
-    std::vector<MPI_Request> requests;
-    requests.reserve(count);
-    for ( int i = 0; i < count; ++i )
-    {
-         auto req_it = _requests_in_flight.find( array_of_requests[i] );
-         ASSERT( _requests_in_flight.end() != req_it, "ERROR: waitall on invalid request: %d", array_of_requests[i] );
-         requests.push_back( req_it->second );
-         _free_requests.insert( req_it->first );
-        _requests_in_flight.erase( req_it );
-    }
-    MPI_CHECK( MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE) );
-}
-
-void cumlMPICommunicator_impl::allreduce(const void* sendbuff, void* recvbuff, int count, datatype_t datatype, op_t op, cudaStream_t stream) const
-{
-#ifdef HAVE_NCCL
-    NCCL_CHECK( ncclAllReduce(sendbuff, recvbuff, count, getNCCLDatatype( datatype ), getNCCLOp( op ), _nccl_comm, stream) );
+  NCCL_CHECK(ncclAllReduce(sendbuff, recvbuff, count, getNCCLDatatype(datatype),
+                           getNCCLOp(op), _nccl_comm, stream));
 #else
-    CUDA_CHECK( cudaStreamSynchronize( stream ) );
-    MPI_CHECK( MPI_Allreduce(sendbuff, recvbuff, count, getMPIDatatype( datatype ), getMPIOp( op ), _mpi_comm) );
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Allreduce(sendbuff, recvbuff, count, getMPIDatatype(datatype),
+                          getMPIOp(op), _mpi_comm));
 #endif
 }
 
-void cumlMPICommunicator_impl::bcast(void* buff, int count, datatype_t datatype, int root, cudaStream_t stream) const
-{
+void cumlMPICommunicator_impl::bcast(void* buff, int count, datatype_t datatype,
+                                     int root, cudaStream_t stream) const {
 #ifdef HAVE_NCCL
-    NCCL_CHECK( ncclBroadcast(buff, buff, count, getNCCLDatatype( datatype ), root, _nccl_comm, stream) );
+  NCCL_CHECK(ncclBroadcast(buff, buff, count, getNCCLDatatype(datatype), root,
+                           _nccl_comm, stream));
 #else
-    CUDA_CHECK( cudaStreamSynchronize( stream ) );
-    MPI_CHECK( MPI_Bcast(buff, count, getMPIDatatype( datatype ), root, _mpi_comm) );
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Bcast(buff, count, getMPIDatatype(datatype), root, _mpi_comm));
 #endif
 }
 
-void cumlMPICommunicator_impl::reduce(const void* sendbuff, void* recvbuff, int count, datatype_t datatype, op_t op, int root, cudaStream_t stream) const
-{
+void cumlMPICommunicator_impl::reduce(const void* sendbuff, void* recvbuff,
+                                      int count, datatype_t datatype, op_t op,
+                                      int root, cudaStream_t stream) const {
 #ifdef HAVE_NCCL
-    NCCL_CHECK( ncclReduce(sendbuff, recvbuff, count, getNCCLDatatype( datatype ), getNCCLOp( op ), root, _nccl_comm, stream) );
+  NCCL_CHECK(ncclReduce(sendbuff, recvbuff, count, getNCCLDatatype(datatype),
+                        getNCCLOp(op), root, _nccl_comm, stream));
 #else
-    CUDA_CHECK( cudaStreamSynchronize( stream ) );
-    MPI_CHECK( MPI_Reduce(sendbuff, recvbuff, count, getMPIDatatype( datatype ), getMPIOp( op ), root, _mpi_comm) );
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Reduce(sendbuff, recvbuff, count, getMPIDatatype(datatype),
+                       getMPIOp(op), root, _mpi_comm));
 #endif
 }
 
-void cumlMPICommunicator_impl::allgather(const void* sendbuff, void* recvbuff, int sendcount, datatype_t datatype, cudaStream_t stream) const
-{
+void cumlMPICommunicator_impl::allgather(const void* sendbuff, void* recvbuff,
+                                         int sendcount, datatype_t datatype,
+                                         cudaStream_t stream) const {
 #ifdef HAVE_NCCL
-    NCCL_CHECK( ncclAllGather(sendbuff, recvbuff, sendcount, getNCCLDatatype( datatype ), _nccl_comm, stream) );
+  NCCL_CHECK(ncclAllGather(sendbuff, recvbuff, sendcount,
+                           getNCCLDatatype(datatype), _nccl_comm, stream));
 #else
-    CUDA_CHECK( cudaStreamSynchronize( stream ) );
-    MPI_CHECK( MPI_Allgather(sendbuff, sendcount, getMPIDatatype( datatype ), recvbuff, sendcount, getMPIDatatype( datatype ), _mpi_comm) );
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Allgather(sendbuff, sendcount, getMPIDatatype(datatype),
+                          recvbuff, sendcount, getMPIDatatype(datatype),
+                          _mpi_comm));
 #endif
 }
 
-void cumlMPICommunicator_impl::allgatherv(const void *sendbuf, void *recvbuf, const int recvcounts[], const int displs[], datatype_t datatype, cudaStream_t stream) const
-{
+void cumlMPICommunicator_impl::allgatherv(const void* sendbuf, void* recvbuf,
+                                          const int recvcounts[],
+                                          const int displs[],
+                                          datatype_t datatype,
+                                          cudaStream_t stream) const {
 #ifdef HAVE_NCCL
-    //From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" - https://arxiv.org/pdf/1812.05964.pdf
-    //Listing 1 on page 4.
-    for (int root = 0; root < _size; ++root) {
-        NCCL_CHECK( ncclBroadcast(sendbuf, static_cast<char*>(recvbuf)+displs[root]*getDatatypeSize( datatype ), recvcounts[root], getNCCLDatatype( datatype ), root, _nccl_comm, stream) );
-    }
+  //From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" - https://arxiv.org/pdf/1812.05964.pdf
+  //Listing 1 on page 4.
+  for (int root = 0; root < _size; ++root) {
+    NCCL_CHECK(ncclBroadcast(
+      sendbuf,
+      static_cast<char*>(recvbuf) + displs[root] * getDatatypeSize(datatype),
+      recvcounts[root], getNCCLDatatype(datatype), root, _nccl_comm, stream));
+  }
 #else
-    CUDA_CHECK( cudaStreamSynchronize( stream ) );
-    MPI_CHECK( MPI_Allgatherv(sendbuf, recvcounts[_rank], getMPIDatatype( datatype ), recvbuf, recvcounts, displs, getMPIDatatype( datatype ), _mpi_comm) );
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Allgatherv(sendbuf, recvcounts[_rank], getMPIDatatype(datatype),
+                           recvbuf, recvcounts, displs,
+                           getMPIDatatype(datatype), _mpi_comm));
 #endif
 }
 
-void cumlMPICommunicator_impl::reducescatter(const void* sendbuff, void* recvbuff, int recvcount, datatype_t datatype, op_t op, cudaStream_t stream) const
-{
+void cumlMPICommunicator_impl::reducescatter(const void* sendbuff,
+                                             void* recvbuff, int recvcount,
+                                             datatype_t datatype, op_t op,
+                                             cudaStream_t stream) const {
 #ifdef HAVE_NCCL
-    NCCL_CHECK( ncclReduceScatter(sendbuff, recvbuff, recvcount, getNCCLDatatype( datatype ), getNCCLOp( op ), _nccl_comm, stream) );
+  NCCL_CHECK(ncclReduceScatter(sendbuff, recvbuff, recvcount,
+                               getNCCLDatatype(datatype), getNCCLOp(op),
+                               _nccl_comm, stream));
 #else
-    CUDA_CHECK( cudaStreamSynchronize( stream ) );
-    std::vector<int> recvcounts(_size,recvcount);
-    MPI_CHECK( MPI_Reduce_scatter(sendbuff, recvbuff, recvcounts.data(), getMPIDatatype( datatype ), getMPIOp( op ), _mpi_comm) );
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  std::vector<int> recvcounts(_size, recvcount);
+  MPI_CHECK(MPI_Reduce_scatter(sendbuff, recvbuff, recvcounts.data(),
+                               getMPIDatatype(datatype), getMPIOp(op),
+                               _mpi_comm));
 #endif
 }
 
 MLCommon::cumlCommunicator::status_t cumlMPICommunicator_impl::syncStream(
   cudaStream_t stream) const {
-
 #ifndef HAVE_NCCL
   cudaError_t cudaErr;
   ncclResult_t ncclErr, ncclAsyncErr;
@@ -393,6 +398,5 @@ MLCommon::cumlCommunicator::status_t cumlMPICommunicator_impl::syncStream(
 #else
   CUDA_CHECK(cudaStreamSynchronize(stream));
 #endif
-
 }
-} // end namespace ML
+}  // end namespace ML

--- a/cpp/comms/mpi/src/cuML_comms_mpi_impl.hpp
+++ b/cpp/comms/mpi/src/cuML_comms_mpi_impl.hpp
@@ -29,53 +29,66 @@
 #include <common/cuml_comms_iface.hpp>
 
 namespace ML {
-    
+
 class cumlMPICommunicator_impl : public MLCommon::cumlCommunicator_iface {
-public:
-    cumlMPICommunicator_impl() =delete;
+ public:
+  cumlMPICommunicator_impl() = delete;
 
-    cumlMPICommunicator_impl(MPI_Comm comm, const bool owns_mpi_comm=false);
+  cumlMPICommunicator_impl(MPI_Comm comm, const bool owns_mpi_comm = false);
 
-    virtual ~cumlMPICommunicator_impl();
+  virtual ~cumlMPICommunicator_impl();
 
-    virtual int getSize() const;
-    virtual int getRank() const;
+  virtual int getSize() const;
+  virtual int getRank() const;
 
-    virtual std::unique_ptr<MLCommon::cumlCommunicator_iface> commSplit( int color, int key ) const;
+  virtual std::unique_ptr<MLCommon::cumlCommunicator_iface> commSplit(
+    int color, int key) const;
 
-    virtual void barrier() const;
+  virtual void barrier() const;
 
-    virtual void isend(const void *buf, int size, int dest, int tag, request_t *request) const;
+  virtual void isend(const void* buf, int size, int dest, int tag,
+                     request_t* request) const;
 
-    virtual void irecv(void *buf, int size, int source, int tag, request_t *request) const;
+  virtual void irecv(void* buf, int size, int source, int tag,
+                     request_t* request) const;
 
-    virtual void waitall(int count, request_t array_of_requests[]) const;
+  virtual void waitall(int count, request_t array_of_requests[]) const;
 
-    virtual void allreduce(const void* sendbuff, void* recvbuff, int count, datatype_t datatype, op_t op, cudaStream_t stream) const;
+  virtual void allreduce(const void* sendbuff, void* recvbuff, int count,
+                         datatype_t datatype, op_t op,
+                         cudaStream_t stream) const;
 
-    virtual void bcast(void* buff, int count, datatype_t datatype, int root, cudaStream_t stream) const;
+  virtual void bcast(void* buff, int count, datatype_t datatype, int root,
+                     cudaStream_t stream) const;
 
-    virtual void reduce(const void* sendbuff, void* recvbuff, int count, datatype_t datatype, op_t op, int root, cudaStream_t stream) const;
+  virtual void reduce(const void* sendbuff, void* recvbuff, int count,
+                      datatype_t datatype, op_t op, int root,
+                      cudaStream_t stream) const;
 
-    virtual void allgather(const void* sendbuff, void* recvbuff, int sendcount, datatype_t datatype, cudaStream_t stream) const;
+  virtual void allgather(const void* sendbuff, void* recvbuff, int sendcount,
+                         datatype_t datatype, cudaStream_t stream) const;
 
-    virtual void allgatherv(const void *sendbuf, void *recvbuf, const int recvcounts[], const int displs[], datatype_t datatype, cudaStream_t stream) const;
+  virtual void allgatherv(const void* sendbuf, void* recvbuf,
+                          const int recvcounts[], const int displs[],
+                          datatype_t datatype, cudaStream_t stream) const;
 
-    virtual void reducescatter(const void* sendbuff, void* recvbuff, int recvcount, datatype_t datatype, op_t op, cudaStream_t stream) const;
+  virtual void reducescatter(const void* sendbuff, void* recvbuff,
+                             int recvcount, datatype_t datatype, op_t op,
+                             cudaStream_t stream) const;
 
-    virtual status_t syncStream(cudaStream_t stream) const;
+  virtual status_t syncStream(cudaStream_t stream) const;
 
-private:
-    bool                                                _owns_mpi_comm;
-    MPI_Comm                                            _mpi_comm;
+ private:
+  bool _owns_mpi_comm;
+  MPI_Comm _mpi_comm;
 #ifdef HAVE_NCCL
-    ncclComm_t                                          _nccl_comm;
+  ncclComm_t _nccl_comm;
 #endif
-    int                                                 _size;
-    int                                                 _rank;
-    mutable request_t                                   _next_request_id;
-    mutable std::unordered_map<request_t,MPI_Request>   _requests_in_flight;
-    mutable std::unordered_set<request_t>               _free_requests;
+  int _size;
+  int _rank;
+  mutable request_t _next_request_id;
+  mutable std::unordered_map<request_t, MPI_Request> _requests_in_flight;
+  mutable std::unordered_set<request_t> _free_requests;
 };
 
-} // end namespace ML
+}  // end namespace ML

--- a/cpp/comms/std/src/cuML_std_comms_impl.cpp
+++ b/cpp/comms/std/src/cuML_std_comms_impl.cpp
@@ -313,8 +313,7 @@ void cumlStdCommunicator_impl::irecv(void *buf, int size, int source, int tag,
 
   ucp_tag_t tag_mask = default_tag_mask;
 
-  if(source == CUML_ANY_SOURCE)
-    tag_mask = any_rank_tag_mask;
+  if (source == CUML_ANY_SOURCE) tag_mask = any_rank_tag_mask;
 
   struct ucx_context *ucp_request =
     ucp_irecv(_ucp_worker, ep_ptr, buf, size, tag, tag_mask, source);

--- a/cpp/comms/std/src/ucp_helper.h
+++ b/cpp/comms/std/src/ucp_helper.h
@@ -79,7 +79,8 @@ struct ucx_context *ucp_isend(ucp_ep_h ep_ptr, const void *buf, int size,
  * @bried Asynchronously receive data from given endpoint with the given tag.
  */
 struct ucx_context *ucp_irecv(ucp_worker_h worker, ucp_ep_h ep_ptr, void *buf,
-                              int size, int tag,  ucp_tag_t tag_mask, int sender_rank) {
+                              int size, int tag, ucp_tag_t tag_mask,
+                              int sender_rank) {
   ucp_tag_t ucp_tag = ((uint32_t)sender_rank << 31) | (uint32_t)tag;
 
   struct ucx_context *ucp_request = (struct ucx_context *)ucp_tag_recv_nb(

--- a/cpp/examples/dbscan/CMakeLists.txt
+++ b/cpp/examples/dbscan/CMakeLists.txt
@@ -17,5 +17,4 @@
 include_directories(${CUDA_INCLUDE_DIRS})
 
 add_executable(dbscan_example dbscan_example.cpp)
-add_dependencies(dbscan_example ${ClangFormat_TARGET})
 target_link_libraries(dbscan_example cuml++)

--- a/cpp/examples/kmeans/CMakeLists.txt
+++ b/cpp/examples/kmeans/CMakeLists.txt
@@ -16,5 +16,4 @@
 
 include_directories(${CUDA_INCLUDE_DIRS})
 add_executable(kmeans_example kmeans_example.cpp)
-add_dependencies(kmeans_example ${ClangFormat_TARGET})
 target_link_libraries(kmeans_example cuml++)

--- a/cpp/include/cuml/common/utils.hpp
+++ b/cpp/include/cuml/common/utils.hpp
@@ -16,10 +16,9 @@
 
 #pragma once
 
-
-#include <cstdio>
 #include <cuda_runtime.h>
 #include <execinfo.h>
+#include <cstdio>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -109,9 +109,8 @@ def run_clang_format(src, dst, exe):
     try:
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:
-        src_path = os.path.join(os.getcwd(), src)
-        print("clang-format failed! Run 'diff -y %s %s' to know more about "
-              "the formatting violations!" % (src_path, dst))
+        print("%s failed! 'diff %s %s' will show formatting violations!" % \
+              (os.path.basename(src), src, dst))
         return False
     return True
 
@@ -130,11 +129,10 @@ def main():
         if not run_clang_format(src, dst, args.exe):
             status = False
     if not status:
-        print("Clang-format failed! You have 2 options:")
+        print("clang-format failed! You have 2 options:")
         print(" 1. Look at formatting differences above and fix them manually")
         print(" 2. Or run the below command to bulk-fix all these at once")
         print("Bulk-fix command: ")
-        print("  cd /path/to/your/cuml/repo")
         print("  python cpp/scripts/run-clang-format.py %s -inplace" % \
               " ".join(sys.argv[1:]))
         sys.exit(-1)

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -19,10 +19,39 @@ import re
 import os
 import subprocess
 import argparse
-import gitutils
 
 
-def listAllSourceFiles(fileRegex, srcdirs, dstdir, inplace):
+VersionRegex = re.compile(r"clang-format version ([0-9.]+)")
+
+
+def parse_args():
+    argparser = argparse.ArgumentParser("Runs clang-format on a project")
+    argparser.add_argument("-dstdir", type=str,
+                           default="/tmp/cuml-clang-format",
+                           help="Path to the current build directory.")
+    argparser.add_argument("-exe", type=str, default="clang-format",
+                           help="Path to clang-format exe")
+    argparser.add_argument("-inplace", default=False, action="store_true",
+                           help="Replace the source files itself.")
+    argparser.add_argument("-regex", type=str,
+                           default=r"[.](cu|cuh|h|hpp|cpp)$",
+                           help="Regex string to filter in sources")
+    argparser.add_argument("dirs", type=str, nargs="*",
+                           help="List of dirs where to find sources")
+    args = argparser.parse_args()
+    args.regexCompiled = re.compile(args.regex)
+    ret = subprocess.check_output("%s --version" % args.exe, shell=True)
+    ret = ret.decode("utf-8")
+    version = VersionRegex.match(ret)
+    if version is None:
+        raise Exception("Failed to figure out clang-format version!")
+    version = version.group(1)
+    if version != "8.0.0":
+        raise Exception("clang-format exe must be v8.0.0 found '%s'" % version)
+    return args
+
+
+def list_all_src_files(fileRegex, srcdirs, dstdir, inplace):
     allFiles = []
     for srcdir in srcdirs:
         for root, dirs, files in os.walk(srcdir):
@@ -38,97 +67,46 @@ def listAllSourceFiles(fileRegex, srcdirs, dstdir, inplace):
     return allFiles
 
 
-def listAllChangedFiles(fileRegex, dstdir, inplace):
-    allFiles = []
-
-    def checkThisFile(f):
-        return True if fileRegex.search(f) else False
-
-    files = gitutils.modifiedFiles(filter=checkThisFile)
-    for f in files:
-        dst = f if inplace else os.path.join(dstdir, f)
-        allFiles.append((f, dst))
-    return allFiles
-
-
-def parseArgs():
-    argparser = argparse.ArgumentParser("Runs clang-format on a project")
-    argparser.add_argument("-dstdir", type=str, default=".",
-                           help="Path to the current build directory.")
-    argparser.add_argument("-exe", type=str, default="clang-format",
-                           help="Path to clang-format exe")
-    argparser.add_argument("-inplace", default=False, action="store_true",
-                           help="Replace the source files itself.")
-    argparser.add_argument("-regex", type=str,
-                           default=r"[.](cu|cuh|h|hpp|cpp)$",
-                           help="Regex string to filter in sources")
-    argparser.add_argument("-onlyChangedFiles", default=False,
-                           action="store_true",
-                           help="Run the formatter on changedFiles only.")
-    argparser.add_argument("-srcdir", type=str, default=".",
-                           help="Path to directory containing the dirs.")
-    argparser.add_argument("dirs", type=str, nargs="*",
-                           help="List of dirs where to find sources")
-    args = argparser.parse_args()
-    args.regexCompiled = re.compile(args.regex)
-    return args
-
-
-def isNewer(src, dst):
-    if not os.path.exists(dst):
-        return True
-    a = os.path.getmtime(src)
-    b = os.path.getmtime(dst)
-    return a >= b
-
-
-def runClangFormat(src, dst, exe):
+def run_clang_format(src, dst, exe):
     dstdir = os.path.dirname(dst)
     if not os.path.exists(dstdir):
         os.makedirs(dstdir)
     # run the clang format command itself
-    if isNewer(src, dst):
-        if src == dst:
-            cmd = "%s -i %s" % (exe, src)
-        else:
-            cmd = "%s %s > %s" % (exe, src, dst)
-        try:
-            subprocess.check_call(cmd, shell=True)
-        except subprocess.CalledProcessError:
-            print("Unable to run clang-format! Maybe your env is not "
-                  "configured properly?")
-            raise
+    if src == dst:
+        cmd = "%s -i %s" % (exe, src)
+    else:
+        cmd = "%s %s > %s" % (exe, src, dst)
+    try:
+        subprocess.check_call(cmd, shell=True)
+    except subprocess.CalledProcessError:
+        print("Failed to run clang-format! Maybe your env is not proper?")
+        raise
     # run the diff to check if there are any formatting issues
     cmd = "diff -q %s %s >/dev/null" % (src, dst)
     try:
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:
         srcPath = os.path.join(os.getcwd(), src)
-        print("clang-format failed! Run 'diff -y %s %s | more' to know more"
-              " about the formatting violations!" % (srcPath, dst))
+        print("clang-format failed! Run 'diff -y %s %s' to know more about "
+              "the formatting violations!" % (srcPath, dst))
         return False
     return True
 
 
 def main():
-    args = parseArgs()
-    # Either run the format checker on only the changed files or all the source
-    # files as specified by the user
-    if args.onlyChangedFiles:
-        allFiles = listAllChangedFiles(args.regexCompiled, args.dstdir,
-                                       args.inplace)
-    else:
-        allFiles = listAllSourceFiles(args.regexCompiled, args.dirs,
-                                      args.dstdir, args.inplace)
+    args = parse_args()
+    allFiles = list_all_src_files(args.regexCompiled, args.dirs, args.dstdir,
+                                  args.inplace)
     # actual format checker
     status = True
     for src, dst in allFiles:
-        if not runClangFormat(src, dst, args.exe):
+        if not run_clang_format(src, dst, args.exe):
             status = False
     if not status:
-        print("Clang-format failed! Look at errors above and fix them, you ")
-        print("can also run the following command to bulk fix all the flagged")
-        print(" violations above:  make fix-format")
+        print("Clang-format failed! You have 2 options:")
+        print(" 1. Look at formatting differences above and fix them manually")
+        print(" 2. Or run the below command to bulk-fix all these at once")
+        print("Bulk-fix command: python %s -inplace" % " ".join(sys.argv))
         sys.exit(-1)
     return
 

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -111,7 +111,9 @@ def main():
         print("Clang-format failed! You have 2 options:")
         print(" 1. Look at formatting differences above and fix them manually")
         print(" 2. Or run the below command to bulk-fix all these at once")
-        print("Bulk-fix command: python %s -inplace" % " ".join(sys.argv))
+        print("Bulk-fix command: ")
+        print("  cd /path/to/your/cuml/repo")
+        print("  python %s -inplace" % " ".join(sys.argv))
         sys.exit(-1)
     return
 

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -52,6 +52,8 @@ def parse_args():
                            help="Regex string to filter in sources")
     argparser.add_argument("-ignore", type=str, default=r"cannylab/bh[.]cu$",
                            help="Regex used to ignore files from matched list")
+    argparser.add_argument("-v", dest="verbose", action="store_true",
+                           help="Print verbose messages")
     argparser.add_argument("dirs", type=str, nargs="*",
                            help="List of dirs where to find sources")
     args = argparser.parse_args()
@@ -90,7 +92,7 @@ def list_all_src_files(file_regex, ignore_regex, srcdirs, dstdir, inplace):
     return allFiles
 
 
-def run_clang_format(src, dst, exe):
+def run_clang_format(src, dst, exe, verbose):
     dstdir = os.path.dirname(dst)
     if not os.path.exists(dstdir):
         os.makedirs(dstdir)
@@ -108,6 +110,8 @@ def run_clang_format(src, dst, exe):
     cmd = "diff -q %s %s >/dev/null" % (src, dst)
     try:
         subprocess.check_call(cmd, shell=True)
+        if verbose:
+            print("%s passed" % os.path.basename(src))
     except subprocess.CalledProcessError:
         print("%s failed! 'diff %s %s' will show formatting violations!" % \
               (os.path.basename(src), src, dst))
@@ -126,7 +130,7 @@ def main():
     # actual format checker
     status = True
     for src, dst in all_files:
-        if not run_clang_format(src, dst, args.exe):
+        if not run_clang_format(src, dst, args.exe, args.verbose):
             status = False
     if not status:
         print("clang-format failed! You have 2 options:")

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -113,7 +113,8 @@ def main():
         print(" 2. Or run the below command to bulk-fix all these at once")
         print("Bulk-fix command: ")
         print("  cd /path/to/your/cuml/repo")
-        print("  python %s -inplace" % " ".join(sys.argv))
+        print("  python cpp/scripts/run-clang-format.py %s -inplace" % \
+              " ".join(sys.argv[1:]))
         sys.exit(-1)
     return
 

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -23,6 +23,18 @@ import tempfile
 
 
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
+# NOTE: populate this list with more top-level dirs as we add more of them to
+#       to the cuml repo
+DEFAULT_DIRS = ["cpp/bench",
+                "cpp/comms/mpi/include",
+                "cpp/comms/mpi/src",
+                "cpp/comms/std/include",
+                "cpp/comms/std/src",
+                "cpp/include",
+                "cpp/examples",
+                "cpp/src",
+                "cpp/src_prims",
+                "cpp/test"]
 
 
 def parse_args():
@@ -55,6 +67,8 @@ def parse_args():
     version = version.group(1)
     if version != "8.0.0":
         raise Exception("clang-format exe must be v8.0.0 found '%s'" % version)
+    if len(args.dirs) == 0:
+        args.dirs = DEFAULT_DIRS
     return args
 
 
@@ -104,6 +118,10 @@ def run_clang_format(src, dst, exe):
 
 def main():
     args = parse_args()
+    # Attempt to making sure that we run this script from root of repo always
+    if not os.path.exists(".git"):
+        print("Error!! This needs to always be run from the root of repo")
+        sys.exit(-1)
     all_files = list_all_src_files(args.regex_compiled, args.ignore_compiled,
                                    args.dirs, args.dstdir, args.inplace)
     # actual format checker

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "nvtx.hpp"
 #include <stdint.h>
 #include <stdlib.h>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include "nvtx.hpp"
 
 namespace ML {
 
@@ -148,14 +148,13 @@ void PUSH_RANGE(const char *name) {
 }
 
 #ifdef ENABLE_EMPTY_MARKER_KERNEL
-__global__ void emptyMarkerKernel() {
-}
-#endif // ENABLE_EMPTY_MARKER_KERNEL
+__global__ void emptyMarkerKernel() {}
+#endif  // ENABLE_EMPTY_MARKER_KERNEL
 
 void POP_RANGE() {
   nvtxRangePop();
 #ifdef ENABLE_EMPTY_MARKER_KERNEL
-  emptyMarkerKernel<<<1,1>>>();
+  emptyMarkerKernel<<<1, 1>>>();
 #endif
 }
 

--- a/cpp/src/comms/cuML_comms_test.hpp
+++ b/cpp/src/comms/cuML_comms_test.hpp
@@ -37,7 +37,8 @@ bool test_collective_allreduce(const ML::cumlHandle& handle);
 bool test_pointToPoint_simple_send_recv(const ML::cumlHandle& handle,
                                         int n_trials);
 
-bool test_pointToPoint_recv_any_rank(const ML::cumlHandle& handle, int numTrials);
+bool test_pointToPoint_recv_any_rank(const ML::cumlHandle& handle,
+                                     int numTrials);
 
 };  // namespace Comms
 };  // end namespace ML

--- a/cpp/src/datasets/make_blobs.cu
+++ b/cpp/src/datasets/make_blobs.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <cuml/datasets/make_blobs.hpp>
 #include <common/cumlHandle.hpp>
+#include <cuml/datasets/make_blobs.hpp>
 #include "random/make_blobs.h"
 
 namespace ML {

--- a/cpp/src/dbscan/dbscan.h
+++ b/cpp/src/dbscan/dbscan.h
@@ -74,7 +74,8 @@ void dbscanFitImpl(const ML::cumlHandle_impl &handle, T *input, Index_ n_rows,
     if (n_batches > 1) {
       std::cout << "Running batched training on " << n_batches
                 << " batches w/ ";
-      std::cout << batchSize * n_rows * sizeof(T) * 1e-6 << " megabytes." << std::endl;
+      std::cout << batchSize * n_rows * sizeof(T) * 1e-6 << " megabytes."
+                << std::endl;
     }
   }
 

--- a/cpp/src/dbscan/dbscan_api.cpp
+++ b/cpp/src/dbscan/dbscan_api.cpp
@@ -15,8 +15,8 @@
  */
 #include "dbscan_api.h"
 #include <cuml/cuml_api.h>
-#include "common/cumlHandle.hpp"
 #include <cuml/cluster/dbscan.hpp>
+#include "common/cumlHandle.hpp"
 
 cumlError_t cumlSpDbscanFit(cumlHandle_t handle, float *input, int n_rows,
                             int n_cols, float eps, int min_pts, int *labels,

--- a/cpp/src/internals/internals.h
+++ b/cpp/src/internals/internals.h
@@ -14,39 +14,36 @@
  * limitations under the License.
  */
 
-
 #pragma once
 
 #include <type_traits>
 
 namespace ML {
-    namespace Internals {
+namespace Internals {
 
-        class Callback {
-            public:
-                virtual ~Callback() {}
-        };
+class Callback {
+ public:
+  virtual ~Callback() {}
+};
 
-        class GraphBasedDimRedCallback : public Callback {
-            public:
+class GraphBasedDimRedCallback : public Callback {
+ public:
+  template <typename T>
+  void setup(int n, int n_components) {
+    this->n = n;
+    this->n_components = n_components;
+    this->isFloat = std::is_same<T, float>::value;
+  }
 
-                template<typename T>
-                void setup(int n, int n_components)
-                {
-                    this->n = n;
-                    this->n_components = n_components;
-                    this->isFloat = std::is_same<T, float>::value;
-                }
+  virtual void on_preprocess_end(void* embeddings) = 0;
+  virtual void on_epoch_end(void* embeddings) = 0;
+  virtual void on_train_end(void* embeddings) = 0;
 
-                virtual void on_preprocess_end(void* embeddings) = 0;
-                virtual void on_epoch_end(void* embeddings) = 0;
-                virtual void on_train_end(void* embeddings) = 0;
+ protected:
+  int n;
+  int n_components;
+  bool isFloat;
+};
 
-            protected:
-                int n;
-                int n_components;
-                bool isFloat;
-        };
-
-    }
-}
+}  // namespace Internals
+}  // namespace ML

--- a/cpp/src/svm/results.h
+++ b/cpp/src/svm/results.h
@@ -23,8 +23,8 @@
 #include <memory>
 
 #include <cub/device/device_select.cuh>
-#include "common/cumlHandle.hpp"
 #include <cuml/common/cuml_allocator.hpp>
+#include "common/cumlHandle.hpp"
 #include "common/device_buffer.hpp"
 #include "common/host_buffer.hpp"
 #include "linalg/binary_op.h"

--- a/cpp/src/svm/svc_impl.h
+++ b/cpp/src/svm/svc_impl.h
@@ -223,8 +223,8 @@ void svcPredict(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
   } else {
     // Calculate the value of the decision function: f(x) = y(x) + b
     MLCommon::LinAlg::unaryOp(
-      preds, y.data(), n_rows,
-      [b] __device__(math_t y) { return y + b; }, stream);
+      preds, y.data(), n_rows, [b] __device__(math_t y) { return y + b; },
+      stream);
   }
   delete kernel;
 }

--- a/cpp/src/svm/svm_model.h
+++ b/cpp/src/svm/svm_model.h
@@ -22,25 +22,25 @@ namespace SVM {
  * Parameters that describe a trained SVM model.
  * All pointers are device pointers.
  */
-template<typename math_t>
+template <typename math_t>
 struct svmModel {
-    int n_support;  //!< Number of support vectors
-    int n_cols; //!< Number of features
-    math_t b; //!< Constant used in the decision function
+  int n_support;  //!< Number of support vectors
+  int n_cols;     //!< Number of features
+  math_t b;       //!< Constant used in the decision function
 
-    //! Non-zero dual coefficients ( dual_coef[i] = \f$ y_i \alpha_i \f$).
-    //! Size [n_support].
-    math_t *dual_coefs;
+  //! Non-zero dual coefficients ( dual_coef[i] = \f$ y_i \alpha_i \f$).
+  //! Size [n_support].
+  math_t *dual_coefs;
 
-    //! Support vectors in column major format. Size [n_support x n_cols].
-    math_t *x_support;
-    //! Indices (from the traning set) of the support vectors, size [n_support].
-    int *support_idx;
+  //! Support vectors in column major format. Size [n_support x n_cols].
+  math_t *x_support;
+  //! Indices (from the traning set) of the support vectors, size [n_support].
+  int *support_idx;
 
-    int n_classes;  //!< Number of classes found in the input labels
-    //! Device pointer for the unique classes. Size [n_classes]
-    math_t *unique_labels;
+  int n_classes;  //!< Number of classes found in the input labels
+  //! Device pointer for the unique classes. Size [n_classes]
+  math_t *unique_labels;
 };
 
-}; // namespace SVM
-}; // namespace ML
+};  // namespace SVM
+};  // namespace ML

--- a/cpp/src/tsne/barnes_hut.h
+++ b/cpp/src/tsne/barnes_hut.h
@@ -215,9 +215,9 @@ void Barnes_Hut(float *VAL, const int *COL, const int *ROW, const int NNZ,
 
     START_TIMER;
     TSNE::RepulsionKernel<<<blocks * FACTOR5, THREADS5, 0, stream>>>(
-      /*errl,*/ theta, epssq, sortl, childl, massl, YY, YY + nnodes + 1, rep_forces,
-      rep_forces + nnodes + 1, Z_norm, theta_squared, NNODES, FOUR_NNODES, n,
-      radiusd_squared, maxdepthd);
+      /*errl,*/ theta, epssq, sortl, childl, massl, YY, YY + nnodes + 1,
+      rep_forces, rep_forces + nnodes + 1, Z_norm, theta_squared, NNODES,
+      FOUR_NNODES, n, radiusd_squared, maxdepthd);
     CUDA_CHECK(cudaPeekAtLastError());
 
     END_TIMER(RepulsionTime);

--- a/cpp/src/tsne/bh_kernels.h
+++ b/cpp/src/tsne/bh_kernels.h
@@ -43,12 +43,10 @@ namespace TSNE {
 /**
  * Intializes the states of objects. This speeds the overall kernel up.
  */
-__global__ void
-InitializationKernel( /*int *restrict errd, */
-                     unsigned *restrict limiter,
-                     int *restrict maxdepthd,
-                     float *restrict radiusd)
-{
+__global__ void InitializationKernel(/*int *restrict errd, */
+                                     unsigned *restrict limiter,
+                                     int *restrict maxdepthd,
+                                     float *restrict radiusd) {
   // errd[0] = 0;
   maxdepthd[0] = 1;
   limiter[0] = 0;
@@ -58,12 +56,10 @@ InitializationKernel( /*int *restrict errd, */
 /**
  * Reset normalization back to 0.
  */
-__global__ void
-Reset_Normalization(float *restrict Z_norm,
-                    float *restrict radiusd_squared,
-                    int *restrict bottomd, const int NNODES,
-                    const float *restrict radiusd)
-{
+__global__ void Reset_Normalization(float *restrict Z_norm,
+                                    float *restrict radiusd_squared,
+                                    int *restrict bottomd, const int NNODES,
+                                    const float *restrict radiusd) {
   Z_norm[0] = 0.0f;
   radiusd_squared[0] = radiusd[0] * radiusd[0];
   // create root node
@@ -73,34 +69,22 @@ Reset_Normalization(float *restrict Z_norm,
 /**
  * Find 1/Z
  */
-__global__ void
-Find_Normalization(float *restrict Z_norm,
-                   const float N)
-{
+__global__ void Find_Normalization(float *restrict Z_norm, const float N) {
   Z_norm[0] = 1.0f / (Z_norm[0] - N);
 }
 
 /**
  * Figures the bounding boxes for every point in the embedding.
  */
-__global__ __launch_bounds__(THREADS1, FACTOR1) void
-BoundingBoxKernel(int *restrict startd,
-                  int *restrict childd,
-                  float *restrict massd,
-                  float *restrict posxd,
-                  float *restrict posyd,
-                  float *restrict maxxd,
-                  float *restrict maxyd,
-                  float *restrict minxd,
-                  float *restrict minyd,
-                  const int FOUR_NNODES,
-                  const int NNODES,
-                  const int N,
-                  unsigned *restrict limiter,
-                  float *restrict radiusd)
-{
+__global__ __launch_bounds__(THREADS1, FACTOR1) void BoundingBoxKernel(
+  int *restrict startd, int *restrict childd, float *restrict massd,
+  float *restrict posxd, float *restrict posyd, float *restrict maxxd,
+  float *restrict maxyd, float *restrict minxd, float *restrict minyd,
+  const int FOUR_NNODES, const int NNODES, const int N,
+  unsigned *restrict limiter, float *restrict radiusd) {
   float val, minx, maxx, miny, maxy;
-  __shared__ float sminx[THREADS1], smaxx[THREADS1], sminy[THREADS1], smaxy[THREADS1];
+  __shared__ float sminx[THREADS1], smaxx[THREADS1], sminy[THREADS1],
+    smaxy[THREADS1];
 
   // initialize with valid data (in case #bodies < #threads)
   minx = maxx = posxd[0];
@@ -109,15 +93,18 @@ BoundingBoxKernel(int *restrict startd,
   // scan all bodies
   const int i = threadIdx.x;
   const int inc = THREADS1 * gridDim.x;
-  for (int j = i + blockIdx.x * THREADS1; j < N; j += inc)
-  {
+  for (int j = i + blockIdx.x * THREADS1; j < N; j += inc) {
     val = posxd[j];
-    if (val < minx)      minx = val;
-    else if (val > maxx) maxx = val;
+    if (val < minx)
+      minx = val;
+    else if (val > maxx)
+      maxx = val;
 
     val = posyd[j];
-    if (val < miny)      miny = val;
-    else if (val > maxy) maxy = val;
+    if (val < miny)
+      miny = val;
+    else if (val > maxy)
+      maxy = val;
   }
 
   // reduction in shared memory
@@ -126,8 +113,7 @@ BoundingBoxKernel(int *restrict startd,
   sminy[i] = miny;
   smaxy[i] = maxy;
 
-  for (int j = THREADS1 / 2; j > i; j /= 2)
-  {
+  for (int j = THREADS1 / 2; j > i; j /= 2) {
     __syncthreads();
     const int k = i + j;
     sminx[i] = minx = fminf(minx, sminx[k]);
@@ -135,10 +121,8 @@ BoundingBoxKernel(int *restrict startd,
     sminy[i] = miny = fminf(miny, sminy[k]);
     smaxy[i] = maxy = fmaxf(maxy, smaxy[k]);
   }
-  
 
-  if (i == 0)
-  {
+  if (i == 0) {
     // write block result to global memory
     const int k = blockIdx.x;
     minxd[k] = minx;
@@ -151,8 +135,7 @@ BoundingBoxKernel(int *restrict startd,
     if (inc != atomicInc(limiter, inc)) return;
 
     // I'm the last block, so combine all block results
-    for (int j = 0; j <= inc; j++)
-    {
+    for (int j = 0; j <= inc; j++) {
       minx = fminf(minx, minxd[j]);
       maxx = fmaxf(maxx, maxxd[j]);
       miny = fminf(miny, minyd[j]);
@@ -167,46 +150,38 @@ BoundingBoxKernel(int *restrict startd,
     posxd[NNODES] = (minx + maxx) * 0.5f;
     posyd[NNODES] = (miny + maxy) * 0.5f;
 
-    #pragma unroll
-    for (int a = 0; a < 4; a++)
-      childd[FOUR_NNODES + a] = -1;
+#pragma unroll
+    for (int a = 0; a < 4; a++) childd[FOUR_NNODES + a] = -1;
   }
 }
-
 
 /**
  * Clear some of the state vectors up.
  */
-__global__ __launch_bounds__(1024, 1) void
-ClearKernel1(int *restrict childd,
-             const int FOUR_NNODES,
-             const int FOUR_N)
-{
+__global__ __launch_bounds__(1024, 1) void ClearKernel1(int *restrict childd,
+                                                        const int FOUR_NNODES,
+                                                        const int FOUR_N) {
   const int inc = blockDim.x * gridDim.x;
-  int k = (FOUR_N & -32) + threadIdx.x + blockIdx.x * blockDim.x; 
+  int k = (FOUR_N & -32) + threadIdx.x + blockIdx.x * blockDim.x;
   if (k < FOUR_N) k += inc;
 
-  // iterate over all cells assigned to thread
-  #pragma unroll
-  for (; k < FOUR_NNODES; k += inc)
-    childd[k] = -1;
+// iterate over all cells assigned to thread
+#pragma unroll
+  for (; k < FOUR_NNODES; k += inc) childd[k] = -1;
 }
-
 
 /**
  * Build the actual KD Tree.
  */
-__global__ __launch_bounds__(THREADS2, FACTOR2) void
-TreeBuildingKernel( /* int *restrict errd, */
-                   int *restrict childd,
-                   const float *restrict posxd,
-                   const float *restrict posyd,
-                   const int NNODES,
-                   const int N,
-                   int *restrict maxdepthd,
-                   int *restrict bottomd,
-                   const float *restrict radiusd)
-{
+__global__ __launch_bounds__(
+  THREADS2, FACTOR2) void TreeBuildingKernel(/* int *restrict errd, */
+                                             int *restrict childd,
+                                             const float *restrict posxd,
+                                             const float *restrict posyd,
+                                             const int NNODES, const int N,
+                                             int *restrict maxdepthd,
+                                             int *restrict bottomd,
+                                             const float *restrict radiusd) {
   int j, depth;
   float x, y, r;
   float px, py;
@@ -223,64 +198,48 @@ TreeBuildingKernel( /* int *restrict errd, */
   int i = threadIdx.x + blockIdx.x * blockDim.x;
 
   // iterate over all bodies assigned to thread
-  while (i < N)
-  {
-    if (skip != 0)
-    {
+  while (i < N) {
+    if (skip != 0) {
       // new body, so start traversing at root
       skip = 0;
       n = NNODES;
       depth = 1;
-      r = radius * 0.5f; 
+      r = radius * 0.5f;
 
-      x = rootx + ( (rootx < (px = posxd[i])) ?
-                    (j = 1, r) : (j = 0, -r) );
+      x = rootx + ((rootx < (px = posxd[i])) ? (j = 1, r) : (j = 0, -r));
 
-      y = rooty + ( (rooty < (py = posyd[i])) ?
-                    (j |= 2, r) : (-r) );
+      y = rooty + ((rooty < (py = posyd[i])) ? (j |= 2, r) : (-r));
     }
 
     // follow path to leaf cell
-    while ((ch = childd[n * 4 + j]) >= N)
-    {
+    while ((ch = childd[n * 4 + j]) >= N) {
       n = ch;
       depth++;
       r *= 0.5f;
 
       // determine which child to follow
-      x += ( (x < px) ?
-             (j = 1, r) : (j = 0, -r) );
+      x += ((x < px) ? (j = 1, r) : (j = 0, -r));
 
-      y += ( (y < py) ?
-             (j |= 2, r) : (-r) );
+      y += ((y < py) ? (j |= 2, r) : (-r));
     }
 
-
-    if (ch != -2)
-    {
+    if (ch != -2) {
       // skip if child pointer is locked and try again later
       locked = n * 4 + j;
 
-      if (ch == -1)
-      {
-        if (atomicCAS(&childd[locked], -1, i) == -1)
-        {
-          if (depth > localmaxdepth)
-            localmaxdepth = depth;
+      if (ch == -1) {
+        if (atomicCAS(&childd[locked], -1, i) == -1) {
+          if (depth > localmaxdepth) localmaxdepth = depth;
 
           i += inc;  // move on to next body
           skip = 1;
         }
-      }
-      else
-      {
-        if (ch == atomicCAS(&childd[locked], ch, -2))
-        { 
+      } else {
+        if (ch == atomicCAS(&childd[locked], ch, -2)) {
           // try to lock
           patch = -1;
 
-          while (ch >= 0)
-          {
+          while (ch >= 0) {
             depth++;
 
             const int cell = atomicSub(bottomd, 1) - 1;
@@ -289,29 +248,20 @@ TreeBuildingKernel( /* int *restrict errd, */
               atomicExch(bottomd, NNODES);
             }
 
-            if (patch != -1)
-              childd[n * 4 + j] = cell;
+            if (patch != -1) childd[n * 4 + j] = cell;
 
-            if (cell > patch)
-              patch = cell;
+            if (cell > patch) patch = cell;
 
             j = (x < posxd[ch]) ? 1 : 0;
-            if (y < posyd[ch])
-              j |= 2;
+            if (y < posyd[ch]) j |= 2;
 
             childd[cell * 4 + j] = ch;
             n = cell;
             r *= 0.5f;
 
-            x += (
-                (x < px) ?
-                (j = 1, r) : (j = 0, -r)
-              );
+            x += ((x < px) ? (j = 1, r) : (j = 0, -r));
 
-            y += (
-                (y < py) ?
-                (j |= 2, r) : (-r)
-              );
+            y += ((y < py) ? (j |= 2, r) : (-r));
 
             ch = childd[n * 4 + j];
             if (r <= 1e-10) break;
@@ -319,8 +269,7 @@ TreeBuildingKernel( /* int *restrict errd, */
 
           childd[n * 4 + j] = i;
 
-          if (depth > localmaxdepth)
-            localmaxdepth = depth;
+          if (depth > localmaxdepth) localmaxdepth = depth;
 
           i += inc;  // move on to next body
           skip = 2;
@@ -329,15 +278,13 @@ TreeBuildingKernel( /* int *restrict errd, */
     }
     __threadfence();
 
-    if (skip == 2)
-      childd[locked] = patch;
+    if (skip == 2) childd[locked] = patch;
   }
 
   // record maximum tree depth
   // if (localmaxdepth >= THREADS5)
   //   localmaxdepth = THREADS5 - 1;
-  if (localmaxdepth > 32)
-    localmaxdepth = 32;
+  if (localmaxdepth > 32) localmaxdepth = 32;
 
   atomicMax(maxdepthd, localmaxdepth);
 }
@@ -345,20 +292,19 @@ TreeBuildingKernel( /* int *restrict errd, */
 /**
  * Clean more state vectors.
  */
-__global__ __launch_bounds__(1024, 1) void
-ClearKernel2(int *restrict startd,
-             float *restrict massd,
-             const int NNODES,
-             const int *restrict bottomd)
-{
+__global__ __launch_bounds__(1024,
+                             1) void ClearKernel2(int *restrict startd,
+                                                  float *restrict massd,
+                                                  const int NNODES,
+                                                  const int *restrict bottomd) {
   const int bottom = bottomd[0];
   const int inc = blockDim.x * gridDim.x;
   int k = (bottom & -32) + threadIdx.x + blockIdx.x * blockDim.x;
   if (k < bottom) k += inc;
 
-  // iterate over all cells assigned to thread
-  #pragma unroll
-  for (; k < NNODES; k+= inc) {
+// iterate over all cells assigned to thread
+#pragma unroll
+  for (; k < NNODES; k += inc) {
     massd[k] = -1.0f;
     startd[k] = -1;
   }
@@ -367,16 +313,10 @@ ClearKernel2(int *restrict startd,
 /**
  * Summarize the KD Tree via cell gathering
  */
-__global__ __launch_bounds__(THREADS3, FACTOR3) void
-SummarizationKernel(int *restrict countd,
-                    const int *restrict childd,
-                    volatile float *restrict massd,
-                    float *restrict posxd,
-                    float *restrict posyd,
-                    const int NNODES,
-                    const int N,
-                    const int *restrict bottomd) 
-{
+__global__ __launch_bounds__(THREADS3, FACTOR3) void SummarizationKernel(
+  int *restrict countd, const int *restrict childd,
+  volatile float *restrict massd, float *restrict posxd, float *restrict posyd,
+  const int NNODES, const int N, const int *restrict bottomd) {
   bool flag = 0;
   float cm, px, py;
   __shared__ int child[THREADS3 * 4];
@@ -389,19 +329,17 @@ SummarizationKernel(int *restrict countd,
 
   const int restart = k;
 
-  for (int j = 0; j < 5; j++) // wait-free pre-passes
+  for (int j = 0; j < 5; j++)  // wait-free pre-passes
   {
     // iterate over all cells assigned to thread
-    while (k <= NNODES)
-    {
-      if (massd[k] < 0.0f)
-      {
-        for (int i = 0; i < 4; i++)
-        {
+    while (k <= NNODES) {
+      if (massd[k] < 0.0f) {
+        for (int i = 0; i < 4; i++) {
           const int ch = childd[k * 4 + i];
           child[i * THREADS3 + threadIdx.x] = ch;
 
-          if ((ch >= N) and ((mass[i * THREADS3 + threadIdx.x] = massd[ch]) < 0))
+          if ((ch >= N) and
+              ((mass[i * THREADS3 + threadIdx.x] = massd[ch]) < 0))
             goto CONTINUE_LOOP;
         }
 
@@ -411,12 +349,10 @@ SummarizationKernel(int *restrict countd,
         py = 0.0f;
         int cnt = 0;
 
-        #pragma unroll
-        for (int i = 0; i < 4; i++)
-        {
+#pragma unroll
+        for (int i = 0; i < 4; i++) {
           const int ch = child[i * THREADS3 + threadIdx.x];
-          if (ch >= 0)
-          {
+          if (ch >= 0) {
             const float m =
               (ch >= N) ? (cnt += countd[ch], mass[i * THREADS3 + threadIdx.x])
                         : (cnt++, massd[ch]);
@@ -435,67 +371,51 @@ SummarizationKernel(int *restrict countd,
         massd[k] = cm;
       }
 
-      CONTINUE_LOOP:
+    CONTINUE_LOOP:
       k += inc;  // move on to next cell
     }
     k = restart;
   }
 
-
   int j = 0;
   // iterate over all cells assigned to thread
-  while (k <= NNODES)
-  {
-    if (massd[k] >= 0)
-    {
+  while (k <= NNODES) {
+    if (massd[k] >= 0) {
       k += inc;
       goto SKIP_LOOP;
     }
 
-
-    if (j == 0)
-    {
+    if (j == 0) {
       j = 4;
-      for (int i = 0; i < 4; i++)
-      {
+      for (int i = 0; i < 4; i++) {
         const int ch = childd[k * 4 + i];
 
         child[i * THREADS3 + threadIdx.x] = ch;
-        if ((ch < N) or
-           ((mass[i * THREADS3 + threadIdx.x] = massd[ch]) >= 0))
+        if ((ch < N) or ((mass[i * THREADS3 + threadIdx.x] = massd[ch]) >= 0))
           j--;
-
       }
-    }
-    else
-    {
+    } else {
       j = 4;
-      for (int i = 0; i < 4; i++)
-      {
+      for (int i = 0; i < 4; i++) {
         const int ch = child[i * THREADS3 + threadIdx.x];
 
-        if ((ch < N) or
-           (mass[i * THREADS3 + threadIdx.x] >= 0) or
-           ((mass[i * THREADS3 + threadIdx.x] = massd[ch]) >= 0))
+        if ((ch < N) or (mass[i * THREADS3 + threadIdx.x] >= 0) or
+            ((mass[i * THREADS3 + threadIdx.x] = massd[ch]) >= 0))
           j--;
-
       }
     }
 
-    if (j == 0)
-    {
+    if (j == 0) {
       // all children are ready
       cm = 0.0f;
       px = 0.0f;
       py = 0.0f;
       int cnt = 0;
 
-      #pragma unroll
-      for (int i = 0; i < 4; i++)
-      {
+#pragma unroll
+      for (int i = 0; i < 4; i++) {
         const int ch = child[i * THREADS3 + threadIdx.x];
-        if (ch >= 0)
-        {
+        if (ch >= 0) {
           const float m =
             (ch >= N) ? (cnt += countd[ch], mass[i * THREADS3 + threadIdx.x])
                       : (cnt++, massd[ch]);
@@ -513,11 +433,9 @@ SummarizationKernel(int *restrict countd,
       flag = 1;
     }
 
-
-    SKIP_LOOP:
+  SKIP_LOOP:
     __syncthreads();
-    if (flag != 0)
-    {
+    if (flag != 0) {
       massd[k] = cm;
       k += inc;
       flag = 0;
@@ -528,15 +446,10 @@ SummarizationKernel(int *restrict countd,
 /**
  * Sort the cells
  */
-__global__ __launch_bounds__(THREADS4, FACTOR4) void
-SortKernel(int *restrict sortd,
-           const int *restrict countd,
-           volatile int *restrict startd,
-           int *restrict childd,
-           const int NNODES,
-           const int N,
-           const int *restrict bottomd)
-{
+__global__ __launch_bounds__(THREADS4, FACTOR4) void SortKernel(
+  int *restrict sortd, const int *restrict countd,
+  volatile int *restrict startd, int *restrict childd, const int NNODES,
+  const int N, const int *restrict bottomd) {
   const int bottom = bottomd[0];
   const int dec = blockDim.x * gridDim.x;
   int k = NNODES + 1 - dec + threadIdx.x + blockIdx.x * blockDim.x;
@@ -544,37 +457,27 @@ SortKernel(int *restrict sortd,
   int limiter = 0;
 
   // iterate over all cells assigned to thread
-  while (k >= bottom)
-  {
+  while (k >= bottom) {
     // To control possible infinite loops
-    if (++limiter > NNODES)
-      break;
+    if (++limiter > NNODES) break;
 
     // Not a child so skip
-    if ((start = startd[k]) < 0)
-      continue;
-
+    if ((start = startd[k]) < 0) continue;
 
     int j = 0;
-    for (int i = 0; i < 4; i++)
-    {
+    for (int i = 0; i < 4; i++) {
       const int ch = childd[k * 4 + i];
-      if (ch >= 0)
-      {
-        if (i != j)
-        {
+      if (ch >= 0) {
+        if (i != j) {
           // move children to front (needed later for speed)
           childd[k * 4 + i] = -1;
           childd[k * 4 + j] = ch;
         }
-        if (ch >= N)
-        {
+        if (ch >= N) {
           // child is a cell
           startd[ch] = start;
           start += countd[ch];  // add #bodies in subtree
-        }
-        else if (start <= NNODES and start >= 0)
-        {
+        } else if (start <= NNODES and start >= 0) {
           // child is a body
           sortd[start++] = ch;
         }
@@ -585,29 +488,26 @@ SortKernel(int *restrict sortd,
   }
 }
 
-
 /**
  * Calculate the repulsive forces using the KD Tree
  */
-__global__ __launch_bounds__(THREADS5, FACTOR5) void
-RepulsionKernel( /* int *restrict errd, */
-                const float theta,
-                const float epssqd,  // correction for zero distance
-                const int *restrict sortd,
-                const int *restrict childd,
-                const float *restrict massd,
-                const float *restrict posxd,
-                const float *restrict posyd,
-                float *restrict velxd,
-                float *restrict velyd,
-                float *restrict Z_norm,
-                const float theta_squared,
-                const int NNODES,
-                const int FOUR_NNODES,
-                const int N,
-                const float *restrict radiusd_squared,
-                const int *restrict maxdepthd)
-{
+__global__ __launch_bounds__(
+  THREADS5,
+  FACTOR5) void RepulsionKernel(/* int *restrict errd, */
+                                const float theta,
+                                const float
+                                  epssqd,  // correction for zero distance
+                                const int *restrict sortd,
+                                const int *restrict childd,
+                                const float *restrict massd,
+                                const float *restrict posxd,
+                                const float *restrict posyd,
+                                float *restrict velxd, float *restrict velyd,
+                                float *restrict Z_norm,
+                                const float theta_squared, const int NNODES,
+                                const int FOUR_NNODES, const int N,
+                                const float *restrict radiusd_squared,
+                                const int *restrict maxdepthd) {
   // Return if max depth is too deep
   // Not possible since I limited it to 32
   // if (maxdepthd[0] > 32)
@@ -620,23 +520,19 @@ RepulsionKernel( /* int *restrict errd, */
   __shared__ int pos[THREADS5], node[THREADS5];
   __shared__ float dq[THREADS5];
 
-  if (threadIdx.x == 0)
-  {
+  if (threadIdx.x == 0) {
     const int max_depth = maxdepthd[0];
     dq[0] = __fdividef(radiusd_squared[0], theta_squared);
 
-    for (int i = 1; i < max_depth; i++)
-    {
+    for (int i = 1; i < max_depth; i++) {
       dq[i] = dq[i - 1] * 0.25f;
       dq[i - 1] += epssqd;
     }
     dq[max_depth - 1] += epssqd;
 
     // Add one so EPS_PLUS_1 can be compared
-    for (int i = 0; i < max_depth; i++)
-      dq[i] += 1.0f;
+    for (int i = 0; i < max_depth; i++) dq[i] += 1.0f;
   }
-
 
   __syncthreads();
   // figure out first thread in each warp (lane 0)
@@ -651,20 +547,18 @@ RepulsionKernel( /* int *restrict errd, */
   // if (diff < 32)
   dq[diff + sbase] = dq[diff];
 
-
   //__syncthreads();
   __threadfence_block();
 
   // iterate over all bodies assigned to thread
   const int MAX_SIZE = FOUR_NNODES + 4;
 
-  for (int k = threadIdx.x + blockIdx.x * blockDim.x; k < N; k += blockDim.x * gridDim.x)
-  {
+  for (int k = threadIdx.x + blockIdx.x * blockDim.x; k < N;
+       k += blockDim.x * gridDim.x) {
     const int i = sortd[k];  // get permuted/sorted index
     // cache position info
-    if (i < 0 or i >= MAX_SIZE)
-      continue;
-    
+    if (i < 0 or i >= MAX_SIZE) continue;
+
     const float px = posxd[i];
     const float py = posyd[i];
 
@@ -675,48 +569,37 @@ RepulsionKernel( /* int *restrict errd, */
     // initialize iteration stack, i.e., push root node onto stack
     int depth = sbase;
 
-    if (SBASE_EQ_THREAD == true)
-    {
+    if (SBASE_EQ_THREAD == true) {
       pos[sbase] = 0;
       node[sbase] = FOUR_NNODES;
     }
 
     do {
-
       // stack is not empty
       int pd = pos[depth];
       int nd = node[depth];
 
-
-      while (pd < 4)
-      {
+      while (pd < 4) {
         const int index = nd + pd++;
-        if (index < 0 or index >= MAX_SIZE)
-          break;
+        if (index < 0 or index >= MAX_SIZE) break;
 
         const int n = childd[index];  // load child pointer
 
         // Non child
-        if (n < 0 or n > NNODES)
-          break;
+        if (n < 0 or n > NNODES) break;
 
         const float dx = px - posxd[n];
         const float dy = py - posyd[n];
-        const float dxy1 = dx*dx + dy*dy + EPS_PLUS_1; 
+        const float dxy1 = dx * dx + dy * dy + EPS_PLUS_1;
 
-
-        if ((n < N) or __all_sync(__activemask(), dxy1 >= dq[depth]))
-        {
+        if ((n < N) or __all_sync(__activemask(), dxy1 >= dq[depth])) {
           const float tdist_2 = __fdividef(massd[n], dxy1 * dxy1);
           normsum += tdist_2 * dxy1;
           vx += dx * tdist_2;
           vy += dy * tdist_2;
-        }
-        else
-        {
+        } else {
           // push cell onto stack
-          if (SBASE_EQ_THREAD == true)
-          {
+          if (SBASE_EQ_THREAD == true) {
             pos[depth] = pd;
             node[depth] = nd;
           }
@@ -726,9 +609,7 @@ RepulsionKernel( /* int *restrict errd, */
         }
       }
 
-
-    } while (--depth >= sbase); // done with this level
-
+    } while (--depth >= sbase);  // done with this level
 
     // update velocity
     velxd[i] += vx;
@@ -737,17 +618,12 @@ RepulsionKernel( /* int *restrict errd, */
   }
 }
 
-
 /**
  * Find the norm(Y)
  */
-__global__ void
-get_norm(const float *restrict Y1,
-         const float *restrict Y2,
-         float *restrict norm,
-         float *restrict norm_add1,
-         const int N)
-{
+__global__ void get_norm(const float *restrict Y1, const float *restrict Y2,
+                         float *restrict norm, float *restrict norm_add1,
+                         const int N) {
   const int i = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (i >= N) return;
   norm[i] = Y1[i] * Y1[i] + Y2[i] * Y2[i];
@@ -757,18 +633,11 @@ get_norm(const float *restrict Y1,
 /**
  * Fast attractive kernel. Uses COO matrix.
  */
-__global__ void
-attractive_kernel_bh(const float *restrict VAL,
-                     const int *restrict COL,
-                     const int *restrict ROW,
-                     const float *restrict Y1,
-                     const float *restrict Y2,
-                     const float *restrict norm,
-                     const float *restrict norm_add1,
-                     float *restrict attract1,
-                     float *restrict attract2,
-                     const int NNZ)
-{
+__global__ void attractive_kernel_bh(
+  const float *restrict VAL, const int *restrict COL, const int *restrict ROW,
+  const float *restrict Y1, const float *restrict Y2,
+  const float *restrict norm, const float *restrict norm_add1,
+  float *restrict attract1, float *restrict attract2, const int NNZ) {
   const int index = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (index >= NNZ) return;
   const int i = ROW[index];
@@ -788,31 +657,20 @@ attractive_kernel_bh(const float *restrict VAL,
 /**
  * Apply gradient updates.
  */
-__global__ __launch_bounds__(THREADS6, FACTOR6) void
-IntegrationKernel(const float eta,
-                  const float momentum,
-                  const float exaggeration,
-                  float *restrict Y1,
-                  float *restrict Y2,
-                  const float *restrict attract1,
-                  const float *restrict attract2,
-                  const float *restrict repel1,
-                  const float *restrict repel2,
-                  float *restrict gains1,
-                  float *restrict gains2,
-                  float *restrict old_forces1,
-                  float *restrict old_forces2,
-                  const float *restrict Z,
-                  const int N)
-{
+__global__ __launch_bounds__(THREADS6, FACTOR6) void IntegrationKernel(
+  const float eta, const float momentum, const float exaggeration,
+  float *restrict Y1, float *restrict Y2, const float *restrict attract1,
+  const float *restrict attract2, const float *restrict repel1,
+  const float *restrict repel2, float *restrict gains1, float *restrict gains2,
+  float *restrict old_forces1, float *restrict old_forces2,
+  const float *restrict Z, const int N) {
   float ux, uy, gx, gy;
 
   // iterate over all bodies assigned to thread
   const int inc = blockDim.x * gridDim.x;
   const float Z_norm = Z[0];
 
-  for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < N; i += inc)
-  {
+  for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < N; i += inc) {
     const float dx = attract1[i] - Z_norm * repel1[i];
     const float dy = attract2[i] - Z_norm * repel2[i];
 

--- a/cpp/src/tsvd/tsvd.h
+++ b/cpp/src/tsvd/tsvd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ void calEig(const cumlHandle_impl &handle, math_t *in, math_t *components,
 
   if (prms.algorithm == solver::COV_EIG_JACOBI) {
     LinAlg::eigJacobi(in, prms.n_cols, prms.n_cols, components, explained_var,
-                      cusolver_handle, stream, allocator,(math_t)prms.tol,
+                      cusolver_handle, stream, allocator, (math_t)prms.tol,
                       prms.n_iterations);
   } else {
     LinAlg::eigDC(in, prms.n_cols, prms.n_cols, components, explained_var,

--- a/cpp/src/umap/runner.h
+++ b/cpp/src/umap/runner.h
@@ -53,7 +53,6 @@ template <int TPB_X, typename T>
 __global__ void init_transform(int *indices, T *weights, int n,
                                const T *embeddings, int embeddings_n,
                                int n_components, T *result, int n_neighbors) {
-
   // row-based matrix 1 thread per row
   int row = (blockIdx.x * TPB_X) + threadIdx.x;
   int i =
@@ -100,8 +99,8 @@ void _fit(const cumlHandle &handle,
   MLCommon::device_buffer<int64_t> knn_indices(d_alloc, stream, n * k);
   MLCommon::device_buffer<T> knn_dists(d_alloc, stream, n * k);
 
-  kNNGraph::run(X, n, X, n, d, knn_indices.data(), knn_dists.data(), k, params, d_alloc,
-                stream);
+  kNNGraph::run(X, n, X, n, d, knn_indices.data(), knn_dists.data(), k, params,
+                d_alloc, stream);
   CUDA_CHECK(cudaPeekAtLastError());
 
   COO<T> rgraph_coo(d_alloc, stream);
@@ -157,8 +156,8 @@ void _fit(const cumlHandle &handle,
   MLCommon::device_buffer<int64_t> knn_indices(d_alloc, stream, n * k);
   MLCommon::device_buffer<T> knn_dists(d_alloc, stream, n * k);
 
-  kNNGraph::run(X, n, X, n, d, knn_indices.data(), knn_dists.data(), k, params, d_alloc,
-                stream);
+  kNNGraph::run(X, n, X, n, d, knn_indices.data(), knn_dists.data(), k, params,
+                d_alloc, stream);
   CUDA_CHECK(cudaPeekAtLastError());
 
   /**
@@ -243,7 +242,7 @@ void _transform(const cumlHandle &handle, float *X, int n, int d, float *orig_X,
    * Perform kNN of X
    */
   MLCommon::device_buffer<int64_t> knn_indices(d_alloc, stream,
-                                            n * params->n_neighbors);
+                                               n * params->n_neighbors);
   MLCommon::device_buffer<T> knn_dists(d_alloc, stream,
                                        n * params->n_neighbors);
 

--- a/cpp/src/umap/supervised.h
+++ b/cpp/src/umap/supervised.h
@@ -243,7 +243,6 @@ void perform_general_intersection(const cumlHandle &handle, T *y,
   MLCommon::device_buffer<int64_t> y_knn_indices(d_alloc, stream, knn_dims);
   MLCommon::device_buffer<T> y_knn_dists(d_alloc, stream, knn_dims);
 
-
   kNNGraph::run(y, rgraph_coo->n_rows, y, rgraph_coo->n_rows, 1,
                 y_knn_indices.data(), y_knn_dists.data(),
                 params->target_n_neighbors, params, d_alloc, stream);

--- a/cpp/src_prims/common/seive.cuh
+++ b/cpp/src_prims/common/seive.cuh
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <vector>
 #include <cuda_utils.h>
+#include <vector>
 
 // Taken from:
 //  https://github.com/teju85/programming/blob/master/euler/include/seive.h
@@ -62,7 +62,7 @@ class Seive {
     auto size = ceildiv<unsigned>(N, sizeof(unsigned) * 8);
     seive.resize(size);
     // assume all to be primes initially
-    for(auto& itr : seive) {
+    for (auto& itr : seive) {
       itr = 0xffffffffu;
     }
     unsigned cid = 0;
@@ -83,12 +83,10 @@ class Seive {
     }
   }
 
-  unsigned getId(unsigned num) const {
-    return (num >> 1);
-  }
+  unsigned getId(unsigned num) const { return (num >> 1); }
 
   unsigned getNum(unsigned id) const {
-    if(id == 0) {
+    if (id == 0) {
       return 2;
     }
     return ((id << 1) + 1);
@@ -112,13 +110,13 @@ class Seive {
     auto bshft = 15u, b = 1u << bshft;
     do {
       unsigned temp = ((g << 1) + b) << bshft--;
-      if(val >= temp) {
+      if (val >= temp) {
         g += b;
         val -= temp;
       }
     } while (b >>= 1);
     return g;
-}
+  }
 
   /** find all primes till this number */
   unsigned N;

--- a/cpp/src_prims/datasets/digits.h
+++ b/cpp/src_prims/datasets/digits.h
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-namespace MLCommon{
+namespace MLCommon {
 namespace Datasets {
 namespace Digits {
 const std::vector<float> digits = {
@@ -16400,6 +16400,6 @@ static const std::vector<int> COL_vector = {
 
 static const int n_samples = 1797;
 static const int n_features = 64;
-} // END Digits
-} // END Datasets
-} // END MLCommon
+}  // namespace Digits
+}  // namespace Datasets
+}  // namespace MLCommon

--- a/cpp/src_prims/linalg/init.h
+++ b/cpp/src_prims/linalg/init.h
@@ -20,7 +20,7 @@ namespace MLCommon {
 namespace LinAlg {
 
 namespace {
-  /**
+/**
    * Like Python range.
    *
    * Fills the output as out[i] = i.

--- a/cpp/src_prims/selection/knn.h
+++ b/cpp/src_prims/selection/knn.h
@@ -20,11 +20,11 @@
 
 #include "distance/distance.h"
 
-#include <faiss/utils/Heap.h>
 #include <faiss/gpu/GpuDistance.h>
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/GpuResources.h>
 #include <faiss/gpu/StandardGpuResources.h>
+#include <faiss/utils/Heap.h>
 #include <faiss/gpu/utils/Limits.cuh>
 #include <faiss/gpu/utils/Select.cuh>
 

--- a/cpp/src_prims/sparse/spectral.h
+++ b/cpp/src_prims/sparse/spectral.h
@@ -128,7 +128,6 @@ void fit_clusters(T *X, int m, int n, int n_neighbors, int n_clusters,
 
   fit_clusters(knn_indices.data(), knn_dists.data(), m, n_neighbors, n_clusters,
                eigen_tol, out, d_alloc, stream);
-
 }
 
 template <typename T>
@@ -233,7 +232,6 @@ void fit_embedding(T *X, int m, int n, int n_neighbors, int n_components,
 
   fit_embedding(knn_indices.data(), knn_dists.data(), m, n_neighbors,
                 n_components, out, d_alloc, stream);
-
 }
 }  // namespace Spectral
 }  // namespace MLCommon

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -105,7 +105,6 @@ if(BUILD_CUML_TESTS)
       sg/umap_test.cu
       )
 
-    add_dependencies(ml ${ClangFormat_TARGET})
     add_dependencies(ml cub)
     add_dependencies(ml cutlass)
 
@@ -140,7 +139,6 @@ if(BUILD_CUML_MG_TESTS)
       mg/test_ml_mg_utils.cu
       )
 
-    add_dependencies(ml_mg ${ClangFormat_TARGET})
     add_dependencies(ml_mg cub)
     add_dependencies(ml_mg cutlass)
 
@@ -265,7 +263,6 @@ if(BUILD_PRIMS_TESTS)
       prims/weighted_mean.cu
       )
 
-    add_dependencies(prims ${ClangFormat_TARGET})
     add_dependencies(prims cub)
     add_dependencies(prims cutlass)
 

--- a/cpp/test/prims/batched/make_symm.cu
+++ b/cpp/test/prims/batched/make_symm.cu
@@ -59,8 +59,8 @@ void naiveBatchMakeSymm(Type *y, const Type *x, int batchSize, int n,
 }
 
 template <typename T>
-class BatchMakeSymmTest :
-    public ::testing::TestWithParam<BatchMakeSymmInputs<T>> {
+class BatchMakeSymmTest
+  : public ::testing::TestWithParam<BatchMakeSymmInputs<T>> {
  protected:
   void SetUp() override {
     params = ::testing::TestWithParam<BatchMakeSymmInputs<T>>::GetParam();
@@ -92,7 +92,8 @@ class BatchMakeSymmTest :
 };
 
 const std::vector<BatchMakeSymmInputs<float>> inputsf = {
-  {0.000001f, 128, 32, 1234ULL}, {0.000001f, 126, 32, 1234ULL},
+  {0.000001f, 128, 32, 1234ULL},
+  {0.000001f, 126, 32, 1234ULL},
   {0.000001f, 125, 32, 1234ULL},
 };
 typedef BatchMakeSymmTest<float> BatchMakeSymmTestF;
@@ -106,7 +107,8 @@ INSTANTIATE_TEST_CASE_P(BatchMakeSymmTests, BatchMakeSymmTestF,
 
 typedef BatchMakeSymmTest<double> BatchMakeSymmTestD;
 const std::vector<BatchMakeSymmInputs<double>> inputsd = {
-  {0.0000001, 128, 32, 1234ULL}, {0.0000001, 126, 32, 1234ULL},
+  {0.0000001, 128, 32, 1234ULL},
+  {0.0000001, 126, 32, 1234ULL},
   {0.0000001, 125, 32, 1234ULL},
 };
 TEST_P(BatchMakeSymmTestD, Result) {

--- a/cpp/test/prims/make_regression.cu
+++ b/cpp/test/prims/make_regression.cu
@@ -79,7 +79,7 @@ class MakeRegressionTest
 
     // Add the bias
     LinAlg::addScalar(values_prod, values_prod, params.bias,
-                           params.n_samples * params.n_targets, stream);
+                      params.n_samples * params.n_targets, stream);
 
     // Count the number of zeroes in the coefficients
     thrust::device_ptr<T> __coef = thrust::device_pointer_cast(coef);

--- a/cpp/test/sg/dbscan_test.cu
+++ b/cpp/test/sg/dbscan_test.cu
@@ -19,10 +19,10 @@
 #include <vector>
 
 #include <cuml/cluster/dbscan.hpp>
-#include <cuml/datasets/make_blobs.hpp>
-#include <cuml/metrics/metrics.hpp>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/cuml.hpp>
+#include <cuml/datasets/make_blobs.hpp>
+#include <cuml/metrics/metrics.hpp>
 
 #include "linalg/cublas_wrappers.h"
 #include "linalg/transpose.h"

--- a/cpp/test/sg/rproj_test.cu
+++ b/cpp/test/sg/rproj_test.cu
@@ -20,9 +20,9 @@
 #include <iostream>
 #include <random>
 #include <vector>
+#include "cuml/random_projection/rproj_c.h"
 #include "distance/distance.h"
 #include "linalg/transpose.h"
-#include "cuml/random_projection/rproj_c.h"
 
 namespace ML {
 

--- a/wiki/cpp/DEVELOPER_GUIDE.md
+++ b/wiki/cpp/DEVELOPER_GUIDE.md
@@ -151,16 +151,18 @@ cuML relies on `clang-format` to enforce code style across all C++ and CUDA sour
 The reasons behind these deviations from the Google style guide are given in comments [here](../../cpp/.clang-format).
 
 ### How is the check done?
-[run-clang-format.py](../../cpp/scripts/run-clang-format.py) is run first by `make`. This script runs clang-format only on modified files. An error is raised if the code diverges from the format suggested by clang-format, and the build fails.
+All formatting checks are done by this python script: [run-clang-format.py](../../cpp/scripts/run-clang-format.py) which is effectively a wrapper over `clang-format`. An error is raised if the code diverges from the format suggested by clang-format. It is expected that the developers run this script to detect and fix formatting violations before creating PR.
+
+After [PR 1468](https://github.com/rapidsai/cuml/pull/1468) goes through, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) will be executed as part of our `gpuCI/cuml/style-check` CI test. If there are any formatting violations, PR author is expected to fix those to get CI passing. Steps needed to fix the formatting violations are described in the following sub-section.
 
 ### How to know the formatting violations?
-When there are formatting errors, `run-clang-format.py` prints a `diff` command, showing where there are formatting differences. Unfortunately, unlike `flake8`, `clang-format` does NOT print descriptions of the violations, but instead directly formats the code. So, the only way currently to know why there are formatting differences is to run the diff command as suggested by this script against each violating source file.
+When there are formatting errors, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints a `diff` command, showing where there are formatting differences. Unfortunately, unlike `flake8`, `clang-format` does NOT print descriptions of the violations, but instead directly formats the code. So, the only way currently to know about formatting differences is to run the diff command as suggested by this script against each violating source file.
 
 ### How to fix the formatting violations?
-When there are formatting violations, `run-clang-format.py` prints an `-inplace` command you can use to automatically fix formatting errors. This is the easiest way to fix formatting errors. [This screencast](https://asciinema.org/a/248215) shows a typical build-fix-build cycle during cuML development.
+When there are formatting violations, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints at the end, the exact command that can be run by developers to fix them. This is the easiest way to fix formatting errors. [This screencast](https://asciinema.org/a/248215) shows a typical build-fix-build cycle during cuML development.
 
 ### clang-format version?
-To avoid spurious code style violations we specify the exact clang-format version required, currently `8.0.0`. This is enforced by a CMake check for the required version. [See here for more details on the dependencies](../../cpp/README.md#dependencies).
+To avoid spurious code style violations we specify the exact clang-format version required, currently `8.0.0`. This is enforced by the [run-clang-format.py](../../cpp/scripts/run-clang-format.py) script itself. Refer [here](../../cpp/README.md#dependencies) for the list of build-time dependencies.
 
 ## Error handling
 Call CUDA APIs via the provided helper macros `CUDA_CHECK`, `CUBLAS_CHECK` and `CUSOLVER_CHECK`. These macros take care of checking the return values of the used API calls and generate an exception when the command is not successful. If you need to avoid an exception, e.g. inside a destructor, use `CUDA_CHECK_NO_THROW`, `CUBLAS_CHECK_NO_THROW ` and `CUSOLVER_CHECK_NO_THROW ` (currently not available, see https://github.com/rapidsai/cuml/issues/229). These macros log the error but do not throw an exception.

--- a/wiki/cpp/DEVELOPER_GUIDE.md
+++ b/wiki/cpp/DEVELOPER_GUIDE.md
@@ -159,7 +159,7 @@ All formatting checks are done by this python script: [run-clang-format.py](../.
 When there are formatting errors, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints a `diff` command, showing where there are formatting differences. Unfortunately, unlike `flake8`, `clang-format` does NOT print descriptions of the violations, but instead directly formats the code. So, the only way currently to know about formatting differences is to run the diff command as suggested by this script against each violating source file.
 
 ### How to fix the formatting violations?
-When there are formatting violations, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints at the end, the exact command that can be run by developers to fix them. This is the easiest way to fix formatting errors. [This screencast](https://asciinema.org/a/248215) shows a typical build-fix-build cycle during cuML development.
+When there are formatting violations, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints at the end, the exact command that can be run by developers to fix them. This is the easiest way to fix formatting errors. [This screencast](https://asciinema.org/a/287367) shows how developers can check for formatting violations in their branches and also how to fix those, before sending out PRs.
 
 ### clang-format version?
 To avoid spurious code style violations we specify the exact clang-format version required, currently `8.0.0`. This is enforced by the [run-clang-format.py](../../cpp/scripts/run-clang-format.py) script itself. Refer [here](../../cpp/README.md#dependencies) for the list of build-time dependencies.

--- a/wiki/cpp/DEVELOPER_GUIDE.md
+++ b/wiki/cpp/DEVELOPER_GUIDE.md
@@ -153,7 +153,7 @@ The reasons behind these deviations from the Google style guide are given in com
 ### How is the check done?
 All formatting checks are done by this python script: [run-clang-format.py](../../cpp/scripts/run-clang-format.py) which is effectively a wrapper over `clang-format`. An error is raised if the code diverges from the format suggested by clang-format. It is expected that the developers run this script to detect and fix formatting violations before creating PR.
 
-After [PR 1468](https://github.com/rapidsai/cuml/pull/1468) goes through, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) will be executed as part of our `gpuCI/cuml/style-check` CI test. If there are any formatting violations, PR author is expected to fix those to get CI passing. Steps needed to fix the formatting violations are described in the following sub-section.
+[run-clang-format.py](../../cpp/scripts/run-clang-format.py) is executed as part of our `gpuCI/cuml/style-check` CI test. If there are any formatting violations, PR author is expected to fix those to get CI passing. Steps needed to fix the formatting violations are described in the subsequent sub-section.
 
 ### How to know the formatting violations?
 When there are formatting errors, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints a `diff` command, showing where there are formatting differences. Unfortunately, unlike `flake8`, `clang-format` does NOT print descriptions of the violations, but instead directly formats the code. So, the only way currently to know about formatting differences is to run the diff command as suggested by this script against each violating source file.

--- a/wiki/cpp/DEVELOPER_GUIDE.md
+++ b/wiki/cpp/DEVELOPER_GUIDE.md
@@ -153,13 +153,27 @@ The reasons behind these deviations from the Google style guide are given in com
 ### How is the check done?
 All formatting checks are done by this python script: [run-clang-format.py](../../cpp/scripts/run-clang-format.py) which is effectively a wrapper over `clang-format`. An error is raised if the code diverges from the format suggested by clang-format. It is expected that the developers run this script to detect and fix formatting violations before creating PR.
 
+#### As part of CI
 [run-clang-format.py](../../cpp/scripts/run-clang-format.py) is executed as part of our `gpuCI/cuml/style-check` CI test. If there are any formatting violations, PR author is expected to fix those to get CI passing. Steps needed to fix the formatting violations are described in the subsequent sub-section.
+
+#### Manually
+Developers can also manually (or setup this command as part of git pre-commit hook) run this check by executing:
+```bash
+python ./cpp/scripts/run-clang-format.py
+```
+From the root of the cuML repository.
 
 ### How to know the formatting violations?
 When there are formatting errors, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints a `diff` command, showing where there are formatting differences. Unfortunately, unlike `flake8`, `clang-format` does NOT print descriptions of the violations, but instead directly formats the code. So, the only way currently to know about formatting differences is to run the diff command as suggested by this script against each violating source file.
 
 ### How to fix the formatting violations?
 When there are formatting violations, [run-clang-format.py](../../cpp/scripts/run-clang-format.py) prints at the end, the exact command that can be run by developers to fix them. This is the easiest way to fix formatting errors. [This screencast](https://asciinema.org/a/287367) shows how developers can check for formatting violations in their branches and also how to fix those, before sending out PRs.
+
+In short, to bulk-fix all the formatting violations, execute the following command:
+```bash
+python ./cpp/scripts/run-clang-format.py -inplace
+```
+From the root of the cuML repository.
 
 ### clang-format version?
 To avoid spurious code style violations we specify the exact clang-format version required, currently `8.0.0`. This is enforced by the [run-clang-format.py](../../cpp/scripts/run-clang-format.py) script itself. Refer [here](../../cpp/README.md#dependencies) for the list of build-time dependencies.


### PR DESCRIPTION
This PR shows a solution to the issue described in #1120 .

Proposed changes in this PR:
1. It removes clang-format completely from the cmake flow. Thereby voiding the need for downloading our libclang conda package for anyone who wants to just build from source. From now onwards, clang-format v8.0.0 is a required dependency only for developers, and obviously the CI.
2. It adds an extra check command inside `ci/checks/style.sh` which directly runs the `cpp/scripts/run-clang-format.py` across all source folders.
3. Fix all remnant formatting issues with the existing source files

How does the new workflow look like?

**Case1**: developer forgets to updates the format and sends a PR
CI will catch any formatting issues, since that checks happens automatically inside `ci/checks/style.sh`. Thus the dev is forced to fix the formatting issues by following the steps described in the error message.

**Case2**: developer explicitly fixes before sending the PR
All is well!