### PR TITLE
[REVIEW] Relax nccl in conda recipes to >=2.4 (matching CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #1551: Change custom kernel to cupy for col/row order transform
 - PR #1533: C++: interface header file separation for SVM
 - PR #1560: Helper function to allocate all new CuPy arrays with RMM memory management
+- PR #1570: Relax nccl in conda recipes to >=2.4 (matching CI)
 
 ## Bug Fixes
 - PR #1470: Documentation: add make_regression, fix ARIMA section

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cupy>=6.6.0,<8.0.0a0
-    - nccl 2.4.*
+    - nccl>=2.4
     - ucx-py {{ minor_version }}
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -40,7 +40,7 @@ requirements:
   run:
     - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
-    - nccl 2.4.*
+    - nccl>=2.4
     - ucx-py {{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 


### PR DESCRIPTION
Closes issue #1566 