### PR TITLE
[REVIEW] Perf optimizations to kmeans - add tiling support for 1-NN computation and use fusedL2-1NN prim for L2 distance metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #1463: Update FAISS submodule to 1.6.1
 - PR #1488: Add codeowners
 - PR #1490: Use dask master instead of conda package for testing
+- PR #1493: kmeans: add tiling support for 1-NN computation and use fusedL2-1NN prim for L2 distance metric
 
 ## Bug Fixes
 

--- a/cpp/bench/sg/kmeans.cu
+++ b/cpp/bench/sg/kmeans.cu
@@ -100,7 +100,7 @@ std::vector<Params> getInputs() {
       p.data.nclasses = nclass;
       p.kmeans.n_clusters = p.data.nclasses;
       for (auto bs_shift : std::vector<int>({16, 18})) {
-        p.kmeans.batch_size = 1 << bs_shift;
+        p.kmeans.batch_samples = 1 << bs_shift;
         out.push_back(p);
       }
     }

--- a/cpp/include/cuml/cluster/kmeans.hpp
+++ b/cpp/include/cuml/cluster/kmeans.hpp
@@ -58,9 +58,12 @@ struct KMeansParams {
   // Oversampling factor for use in the k-means|| algorithm.
   double oversampling_factor = 2.0;
 
+  // batch_samples and batch_centroids are used to tile 1NN computation which is
+  // useful to optimize/control the memory footprint
+  // Default tile is [batch_samples x n_clusters] i.e. when batch_centroids is 0
+  // then don't tile the centroids
   int batch_samples = 1 << 15;
-
-  int batch_centroids = 1024;
+  int batch_centroids = 0;  // if 0 then batch_centroids = n_clusters
 
   bool inertia_check = false;
 };

--- a/cpp/include/cuml/cluster/kmeans.hpp
+++ b/cpp/include/cuml/cluster/kmeans.hpp
@@ -58,7 +58,9 @@ struct KMeansParams {
   // Oversampling factor for use in the k-means|| algorithm.
   double oversampling_factor = 2.0;
 
-  int batch_size = 1 << 15;
+  int batch_samples = 1 << 15;
+
+  int batch_centroids = 1024;
 
   bool inertia_check = false;
 };

--- a/cpp/src/kmeans/common.cuh
+++ b/cpp/src/kmeans/common.cuh
@@ -331,7 +331,7 @@ void minClusterAndDistance(
         centroids.template view<2>({nc, n_features}, {cIdx, 0});
 
       if (metric == MLCommon::Distance::EucExpandedL2 ||
-          MLCommon::Distance::EucExpandedL2Sqrt) {
+          metric == MLCommon::Distance::EucExpandedL2Sqrt) {
         auto centroidsNormView = centroidsNorm.template view<1>({nc}, {cIdx});
         workspace.resize((sizeof(int)) * ns, stream);
 

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -51,7 +51,8 @@ cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans":
         int seed,
         int metric,
         double oversampling_factor,
-        int batch_size,
+        int batch_samples,
+        int batch_centroids,
         bool inertia_check
 
     cdef void fit_predict(cumlHandle& handle,
@@ -295,7 +296,7 @@ class KMeans(Base):
         params.verbose = <int>self.verbose
         params.seed = <int>self.random_state
         params.metric = 0   # distance metric as squared L2: @todo - support other metrics # noqa: E501
-        params.batch_size=<int>self.max_samples_per_batch
+        params.batch_samples=<int>self.max_samples_per_batch
         params.oversampling_factor=<double>self.oversampling_factor
         self._params = params
 

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -54,7 +54,8 @@ cdef extern from "cumlprims/opg/kmeans.hpp" namespace \
         int seed,
         int metric,
         double oversampling_factor,
-        int batch_size,
+        int batch_samples,
+        int batch_centroids,
         bool inertia_check
 
 cdef extern from "cumlprims/opg/kmeans.hpp" namespace "ML::kmeans::opg" nogil:


### PR DESCRIPTION
This PR introduces the following performance-oriented changes to k-means -
- Adds tiling support during nearest-neighbor computation - this fixes OOM issues and also helps in fine-tuning/controlling the memory footprint requirements. Fixes Issue #1294 
- Use PR #1483 (fuse L2 distance and nearest-neighbor computations into a single kernel) to optimize the control-flow with L2 distance metric.

Tagging @cjnolet and @teju85 for review.
