### PR TITLE
Ensure `CumlArray` provided `dtype` conforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - PR #2252: Add benchmark for the Gram matrix prims
 - PR #2271: Clarify doc for _unique default implementation in OneHotEncoder
 - PR #2272: Add docs build.sh script to repository
+- PR #2276: Ensure `CumlArray` provided `dtype` conforms
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
 - PR #2257: Update QN and LogisticRegression to use CumlArray
 - PR #2259: Add CumlArray support to Naive Bayes
 - PR #2252: Add benchmark for the Gram matrix prims
-- PR #2271: Clarify doc for _unique default implementation in OneHotEncoder
+- PR #2271: Clarify doc for `_unique` default implementation in OneHotEncoder
 - PR #2272: Add docs build.sh script to repository
 - PR #2276: Ensure `CumlArray` provided `dtype` conforms
 

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -118,6 +118,8 @@ class CumlArray(Buffer):
                             " Array.empty().")
         elif isinstance(data, memoryview):
             data = np.asarray(data)
+        if dtype is not None:
+            dtype = np.dtype(dtype)
 
         if _check_low_level_type(data):
             if dtype is None or shape is None or order is None:
@@ -139,7 +141,7 @@ class CumlArray(Buffer):
         # Post processing of meta data
         if detailed_construction:
             self.shape = shape
-            self.dtype = np.dtype(dtype)
+            self.dtype = dtype
             self.order = order
             self.strides = _order_to_strides(order, shape, dtype)
 


### PR DESCRIPTION
Make sure that if `dtype` is specified in `CumlArray` that it is coerced into a NumPy `dtype` object, which can more easily be worked with. If `dtype` is some non-`None` value that cannot be coerced, this will ensure we raise early before using `dtype` later.