### PR TITLE
[REVIEW] Remove Scikit-learn exception and dependency in SVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #1557: Increasing threshold for kmeans score
 - PR #1562: Increasing threshold even higher
 - PR #1564: Fixed a typo in function cumlMPICommunicator_impl::syncStream
+- PR #1569: Remove Scikit-learn exception and depedenncy in SVM
 
 # cuML 0.11.0 (11 Dec 2019)
 

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -33,7 +33,6 @@ from cuml.common.handle cimport cumlHandle
 from cuml.utils import input_to_dev_array, zeros, get_cudf_column_ptr, \
     device_array_from_ptr, get_dev_array_ptr
 from libcpp cimport bool
-from sklearn.exceptions import NotFittedError
 from cuml.svm.svm_base import SVMBase
 
 cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -33,7 +33,6 @@ from cuml.common.handle cimport cumlHandle
 from cuml.utils import input_to_dev_array, zeros, get_cudf_column_ptr, \
     device_array_from_ptr, get_dev_array_ptr
 from libcpp cimport bool
-from sklearn.exceptions import NotFittedError
 
 cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":
     enum KernelType:
@@ -286,7 +285,7 @@ class SVMBase(Base):
         if self._c_kernel != LINEAR:
             raise AttributeError("coef_ is only available for linear kernels")
         if self._model is None:
-            raise NotFittedError("Call fit before prediction")
+            raise RuntimeError("Call fit before prediction")
         if self._coef_ is None:
             self._coef_ = self._calc_coef()
         return self._coef_
@@ -499,7 +498,7 @@ class SVMBase(Base):
         """
 
         if self._model is None:
-            raise NotFittedError("Call fit before prediction")
+            raise RuntimeError("Call fit before prediction")
 
         cdef uintptr_t X_ptr
         X_m, X_ptr, n_rows, n_cols, pred_dtype = \

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -34,7 +34,6 @@ from cuml.common.handle cimport cumlHandle
 from cuml.utils import input_to_dev_array, zeros, get_cudf_column_ptr, \
     device_array_from_ptr, get_dev_array_ptr
 from libcpp cimport bool
-from sklearn.exceptions import NotFittedError
 from cuml.svm.svm_base import SVMBase
 
 cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":


### PR DESCRIPTION
Closes issue #1565 

We do not want to introduce the requirement of Scikit at runtime for a single exception type