### PR TITLE
[REVIEW] Decorator to allocate CuPy arrays with RMM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - PR #1721: Improving UMAP pytests
 - PR #1717: Call `rmm_cupy_allocator` for CuPy allocations
 - PR #1718: Import `using_allocator` from `cupy.cuda`
+- PR #1726: Decorator to allocate CuPy arrays with RMM
 
 ## Bug Fixes
 - PR #1594: Train-test split is now reproducible

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -226,7 +226,7 @@ class LogisticRegression(Base):
         else:
             self.verb_prefix = ""
 
-    @with_cupy_rmm()
+    @with_cupy_rmm
     def fit(self, X, y, convert_dtype=False):
         """
         Fit the model with X and y.

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -27,7 +27,8 @@ import rmm
 from cuml.solvers import QN
 from cuml.common.base import Base
 from cuml.metrics.accuracy import accuracy_score
-from cuml.utils import input_to_dev_array, rmm_cupy_ary
+from cuml.utils import input_to_dev_array
+from cuml.utils import with_cupy_rmm
 
 
 supported_penalties = ['l1', 'l2', 'none', 'elasticnet']
@@ -225,6 +226,7 @@ class LogisticRegression(Base):
         else:
             self.verb_prefix = ""
 
+    @with_cupy_rmm()
     def fit(self, X, y, convert_dtype=False):
         """
         Fit the model with X and y.
@@ -253,7 +255,7 @@ class LogisticRegression(Base):
         # Not needed to check dtype since qn class checks it already
         y_m, _, _, _, _ = input_to_dev_array(y)
 
-        unique_labels = rmm_cupy_ary(cp.unique, y_m)
+        unique_labels = cp.unique(y_m)
         num_classes = len(unique_labels)
 
         if num_classes > 2:

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -23,7 +23,7 @@ import scipy.sparse
 
 import cupy.prof
 
-from cuml.utils import rmm_cupy_ary
+from cuml.utils import with_cupy_rmm
 
 import warnings
 
@@ -178,6 +178,7 @@ class MultinomialNB(object):
     0.9244298934936523
 
     """
+    @with_cupy_rmm
     def __init__(self, alpha=1.0, fit_prior=True, class_prior=None):
 
         """
@@ -199,8 +200,7 @@ class MultinomialNB(object):
         self.fit_prior = fit_prior
 
         if class_prior is not None:
-            class_prior = rmm_cupy_ary(cp.asarray, class_prior,
-                                       dtype=class_prior.dtype)
+            class_prior = cp.asarray(class_prior, dtype=class_prior.dtype)
 
         self.class_prior = class_prior
 
@@ -212,6 +212,7 @@ class MultinomialNB(object):
         self.n_features_ = None
 
     @cp.prof.TimeRangeDecorator(message="fit()", color_id=0)
+    @with_cupy_rmm
     def fit(self, X, y, sample_weight=None):
         """
         Fit Naive Bayes classifier according to X, y
@@ -232,16 +233,16 @@ class MultinomialNB(object):
     def _partial_fit(self, X, y, sample_weight=None, _classes=None):
 
         if isinstance(X, np.ndarray) or isinstance(X, cp.ndarray):
-            X = rmm_cupy_ary(cp.asarray, X, X.dtype)
+            X = cp.asarray(X, X.dtype)
         elif scipy.sparse.isspmatrix(X) or cp.sparse.isspmatrix(X):
             X = X.tocoo()
-            rows = rmm_cupy_ary(cp.asarray, X.row, dtype=X.row.dtype)
-            cols = rmm_cupy_ary(cp.asarray, X.col, dtype=X.col.dtype)
-            data = rmm_cupy_ary(cp.asarray, X.data, dtype=X.data.dtype)
+            rows = cp.asarray(X.row, dtype=X.row.dtype)
+            cols = cp.asarray(X.col, dtype=X.col.dtype)
+            data = cp.asarray(X.data, dtype=X.data.dtype)
             X = cp.sparse.coo_matrix((data, (rows, cols)), shape=X.shape)
 
         if isinstance(y, np.ndarray) or isinstance(y, cp.ndarray):
-            y = rmm_cupy_ary(cp.asarray, y, y.dtype)
+            y = cp.asarray(y, y.dtype)
 
         Y, label_classes = make_monotonic(y, copy=True)
 
@@ -318,6 +319,7 @@ class MultinomialNB(object):
                                  _classes=classes)
 
     @cp.prof.TimeRangeDecorator(message="predict()", color_id=1)
+    @with_cupy_rmm
     def predict(self, X):
 
         """
