### PR TITLE
Rely on cuDF's `Serializable` in `CumlArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - PR #2271: Clarify doc for `_unique` default implementation in OneHotEncoder
 - PR #2272: Add docs build.sh script to repository
 - PR #2276: Ensure `CumlArray` provided `dtype` conforms
+- PR #2281: Rely on cuDF's `Serializable` in `CumlArray`
 
 ## Bug Fixes
 - PR #1939: Fix syntax error in cuml.common.array

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -16,7 +16,6 @@
 
 import cupy as cp
 import numpy as np
-import pickle
 
 from rmm import DeviceBuffer
 from cudf.core import Buffer, Series, DataFrame
@@ -170,12 +169,6 @@ class CumlArray(Buffer):
 
     def __setitem__(self, slice, value):
         cp.asarray(self).__setitem__(slice, value)
-
-    def __reduce_ex__(self, protocol):
-        data = self.to_output('numpy')
-        if protocol >= 5:
-            data = pickle.PickleBuffer(data)
-        return self.__class__, (data,)
 
     def __len__(self):
         return self.shape[0]


### PR DESCRIPTION
Depends on PR ( https://github.com/rapidsai/cudf/pull/5139 ) and nightlies with that change.

Update `CumlArray` to rely on cuDF's `Serializable`, which cuDF's `Buffer` inherits from. In particular `Serializable` already provides pickling support through a `__reduce_ex__` method of its own, which just builds off of the `serialize` and `deserialize` methods that all `Serializable` subclasses must implement and `CumlArray` already does (either by directly implementing them or relying on cuDF `Buffer`'s implementations). So no extra work is needed to just drop this.