### PR TITLE
[HOTFIX][REVIEW] Defer knn mnmg to 0.12 nightly builds and disable ucx-py dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - PR #1295: Cython side of MNMG PCA
 - PR #1218: prims: histogram prim
 - PR #1129: C++: Separate include folder for C++ API distribution
-- PR #1282: OPG KNN MNMG
+- PR #1282: OPG KNN MNMG Code (disabled for 0.11)
 - PR #1242: Initial implementation of FIL sparse forests
 - PR #1194: Initial ARIMA time-series modeling support.
 - PR #1286: Importing treelite models as FIL sparse forests
@@ -88,6 +88,7 @@
 - PR #1438: KNN Classifier to properly return Dataframe with Dataframe input
 - PR #1425: Deprecate seed and use random_state similar to Scikit-learn in train_test_split
 - PR #1458: Add joblib as an explicit requirement
+- PR #1474: Defer knn mnmg to 0.12 nightly builds and disable ucx-py dependency
 
 # cuML 0.10.0 (16 Oct 2019)
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Output:
 dtype: int32
 ```
 
-cuML also features multi-GPU and multi-node-multi-GPU operation, using [Dask](https://www.dask.org), for a 
-growing list of algorithms. The following Python snippet reads input from a CSV file and performs 
+cuML also features multi-GPU and multi-node-multi-GPU operation, using [Dask](https://www.dask.org), for a
+growing list of algorithms. The following Python snippet reads input from a CSV file and performs
 a NearestNeighbors query across a cluster of Dask workers, using multiple GPUs on a single node:
 ```python
 # Create a Dask CUDA cluster w/ one worker per device
