### PR TITLE
[REVIEW] Add CPU-only and dataset sweep params to benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #2150: Remove deprecated RMM calls in RMM allocator adapter
 - PR #2146: Remove deprecated kalman filter
 - PR #2156: Add Docker 19 support to local gpuci build
+- PR #2175: Allow CPU-only and dataset params for benchmark sweeps
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/python/cuml/benchmark/run_benchmarks.py
+++ b/python/cuml/benchmark/run_benchmarks.py
@@ -43,13 +43,14 @@ def extract_param_overrides(params_to_sweep):
         key, val_string = p.split("=")
         vals = json.loads(val_string)
         if not isinstance(vals, list):
-            vals = [vals] # Handle single-element sweep cleanly
+            vals = [vals]  # Handle single-element sweep cleanly
         single_param_lists.append([(key, val) for val in vals])
 
     # Create dicts with the cartesian product of all arg-based lists
     tuple_list = itertools.product(*single_param_lists)
     dict_list = [dict(tl) for tl in tuple_list]
     return dict_list
+
 
 if __name__ == '__main__':
     import argparse

--- a/python/cuml/benchmark/run_benchmarks.py
+++ b/python/cuml/benchmark/run_benchmarks.py
@@ -42,13 +42,14 @@ def extract_param_overrides(params_to_sweep):
     for p in params_to_sweep:
         key, val_string = p.split("=")
         vals = json.loads(val_string)
+        if not isinstance(vals, list):
+            vals = [vals] # Handle single-element sweep cleanly
         single_param_lists.append([(key, val) for val in vals])
 
     # Create dicts with the cartesian product of all arg-based lists
     tuple_list = itertools.product(*single_param_lists)
     dict_list = [dict(tl) for tl in tuple_list]
     return dict_list
-
 
 if __name__ == '__main__':
     import argparse
@@ -64,9 +65,10 @@ if __name__ == '__main__':
           # Simple logistic regression
           python run_benchmarks.py --dataset classification LogisticRegression
 
-          # Compare impact of RF parameters and data sets
+          # Compare impact of RF parameters and data sets for multiclass
           python run_benchmarks.py --dataset classification  \
                 --max-rows 100000 --min-rows 10000 \
+                --dataset-param-sweep n_classes=[2,8] \
                 --cuml-param-sweep n_bins=[4,16] n_estimators=[10,100] \
                 --csv results.csv \
                 RandomForestClassifier
