### PR TITLE
[REVIEW] Skip treelite patch if it's already been applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #1617: Fixing pickling issues for SVC and SVR
 - PR #1634: Fix title in KNN docs
 - PR #1627: Adding a check for multi-class data in RF classification
+- PR #1654: Skip treelite patch if it's already been applied
 
 # cuML 0.12.0 (Date TBD)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -285,8 +285,8 @@ ExternalProject_Add(faiss
                             --with-cuda-arch=${FAISS_GPU_ARCHS}
                             -v
   PREFIX            ${FAISS_DIR}
-  BUILD_COMMAND     $(MAKE) -j${PARALLEL_LEVEL} VERBOSE=1
-  INSTALL_COMMAND   $(MAKE) -s install > /dev/null
+  BUILD_COMMAND     ${CMAKE_MAKE_PROGRAM} -j${PARALLEL_LEVEL} VERBOSE=1
+  INSTALL_COMMAND   ${CMAKE_MAKE_PROGRAM} -s install > /dev/null
   UPDATE_COMMAND    ""
   BUILD_IN_SOURCE   1
 )
@@ -313,7 +313,7 @@ ExternalProject_Add(treelite
                       -DENABLE_PROTOBUF=ON
                       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
     UPDATE_COMMAND    ""
-    PATCH_COMMAND     patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/treelite_protobuf.patch
+    PATCH_COMMAND     patch -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/treelite_protobuf.patch || true
 )
 
 add_dependencies(treelite faiss)


### PR DESCRIPTION
This PR updates the CMakeLists.txt file to continue if the treelite patch has already been applied.

Today, the first time `cmake` is run, the `treelite` package's CMakeLists.txt is patched. But if `cmake` is run again without cleaning the `build` directory, the build will fail, because the file in the current directory has already been patched.