### PR TITLE
[REVIEW] Faster Treelite serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - PR #2257: Update QN and LogisticRegression to use CumlArray
 - PR #2259: Add CumlArray support to Naive Bayes
 - PR #2252: Add benchmark for the Gram matrix prims
+- PR #2263: Faster serialization for Treelite objects with RF
 - PR #2264: Reduce build time for cuML by using make_blobs from libcuml++ interface
 - PR #2269: Add docs targets to build.sh and fix python cuml.common docs
 - PR #2271: Clarify doc for `_unique` default implementation in OneHotEncoder

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -105,8 +105,18 @@ logger "Resetting LD_LIBRARY_PATH..."
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
 export LD_LIBRARY_PATH_CACHED=""
 
-logger "Install Treelite for GPU testing..."
-python -m pip install -v treelite==0.91
+logger "Build treelite for GPU testing..."
+# FIXME: Upload new Treelite to PyPI / Conda
+
+cd $WORKSPACE/cpp/build/treelite/src/treelite
+mkdir build
+cd build
+cmake ..
+make -j${PARALLEL_LEVEL}
+cd ../python
+python setup.py install
+cd ../runtime/python
+python setup.py install
 
 cd $WORKSPACE
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -105,18 +105,8 @@ logger "Resetting LD_LIBRARY_PATH..."
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
 export LD_LIBRARY_PATH_CACHED=""
 
-logger "Build treelite for GPU testing..."
-# FIXME: Upload new Treelite to PyPI / Conda
-
-cd $WORKSPACE/cpp/build/treelite/src/treelite
-mkdir build
-cd build
-cmake ..
-make -j${PARALLEL_LEVEL}
-cd ../python
-python setup.py install
-cd ../runtime/python
-python setup.py install
+logger "Install Treelite for GPU testing..."
+python -m pip install -v treelite==0.92rc2 treelite_runtime==0.92rc2
 
 cd $WORKSPACE
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -106,7 +106,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
 export LD_LIBRARY_PATH_CACHED=""
 
 logger "Install Treelite for GPU testing..."
