### PR TITLE
[REVIEW] Update to use __reduce_ex__ in CumlArray to override cudf.Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 - PR #2217: Fix opg_utils naming to fix singlegpu build
 - PR #2223: Fix bug in ARIMA C++ benchmark
 - PR #2224: Temporary fix for CI until new Dask version is released
+- PR #2228: Update to use __reduce_ex__ in CumlArray to override cudf.Buffer
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -169,7 +169,10 @@ class CumlArray(Buffer):
         cp.asarray(self).__setitem__(slice, value)
 
     def __reduce_ex__(self, protocol):
-        return self.__class__, (self.to_output('numpy'),)
+        data = self.to_output('numpy')
+        if protocol >= 5:
+            data = pickle.PickleBuffer(data)
+        return self.__class__, (data,)
 
     def __len__(self):
         return self.shape[0]

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -16,6 +16,7 @@
 
 import cupy as cp
 import numpy as np
+import pickle
 
 from rmm import DeviceBuffer
 from cudf.core import Buffer, Series, DataFrame

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -171,9 +171,6 @@ class CumlArray(Buffer):
     def __reduce_ex__(self, protocol):
         return self.__class__, (self.to_output('numpy'),)
 
-    def __reduce__(self, protocol):
-        return self.__class__, (self.to_output('numpy'),)
-
     def __len__(self):
         return self.shape[0]
 

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -168,7 +168,7 @@ class CumlArray(Buffer):
     def __setitem__(self, slice, value):
         cp.asarray(self).__setitem__(slice, value)
 
-    def __reduce__(self):
+    def __reduce_ex__(self, protocol):
         return self.__class__, (self.to_output('numpy'),)
 
     def __len__(self):

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -171,6 +171,9 @@ class CumlArray(Buffer):
     def __reduce_ex__(self, protocol):
         return self.__class__, (self.to_output('numpy'),)
 
+    def __reduce__(self, protocol):
+        return self.__class__, (self.to_output('numpy'),)
+
     def __len__(self):
         return self.shape[0]
 

--- a/python/cuml/metrics/_ranking.py
+++ b/python/cuml/metrics/_ranking.py
@@ -16,8 +16,8 @@
 
 import cupy as cp
 import numpy as np
-from cuml.utils.memory_utils import with_cupy_rmm
-from cuml.utils import input_to_cuml_array
+from cuml.common.memory_utils import with_cupy_rmm
+from cuml.common import input_to_cuml_array
 import math
 
 

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -404,7 +404,7 @@ def test_deepcopy(input_type):
 def create_input(input_type, dtype, shape, order):
     float_dtypes = [np.float16, np.float32, np.float64]
     if dtype in float_dtypes:
-        rand_ary = np.random.random(shape)
+        rand_ary = cp.random.random(shape)
     else:
         rand_ary = cp.random.randint(100, size=shape)
 


### PR DESCRIPTION
cuDF's PR https://github.com/rapidsai/cudf/pull/5132 to optimize `__reduce_ex__` in cudf.Buffer broke pickling and serialization in CumlArray, since there only `__reduce__` was being implemented. This PR addresses that by adding an explicit `__reduce_ex__` in addition to `__reduce__`. 