### PR TITLE
[REVIEW] LinearRegression CumlArray update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #1689: Add framework for cuML Dask serializers
 - PR #1709: Add `decision_function()` and `predict_proba()` for LogisticRegression
 - PR #1714: Add `print_env.sh` file to gather important environment details
+- PR #1750: LinearRegression CumlArray for configurable output
 
 ## Improvements
 - PR #1644: Add `predict_proba()` for FIL binary classifier
@@ -44,7 +45,7 @@
 - PR #1706: Remove multi-class bug from QuasiNewton
 - PR #1699: Limit CuPy to <7.2 temporarily
 - PR #1708: Correctly deallocate cuML handles in Cython
-- PR #1730: Fixes to KF for test stability (mainly in CUDA 10.2) 
+- PR #1730: Fixes to KF for test stability (mainly in CUDA 10.2)
 - PR #1729: Fixing naive bayes UCX serialization problem in fit()
 
 # cuML 0.12.0 (Date TBD)

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,10 +31,10 @@ from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
 
+from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.handle cimport cumlHandle
-from cuml.utils import get_cudf_column_ptr, get_dev_array_ptr, \
-    input_to_dev_array, zeros
+from cuml.utils import input_to_cuml_array
 
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
 
@@ -185,24 +185,14 @@ class LinearRegression(Base):
     """
 
     def __init__(self, algorithm='eig', fit_intercept=True, normalize=False,
-                 handle=None):
+                 handle=None, verbose=False, output_type=None):
+        super(LinearRegression, self).__init__(handle=handle, verbose=verbose,
+                                               output_type=output_type)
 
-        """
-        Initializes the linear regression class.
+        # internal array attributes
+        self._coef_ = None  # accessed via estimator.coef_
+        self._intercept_ = None  # accessed via estimator.intercept_
 
-        Parameters
-        ----------
-        algorithm : Type: string. 'eig' (default) and 'svd' are supported
-        algorithms.
-        fit_intercept: boolean. For more information, see `scikitlearn's OLS
-        <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html>`_.
-        normalize: boolean. For more information, see `scikitlearn's OLS
-        <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html>`_.
-
-        """
-        super(LinearRegression, self).__init__(handle=handle, verbose=False)
-        self.coef_ = None
-        self.intercept_ = None
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         if algorithm in ['svd', 'eig']:
@@ -243,15 +233,19 @@ class LinearRegression(Base):
 
         """
 
-        cdef uintptr_t X_ptr, y_ptr
-        X_m, X_ptr, n_rows, self.n_cols, self.dtype = \
-            input_to_dev_array(X, check_dtype=[np.float32, np.float64])
+        self._set_output_type(X)
 
-        y_m, y_ptr, _, _, _ = \
-            input_to_dev_array(y, check_dtype=self.dtype,
-                               convert_to_dtype=(self.dtype if convert_dtype
-                                                 else None),
-                               check_rows=n_rows, check_cols=1)
+        cdef uintptr_t X_ptr, y_ptr
+        X_m, n_rows, self.n_cols, self.dtype = \
+            input_to_cuml_array(X, check_dtype=[np.float32, np.float64])
+        X_ptr = X_m.ptr
+
+        y_m, _, _, _ = \
+            input_to_cuml_array(y, check_dtype=self.dtype,
+                                convert_to_dtype=(self.dtype if convert_dtype
+                                                  else None),
+                                check_rows=n_rows, check_cols=1)
+        y_ptr = y_m.ptr
 
         if self.n_cols < 1:
             msg = "X matrix must have at least a column"
@@ -267,9 +261,8 @@ class LinearRegression(Base):
                           "column currently.", UserWarning)
             self.algo = 0
 
-        self.coef_ = cudf.Series(zeros(self.n_cols,
-                                       dtype=self.dtype))
-        cdef uintptr_t coef_ptr = get_cudf_column_ptr(self.coef_)
+        self._coef_ = CumlArray.zeros(self.n_cols, dtype=self.dtype)
+        cdef uintptr_t coef_ptr = self._coef_.ptr
 
         cdef float c_intercept1
         cdef double c_intercept2
