### PR TITLE
[REVIEW] cleaning up cmake flow based on guidelines in "effective cmake"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #1947: Cleaning up cmake
+
 ## Bug Fixes
 
 - PR #1941: Remove c++ cuda flag that was getting duplicated in CMake

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 set(Protobuf_USE_STATIC_LIBS ON)
 find_package(Protobuf REQUIRED)
 
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${cuml_SOURCE_DIR}/cmake)
 
 ##############################################################################
 # - External Dependencies-----------------------------------------------------
@@ -149,7 +149,7 @@ set(FAISS_DIR ${CMAKE_CURRENT_BINARY_DIR}/faiss CACHE STRING
 set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")
 
-set(CUML_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include CACHE STRING
+set(CUML_INCLUDE_DIR ${cuml_SOURCE_DIR}/include CACHE STRING
   "Path to cuml include directories")
 
 ##############################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -363,7 +363,7 @@ endif(BUILD_CUML_MPI_COMMS)
 ###################################################################################################
 # - build examples -------------------------------------------------------------------------
 
-if (BUILD_CUML_EXAMPLES)
+if(BUILD_CUML_EXAMPLES)
   add_subdirectory(examples)
 endif(BUILD_CUML_EXAMPLES)
 
@@ -379,7 +379,9 @@ install(DIRECTORY ${CUML_INCLUDE_DIR}/cuml DESTINATION include)
 ##############################################################################
 # - build benchmark executable -----------------------------------------------
 
-add_subdirectory(bench ${PROJECT_BINARY_DIR}/bench)
+if(BUILD_CUML_BENCH)
+  add_subdirectory(bench ${PROJECT_BINARY_DIR}/bench)
+endif(BUILD_CUML_BENCH)
 
 ##############################################################################
 # - doxygen targets ----------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -241,9 +241,9 @@ include(cmake/Dependencies.cmake)
 
 set(CUML_INCLUDE_DIRECTORIES
   ${CUML_INCLUDE_DIR}
-  src
-  src_prims
-  test/prims
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/src_prims
+  ${CMAKE_CURRENT_SOURCE_DIR}/test/prims
   ${FAISS_DIR}/src/
   ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
   ${CUTLASS_DIR}/src/cutlass
@@ -261,8 +261,6 @@ set(CUML_LINK_LIBRARIES
   ${CUDA_nvgraph_LIBRARY}
   ${ZLIB_LIBRARIES}
   ${Protobuf_LIBRARIES}
-  treelitelib
-  dmlclib
   faisslib)
 
 ##############################################################################
@@ -317,7 +315,10 @@ if(BUILD_CUML_CPP_LIBRARY)
   target_include_directories(${CUML_CPP_TARGET}
     PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 
-  target_link_libraries(${CUML_CPP_TARGET} ${CUML_LINK_LIBRARIES})
+  target_link_libraries(${CUML_CPP_TARGET}
+    ${CUML_LINK_LIBRARIES}
+    treelitelib
+    dmlclib)
   # If we export the libdmlc symbols, they can lead to weird crashes with other
   # libraries that use libdmlc. This just hides the symbols internally.
   target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libdmlc.a")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -134,12 +134,6 @@ set(CMAKE_MODULE_PATH ${cuml_SOURCE_DIR}/cmake)
 ##############################################################################
 # - External Dependencies-----------------------------------------------------
 
-set(CUB_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub CACHE STRING
-  "Path to cub repo")
-
-set(CUTLASS_DIR ${CMAKE_CURRENT_BINARY_DIR}/cutlass CACHE STRING
-  "Path to the cutlass repo")
-
 set(CUDA_nvgraph_LIBRARY ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libnvgraph.so CACHE STRING
   "Path to nvGraph lib")
 
@@ -244,33 +238,15 @@ set(CMAKE_CUDA_FLAGS
   "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=unrecognized_gcc_pragma")
 
 ##############################################################################
+# - dependencies -------------------------------------------------------------
+
+include(cmake/Dependencies.cmake)
+
+##############################################################################
 # - Cloning header only libraries---------------------------------------------
 
 include(ExternalProject)
 
-ExternalProject_Add(cub
-  GIT_REPOSITORY    https://github.com/NVlabs/cub.git
-  GIT_TAG           v1.8.0
-  PREFIX            ${CUB_DIR}
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-)
-
-ExternalProject_Add(cutlass
-  GIT_REPOSITORY    https://github.com/NVIDIA/cutlass.git
-  GIT_TAG           v1.0.1
-  PREFIX            ${CUTLASS_DIR}
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-)
-
-# dependencies will be added in sequence, so if a new project `project_b` is added
-# after `project_a`, please add the dependency add_dependencies(project_b project_a)
-# This allows the cloning to happen sequentially, enhancing the printing at
-# compile time, helping significantly to troubleshoot build issues.
-add_dependencies(cutlass cub)
 
 ##############################################################################
 # - FAISS Build  -------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -239,7 +239,7 @@ include(cmake/Dependencies.cmake)
 ##############################################################################
 # - include paths ------------------------------------------------------------
 
-include_directories(
+set(CUML_INCLUDE_DIRECTORIES
   ${CUML_INCLUDE_DIR}
   src
   src_prims
@@ -252,15 +252,23 @@ include_directories(
   ${TREELITE_DIR}/include/fmt
   ${ZLIB_INCLUDE_DIRS$})
 
-set(PRIMS_TEST_UTILS
-    src_prims/cuda_utils.h
-    src_prims/utils.h)
+set(CUML_LINK_LIBRARIES
+  ${CUDA_cublas_LIBRARY}
+  ${CUDA_curand_LIBRARY}
+  ${CUDA_cusolver_LIBRARY}
+  ${CUDA_CUDART_LIBRARY}
+  ${CUDA_cusparse_LIBRARY}
+  ${CUDA_nvgraph_LIBRARY}
+  ${ZLIB_LIBRARIES}
+  ${Protobuf_LIBRARIES}
+  treelitelib
+  dmlclib
+  faisslib)
 
 ##############################################################################
 # - build libcuml++ shared library -------------------------------------------
 
 if(BUILD_CUML_CPP_LIBRARY)
-
   set(CUML_CPP_TARGET "cuml++")
 
   add_library(${CUML_CPP_TARGET} SHARED
@@ -295,22 +303,7 @@ if(BUILD_CUML_CPP_LIBRARY)
     src/tsvd/tsvd.cu
     src/umap/umap.cu
     src/arima/batched_kalman.cu
-    src/arima/batched_arima.cu
-    )
-
-  set(CUML_LINK_LIBRARIES
-    ${CUDA_cublas_LIBRARY}
-    ${CUDA_curand_LIBRARY}
-    ${CUDA_cusolver_LIBRARY}
-    ${CUDA_CUDART_LIBRARY}
-    ${CUDA_cusparse_LIBRARY}
-    ${CUDA_nvgraph_LIBRARY}
-    ${ZLIB_LIBRARIES}
-    ${Protobuf_LIBRARIES}
-    treelitelib
-    dmlclib
-    faisslib
-    )
+    src/arima/batched_arima.cu)
 
   if(OPENMP_FOUND)
     set(CUML_LINK_LIBRARIES ${CUML_LINK_LIBRARIES} OpenMP::OpenMP_CXX Threads::Threads)
@@ -320,6 +313,9 @@ if(BUILD_CUML_CPP_LIBRARY)
     set(CUML_LINK_LIBRARIES ${CUML_LINK_LIBRARIES} nvToolsExt)
     link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib64)
   endif(NVTX)
+
+  target_include_directories(${CUML_CPP_TARGET}
+    PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${CUML_CPP_TARGET} ${CUML_LINK_LIBRARIES})
   # If we export the libdmlc symbols, they can lead to weird crashes with other
@@ -331,7 +327,6 @@ endif(BUILD_CUML_CPP_LIBRARY)
 # - build libcuml C shared library -------------------------------------------
 
 if(BUILD_CUML_C_LIBRARY)
-
   set(CUML_C_TARGET "cuml")
 
   add_library(${CUML_C_TARGET} SHARED
@@ -340,6 +335,9 @@ if(BUILD_CUML_C_LIBRARY)
     src/glm/glm_api.cpp
     src/holtwinters/holtwinters_api.cpp
     src/svm/svm_api.cpp)
+
+  target_include_directories(${CUML_C_TARGET}
+    PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${CUML_C_TARGET} ${CUML_CPP_TARGET})
 endif(BUILD_CUML_C_LIBRARY)
@@ -359,7 +357,7 @@ if(BUILD_CUML_STD_COMMS)
 endif(BUILD_CUML_STD_COMMS)
 
 if(BUILD_CUML_MPI_COMMS)
-	add_subdirectory(comms/mpi)
+  add_subdirectory(comms/mpi)
 endif(BUILD_CUML_MPI_COMMS)
 
 ###################################################################################################
@@ -376,7 +374,7 @@ install(TARGETS ${CUML_CPP_TARGET}
                 ${CUML_C_TARGET}
         DESTINATION lib)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/cuml DESTINATION include)
+install(DIRECTORY ${CUML_INCLUDE_DIR}/cuml DESTINATION include)
 
 ##############################################################################
 # - build benchmark executable -----------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -322,6 +322,8 @@ if(BUILD_CUML_CPP_LIBRARY)
   # If we export the libdmlc symbols, they can lead to weird crashes with other
   # libraries that use libdmlc. This just hides the symbols internally.
   target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libdmlc.a")
+  # same as above, but for protobuf library
+  target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libprotobuf.a")
 endif(BUILD_CUML_CPP_LIBRARY)
 
 ##############################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 set(Protobuf_USE_STATIC_LIBS ON)
 find_package(Protobuf REQUIRED)
 
-set(CMAKE_MODULE_PATH ${cuml_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 ##############################################################################
 # - External Dependencies-----------------------------------------------------
@@ -137,13 +137,7 @@ set(CMAKE_MODULE_PATH ${cuml_SOURCE_DIR}/cmake)
 set(CUDA_nvgraph_LIBRARY ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libnvgraph.so CACHE STRING
   "Path to nvGraph lib")
 
-set(FAISS_DIR ${CMAKE_CURRENT_BINARY_DIR}/faiss CACHE STRING
-  "Path to FAISS source directory")
-
-set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
-  "Path to treelite install directory")
-
-set(CUML_INCLUDE_DIR ${cuml_SOURCE_DIR}/include CACHE STRING
+set(CUML_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include CACHE STRING
   "Path to cuml include directories")
 
 ##############################################################################
@@ -241,73 +235,6 @@ set(CMAKE_CUDA_FLAGS
 # - dependencies -------------------------------------------------------------
 
 include(cmake/Dependencies.cmake)
-
-##############################################################################
-# - Cloning header only libraries---------------------------------------------
-
-include(ExternalProject)
-
-
-##############################################################################
-# - FAISS Build  -------------------------------------------------------------
-
-ExternalProject_Add(faiss
-  GIT_REPOSITORY    https://github.com/facebookresearch/faiss.git
-  GIT_TAG           v1.6.1
-  CONFIGURE_COMMAND LIBS=-pthread
-                    CPPFLAGS=-w
-                    LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib
-                            ${CMAKE_CURRENT_BINARY_DIR}/faiss/src/faiss/configure
-                            --prefix=${CMAKE_CURRENT_BINARY_DIR}/faiss
-                            --with-blas=${BLAS_LIBRARIES}
-                            --with-cuda=${CUDA_TOOLKIT_ROOT_DIR}
-                            --with-cuda-arch=${FAISS_GPU_ARCHS}
-                            -v
-  PREFIX            ${FAISS_DIR}
-  BUILD_COMMAND     ${CMAKE_MAKE_PROGRAM} -j${PARALLEL_LEVEL} VERBOSE=1
-  INSTALL_COMMAND   ${CMAKE_MAKE_PROGRAM} -s install > /dev/null
-  UPDATE_COMMAND    ""
-  BUILD_IN_SOURCE   1
-)
-
-add_dependencies(faiss cutlass)
-
-ExternalProject_Get_Property(faiss install_dir)
-
-add_library(faisslib STATIC IMPORTED)
-
-add_dependencies(faisslib faiss)
-
-set_property(TARGET faisslib PROPERTY IMPORTED_LOCATION ${FAISS_DIR}/lib/libfaiss.a)
-
-##############################################################################
-# - treelite build -----------------------------------------------------------
-
-ExternalProject_Add(treelite
-    GIT_REPOSITORY    https://github.com/dmlc/treelite.git
-    GIT_TAG           6fd01e4f1890950bbcf9b124da24e886751bffe6
-    PREFIX            ${TREELITE_DIR}
-    CMAKE_ARGS        -DBUILD_SHARED_LIBS=OFF
-                      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                      -DENABLE_PROTOBUF=ON
-                      -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-    UPDATE_COMMAND    ""
-    PATCH_COMMAND     patch -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/treelite_protobuf.patch || true
-)
-
-add_dependencies(treelite faiss)
-
-add_library(dmlclib STATIC IMPORTED)
-add_library(treelitelib STATIC IMPORTED)
-add_library(treelite_runtimelib SHARED IMPORTED)
-
-add_dependencies(dmlclib treelite)
-add_dependencies(treelitelib treelite)
-add_dependencies(treelite_runtimelib treelite)
-
-set_property(TARGET dmlclib PROPERTY IMPORTED_LOCATION ${TREELITE_DIR}/lib/libdmlc.a)
-set_property(TARGET treelitelib PROPERTY IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite.a)
-set_property(TARGET treelite_runtimelib PROPERTY IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite_runtime.so)
 
 ##############################################################################
 # - include paths ------------------------------------------------------------
@@ -449,8 +376,7 @@ install(TARGETS ${CUML_CPP_TARGET}
                 ${CUML_C_TARGET}
         DESTINATION lib)
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/cuml
-        DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/cuml DESTINATION include)
 
 ##############################################################################
 # - build benchmark executable -----------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -250,9 +250,7 @@ set(CUML_LINK_LIBRARIES
   ${CUDA_cusolver_LIBRARY}
   ${CUDA_CUDART_LIBRARY}
   ${CUDA_cusparse_LIBRARY}
-  ${CUDA_nvgraph_LIBRARY}
-  ${Protobuf_LIBRARIES}
-  faisslib)
+  ${CUDA_nvgraph_LIBRARY})
 
 ##############################################################################
 # - build libcuml++ shared library -------------------------------------------
@@ -307,9 +305,13 @@ if(BUILD_CUML_CPP_LIBRARY)
     PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${CUML_CPP_TARGET}
-    ${CUML_LINK_LIBRARIES}
-    treelitelib
-    dmlclib)
+    PUBLIC
+      ${CUML_LINK_LIBRARIES}
+    PRIVATE
+      ${Protobuf_LIBRARIES}
+      faisslib
+      treelitelib
+      dmlclib)
   # If we export the libdmlc symbols, they can lead to weird crashes with other
   # libraries that use libdmlc. This just hides the symbols internally.
   target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libdmlc.a")
@@ -333,7 +335,7 @@ if(BUILD_CUML_C_LIBRARY)
   target_include_directories(${CUML_C_TARGET}
     PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 
-  target_link_libraries(${CUML_C_TARGET} ${CUML_CPP_TARGET})
+  target_link_libraries(${CUML_C_TARGET} PUBLIC ${CUML_CPP_TARGET})
 endif(BUILD_CUML_C_LIBRARY)
 
 ##############################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -251,7 +251,6 @@ set(CUML_LINK_LIBRARIES
   ${CUDA_CUDART_LIBRARY}
   ${CUDA_cusparse_LIBRARY}
   ${CUDA_nvgraph_LIBRARY}
-  ${ZLIB_LIBRARIES}
   ${Protobuf_LIBRARIES}
   faisslib)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -272,11 +272,13 @@ if(BUILD_CUML_CPP_LIBRARY)
   set(CUML_CPP_TARGET "cuml++")
 
   add_library(${CUML_CPP_TARGET} SHARED
+    src/arima/batched_kalman.cu
+    src/arima/batched_arima.cu
     src/common/cumlHandle.cpp
     src/common/cuml_api.cpp
     src/common/cuML_comms_impl.cpp
-    src/comms/cuML_comms_test.cpp
     src/common/nvtx.cu
+    src/comms/cuML_comms_test.cpp
     src/datasets/make_blobs.cu
     src/datasets/make_regression.cu
     src/dbscan/dbscan.cu
@@ -301,9 +303,7 @@ if(BUILD_CUML_CPP_LIBRARY)
     src/tsa/stationarity.cu
     src/tsne/tsne.cu
     src/tsvd/tsvd.cu
-    src/umap/umap.cu
-    src/arima/batched_kalman.cu
-    src/arima/batched_arima.cu)
+    src/umap/umap.cu)
 
   if(OPENMP_FOUND)
     set(CUML_LINK_LIBRARIES ${CUML_LINK_LIBRARIES} OpenMP::OpenMP_CXX Threads::Threads)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2019, NVIDIA CORPORATION.