@@ -336,21 +338,21 @@ class MultinomialNB(object):
         """
 
         if isinstance(X, np.ndarray) or isinstance(X, cp.ndarray):
-            X = rmm_cupy_ary(cp.asarray, X, X.dtype)
+            X = cp.asarray(X, X.dtype)
         elif scipy.sparse.isspmatrix(X) or cp.sparse.isspmatrix(X):
             X = X.tocoo()
-            rows = rmm_cupy_ary(cp.asarray, X.row, dtype=X.row.dtype)
-            cols = rmm_cupy_ary(cp.asarray, X.col, dtype=X.col.dtype)
-            data = rmm_cupy_ary(cp.asarray, X.data, dtype=X.data.dtype)
+            rows = cp.asarray(X.row, dtype=X.row.dtype)
+            cols = cp.asarray(X.col, dtype=X.col.dtype)
+            data = cp.asarray(X.data, dtype=X.data.dtype)
             X = cp.sparse.coo_matrix((data, (rows, cols)), shape=X.shape)
 
         jll = self._joint_log_likelihood(X)
-        indices = rmm_cupy_ary(cp.argmax, jll, axis=1)\
-            .astype(self.classes_.dtype)
+        indices = cp.argmax(jll, axis=1).astype(self.classes_.dtype)
 
         y_hat = invert_labels(indices, classes=self.classes_)
         return y_hat
 
+    @with_cupy_rmm
     def predict_log_proba(self, X):
 
         """
@@ -372,12 +374,12 @@ class MultinomialNB(object):
         """
 
         if isinstance(X, np.ndarray) or isinstance(X, cp.ndarray):
-            X = rmm_cupy_ary(cp.asarray, X, X.dtype)
+            X = cp.asarray(X, X.dtype)
         elif scipy.sparse.isspmatrix(X) or cp.sparse.isspmatrix(X):
             X = X.tocoo()
-            rows = rmm_cupy_ary(cp.asarray, X.row, dtype=X.row.dtype)
-            cols = rmm_cupy_ary(cp.asarray, X.col, dtype=X.col.dtype)
-            data = rmm_cupy_ary(cp.asarray, X.data, dtype=X.data.dtype)
+            rows = cp.asarray(X.row, dtype=X.row.dtype)
+            cols = cp.asarray(X.col, dtype=X.col.dtype)
+            data = cp.asarray(X.data, dtype=X.data.dtype)
             X = cp.sparse.coo_matrix((data, (rows, cols)), shape=X.shape)
 
         jll = self._joint_log_likelihood(X)
@@ -387,12 +389,12 @@ class MultinomialNB(object):
         # Compute log(sum(exp()))
 
         # Subtract max in exp to prevent inf
-        a_max = rmm_cupy_ary(cp.amax, jll, axis=1, keepdims=True)
+        a_max = cp.amax(jll, axis=1, keepdims=True)
 
-        exp = rmm_cupy_ary(cp.exp, jll - a_max)
-        logsumexp = rmm_cupy_ary(cp.log, rmm_cupy_ary(cp.sum, exp, axis=1))
+        exp = cp.exp(jll - a_max)
+        logsumexp = cp.log(cp.sum(exp, axis=1))
 
-        a_max = rmm_cupy_ary(cp.squeeze, a_max, axis=1)
+        a_max = cp.squeeze(a_max, axis=1)
 
         log_prob_x = a_max + logsumexp
 
@@ -400,6 +402,7 @@ class MultinomialNB(object):
             log_prob_x = log_prob_x.reshape((1, log_prob_x.shape[0]))
         return jll - log_prob_x.T
 
+    @with_cupy_rmm
     def predict_proba(self, X):
         """
         Return probability estimates for the test vector X.
