### PR TITLE
[Review] [DOC] Fix placement of SVM parameter documentation and add examples [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - PR #2165: Fit function test correction
 - PR #2166: Fix handling of temp file in RF pickling
 - PR #2183: Fix RAFT in nightly package
+- PR #2191: Fix placement of SVM parameter documentation and add examples
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -102,6 +102,95 @@ class SVR(SVMBase):
     """
     SVR (Epsilon Support Vector Regression)
 
+    Construct an SVC classifier for training and predictions.
+
+    Examples
+    ---------
+    .. code-block:: python
+
+            import numpy as np
+            from cuml.svm import SVR
+            X = np.array([[1], [2], [3], [4], [5]], dtype=np.float32)
+            y = np.array([1.1, 4, 5, 3.9, 1.], dtype = np.float32)
+            reg = SVR(kernel='rbf', gamma='scale', C=10, epsilon=0.1)
+            reg.fit(X, y)
+            print("Predicted values:", reg.predict(X))
+
+    Output:
+
+    .. code-block:: none
+
+            Predicted values: [1.200474 3.8999617 5.100488 3.7995374 1.0995375]
+
+    Parameters
+    ----------
+    handle : cuml.Handle
+        If it is None, a new one is created for this class
+    C : float (default = 1.0)
+        Penalty parameter C
+    kernel : string (default='rbf')
+        Specifies the kernel function. Possible options: 'linear', 'poly',
+        'rbf', 'sigmoid'. Currently precomputed kernels are not supported.
+    degree : int (default=3)
+        Degree of polynomial kernel function.
+    gamma : float or string (default = 'scale')
+        Coefficient for rbf, poly, and sigmoid kernels. You can specify the
+        numeric value, or use one of the following options:
+        - 'auto': gamma will be set to 1 / n_features
+        - 'scale': gamma will be se to 1 / (n_features * X.var())
+    coef0 : float (default = 0.0)
+        Independent term in kernel function, only signifficant for poly and
+        sigmoid
+    tol : float (default = 1e-3)
+        Tolerance for stopping criterion.
+    epsilon: float (default = 0.1)
+        epsilon parameter of the epsiron-SVR model. There is no penalty
+        associated to points that are predicted within the epsilon-tube
+        around the target values.
+    cache_size : float (default = 200 MiB)
+        Size of the kernel cache during training in MiB. The default is a
+        conservative value, increase it to improve the training time, at
+        the cost of higher memory footprint. After training the kernel
+        cache is deallocated.
+        During prediction, we also need a temporary space to store kernel
+        matrix elements (this can be signifficant if n_support is large).
+        The cache_size variable sets an upper limit to the prediction
+        buffer as well.
+    max_iter : int (default = 100*n_samples)
+        Limit the number of outer iterations in the solver
+    nochange_steps : int (default = 1000)
+        We monitor how much our stopping criteria changes during outer
+        iterations. If it does not change (changes less then 1e-3*tol)
+        for nochange_steps consecutive steps, then we stop training.
+    verbose : bool (default = False)
+        verbose mode
+
+    Attributes
+    ----------
+    n_support_ : int
+        The total number of support vectors. Note: this will change in the
+        future to represent number support vectors for each class (like
+        in Sklearn, see Issue #956)
+    support_ : int, shape = [n_support]
+        Device array of suppurt vector indices
+    support_vectors_ : float, shape [n_support, n_cols]
+        Device array of support vectors
+    dual_coef_ : float, shape = [1, n_support]
+        Device array of coefficients for support vectors
+    intercept_ : int
+        The constant in the decision function
+    fit_status_ : int
+        0 if SVM is correctly fitted
+    coef_ : float, shape [1, n_cols]
+        Only available for linear kernels. It is the normal of the
+        hyperplane.
+        coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]
+
+    For additional docs, see `scikitlearn's SVR
+    <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html>`_.
+
+    Notes
+    -----
     The solver uses the SMO method to fit the regressor. We use the Optimized
     Hierarchical Decomposition [1] variant of the SMO algorithm, similar to [2]
 
@@ -119,76 +208,6 @@ class SVR(SVMBase):
                  gamma='scale', coef0=0.0, tol=1e-3, epsilon=0.1,
                  cache_size=200.0, max_iter=-1, nochange_steps=1000,
                  verbose=False):
-        """
-        Construct an SVC classifier for training and predictions.
-
-        Parameters
-        ----------
-        handle : cuml.Handle
-            If it is None, a new one is created for this class
-        C : float (default = 1.0)
-            Penalty parameter C
-        kernel : string (default='rbf')
-            Specifies the kernel function. Possible options: 'linear', 'poly',
-            'rbf', 'sigmoid'. Currently precomputed kernels are not supported.
-        degree : int (default=3)
-            Degree of polynomial kernel function.
-        gamma : float or string (default = 'scale')
-            Coefficient for rbf, poly, and sigmoid kernels. You can specify the
-            numeric value, or use one of the following options:
-            - 'auto': gamma will be set to 1 / n_features
-            - 'scale': gamma will be se to 1 / (n_features * X.var())
-        coef0 : float (default = 0.0)
-            Independent term in kernel function, only signifficant for poly and
-            sigmoid
-        tol : float (default = 1e-3)
-            Tolerance for stopping criterion.
-        epsilon: float (default = 0.1)
-            epsilon parameter of the epsiron-SVR model. There is no penalty
-            associated to points that are predicted within the epsilon-tube
-            around the target values.
-        cache_size : float (default = 200 MiB)
-            Size of the kernel cache during training in MiB. The default is a
-            conservative value, increase it to improve the training time, at
-            the cost of higher memory footprint. After training the kernel
-            cache is deallocated.
-            During prediction, we also need a temporary space to store kernel
-            matrix elements (this can be signifficant if n_support is large).
-            The cache_size variable sets an upper limit to the prediction
-            buffer as well.
-        max_iter : int (default = 100*n_samples)
-            Limit the number of outer iterations in the solver
-        nochange_steps : int (default = 1000)
-            We monitor how much our stopping criteria changes during outer
-            iterations. If it does not change (changes less then 1e-3*tol)
-            for nochange_steps consecutive steps, then we stop training.
-        verbose : bool (default = False)
-            verbose mode
-
-        Attributes
-        ----------
-        n_support_ : int
-            The total number of support vectors. Note: this will change in the
-            future to represent number support vectors for each class (like
-            in Sklearn, see Issue #956)
-        support_ : int, shape = [n_support]
-            Device array of suppurt vector indices
-        support_vectors_ : float, shape [n_support, n_cols]
-            Device array of support vectors
-        dual_coef_ : float, shape = [1, n_support]
-            Device array of coefficients for support vectors
-        intercept_ : int
-            The constant in the decision function
-        fit_status_ : int
-            0 if SVM is correctly fitted
-        coef_ : float, shape [1, n_cols]
-            Only available for linear kernels. It is the normal of the
-            hyperplane.
-            coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]
-
-        For additional docs, see `scikitlearn's SVR
-        <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html>`_.
-        """
         super(SVR, self).__init__(handle, C, kernel, degree, gamma, coef0, tol,
                                   cache_size, max_iter, nochange_steps,
                                   verbose, epsilon)


### PR DESCRIPTION
The documentation of the parameters and attributes of SVC and SVR are not rendered in the [online doc](https://docs.rapids.ai/api/cuml/stable/api.html#support-vector-machines) because the docstring is not positioned correctly. This is fixed by moving the docstring from ` __init__` to the class description. 

Additionally missing examples are added for both SVR and SVC (see https://github.com/rapidsai/cuml/issues/1447). 