@@ -147,6 +149,20 @@ if __name__ == '__main__':
                 key=val_list, where val_list may be a comma-separated list''',
     )
     parser.add_argument(
+        '--cpu-param-sweep',
+        nargs='*',
+        type=str,
+        help='''Parameter values to vary for CPU only, in the form:
+                key=val_list, where val_list may be a comma-separated list''',
+    )
+    parser.add_argument(
+        '--dataset-param-sweep',
+        nargs='*',
+        type=str,
+        help='''Parameter values to vary for dataset generator, in the form
+                key=val_list, where val_list may be a comma-separated list'''
+    )
+    parser.add_argument(
         '--default-size',
         action='store_true',
         help='Only run datasets at default size',
@@ -212,6 +228,9 @@ if __name__ == '__main__':
 
     param_override_list = extract_param_overrides(args.param_sweep)
     cuml_param_override_list = extract_param_overrides(args.cuml_param_sweep)
+    cpu_param_override_list = extract_param_overrides(args.cpu_param_sweep)
+    dataset_param_override_list = extract_param_overrides(
+        args.dataset_param_sweep)
 
     if args.algorithms:
         algos_to_run = []
@@ -233,6 +252,8 @@ if __name__ == '__main__':
         test_fraction=args.test_split,
         param_override_list=param_override_list,
         cuml_param_override_list=cuml_param_override_list,
+        cpu_param_override_list=cpu_param_override_list,
+        dataset_param_override_list=dataset_param_override_list,
         run_cpu=(not args.skip_cpu),
         raise_on_error=args.raise_on_error,
         n_reps=args.n_reps

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -16,6 +16,7 @@
 """Wrappers to run ML benchmarks"""
 
 import time
+import itertools
 import numpy as np
 import pandas as pd
 
@@ -73,11 +74,13 @@ class SpeedupComparisonRunner:
         param_overrides={},
         cuml_param_overrides={},
         cpu_param_overrides={},
+        dataset_param_overrides={},
         run_cpu=True,
         verbose=False,
     ):
         data = datagen.gen_data(
-            self.dataset_name, self.input_type, n_samples, n_features
+            self.dataset_name, self.input_type, n_samples, n_features,
+            **dataset_param_overrides
         )
 
         setup_overrides = algo_pair.setup_cuml(
@@ -95,11 +98,15 @@ class SpeedupComparisonRunner:
         cu_elapsed = np.min(cuml_timer.timings)
 
         if run_cpu and algo_pair.cpu_class is not None:
-            setup_overrides = algo_pair.setup_cpu(data, **param_overrides)
+            setup_overrides = algo_pair.setup_cpu(data,
+                                                  **param_overrides,
+                                                  **cpu_param_overrides)
 
             cpu_timer = BenchmarkTimer(self.n_reps)
             for rep in cpu_timer.benchmark_runs():
-                algo_pair.run_cpu(data, **param_overrides, **setup_overrides)
+                algo_pair.run_cpu(data, **param_overrides,
+                                  **cpu_param_overrides,
+                                  **setup_overrides)
             cpu_elapsed = np.min(cpu_timer.timings)
         else:
             cpu_elapsed = 0.0
@@ -118,7 +125,9 @@ class SpeedupComparisonRunner:
             n_samples=n_samples,
             n_features=n_features,
             **param_overrides,
-            **cuml_param_overrides
+            **cuml_param_overrides,
+            **cpu_param_overrides,
+            **dataset_param_overrides
         )
 
     def run(
@@ -127,6 +136,7 @@ class SpeedupComparisonRunner:
         param_overrides={},
         cuml_param_overrides={},
         cpu_param_overrides={},
+        dataset_param_overrides={},
         *,
         run_cpu=True,
         raise_on_error=False,
@@ -142,10 +152,11 @@ class SpeedupComparisonRunner:
                             ns,
                             nf,
                             param_overrides,
-                            cuml_param_overrides,
-                            cpu_param_overrides,
-                            run_cpu,
-                            verbose,
+                            cuml_param_overrides=cuml_param_overrides,
+                            cpu_param_overrides=cpu_param_overrides,
+                            dataset_param_overrides=dataset_param_overrides,
+                            run_cpu=run_cpu,
+                            verbose=verbose,
                         )
                     )
                 except Exception as e:
@@ -186,6 +197,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
         param_overrides={},
         cuml_param_overrides={},
         cpu_param_overrides={},
+        dataset_param_overrides={},
         run_cpu=True,
         verbose=False,
     ):
@@ -195,6 +207,7 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             n_samples,
             n_features,
             test_fraction=self.test_fraction,
+            **dataset_param_overrides
         )
 
         setup_override = algo_pair.setup_cuml(
@@ -229,12 +242,16 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
 
         cpu_accuracy = 0.0
         if run_cpu and algo_pair.cpu_class is not None:
-            setup_override = algo_pair.setup_cpu(data, **param_overrides)
+            setup_override = algo_pair.setup_cpu(data,
+                                                 **param_overrides,
+                                                 **cpu_param_overrides)
 
             cpu_timer = BenchmarkTimer(self.n_reps)
             for rep in cpu_timer.benchmark_runs():
                 cpu_model = algo_pair.run_cpu(
-                    data, **param_overrides, **setup_override
+                    data, **param_overrides,
+                    **cpu_param_overrides,
+                    **setup_override
                 )
             cpu_elapsed = np.min(cpu_timer.timings)
 
@@ -262,7 +279,9 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             n_samples=n_samples,
             n_features=n_features,
             **param_overrides,
-            **cuml_param_overrides
+            **cuml_param_overrides,
+            **cpu_param_overrides,
+            **dataset_param_overrides
         )
 
 
@@ -273,6 +292,8 @@ def run_variations(
     bench_dims,
     param_override_list=[{}],
     cuml_param_override_list=[{}],
+    cpu_param_override_list=[{}],
+    dataset_param_override_list=[{}],
     input_type="numpy",
     test_fraction=0.1,
     run_cpu=True,
@@ -299,6 +320,10 @@ def run_variations(
       Each dict specifies parameters to override in one run of the algorithm.
     cuml_param_override_list : list of dict
       Dicts containing parameters to pass to __init__ of the cuml algo only.
+    cpu_param_override_list : list of dict
+      Dicts containing parameters to pass to __init__ of the cpu algo only.
+    dataset_param_override_list : dict
+      Dicts containing parameters to pass to dataset generator function
     test_fraction : float
       The fraction of data to use for testing.
     run_cpu : boolean
@@ -312,19 +337,24 @@ def run_variations(
     all_results = []
     for algo in algos:
         print("Running %s..." % (algo.name))
-        for param_overrides in param_override_list:
-            for cuml_param_overrides in cuml_param_override_list:
-                results = runner.run(
-                    algo,
-                    param_overrides,
-                    cuml_param_overrides,
-                    run_cpu=run_cpu,
-                    raise_on_error=raise_on_error,
+        for overrides, cuml_overrides, cpu_overrides, dataset_overrides in \
+            itertools.product(param_override_list,
+                              cuml_param_override_list,
+                              cpu_param_override_list,
+                              dataset_param_override_list):
+            results = runner.run(
+                algo,
+                overrides,
+                cuml_param_overrides=cuml_overrides,
+                cpu_param_overrides=cpu_overrides,
+                dataset_param_overrides=dataset_overrides,
+                run_cpu=run_cpu,
+                raise_on_error=raise_on_error,
+            )
+            for r in results:
+                all_results.append(
+                    {"algo": algo.name, "input": input_type, **r}
                 )
-                for r in results:
-                    all_results.append(
-                        {"algo": algo.name, "input": input_type, **r}
-                    )
 
     print("Finished all benchmark runs")
     results_df = pd.DataFrame.from_records(all_results)


### PR DESCRIPTION
For some benchmarks, we want to test a variety of CPU parameters or different dataset parameters for comparison. Most importantly, we want to be able to vary n_jobs, but other params are relevant too.