@@ -417,8 +420,9 @@ class MultinomialNB(object):
             The columns correspond to the classes in sorted order, as they
             appear in the attribute classes_.
         """
-        return rmm_cupy_ary(cp.exp, self.predict_log_proba(X))
+        return cp.exp(self.predict_log_proba(X))
 
+    @with_cupy_rmm
     def score(self, X, y, sample_weight=None):
         """
         Return the mean accuracy on the given test data and labels.
@@ -444,15 +448,13 @@ class MultinomialNB(object):
         score : float Mean accuracy of self.predict(X) with respect to y.
         """
         y_hat = self.predict(X)
-        return accuracy_score(y_hat, rmm_cupy_ary(cp.asarray, y,
-                                                  dtype=y.dtype))
+        return accuracy_score(y_hat, cp.asarray(y, dtype=y.dtype))
 
     def _init_counters(self, n_effective_classes, n_features, dtype):
-        self.class_count_ = rmm_cupy_ary(cp.zeros, n_effective_classes,
-                                         order="F", dtype=dtype)
-        self.feature_count_ = rmm_cupy_ary(cp.zeros,
-                                           (n_effective_classes, n_features),
-                                           order="F", dtype=dtype)
+        self.class_count_ = cp.zeros(n_effective_classes,
+                                     order="F", dtype=dtype)
+        self.feature_count_ = cp.zeros((n_effective_classes, n_features),
+                                       order="F", dtype=dtype)
 
     def _count(self, X, Y):
         """
@@ -472,11 +474,10 @@ class MultinomialNB(object):
             warnings.warn("Y dtype does not match classes_ dtype. Y will be "
                           "converted, which will increase memory consumption")
 
-        counts = rmm_cupy_ary(cp.zeros, (self.n_classes_, self.n_features_),
-                              order="F", dtype=X.dtype)
+        counts = cp.zeros((self.n_classes_, self.n_features_), order="F",
+                          dtype=X.dtype)
 
-        class_c = rmm_cupy_ary(cp.zeros, self.n_classes_, order="F",
-                               dtype=X.dtype)
+        class_c = cp.zeros(self.n_classes_, order="F", dtype=X.dtype)
 
         n_rows = X.shape[0]
         n_cols = X.shape[1]
@@ -530,15 +531,15 @@ class MultinomialNB(object):
                 raise ValueError("Number of classes must match "
                                  "number of priors")
 
-            self.class_log_prior_ = rmm_cupy_ary(cp.log, class_prior)
+            self.class_log_prior_ = cp.log(class_prior)
 
         elif self.fit_prior:
-            log_class_count = rmm_cupy_ary(cp.log, self.class_count_)
+            log_class_count = cp.log(self.class_count_)
             self.class_log_prior_ = log_class_count - \
-                rmm_cupy_ary(cp.log, self.class_count_.sum())
+                cp.log(self.class_count_.sum())
         else:
-            self.class_log_prior_ = rmm_cupy_ary(cp.full, self.n_classes_,
-                                                 -math.log(self.n_classes_))
+            self.class_log_prior_ = cp.full(self.n_classes_,
+                                            -math.log(self.n_classes_))
 
     def _update_feature_log_prob(self, alpha):
 
@@ -553,9 +554,8 @@ class MultinomialNB(object):
         """
         smoothed_fc = self.feature_count_ + alpha
         smoothed_cc = smoothed_fc.sum(axis=1).reshape(-1, 1)
-        self.feature_log_prob_ = (rmm_cupy_ary(cp.log, smoothed_fc) -
-                                  rmm_cupy_ary(cp.log,
-                                               smoothed_cc.reshape(-1, 1)))
+        self.feature_log_prob_ = (cp.log(smoothed_fc) -
+                                  cp.log(smoothed_cc.reshape(-1, 1)))
 
     def _joint_log_likelihood(self, X):
         """

