### PR TITLE
[REVIEW] Fix RAFT in nightly package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - PR #2162: Use stream in transpose prim
 - PR #2165: Fit function test correction
 - PR #2166: Fix handling of temp file in RF pickling
+- PR #2183: Fix RAFT in nightly package
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/cuml/test/dask/test_comms.py
+++ b/python/cuml/test/dask/test_comms.py
@@ -116,7 +116,7 @@ def test_allreduce(cluster):
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [1, 5])
-@pytest.mark.skipt("Skipping to unblock GH CI, see issue "
+@pytest.mark.skip("Skipping to unblock GH CI, see issue "
                    "https://github.com/rapidsai/dask-cuda/issues/288")
 def test_send_recv(n_trials, ucx_cluster):
 

--- a/python/cuml/test/dask/test_comms.py
+++ b/python/cuml/test/dask/test_comms.py
@@ -117,7 +117,7 @@ def test_allreduce(cluster):
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [1, 5])
 @pytest.mark.skip("Skipping to unblock GH CI, see issue "
-                   "https://github.com/rapidsai/dask-cuda/issues/288")
+                  "https://github.com/rapidsai/dask-cuda/issues/288")
 def test_send_recv(n_trials, ucx_cluster):
 
     client = Client(ucx_cluster)

--- a/python/cuml/test/dask/test_comms.py
+++ b/python/cuml/test/dask/test_comms.py
@@ -116,6 +116,8 @@ def test_allreduce(cluster):
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [1, 5])
+@pytest.mark.skipt("Skipping to unblock GH CI, see issue "
+                   "https://github.com/rapidsai/dask-cuda/issues/288")
 def test_send_recv(n_trials, ucx_cluster):
 
     client = Client(ucx_cluster)

--- a/python/setuputils.py
+++ b/python/setuputils.py
@@ -120,7 +120,8 @@ def clone_repo_if_needed(name, cpp_build_path=None,
                                            git_info_file=git_info_file)
 
     if repo_cloned:
-        repo_path = '_external_repositories/' + name + '/'
+        repo_path = (
+            _get_repo_path() + '/python/_external_repositories/' + name + '/')
     else:
         repo_path = os.path.join(cpp_build_path, name + '/src/' + name + '/')
 
@@ -174,8 +175,7 @@ def get_submodule_dependency(repo,
         print("-- Third party repositories have not been found so they " +
               "will be cloned. To avoid this set the environment " +
               "variable CUML_BUILD_PATH, containing the absolute " +
-              "path of the root of the repository to the " +
-              "folder where libcuml++ was built.")
+              "path to the build folder where libcuml++ was built.")
 
         for repo in repos:
             clone_repo(repo, repo_info[repo][0], repo_info[repo][1])


### PR DESCRIPTION
Closes #2181 

A small oversight in `setuputils` made it so that conda-build didn't include the raft code in the package, this PR fixes that. Relevant changes extracted from #2180 to allow a faster review. 