### PR TITLE
Import `using_allocator` from `cupy.cuda`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #1647: storage_type=AUTO uses SPARSE for large models
 - PR #1668: Update the warning statement thrown in RF when the seed is set but n_streams is not 1
 - PR #1662: use of direct cusparse calls for coo2csr, instead of depending on nvgraph
+- PR #1718: Import `using_allocator` from `cupy.cuda`
 
 ## Bug Fixes
 - PR #1594: Train-test split is now reproducible

--- a/python/cuml/utils/memory_utils.py
+++ b/python/cuml/utils/memory_utils.py
@@ -20,6 +20,14 @@ import rmm
 
 from cuml.utils.import_utils import check_min_cupy_version
 
+try:
+    from cupy.cuda import using_allocator as cupy_using_allocator
+except ImportError:
+    try:
+        from cupy.cuda.memory import using_allocator as cupy_using_allocator
+    except ImportError:
+        pass
+
 
 def rmm_cupy_ary(cupy_fn, *args, **kwargs):
     """
@@ -61,7 +69,7 @@ def rmm_cupy_ary(cupy_fn, *args, **kwargs):
     # using_allocator was introduced in CuPy 7. Once 7+ is required,
     # this check can be removed alongside the else code path.
     if check_min_cupy_version("7.0"):
-        with cp.cuda.memory.using_allocator(rmm.rmm_cupy_allocator):
+        with cupy_using_allocator(rmm.rmm_cupy_allocator):
             result = cupy_fn(*args, **kwargs)
 
     else:


### PR DESCRIPTION
As `using_allocator` is intended to live in `cupy.cuda`, `import` it from there. If that fails, fallback to `import`ing from `cupy.cuda.memory`. If that fails, the CuPy version used simply precedes the addition of this feature.

xref: https://github.com/cupy/cupy/pull/2952 (originally)
xref: https://github.com/cupy/cupy/pull/2951 (merged)