### PR TITLE
add commit_hash to meta.yaml in conda packages [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - PR #2242: Pandas input support with output as NumPy arrays by default
 
 ## Improvements
+
+- PR #2260: Add commit_hash to meta.yaml
 - PR #1931: C++: enabled doxygen docs for all of the C++ codebase
 - PR #1944: Support for dask_cudf.core.Series in _extract_partitions
 - PR #1947: Cleaning up cmake

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ set -e
 
 NUMARGS=$#
 ARGS=$*
+GIT_COMMIT=${GIT_COMMIT:=$(git rev-parse HEAD)}
 
 # NOTE: ensure all dir changes are relative to the location of this
 # script, and that this script resides in the repo dir!

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -7,6 +7,7 @@
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 {% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+{% set git_commit=environ.get( 'GIT_FULL_HASH', environ.get('GIT_COMMIT', '')) %}
 
 package:
   name: cuml
@@ -54,3 +55,6 @@ about:
   license: Apache-2.0
   # license_file: LICENSE
   summary: cuML library
+
+extra:
+  commit_hash: {{ git_commit }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -8,6 +8,8 @@
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major = environ.get('CUDA', '9.2').split('.')[0] %}
 {% set cuda_minor = environ.get('CUDA', '9.2').split('.')[1] %}
+{% set git_commit=environ.get( 'GIT_FULL_HASH', environ.get('GIT_COMMIT', '')) %}
+
 package:
   name: libcuml
   version: {{ version }}
@@ -50,3 +52,6 @@ about:
   license: Apache-2.0
   # license_file: LICENSE
   summary: libcuml library
+
+extra:
+  commit_hash: {{ git_commit }}


### PR DESCRIPTION
As a consumer of RapidsAI Conda package(s) it is often important to be able to identify the git commit associated with a particular build of one or more packages installed in an environment.

Embed in each conda package tarball a reference to the commit from which
the package was built. Currently there is no easy way to identify with
certainty the commit associated with a particular package.

After this feature has been replicated to a given package, team members wishing to identify the commit hash associated with the package build can execute the following python snippet to extract the commit hash for each rapids package in the current conda environment.


```
from io import BytesIO

import requests
import tarfile
import bz2

import os
import yaml
import tempfile
import logging

pkgurl='https://anaconda.org/{channel}/{conda_pkg}/{version}/download/linux-64/{conda_pkg}-{version}-{build}.tar.bz2'

def retrieve_commit_hash_for_build( channel, conda_pkg, version, build ):
    dest=tempfile.mkdtemp()
    try:
        with requests.get( pkgurl.format( **locals() ) ) as resp:
            with tarfile.open( fileobj=BytesIO( resp.content ), mode='r:bz2' ) as tfile:
                meta=tfile.extract( 'info/recipe/meta.yaml', dest )
                yo=yaml.safe_load( open( os.path.join( dest, 'info/recipe/meta.yaml' )) )
                return yo.get('extra',{}).get('commit_hash','unsupported')
    except requests.exceptions.RequestException as reqex:
        logging.getLogger().exception( reqex )
    except tarfile.TarError as terror:
        logging.getLogger().exception( terror )
    except e:
        logging.getLogger().exception( e )


import subprocess
import json

it=subprocess.run( ['conda', 'list', '--json'], capture_output=True )
jo=json.loads( it.stdout )
for pkg in filter( lambda x: x['channel'].startswith('rapids'), jo ):
   print( "{}/{}/{}/{} == {}".format( pkg.get('channel',''),
                                      pkg.get('name',''),
				      pkg.get('version',''),
				      pkg.get('build_string',''),
                                      retrieve_commit_hash_for_build( channel=pkg.get('channel',''),
   	          		                                      conda_pkg=pkg.get('name',''),
   	          		                                      version=pkg.get('version',''),
   	          		                                      build=pkg.get('build_string','') ) ) )
```
