### PR TITLE
[REVIEW] Fixed a typo in function cumlMPICommunicator_impl::syncStream 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #1547: Fixing MNMG kmeans score. Fixing UMAP pickling before fit(). Fixing UMAP test failures.
 - PR #1557: Increasing threshold for kmeans score
 - PR #1562: Increasing threshold even higher
+- PR #1564: Fixed a typo in function cumlMPICommunicator_impl::syncStream
 
 # cuML 0.11.0 (11 Dec 2019)
 

--- a/cpp/comms/mpi/src/cuML_comms_mpi_impl.cpp
+++ b/cpp/comms/mpi/src/cuML_comms_mpi_impl.cpp
@@ -117,8 +117,8 @@ MPI_Datatype getMPIDatatype(
     case MLCommon::cumlCommunicator::DOUBLE:
       return MPI_DOUBLE;
     default:
-    // Execution should never reach here. This takes care of compiler warning.
-    return MPI_DOUBLE;
+      // Execution should never reach here. This takes care of compiler warning.
+      return MPI_DOUBLE;
   }
 }
 
@@ -133,8 +133,8 @@ MPI_Op getMPIOp(const cumlMPICommunicator_impl::op_t op) {
     case MLCommon::cumlCommunicator::MAX:
       return MPI_MAX;
     default:
-    // Execution should never reach here. This takes care of compiler warning.
-    return MPI_MAX;
+      // Execution should never reach here. This takes care of compiler warning.
+      return MPI_MAX;
   }
 }
 
@@ -159,8 +159,8 @@ ncclDataType_t getNCCLDatatype(
     case MLCommon::cumlCommunicator::DOUBLE:
       return ncclDouble;
     default:
-    // Execution should never reach here. This takes care of compiler warning.
-    return ncclDouble;
+      // Execution should never reach here. This takes care of compiler warning.
+      return ncclDouble;
   }
 }
 
@@ -175,8 +175,8 @@ ncclRedOp_t getNCCLOp(const cumlMPICommunicator_impl::op_t op) {
     case MLCommon::cumlCommunicator::MAX:
       return ncclMax;
     default:
-    // Execution should never reach here. This takes care of compiler warning.
-    return ncclMax;
+      // Execution should never reach here. This takes care of compiler warning.
+      return ncclMax;
   }
 }
 #endif

--- a/cpp/comms/mpi/src/cuML_comms_mpi_impl.cpp
+++ b/cpp/comms/mpi/src/cuML_comms_mpi_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,9 @@ size_t getDatatypeSize(const cumlMPICommunicator_impl::datatype_t datatype) {
       return sizeof(float);
     case MLCommon::cumlCommunicator::DOUBLE:
       return sizeof(double);
+    default:
+      // Execution should never reach here. This takes care of compiler warning.
+      return 0;
   }
 }
 
@@ -113,6 +116,9 @@ MPI_Datatype getMPIDatatype(
       return MPI_FLOAT;
     case MLCommon::cumlCommunicator::DOUBLE:
       return MPI_DOUBLE;
+    default:
+    // Execution should never reach here. This takes care of compiler warning.
+    return MPI_DOUBLE;
   }
 }
 
@@ -126,6 +132,9 @@ MPI_Op getMPIOp(const cumlMPICommunicator_impl::op_t op) {
       return MPI_MIN;
     case MLCommon::cumlCommunicator::MAX:
       return MPI_MAX;
+    default:
+    // Execution should never reach here. This takes care of compiler warning.
+    return MPI_MAX;
   }
 }
 
@@ -149,6 +158,9 @@ ncclDataType_t getNCCLDatatype(
       return ncclFloat;
     case MLCommon::cumlCommunicator::DOUBLE:
       return ncclDouble;
+    default:
+    // Execution should never reach here. This takes care of compiler warning.
+    return ncclDouble;
   }
 }
 
@@ -162,6 +174,9 @@ ncclRedOp_t getNCCLOp(const cumlMPICommunicator_impl::op_t op) {
       return ncclMin;
     case MLCommon::cumlCommunicator::MAX:
       return ncclMax;
+    default:
+    // Execution should never reach here. This takes care of compiler warning.
+    return ncclMax;
   }
 }
 #endif
@@ -365,7 +380,7 @@ void cumlMPICommunicator_impl::reducescatter(const void* sendbuff,
 
 MLCommon::cumlCommunicator::status_t cumlMPICommunicator_impl::syncStream(
   cudaStream_t stream) const {
-#ifndef HAVE_NCCL
+#ifdef HAVE_NCCL
   cudaError_t cudaErr;
   ncclResult_t ncclErr, ncclAsyncErr;
   while (1) {
@@ -397,6 +412,7 @@ MLCommon::cumlCommunicator::status_t cumlMPICommunicator_impl::syncStream(
   }
 #else
   CUDA_CHECK(cudaStreamSynchronize(stream));
+  return status_t::commStatusSuccess;
 #endif
 }
 }  // end namespace ML


### PR DESCRIPTION
Overview of changes
- The `#ifndef` in the `cumlMPICommunicator_impl::syncStream` should be `#ifdef`, as the `if` path has all the NCCL calls. 
- In the non-NCCL path, the function must return some value.
- Added default case to switch statements to take care of compiler warnings. 

Overall this is a minor edit. Tagging @cjnolet, @jirikraus for review.