### PR TITLE
[REVIEW] Quickfix - chunkage in dask make_regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - PR #1751: Updated RF documentation
 - PR #1765: Update the checks for using RF GPU predict
 - PR #1793: Updated fil pyx to solve memory leakage issue
+- PR #1803: Quickfix - chunkage in dask make_regression
 
 # cuML 0.12.0 (Date TBD)
 

--- a/python/cuml/dask/datasets/regression.py
+++ b/python/cuml/dask/datasets/regression.py
@@ -211,12 +211,14 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
                                               chunks=(n_samples_per_part, -1))
 
     y = da.dot(X[:, :n_informative], ground_truth) + bias
+    X = X.rechunk((None, -1))
 
     if n_informative != n_features:
         zeroes = 0.0 * rs.standard_normal((n_features -
                                            n_informative,
                                            n_targets))
         ground_truth = da.concatenate([ground_truth, zeroes], axis=0)
+        ground_truth = ground_truth.rechunk(-1)
 
     # Add noise
     if noise > 0.0:

--- a/python/cuml/test/dask/test_datasets.py
+++ b/python/cuml/test/dask/test_datasets.py
@@ -125,12 +125,16 @@ def test_make_regression(n_samples, n_features, n_informative,
         else:
             assert values.shape == (n_samples,), "values shape mismatch"
 
+        assert len(out.chunks[1]) == 1
+
         if coef:
             if n_targets > 1:
                 assert coefs.shape == (n_features, n_targets), \
                        "coefs shape mismatch"
+                assert len(coefs.chunks[1]) == 1
             else:
                 assert coefs.shape == (n_features,), "coefs shape mismatch"
+                assert len(coefs.chunks[0]) == 1
 
             test1 = da.all(da.sum(coefs != 0.0, axis=0) == n_informative)
 


### PR DESCRIPTION
Fixes the chunkage of the second dimension for X and coefs outputs.