### PR TITLE
[REVIEW] different in and out types for elementwise operations in ml-prims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #1726: Decorator to allocate CuPy arrays with RMM
 - PR #1748: Test serializing `CumlArray` objects
 - PR #1762: Update CuPy requirement to 7
+- PR #1768: C++: Different input and output types for add and subtract prims
 
 ## Bug Fixes
 - PR #1594: Train-test split is now reproducible

--- a/cpp/src_prims/linalg/add.h
+++ b/cpp/src_prims/linalg/add.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,21 +23,24 @@ namespace MLCommon {
 namespace LinAlg {
 
 /**
- * @defgroup ScalarOps Scalar operations on the input buffer
- * @tparam math_t data-type upon which the math operation will be performed
+ * @brief Elementwise scalar add operation on the input buffer
+ *
+ * @tparam InT     input data-type. Also the data-type upon which the math ops
+ *                 will be performed
+ * @tparam OutT    output data-type
  * @tparam IdxType Integer type used to for addressing
+ *
  * @param out the output buffer
  * @param in the input buffer
  * @param scalar the scalar used in the operations
  * @param len number of elements in the input buffer
  * @param stream cuda stream where to launch work
  */
-template <typename math_t, typename IdxType = int>
-void addScalar(math_t *out, const math_t *in, math_t scalar, IdxType len,
+template <typename InT, typename OutT = InT, typename IdxType = int>
+void addScalar(OutT *out, const InT *in, InT scalar, IdxType len,
                cudaStream_t stream) {
-  unaryOp(
-    out, in, len, [scalar] __device__(math_t in) { return in + scalar; },
-    stream);
+  auto op = [scalar] __device__(InT in) { return OutT(in + scalar); };
+  unaryOp<InT, decltype(op), IdxType, OutT>(out, in, len, op, stream);
 }
 
 /**

--- a/cpp/src_prims/linalg/add.h
+++ b/cpp/src_prims/linalg/add.h
@@ -30,10 +30,10 @@ namespace LinAlg {
  * @tparam OutT    output data-type
  * @tparam IdxType Integer type used to for addressing
  *
- * @param out the output buffer
- * @param in the input buffer
+ * @param out    the output buffer
+ * @param in     the input buffer
  * @param scalar the scalar used in the operations
- * @param len number of elements in the input buffer
+ * @param len    number of elements in the input buffer
  * @param stream cuda stream where to launch work
  */
 template <typename InT, typename OutT = InT, typename IdxType = int>

--- a/cpp/src_prims/linalg/add.h
+++ b/cpp/src_prims/linalg/add.h
@@ -44,21 +44,23 @@ void addScalar(OutT *out, const InT *in, InT scalar, IdxType len,
 }
 
 /**
- * @defgroup BinaryOps Element-wise binary operations on the input buffers
- * @tparam math_t data-type upon which the math operation will be performed
+ * @brief Elementwise add operation on the input buffers
+ * @tparam InT     input data-type. Also the data-type upon which the math ops
+ *                 will be performed
+ * @tparam OutT    output data-type
  * @tparam IdxType Integer type used to for addressing
- * @param out the output buffer
- * @param in1 the first input buffer
- * @param in2 the second input buffer
- * @param len number of elements in the input buffers
+ *
+ * @param out    the output buffer
+ * @param in1    the first input buffer
+ * @param in2    the second input buffer
+ * @param len    number of elements in the input buffers
  * @param stream cuda stream where to launch work
  */
-template <typename math_t, typename IdxType = int>
-void add(math_t *out, const math_t *in1, const math_t *in2, IdxType len,
+template <typename InT, typename OutT = InT, typename IdxType = int>
+void add(OutT *out, const InT *in1, const InT *in2, IdxType len,
          cudaStream_t stream) {
-  binaryOp(
-    out, in1, in2, len, [] __device__(math_t a, math_t b) { return a + b; },
-    stream);
+  auto op = [] __device__(InT a, InT b) { return OutT(a + b); };
+  binaryOp<InT, decltype(op), OutT, IdxType>(out, in1, in2, len, op, stream);
 }
 
 template <class math_t, typename IdxType>

--- a/cpp/src_prims/linalg/subtract.h
+++ b/cpp/src_prims/linalg/subtract.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/linalg/subtract.h
+++ b/cpp/src_prims/linalg/subtract.h
@@ -24,15 +24,18 @@ namespace MLCommon {
 namespace LinAlg {
 
 /**
- * @defgroup ScalarOps Scalar operations on the input buffer
- * @tparam math_t data-type upon which the math operation will be performed
+ * @brief Elementwise scalar subtraction operation on the input buffer
+ *
+ * @tparam InT     input data-type. Also the data-type upon which the math ops
+ *                 will be performed
+ * @tparam OutT    output data-type
  * @tparam IdxType Integer type used to for addressing
- * @param out the output buffer
- * @param in the input buffer
+ *
+ * @param out    the output buffer
+ * @param in     the input buffer
  * @param scalar the scalar used in the operations
- * @param len number of elements in the input buffer
+ * @param len    number of elements in the input buffer
  * @param stream cuda stream where to launch work
- * @{
  */
 template <typename InT, typename OutT = InT, typename IdxType = int>
 void subtractScalar(OutT *out, const InT *in, InT scalar, IdxType len,

--- a/cpp/src_prims/linalg/subtract.h
+++ b/cpp/src_prims/linalg/subtract.h
@@ -41,7 +41,7 @@ template <typename InT, typename OutT = InT, typename IdxType = int>
 void subtractScalar(OutT *out, const InT *in, InT scalar, IdxType len,
                     cudaStream_t stream) {
   auto op = [scalar] __device__(InT in) { return OutT(in - scalar); };
-  unaryOp<InT, decltype(op), OutT, IdxType>(out, in, len, op, stream);
+  unaryOp<InT, decltype(op), IdxType, OutT>(out, in, len, op, stream);
 }
 
 /**

--- a/cpp/src_prims/linalg/subtract.h
+++ b/cpp/src_prims/linalg/subtract.h
@@ -45,22 +45,23 @@ void subtractScalar(OutT *out, const InT *in, InT scalar, IdxType len,
 }
 
 /**
- * @defgroup BinaryOps Element-wise binary operations on the input buffers
- * @tparam math_t data-type upon which the math operation will be performed
+ * @brief Elementwise subtraction operation on the input buffers
+ * @tparam InT     input data-type. Also the data-type upon which the math ops
+ *                 will be performed
+ * @tparam OutT    output data-type
  * @tparam IdxType Integer type used to for addressing
- * @param out the output buffer
- * @param in1 the first input buffer
- * @param in2 the second input buffer
- * @param len number of elements in the input buffers
+ *
+ * @param out    the output buffer
+ * @param in1    the first input buffer
+ * @param in2    the second input buffer
+ * @param len    number of elements in the input buffers
  * @param stream cuda stream where to launch work
- * @{
  */
-template <typename math_t, typename IdxType = int>
-void subtract(math_t *out, const math_t *in1, const math_t *in2, IdxType len,
+template <typename InT, typename OutT = InT, typename IdxType = int>
+void subtract(OutT *out, const InT *in1, const InT *in2, IdxType len,
               cudaStream_t stream) {
-  binaryOp(
-    out, in1, in2, len, [] __device__(math_t a, math_t b) { return a - b; },
-    stream);
+  auto op = [] __device__(InT a, InT b) { return OutT(a - b); };
+  binaryOp<InT, decltype(op), OutT, IdxType>(out, in1, in2, len, op, stream);
 }
 
 template <class math_t, typename IdxType>

--- a/cpp/src_prims/linalg/subtract.h
+++ b/cpp/src_prims/linalg/subtract.h
@@ -34,12 +34,11 @@ namespace LinAlg {
  * @param stream cuda stream where to launch work
  * @{
  */
-template <typename math_t, typename IdxType = int>
-void subtractScalar(math_t *out, const math_t *in, math_t scalar, IdxType len,
+template <typename InT, typename OutT = InT, typename IdxType = int>
+void subtractScalar(OutT *out, const InT *in, InT scalar, IdxType len,
                     cudaStream_t stream) {
-  unaryOp(
-    out, in, len, [scalar] __device__(math_t in) { return in - scalar; },
-    stream);
+  auto op = [scalar] __device__(InT in) { return OutT(in - scalar); };
+  unaryOp<InT, decltype(op), OutT, IdxType>(out, in, len, op, stream);
 }
 
 /**

--- a/cpp/test/prims/add.cu
+++ b/cpp/test/prims/add.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/add.cu
+++ b/cpp/test/prims/add.cu
@@ -63,7 +63,7 @@ class AddTest : public ::testing::TestWithParam<AddInputs<InT, OutT>> {
 };
 
 const std::vector<AddInputs<float>> inputsf = {
-  {0.000001f, 1024 * 1024,     1234ULL},
+  {0.000001f, 1024 * 1024, 1234ULL},
   {0.000001f, 1024 * 1024 + 2, 1234ULL},
   {0.000001f, 1024 * 1024 + 1, 1234ULL},
 };
@@ -72,7 +72,7 @@ TEST_P(AddTestF, Result) { compare(); }
 INSTANTIATE_TEST_CASE_P(AddTests, AddTestF, ::testing::ValuesIn(inputsf));
 
 const std::vector<AddInputs<double>> inputsd = {
-  {0.00000001, 1024 * 1024,     1234ULL},
+  {0.00000001, 1024 * 1024, 1234ULL},
   {0.00000001, 1024 * 1024 + 2, 1234ULL},
   {0.00000001, 1024 * 1024 + 1, 1234ULL},
 };
@@ -81,7 +81,7 @@ TEST_P(AddTestD, Result) { compare(); }
 INSTANTIATE_TEST_CASE_P(AddTests, AddTestD, ::testing::ValuesIn(inputsd));
 
 const std::vector<AddInputs<float, double>> inputsfd = {
-  {0.00000001, 1024 * 1024,     1234ULL},
+  {0.00000001, 1024 * 1024, 1234ULL},
   {0.00000001, 1024 * 1024 + 2, 1234ULL},
   {0.00000001, 1024 * 1024 + 1, 1234ULL},
 };

--- a/cpp/test/prims/add.cu
+++ b/cpp/test/prims/add.cu
@@ -23,57 +23,71 @@
 namespace MLCommon {
 namespace LinAlg {
 
-template <typename T>
-class AddTest : public ::testing::TestWithParam<AddInputs<T>> {
+template <typename InT, typename OutT = InT>
+class AddTest : public ::testing::TestWithParam<AddInputs<InT, OutT>> {
  protected:
   void SetUp() override {
-    params = ::testing::TestWithParam<AddInputs<T>>::GetParam();
+    params = ::testing::TestWithParam<AddInputs<InT, OutT>>::GetParam();
     Random::Rng r(params.seed);
     int len = params.len;
-    cudaStream_t stream;
     CUDA_CHECK(cudaStreamCreate(&stream));
-
     allocate(in1, len);
     allocate(in2, len);
     allocate(out_ref, len);
     allocate(out, len);
-    r.uniform(in1, len, T(-1.0), T(1.0), stream);
-    r.uniform(in2, len, T(-1.0), T(1.0), stream);
-    naiveAddElem(out_ref, in1, in2, len);
-    add(out, in1, in2, len, stream);
-
-    CUDA_CHECK(cudaStreamDestroy(stream));
+    r.uniform(in1, len, InT(-1.0), InT(1.0), stream);
+    r.uniform(in2, len, InT(-1.0), InT(1.0), stream);
+    naiveAddElem<InT, OutT>(out_ref, in1, in2, len);
+    add<InT, OutT>(out, in1, in2, len, stream);
   }
 
   void TearDown() override {
+    CUDA_CHECK(cudaStreamSynchronize(stream));
     CUDA_CHECK(cudaFree(in1));
     CUDA_CHECK(cudaFree(in2));
     CUDA_CHECK(cudaFree(out_ref));
     CUDA_CHECK(cudaFree(out));
+    CUDA_CHECK(cudaStreamDestroy(stream));
+  }
+
+  void compare() {
+    ASSERT_TRUE(devArrMatch(out_ref, out, params.len,
+                            CompareApprox<OutT>(params.tolerance)));
   }
 
  protected:
-  AddInputs<T> params;
-  T *in1, *in2, *out_ref, *out;
+  AddInputs<InT, OutT> params;
+  InT *in1, *in2;
+  OutT *out_ref, *out;
+  cudaStream_t stream;
 };
 
-const std::vector<AddInputs<float>> inputsf2 = {
-  {0.000001f, 1024 * 1024, 1234ULL}};
+const std::vector<AddInputs<float>> inputsf = {
+  {0.000001f, 1024 * 1024,     1234ULL},
+  {0.000001f, 1024 * 1024 + 2, 1234ULL},
+  {0.000001f, 1024 * 1024 + 1, 1234ULL},
+};
 typedef AddTest<float> AddTestF;
-TEST_P(AddTestF, Result) {
-  ASSERT_TRUE(devArrMatch(out_ref, out, params.len,
-                          CompareApprox<float>(params.tolerance)));
-}
-INSTANTIATE_TEST_CASE_P(AddTests, AddTestF, ::testing::ValuesIn(inputsf2));
+TEST_P(AddTestF, Result) { compare(); }
+INSTANTIATE_TEST_CASE_P(AddTests, AddTestF, ::testing::ValuesIn(inputsf));
 
-const std::vector<AddInputs<double>> inputsd2 = {
-  {0.00000001, 1024 * 1024, 1234ULL}};
+const std::vector<AddInputs<double>> inputsd = {
+  {0.00000001, 1024 * 1024,     1234ULL},
+  {0.00000001, 1024 * 1024 + 2, 1234ULL},
+  {0.00000001, 1024 * 1024 + 1, 1234ULL},
+};
 typedef AddTest<double> AddTestD;
-TEST_P(AddTestD, Result) {
-  ASSERT_TRUE(devArrMatch(out_ref, out, params.len,
-                          CompareApprox<double>(params.tolerance)));
-}
-INSTANTIATE_TEST_CASE_P(AddTests, AddTestD, ::testing::ValuesIn(inputsd2));
+TEST_P(AddTestD, Result) { compare(); }
+INSTANTIATE_TEST_CASE_P(AddTests, AddTestD, ::testing::ValuesIn(inputsd));
+
+const std::vector<AddInputs<float, double>> inputsfd = {
+  {0.00000001, 1024 * 1024,     1234ULL},
+  {0.00000001, 1024 * 1024 + 2, 1234ULL},
+  {0.00000001, 1024 * 1024 + 1, 1234ULL},
+};
+typedef AddTest<float, double> AddTestFD;
+TEST_P(AddTestFD, Result) { compare(); }
+INSTANTIATE_TEST_CASE_P(AddTests, AddTestFD, ::testing::ValuesIn(inputsfd));
 
 }  // end namespace LinAlg
 }  // end namespace MLCommon

--- a/cpp/test/prims/add.h
+++ b/cpp/test/prims/add.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/add.h
+++ b/cpp/test/prims/add.h
@@ -22,32 +22,33 @@
 namespace MLCommon {
 namespace LinAlg {
 
-template <typename Type>
-__global__ void naiveAddElemKernel(Type *out, const Type *in1, const Type *in2,
+template <typename InT, typename OutT = InT>
+__global__ void naiveAddElemKernel(OutT *out, const InT *in1, const InT *in2,
                                    int len) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
   if (idx < len) {
-    out[idx] = in1[idx] + in2[idx];
+    out[idx] = OutT(in1[idx] + in2[idx]);
   }
 }
 
-template <typename Type>
-void naiveAddElem(Type *out, const Type *in1, const Type *in2, int len) {
+template <typename InT, typename OutT = InT>
+void naiveAddElem(OutT *out, const InT *in1, const InT *in2, int len) {
   static const int TPB = 64;
   int nblks = ceildiv(len, TPB);
-  naiveAddElemKernel<Type><<<nblks, TPB>>>(out, in1, in2, len);
+  naiveAddElemKernel<InT, OutT><<<nblks, TPB>>>(out, in1, in2, len);
   CUDA_CHECK(cudaPeekAtLastError());
 }
 
-template <typename T>
+template <typename InT, typename OutT = InT>
 struct AddInputs {
-  T tolerance;
+  OutT tolerance;
   int len;
   unsigned long long int seed;
 };
 
-template <typename T>
-::std::ostream &operator<<(::std::ostream &os, const AddInputs<T> &dims) {
+template <typename InT, typename OutT = InT>
+::std::ostream &operator<<(::std::ostream &os,
+                           const AddInputs<InT, OutT> &dims) {
   return os;
 }
 


### PR DESCRIPTION
This PR addresses the request for the same in [here](https://github.com/rapidsai/cuml/pull/1719#discussion_r385341776).