### PR TITLE
[gpuCI] Auto-merge branch-0.12 to branch-0.13 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuML 0.12.0 (Date TBD)
+# cuML 0.12.0 (04 Feb 2020)
 
 ## New Features
 - PR #1483: prims: Fused L2 distance and nearest-neighbor prim


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.12` that creates a PR to keep `branch-0.13` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.