### PR TITLE
[REVIEW] Throw AttributeError in base for unknown attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - PR #1851: Fix for cuDF behavior change for multidimensional arrays
 - PR #1852: Remove Thrust warnings
 - PR #1868: Turning off IPC caching until it is fixed in UCX-py/UCX
+- PR #1887: Fix hasattr for missing attributes on base models
 
 # cuML 0.12.0 (Date TBD)
 

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -284,7 +284,7 @@ def all_algorithms():
         AlgorithmPair(
             sklearn.linear_model.LogisticRegression,
             cuml.linear_model.LogisticRegression,
-            shared_args=dict(), # Use default solvers
+            shared_args=dict(),  # Use default solvers
             name="LogisticRegression",
             accepts_labels=True,
             accuracy_function=metrics.accuracy_score,

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -284,7 +284,7 @@ def all_algorithms():
         AlgorithmPair(
             sklearn.linear_model.LogisticRegression,
             cuml.linear_model.LogisticRegression,
-            shared_args=dict(solver="lbfgs"),
+            shared_args=dict(), # Use default solvers
             name="LogisticRegression",
             accepts_labels=True,
             accuracy_function=metrics.accuracy_score,

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -254,6 +254,8 @@ class Base:
                 return self.__dict__[real_name].to_output(self.output_type)
             else:
                 return self.__dict__[real_name]
+        else:
+            raise AttributeError
 
     def _set_output_type(self, input):
         """

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -32,6 +32,7 @@ def test_base_class_usage_with_handle():
     base.handle.sync()
     del base
 
+
 def test_base_hasattr():
     base = cuml.Base()
     # With __getattr__ overriding magic, hasattr should still return

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -31,3 +31,10 @@ def test_base_class_usage_with_handle():
     base = cuml.Base(handle=handle)
     base.handle.sync()
     del base
+
+def test_base_hasattr():
+    base = cuml.Base()
+    # With __getattr__ overriding magic, hasattr should still return
+    # True only for valid attributes
+    assert hasattr(base, "handle")
+    assert not hasattr(base, "somefakeattr")

--- a/python/cuml/test/test_benchmark.py
+++ b/python/cuml/test/test_benchmark.py
@@ -16,6 +16,7 @@ from cuml.benchmark import datagen, algorithms
 from cuml.benchmark.bench_helper_funcs import _training_data_to_numpy
 from cuml.benchmark.runners import AccuracyComparisonRunner, \
     SpeedupComparisonRunner, run_variations
+from cuml.utils.import_utils import has_umap, has_xgboost
 
 import numpy as np
 import cudf
@@ -165,6 +166,27 @@ def test_accuracy_runner():
 
     assert results["cuml_acc"] == pytest.approx(0.80)
 
+
+# Only test a few algorithms (which collectively span several types)
+# to reduce runtime burden
+@pytest.mark.parametrize('algo_name', ['UMAP',
+                                       'DBSCAN',
+                                       'LogisticRegression',
+                                       'ElasticNet',
+                                       'FIL'])
+def test_real_algos_runner(algo_name):
+    pair = algorithms.algorithm_by_name(algo_name)
+
+    if (algo_name == 'UMAP' and not has_umap()) or \
+       (algo_name == 'FIL' and not has_xgboost()):
+        pytest.xfail()
+
+    runner = AccuracyComparisonRunner(
+        [20], [5], dataset_name='classification', test_fraction=0.20
+    )
+    results = runner.run(pair)[0]
+    print(results)
+    assert results["cuml_acc"] is not None
 
 @pytest.mark.parametrize('input_type', ['numpy', 'cudf', 'pandas', 'gpuarray'])
 def test_training_data_to_numpy(input_type):

--- a/python/cuml/test/test_benchmark.py
+++ b/python/cuml/test/test_benchmark.py
@@ -188,6 +188,7 @@ def test_real_algos_runner(algo_name):
     print(results)
     assert results["cuml_acc"] is not None
 
+
 @pytest.mark.parametrize('input_type', ['numpy', 'cudf', 'pandas', 'gpuarray'])
 def test_training_data_to_numpy(input_type):
     X, y, *_ = datagen.gen_data(


### PR DESCRIPTION
Without this, `hasattr(some_model, "whateverstring")` always returns true. This was breaking a few benchmarks that look at like `hasttr(model, "predict")`, but it's a more general fix too.