### PR TITLE
[REVIEW] Update CuPy requirement to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #1723: Update RF Classifier to throw an exception for multi-class pickling
 - PR #1726: Decorator to allocate CuPy arrays with RMM
 - PR #1748: Test serializing `CumlArray` objects
+- PR #1762: Update CuPy requirement to 7
 
 ## Bug Fixes
 - PR #1594: Train-test split is now reproducible

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -43,7 +43,7 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c rapidsai/label/xgboost -c nvidia \
-      "cupy>=6.6.0,<7.2.0a0" \
+      "cupy>=7,<8.0.0a0" \
       "cudatoolkit=${CUDA_REL}" \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \

--- a/conda/environments/cuml_dev_cuda10.0.yml
+++ b/conda/environments/cuml_dev_cuda10.0.yml
@@ -9,7 +9,7 @@ dependencies:
 - libclang=8.0.0
 - cmake=3.14.5
 - numba>=0.46
-- cupy>=6.6.0,<7.2.0a0
+- cupy>=7,<8.0.0a0
 - cudf=0.13*
 - rmm=0.13*
 - cython>=0.29,<0.30

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -9,7 +9,7 @@ dependencies:
 - libclang=8.0.0
 - cmake=3.14.5
 - numba>=0.46
-- cupy>=6.6.0,<7.2.0a0
+- cupy>=7,<8.0.0a0
 - cudf=0.13*
 - rmm=0.13*
 - cython>=0.29,<0.30

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -9,7 +9,7 @@ dependencies:
 - libclang=8.0.0
 - cmake=3.14.5
 - numba>=0.46
-- cupy>=6.6.0,<7.2.0a0
+- cupy>=7,<8.0.0a0
 - cudf=0.13*
 - rmm=0.13*
 - cython>=0.29,<0.30

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - cupy>=6.6.0,<7.2.0a0
+    - cupy>=7,<8.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}
     - joblib >=0.11


### PR DESCRIPTION
Given PR #1726 we now require CuPy 7+ for its allocator context functionality. 