### PR TITLE
[REVIEW] Update nccl to 2.5 for CUDA 10.2

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,7 +53,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/x
       "cmake==3.14.3" \
       "umap-learn" \
       "protobuf >=3.4.1,<4.0.0" \
-      "nccl>=2.4" \
+      "nccl>=2.5" \
       "dask>=2.8.0" \
       "distributed>=2.8.0" \
       "dask-cudf=${MINOR_VERSION}" \

--- a/conda/environments/cuml_dev_cuda10.0.yml
+++ b/conda/environments/cuml_dev_cuda10.0.yml
@@ -22,7 +22,7 @@ dependencies:
 - dask-cuda=0.13*
 - dask-cudf=0.13*
 - ucx-py=0.13*
-- nccl>=2.4
+- nccl>=2.5
 - libcumlprims=0.13*
 - statsmodels
 - protobuf >=3.4.1,<4.0.0

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -22,7 +22,7 @@ dependencies:
 - dask-cuda=0.13*
 - dask-cudf=0.13*
 - ucx-py=0.13*
-- nccl>=2.4
+- nccl>=2.5
 - libcumlprims=0.13*
 - statsmodels
 - protobuf >=3.4.1,<4.0.0

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -5,7 +5,7 @@ channels:
 - rapidsai-nightly
 - conda-forge
 dependencies:
-- cudatoolkit=9.2
+- cudatoolkit=10.2
 - libclang=8.0.0
 - cmake=3.14.5
 - numba>=0.46
@@ -22,7 +22,7 @@ dependencies:
 - dask-cuda=0.13*
 - dask-cudf=0.13*
 - ucx-py=0.13*
-- nccl>=2.4
+- nccl>=2.5
 - libcumlprims=0.13*
 - statsmodels
 - protobuf >=3.4.1,<4.0.0

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cupy>=6.6.0,<8.0.0a0
-    - nccl>=2.4
+    - nccl>=2.5
     - ucx-py {{ minor_version }}
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cmake>=3.14
     - libclang
   host:
-    - nccl 2.4.*
+    - nccl 2.5.*
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - libcumlprims {{ minor_version }}
@@ -40,7 +40,7 @@ requirements:
   run:
     - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
-    - nccl>=2.4
+    - nccl>=2.5
     - ucx-py {{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 


### PR DESCRIPTION
nccl 2.4 does not have CUDA 10.2 support. 2.5 does and in a effort to enable testing and move RAPIDS to CUDA 10.2 we need to update cuml to use nccl 2.5

This is the only repo in RAPIDS that pins nccl, so once this is merged we can move forward with opening 10.2 testing