### PR TITLE
[REVIEW] Documentation: add make_regression and fix ARIMAModel path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 
+- PR #1470: Documentation: add make_regression, fix ARIMA section
 
 # cuML 0.11.0 (Date TBD)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,7 @@ Dataset Generation (Single-GPU)
 -------------------------------
 
   .. automethod:: cuml.datasets.make_blobs
+  .. automethod:: cuml.datasets.make_regression
 
 
 Dataset Generation (Dask-based Multi-GPU)

--- a/python/cuml/datasets/__init__.py
+++ b/python/cuml/datasets/__init__.py
@@ -15,3 +15,4 @@
 #
 
 from cuml.datasets.blobs import blobs as make_blobs
+from cuml.datasets.regression import make_regression

--- a/python/cuml/tsa/__init__.py
+++ b/python/cuml/tsa/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 #
 from cuml.tsa.holtwinters import ExponentialSmoothing
+from cuml.tsa.arima import ARIMAModel


### PR DESCRIPTION
This PR adds `make_regression` to the docs and adds `ARIMAModel` to the corresponding `__init__.py` to fix the broken section in the docs.