### PR TITLE
[REVIEW] Fix linker errors and improve treelite debugging to support XGBoost 1.0 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #1661: Fix nvstring variable name
 - PR #1670: Lasso & ElasticNet - cuml Handle added
 - PR #1671: Update for accessing cuDF Series pointer
+- PR #1642: Support XGBoost 1.0+ models in FIL
 
 # cuML 0.12.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - PR #1661: Fix nvstring variable name
 - PR #1670: Lasso & ElasticNet - cuml Handle added
 - PR #1671: Update for accessing cuDF Series pointer
-- PR #1642: Support XGBoost 1.0+ models in FIL
+- PR #1652: Support XGBoost 1.0+ models in FIL
 
 # cuML 0.12.0 (Date TBD)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -70,6 +70,7 @@ logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
 
 # Install XGBoost snapshot (1.0rc2)
+# TODO: automate pulling of latest nightlies: https://github.com/rapidsai/cuml/issues/1678
 logger "pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc2%2B69fc8a632f5d6a8afc66135ad4d8f102bb4e0d47-py2.py3-none-manylinux1_x86_64.whl --upgrade --no-deps"
 pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc2%2B69fc8a632f5d6a8afc66135ad4d8f102bb4e0d47-py2.py3-none-manylinux1_x86_64.whl --upgrade --no-deps
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -60,7 +60,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=0.12*" \
       "statsmodels" \
-      "rapids-xgboost>=0.12"
+      "rapids-xgboost>=0.13"
 
 
 # Install the master version of dask, distributed, and dask-ml

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,14 +59,20 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=0.12*" \
-      "statsmodels" \
-      "xgboost=0.90.rapidsdev1"
+      "statsmodels"
+
+
 
 # Install the master version of dask, distributed, and dask-ml
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
 logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+
+# Install XGBoost snapshot
+logger "pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc1%2B5ca21f252a4b70795efc0895fbfbd385319223ce-py2.py3-none-manylinux1_x86_64.whl --no-deps"
+pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc1%2B5ca21f252a4b70795efc0895fbfbd385319223ce-py2.py3-none-manylinux1_x86_64.whl --upgrade --no-deps
+
 
 logger "Check versions..."
 python --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -69,9 +69,10 @@ pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
 logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
 
-# Install XGBoost snapshot
-logger "pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc1%2B5ca21f252a4b70795efc0895fbfbd385319223ce-py2.py3-none-manylinux1_x86_64.whl --no-deps"
-pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc1%2B5ca21f252a4b70795efc0895fbfbd385319223ce-py2.py3-none-manylinux1_x86_64.whl --upgrade --no-deps
+# Install XGBoost snapshot (1.0rc2)
+logger "pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc2%2B69fc8a632f5d6a8afc66135ad4d8f102bb4e0d47-py2.py3-none-manylinux1_x86_64.whl --upgrade --no-deps"
+pip install https://s3-us-west-2.amazonaws.com/xgboost-nightly-builds/release_1.0.0/xgboost-1.0.0rc2%2B69fc8a632f5d6a8afc66135ad4d8f102bb4e0d47-py2.py3-none-manylinux1_x86_64.whl --upgrade --no-deps
+
 
 
 logger "Check versions..."

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,8 +59,8 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=0.12*" \
-      "statsmodels"
-
+      "statsmodels" \
+      "rapids-xgboost>=0.12"
 
 
 # Install the master version of dask, distributed, and dask-ml

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -306,7 +306,7 @@ set_property(TARGET faisslib PROPERTY IMPORTED_LOCATION ${FAISS_DIR}/lib/libfais
 
 ExternalProject_Add(treelite
     GIT_REPOSITORY    https://github.com/dmlc/treelite.git
-    GIT_TAG           f772480cbc3fcb67edc1ef70d0affc3dcfedbf9e
+    GIT_TAG           6fd01e4f1890950bbcf9b124da24e886751bffe6
     PREFIX            ${TREELITE_DIR}
     CMAKE_ARGS        -DBUILD_SHARED_LIBS=OFF
                       -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -416,6 +416,7 @@ if(BUILD_CUML_CPP_LIBRARY)
   endif(NVTX)
 
   target_link_libraries(${CUML_CPP_TARGET} ${CUML_LINK_LIBRARIES})
+  target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libdmlc.a")
 endif(BUILD_CUML_CPP_LIBRARY)
 
 ##############################################################################
@@ -433,7 +434,6 @@ if(BUILD_CUML_C_LIBRARY)
     src/svm/svm_api.cpp)
 
   target_link_libraries(${CUML_C_TARGET} ${CUML_CPP_TARGET})
-
 endif(BUILD_CUML_C_LIBRARY)
 
 ##############################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -416,6 +416,8 @@ if(BUILD_CUML_CPP_LIBRARY)
   endif(NVTX)
 
   target_link_libraries(${CUML_CPP_TARGET} ${CUML_LINK_LIBRARIES})
+  # If we export the libdmlc symbols, they can lead to weird crashes with other
+  # libraries that use libdmlc. This just hides the symbols internally.
   target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libdmlc.a")
 endif(BUILD_CUML_CPP_LIBRARY)
 

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -58,6 +58,7 @@ cdef extern from "treelite/c_api.h":
                                        ModelHandle* out) except +
     cdef int TreeliteLoadProtobufModel(const char* filename,
                                        ModelHandle* out) except +
