### PR TITLE
[REVIEW] Apply same fix to RF regression that was applied to classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PR #1795: Add capability to build CumlArray from bytearray/memoryview objects
 
 ## Bug Fixes
+- PR #1833: Fix depth issue in shallow RF regression estimators
 - PR #1770: Warn that KalmanFilter is deprecated
 - PR #1775: Allow CumlArray to work with inputs that have no 'strides' in array interface
 - PR #1594: Train-test split is now reproducible

--- a/cpp/src/decisiontree/levelalgo/levelhelper_regressor.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_regressor.cuh
@@ -411,7 +411,7 @@ void leaf_eval_regression(float *gain, int curr_depth,
   sparse_nodelist.clear();
 
   int non_leaf_counter = 0;
-  bool condition_global = (curr_depth == max_depth);
+  bool condition_global = (curr_depth >= max_depth - 1);
   if (max_leaves != -1)
     condition_global = condition_global || (tree_leaf_cnt >= max_leaves);
 


### PR DESCRIPTION
Can't believe I missed this last time! The same max_depth issue from #1787 appears in the regression case as well. I tested this on a python version of the pre-quantized airline regression dataset. Without the fix, R2 score is much lower on cuML RF than sklearn for trees shallower than ~depth 15, but with the fix, we track sklearn pretty closely for shallow trees.