### PR TITLE
[REVIEW] Clarify _unique default implementation in OneHotEncoder [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #2231: Using OPG structs from `cuml.common` in decomposition algorithms
 - PR #2259: Add CumlArray support to Naive Bayes
 - PR #2252: Add benchmark for the Gram matrix prims
+- PR #2271: Clarify doc for _unique default implementation in OneHotEncoder
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -175,11 +175,14 @@ class OneHotEncoder:
             return X
 
     def _check_input_fit(self, X, is_categories=False):
-        """Helper function used in fit. Can be overridden in subclasses"""
+        """Helper function used in fit. Can be overridden in subclasses. """
         return self._check_input(X, is_categories=is_categories)
 
     def _unique(self, inp):
-        """Helper function used in fit. Can be overridden in subclasses"""
+        """Helper function used in fit. Can be overridden in subclasses. """
+
+        # Default implementation passes input through directly since this is
+        # performed in `LabelEncoder.fit()`
         return inp
 
     def _has_unknown(self, X_cat, encoder_cat):


### PR DESCRIPTION
Addresses https://github.com/rapidsai/cuml/pull/1994#pullrequestreview-413614390.