--- a/python/cuml/test/test_allocator.py
+++ b/python/cuml/test/test_allocator.py
@@ -27,10 +27,7 @@ from cuml.test.test_naive_bayes import scipy_to_cp
 try:
     from cupy.cuda import using_allocator as cupy_using_allocator
 except ImportError:
-    try:
-        from cupy.cuda.memory import using_allocator as cupy_using_allocator
-    except ImportError:
-        pass
+    from cupy.cuda.memory import using_allocator as cupy_using_allocator
 
 
 def dummy_allocator(nbytes):
@@ -64,8 +61,6 @@ def test_naive_bayes(nlp_20news):
     with cupy_using_allocator(dummy_allocator):
         model = MultinomialNB()
         model.fit(X, y)
-
-        cp.cuda.Stream.null.synchronize()
 
         y_hat = model.predict(X)
         y_hat = model.predict(X)

--- a/python/cuml/test/test_allocator.py
+++ b/python/cuml/test/test_allocator.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+import cupy as cp
+import numpy as np
+
+from cuml import LogisticRegression
+from cuml.naive_bayes import MultinomialNB
+from cuml.test.utils import small_classification_dataset
+from cuml.test.test_naive_bayes import scipy_to_cp
+
+try:
+    from cupy.cuda import using_allocator as cupy_using_allocator
+except ImportError:
+    try:
+        from cupy.cuda.memory import using_allocator as cupy_using_allocator
+    except ImportError:
+        pass
+
+
+def dummy_allocator(nbytes):
+    raise AssertionError("Dummy allocator should not be called")
+
+
+def test_dummy_allocator():
+    with pytest.raises(AssertionError):
+        with cupy_using_allocator(dummy_allocator):
+            a = cp.arange(10)
+            del a
+
+
+def test_logistic_regression():
+    with cupy_using_allocator(dummy_allocator):
+        X_train, X_test, y_train, y_test = \
+            small_classification_dataset(np.float32)
+        y_train = y_train.astype(np.float32)
+        y_test = y_test.astype(np.float32)
+        culog = LogisticRegression()
+        culog.fit(X_train, y_train)
+        culog.predict(X_train)
+
+
+def test_naive_bayes(nlp_20news):
+    X, y = nlp_20news
+
+    X = scipy_to_cp(X, cp.float32).astype(cp.float32)
+    y = y.astype(cp.int32)
+
+    with cupy_using_allocator(dummy_allocator):
+        model = MultinomialNB()
+        model.fit(X, y)
+
+        cp.cuda.Stream.null.synchronize()
+
+        y_hat = model.predict(X)
+        y_hat = model.predict(X)
+        y_hat = model.predict_proba(X)
+        y_hat = model.predict_log_proba(X)
+        y_hat = model.score(X, y)
+
+        del y_hat

--- a/python/cuml/test/test_naive_bayes.py
+++ b/python/cuml/test/test_naive_bayes.py
@@ -81,8 +81,8 @@ def test_basic_fit_predict_dense_numpy(x_dtype, y_dtype, nlp_20news):
     X = scipy_to_cp(X, x_dtype).astype(x_dtype)
     y = y.astype(y_dtype)
 
-    X = X.tocsr()[0:5000].todense()
-    y = y[:5000]
+    X = X.tocsr()[0:500].todense()
+    y = y[:500]
 
     model = MultinomialNB()
     model.fit(np.ascontiguousarray(cp.asnumpy(X)), y)

--- a/python/cuml/utils/__init__.py
+++ b/python/cuml/utils/__init__.py
@@ -17,6 +17,7 @@
 from cuml.utils.pointer_utils import device_of_gpu_matrix
 
 from cuml.utils.memory_utils import rmm_cupy_ary
