### PR TITLE
[REVIEW] Combine futures call as a tuple in dask RF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #2078: Ignore negative cache indices in get_vecs
 - PR #2084: Fixed cuda-memcheck errors with COO unit-tests
 - PR #2087: Fixed cuda-memcheck errors with dispersion prim
+- PR #2119: Combine futures call as a tuple in dask RF
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -20,7 +20,7 @@ from cuml.dask.common import raise_exception_from_futures, workers_to_parts
 from cuml.ensemble import RandomForestClassifier as cuRFC
 from dask.distributed import default_client, wait
 from cuml.dask.common.part_utils import _extract_partitions
-
+from cuml.dask.datasets.blobs import get_X, get_labels
 
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.input_utils import DistributedDataHandler
@@ -391,13 +391,30 @@ class RandomForestClassifier(DelayedPredictionMixin):
         """
 
         c = default_client()
-
         self.num_classes = len(y.unique())
-        X_futures = workers_to_parts(c.sync(_extract_partitions, X))
-        y_futures = workers_to_parts(c.sync(_extract_partitions, y))
 
-        X_partition_workers = [w for w, xc in X_futures.items()]
-        y_partition_workers = [w for w, xc in y_futures.items()]
+        tuple_futures = c.sync(_extract_partitions, (X, y))
+
+        X_futures = {}
+        y_futures = {}
+        X_partition_workers = []
+        y_partition_workers = []
+
+        for i in range(len(tuple_futures)):
+            w = tuple_futures[i][0]
+            xc = tuple_futures[i][1]
+
+            if w not in X_futures.keys():
+                X_futures[w] = []
+                y_futures[w] = []
+
+            X_partition_workers.append(w)
+            y_partition_workers.append(w)
+
+            X_future = c.submit(get_X, xc, workers=[w])
+            y_future = c.submit(get_labels, xc, workers=[w])
+            X_futures[w].append(X_future)
+            y_futures[w].append(y_future)
 
         if set(X_partition_workers) != set(self.workers) or \
            set(y_partition_workers) != set(self.workers):
@@ -420,6 +437,7 @@ class RandomForestClassifier(DelayedPredictionMixin):
                     y_futures[w],
                     convert_dtype,
                     random.random(),
+                    pure=False,
                     workers=[w],
                 )
             )

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -16,7 +16,7 @@
 
 import cudf
 
-from cuml.dask.common import raise_exception_from_futures, workers_to_parts
+from cuml.dask.common import raise_exception_from_futures
 from cuml.ensemble import RandomForestClassifier as cuRFC
 from dask.distributed import default_client, wait
 from cuml.dask.common.part_utils import _extract_partitions

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -23,6 +23,7 @@ from dask.distributed import default_client, wait
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.input_utils import DistributedDataHandler
 from cuml.dask.common.part_utils import _extract_partitions
+from cuml.dask.datasets.blobs import get_X, get_labels
 
 import math
 import random

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -16,7 +16,7 @@
 
 import cudf
 
-from cuml.dask.common import raise_exception_from_futures, workers_to_parts
+from cuml.dask.common import raise_exception_from_futures
 from cuml.ensemble import RandomForestRegressor as cuRFR
 
 from dask.distributed import default_client, wait


### PR DESCRIPTION
Calling `cumlDaskRF.fit(X_train, y_train)` resulted in the following error.

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<timed exec> in <module>
/opt/conda/envs/rapids/lib/python3.6/site-packages/cuml/dask/ensemble/randomforestclassifier.py in fit(self, X, y, convert_dtype)
    409             """ % (str(X_partition_workers),
    410                    str(y_partition_workers),
--> 411                    str(self.workers)))
    412 
    413         futures = list()
ValueError: 
              X is not partitioned on the same workers expected by RF
              X workers: ['tcp://127.0.0.1:39963', 'tcp://127.0.0.1:44215']
              y workers: ['tcp://127.0.0.1:39963']
              RF workers: dict_keys(['tcp://127.0.0.1:39963', 'tcp://127.0.0.1:44215'])
```

And @divyegala suggested to combine the calls for the future objects to split both X and y to all workers to avoid the error.