### PR TITLE
[REVIEW] Fix parameter name verbose to verbosity in mnmg OneHotEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
 - PR #2249: Fix bug in UMAP continuous target metrics
 - PR #2258: Fix doxygen build break
 - PR #2255: Set random_state for train_test_split function in dask RF
+- PR #2274: Fix parameter name verbose to verbosity in mnmg OneHotEncoder
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/cuml/dask/preprocessing/encoders.py
+++ b/python/cuml/dask/preprocessing/encoders.py
@@ -17,6 +17,7 @@ from cuml.common import with_cupy_rmm
 from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedTransformMixin
 from cuml.dask.common.base import DelayedInverseTransformMixin
+import cuml.common.logger as logger
 
 from toolz import first
 
@@ -73,9 +74,9 @@ class OneHotEncoder(BaseEstimator, DelayedTransformMixin,
         will be denoted as None.
     """
 
-    def __init__(self, client=None, verbose=False, **kwargs):
+    def __init__(self, client=None, verbosity=logger.LEVEL_INFO, **kwargs):
         super(OneHotEncoder, self).__init__(client=client,
-                                            verbose=verbose,
+                                            verbosity=verbosity,
                                             **kwargs)
 
     @with_cupy_rmm


### PR DESCRIPTION
Fix CI errors introduced by #1994.