+    cdef const char* TreeliteGetLastError()
 
 
 cdef class TreeliteModel():
@@ -121,16 +122,19 @@ cdef class TreeliteModel():
         if model_type == "xgboost":
             res = TreeliteLoadXGBoostModel(filename_bytes, &handle)
             if res < 0:
-                raise RuntimeError("Failed to load %s" % filename)
+                err = TreeliteGetLastError()
+                raise RuntimeError("Failed to load %s (%s)" % (filename, err))
         elif model_type == "protobuf":
             # XXX Not tested
             res = TreeliteLoadProtobufModel(filename_bytes, &handle)
             if res < 0:
-                raise RuntimeError("Failed to load %s" % filename)
+                err = TreeliteGetLastError()
+                raise RuntimeError("Failed to load %s (%s)" % (filename, err))
         elif model_type == "lightgbm":
             res = TreeliteLoadLightGBMModel(filename_bytes, &handle)
             if res < 0:
-                raise RuntimeError("Failed to load %s" % filename)
+                err = TreeliteGetLastError()
+                raise RuntimeError("Failed to load %s (%s)" % (filename, err))
         else:
             raise ValueError("Unknown model type %s" % model_type)
         model = TreeliteModel()

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -302,7 +302,7 @@ def test_fil_skl_regression(n_rows, n_columns, n_estimators, max_depth,
     fil_preds = np.asarray(fm.predict(X_validation))
     fil_mse = mean_squared_error(y_validation, fil_preds)
 
-    assert fil_mse == pytest.approx(skl_mse, 1e-5)
+    assert fil_mse == pytest.approx(skl_mse, 1e-4)
     assert array_equal(fil_preds, skl_preds)
 
 

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -111,7 +111,8 @@ def test_fil_classification(n_rows, n_columns, num_rounds, tmp_path):
     model_path = os.path.join(tmp_path, 'xgb_class.model')
 
     bst = _build_and_save_xgboost(model_path, X_train, y_train,
-                                  num_rounds, classification)
+                                  num_rounds=num_rounds,
+                                  classification=classification)
 
     dvalidation = xgb.DMatrix(X_validation, label=y_validation)
     xgb_preds = bst.predict(dvalidation)
@@ -163,8 +164,8 @@ def test_fil_regression(n_rows, n_columns, num_rounds, tmp_path, max_depth):
     model_path = os.path.join(tmp_path, 'xgb_reg.model')
     bst = _build_and_save_xgboost(model_path, X_train,
                                   y_train,
-                                  num_rounds,
-                                  classification,
+                                  classification=classification,
+                                  num_rounds=num_rounds,
                                   xgboost_params={'max_depth': max_depth})
 
     dvalidation = xgb.DMatrix(X_validation, label=y_validation)


### PR DESCRIPTION
This change updates the build step to stop the symbol collision we've been getting between FIL and XGBoost 1.0 pip packages. However, we still get a FIL failure, so this is a WIP to help debugging. I also added explicit logging of treelite failure messages:

Typical error: ```
RuntimeError: Failed to load ./xgb_class.model (b'[21:58:45] /home/jzedlewski/code/rapidsai/cuml/cpp/build/treelite/src/treelite/src/frontend/xgboost.cc:318: Check failed: param.num_roots == 1 (0 vs. 1) Invalid XGBoost model file: treelite does not support trees with multiple roots\n\nStack trace returned 10 entries:\n[bt] (0) /home/jzedlewski/anaconda3/envs/cuml_dev/lib/libcuml++.so(dmlc::StackTrace[abi:cxx11]()+0x17f) [0x7f2d588ac0bf]\n[bt] (1) /home/jzedlewski/anaconda3/envs/cuml_dev/lib/libcuml++.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x39) [0x7f2d588ad439]\n[bt] (2) /home/jzedlewski/anaconda3/envs/cuml_dev/lib/libcuml++.so(+0x647b1b) [0x7f2d588f1b1b]\n[bt] (3) /home/jzedlewski/anaconda3/envs/cuml_dev/lib/libcuml++.so(treelite::frontend::LoadXGBoostModel(char const*)+0xaf) [0x7f2d588f4a2f]\n[bt] (4) /home/jzedlewski/anaconda3/envs/cuml_dev/lib/libcuml++.so(TreeliteLoadXGBoostModel+0x29) [0x7f2d5889e839]\n[bt] (5) /home/jzedlewski/code/rapidsai/cuml/python/cuml/fil/fil.cpython-37m-x86_64-linux-gnu.so(+0x16ce8) [0x7f2df1c9ece8]\n[bt] (6) python(PyCFunction_Call+0x65) [0x55b2ba180d05]\n[bt] (7) /home/jzedlewski/code/rapidsai/cuml/python/cuml/fil/fil.cpython-37m-x86_64-linux-gnu.so(+0xebc3) [0x7f2df1c96bc3]\n[bt] (8) python(_PyObject_FastCallKeywords+0x49b) [0x55b2ba1ca85b]\n[bt] (9) python(_PyEval_EvalFrameDefault+0x5787) [0x55b2ba21f4c7]\n\n')
```