### PR TITLE
[REVIEW] remove zlib from cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #1946: Removed zlib dependency from cmake
+
 ## Bug Fixes
 
 - PR #1941: Remove c++ cuda flag that was getting duplicated in CMake

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -113,13 +113,6 @@ if (NOT DISABLE_OPENMP OR NOT ${DISABLE_OPENMP})
   endif(OPENMP_FOUND)
 endif(NOT DISABLE_OPENMP OR NOT ${DISABLE_OPENMP})
 
-find_package(ZLIB REQUIRED)
-if(ZLIB_FOUND)
-  message(STATUS "ZLib found in ${ZLIB_INCLUDE_DIRS}")
-else()
-  message(FATAL_ERROR "ZLib not found, please check your settings.")
-endif(ZLIB_FOUND)
-
 if(NOT DEFINED BLAS_LIBRARIES)
   find_package( BLAS REQUIRED )
 else()
@@ -346,8 +339,7 @@ include_directories(
   ${CUTLASS_DIR}/src/cutlass
   ${CUB_DIR}/src/cub
   ${TREELITE_DIR}/include
-  ${TREELITE_DIR}/include/fmt
-  ${ZLIB_INCLUDE_DIRS$})
+  ${TREELITE_DIR}/include/fmt)
 
 set(PRIMS_TEST_UTILS
     src_prims/cuda_utils.h
@@ -402,7 +394,6 @@ if(BUILD_CUML_CPP_LIBRARY)
     ${CUDA_CUDART_LIBRARY}
     ${CUDA_cusparse_LIBRARY}
     ${CUDA_nvgraph_LIBRARY}
-    ${ZLIB_LIBRARIES}
     ${Protobuf_LIBRARIES}
     treelitelib
     dmlclib

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -15,13 +15,12 @@ The `test` directory has subdirectories that reflect this distinction between th
 ## Setup
 ### Dependencies
 
-1. zlib
-2. cmake (>= 3.14)
-3. CUDA (>= 9.2)
-4. gcc (>=5.4.0)
-5. BLAS - Any BLAS compatible with cmake's [FindBLAS](https://cmake.org/cmake/help/v3.14/module/FindBLAS.html). Note that the blas has to be installed to the same folder system as cmake, for example if using conda installed cmake, the blas implementation should also be installed in the conda environment.
-6. clang-format (= 8.0.0) - enforces uniform C++ coding style; required to build cuML from source. The RAPIDS conda channel provides a package. If not using conda, install using your OS package manager.
-7. UCX with CUDA support [optional] (>=1.7) - enables point-to-point messaging in the cuML communicator.
+1. cmake (>= 3.14)
+2. CUDA (>= 9.2)
+3. gcc (>=5.4.0)
+4. BLAS - Any BLAS compatible with cmake's [FindBLAS](https://cmake.org/cmake/help/v3.14/module/FindBLAS.html). Note that the blas has to be installed to the same folder system as cmake, for example if using conda installed cmake, the blas implementation should also be installed in the conda environment.
+5. clang-format (= 8.0.0) - enforces uniform C++ coding style; required to build cuML from source. The RAPIDS conda channel provides a package. If not using conda, install using your OS package manager.
+6. UCX with CUDA support [optional] (>=1.7) - enables point-to-point messaging in the cuML communicator.
 
 ### Building cuML:
 

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -75,9 +75,7 @@ if(BUILD_CUML_TESTS)
         treelite_runtimelib
         ${CUML_CPP_TARGET}
         ${CUML_C_TARGET}
-        pthread
-        ${ZLIB_LIBRARIES}
-    )
+        pthread)
 
     # (please keep the filenames in alphabetical order)
     add_executable(ml
@@ -131,9 +129,7 @@ if(BUILD_CUML_MG_TESTS)
         ${CUDA_nvgraph_LIBRARY}
         faisslib
         ${CUML_CPP_TARGET}
-        pthread
-        ${ZLIB_LIBRARIES}
-    )
+        pthread)
 
     # (please keep the filenames in alphabetical order)
     add_executable(ml_mg
@@ -162,10 +158,8 @@ if(BUILD_PRIMS_TESTS)
         ${CUDA_cusparse_LIBRARY}
         pthread
         faisslib
-        ${ZLIB_LIBRARIES}
         OpenMP::OpenMP_CXX
-        Threads::Threads
-    )
+        Threads::Threads)
 
     # (please keep the filenames in alphabetical order)
     add_executable(prims


### PR DESCRIPTION
None of our C++ sources use zlib anymore. Hence, removing this stray dependency from our cmake build flow.