+# Copyright (c) 2018-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -35,7 +35,8 @@ if(BUILD_CUML_BENCH)
     benchmarklib)
 
   target_include_directories(sg_benchmark
-    PRIVATE ${GBENCH_DIR}/include)
+    PRIVATE ${GBENCH_DIR}/include
+    ${CUML_INCLUDE_DIRECTORIES})
 endif(BUILD_CUML_BENCH)
 
 ##############################################################################
@@ -63,5 +64,5 @@ if(BUILD_CUML_PRIMS_BENCH)
 
   target_include_directories(prims_benchmark
     PRIVATE ${GBENCH_DIR}/include
-    src_prims)
+    ${CUML_INCLUDE_DIRECTORIES})
 endif(BUILD_CUML_PRIMS_BENCH)

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -19,8 +19,6 @@ cmake_policy(SET CMP0079 NEW)
 ###################################################################################################
 # - build cuml bench executable -------------------------------------------------------------------
 
-# TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite
-
 set(GBENCH_DIR ${CMAKE_CURRENT_BINARY_DIR}/benchmark)
 set(GBENCH_BINARY_DIR ${PROJECT_BINARY_DIR}/benchmark)
 set(GBENCH_INSTALL_DIR ${GBENCH_BINARY_DIR}/install)

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -1,3 +1,4 @@
+#=============================================================================
 # Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,36 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+#=============================================================================
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0079 NEW)
 
 ###################################################################################################
 # - build cuml bench executable -------------------------------------------------------------------
