### PR TITLE
[REVIEW] TSNE - refactored `should_downcast` to `convert_dtype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #1634: Fix title in KNN docs
 - PR #1627: Adding a check for multi-class data in RF classification
 - PR #1654: Skip treelite patch if it's already been applied
+- PR #1659: TSNE - introduce 'convert_dtype' and refactor class attr 'Y' to 'embedding_'
 
 # cuML 0.12.0 (Date TBD)
 

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -310,10 +310,9 @@ class TSNE(Base):
             X contains a sample per row.
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
             ndarray, cuda array interface compliant array like CuPy
-        y : array-like (device or host) shape = (n_samples, 1)
-            y contains a label per row.
-            Acceptable formats: cuDF Series, NumPy ndarray, Numba device
-            ndarray, cuda array interface compliant array like CuPy
+        convert_dtype : bool, optional (default = True)
+            When set to True, the fit method will automatically
+            convert the inputs to np.float32.
         """
         cdef int n, p
         cdef cumlHandle* handle_ = <cumlHandle*><size_t>self.handle.getHandle()
@@ -421,6 +420,9 @@ class TSNE(Base):
             X contains a sample per row.
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
             ndarray, cuda array interface compliant array like CuPy
+        convert_dtype : bool, optional (default = True)
+            When set to True, the fit_transform method will automatically
+            convert the inputs to np.float32.
 
         Returns
         --------

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -456,8 +456,8 @@ class TSNE(Base):
         state = self.__dict__.copy()
 
         if "embedding_" in state:
-            state["embedding_"] = cudf.DataFrame.
-                                    from_gpu_matrix(state["embedding_"])
+            state["embedding_"] = cudf.DataFrame.from_gpu_matrix(
+                                    state["embedding_"])
 
         if "handle" in state:
             del state["handle"]

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -305,9 +305,9 @@ class TSNE(Base):
         # Function only to check attribute Y
         # while will be deprecated in 0.14
         if attr == "Y":
-            warnings.warn("""Attribute Y is deprecated and will be dropped in
-                          version 0.14, access the embeddings using the 
-                          attribute ‘embeddings_’ instead.""", 
+            warnings.warn("Attribute Y is deprecated and will be dropped in "
+                          "version 0.14, access the embeddings using the "
+                          "attribute ‘embeddings_’ instead.",
                           DeprecationWarning)
             return self.embedding_
 
@@ -456,7 +456,8 @@ class TSNE(Base):
         state = self.__dict__.copy()
 
         if "embedding_" in state:
-            state["embedding_"] = cudf.DataFrame.from_gpu_matrix(state["embedding_"])
+            state["embedding_"] = cudf.DataFrame.
+                                    from_gpu_matrix(state["embedding_"])
 
         if "handle" in state:
             del state["handle"]

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -457,7 +457,7 @@ class TSNE(Base):
 
         if "embedding_" in state:
             state["embedding_"] = cudf.DataFrame.from_gpu_matrix(
-                                    state["embedding_"])
+                state["embedding_"])
 
         if "handle" in state:
             del state["handle"]

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -301,15 +301,13 @@ class TSNE(Base):
 
         return
 
-    def __getattr__(self, attr):
-        # Function only to check attribute Y
-        # while will be deprecated in 0.14
-        if attr == "Y":
-            warnings.warn("Attribute Y is deprecated and will be dropped in "
-                          "version 0.14, access the embeddings using the "
-                          "attribute ‘embeddings_’ instead.",
-                          DeprecationWarning)
-            return self.embedding_
+    @property
+    def Y(self):
+        warnings.warn("Attribute Y is deprecated and will be dropped in "
+                      "version 0.14, access the embeddings using the "
+                      "attribute ‘embedding_’ instead.",
+                      DeprecationWarning)
+        return self.embedding_
 
     def fit(self, X, convert_dtype=True):
         """Fit X into an embedded space.
@@ -417,7 +415,7 @@ class TSNE(Base):
         return self
 
     def __del__(self):
-        if "embedding_" in self.__dict__:
+        if hasattr(self, 'embedding_'):
             del self.embedding_
             self.embedding_ = None
 
@@ -439,7 +437,7 @@ class TSNE(Base):
         X_new : array, shape (n_samples, n_components)
                 Embedding of the training data in low-dimensional space.
         """
-        self.fit(X, convert_dtype)
+        self.fit(X, convert_dtype=convert_dtype)
 
         if isinstance(X, cudf.DataFrame):
             if isinstance(self.embedding_, cudf.DataFrame):


### PR DESCRIPTION
This PR addresses #1582. It also deprecates attribute `Y`, and replaces with `embedding_` to follow sklearn convention