### PR TITLE
[REVIEW] Small train_test_split and cuDF Series tests fixes for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@
 - PR #1852: Remove Thrust warnings
 - PR #1868: Turning off IPC caching until it is fixed in UCX-py/UCX
 - PR #1877: Remove resetting index in shuffling in train_test_split
-- PR #1888: Small tran_test_split test fix
+- PR #1888: Small train_test_split test fix
 
 # cuML 0.12.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - PR #1852: Remove Thrust warnings
 - PR #1868: Turning off IPC caching until it is fixed in UCX-py/UCX
 - PR #1877: Remove resetting index in shuffling in train_test_split
+- PR #1888: Small tran_test_split test fix
 
 # cuML 0.12.0 (Date TBD)
 

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -262,7 +262,7 @@ def test_output(output_type, dtype, order, shape):
             assert cp.all(cp.asarray(cuda.to_device(inp)) == cp.asarray(res))
 
         elif output_type == 'series':
-            comp = cudf.Series(inp) == res
+            comp = cudf.Series(np.ravel(inp)) == res
             assert np.all(comp.to_array())
 
         elif output_type == 'dataframe':

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -49,8 +49,8 @@ def test_split_dataframe(train_size):
     )
     y_reconstructed = y_train.append(y_test).sort_values()
 
-    assert all(X_reconstructed == X)
-    assert all(y_reconstructed == y)
+    assert all(X_reconstructed.reset_index(drop=True) == X)
+    assert all(y_reconstructed.reset_index(drop=True) == y)
 
 
 def test_split_column():


### PR DESCRIPTION
Adjustment to compare dataframe results in train_test_split, after not resetting the index fix from yesterday.