-
-set(GBENCH_DIR ${CMAKE_CURRENT_BINARY_DIR}/benchmark)
-set(GBENCH_BINARY_DIR ${PROJECT_BINARY_DIR}/benchmark)
-set(GBENCH_INSTALL_DIR ${GBENCH_BINARY_DIR}/install)
-set(GBENCH_LIB ${GBENCH_INSTALL_DIR}/lib/libbenchmark.a)
-
-include(ExternalProject)
-ExternalProject_Add(benchmark
-  GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           bf4f2ea0bd1180b34718ac26eb79b170a4f6290e
-  PREFIX            ${GBENCH_DIR}
-  CMAKE_ARGS        -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
-                    -DBENCHMARK_ENABLE_TESTING=OFF
-                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                    -DCMAKE_BUILD_TYPE=Release
-                    -DCMAKE_INSTALL_LIBDIR=lib
-  UPDATE_COMMAND    ""
-)
-
-add_library(benchmarklib STATIC IMPORTED)
-add_dependencies(benchmarklib benchmark)
-set_property(TARGET benchmarklib PROPERTY
-  IMPORTED_LOCATION ${GBENCH_DIR}/lib/libbenchmark.a)
 
 if(BUILD_CUML_BENCH)
   set(CUML_SG_BENCH_TARGET "sg_benchmark")

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0079 NEW)
 
-###################################################################################################
-# - build cuml bench executable -------------------------------------------------------------------
+##############################################################################
+# - build cuml bench executable ----------------------------------------------
 
 if(BUILD_CUML_BENCH)
   set(CUML_SG_BENCH_TARGET "sg_benchmark")
@@ -39,6 +39,9 @@ if(BUILD_CUML_BENCH)
   target_include_directories(${CUML_SG_BENCH_TARGET}
     PRIVATE ${GBENCH_DIR}/include)
 endif(BUILD_CUML_BENCH)
+
+##############################################################################
+# - build prims bench executable ----------------------------------------------
 
 if(BUILD_CUML_PRIMS_BENCH)
   set(CUML_PRIMS_BENCH_TARGET "prims_benchmark")

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -20,13 +20,8 @@ cmake_policy(SET CMP0079 NEW)
 # - build cuml bench executable ----------------------------------------------
 
 if(BUILD_CUML_BENCH)
-  set(CUML_SG_BENCH_TARGET "sg_benchmark")
-  set(ML_BENCH_LINK_LIBRARIES
-    ${CUML_CPP_TARGET}
-    benchmarklib
-    )
   # (please keep the filenames in alphabetical order)