@@ -332,16 +325,22 @@ class LinearRegression(Base):
            Dense vector (floats or doubles) of shape (n_samples, 1)
 
         """
-        cdef uintptr_t X_ptr
-        X_m, X_ptr, n_rows, n_cols, dtype = \
-            input_to_dev_array(X, check_dtype=self.dtype,
-                               convert_to_dtype=(self.dtype if convert_dtype
-                                                 else None),
-                               check_cols=self.n_cols)
 
-        cdef uintptr_t coef_ptr = get_cudf_column_ptr(self.coef_)
-        preds = cudf.Series(zeros(n_rows, dtype=dtype))
-        cdef uintptr_t preds_ptr = get_cudf_column_ptr(preds)
+        out_type = self._get_output_type(X)
+
+        cdef uintptr_t X_ptr
+        X_m, n_rows, n_cols, dtype = \
+            input_to_cuml_array(X, check_dtype=self.dtype,
+                                convert_to_dtype=(self.dtype if convert_dtype
+                                                  else None),
+                                check_cols=self.n_cols)
+        X_ptr = X_m.ptr
+
+        cdef uintptr_t coef_ptr = self._coef_.ptr
+
+        preds = CumlArray.zeros(n_rows, dtype=dtype)
+        cdef uintptr_t preds_ptr = preds.ptr
+
         cdef cumlHandle* handle_ = <cumlHandle*><size_t>self.handle.getHandle()
 
         if dtype.type == np.float32:
@@ -365,49 +364,7 @@ class LinearRegression(Base):
 
         del(X_m)
 
-        return preds
+        return preds.to_output(out_type)
 
-    def get_params(self, deep=True):
-        """
-        Scikit-learn style function that returns the estimator parameters.
-
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        params = dict()
-        variables = ['algorithm', 'fit_intercept', 'normalize']
-        for key in variables:
-            var_value = getattr(self, key, None)
-            params[key] = var_value
-        return params
-
-    def set_params(self, **params):
-        """
-        Sklearn style set parameter state to dictionary of params.
-
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        if not params:
-            return self
-        variables = ['algorithm', 'fit_intercept', 'normalize']
-        for key, value in params.items():
-            if key not in variables:
-                raise ValueError('Invalid parameter %s for estimator')
-            else:
-                setattr(self, key, value)
-        if 'algorithm' in params.keys():
-            self.algo = self._get_algorithm_int(self.algorithm)
-        return self
-
-    def __getstate__(self):
-        state = self.__dict__.copy()
-
-        del state['handle']
-        return state
-
-    def __setstate__(self, state):
-        super(LinearRegression, self).__init__(handle=None)
-        self.__dict__.update(state)
+    def get_param_names(self):
+        return ['algorithm', 'fit_intercept', 'normalize']

--- a/python/cuml/test/test_linear_model.py
+++ b/python/cuml/test/test_linear_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ def test_linear_regression_model(datatype, algorithm, nrows, column_info):
 
     # fit and predict cuml linear regression model
     cuols.fit(X_train, y_train)
-    cuols_predict = cuols.predict(X_test).to_array()
+    cuols_predict = cuols.predict(X_test)
 
     if nrows < 500000:
         # sklearn linear regression model initialization, fit and predict
@@ -100,7 +100,7 @@ def test_linear_regression_model_default(datatype):
 
     # fit and predict cuml linear regression model
     cuols.fit(X_train, y_train)
-    cuols_predict = cuols.predict(X_test).to_array()
+    cuols_predict = cuols.predict(X_test)
 
     # sklearn linear regression model initialization and fit
     skols = skLinearRegression()


### PR DESCRIPTION
PR updates LinearRegression to use CumlArray, which is needed for #1738, and also serves as a good example for how to update a typical algorithm. 