### PR TITLE
[REVIEW] dealloc in handle.pyx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #1671: Update for accessing cuDF Series pointer
 - PR #1652: Support XGBoost 1.0+ models in FIL
 - PR #1699: Limit CuPy to <7.2 temporarily
+- PR #1708: Correctly deallocate cuML handles in Cython
 
 # cuML 0.12.0 (Date TBD)
 

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -1,4 +1,4 @@
-#
+ #
 # Copyright (c) 2019, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,7 +63,7 @@ cdef class Handle:
     def __cinit__(self, n_streams=0):
         self.h = <size_t>(new cumlHandle(n_streams))
 
-    def __dealloc_(self):
+    def __dealloc__(self):
         h_ = <cumlHandle*>self.h
         del h_
 

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -1,4 +1,4 @@
- #
+#
 # Copyright (c) 2019, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Closes #1705 

Fix for the deallocator of the handle class. Before this, the resources possessed by the handle associated to estimators were not being freed correctly, which in CUDA 10.2 in particular led to out of memory problems. 