### PR TITLE
[REVIEW] Make cuML Handle picklable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #1709: Add `decision_function()` and `predict_proba()` for LogisticRegression
 - PR #1714: Add `print_env.sh` file to gather important environment details
 - PR #1750: LinearRegression CumlArray for configurable output
+- PR #1778: Make cuML Handle picklable
 
 ## Improvements
 - PR #1644: Add `predict_proba()` for FIL binary classifier

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -233,15 +233,12 @@ class Base:
         return self
 
     def __getstate__(self):
-        state = self.__dict__.copy()
-        # Remove the unpicklable handle.
-        if 'handle' in state:
-            del state['handle']
-        return state
+        # getstate and setstate are needed to tell pickle to treat this
+        # as regular python classes instead of triggering __getattr__
+        return self.__dict__
 
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self.handle = cuml.common.handle.Handle()
+    def __setstate__(self, d):
+        self.__dict__.update(d)
 
     def __getattr__(self, attr):
         """

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -91,7 +91,6 @@ cdef class Handle:
         cdef cumlHandle* h_ = <cumlHandle*>self.h
         h_.setDeviceAllocator(rmmAlloc)
 
-
     def sync(self):
         """
         Issues a sync on the stream set for this handle.

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -59,8 +59,10 @@ cdef class Handle:
     # python world cannot access to this raw object directly, hence use
     # 'size_t'!
     cdef size_t h
+    cdef int n_streams
 
     def __cinit__(self, n_streams=0):
+        self.n_streams = <int>n_streams
         self.h = <size_t>(new cumlHandle(n_streams))
 
     def __dealloc__(self):
@@ -105,3 +107,10 @@ cdef class Handle:
     def getNumInternalStreams(self):
         cdef cumlHandle* h_ = <cumlHandle*>self.h
         return h_.getNumInternalStreams()
+
+    def __getstate__(self):
+        return self.n_streams
+
+    def __setstate__(self, state):
+        self.n_streams = state
+        self.h = <size_t>(new cumlHandle(self.n_streams))

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -68,12 +68,6 @@ cdef class Handle:
         self.n_streams = n_streams
         self.h = <size_t>(new cumlHandle(n_streams))
 
-        # setting RMM as allocator
-        cdef shared_ptr[deviceAllocator] rmmAlloc = (
-            shared_ptr[deviceAllocator](new rmmAllocatorAdapter()))
-        cdef cumlHandle* h_ = <cumlHandle*>self.h
-        h_.setDeviceAllocator(rmmAlloc)
-
     def __dealloc__(self):
         h_ = <cumlHandle*>self.h
         del h_
@@ -82,6 +76,21 @@ cdef class Handle:
         cdef size_t s = <size_t>stream.getStream()
         cdef cumlHandle* h_ = <cumlHandle*>self.h
         h_.setStream(<_Stream>s)
+
+    # TODO: in future, we should just enable RMM by default
+    def enableRMM(self):
+        """
+        Enables to use RMM as the allocator for all device memory allocations
+        inside cuML C++ world. Currently, there are only 2 kinds of allocators.
+        First, the usual cudaMalloc/Free, which is the default for cumlHandle.
+        Second, the allocator based on RMM. So, this function, basically makes
+        the cumlHandle use a more efficient allocator, instead of the default.
+        """
+        cdef shared_ptr[deviceAllocator] rmmAlloc = (
+            shared_ptr[deviceAllocator](new rmmAllocatorAdapter()))
+        cdef cumlHandle* h_ = <cumlHandle*>self.h
+        h_.setDeviceAllocator(rmmAlloc)
+
 
     def sync(self):
         """

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -59,11 +59,20 @@ cdef class Handle:
     # python world cannot access to this raw object directly, hence use
     # 'size_t'!
     cdef size_t h
+
+    # not using __dict__ unless we need it to keep this Extension as lean as
+    # possible
     cdef int n_streams
 
     def __cinit__(self, n_streams=0):
-        self.n_streams = <int>n_streams
+        self.n_streams = n_streams
         self.h = <size_t>(new cumlHandle(n_streams))
+
+        # setting RMM as allocator
+        cdef shared_ptr[deviceAllocator] rmmAlloc = (
+            shared_ptr[deviceAllocator](new rmmAllocatorAdapter()))
+        cdef cumlHandle* h_ = <cumlHandle*>self.h
+        h_.setDeviceAllocator(rmmAlloc)
 
     def __dealloc__(self):
         h_ = <cumlHandle*>self.h
@@ -73,20 +82,6 @@ cdef class Handle:
         cdef size_t s = <size_t>stream.getStream()
         cdef cumlHandle* h_ = <cumlHandle*>self.h
         h_.setStream(<_Stream>s)
-
-    # TODO: in future, we should just enable RMM by default
-    def enableRMM(self):
-        """
-        Enables to use RMM as the allocator for all device memory allocations
-        inside cuML C++ world. Currently, there are only 2 kinds of allocators.
-        First, the usual cudaMalloc/Free, which is the default for cumlHandle.
-        Second, the allocator based on RMM. So, this function, basically makes
-        the cumlHandle use a more efficient allocator, instead of the default.
-        """
-        cdef shared_ptr[deviceAllocator] rmmAlloc = (
-            shared_ptr[deviceAllocator](new rmmAllocatorAdapter()))
-        cdef cumlHandle* h_ = <cumlHandle*>self.h
-        h_.setDeviceAllocator(rmmAlloc)
 
     def sync(self):
         """

--- a/python/cuml/test/test_handle.py
+++ b/python/cuml/test/test_handle.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/test/test_handle.py
+++ b/python/cuml/test/test_handle.py
@@ -26,3 +26,7 @@ def test_pickle(n_streams):
     b = pickle.loads(ap)
 
     assert isinstance(b, Handle)
+    assert b.getNumInternalStreams() == n_streams
+
+    # Add any additional asserts as parameters are added here
+    # If Handle gets a dict, add a proper comparison here.

--- a/python/cuml/test/test_handle.py
+++ b/python/cuml/test/test_handle.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pickle
+import pytest
+
+from cuml.common.handle import Handle
+
+
+@pytest.mark.parametrize('n_streams', [0, 1, 10])
+def test_pickle(n_streams):
+    a = Handle(n_streams=n_streams)
+    ap = pickle.dumps(a)
+    b = pickle.loads(ap)
+
+    assert isinstance(b, Handle)


### PR DESCRIPTION
PR adds ability to the Cython cuML handle to be pickled. This accomplishes 2 main things:

1. No more need for setstate/getstate custom code and workarounds. This combined with CumlArray means that only a few exceptional classes need custom pickling code. 
2. Prior handling of unpickling by deleting the handle made that the number of streams (and any other future exposed handle information) was recovered as 1 instead of as the number of streams that the handle had. 

Didn't remove the remainder of classes that have a custom set/getstate that delete the handle, since they need to be refactored for CumlArray anyways. 

