### PR TITLE
added cub/cutlass as dependencies for prims-bench build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #1482: Updated the code to remove sklearn from the mbsgd stress test
 - PR #1491: Update dev environments for 0.12
 - PR #1498: Add build.sh to code owners
+- PR #1505: cmake: added correct dependencies for prims-bench build
 
 # cuML 0.11.0 (11 Dec 2019)
 

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -82,6 +82,8 @@ if(BUILD_CUML_PRIMS_BENCH)
     prims/rng.cu
     prims/main.cpp
     )
+  add_dependencies(${CUML_PRIMS_BENCH_TARGET} cub)
+  add_dependencies(${CUML_PRIMS_BENCH_TARGET} cutlass)
   target_link_libraries(${CUML_PRIMS_BENCH_TARGET} benchmarklib)
   target_include_directories(${CUML_PRIMS_BENCH_TARGET}
     PRIVATE ${GBENCH_DIR}/include


### PR DESCRIPTION
Or else, it can cause prims-bench to start building before cub/cutlass were sync'ed, leading to build failure.