### PR TITLE
[WIP] Fix Dask RF predict memleak and SG RF fit memleak

### DIFF
--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -114,6 +114,9 @@ template <class T, class L>
 void null_trees_ptr(RandomForestMetaData<T, L>*& forest);
 
 template <class T, class L>
+void free_trees_array(RandomForestMetaData<T, L>* forest);
+
+template <class T, class L>
 void print_rf_summary(const RandomForestMetaData<T, L>* forest);
 
 template <class T, class L>

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -108,6 +108,8 @@ struct RandomForestMetaData {
   DecisionTree::TreeMetaDataNode<T, L>* trees;
   RF_params rf_params;
   //TODO can add prepare, train time, if needed
+
+  RandomForestMetaData() : trees(nullptr) {}
 };
 
 template <class T, class L>

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -230,6 +230,14 @@ void null_trees_ptr(RandomForestMetaData<T, L>*& forest) {
 }
 
 template <class T, class L>
+void free_trees_array(RandomForestMetaData<T, L>* forest) {
+  if (forest->trees != nullptr) {
+    delete[] forest->trees;
+    forest->trees = nullptr;
+  }
+}
+
+template <class T, class L>
 void _print_rf(const RandomForestMetaData<T, L>* forest, bool summary) {
   ML::PatternSetter _("%v");
   if (!forest || !forest->trees) {
@@ -767,6 +775,11 @@ template void null_trees_ptr<float, int>(RandomForestClassifierF*& forest);
 template void null_trees_ptr<double, int>(RandomForestClassifierD*& forest);
 template void null_trees_ptr<float, float>(RandomForestRegressorF*& forest);
 template void null_trees_ptr<double, double>(RandomForestRegressorD*& forest);
+
+template void free_trees_array<float, int>(RandomForestClassifierF* forest);
+template void free_trees_array<double, int>(RandomForestClassifierD* forest);
+template void free_trees_array<float, float>(RandomForestRegressorF* forest);
+template void free_trees_array<double, double>(RandomForestRegressorD* forest);
 
 template void build_treelite_forest<float, int>(
   ModelHandle* model, const RandomForestMetaData<float, int>* forest,

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -336,13 +336,15 @@ class RandomForestClassifier(DelayedPredictionMixin,
         # XXX is there a way to avoid retransmitting the protobuf here?
         # Merge all worker models into a single one and
         combined_model = self.rfs[last_worker].result()
+        all_tl_mods = []
         try:
             all_tl_mods = [combined_model._alloc_and_build_tl_from_protobuf(mb)
                            for mb in mod_bytes]
+            del mod_bytes # Clear to save memory
+            del model_protobuf_futures
 
             combined_model._concatenate_treelite_handles(
                 treelite_handles=all_tl_mods)
-
         finally:
             # Make sure we free the memory from cython-allocated objects
             for treelite_handle in all_tl_mods:

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -104,6 +104,7 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
 
     cdef vector[unsigned char] save_model_protobuf(ModelHandle) except +
 
+    cdef void null_trees_ptr[T, L](RandomForestMetaData[T, L]*&) except +
     cdef void free_trees_array[T, L](RandomForestMetaData[T, L]*) except +
     cdef void print_rf_summary[T, L](RandomForestMetaData[T, L]*) except +
     cdef void print_rf_detailed[T, L](RandomForestMetaData[T, L]*) except +

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -104,6 +104,7 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
 
     cdef vector[unsigned char] save_model_protobuf(ModelHandle) except +
 
+    cdef void free_trees_array[T, L](RandomForestMetaData[T, L]*) except +
     cdef void print_rf_summary[T, L](RandomForestMetaData[T, L]*) except +
     cdef void print_rf_detailed[T, L](RandomForestMetaData[T, L]*) except +
 

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -361,13 +361,7 @@ class RandomForestClassifier(Base):
         self.__dict__.update(state)
 
     def __del__(self):
-        if self.n_cols:
-            if self.dtype == np.float32:
-                free(<RandomForestMetaData[float, int]*><uintptr_t>
-                     self.rf_forest)
-            else:
-                free(<RandomForestMetaData[double, int]*><uintptr_t>
-                     self.rf_forest64)
+        self._reset_forest_data()
 
         if self.treelite_handle:
             tl.free_treelite_model(self.treelite_handle)
@@ -377,6 +371,11 @@ class RandomForestClassifier(Base):
         # Only if model is fitted before
         # Clears the data of the forest to prepare for next fit
         if self.n_cols:
+            free_trees_array(<RandomForestMetaData[float, int]*><uintptr_t>
+                             self.rf_forest)
+            free_trees_array(<RandomForestMetaData[double, int]*><uintptr_t>
+                             self.rf_forest64)
+
             free(<RandomForestMetaData[float, int]*><uintptr_t>
                  self.rf_forest)
             free(<RandomForestMetaData[double, int]*><uintptr_t>

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -320,7 +320,7 @@ class RandomForestClassifier(Base):
         cdef size_t params_t64
         if self.n_cols:
             # only if model has been fit previously
-            self.model_pbuf_bytes = self._get_protobuf_bytes()
+            model_pbuf_bytes = self._get_protobuf_bytes()
             params_t = <uintptr_t> self.rf_forest
             rf_forest = \
                 <RandomForestMetaData[float, int]*>params_t
@@ -331,9 +331,12 @@ class RandomForestClassifier(Base):
                 state["rf_params"] = rf_forest.rf_params
             else:
                 state["rf_params64"] = rf_forest64.rf_params
+        else:
+            model_pbuf_bytes = bytearray()
         state['n_cols'] = self.n_cols
         state["verbose"] = self.verbose
-        state["model_pbuf_bytes"] = self.model_pbuf_bytes
+        state["model_pbuf_bytes"] = model_pbuf_bytes
+        state["treelite_handle"] = None
 
         return state
 
@@ -366,6 +369,10 @@ class RandomForestClassifier(Base):
                 free(<RandomForestMetaData[double, int]*><uintptr_t>
                      self.rf_forest64)
 
+        if self.treelite_handle:
+            tl.free_treelite_model(self.treelite_handle)
+            self.treelite_handle = None
+
     def _reset_forest_data(self):
         # Only if model is fitted before
         # Clears the data of the forest to prepare for next fit
@@ -389,11 +396,17 @@ class RandomForestClassifier(Base):
                              " please read the documentation")
 
     def _obtain_treelite_handle(self):
+        """Either return a pre-built treelite_handle representing this model
+        or build a new one. Caller does not have to free, as the destructor
+        will clean up self.treelite_handle."""
+        if self.treelite_handle:
+            return self.treelite_handle # Use cached version
+
         cdef ModelHandle cuml_model_ptr = NULL
         cdef RandomForestMetaData[float, int] *rf_forest = \
             <RandomForestMetaData[float, int]*><uintptr_t> self.rf_forest
         if self.num_classes > 2:
-            raise NotImplementedError("Pickling for multi-class "
+            raise NotImplementedError("Serialization for multi-class "
                                       "classification models is currently not "
                                       "implemented. Please check cuml issue "
                                       "#1679 for more information.")
@@ -402,16 +415,17 @@ class RandomForestClassifier(Base):
         with cython.boundscheck(False):
             model_pbuf_vec.assign(& model_pbuf_mv[0],
                                   & model_pbuf_mv[model_pbuf_mv.shape[0]])
-        if self.treelite_handle is None:
-            task_category = CLASSIFICATION_MODEL
-            build_treelite_forest(
-                & cuml_model_ptr,
-                rf_forest,
-                <int> self.n_cols,
-                <int> task_category,
-                model_pbuf_vec)
-            mod_ptr = <uintptr_t> cuml_model_ptr
-            self.treelite_handle = ctypes.c_void_p(mod_ptr).value
+
+        task_category = CLASSIFICATION_MODEL
+        build_treelite_forest(
+            & cuml_model_ptr,
+            rf_forest,
+            <int> self.n_cols,
+            <int> task_category,
+            model_pbuf_vec)
+        mod_ptr = <uintptr_t> cuml_model_ptr
+        self.treelite_handle = ctypes.c_void_p(mod_ptr).value
+
         return self.treelite_handle
 
     def _get_protobuf_bytes(self):
@@ -512,7 +526,10 @@ class RandomForestClassifier(Base):
     TODO : Move functions duplicated in the RF classifier and regressor
            to a shared file. Cuml issue #1854 has been created to track this.
     """
-    def _tl_model_handles(self, model_bytes):
+    def _alloc_and_build_tl_from_protobuf(self, model_bytes):
+        """Creates a treelite model from the protobuf format model_bytes
+        and returns its TreeliteHandle.
+        The caller must free the resulting model."""
         cdef ModelHandle cuml_model_ptr = NULL
         cdef RandomForestMetaData[float, int] *rf_forest = \
             <RandomForestMetaData[float, int]*><uintptr_t> self.rf_forest
@@ -526,12 +543,12 @@ class RandomForestClassifier(Base):
 
         return ctypes.c_void_p(mod_handle).value
 
-    def _concatenate_treelite_handle(self, treelite_handle):
+    def _concatenate_treelite_handles(self, treelite_handles):
         cdef ModelHandle concat_model_handle = NULL
         cdef vector[ModelHandle] *model_handles \
             = new vector[ModelHandle]()
         cdef uintptr_t mod_ptr
-        for i in treelite_handle:
+        for i in treelite_handles:
             mod_ptr = <uintptr_t>i
             model_handles.push_back((
                 <ModelHandle> mod_ptr))
@@ -539,11 +556,15 @@ class RandomForestClassifier(Base):
         concat_model_handle = concatenate_trees(deref(model_handles))
         cdef uintptr_t concat_model_ptr = <uintptr_t> concat_model_handle
         self.treelite_handle = concat_model_ptr
-        cdef vector[unsigned char] pbuf_mod_info = \
-            save_model(<ModelHandle> concat_model_ptr)
-        cdef unsigned char[::1] pbuf_mod_view = \
-            <unsigned char[:pbuf_mod_info.size():1]>pbuf_mod_info.data()
-        self.model_pbuf_bytes = bytearray(memoryview(pbuf_mod_view))
+
+        # XXX Do we need this pbuf_bytes? It seems like we're already
+        # on the client side by then and the treelite model is sufficient
+        # cdef vector[unsigned char] pbuf_mod_info = \
+        #     save_model(<ModelHandle> concat_model_ptr)
+        # cdef unsigned char[::1] pbuf_mod_view = \
+        #     <unsigned char[:pbuf_mod_info.size():1]>pbuf_mod_info.data()
+        # self.model_pbuf_bytes = bytearray(memoryview(pbuf_mod_view))
+
         return self
 
     def fit(self, X, y, convert_dtype=False):
@@ -692,13 +713,15 @@ class RandomForestClassifier(Base):
         cdef RandomForestMetaData[float, int] *rf_forest = \
             <RandomForestMetaData[float, int]*><uintptr_t> self.rf_forest
 
-        build_treelite_forest(& cuml_model_ptr,
-                              rf_forest,
-                              <int> n_cols,
-                              <int> num_classes,
-                              <vector[unsigned char] &> self.model_pbuf_bytes)
-        mod_ptr = <uintptr_t> cuml_model_ptr
-        treelite_handle = ctypes.c_void_p(mod_ptr).value
+        # XXX Can we just use _obtain_treelite_handle here?
+        if not self.treelite_handle:
+            build_treelite_forest(& cuml_model_ptr,
+                                  rf_forest,
+                                  <int> n_cols,
+                                  <int> num_classes,
+                                  <vector[unsigned char] &> self.model_pbuf_bytes)
+            mod_ptr = <uintptr_t> cuml_model_ptr
+            self.treelite_handle = ctypes.c_void_p(mod_ptr).value
 
         storage_type = \
             _check_fil_parameter_validity(depth=self.max_depth,
@@ -707,7 +730,7 @@ class RandomForestClassifier(Base):
 
         fil_model = ForestInference()
         tl_to_fil_model = \
-            fil_model.load_from_randomforest(treelite_handle,
+            fil_model.load_from_randomforest(self.treelite_handle,
                                              output_class=output_class,
                                              threshold=threshold,
                                              algo=algo,
@@ -715,7 +738,7 @@ class RandomForestClassifier(Base):
 
         preds = tl_to_fil_model.predict(X, output_type=out_type,
                                         predict_proba=predict_proba)
-        tl.free_treelite_model(treelite_handle)
+
         return preds
 
     def _predict_model_on_cpu(self, X, convert_dtype):

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -397,7 +397,8 @@ class RandomForestRegressor(Base):
 
     def _get_protobuf_bytes(self):
         """
-        Returns the self.model_pbuf_bytes.
+        Returns protobuf-serialized version of model as bytearray.
+
         Cuml RF model gets converted to treelite protobuf bytes by:
             1. converting the cuml RF model to a treelite model. The treelite
             models handle (pointer) is returned
@@ -517,11 +518,7 @@ class RandomForestRegressor(Base):
         concat_model_handle = concatenate_trees(deref(model_handles))
         cdef uintptr_t concat_model_ptr = <uintptr_t> concat_model_handle
         self.treelite_handle = concat_model_ptr
-        cdef vector[unsigned char] pbuf_mod_info = \
-            save_model(<ModelHandle> concat_model_ptr)
-        cdef unsigned char[::1] pbuf_mod_view = \
-            <unsigned char[:pbuf_mod_info.size():1]>pbuf_mod_info.data()
-        self.model_pbuf_bytes = bytearray(memoryview(pbuf_mod_view))
+
         return self
 
     def fit(self, X, y, convert_dtype=False):

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -343,16 +343,15 @@ class RandomForestRegressor(Base):
         self.__dict__.update(state)
 
     def __del__(self):
-        if self.n_cols:
-            if self.dtype == np.float32:
-                free(<RandomForestMetaData[float, float]*><uintptr_t>
-                     self.rf_forest)
-            else:
-                free(<RandomForestMetaData[double, double]*><uintptr_t>
-                     self.rf_forest64)
+        self._reset_forest_data()
 
     def _reset_forest_data(self):
         if self.n_cols:
+            free_trees_array(<RandomForestMetaData[float, float]*><uintptr_t>
+                             self.rf_forest)
+            free_trees_array(<RandomForestMetaData[double, double]*><uintptr_t>
+                             self.rf_forest64)
+
             # Only if the model is fitted before
             # Clears the data of the forest to prepare for next fit
             free(<RandomForestMetaData[float, float]*><uintptr_t>


### PR DESCRIPTION
@miroenev noticed some memory leaks in Dask-RF, particularly noticeable with large trees.

It seems the allocated treelite model stored in `self.treelite_model` is not being cleaned up in some cases, and the same issue is happening with the converted models in the concatenation approach. This approach moves responsibility for self.treelite_model to the destructor (__del__) and explicitly cleans up after concat.

Along the way, noticed a few points where we could use `self.treelite_model` to avoid re-converting the tree. I believe we could centralize all the tree conversion logic in `_obtain_treelite_model` (whereas right now single-gpu `predict` also has its own version), but I'm not positive whether I'm missing something there.

I will attach a notebook demo'ing the difference in memory usage. concat_treelite_models is takes about 40% less time on 2 gpus, and rf.predict in a loop for single-gpu takes about 60% less time than the previous code.

I can hold off on merge until the code centralization/refactor is ready - I think that will make the merge easier.