### PR TITLE
[WIP] Fix crash in memcpy in rf classifier

### DIFF
--- a/cpp/src/decisiontree/levelalgo/levelfunc_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelfunc_classifier.cuh
@@ -150,6 +150,8 @@ void grow_deep_tree_classification(
                      split_algo, d_split_colidx, d_split_binidx,
                      d_new_node_flags, flagsptr, tempmem);
 
+    ASSERT(2 * n_nodes * n_unique_labels <= tempmem->h_parent_hist->size(),
+           "Copying histogram too large for h_parent_hist");
     memcpy(h_parent_hist, h_child_hist,
            2 * n_nodes * n_unique_labels * sizeof(unsigned int));
   }

--- a/cpp/src/decisiontree/memory.cuh
+++ b/cpp/src/decisiontree/memory.cuh
@@ -229,15 +229,15 @@ void TemporaryMemory<T, L>::LevelMemAllocator(int nrows, int ncols,
     h_histogram = new MLCommon::host_buffer<unsigned int>(host_allocator,
                                                           stream, histcount);
     h_parent_hist = new MLCommon::host_buffer<unsigned int>(
-      host_allocator, stream, maxnodes * n_unique);
+      host_allocator, stream, 2 * maxnodes * n_unique);
     h_child_hist = new MLCommon::host_buffer<unsigned int>(
       host_allocator, stream, 2 * maxnodes * n_unique);
     d_parent_hist = new MLCommon::device_buffer<unsigned int>(
-      device_allocator, stream, maxnodes * n_unique);
+      device_allocator, stream, 2 * maxnodes * n_unique);
     d_child_hist = new MLCommon::device_buffer<unsigned int>(
       device_allocator, stream, 2 * maxnodes * n_unique);
     totalmem += histcount * sizeof(unsigned int);
-    totalmem += n_unique * maxnodes * 3 * sizeof(unsigned int);
+    totalmem += n_unique * maxnodes * 4 * sizeof(unsigned int);
   }
   //Calculate Max nodes in shared memory.
   if (typeid(L) == typeid(int)) {


### PR DESCRIPTION
Early WIP. Not sure if this is the right approach, but it fixes the original crash. I can repro the crash with:

bench/sg_benchmark --benchmark_filter='RFClassifier<float>/blobs/4

This change restores that to harmony. I have not looked into the regressor side in detail, but at first glance it does not seem to have the same issue.