### PR TITLE
Fix handling of temp file in RF pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - PR #2153: Added missing namespaces to some Decision Tree files
 - PR #2155: C++: fix doxygen build break
 - PR #2165: Fit function test correction
+- PR #2166: Fix handling of temp file in RF pickling
 
 # cuML 0.13.0 (Date TBD)
 

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -282,8 +282,10 @@ void build_treelite_forest(ModelHandle* model,
     // create a temp file
     const char* filename = std::tmpnam(nullptr);
     // write the model bytes into the temp file
-    std::ofstream file(filename, std::ios::binary);
-    file.write((char*)&data[0], data.size());
+    {
+      std::ofstream file(filename, std::ios::binary);
+      file.write((char*)&data[0], data.size());
+    }
     // read the file as a protobuf model
     TREELITE_CHECK(TreeliteLoadProtobufModel(filename, model));
   }

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -599,13 +599,15 @@ def test_svc_pickle_nofit(tmpdir, datatype, nrows, ncols, n_info):
 
     pickle_save_load(tmpdir, create_mod, assert_model)
 
+
 def test_small_rf(tmpdir):
+
     result = {}
+
     def create_mod():
         n_samples = 100
         n_features = 20
         n_info = 10
-        data_type = np.float32
 
         X_train, y_train, X_test = make_classification_dataset(np.float32,
                                                                n_samples,


### PR DESCRIPTION
Closes #2141, by ensuring that the temporary file gets closed properly before passing it to Treelite. 

When the RF model is small (few bytes), not all bytes would be written to the disk immediately because the `write()` call is buffered. Closing the file will ensure that all bytes  are written.