### PR TITLE
[REVIEW] speeding up dask rf tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #2080: Improved import of sparse FIL forests from treelite
 - PR #2090: Upgrade C++ build to C++14 standard
 - PR #2089: CI: enabled cuda-memcheck on ml-prims unit-tests during nightly build
+- PR #2120: Speeding up dask RandomForest tests
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/python/cuml/test/dask/test_random_forest.py
+++ b/python/cuml/test/dask/test_random_forest.py
@@ -34,7 +34,6 @@ import cudf
 import cupy as cp
 import dask_cudf
 import pytest
-import rmm
 
 import numpy as np
 import pandas as pd

--- a/python/cuml/test/dask/test_random_forest.py
+++ b/python/cuml/test/dask/test_random_forest.py
@@ -67,7 +67,7 @@ def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     return X_train_df, y_train_df
 
 
-@pytest.mark.parametrize('partitions_per_worker', [1, 3])
+@pytest.mark.parametrize('partitions_per_worker', [3])
 def test_rf_classification_dask_cudf(partitions_per_worker, cluster):
 
     # Use CUDA_VISIBLE_DEVICES to control the number of workers
@@ -107,7 +107,7 @@ def test_rf_classification_dask_cudf(partitions_per_worker, cluster):
 
 @pytest.mark.xfail(reason="Intermittent failure of test observed. For"
                    "more information please check cuml issue #1934")
-@pytest.mark.parametrize('partitions_per_worker', [1, 5])
+@pytest.mark.parametrize('partitions_per_worker', [5])
 def test_rf_regression_dask_fil(partitions_per_worker, cluster):
 
     # Use CUDA_VISIBLE_DEVICES to control the number of workers
@@ -161,52 +161,7 @@ def test_rf_regression_dask_fil(partitions_per_worker, cluster):
         c.close()
 
 
-@pytest.mark.parametrize('partitions_per_worker', [1, 5])
-@pytest.mark.parametrize('output_class', [True, False])
-def test_rf_classification_dask_fil(partitions_per_worker, cluster,
-                                    output_class):
-
-    # Use CUDA_VISIBLE_DEVICES to control the number of workers
-    c = Client(cluster)
-
-    try:
-
-        X, y = make_classification(n_samples=10000, n_features=30,
-                                   n_clusters_per_class=1, n_informative=20,
-                                   random_state=123, n_classes=2)
-
-        X = X.astype(np.float32)
-        y = y.astype(np.int32)
-
-        X_train, X_test, y_train, y_test = \
-            train_test_split(X, y, test_size=1000)
-
-        cu_rf_params = {
-            'n_estimators': 25,
-            'max_depth': 13,
-            'n_bins': 15,
-        }
-
-        X_train_df, y_train_df = _prep_training_data(c, X_train, y_train,
-                                                     partitions_per_worker)
-        X_test_df, _ = _prep_training_data(c, X_test, y_test,
-                                           partitions_per_worker)
-        cu_rf_mg = cuRFC_mg(**cu_rf_params)
-        cu_rf_mg.fit(X_train_df, y_train_df)
-        cu_rf_mg_predict = cu_rf_mg.predict(X_test_df, output_class).compute()
-        cu_rf_mg_predict = cp.asnumpy(cp.array(cu_rf_mg_predict))
-        if not output_class:
-            cu_rf_mg_predict = np.round(cu_rf_mg_predict)
-
-        acc_score = accuracy_score(cu_rf_mg_predict, y_test, normalize=True)
-
-        assert acc_score > 0.8
-
-    finally:
-        c.close()
-
-
-@pytest.mark.parametrize('partitions_per_worker', [1, 5])
+@pytest.mark.parametrize('partitions_per_worker', [5])
 @pytest.mark.parametrize('output_class', [True, False])
 def test_rf_classification_dask_array(partitions_per_worker, cluster,
                                       output_class):
@@ -250,7 +205,7 @@ def test_rf_classification_dask_array(partitions_per_worker, cluster,
         c.close()
 
 
-@pytest.mark.parametrize('partitions_per_worker', [1, 5])
+@pytest.mark.parametrize('partitions_per_worker', [5])
 def test_rf_regression_dask_cpu(partitions_per_worker, cluster):
 
     # Use CUDA_VISIBLE_DEVICES to control the number of workers

--- a/python/cuml/test/dask/test_random_forest.py
+++ b/python/cuml/test/dask/test_random_forest.py
@@ -37,7 +37,6 @@ import pytest
 
 import numpy as np
 import pandas as pd
-import rmm
 
 from cuml.dask.ensemble import RandomForestClassifier as cuRFC_mg
 from cuml.dask.ensemble import RandomForestRegressor as cuRFR_mg


### PR DESCRIPTION
Closes #1989. On average, this speeds up those tests by 5x