### PR TITLE
Remove GPU arch < 60 from CMake build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - PR #2107: Fix PCA transform
 - PR #2109: input_to_cuml_array __cuda_array_interface__ bugfix
 - PR #2117: cuDF __array__ exception small fixes
+- PR #2144: Remove GPU arch < 60 from CMake build
 
 # cuML 0.13.0 (Date TBD)
 

--- a/cpp/cmake/EvalGpuArchs.cmake
+++ b/cpp/cmake/EvalGpuArchs.cmake
@@ -54,6 +54,15 @@ int main(int argc, char** argv) {
       ${eval_file}
     OUTPUT_VARIABLE __gpu_archs
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  message("Auto detection of gpu-archs: ${__gpu_archs}")
-  set(${gpu_archs} ${__gpu_archs} PARENT_SCOPE)
+  set(__gpu_archs_filtered "${__gpu_archs}")
+  foreach(arch ${__gpu_archs})
+    if (arch VERSION_LESS 60)
+      list(REMOVE_ITEM __gpu_archs_filtered ${arch})
+    endif()
+  endforeach()
+  if (NOT __gpu_archs_filtered)
+    message(FATAL_ERROR "No supported GPU arch found on this system")
+  endif()
+  message("Auto detection of gpu-archs: ${__gpu_archs_filtered}")
+  set(${gpu_archs} ${__gpu_archs_filtered} PARENT_SCOPE)
 endfunction(evaluate_gpu_archs)


### PR DESCRIPTION
Fixes #2143, by excluding detected GPU arches that's lower than 60. This is because CuML uses `atomicAdd(double*, double)`.