### PR TITLE
[REVIEW] Fix bug with array interface missing strides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #1768: C++: Different input and output types for add and subtract prims
 
 ## Bug Fixes
+- PR #1775: Allow CumlArray to work with inputs that have no 'strides' in array interface
 - PR #1594: Train-test split is now reproducible
 - PR #1590: Fix destination directory structure for run-clang-format.py
 - PR #1611: Fixing pickling errors for KNN classifier and regressor

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -141,7 +141,7 @@ class CumlArray(Buffer):
             super(CumlArray, self).__init__(data=data, owner=owner)
             self.shape = ary_interface['shape']
             self.dtype = np.dtype(data.dtype)
-            if ary_interface['strides'] is None:
+            if ary_interface.get('strides', None) is None:
                 self.order = 'C'
                 self.strides = _order_to_strides(self.order, self.shape,
                                                  self.dtype)


### PR DESCRIPTION
Reported by Zahra when using numba 0.46.0 and cupy 6.7.0. I cannot get this to repro with more modern libraries (hence no reproducing test), but the array inteface spec does allow the interface to omit 'strides', so the change seems fair.