-python -m pip install -v treelite==0.92rc2 treelite_runtime==0.92rc2
+python -m pip install -v treelite==0.92 treelite_runtime==0.92
 
 cd $WORKSPACE
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -284,7 +284,7 @@ set(CUML_INCLUDE_DIRECTORIES
   ${CUB_DIR}/src/cub
   ${SPDLOG_DIR}/src/spdlog/include
   ${TREELITE_DIR}/include
-  ${TREELITE_DIR}/include/fmt
+  ${TREELITE_DIR}/src/treelite/include
   ${RAFT_DIR}/cpp/include)
 
 set(CUML_LINK_LIBRARIES

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -130,6 +130,7 @@ ExternalProject_Add(treelite
     PREFIX            ${TREELITE_DIR}
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+                      -DENABLE_PROTOBUF=ON
     BUILD_BYPRODUCTS  ${TREELITE_DIR}/src/treelite-build/libtreelite_static.a
                       ${TREELITE_DIR}/src/treelite-build/_deps/dmlccore-build/libdmlc.a
                       ${TREELITE_DIR}/src/treelite-build/libtreelite_runtime.so

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -126,7 +126,7 @@ set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")
 ExternalProject_Add(treelite
     GIT_REPOSITORY    https://github.com/dmlc/treelite.git
-    GIT_TAG           107faa5b63082f5054ae18873a3716e180f64514
+    GIT_TAG           0.92rc2
     PREFIX            ${TREELITE_DIR}
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -126,28 +126,25 @@ set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")
 ExternalProject_Add(treelite
     GIT_REPOSITORY    https://github.com/dmlc/treelite.git
-    GIT_TAG           6fd01e4f1890950bbcf9b124da24e886751bffe6
+    GIT_TAG           107faa5b63082f5054ae18873a3716e180f64514
     PREFIX            ${TREELITE_DIR}
-    CMAKE_ARGS        -DBUILD_SHARED_LIBS=OFF
-                      -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                      -DENABLE_PROTOBUF=ON
+    CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-    BUILD_BYPRODUCTS  ${TREELITE_DIR}/lib/libtreelite.a
-                      ${TREELITE_DIR}/lib/libdmlc.a
-                      ${TREELITE_DIR}/lib/libtreelite_runtime.so
-    UPDATE_COMMAND    ""
-    PATCH_COMMAND     patch -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/treelite_protobuf.patch || true)
+    BUILD_BYPRODUCTS  ${TREELITE_DIR}/src/treelite-build/libtreelite_static.a
+                      ${TREELITE_DIR}/src/treelite-build/_deps/dmlccore-build/libdmlc.a
+                      ${TREELITE_DIR}/src/treelite-build/libtreelite_runtime.so
+    UPDATE_COMMAND    "")
 
 add_library(dmlclib STATIC IMPORTED)
 add_library(treelitelib STATIC IMPORTED)
 add_library(treelite_runtimelib SHARED IMPORTED)
 
 set_property(TARGET dmlclib PROPERTY
-  IMPORTED_LOCATION ${TREELITE_DIR}/lib/libdmlc.a)
+  IMPORTED_LOCATION ${TREELITE_DIR}/src/treelite-build/_deps/dmlccore-build/libdmlc.a)
 set_property(TARGET treelitelib PROPERTY
-  IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite.a)
+  IMPORTED_LOCATION ${TREELITE_DIR}/src/treelite-build/libtreelite_static.a)
 set_property(TARGET treelite_runtimelib PROPERTY
-  IMPORTED_LOCATION ${TREELITE_DIR}/lib/libtreelite_runtime.so)
+  IMPORTED_LOCATION ${TREELITE_DIR}/src/treelite-build/libtreelite_runtime.so)
 
 add_dependencies(dmlclib treelite)
 add_dependencies(treelitelib treelite)

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -126,7 +126,7 @@ set(TREELITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/treelite CACHE STRING
   "Path to treelite install directory")
 ExternalProject_Add(treelite
     GIT_REPOSITORY    https://github.com/dmlc/treelite.git
-    GIT_TAG           0.92rc2
+    GIT_TAG           0.92
     PREFIX            ${TREELITE_DIR}
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -132,10 +132,7 @@ void print_rf_detailed(const RandomForestMetaData<T, L>* forest);
 template <class T, class L>
 void build_treelite_forest(ModelHandle* model,
                            const RandomForestMetaData<T, L>* forest,
-                           int num_features, int task_category,
-                           std::vector<unsigned char>& data);
-
-std::vector<unsigned char> save_model(ModelHandle model);
+                           int num_features, int task_category);
 
 ModelHandle concatenate_trees(std::vector<ModelHandle> treelite_handles);
 

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -96,7 +96,6 @@ void build_treelite_tree(TreeBuilderHandle tree_builder,
                          int num_output_group) {
   int node_id = 0;
   TREELITE_CHECK(TreeliteTreeBuilderCreateNode(tree_builder, node_id));
-  TREELITE_CHECK(TreeliteTreeBuilderSetRootNode(tree_builder, node_id));
 
   std::queue<Node_ID_info<T, L>> cur_level_queue;
   std::queue<Node_ID_info<T, L>> next_level_queue;
@@ -138,7 +137,7 @@ void build_treelite_tree(TreeBuilderHandle tree_builder,
           TREELITE_CHECK(TreeliteTreeBuilderSetLeafNode(
             tree_builder, q_node.unique_node_id, q_node.node.prediction));
         } else {
-          std::vector<double> leaf_vector(num_output_group);
+          std::vector<float> leaf_vector(num_output_group);
           for (int j = 0; j < num_output_group; j++) {
             if (q_node.node.prediction == j) {
               leaf_vector[j] = 1;
@@ -157,6 +156,7 @@ void build_treelite_tree(TreeBuilderHandle tree_builder,
     // The cur_level_queue is empty here, as all the elements are already poped out.
     cur_level_queue.swap(next_level_queue);
   }
+  TREELITE_CHECK(TreeliteTreeBuilderSetRootNode(tree_builder, 0));
 }
 
 /**

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -451,7 +451,7 @@ class TreeliteFilTest : public BaseFilTest {
   int node_to_treelite(tlf::TreeBuilder* builder, int* pkey, int root,
                        int node) {
     int key = (*pkey)++;
-    TL_CPP_CHECK(builder->CreateNode(key));
+    builder->CreateNode(key);
     int feature;
     float threshold;
     fil::val_t output;
@@ -462,13 +462,13 @@ class TreeliteFilTest : public BaseFilTest {
       switch (ps.leaf_payload_type) {
         case fil::leaf_value_t::FLOAT_SCALAR:
           // default is fil::FLOAT_SCALAR
-          TL_CPP_CHECK(builder->SetLeafNode(key, output.f));
+          builder->SetLeafNode(key, output.f);
           break;
         case fil::leaf_value_t::INT_CLASS_LABEL:
           std::vector<tl::tl_float> vec(ps.num_classes);
           for (int i = 0; i < ps.num_classes; ++i)
             vec[i] = i == output.idx ? 1.0f : 0.0f;
-          TL_CPP_CHECK(builder->SetLeafVectorNode(key, vec));
+          builder->SetLeafVectorNode(key, vec);
       }
     } else {
       int left = root + 2 * (node - root) + 1;
@@ -495,8 +495,8 @@ class TreeliteFilTest : public BaseFilTest {
       }
       int left_key = node_to_treelite(builder, pkey, root, left);
       int right_key = node_to_treelite(builder, pkey, root, right);
-      TL_CPP_CHECK(builder->SetNumericalTestNode(
-        key, feature, ps.op, threshold, default_left, left_key, right_key));
+      builder->SetNumericalTestNode(key, feature, ps.op, threshold,
+                                    default_left, left_key, right_key);
     }
     return key;
   }
@@ -528,14 +528,14 @@ class TreeliteFilTest : public BaseFilTest {
       int key_counter = 0;
       int root = i_tree * tree_num_nodes();
       int root_key = node_to_treelite(tree_builder, &key_counter, root, root);
-      TL_CPP_CHECK(tree_builder->SetRootNode(root_key));
+      tree_builder->SetRootNode(root_key);
       // InsertTree() consumes tree_builder
       TL_CPP_CHECK(model_builder->InsertTree(tree_builder));
     }
 
     // commit the model
     std::unique_ptr<tl::Model> model(new tl::Model);
-    TL_CPP_CHECK(model_builder->CommitModel(model.get()));
+    model_builder->CommitModel(model.get());
 
     // init FIL forest with the model
     fil::treelite_params_t params;

--- a/cpp/test/sg/rf_treelite_test.cu
+++ b/cpp/test/sg/rf_treelite_test.cu
@@ -343,7 +343,6 @@ class RfConcatTestClf : public RfTreeliteTestCommon<T, L> {
 
     for (int i = 0; i < 3; i++) {
       ModelHandle model;
-      std::vector<unsigned char> vec_data;
 
       this->rf_params.n_trees = this->rf_params.n_trees + i;
 
@@ -351,7 +350,7 @@ class RfConcatTestClf : public RfTreeliteTestCommon<T, L> {
           this->params.n_rows, this->params.n_cols, this->labels_d,
           labels_map.size(), this->rf_params);
       build_treelite_forest(&model, this->all_forest_info[i],
-                            this->params.n_cols, this->task_category, vec_data);
+                            this->params.n_cols, this->task_category);
       this->treelite_indiv_handles.push_back(model);
     }
 
@@ -413,14 +412,14 @@ class RfConcatTestReg : public RfTreeliteTestCommon<T, L> {
 
     for (int i = 0; i < 3; i++) {
       ModelHandle model;
-      std::vector<unsigned char> vec_data;
+
       this->rf_params.n_trees = this->rf_params.n_trees + i;
 
       fit(*(this->handle), this->all_forest_info[i], this->data_d,
           this->params.n_rows, this->params.n_cols, this->labels_d,
           this->rf_params);
       build_treelite_forest(&model, this->all_forest_info[i],
-                            this->params.n_cols, this->task_category, vec_data);
+                            this->params.n_cols, this->task_category);
       CUDA_CHECK(cudaStreamSynchronize(this->stream));
       this->treelite_indiv_handles.push_back(model);
     }

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ from cuml.common.import_utils import has_treelite
 
 if has_treelite():
     import treelite
-    import treelite.runtime
 
 if has_umap():
     import umap
@@ -193,11 +192,10 @@ def _treelite_format_hook(data):
     from cuml.common.import_utils import has_treelite
 
     if has_treelite():
-        import treelite
-        import treelite.runtime
+        import treelite_runtime
     else:
         raise ImportError("No treelite package found")
-    return treelite.runtime.Batch.from_npy2d(data[0]), data[1]
+    return treelite_runtime.Batch.from_npy2d(data[0]), data[1]
 
 
 def all_algorithms():

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -149,7 +149,7 @@ def _build_treelite_classifier(m, data, args, tmpdir):
     from cuml.common.import_utils import has_treelite, has_xgboost
     if has_treelite():
         import treelite
-        import treelite.runtime
+        import treelite_runtime
     else:
         raise ImportError("No treelite package found")
     if has_xgboost():
@@ -168,10 +168,11 @@ def _build_treelite_classifier(m, data, args, tmpdir):
     bst.load_model(model_path)
     tl_model = treelite.Model.from_xgboost(bst)
     tl_model.export_lib(
-        toolchain="gcc", libpath=model_path+"treelite.so",
+        toolchain="gcc", libpath=os.path.join(tmpdir, 'treelite.so'),
         params={'parallel_comp': 40}, verbose=False
     )
-    return treelite.runtime.Predictor(model_path+"treelite.so", verbose=False)
+    return treelite_runtime.Predictor(os.path.join(tmpdir, 'treelite.so'),
+                                      verbose=False)
 
 
 def _treelite_fil_accuracy_score(y_true, y_pred):

--- a/python/cuml/dask/ensemble/base.py
+++ b/python/cuml/dask/ensemble/base.py
@@ -110,7 +110,7 @@ class BaseRandomForestModel(object):
         model_serialized_futures = list()
         for w in self.workers:
             model_serialized_futures.append(
-                dask.delayed(_get_model_serialized)
+                dask.delayed(_get_serialized_model)
                 (self.rfs[w]))
         mod_bytes = self.client.compute(model_serialized_futures, sync=True)
         last_worker = w
@@ -118,7 +118,8 @@ class BaseRandomForestModel(object):
         model = self.rfs[last_worker].result()
         all_tl_mod_handles = [
                 model._tl_handle_from_bytes(indiv_worker_model_bytes)
-                for indiv_worker_model_bytes in mod_bytes]
+                for indiv_worker_model_bytes in mod_bytes
+        ]
 
         model._concatenate_treelite_handle(all_tl_mod_handles)
         for tl_handle in all_tl_mod_handles:
@@ -195,5 +196,5 @@ def _func_set_params(model, **params):
     return model.set_params(**params)
 
 
-def _get_model_serialized(model):
-    return model._get_model_serialized()
+def _get_serialized_model(model):
+    return model._get_serialized_model()

--- a/python/cuml/dask/ensemble/base.py
+++ b/python/cuml/dask/ensemble/base.py
@@ -107,17 +107,18 @@ class BaseRandomForestModel(object):
         to create a single model. The concatenated model is then converted to
         bytes format.
         """
-        model_protobuf_futures = list()
+        model_serialized_futures = list()
         for w in self.workers:
-            model_protobuf_futures.append(
-                dask.delayed(_get_protobuf_bytes)
+            model_serialized_futures.append(
+                dask.delayed(_get_model_serialized)
                 (self.rfs[w]))
-        mod_bytes = self.client.compute(model_protobuf_futures, sync=True)
+        mod_bytes = self.client.compute(model_serialized_futures, sync=True)
         last_worker = w
         all_tl_mod_handles = []
         model = self.rfs[last_worker].result()
-        all_tl_mod_handles = [model._tl_model_handles(pbuf_bytes)
-                              for pbuf_bytes in mod_bytes]
+        all_tl_mod_handles = [
+                model._tl_handle_from_bytes(indiv_worker_model_bytes)
+                for indiv_worker_model_bytes in mod_bytes]
 
         model._concatenate_treelite_handle(all_tl_mod_handles)
         for tl_handle in all_tl_mod_handles:
@@ -194,5 +195,5 @@ def _func_set_params(model, **params):
     return model.set_params(**params)
 
 
-def _get_protobuf_bytes(model):
-    return model._get_protobuf_bytes()
+def _get_model_serialized(model):
+    return model._get_model_serialized()

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -41,8 +41,6 @@ cimport cuml.common.cuda
 cdef extern from "treelite/c_api.h":
     ctypedef void* ModelHandle
     ctypedef void* ModelBuilderHandle
-    cdef int TreeliteExportProtobufModel(const char* filename,
-                                         ModelHandle model)
     cdef const char* TreeliteGetLastError()
 
 cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
@@ -99,10 +97,7 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
     cdef void build_treelite_forest[T, L](ModelHandle*,
                                           RandomForestMetaData[T, L]*,
                                           int,
-                                          int,
-                                          vector[unsigned char] &) except +
-
-    cdef vector[unsigned char] save_model_protobuf(ModelHandle) except +
+                                          int) except +
 
     cdef void delete_rf_metadata[T, L](RandomForestMetaData[T, L]*) except +
     cdef void print_rf_summary[T, L](RandomForestMetaData[T, L]*) except +

--- a/python/cuml/ensemble/randomforest_shared.pyx
+++ b/python/cuml/ensemble/randomforest_shared.pyx
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+from libcpp.vector cimport vector
+from cython.operator cimport dereference as deref, preincrement as inc
+from cpython.object cimport PyObject
+from libc.stdint cimport uintptr_t
+from typing import Tuple, Dict, List, Union
+import numpy as np
+
+cdef extern from "treelite/tree.h" namespace "treelite":
+    cdef struct PyBufferFrame:
+        void* buf
+        char* format
+        size_t itemsize
+        size_t nitem
+    cdef cppclass Model:
+        vector[PyBufferFrame] GetPyBuffer() except +
+        void InitFromPyBuffer(vector[PyBufferFrame] frames) except +
+
+cdef extern from "Python.h":
+    Py_buffer* PyMemoryView_GET_BUFFER(PyObject* mview)
+
+cdef class PyBufferFrameWrapper:
+    cdef PyBufferFrame _handle
+    cdef Py_ssize_t shape[1]
+    cdef Py_ssize_t strides[1]
+
+    def __cinit__(self):
+        pass
+
+    def __dealloc__(self):
+        pass
+
+    def __getbuffer__(self, Py_buffer* buffer, int flags):
+        cdef Py_ssize_t itemsize = self._handle.itemsize
+
+        self.shape[0] = self._handle.nitem
+        self.strides[0] = itemsize
+
+        buffer.buf = self._handle.buf
+        buffer.format = self._handle.format
+        buffer.internal = NULL
+        buffer.itemsize = itemsize
+        buffer.len = self._handle.nitem * itemsize
+        buffer.ndim = 1
+        buffer.obj = self
+        buffer.readonly = 0
+        buffer.shape = self.shape
+        buffer.strides = self.strides
+        buffer.suboffsets = NULL
+
+    def __releasebuffer__(self, Py_buffer *buffer):
+        pass
+
+cdef PyBufferFrameWrapper MakePyBufferFrameWrapper(PyBufferFrame handle):
+    cdef PyBufferFrameWrapper wrapper = PyBufferFrameWrapper()
+    wrapper._handle = handle
+    return wrapper
+
+cdef list _get_frames(ModelHandle model):
+    frames = []
+    cdef Model* model_obj = <Model*>model
+    cdef vector[PyBufferFrame] interface = model_obj.GetPyBuffer()
+    cdef vector[PyBufferFrame].iterator it = interface.begin()
+    while it != interface.end():
+        v = deref(it)
+        w = MakePyBufferFrameWrapper(v)
+        frames.append(memoryview(w))
+        inc(it)
+    return frames
+
+cdef ModelHandle _init_from_frames(vector[PyBufferFrame] frames) except *:
+    cdef Model* model_obj = new Model()
+    model_obj.InitFromPyBuffer(frames)
+    cdef ModelHandle handle = <ModelHandle>model_obj
+    return handle
+
+
+def get_frames(model: uintptr_t) -> List[memoryview]:
+    return _get_frames(<ModelHandle> model)
+
+
+def init_from_frames(frames: List[np.ndarray],
+                     format_str: List[str], itemsize: List[int]) -> uintptr_t:
+    cdef vector[PyBufferFrame] cpp_frames
+    cdef Py_buffer* buf
+    cdef PyBufferFrame cpp_frame
+    for i, frame in enumerate(frames):
+        x = memoryview(frame)
+        buf = PyMemoryView_GET_BUFFER(<PyObject*>x)
+        cpp_frame.buf = buf.buf
+        cpp_frame.format = format_str[i]
+        cpp_frame.itemsize = itemsize[i]
+        cpp_frame.nitem = buf.len // itemsize[i]
+        cpp_frames.push_back(cpp_frame)
+    return <uintptr_t> _init_from_frames(cpp_frames)
+
+
+def treelite_serialize(
+    model: uintptr_t
+) -> Dict[str, Union[List[str], List[np.ndarray]]]:
+    frames = get_frames(model)
+    header = {'format_str': [x.format.encode('utf-8') for x in frames],
+              'itemsize': [x.itemsize for x in frames]}
+    return {'header': header, 'frames': [np.asarray(x) for x in frames]}
+
+
+def treelite_deserialize(
+    payload: Dict[str, Union[List[str], List[bytes]]]
+) -> uintptr_t:
+    header, frames = payload['header'], payload['frames']
+    return init_from_frames(frames, header['format_str'], header['itemsize'])

--- a/python/cuml/ensemble/randomforest_shared.pyx
+++ b/python/cuml/ensemble/randomforest_shared.pyx
@@ -95,11 +95,12 @@ def init_from_frames(frames: List[np.ndarray],
     cdef vector[PyBufferFrame] cpp_frames
     cdef Py_buffer* buf
     cdef PyBufferFrame cpp_frame
+    format_bytes = [s.encode('utf-8') for s in format_str]
     for i, frame in enumerate(frames):
         x = memoryview(frame)
         buf = PyMemoryView_GET_BUFFER(<PyObject*>x)
         cpp_frame.buf = buf.buf
-        cpp_frame.format = format_str[i]
+        cpp_frame.format = format_bytes[i]
         cpp_frame.itemsize = itemsize[i]
         cpp_frame.nitem = buf.len // itemsize[i]
         cpp_frames.push_back(cpp_frame)
@@ -110,7 +111,7 @@ def treelite_serialize(
     model: uintptr_t
 ) -> Dict[str, Union[List[str], List[np.ndarray]]]:
     frames = get_frames(model)
-    header = {'format_str': [x.format.encode('utf-8') for x in frames],
+    header = {'format_str': [x.format for x in frames],
               'itemsize': [x.itemsize for x in frames]}
     return {'header': header, 'frames': [np.asarray(x) for x in frames]}
 

--- a/python/cuml/ensemble/randomforest_shared.pyx
+++ b/python/cuml/ensemble/randomforest_shared.pyx
@@ -77,22 +77,13 @@ cdef PyBufferFrameWrapper MakePyBufferFrameWrapper(PyBufferFrame handle):
     return wrapper
 
 cdef list _get_frames(ModelHandle model):
-    frames = []
-    cdef Model* model_obj = <Model*>model
-    cdef vector[PyBufferFrame] interface = model_obj.GetPyBuffer()
-    cdef vector[PyBufferFrame].iterator it = interface.begin()
-    while it != interface.end():
-        v = deref(it)
-        w = MakePyBufferFrameWrapper(v)
-        frames.append(memoryview(w))
-        inc(it)
-    return frames
+    return [memoryview(MakePyBufferFrameWrapper(v))
+            for v in (<Model*>model).GetPyBuffer()]
 
 cdef ModelHandle _init_from_frames(vector[PyBufferFrame] frames) except *:
     cdef Model* model_obj = new Model()
     model_obj.InitFromPyBuffer(frames)
-    cdef ModelHandle handle = <ModelHandle>model_obj
-    return handle
+    return <ModelHandle>model_obj
 
 
 def get_frames(model: uintptr_t) -> List[memoryview]:

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -420,7 +420,7 @@ class RandomForestClassifier(Base):
                                       "#1679 for more information.")
         if self.treelite_serialized_model:  # bytes -> Treelite
             tl_handle = <ModelHandle><uintptr_t>treelite_deserialize(
-                    self.treelite_serialized_model)
+                self.treelite_serialized_model)
         else:                 # RF -> Treelite
             task_category = CLASSIFICATION_MODEL
             build_treelite_forest(

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -292,7 +292,7 @@ class RandomForestRegressor(Base):
                           " the exact same results at this time.")
         self.rf_forest = None
         self.rf_forest64 = None
-        self.model_serialized = None
+        self.treelite_serialized_model = None
 
     """
     TODO:
@@ -307,7 +307,7 @@ class RandomForestRegressor(Base):
         cdef size_t params_t64
         if self.n_cols:
             # only if model has been fit previously
-            self._get_model_serialized()  # Ensure we have this cached
+            self._get_serialized_model()  # Ensure we have this cached
             if self.rf_forest:
                 params_t = <uintptr_t> self.rf_forest
                 rf_forest = \
@@ -322,7 +322,7 @@ class RandomForestRegressor(Base):
 
         state['n_cols'] = self.n_cols
         state["verbose"] = self.verbose
-        state["model_serialized"] = self.model_serialized
+        state["treelite_serialized_model"] = self.treelite_serialized_model
         state['handle'] = self.handle
         state["treelite_handle"] = None
 
@@ -344,7 +344,7 @@ class RandomForestRegressor(Base):
             rf_forest64.rf_params = state["rf_params64"]
             state["rf_forest64"] = <uintptr_t>rf_forest64
 
-        self.model_serialized = state["model_serialized"]
+        self.treelite_serialized_model = state["treelite_serialized_model"]
         self.__dict__.update(state)
 
     def __del__(self):
@@ -367,7 +367,7 @@ class RandomForestRegressor(Base):
             TreeliteModel.free_treelite_model(self.treelite_handle)
 
         self.treelite_handle = None
-        self.model_serialized = None
+        self.treelite_serialized_model = None
         self.n_cols = None
 
     def _get_max_feat_val(self):
@@ -397,11 +397,12 @@ class RandomForestRegressor(Base):
         cdef ModelHandle tl_handle = NULL
         cdef RandomForestMetaData[float, float] *rf_forest = \
             <RandomForestMetaData[float, float]*><uintptr_t> self.rf_forest
-        assert self.model_serialized or self.rf_forest, \
+        assert self.treelite_serialized_model or self.rf_forest, \
             "Attempting to create treelite from un-fit forest."
 
-        if self.model_serialized:  # bytes -> Treelite
-            tl_handle_int = treelite_deserialize(self.model_serialized)
+        if self.treelite_serialized_model:  # bytes -> Treelite
+            tl_handle_int = \
+                treelite_deserialize(self.treelite_serialized_model)
             tl_handle = <ModelHandle>tl_handle_int
         else:                 # RF -> Treelite
             task_category = REGRESSION_MODEL
@@ -413,25 +414,26 @@ class RandomForestRegressor(Base):
         self.treelite_handle = ctypes.c_void_p(<uintptr_t>tl_handle).value
         return self.treelite_handle
 
-    def _get_model_serialized(self):
+    def _get_serialized_model(self):
         """
-        Returns the self.model_serialized.
+        Returns the self.treelite_serialized_model.
         Cuml RF model gets converted to treelite protobuf bytes by:
             1. converting the cuml RF model to a treelite model. The treelite
             models handle (pointer) is returned
             2. The treelite model handle is converted to bytes.
-        The treelite model bytes are stored in `self.model_serialized`. If the
-        model bytes are present, we can skip _obtain_treelite_handle().
+        The treelite model bytes are stored in
+        `self.treelite_serialized_model`. If the model bytes are present, we
+        can skip _obtain_treelite_handle().
         """
-        if self.model_serialized:
-            return self.model_serialized
+        if self.treelite_serialized_model:
+            return self.treelite_serialized_model
         elif self.treelite_handle:
             fit_mod_ptr = self.treelite_handle
         else:
             fit_mod_ptr = self._obtain_treelite_handle()
         cdef uintptr_t model_ptr = <uintptr_t> fit_mod_ptr
-        self.model_serialized = treelite_serialize(model_ptr)
-        return self.model_serialized
+        self.treelite_serialized_model = treelite_serialize(model_ptr)
+        return self.treelite_serialized_model
 
     def convert_to_treelite_model(self):
         """
@@ -499,11 +501,11 @@ class RandomForestRegressor(Base):
     TODO : Move functions duplicated in the RF classifier and regressor
            to a shared file. Cuml issue #1854 has been created to track this.
     """
-    def _tl_handle_from_bytes(self, model_serialized):
-        if not model_serialized:
+    def _tl_handle_from_bytes(self, treelite_serialized_model):
+        if not treelite_serialized_model:
             raise ValueError(
                 '_tl_handle_from_bytes() requires non-empty serialized model')
-        tl_handle_int = treelite_deserialize(model_serialized)
+        tl_handle_int = treelite_deserialize(treelite_serialized_model)
         return ctypes.c_void_p(tl_handle_int).value
 
     def _concatenate_treelite_handle(self, treelite_handle):
@@ -520,7 +522,7 @@ class RandomForestRegressor(Base):
         concat_model_handle = concatenate_trees(deref(model_handles))
         cdef uintptr_t concat_model_ptr = <uintptr_t> concat_model_handle
         self.treelite_handle = concat_model_ptr
-        self.model_serialized = treelite_serialize(concat_model_ptr)
+        self.treelite_serialized_model = treelite_serialize(concat_model_ptr)
 
         # Fix up some instance variables that should match the new TL model
         tl_model = TreeliteModel.from_treelite_model_handle(
@@ -910,7 +912,7 @@ class RandomForestRegressor(Base):
         -----------
         params : dict of new params
         """
-        self.model_serialized = None
+        self.treelite_serialized_model = None
         if not params:
             return self
         for key, value in params.items():

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -400,7 +400,7 @@ class RandomForestRegressor(Base):
 
         if self.treelite_serialized_model:  # bytes -> Treelite
             tl_handle = <ModelHandle><uintptr_t>treelite_deserialize(
-                    self.treelite_serialized_model)
+                self.treelite_serialized_model)
         else:                 # RF -> Treelite
             task_category = REGRESSION_MODEL
             build_treelite_forest(

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -39,6 +39,8 @@ from cuml.ensemble.randomforest_common import _check_fil_parameter_validity, \
     _check_fil_sparse_format_value, _obtain_treelite_model, _obtain_fil_model
 
 from cuml.ensemble.randomforest_shared cimport *
+from cuml.ensemble.randomforest_shared import treelite_serialize, \
+    treelite_deserialize
 from cuml.fil.fil import TreeliteModel
 from cuml.common import input_to_cuml_array, input_to_dev_array, \
     zeros, get_cudf_column_ptr
@@ -277,10 +279,10 @@ class RandomForestRegressor(Base):
         self.max_depth = max_depth
         self.max_features = max_features
         self.bootstrap = bootstrap
+        self.treelite_handle = None
         self.n_bins = n_bins
         self.n_cols = None
         self.dtype = None
-        self.treelite_handle = None
         self.accuracy_metric = accuracy_metric
         self.quantile_per_tree = quantile_per_tree
         self.n_streams = handle.getNumInternalStreams()
@@ -290,7 +292,7 @@ class RandomForestRegressor(Base):
                           " the exact same results at this time.")
         self.rf_forest = None
         self.rf_forest64 = None
-        self.model_pbuf_bytes = bytearray()
+        self.model_serialized = None
 
     """
     TODO:
@@ -305,7 +307,7 @@ class RandomForestRegressor(Base):
         cdef size_t params_t64
         if self.n_cols:
             # only if model has been fit previously
-            self._get_protobuf_bytes()  # Ensure we have this cached
+            self._get_model_serialized()  # Ensure we have this cached
             if self.rf_forest:
                 params_t = <uintptr_t> self.rf_forest
                 rf_forest = \
@@ -320,7 +322,7 @@ class RandomForestRegressor(Base):
 
         state['n_cols'] = self.n_cols
         state["verbose"] = self.verbose
-        state["model_pbuf_bytes"] = self.model_pbuf_bytes
+        state["model_serialized"] = self.model_serialized
         state['handle'] = self.handle
         state["treelite_handle"] = None
 
@@ -342,7 +344,7 @@ class RandomForestRegressor(Base):
             rf_forest64.rf_params = state["rf_params64"]
             state["rf_forest64"] = <uintptr_t>rf_forest64
 
-        self.model_pbuf_bytes = state["model_pbuf_bytes"]
+        self.model_serialized = state["model_serialized"]
         self.__dict__.update(state)
 
     def __del__(self):
@@ -365,7 +367,7 @@ class RandomForestRegressor(Base):
             TreeliteModel.free_treelite_model(self.treelite_handle)
 
         self.treelite_handle = None
-        self.model_pbuf_bytes = bytearray()
+        self.model_serialized = None
         self.n_cols = None
 
     def _get_max_feat_val(self):
@@ -391,58 +393,45 @@ class RandomForestRegressor(Base):
         delete the returned model."""
         if self.treelite_handle is not None:
             return self.treelite_handle  # Cached version
-
-        cdef ModelHandle cuml_model_ptr = NULL
+        cdef uintptr_t tl_handle_int
+        cdef ModelHandle tl_handle = NULL
         cdef RandomForestMetaData[float, float] *rf_forest = \
             <RandomForestMetaData[float, float]*><uintptr_t> self.rf_forest
-        assert len(self.model_pbuf_bytes) > 0 or self.rf_forest, \
+        assert self.model_serialized or self.rf_forest, \
             "Attempting to create treelite from un-fit forest."
 
-        cdef unsigned char[::1] model_pbuf_mv = self.model_pbuf_bytes
-        cdef vector[unsigned char] model_pbuf_vec
-        with cython.boundscheck(False):
-            model_pbuf_vec.assign(& model_pbuf_mv[0],
-                                  & model_pbuf_mv[model_pbuf_mv.shape[0]])
-
-        task_category = REGRESSION_MODEL
-        build_treelite_forest(
-            & cuml_model_ptr,
-            rf_forest,
-            <int> self.n_cols,
-            <int> task_category,
-            model_pbuf_vec)
-        mod_ptr = <uintptr_t> cuml_model_ptr
-        self.treelite_handle = ctypes.c_void_p(mod_ptr).value
+        if self.model_serialized:  # bytes -> Treelite
+            tl_handle_int = treelite_deserialize(self.model_serialized)
+            tl_handle = <ModelHandle>tl_handle_int
+        else:                 # RF -> Treelite
+            task_category = REGRESSION_MODEL
+            build_treelite_forest(
+                &tl_handle,
+                rf_forest,
+                <int> self.n_cols,
+                <int> task_category)
+        self.treelite_handle = ctypes.c_void_p(<uintptr_t>tl_handle).value
         return self.treelite_handle
 
-    def _get_protobuf_bytes(self):
+    def _get_model_serialized(self):
         """
-        Returns the self.model_pbuf_bytes.
+        Returns the self.model_serialized.
         Cuml RF model gets converted to treelite protobuf bytes by:
             1. converting the cuml RF model to a treelite model. The treelite
             models handle (pointer) is returned
-            2. The treelite model handle is used to convert the treelite model
-            to a treelite protobuf model which is stored in a temporary file.
-            The protobuf model information is read from the temporary file and
-            the byte information is returned.
-        The treelite handle is stored `self.treelite_handle` and the treelite
-        protobuf model bytes are stored in `self.model_pbuf_bytes`. If either
-        of information is already present in the model then the respective
-        step is skipped.
+            2. The treelite model handle is converted to bytes.
+        The treelite model bytes are stored in `self.model_serialized`. If the
+        model bytes are present, we can skip _obtain_treelite_handle().
         """
-        if self.model_pbuf_bytes:
-            return self.model_pbuf_bytes
+        if self.model_serialized:
+            return self.model_serialized
         elif self.treelite_handle:
             fit_mod_ptr = self.treelite_handle
         else:
             fit_mod_ptr = self._obtain_treelite_handle()
         cdef uintptr_t model_ptr = <uintptr_t> fit_mod_ptr
-        cdef vector[unsigned char] pbuf_mod_info = \
-            save_model(<ModelHandle> model_ptr)
-        cdef unsigned char[::1] pbuf_mod_view = \
-            <unsigned char[:pbuf_mod_info.size():1]>pbuf_mod_info.data()
-        self.model_pbuf_bytes = bytearray(memoryview(pbuf_mod_view))
-        return self.model_pbuf_bytes
+        self.model_serialized = treelite_serialize(model_ptr)
+        return self.model_serialized
 
     def convert_to_treelite_model(self):
         """
@@ -510,19 +499,12 @@ class RandomForestRegressor(Base):
     TODO : Move functions duplicated in the RF classifier and regressor
            to a shared file. Cuml issue #1854 has been created to track this.
     """
-    def _tl_model_handles(self, model_bytes):
-        task_category = REGRESSION_MODEL
-        cdef ModelHandle tl_model_ptr = NULL
-        cdef RandomForestMetaData[float, float] *rf_forest = \
-            <RandomForestMetaData[float, float]*><uintptr_t> self.rf_forest
-        build_treelite_forest(& tl_model_ptr,
-                              rf_forest,
-                              <int> self.n_cols,
-                              <int> task_category,
-                              <vector[unsigned char] &> model_bytes)
-        mod_handle = <uintptr_t> tl_model_ptr
-
-        return ctypes.c_void_p(mod_handle).value
+    def _tl_handle_from_bytes(self, model_serialized):
+        if not model_serialized:
+            raise ValueError(
+                '_tl_handle_from_bytes() requires non-empty serialized model')
+        tl_handle_int = treelite_deserialize(model_serialized)
+        return ctypes.c_void_p(tl_handle_int).value
 
     def _concatenate_treelite_handle(self, treelite_handle):
         cdef ModelHandle concat_model_handle = NULL
@@ -538,11 +520,7 @@ class RandomForestRegressor(Base):
         concat_model_handle = concatenate_trees(deref(model_handles))
         cdef uintptr_t concat_model_ptr = <uintptr_t> concat_model_handle
         self.treelite_handle = concat_model_ptr
-        cdef vector[unsigned char] pbuf_mod_info = \
-            save_model(<ModelHandle> concat_model_ptr)
-        cdef unsigned char[::1] pbuf_mod_view = \
-            <unsigned char[:pbuf_mod_info.size():1]>pbuf_mod_info.data()
-        self.model_pbuf_bytes = bytearray(memoryview(pbuf_mod_view))
+        self.model_serialized = treelite_serialize(concat_model_ptr)
 
         # Fix up some instance variables that should match the new TL model
         tl_model = TreeliteModel.from_treelite_model_handle(
@@ -659,7 +637,6 @@ class RandomForestRegressor(Base):
     def _predict_model_on_gpu(self, X, algo, convert_dtype,
                               fil_sparse_format):
         out_type = self._get_output_type(X)
-        cdef ModelHandle cuml_model_ptr = NULL
         _, n_rows, n_cols, dtype = \
             input_to_cuml_array(X, order='F',
                                 check_cols=self.n_cols)
@@ -933,7 +910,7 @@ class RandomForestRegressor(Base):
         -----------
         params : dict of new params
         """
-        self.model_pbuf_bytes = []
+        self.model_serialized = None
         if not params:
             return self
         for key, value in params.items():

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -61,6 +61,8 @@ cdef extern from "treelite/c_api.h":
     cdef int TreeliteQueryNumFeature(ModelHandle handle, size_t* out) except +
     cdef int TreeliteLoadLightGBMModel(const char* filename,
                                        ModelHandle* out) except +
+    cdef int TreeliteLoadProtobufModel(const char* filename,	
+                                       ModelHandle* out) except +
     cdef const char* TreeliteGetLastError()
 
 
@@ -127,7 +129,7 @@ cdef class TreeliteModel():
             Path to treelite model file to load
 
         model_type : string
-            Type of model: 'xgboost', or 'lightgbm'
+            Type of model: 'xgboost', 'protobuf', or 'lightgbm'
         """
         filename_bytes = filename.encode("UTF-8")
         cdef ModelHandle handle
@@ -135,6 +137,12 @@ cdef class TreeliteModel():
             res = TreeliteLoadXGBoostModel(filename_bytes, &handle)
             if res < 0:
                 err = TreeliteGetLastError()
+                raise RuntimeError("Failed to load %s (%s)" % (filename, err))
+        elif model_type == "protobuf":	
+            # XXX Not tested	
+            res = TreeliteLoadProtobufModel(filename_bytes, &handle)	
+            if res < 0:	
+                err = TreeliteGetLastError()	
                 raise RuntimeError("Failed to load %s (%s)" % (filename, err))
         elif model_type == "lightgbm":
             res = TreeliteLoadLightGBMModel(filename_bytes, &handle)

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -61,8 +61,6 @@ cdef extern from "treelite/c_api.h":
     cdef int TreeliteQueryNumFeature(ModelHandle handle, size_t* out) except +
     cdef int TreeliteLoadLightGBMModel(const char* filename,
                                        ModelHandle* out) except +
-    cdef int TreeliteLoadProtobufModel(const char* filename,
-                                       ModelHandle* out) except +
     cdef const char* TreeliteGetLastError()
 
 
@@ -129,18 +127,12 @@ cdef class TreeliteModel():
             Path to treelite model file to load
 
         model_type : string
-            Type of model: 'xgboost', 'protobuf', or 'lightgbm'
+            Type of model: 'xgboost', or 'lightgbm'
         """
         filename_bytes = filename.encode("UTF-8")
         cdef ModelHandle handle
         if model_type == "xgboost":
             res = TreeliteLoadXGBoostModel(filename_bytes, &handle)
-            if res < 0:
-                err = TreeliteGetLastError()
-                raise RuntimeError("Failed to load %s (%s)" % (filename, err))
-        elif model_type == "protobuf":
-            # XXX Not tested
-            res = TreeliteLoadProtobufModel(filename_bytes, &handle)
             if res < 0:
                 err = TreeliteGetLastError()
                 raise RuntimeError("Failed to load %s (%s)" % (filename, err))

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -61,7 +61,7 @@ cdef extern from "treelite/c_api.h":
     cdef int TreeliteQueryNumFeature(ModelHandle handle, size_t* out) except +
     cdef int TreeliteLoadLightGBMModel(const char* filename,
                                        ModelHandle* out) except +
-    cdef int TreeliteLoadProtobufModel(const char* filename,	
+    cdef int TreeliteLoadProtobufModel(const char* filename,
                                        ModelHandle* out) except +
     cdef const char* TreeliteGetLastError()
 
@@ -138,11 +138,11 @@ cdef class TreeliteModel():
             if res < 0:
                 err = TreeliteGetLastError()
                 raise RuntimeError("Failed to load %s (%s)" % (filename, err))
-        elif model_type == "protobuf":	
-            # XXX Not tested	
-            res = TreeliteLoadProtobufModel(filename_bytes, &handle)	
-            if res < 0:	
-                err = TreeliteGetLastError()	
+        elif model_type == "protobuf":
+            # XXX Not tested
+            res = TreeliteLoadProtobufModel(filename_bytes, &handle)
+            if res < 0:
+                err = TreeliteGetLastError()
                 raise RuntimeError("Failed to load %s (%s)" % (filename, err))
         elif model_type == "lightgbm":
             res = TreeliteLoadLightGBMModel(filename_bytes, &handle)


### PR DESCRIPTION
## Summary
Speed up serialization of Treelite model objects and reduce overhead in multi-GPU RF prediction.

## Features
* Flat object layout: now Tree is an array of POD objects (Node). As a consequence, all queries for a give node should now be made via methods of Tree class.
* Binary serialization without depending on Protobuf
* Eliminate the use of tempfile.

## Benchmark setup
* Using [this script](https://github.com/hcho3/cuml/tree/rf_benchmark) by @Salonijain27. See the link for instructions.
* AWS EC2 instance g4dn.12xlarge, T4 GPU (16 GB GDDR6) X 4
* Benchmark setting: `n_gpus=2, n_gb=2, n_features=20, depth=25, n_estimators=10`. This leads to a forest consisting of 10 depth-25 trees, and we run through 25 million data rows.

## Benchmark Results

### Aggregate

|Before | After |
|-----|----|
| 269.0 sec | 109.4 sec (**2.46x speedup**) |

### Breakdown by components
Notice that some of the overhead is still yet to be explained. Also note that the actual prediction time is a small portion of the total run time. Due to the nature of distributed algorithm, timing measures are approximate.

**Current cuML**

  | Master | Worker 0 | Worker 1
-- | -- | -- | --
RF->Treelite |   | 32.6 | 32.8
Treelite->Protobuf |   | 10.8 | 11.3
(Copy models workers -> master) |   |   |  
Protobuf->Treelite |   | 26.6 | 23.8
Concatenate Treelite handles | 23.3 |   |  
(Copy model master -> workers) |   |   |  
Protobuf->Treelite |   | 52.2 | 52.3
Treelite->FIL |   | 8.6 | 8.5
FIL predict |   | 2.9 | 1.1

**This PR**

  | Master | Worker 0 | Worker 1
-- | -- | -- | --
RF->Treelite |   | 22.1 | 22.5
Treelite->Bytes |   | < 0.001 | < 0.001
(Copy models workers -> master) |   |   |  
Bytes->Treelite |   | < 0.001 | < 0.001
Concatenate Treelite handles | 3.1 |   |  
(Copy model master -> workers) |   |   |  
Bytes->Treelite |   | < 0.001 | < 0.001
Treelite->FIL |   | 4.8 | 4.7
FIL predict |   | 4.9 | 1.1