@@ -83,8 +83,8 @@ repo](https://github.com/rapidsai/notebooks-contrib).
 | | Stochastic Gradient Descent (SGD), Coordinate Descent (CD), and Quasi-Newton (QN) (including L-BFGS and OWL-QN) solvers for linear models  | |
 | **Nonlinear Models for Regression or Classification** | Random Forest (RF) Classification | Experimental multi-node multi-GPU via Dask |
 | | Random Forest (RF) Regression | Experimental multi-node multi-GPU via Dask |
-|  | K-Nearest Neighbors (KNN) Classification | Multi-node multi-GPU via Dask. Uses [Faiss](https://github.com/facebookresearch/faiss) for Nearest Neighbors Query. |
-|  | K-Nearest Neighbors (KNN) Regression | Multi-node multi-GPU via Dask. Uses [Faiss](https://github.com/facebookresearch/faiss) for Nearest Neighbors Query. |
+|  | K-Nearest Neighbors (KNN) Classification | Multi-node multi-GPU via Dask, available in version 0.12 branch and nightly conda packages. Uses [Faiss](https://github.com/facebookresearch/faiss) for Nearest Neighbors Query. |
+|  | K-Nearest Neighbors (KNN) Regression | Multi-node multi-GPU via Dask, available in version 0.12 branch and nightly conda packages. Uses [Faiss](https://github.com/facebookresearch/faiss) for Nearest Neighbors Query.  |
 |  | Support Vector Machine Classifier (SVC) | |
 | **Time Series** | Linear Kalman Filter | |
 |  | Holt-Winters Exponential Smoothing | |

--- a/build.sh
+++ b/build.sh
@@ -132,8 +132,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libcuml || hasArg prims || hasArg bench; then
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
           -DBUILD_CUML_C_LIBRARY=ON \
           -DBUILD_CUML_STD_COMMS=ON \
-          -DWITH_UCX=ON \
-          -DUCX_LIBRARY=${INSTALL_PREFIX}/lib/libucp.so \
+          -DWITH_UCX=OFF \
           -DBUILD_CUML_MPI_COMMS=OFF \
           -DPARALLEL_LEVEL=${PARALLEL_LEVEL} \
           -DNCCL_PATH=${INSTALL_PREFIX} \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -60,7 +60,6 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "statsmodels" \
-      "ucx-py=0.11*" \
       "xgboost=0.90.rapidsdev1"
 
 

--- a/conda/environments/cuml_dev_cuda10.0.yml
+++ b/conda/environments/cuml_dev_cuda10.0.yml
@@ -25,5 +25,4 @@ dependencies:
 - nccl>=2.4
 - libcumlprims=0.11*
 - statsmodels
-- ucx-py=0.11*
 - protobuf >=3.4.1,<4.0.0

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -25,5 +25,4 @@ dependencies:
 - nccl>=2.4
 - libcumlprims=0.11*
 - statsmodels
-- ucx-py=0.11*
 - protobuf >=3.4.1,<4.0.0

--- a/conda/environments/cuml_dev_cuda9.2.yml
+++ b/conda/environments/cuml_dev_cuda9.2.yml
@@ -25,5 +25,4 @@ dependencies:
 - nccl>=2.4
 - libcumlprims=0.11*
 - statsmodels
-- ucx-py=0.11*
 - protobuf >=3.4.1,<4.0.0

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
-    - ucx-py=0.11
   run:
     - python x.x
     - cudf {{ minor_version }}
@@ -42,7 +41,6 @@ requirements:
     - libcumlprims {{ minor_version }}
     - cupy>=6.5,<7.0
     - nccl 2.4.*
-    - ucx-py=0.11
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -29,7 +29,6 @@ requirements:
   build:
     - cmake>=3.14
     - libclang
-    - ucx-py=0.11
   host:
     - nccl 2.4.*
     - cudf {{ minor_version }}
@@ -37,13 +36,11 @@ requirements:
     - libcumlprims {{ minor_version }}
     - lapack
     - protobuf >=3.4.1,<4.0.0
-    - ucx-py=0.11
   run:
     - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
     - nccl 2.4.*
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - ucx-py=0.11
 
 about:
   home: http://rapids.ai/

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,8 +57,8 @@ Benchmarking
 
   .. automodule:: cuml.benchmark.datagen
     :members:
-    
-       
+
+
 
 Utilities for I/O and Numba
 ---------------------------
@@ -74,7 +74,7 @@ Utilities for Dask and Multi-GPU Preprocessing
 
   .. automodule:: cuml.dask.common.utils
      :members:
-  
+
 
 Regression and Classification
 =============================
@@ -109,7 +109,7 @@ ElasticNet Regression
 .. autoclass:: cuml.ElasticNet
     :members:
 
-Mini Batch SGD Classifier 
+Mini Batch SGD Classifier
 -------------------------
 
 .. autoclass:: cuml.MBSGDClassifier
@@ -276,13 +276,6 @@ Random Forest
     :members:
 
 .. autoclass:: cuml.dask.ensemble.RandomForestRegressor
-    :members:
-
-
-Nearest Neighbors
------------------
-
-.. autoclass:: cuml.dask.neighbors.NearestNeighbors
     :members:
 
 

--- a/python/cuml/dask/neighbors/nearest_neighbors.py
+++ b/python/cuml/dask/neighbors/nearest_neighbors.py
@@ -40,6 +40,11 @@ class NearestNeighbors(object):
     """
     def __init__(self, client=None, streams_per_handle=0, verbose=False,
                  **kwargs):
+
+        raise NotImplementedError("Multi-GPU KNN is not available in RAPIDS "
+                                  "0.11, it will be enabled in the next "
+                                  "release. Legacy version is available in "
+                                  "0.10.")
         self.client = default_client() if client is None else client
         self.model_args = kwargs
         self.X = None

--- a/python/cuml/test/dask/conftest.py
+++ b/python/cuml/test/dask/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from dask_cuda import initialize
 from dask_cuda import LocalCUDACluster
 
-enable_tcp_over_ucx = True
+enable_tcp_over_ucx = False
 enable_nvlink = False
 enable_infiniband = False
 

--- a/python/cuml/test/dask/test_comms.py
+++ b/python/cuml/test/dask/test_comms.py
@@ -117,7 +117,7 @@ def test_allreduce(cluster):
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [5])
-@pytest.skip("ucx functionality available in cuML 0.12+")
+@pytest.mark.skip("ucx functionality available in cuML 0.12+")
 def test_send_recv(n_trials, ucx_cluster):
 
     client = Client(ucx_cluster)
@@ -146,7 +146,7 @@ def test_send_recv(n_trials, ucx_cluster):
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [5])
-@pytest.skip("ucx functionality available in cuML 0.12+")
+@pytest.mark.skip("ucx functionality available in cuML 0.12+")
 def test_recv_any_rank(n_trials, ucx_cluster):
 
     client = Client(ucx_cluster)

--- a/python/cuml/test/dask/test_comms.py
+++ b/python/cuml/test/dask/test_comms.py
@@ -117,6 +117,7 @@ def test_allreduce(cluster):
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [5])
+@pytest.skip("ucx functionality available in cuML 0.12+")
 def test_send_recv(n_trials, ucx_cluster):
 
     client = Client(ucx_cluster)
@@ -145,6 +146,7 @@ def test_send_recv(n_trials, ucx_cluster):
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [5])
+@pytest.skip("ucx functionality available in cuML 0.12+")
 def test_recv_any_rank(n_trials, ucx_cluster):
 
     client = Client(ucx_cluster)

--- a/python/cuml/test/dask/test_nearest_neighbors.py
+++ b/python/cuml/test/dask/test_nearest_neighbors.py
@@ -76,7 +76,7 @@ def test_011_exception():
 @pytest.mark.parametrize("n_parts", [unit_param(1), unit_param(5),
                                      quality_param(7), stress_param(50)])
 @pytest.mark.parametrize("streams_per_handle", [1, 5])
-@pytest.skip("MNMG KNN available in cuML 0.12+")
+@pytest.mark.skip("MNMG KNN available in cuML 0.12+")
 def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
                      streams_per_handle, cluster):
 
@@ -119,7 +119,7 @@ def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
 @pytest.mark.parametrize("ncols", [unit_param(10), stress_param(500)])
 @pytest.mark.parametrize("n_parts", [unit_param(10), stress_param(100)])
 @pytest.mark.parametrize("batch_size", [unit_param(100), stress_param(1e3)])
-@pytest.skip("MNMG KNN available in cuML 0.12+")
+@pytest.mark.skip("MNMG KNN available in cuML 0.12+")
 def test_batch_size(nrows, ncols, n_parts,
                     batch_size, cluster):
 
@@ -160,6 +160,7 @@ def test_batch_size(nrows, ncols, n_parts,
         client.close()
 
 
+@pytest.mark.skip("MNMG KNN available in cuML 0.12+")
 def test_return_distance(cluster):
 
     client = Client(cluster)
@@ -198,7 +199,7 @@ def test_return_distance(cluster):
         client.close()
 
 
-@pytest.skip("MNMG KNN available in cuML 0.12+")
+@pytest.mark.skip("MNMG KNN available in cuML 0.12+")
 def test_default_n_neighbors(cluster):
 
     client = Client(cluster)

--- a/python/cuml/test/dask/test_nearest_neighbors.py
+++ b/python/cuml/test/dask/test_nearest_neighbors.py
@@ -58,6 +58,13 @@ def _prep_training_data(c, X_train, partitions_per_worker):
     return X_train_df
 
 
+def test_011_exception():
+    from cuml.dask.neighbors import NearestNeighbors as daskNN
+
+    with pytest.raises(NotImplementedError):
+        cumlModel = daskNN()  # noqa: F841
+
+
 @pytest.mark.parametrize("nrows", [unit_param(1e3), unit_param(1e4),
                                    quality_param(1e6),
                                    stress_param(5e8)])
@@ -69,6 +76,7 @@ def _prep_training_data(c, X_train, partitions_per_worker):
 @pytest.mark.parametrize("n_parts", [unit_param(1), unit_param(5),
                                      quality_param(7), stress_param(50)])
 @pytest.mark.parametrize("streams_per_handle", [1, 5])
+@pytest.skip("MNMG KNN available in cuML 0.12+")
 def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
                      streams_per_handle, cluster):
 
@@ -111,6 +119,7 @@ def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
 @pytest.mark.parametrize("ncols", [unit_param(10), stress_param(500)])
 @pytest.mark.parametrize("n_parts", [unit_param(10), stress_param(100)])
 @pytest.mark.parametrize("batch_size", [unit_param(100), stress_param(1e3)])
+@pytest.skip("MNMG KNN available in cuML 0.12+")
 def test_batch_size(nrows, ncols, n_parts,
                     batch_size, cluster):
 
@@ -189,6 +198,7 @@ def test_return_distance(cluster):
         client.close()
 
 
+@pytest.skip("MNMG KNN available in cuML 0.12+")
 def test_default_n_neighbors(cluster):
 
     client = Client(cluster)

--- a/python/cuml/test/test_linear_model.py
+++ b/python/cuml/test/test_linear_model.py
@@ -216,7 +216,7 @@ def test_logistic_regression(num_classes, dtype, penalty, l1_ratio,
     # Setting tolerance to lowest possible per loss to detect regressions
     # as much as possible
 
-    assert culog.score(X_test, y_test) >= sklog.score(X_test, y_test) - 0.052
+    assert culog.score(X_test, y_test) >= sklog.score(X_test, y_test) - 0.06
 
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])

--- a/python/setup.py
+++ b/python/setup.py
@@ -129,7 +129,8 @@ if "--singlegpu" in sys.argv:
     sys.argv.remove('--singlegpu')
 else:
     libs.append('cumlprims')
-    libs.append("ucp")
+    # ucx/ucx-py related functionality available in version 0.12+
+    # libs.append("ucp")
 
     sys_include = os.path.dirname(sysconfig.get_path("include"))
     include_dirs.append("%s/cumlprims" % sys_include)


### PR DESCRIPTION
Defer knn mnmg to 0.12, and disable ucx-py related functionality. Also includes small fix from #1465 to avoid that sporadic test fail

Note: the auto merger will disable it for 0.12 temporarily, will create a PR to 0.12 once this one is merged to re-enable asap