### PR TITLE
Hide deprecation warnings by default, add flag to `build.sh` to show [skip-ci]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,24 +18,25 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libcuml cuml prims bench prims-bench -v -g -n --allgpuarch --singlegpu --nvtx -h --help"
+VALIDARGS="clean libcuml cuml prims bench prims-bench -v -g -n --allgpuarch --singlegpu --nvtx --show_depr_warn -h --help"
 HELP="$0 [<target> ...] [<flag> ...]
  where <target> is:
-   clean         - remove all existing build artifacts and configuration (start over)
-   libcuml       - build the cuml C++ code only. Also builds the C-wrapper library
-                   around the C++ code.
-   cuml          - build the cuml Python package
-   prims         - build the ML prims tests
-   bench         - build the cuml C++ benchmark
-   prims-bench   - build the ml-prims C++ benchmark
+   clean            - remove all existing build artifacts and configuration (start over)
+   libcuml          - build the cuml C++ code only. Also builds the C-wrapper library
+                      around the C++ code.
+   cuml             - build the cuml Python package
+   prims            - build the ML prims tests
+   bench            - build the cuml C++ benchmark
+   prims-bench      - build the ml-prims C++ benchmark
  and <flag> is:
-   -v            - verbose build mode
-   -g            - build for debug
-   -n            - no install step
-   --allgpuarch  - build for all supported GPU architectures
-   --singlegpu   - Build cuml without multigpu support (multigpu requires libcumlprims)
-   --nvtx        - Enable nvtx for profiling support
-   -h            - print this text
+   -v               - verbose build mode
+   -g               - build for debug
+   -n               - no install step
+   --allgpuarch     - build for all supported GPU architectures
+   --singlegpu      - Build cuml without multigpu support (multigpu requires libcumlprims)
+   --nvtx           - Enable nvtx for profiling support
+   --show_depr_warn - show cmake deprecation warnings
+   -h               - print this text
 
  default action (no args) is to build and install 'libcuml', 'cuml', and 'prims' targets only for the detected GPU arch
 "
@@ -52,6 +53,7 @@ BUILD_ALL_GPU_ARCH=0
 SINGLEGPU=""
 NVTX=OFF
 CLEAN=0
+BUILD_DISABLE_DEPRECATION_WARNING=ON
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
@@ -98,6 +100,9 @@ fi
 if hasArg --nvtx; then
     NVTX=ON
 fi
+if hasArg --show_depr_warn; then
+    BUILD_DISABLE_DEPRECATION_WARNING=OFF
+fi
 if hasArg clean; then
     CLEAN=1
 fi
@@ -142,6 +147,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libcuml || hasArg prims || hasArg bench || ha
           -DNVTX=${NVTX} \
           -DPARALLEL_LEVEL=${PARALLEL_LEVEL} \
           -DNCCL_PATH=${INSTALL_PREFIX} \
+          -DDISABLE_DEPRECATION_WARNING=${BUILD_DISABLE_DEPRECATION_WARNING} \
           -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} ..
 
 fi


### PR DESCRIPTION
This is to reduce the log file bloat for users and in gpuCI after the deprecation warnings added from other libraries.

Follows rapidsai/cudf#4698