### PR TITLE
[REVIEW] python setup.py updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@
 
 ## Improvements
 - PR #1927: Use Cython's `new_build_ext` (if available)
-
 - PR #1946: Removed zlib dependency from cmake
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array
-
 - PR #1941: Remove c++ cuda flag that was getting duplicated in CMake
+- PR #1971: python: Correctly honor --singlegpu option and CUML_BUILD_PATH env variable
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/setup.py
+++ b/python/setup.py
@@ -99,8 +99,6 @@ else:
 
 libs = ['cuda',
         'cuml++',
-        'cumlcomms',
-        'nccl',
         'rmm']
 
 include_dirs = ['../cpp/src',
@@ -137,6 +135,8 @@ else:
     libs.append('cumlprims')
     # ucx/ucx-py related functionality available in version 0.12+
     # libs.append("ucp")
+    libs.append('cumlcomms')
+    libs.append('nccl')
 
     sys_include = os.path.dirname(sysconfig.get_path("include"))
     include_dirs.append("%s/cumlprims" % sys_include)

--- a/python/setup.py
+++ b/python/setup.py
@@ -149,7 +149,7 @@ extensions = [
     Extension("*",
               sources=["cuml/**/**/*.pyx"],
               include_dirs=include_dirs,
-              library_dirs=[get_python_lib()],
+              library_dirs=[get_python_lib(), libcuml_path],
               runtime_library_dirs=[cuda_lib_dir,
                                     os.path.join(os.sys.prefix, "lib")],
               libraries=libs,


### PR DESCRIPTION
This PR has the following changes:
1. When `--singlegpu` option is passed, do not try to link against cumlcomms and nccl libraries.
2. When a custom `CUML_BUILD_PATH` is passed, it is safer to link against libcuml++ from this directory.