### PR TITLE
[REVIEW] enable nightly memcheck for ml-prims unit-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #2047: Make internal streams non-blocking w.r.t. NULL stream
 - PR #2058: Use CumlArray in Random Projection
 - PR #2080: Improved import of sparse FIL forests from treelite
+- PR #2089: CI: enabled cuda-memcheck on ml-prims unit-tests during nightly build
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -137,3 +137,8 @@ pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v -s -m "not memlea
 logger "Run ml-prims test..."
 cd $WORKSPACE/cpp/build
 GTEST_OUTPUT="xml:${WORKSPACE}/test-results/prims/" ./test/prims
+
+if [ "$BUILD_MODE" = "branch" && "$BUILD_TYPE" = "gpu" ]; then
+    cd $WORKSPACE/cpp/build
+    python ../scripts/cuda-memcheck.py -tool memcheck -exe ./test/prims
+fi

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -138,6 +138,10 @@ logger "Run ml-prims test..."
 cd $WORKSPACE/cpp/build
 GTEST_OUTPUT="xml:${WORKSPACE}/test-results/prims/" ./test/prims
 
+################################################################################
+# TEST - Run GoogleTest for ml-prims, but with cuda-memcheck enabled
+################################################################################
+
 if [ "$BUILD_MODE" = "branch" && "$BUILD_TYPE" = "gpu" ]; then
     cd $WORKSPACE/cpp/build
     python ../scripts/cuda-memcheck.py -tool memcheck -exe ./test/prims


### PR DESCRIPTION
With all related issues in #2020 fixed, now is the right time to add a nightly command to run ml-prims unit-tests with cuda-memcheck.

As per discussions in the issue #433 I have added such a nightly command inside `ci/gpu/build.sh`. @raydouglass can you review and tell if this is the right way to add a command to be run during nightly build?