+from cuml.utils.memory_utils import with_cupy_rmm
 
 from cuml.utils.numba_utils import row_matrix, zeros, device_array_from_ptr
 

--- a/python/cuml/utils/memory_utils.py
+++ b/python/cuml/utils/memory_utils.py
@@ -19,6 +19,7 @@ import numpy as np
 import rmm
 
 from cuml.utils.import_utils import check_min_cupy_version
+from functools import wraps
 
 try:
     from cupy.cuda import using_allocator as cupy_using_allocator
@@ -33,7 +34,7 @@ def with_cupy_rmm(func):
     """
 
     Decorator to call CuPy functions with RMM memory management. Use it
-    to decorate any function that will call CuPy functions, this will ensure
+    to decorate any function that will call CuPy functions. This will ensure
     that those calls use RMM for memory allocation instead of the default
     CuPy pool. Example:
 
@@ -44,6 +45,7 @@ def with_cupy_rmm(func):
             a = cp.arange(10) # uses RMM for allocation
 
     """
+    @wraps(func)
     def cupy_rmm_wrapper(*args, **kwargs):
         with cupy_using_allocator(rmm.rmm_cupy_allocator):
             return func(*args, **kwargs)

--- a/python/cuml/utils/memory_utils.py
+++ b/python/cuml/utils/memory_utils.py
@@ -30,6 +30,20 @@ except ImportError:
 
 
 def with_cupy_rmm(func):
+    """
+
+    Decorator to call CuPy functions with RMM memory management. Use it
+    to decorate any function that will call CuPy functions, this will ensure
+    that those calls use RMM for memory allocation instead of the default
+    CuPy pool. Example:
+
+    .. code-block:: python
+
+        @with_cupy_rmm
+        def fx(...):
+            a = cp.arange(10) # uses RMM for allocation
+
+    """
     def cupy_rmm_wrapper(*args, **kwargs):
         with cupy_using_allocator(rmm.rmm_cupy_allocator):
             return func(*args, **kwargs)

--- a/python/cuml/utils/memory_utils.py
+++ b/python/cuml/utils/memory_utils.py
@@ -29,6 +29,14 @@ except ImportError:
         pass
 
 
+def with_cupy_rmm(func):
+    def cupy_rmm_wrapper(*args, **kwargs):
+        with cupy_using_allocator(rmm.rmm_cupy_allocator):
+            return func(*args, **kwargs)
+
+    return cupy_rmm_wrapper
+
+
 def rmm_cupy_ary(cupy_fn, *args, **kwargs):
     """
 

--- a/python/cuml/utils/numba_utils.py
+++ b/python/cuml/utils/numba_utils.py
@@ -18,11 +18,12 @@ import cupy as cp
 import numpy as np
 import rmm
 
-from cuml.utils import rmm_cupy_ary
+from cuml.utils import with_cupy_rmm
 from numba import cuda
 from numba.cuda.cudadrv.driver import driver
 
 
+@with_cupy_rmm
 def row_matrix(df):
     """Compute the C (row major) version gpu matrix of df
 
@@ -34,7 +35,7 @@ def row_matrix(df):
 
     col_major = df.as_gpu_matrix(order='F')
 
-    row_major = rmm_cupy_ary(cp.array, col_major, order='C')
+    row_major = cp.array(col_major, order='C')
 
     return cuda.as_cuda_array(row_major)
 


### PR DESCRIPTION
Decorator proposal to replace rmm_cupy_ary, with what should be less overhead for the code, reviewers and execution. This would make our minimum required version of CuPy 7.0

Decorator needs to be used in the top most function that will call things that allocate CuPy arrays. In logistic regression that was very obvious, but in Naive Bayes a little bit less so. But the guideline I would propose for CuPy based estimators, like NB, is to add the decorator to user accessible methods (fit/predict/etc) and not to the internal ones (starting with `_`), since those are called by the user accessible ones. Since that is the case, they inherit being executed in the `with` context of the decorator. 