-  add_executable(${CUML_SG_BENCH_TARGET}
+  add_executable(sg_benchmark
     sg/dbscan.cu
     sg/kmeans.cu
     sg/main.cpp
@@ -34,8 +29,12 @@ if(BUILD_CUML_BENCH)
     sg/rf_regressor.cu
     sg/umap.cu
     )
-  target_link_libraries(${CUML_SG_BENCH_TARGET} ${ML_BENCH_LINK_LIBRARIES})
-  target_include_directories(${CUML_SG_BENCH_TARGET}
+
+  target_link_libraries(sg_benchmark
+    ${CUML_CPP_TARGET}
+    benchmarklib)
+
+  target_include_directories(sg_benchmark
     PRIVATE ${GBENCH_DIR}/include)
 endif(BUILD_CUML_BENCH)
 
@@ -43,9 +42,8 @@ endif(BUILD_CUML_BENCH)
 # - build prims bench executable ----------------------------------------------
 
 if(BUILD_CUML_PRIMS_BENCH)
-  set(CUML_PRIMS_BENCH_TARGET "prims_benchmark")
   # (please keep the filenames in alphabetical order)
-  add_executable(${CUML_PRIMS_BENCH_TARGET}
+  add_executable(prims_benchmark
     prims/add.cu
     prims/distance_cosine.cu
     prims/distance_exp_l2.cu
@@ -57,12 +55,13 @@ if(BUILD_CUML_PRIMS_BENCH)
     prims/permute.cu
     prims/reduce.cu
     prims/rng.cu
-    prims/main.cpp
-    )
-  add_dependencies(${CUML_PRIMS_BENCH_TARGET} cub)
-  add_dependencies(${CUML_PRIMS_BENCH_TARGET} cutlass)
-  target_link_libraries(${CUML_PRIMS_BENCH_TARGET} benchmarklib)
-  target_include_directories(${CUML_PRIMS_BENCH_TARGET}
+    prims/main.cpp)
+
+  add_dependencies(prims_benchmark cutlass)
+
+  target_link_libraries(prims_benchmark benchmarklib)
+
+  target_include_directories(prims_benchmark
     PRIVATE ${GBENCH_DIR}/include
     src_prims)
 endif(BUILD_CUML_PRIMS_BENCH)

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -14,7 +14,6 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0079 NEW)
 
 ##############################################################################

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -72,7 +72,7 @@ set_property(TARGET faisslib PROPERTY
   IMPORTED_LOCATION ${FAISS_DIR}/lib/libfaiss.a)
 
 ##############################################################################
-# - google benchmark ---------------------------------------------------------
+# - treelite build -----------------------------------------------------------
 
 set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -16,6 +16,9 @@
 
 include(ExternalProject)
 
+##############################################################################
+# - cub - (header only) ------------------------------------------------------
+
 set(CUB_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub CACHE STRING "Path to cub repo")
 set(CUB_VERSION v1.8.0 CACHE STRING "cub branch version to use")
 ExternalProject_Add(cub
@@ -25,6 +28,9 @@ ExternalProject_Add(cub
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   "")
+
+##############################################################################
+# - cutlass - (header only) --------------------------------------------------
 
 set(CUTLASS_DIR ${CMAKE_CURRENT_BINARY_DIR}/cutlass CACHE STRING
   "Path to the cutlass repo")
@@ -36,6 +42,9 @@ ExternalProject_Add(cutlass
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   "")
+
+##############################################################################
+# - faiss --------------------------------------------------------------------
 
 set(FAISS_DIR ${CMAKE_CURRENT_BINARY_DIR}/faiss CACHE STRING
   "Path to FAISS source directory")
@@ -61,6 +70,9 @@ ExternalProject_Get_Property(faiss install_dir)
 add_library(faisslib STATIC IMPORTED)
 set_property(TARGET faisslib PROPERTY
   IMPORTED_LOCATION ${FAISS_DIR}/lib/libfaiss.a)
+
+##############################################################################
+# - google benchmark ---------------------------------------------------------
 
 set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")
@@ -88,6 +100,9 @@ set_property(TARGET treelite_runtimelib PROPERTY
 add_dependencies(dmlclib treelite)
 add_dependencies(treelitelib treelite)
 add_dependencies(treelite_runtimelib treelite)
+
+##############################################################################
+# - googletest ---------------------------------------------------------------
 
 set(GTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest CACHE STRING
   "Path to googletest repo")

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -86,6 +86,29 @@ set_property(TARGET treelitelib PROPERTY
 set_property(TARGET treelite_runtimelib PROPERTY
   IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite_runtime.so)
 
+set(GBENCH_DIR ${CMAKE_CURRENT_BINARY_DIR}/benchmark CACHE STRING
+  "Path to google benchmark repo")
+set(GBENCH_TAG bf4f2ea0bd1180b34718ac26eb79b170a4f6290e CACHE STRING
+  "Google benchmark commit tag to be used")
+set(GBENCH_BINARY_DIR ${PROJECT_BINARY_DIR}/benchmark)
+set(GBENCH_INSTALL_DIR ${GBENCH_BINARY_DIR}/install)
+set(GBENCH_LIB ${GBENCH_INSTALL_DIR}/lib/libbenchmark.a)
+include(ExternalProject)
+ExternalProject_Add(benchmark
+  GIT_REPOSITORY    https://github.com/google/benchmark.git
+  GIT_TAG           ${GBENCH_TAG}
+  PREFIX            ${GBENCH_DIR}
+  CMAKE_ARGS        -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
+                    -DBENCHMARK_ENABLE_TESTING=OFF
+                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                    -DCMAKE_BUILD_TYPE=Release
+                    -DCMAKE_INSTALL_LIBDIR=lib
+  UPDATE_COMMAND    "")
+add_library(benchmarklib STATIC IMPORTED)
+add_dependencies(benchmarklib benchmark)
+set_property(TARGET benchmarklib PROPERTY
+  IMPORTED_LOCATION ${GBENCH_DIR}/lib/libbenchmark.a)
+
 # dependencies will be added in sequence, so if a new project `project_b` is added
 # after `project_a`, please add the dependency add_dependencies(project_b project_a)
 # This allows the cloning to happen sequentially, enhancing the printing at

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -85,6 +85,34 @@ set_property(TARGET treelitelib PROPERTY
   IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite.a)
 set_property(TARGET treelite_runtimelib PROPERTY
   IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite_runtime.so)
+add_dependencies(dmlclib treelite)
+add_dependencies(treelitelib treelite)
+add_dependencies(treelite_runtimelib treelite)
+
+set(GTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest CACHE STRING
+  "Path to googletest repo")
+set(GTEST_TAG 6ce9b98f541b8bcd84c5c5b3483f29a933c4aefb CACHE STRING
+  "Googletest commit tag to be used")
+set(GTEST_BINARY_DIR ${PROJECT_BINARY_DIR}/googletest)
+set(GTEST_INSTALL_DIR ${GTEST_BINARY_DIR}/install)
+set(GTEST_LIB ${GTEST_INSTALL_DIR}/lib/libgtest_main.a)
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           ${GTEST_TAG}
+  PREFIX            ${GTEST_DIR}
+  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                    -DBUILD_SHARED_LIBS=OFF
+                    -DCMAKE_INSTALL_LIBDIR=lib
+  UPDATE_COMMAND    "")
+add_library(gtestlib STATIC IMPORTED)
+add_library(gtest_mainlib STATIC IMPORTED)
+set_property(TARGET gtestlib PROPERTY
+  IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest.a)
+set_property(TARGET gtest_mainlib PROPERTY
+  IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest_main.a)
+add_dependencies(gtestlib googletest)
+add_dependencies(gtest_mainlib googletest)
 
 set(GBENCH_DIR ${CMAKE_CURRENT_BINARY_DIR}/benchmark CACHE STRING
   "Path to google benchmark repo")
@@ -117,6 +145,5 @@ add_dependencies(cutlass cub)
 add_dependencies(faiss cutlass)
 add_dependencies(faisslib faiss)
 add_dependencies(treelite faiss)
-add_dependencies(dmlclib treelite)
-add_dependencies(treelitelib treelite)
-add_dependencies(treelite_runtimelib treelite)
+add_dependencies(googletest treelite)
+add_dependencies(benchmark googletest)

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -1,0 +1,45 @@
+#=============================================================================
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+include(ExternalProject)
+
+set(CUB_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub CACHE STRING "Path to cub repo")
+set(CUB_VERSION v1.8.0 CACHE STRING "cub branch version to use")
+ExternalProject_Add(cub
+  GIT_REPOSITORY    https://github.com/NVlabs/cub.git
+  GIT_TAG           ${CUB_VERSION}
+  PREFIX            ${CUB_DIR}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+)
+
+set(CUTLASS_DIR ${CMAKE_CURRENT_BINARY_DIR}/cutlass CACHE STRING
+  "Path to the cutlass repo")
+ExternalProject_Add(cutlass
+  GIT_REPOSITORY    https://github.com/NVIDIA/cutlass.git
+  GIT_TAG           v1.0.1
+  PREFIX            ${CUTLASS_DIR}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+)
+
+# dependencies will be added in sequence, so if a new project `project_b` is added
+# after `project_a`, please add the dependency add_dependencies(project_b project_a)
+# This allows the cloning to happen sequentially, enhancing the printing at
+# compile time, helping significantly to troubleshoot build issues.
+add_dependencies(cutlass cub)

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -20,10 +20,9 @@ include(ExternalProject)
 # - cub - (header only) ------------------------------------------------------
 
 set(CUB_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub CACHE STRING "Path to cub repo")
-set(CUB_VERSION v1.8.0 CACHE STRING "cub branch version to use")
 ExternalProject_Add(cub
   GIT_REPOSITORY    https://github.com/NVlabs/cub.git
-  GIT_TAG           ${CUB_VERSION}
+  GIT_TAG           v1.8.0
   PREFIX            ${CUB_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
@@ -34,10 +33,9 @@ ExternalProject_Add(cub
 
 set(CUTLASS_DIR ${CMAKE_CURRENT_BINARY_DIR}/cutlass CACHE STRING
   "Path to the cutlass repo")
-set(CUTLASS_VERSION v1.0.1 CACHE STRING "cutlass branch version to use")
 ExternalProject_Add(cutlass
   GIT_REPOSITORY    https://github.com/NVIDIA/cutlass.git
-  GIT_TAG           ${CUTLASS_VERSION}
+  GIT_TAG           v1.0.1
   PREFIX            ${CUTLASS_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
@@ -48,10 +46,9 @@ ExternalProject_Add(cutlass
 
 set(FAISS_DIR ${CMAKE_CURRENT_BINARY_DIR}/faiss CACHE STRING
   "Path to FAISS source directory")
-set(FAISS_VERSION v1.6.1 CACHE STRING "faiss branch version to use")
 ExternalProject_Add(faiss
   GIT_REPOSITORY    https://github.com/facebookresearch/faiss.git
-  GIT_TAG           ${FAISS_VERSION}
+  GIT_TAG           v1.6.1
   CONFIGURE_COMMAND LIBS=-pthread
                     CPPFLAGS=-w
                     LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib
@@ -76,11 +73,9 @@ set_property(TARGET faisslib PROPERTY
 
 set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")
-set(TREELITE_TAG 6fd01e4f1890950bbcf9b124da24e886751bffe6 CACHE STRING
-  "Treelite commit tag to be used")
 ExternalProject_Add(treelite
     GIT_REPOSITORY    https://github.com/dmlc/treelite.git
-    GIT_TAG           ${TREELITE_TAG}
+    GIT_TAG           6fd01e4f1890950bbcf9b124da24e886751bffe6
     PREFIX            ${TREELITE_DIR}
     CMAKE_ARGS        -DBUILD_SHARED_LIBS=OFF
                       -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -106,15 +101,13 @@ add_dependencies(treelite_runtimelib treelite)
 
 set(GTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest CACHE STRING
   "Path to googletest repo")
-set(GTEST_TAG 6ce9b98f541b8bcd84c5c5b3483f29a933c4aefb CACHE STRING
-  "Googletest commit tag to be used")
 set(GTEST_BINARY_DIR ${PROJECT_BINARY_DIR}/googletest)
 set(GTEST_INSTALL_DIR ${GTEST_BINARY_DIR}/install)
 set(GTEST_LIB ${GTEST_INSTALL_DIR}/lib/libgtest_main.a)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           ${GTEST_TAG}
+  GIT_TAG           6ce9b98f541b8bcd84c5c5b3483f29a933c4aefb
   PREFIX            ${GTEST_DIR}
   CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                     -DBUILD_SHARED_LIBS=OFF
@@ -131,15 +124,13 @@ add_dependencies(gtest_mainlib googletest)
 
 set(GBENCH_DIR ${CMAKE_CURRENT_BINARY_DIR}/benchmark CACHE STRING
   "Path to google benchmark repo")
-set(GBENCH_TAG bf4f2ea0bd1180b34718ac26eb79b170a4f6290e CACHE STRING
-  "Google benchmark commit tag to be used")
 set(GBENCH_BINARY_DIR ${PROJECT_BINARY_DIR}/benchmark)
 set(GBENCH_INSTALL_DIR ${GBENCH_BINARY_DIR}/install)
 set(GBENCH_LIB ${GBENCH_INSTALL_DIR}/lib/libbenchmark.a)
 include(ExternalProject)
 ExternalProject_Add(benchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           ${GBENCH_TAG}
+  GIT_TAG           bf4f2ea0bd1180b34718ac26eb79b170a4f6290e
   PREFIX            ${GBENCH_DIR}
   CMAKE_ARGS        -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
                     -DBENCHMARK_ENABLE_TESTING=OFF

--- a/cpp/examples/dbscan/CMakeLists.txt
+++ b/cpp/examples/dbscan/CMakeLists.txt
@@ -1,5 +1,5 @@
-#
-# Copyright (c) 2019, NVIDIA CORPORATION.
+#=============================================================================
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+#=============================================================================
 
 include_directories(${CUDA_INCLUDE_DIRS})
 

--- a/cpp/examples/dbscan/CMakeLists.txt
+++ b/cpp/examples/dbscan/CMakeLists.txt
@@ -14,7 +14,6 @@
 # limitations under the License.
 #=============================================================================
 
-include_directories(${CUDA_INCLUDE_DIRS})
-
 add_executable(dbscan_example dbscan_example.cpp)
+target_include_directories(dbscan_example PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 target_link_libraries(dbscan_example cuml++)

--- a/cpp/examples/kmeans/CMakeLists.txt
+++ b/cpp/examples/kmeans/CMakeLists.txt
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-include_directories(${CUDA_INCLUDE_DIRS})
 add_executable(kmeans_example kmeans_example.cpp)
+target_include_directories(kmeans_example PRIVATE ${CUML_INCLUDE_DIRECTORIES})
 target_link_libraries(kmeans_example cuml++)

--- a/cpp/examples/kmeans/CMakeLists.txt
+++ b/cpp/examples/kmeans/CMakeLists.txt
@@ -1,5 +1,5 @@
-#
-# Copyright (c) 2019, NVIDIA CORPORATION.
+#=============================================================================
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+#=============================================================================
 
 add_executable(kmeans_example kmeans_example.cpp)
 target_include_directories(kmeans_example PRIVATE ${CUML_INCLUDE_DIRECTORIES})

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CUML_TEST_INCLUDE_DIRS
 
 set(CUML_TEST_LINK_LIBRARIES
   treelite_runtimelib
+  ${CUML_LINK_LIBRARIES}
   ${CUML_CPP_TARGET}
   gtestlib
   gtest_mainlib)
@@ -188,5 +189,6 @@ if(BUILD_PRIMS_TESTS)
   target_link_libraries(prims
     gtestlib
     gtest_mainlib
-    ${CUML_LINK_LIBRARIES})
+    ${CUML_LINK_LIBRARIES}
+    faisslib)
 endif(BUILD_PRIMS_TESTS)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -57,223 +57,199 @@ include_directories(
   ${TREELITE_DIR}/runtime/native/include
 )
 
-###################################################################################################
-# - build ml_test executable ----------------------------------------------------------------
+##############################################################################
+# - build ml_test executable -------------------------------------------------
 
 if(BUILD_CUML_TESTS)
-
-    set(ML_TEST_LINK_LIBRARIES
-        ${CUDA_cublas_LIBRARY}
-        ${CUDA_curand_LIBRARY}
-        ${CUDA_cusolver_LIBRARY}
-        ${CUDA_cusparse_LIBRARY}
-        ${CUDA_CUDART_LIBRARY}
-        ${CUDA_cusparse_LIBRARY}
-        ${CUDA_nvgraph_LIBRARY}
-        faisslib
-        treelite_runtimelib
-        ${CUML_CPP_TARGET}
-        ${CUML_C_TARGET}
-        pthread
-        ${ZLIB_LIBRARIES}
-    )
-
-    # (please keep the filenames in alphabetical order)
-    add_executable(ml
-      sg/cd_test.cu
-      sg/dbscan_test.cu
-      sg/fil_test.cu
-      sg/handle_test.cu
-      sg/holtwinters_test.cu
-      sg/kmeans_test.cu
-      sg/knn_test.cu
-      sg/lkf_test.cu
-      sg/ols.cu
-      sg/pca_test.cu
-      sg/quasi_newton.cu
-      sg/rf_accuracy_test.cu
-      sg/rf_test.cu
-      sg/rf_treelite_test.cu
-      sg/ridge.cu
-      sg/rproj_test.cu
-      sg/sgd.cu
-      sg/spectral_test.cu
-      sg/svc_test.cu
-      sg/trustworthiness_test.cu
-      sg/tsne_test.cu
-      sg/tsvd_test.cu
-      sg/umap_test.cu
-      )
-
-    add_dependencies(ml cub)
-    add_dependencies(ml cutlass)
-
-    target_link_libraries(ml
-      gtestlib
-      gtest_mainlib
-      ${ML_TEST_LINK_LIBRARIES})
-
+  set(ML_TEST_LINK_LIBRARIES
+    ${CUDA_cublas_LIBRARY}
+    ${CUDA_curand_LIBRARY}
+    ${CUDA_cusolver_LIBRARY}
+    ${CUDA_cusparse_LIBRARY}
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_cusparse_LIBRARY}
+    ${CUDA_nvgraph_LIBRARY}
+    faisslib
+    treelite_runtimelib
+    ${CUML_CPP_TARGET}
+    ${CUML_C_TARGET}
+    pthread
+    ${ZLIB_LIBRARIES})
+  # (please keep the filenames in alphabetical order)
+  add_executable(ml
+    sg/cd_test.cu
+    sg/dbscan_test.cu
+    sg/fil_test.cu
+    sg/handle_test.cu
+    sg/holtwinters_test.cu
+    sg/kmeans_test.cu
+    sg/knn_test.cu
+    sg/lkf_test.cu
+    sg/ols.cu
+    sg/pca_test.cu
+    sg/quasi_newton.cu
+    sg/rf_accuracy_test.cu
+    sg/rf_test.cu
+    sg/rf_treelite_test.cu
+    sg/ridge.cu
+    sg/rproj_test.cu
+    sg/sgd.cu
+    sg/spectral_test.cu
+    sg/svc_test.cu
+    sg/trustworthiness_test.cu
+    sg/tsne_test.cu
+    sg/tsvd_test.cu
+    sg/umap_test.cu)
+  add_dependencies(ml cutlass)
+  target_link_libraries(ml
+    gtestlib
+    gtest_mainlib
+    ${ML_TEST_LINK_LIBRARIES})
 endif(BUILD_CUML_TESTS)
 
-###################################################################################################
-# - build test_ml_mg executable ----------------------------------------------------------------
+##############################################################################
+# - build test_ml_mg executable ----------------------------------------------
 
 if(BUILD_CUML_MG_TESTS)
-
-    set(ML_MG_TEST_LINK_LIBRARIES
-        ${CUDA_cublas_LIBRARY}
-        ${CUDA_curand_LIBRARY}
-        ${CUDA_cusolver_LIBRARY}
-        ${CUDA_cusparse_LIBRARY}
-        ${CUDA_CUDART_LIBRARY}
-        ${CUDA_cusparse_LIBRARY}
-        ${CUDA_nvgraph_LIBRARY}
-        faisslib
-        ${CUML_CPP_TARGET}
-        pthread
-        ${ZLIB_LIBRARIES}
-    )
-
-    # (please keep the filenames in alphabetical order)
-    add_executable(ml_mg
-      mg/test_ml_mg_utils.cu
-      )
-
-    add_dependencies(ml_mg cub)
-    add_dependencies(ml_mg cutlass)
-
-    target_link_libraries(ml_mg
-      gtestlib
-      gtest_mainlib
-      ${ML_MG_TEST_LINK_LIBRARIES})
-
+  set(ML_MG_TEST_LINK_LIBRARIES
+    ${CUDA_cublas_LIBRARY}
+    ${CUDA_curand_LIBRARY}
+    ${CUDA_cusolver_LIBRARY}
+    ${CUDA_cusparse_LIBRARY}
+    ${CUDA_CUDART_LIBRARY}
+    ${CUDA_cusparse_LIBRARY}
+    ${CUDA_nvgraph_LIBRARY}
+    faisslib
+    ${CUML_CPP_TARGET}
+    pthread
+    ${ZLIB_LIBRARIES})
+  # (please keep the filenames in alphabetical order)
+  add_executable(ml_mg
+    mg/test_ml_mg_utils.cu)
+  add_dependencies(ml_mg cutlass)
+  target_link_libraries(ml_mg
+    gtestlib
+    gtest_mainlib
+    ${ML_MG_TEST_LINK_LIBRARIES})
 endif(BUILD_CUML_MG_TESTS)
 
-###################################################################################################
-# - build prims_test executable ----------------------------------------------------------------
+##############################################################################
+# - build prims_test executable ----------------------------------------------
 
 if(BUILD_PRIMS_TESTS)
-
-    set(PRIMS_LINK_LIBRARIES
-        ${CUDA_cublas_LIBRARY}
-        ${CUDA_curand_LIBRARY}
-        ${CUDA_cusolver_LIBRARY}
-        ${CUDA_cusparse_LIBRARY}
-        pthread
-        faisslib
-        ${ZLIB_LIBRARIES}
-        OpenMP::OpenMP_CXX
-        Threads::Threads
-    )
-
-    # (please keep the filenames in alphabetical order)
-    add_executable(prims
-      prims/add.cu
-      prims/add_sub_dev_scalar.cu
-      prims/adjustedRandIndex.cu
-      prims/batched/csr.cu
-      prims/batched/gemv.cu
-      prims/batched/information_criterion.cu
-      prims/batched/make_symm.cu
-      prims/batched/matrix.cu
-      prims/binary_op.cu
-      prims/ternary_op.cu
-      prims/cache.cu
-      prims/coalesced_reduction.cu
-      prims/cuda_utils.cu
-      prims/columnSort.cu
-      prims/completenessScore.cu
-      prims/contingencyMatrix.cu
-      prims/coo.cu
-      prims/cov.cu
-      prims/csr.cu
-      prims/decoupled_lookback.cu
-      prims/device_utils.cu
-      prims/dispersion.cu
-      prims/dist_adj.cu
-      prims/dist_cos.cu
-      prims/dist_euc_exp.cu
-      prims/dist_euc_unexp.cu
-      prims/dist_l1.cu
-      prims/divide.cu
-      prims/eig.cu
-      prims/eig_sel.cu
-      prims/eltwise.cu
-      prims/eltwise2d.cu
-      prims/entropy.cu
-      prims/epsilon_neighborhood.cu
-      prims/fast_int_div.cu
-      prims/fused_l2_nn.cu
-      prims/gather.cu
-      prims/gemm.cu
-      prims/gemm_layout.cu
-      prims/gram.cu
-      prims/grid_sync.cu
-      prims/hinge.cu
-      prims/histogram.cu
-      prims/homogeneityScore.cu
-      prims/host_buffer.cu
-      prims/jones_transform.cu
-      prims/klDivergence.cu
-      prims/knn_classify.cu
-      prims/knn_regression.cu
-      prims/knn.cu
-      prims/kselection.cu
-      prims/label.cu
-      prims/linearReg.cu
-      prims/log.cu
-      prims/logisticReg.cu
-      prims/make_blobs.cu
-      prims/make_regression.cu
-      prims/map_then_reduce.cu
-      prims/math.cu
-      prims/matrix.cu
-      prims/matrix_vector_op.cu
-      prims/mean.cu
-      prims/mean_center.cu
-      prims/minmax.cu
-      prims/mvg.cu
-      prims/multiply.cu
-      prims/mutualInfoScore.cu
-      prims/norm.cu
-      prims/penalty.cu
-      prims/permute.cu
-      prims/power.cu
-      prims/randIndex.cu
-      prims/reduce.cu
-      prims/reduce_cols_by_key.cu
-      prims/reduce_rows_by_key.cu
-      prims/reverse.cu
-      prims/rng.cu
-      prims/rng_int.cu
-      prims/rsvd.cu
-      prims/sample_without_replacement.cu
-      prims/scatter.cu
-      prims/score.cu
-      prims/seive.cu
-      prims/sigmoid.cu
-      prims/silhouetteScore.cu
-      prims/sqrt.cu
-      prims/stationarity.cu
-      prims/stddev.cu
-      prims/strided_reduction.cu
-      prims/subtract.cu
-      prims/sum.cu
-      prims/svd.cu
-      prims/ternary_op.cu
-      prims/transpose.cu
-      prims/trustworthiness.cu
-      prims/unary_op.cu
-      prims/vMeasure.cu
-      prims/weighted_mean.cu
-      )
-
-    add_dependencies(prims cub)
-    add_dependencies(prims cutlass)
-
-    target_link_libraries(prims
-      gtestlib
-      gtest_mainlib
-      ${PRIMS_LINK_LIBRARIES})
-
+  set(PRIMS_LINK_LIBRARIES
+    ${CUDA_cublas_LIBRARY}
+    ${CUDA_curand_LIBRARY}
+    ${CUDA_cusolver_LIBRARY}
+    ${CUDA_cusparse_LIBRARY}
+    pthread
+    faisslib
+    ${ZLIB_LIBRARIES}
+    OpenMP::OpenMP_CXX
+    Threads::Threads)
+  # (please keep the filenames in alphabetical order)
+  add_executable(prims
+    prims/add.cu
+    prims/add_sub_dev_scalar.cu
+    prims/adjustedRandIndex.cu
+    prims/batched/csr.cu
+    prims/batched/gemv.cu
+    prims/batched/information_criterion.cu
+    prims/batched/make_symm.cu
+    prims/batched/matrix.cu
+    prims/binary_op.cu
+    prims/ternary_op.cu
+    prims/cache.cu
+    prims/coalesced_reduction.cu
+    prims/cuda_utils.cu
+    prims/columnSort.cu
+    prims/completenessScore.cu
+    prims/contingencyMatrix.cu
+    prims/coo.cu
+    prims/cov.cu
+    prims/csr.cu
+    prims/decoupled_lookback.cu
+    prims/device_utils.cu
+    prims/dispersion.cu
+    prims/dist_adj.cu
+    prims/dist_cos.cu
+    prims/dist_euc_exp.cu
+    prims/dist_euc_unexp.cu
+    prims/dist_l1.cu
+    prims/divide.cu
+    prims/eig.cu
+    prims/eig_sel.cu
+    prims/eltwise.cu
+    prims/eltwise2d.cu
+    prims/entropy.cu
+    prims/epsilon_neighborhood.cu
+    prims/fast_int_div.cu
+    prims/fused_l2_nn.cu
+    prims/gather.cu
+    prims/gemm.cu
+    prims/gemm_layout.cu
+    prims/gram.cu
+    prims/grid_sync.cu
+    prims/hinge.cu
+    prims/histogram.cu
+    prims/homogeneityScore.cu
+    prims/host_buffer.cu
+    prims/jones_transform.cu
+    prims/klDivergence.cu
+    prims/knn_classify.cu
+    prims/knn_regression.cu
+    prims/knn.cu
+    prims/kselection.cu
+    prims/label.cu
+    prims/linearReg.cu
+    prims/log.cu
+    prims/logisticReg.cu
+    prims/make_blobs.cu
+    prims/make_regression.cu
+    prims/map_then_reduce.cu
+    prims/math.cu
+    prims/matrix.cu
+    prims/matrix_vector_op.cu
+    prims/mean.cu
+    prims/mean_center.cu
+    prims/minmax.cu
+    prims/mvg.cu
+    prims/multiply.cu
+    prims/mutualInfoScore.cu
+    prims/norm.cu
+    prims/penalty.cu
+    prims/permute.cu
+    prims/power.cu
+    prims/randIndex.cu
+    prims/reduce.cu
+    prims/reduce_cols_by_key.cu
+    prims/reduce_rows_by_key.cu
+    prims/reverse.cu
+    prims/rng.cu
+    prims/rng_int.cu
+    prims/rsvd.cu
+    prims/sample_without_replacement.cu
+    prims/scatter.cu
+    prims/score.cu
+    prims/seive.cu
+    prims/sigmoid.cu
+    prims/silhouetteScore.cu
+    prims/sqrt.cu
+    prims/stationarity.cu
+    prims/stddev.cu
+    prims/strided_reduction.cu
+    prims/subtract.cu
+    prims/sum.cu
+    prims/svd.cu
+    prims/ternary_op.cu
+    prims/transpose.cu
+    prims/trustworthiness.cu
+    prims/unary_op.cu
+    prims/vMeasure.cu
+    prims/weighted_mean.cu)
+  add_dependencies(prims cutlass)
+  target_link_libraries(prims
+    gtestlib
+    gtest_mainlib
+    ${PRIMS_LINK_LIBRARIES})
 endif(BUILD_PRIMS_TESTS)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -17,8 +17,6 @@
 # Policy CMP0079 set as NEW as of 3.13 allows googletest be built outside this folder
 cmake_policy(SET CMP0079 NEW)
 
-project(cuml_test LANGUAGES CXX CUDA)
-
 set(CUML_TEST_INCLUDE_DIRS
   ${GTEST_DIR}/include
   ${TREELITE_DIR}/runtime/native/include)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -14,38 +14,10 @@
 # limitations under the License.
 #=============================================================================
 
+# Policy CMP0079 set as NEW as of 3.13 allows googletest be built outside this folder
 cmake_policy(SET CMP0079 NEW)
 
 project(cuml_test LANGUAGES CXX CUDA)
-
-# Policy CMP0079 set as NEW as of 3.13 allows googletest be built outside this folder
-
-set(GTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest)
-set(GTEST_BINARY_DIR ${PROJECT_BINARY_DIR}/googletest)
-set(GTEST_INSTALL_DIR ${GTEST_BINARY_DIR}/install)
-set(GTEST_LIB ${GTEST_INSTALL_DIR}/lib/libgtest_main.a)
-
-include(ExternalProject)
-ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           6ce9b98f541b8bcd84c5c5b3483f29a933c4aefb
-  PREFIX            ${GTEST_DIR}
-  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                    -DBUILD_SHARED_LIBS=OFF
-                    -DCMAKE_INSTALL_LIBDIR=lib
-  UPDATE_COMMAND    ""
-)
-
-add_dependencies(googletest ${CUML_CPP_TARGET})
-
-add_library(gtestlib STATIC IMPORTED)
-add_library(gtest_mainlib STATIC IMPORTED)
-
-add_dependencies(gtestlib googletest)
-add_dependencies(gtest_mainlib googletest)
-
-set_property(TARGET gtestlib PROPERTY IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest.a)
-set_property(TARGET gtest_mainlib PROPERTY IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest_main.a)
 
 include_directories(
   ${GTEST_DIR}/include

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -29,7 +29,6 @@ if(BUILD_CUML_TESTS)
     ${CUDA_cublas_LIBRARY}
     ${CUDA_curand_LIBRARY}
     ${CUDA_cusolver_LIBRARY}
-    ${CUDA_cusparse_LIBRARY}
     ${CUDA_CUDART_LIBRARY}
     ${CUDA_cusparse_LIBRARY}
     ${CUDA_nvgraph_LIBRARY}

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -47,7 +47,6 @@ add_dependencies(gtest_mainlib googletest)
 set_property(TARGET gtestlib PROPERTY IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest.a)
 set_property(TARGET gtest_mainlib PROPERTY IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest_main.a)
 
-set(CUML_SG_BENCH_TARGET "sg_benchmark")
 set(ML_BENCH_LINK_LIBRARIES
   gtestlib
   ${CUML_CPP_TARGET}

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -19,10 +19,9 @@ cmake_policy(SET CMP0079 NEW)
 
 project(cuml_test LANGUAGES CXX CUDA)
 
-include_directories(
+set(CUML_TEST_INCLUDE_DIRS
   ${GTEST_DIR}/include
-  ${TREELITE_DIR}/runtime/native/include
-)
+  ${TREELITE_DIR}/runtime/native/include)
 
 ##############################################################################
 # - build ml_test executable -------------------------------------------------
@@ -40,8 +39,8 @@ if(BUILD_CUML_TESTS)
     treelite_runtimelib
     ${CUML_CPP_TARGET}
     ${CUML_C_TARGET}
-    pthread
-    ${ZLIB_LIBRARIES})
+    pthread)
+
   # (please keep the filenames in alphabetical order)
   add_executable(ml
     sg/cd_test.cu
@@ -67,7 +66,9 @@ if(BUILD_CUML_TESTS)
     sg/tsne_test.cu
     sg/tsvd_test.cu
     sg/umap_test.cu)
-  add_dependencies(ml cutlass)
+
+  target_include_directories(ml PRIVATE ${CUML_TEST_INCLUDE_DIRS})
+
   target_link_libraries(ml
     gtestlib
     gtest_mainlib
@@ -88,12 +89,14 @@ if(BUILD_CUML_MG_TESTS)
     ${CUDA_nvgraph_LIBRARY}
     faisslib
     ${CUML_CPP_TARGET}
-    pthread
-    ${ZLIB_LIBRARIES})
+    pthread)
+
   # (please keep the filenames in alphabetical order)
   add_executable(ml_mg
     mg/test_ml_mg_utils.cu)
-  add_dependencies(ml_mg cutlass)
+
+  target_include_directories(ml_mg PRIVATE ${CUML_TEST_INCLUDE_DIRS})
+
   target_link_libraries(ml_mg
     gtestlib
     gtest_mainlib
@@ -111,9 +114,9 @@ if(BUILD_PRIMS_TESTS)
     ${CUDA_cusparse_LIBRARY}
     pthread
     faisslib
-    ${ZLIB_LIBRARIES}
     OpenMP::OpenMP_CXX
     Threads::Threads)
+
   # (please keep the filenames in alphabetical order)
   add_executable(prims
     prims/add.cu
@@ -214,7 +217,11 @@ if(BUILD_PRIMS_TESTS)
     prims/unary_op.cu
     prims/vMeasure.cu
     prims/weighted_mean.cu)
+
+  target_include_directories(prims PRIVATE ${CUML_TEST_INCLUDE_DIRS})
+
   add_dependencies(prims cutlass)
+
   target_link_libraries(prims
     gtestlib
     gtest_mainlib

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -18,24 +18,22 @@
 cmake_policy(SET CMP0079 NEW)
 
 set(CUML_TEST_INCLUDE_DIRS
+  ${CUML_INCLUDE_DIRECTORIES}
   ${GTEST_DIR}/include
   ${TREELITE_DIR}/runtime/native/include)
+
+set(CUML_TEST_LINK_LIBRARIES
+  ${CUML_LINK_LIBRARIES}
+  treelite_runtimelib
+  ${CUML_CPP_TARGET}
+  pthread
+  gtestlib
+  gtest_mainlib)
 
 ##############################################################################
 # - build ml_test executable -------------------------------------------------
 
 if(BUILD_CUML_TESTS)
-  set(ML_TEST_LINK_LIBRARIES
-    ${CUDA_cublas_LIBRARY}
-    ${CUDA_curand_LIBRARY}
-    ${CUDA_cusolver_LIBRARY}
-    ${CUDA_CUDART_LIBRARY}
-    ${CUDA_cusparse_LIBRARY}
-    ${CUDA_nvgraph_LIBRARY}
-    faisslib
-    treelite_runtimelib
-    ${CUML_CPP_TARGET}
-    pthread)
 
   # (please keep the filenames in alphabetical order)
   add_executable(ml
@@ -65,54 +63,26 @@ if(BUILD_CUML_TESTS)
 
   target_include_directories(ml PRIVATE ${CUML_TEST_INCLUDE_DIRS})
 
-  target_link_libraries(ml
-    gtestlib
-    gtest_mainlib
-    ${ML_TEST_LINK_LIBRARIES})
+  target_link_libraries(ml ${CUML_TEST_LINK_LIBRARIES})
 endif(BUILD_CUML_TESTS)
 
 ##############################################################################
 # - build test_ml_mg executable ----------------------------------------------
 
 if(BUILD_CUML_MG_TESTS)
-  set(ML_MG_TEST_LINK_LIBRARIES
-    ${CUDA_cublas_LIBRARY}
-    ${CUDA_curand_LIBRARY}
-    ${CUDA_cusolver_LIBRARY}
-    ${CUDA_cusparse_LIBRARY}
-    ${CUDA_CUDART_LIBRARY}
-    ${CUDA_cusparse_LIBRARY}
-    ${CUDA_nvgraph_LIBRARY}
-    faisslib
-    ${CUML_CPP_TARGET}
-    pthread)
-
   # (please keep the filenames in alphabetical order)
   add_executable(ml_mg
     mg/test_ml_mg_utils.cu)
 
   target_include_directories(ml_mg PRIVATE ${CUML_TEST_INCLUDE_DIRS})
 
-  target_link_libraries(ml_mg
-    gtestlib
-    gtest_mainlib
-    ${ML_MG_TEST_LINK_LIBRARIES})
+  target_link_libraries(ml_mg ${CUML_TEST_LINK_LIBRARIES})
 endif(BUILD_CUML_MG_TESTS)
 
 ##############################################################################
 # - build prims_test executable ----------------------------------------------
 
 if(BUILD_PRIMS_TESTS)
-  set(PRIMS_LINK_LIBRARIES
-    ${CUDA_cublas_LIBRARY}
-    ${CUDA_curand_LIBRARY}
-    ${CUDA_cusolver_LIBRARY}
-    ${CUDA_cusparse_LIBRARY}
-    pthread
-    faisslib
-    OpenMP::OpenMP_CXX
-    Threads::Threads)
-
   # (please keep the filenames in alphabetical order)
   add_executable(prims
     prims/add.cu
@@ -218,8 +188,5 @@ if(BUILD_PRIMS_TESTS)
 
   add_dependencies(prims cutlass)
 
-  target_link_libraries(prims
-    gtestlib
-    gtest_mainlib
-    ${PRIMS_LINK_LIBRARIES})
+  target_link_libraries(prims ${CUML_TEST_LINK_LIBRARIES})
 endif(BUILD_PRIMS_TESTS)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+#=============================================================================
 # Copyright (c) 2018-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+#=============================================================================
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0079 NEW)
 
 project(cuml_test LANGUAGES CXX CUDA)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -47,11 +47,6 @@ add_dependencies(gtest_mainlib googletest)
 set_property(TARGET gtestlib PROPERTY IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest.a)
 set_property(TARGET gtest_mainlib PROPERTY IMPORTED_LOCATION ${GTEST_DIR}/lib/libgtest_main.a)
 
-set(ML_BENCH_LINK_LIBRARIES
-  gtestlib
-  ${CUML_CPP_TARGET}
-)
-
 include_directories(
   ${GTEST_DIR}/include
   ${TREELITE_DIR}/runtime/native/include

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -23,10 +23,8 @@ set(CUML_TEST_INCLUDE_DIRS
   ${TREELITE_DIR}/runtime/native/include)
 
 set(CUML_TEST_LINK_LIBRARIES
-  ${CUML_LINK_LIBRARIES}
   treelite_runtimelib
   ${CUML_CPP_TARGET}
-  pthread
   gtestlib
   gtest_mainlib)
 
@@ -187,5 +185,8 @@ if(BUILD_PRIMS_TESTS)
 
   add_dependencies(prims cutlass)
 
-  target_link_libraries(prims ${CUML_TEST_LINK_LIBRARIES})
+  target_link_libraries(prims
+    gtestlib
+    gtest_mainlib
+    ${CUML_LINK_LIBRARIES})
 endif(BUILD_PRIMS_TESTS)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -36,7 +36,6 @@ if(BUILD_CUML_TESTS)
     faisslib
     treelite_runtimelib
     ${CUML_CPP_TARGET}
-    ${CUML_C_TARGET}
     pthread)
 
   # (please keep the filenames in alphabetical order)

--- a/python/setuputils.py
+++ b/python/setuputils.py
@@ -72,8 +72,9 @@ def get_repo_cmake_info(names, file_path):
             the names of the cmake git clone instruction
             `ExternalProject_Add(name`
         file_path : String
-            Relative path of the location of the CMakeLists.txt to extract the
-            information.
+            Relative path of the location of the CMakeLists.txt (or the cmake
+            module which contains ExternalProject_Add definitions) to extract
+            the information.
 
     Returns
         -------
@@ -103,7 +104,7 @@ def get_repo_cmake_info(names, file_path):
 
 
 def get_submodule_dependencies(repos,
-                               file_path='../cpp/CMakeLists.txt',
+                               file_path='../cpp/cmake/Dependencies.cmake',
                                libcuml_path='../cpp/build/'):
 
     """
@@ -118,8 +119,9 @@ def get_submodule_dependencies(repos,
             the names of the cmake git clone instruction
             `ExternalProject_Add(name`
         file_path : String
-            Relative path of the location of the CMakeLists.txt to extract the
-            information. By deafault it will look in the standard location
+            Relative path of the location of the CMakeLists.txt (or the cmake
+            module which contains ExternalProject_Add definitions) to extract
+            the information. By default it will look in the standard location
             `cuml_repo_root/cpp`
         libcuml_path : String
             Relative location of the build folder to look if repositories


### PR DESCRIPTION
Aims to fix issues mentioned in issue #1134 .

1. Removes all `include_directories` usage and replaces them with `target_include_directories`
2. Similarly for `target_link_libraries`
3. Use `CMAKE_CURRENT_SOURCE_DIR` to refer to cuml cpp folder, especially useful for cases when users want to use cuml as a submodule
4. Various code reformatting to reduce multiple duplicate sections in all of CMakeLists.txt
5. A separate `cmake/Dependencies.cmake` to list all external-projects that are downloaded and built during compilation.

@dantegd and @JohnZed this PR is now ready for review.