### PR TITLE
[REVIEW] Remove c++ cuda flag that was getting duplicated in CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug Fixes
 
+- PR #1941: Remove c++ cuda flag that was getting duplicated in CMake
+
 # cuML 0.13.0 (Date TBD)
 
 ## New Features

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -177,7 +177,6 @@ if(OPENMP_FOUND)
 endif(OPENMP_FOUND)
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std=c++11")
 
 if(LINE_INFO)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -178,6 +178,10 @@ endif(OPENMP_FOUND)
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 
+if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std=c++11")
+endif(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+
 if(LINE_INFO)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo")
 endif(LINE_INFO)


### PR DESCRIPTION
CMake was defining the C++ std level in two lines: 

`set(CMAKE_CXX_STANDARD 11)`
`set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std=c++11")`

which was innocuous until cmake 3.17 has done a subtle change of how it is propagating, which is not agreeing with CUDA10.0 nvcc in CI. 