### PR TITLE
[REVIEW] Rely on subclassing for cuML Array serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #1812: C++: bench: UMAP benchmark cases added
 - PR #1795: Add capability to build CumlArray from bytearray/memoryview objects
 - PR #1816: Add ARIMA notebook
+- PR #1848: Rely on subclassing for cuML Array serialization
 
 ## Bug Fixes
 - PR #1833: Fix depth issue in shallow RF regression estimators

--- a/python/cuml/comm/serialize.py
+++ b/python/cuml/comm/serialize.py
@@ -47,8 +47,6 @@ try:
                      dask_serialize, dask_deserialize)
 
     copyreg.pickle(cp.cusparse.MatDescriptor, serialize_mat_descriptor)
-
-
 except ImportError:
     # distributed is probably not installed on the system
     pass

--- a/python/cuml/comm/serialize.py
+++ b/python/cuml/comm/serialize.py
@@ -15,45 +15,4 @@
 #
 
 
-import pickle
-
-import cudf
-import cuml
-
-
-# all (de-)serializtion are attached to cuML Objects
-serializable_classes = (cuml.common.CumlArray,)
-
-
-try:
-    from distributed.protocol import dask_deserialize, dask_serialize
-    from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
-    from distributed.utils import log_errors
-
-    @cuda_serialize.register(serializable_classes)
-    def cuda_serialize_cuml_object(x):
-        with log_errors():
-            header, frames = x.serialize()
-            assert all(isinstance(f, cudf.core.buffer.Buffer) for f in frames)
-            return header, frames
-
-    # all (de-)serializtion are attached to cuML Objects
-    @dask_serialize.register(serializable_classes)
-    def dask_serialize_cuml_object(x):
-        with log_errors():
-            header, frames = x.serialize()
-            frames = [f.to_host_array().data for f in frames]
-            return header, frames
-
-    @cuda_deserialize.register(serializable_classes)
-    @dask_deserialize.register(serializable_classes)
-    def deserialize_cuml_object(header, frames):
-        with log_errors():
-            cuml_typ = pickle.loads(header["type-serialized"])
-            cuml_obj = cuml_typ.deserialize(header, frames)
-            return cuml_obj
-
-
-except ImportError:
-    # distributed is probably not installed on the system
-    pass
+import cudf.comm.serialize  # noqa: F401


### PR DESCRIPTION
As all of Dask serializers will handle serialization of subclasses, drop all explicit serialization functions here and just rely on cuDF's implementations. Though do make sure to `import cudf.comm.serialize` here to ensure that Dask registers them before serialization. That way Dask will determine `CumlArray` is a subclass` of `Buffer` and can be serialized through that functionality. Should cutdown on the boilerplate we need to maintain in cuML.

FYI This will allow the checks being added to cuDF in PR ( https://github.com/rapidsai/cudf/pull/4423 ) to apply to `CumlArray` as a matter of course.

Would wait until PRs affecting serialization like PR ( https://github.com/rapidsai/cuml/pull/1805 ) are merged before considering this to avoid introducing conflicts.