### PR TITLE
[REVIEW] Add docs build.sh [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #2231: Using OPG structs from `cuml.common` in decomposition algorithms
 - PR #2259: Add CumlArray support to Naive Bayes
 - PR #2252: Add benchmark for the Gram matrix prims
+- PR #2272: Add docs build.sh script to repository
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -1,37 +1,22 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
-#########################################
-# cuML GPU build and test script for CI #
-#########################################
-set -ex
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#################################
+# cuML Docs build script for CI #
+#################################
 
-# Logger function for build status output
-function logger() {
-  echo -e "\n>>>> $@\n"
-}
+if [ -z "$PROJECT_WORKSPACE" ]; then
+    echo ">>>> ERROR: Could not detect PROJECT_WORKSPACE in environment"
+    echo ">>>> WARNING: This script contains git commands meant for automated building, do not run locally"
+    exit 1
+fi
 
-# Set path and build parallel level
+export DOCS_WORKSPACE=$WORKSPACE/docs
 export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=4
-export CUDA_REL=${CUDA_VERSION%.*}
-export CUDF_VERSION=0.8.*
-export RMM_VERSION=0.8.*
-
-# Set home to the job's workspace
 export HOME=$WORKSPACE
-export DOCS_DIR=/data/docs/html
-
-while getopts "d" option; do
-    case ${option} in
-        d)
-            DOCS_DIR=${OPTARG}
-            ;;
-    esac
-done
-
-################################################################################
-# SETUP - Check environment
-################################################################################
+export PROJECT_WORKSPACE=/rapids/cuml
+export LIBCUDF_KERNEL_CACHE_PATH="$HOME/.jitify-cache"
+export NIGHTLY_VERSION=$(echo $BRANCH_VERSION | awk -F. '{print $2}')
+export PROJECTS=(cuml libcuml)
 
 logger "Check environment..."
 env
@@ -40,11 +25,11 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Activate conda env..."
-source activate gdf
-conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge \
-    cudf=$CUDF_VERSION rmm=$RMM_VERSION cudatoolkit=$CUDA_REL
+source activate rapids
+# TODO: Move installs to docs-build-env meta package
+conda install -c anaconda beautifulsoup4 jq
+pip install sphinx-markdown-tables
 
-pip install numpydoc sphinx sphinx-rtd-theme sphinxcontrib-websupport
 
 logger "Check versions..."
 python --version
@@ -52,31 +37,39 @@ $CC --version
 $CXX --version
 conda list
 
-################################################################################
-# BUILD - Build libcuml and cuML from source
-################################################################################
-
-cd $WORKSPACE
-git submodule update --init --recursive
-
-logger "Build libcuml..."
-$WORKSPACE/build.sh clean libcuml cuml
-
-################################################################################
-# BUILD - Build doxygen docs
-################################################################################
-
-cd $WORKSPACE/cpp/build
-logger "Build doxygen docs..."
+# Build Doxygen docs
+logger "Build Doxygen docs..."
+cd $PROJECT_WORKSPACE/cpp/build
 make doc
-
-################################################################################
-# BUILD - Build docs
-################################################################################
-
-logger "Build docs..."
-cd $WORKSPACE/docs
+	
+# Build Python docs
+logger "Build Sphinx docs..."
+cd $PROJECT_WORKSPACE/docs
 make html
 
-rm -rf ${DOCS_DIR}/*
-mv build/html/* $DOCS_DIR
+#Commit to Website
+cd $DOCS_WORKSPACE
+
+for PROJECT in ${PROJECTS[@]}; do
+    if [ ! -d "api/$PROJECT/$BRANCH_VERSION" ]; then
+        mkdir -p api/$PROJECT/$BRANCH_VERSION
+    fi
+    rm -rf $DOCS_WORKSPACE/api/$PROJECT/$BRANCH_VERSION/*	
+done
+
+
+mv $PROJECT_WORKSPACE/cpp/build/html/* $DOCS_WORKSPACE/api/libcuml/$BRANCH_VERSION
+mv $PROJECT_WORKSPACE/docs/build/html/* $DOCS_WORKSPACE/api/cuml/$BRANCH_VERSION
+
+# Customize HTML documentation
+./update_symlinks.sh $NIGHTLY_VERSION
+./customization/lib_map.sh
+
+
+for PROJECT in ${PROJECTS[@]}; do
+    echo ""
+    echo "Customizing: $PROJECT"
+    ./customization/customize_docs_in_folder.sh api/$PROJECT/ $NIGHTLY_VERSION
+    git add $DOCS_WORKSPACE/api/$PROJECT/*
+done
+


### PR DESCRIPTION
Moving the docs build script used in our Jenkins job into the repository itself to streamline docs building pipeline and to push possible docs build changes to developer view for editing.

This script is written to run in a devel docker image for RAPIDS, which assumes the project is already built from source in PROJECT_WORKSPACE (this variable is defined inside the jenkins job as /rapids/$PROJECT).

The script also assumes that the docs repo is cloned and located in $DOCS_WORKSPACE. After building all the docs, it will move all html files into the proper api folders in this repo, then add the relevant folders for a git commit and git push to be executed inside the Jenkins job.