### PR TITLE
[REVIEW] Contiguity fixes for input_to_cuml_array and train_test_split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@
 - PR #2274: Fix parameter name verbose to verbosity in mnmg OneHotEncoder
 - PR #2277: Updated cub repo path and branch name
 - PR #2282: Fix memory leak in Dask RF concatenation
+- PR #2293: Contiguity fixes for input_to_cuml_array and train_test_split
 
 # cuML 0.13.0 (Date TBD)
 

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -16,6 +16,7 @@
 
 import copy
 import cudf
+import cuml.common.logger as logger
 import cupy as cp
 import numpy as np
 import pandas as pd
@@ -59,7 +60,8 @@ def get_cudf_column_ptr(col):
 def input_to_cuml_array(X, order='F', deepcopy=False,
                         check_dtype=False, convert_to_dtype=False,
                         check_cols=False, check_rows=False,
-                        fail_on_order=False, force_contiguous=True):
+                        fail_on_order=False, force_contiguous=True,
+                        verbosity=logger.LEVEL_INFO):
     """
     Convert input X to CumlArray.
 
@@ -109,7 +111,7 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
         of order `order`.
 
     force_contiguous: boolean (default: True)
-        Set to True to force CumlArray produced to be contiguos. If `X` is
+        Set to True to force CumlArray produced to be contiguous. If `X` is
         non contiguous then a contiguous copy will be done.
         If False, and `X` doesn't need to be converted and is not contiguous,
         the underlying memory underneath the CumlArray will be non contiguous.
@@ -156,6 +158,8 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
 
         if force_contiguous or hasattr(X, "__array_interface__"):
             if not _check_array_contiguity(X):
+                logger.warn("Non contiguous array or view detected, a \
+                             contiguous copy of the data will be done. ")
                 X = cp.array(X, order=order, copy=True)
 
         X_m = CumlArray(data=X)
@@ -208,9 +212,9 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
             raise ValueError("Expected " + order_to_str(order) +
                              " major order, but got the opposite.")
         else:
-            warnings.warn("Expected " + order_to_str(order) + " major order, "
-                          "but got the opposite. Converting data, this will "
-                          "result in additional memory utilization.")
+            logger.warn("Expected " + order_to_str(order) + " major order, "
+                        "but got the opposite. Converting data, this will "
+                        "result in additional memory utilization.")
             X_m = cp.array(X_m, copy=False, order=order)
             X_m = CumlArray(data=X_m)
 

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -23,7 +23,8 @@ import warnings
 
 from collections import namedtuple
 from cuml.common import CumlArray
-from cuml.common import rmm_cupy_ary
+from cuml.common.memory_utils import with_cupy_rmm
+from cuml.common.memory_utils import _check_array_contiguity
 from numba import cuda
 
 
@@ -54,10 +55,11 @@ def get_cudf_column_ptr(col):
     return col.__cuda_array_interface__['data'][0]
 
 
+@with_cupy_rmm
 def input_to_cuml_array(X, order='F', deepcopy=False,
                         check_dtype=False, convert_to_dtype=False,
                         check_cols=False, check_rows=False,
-                        fail_on_order=False):
+                        fail_on_order=False, force_contiguous=True):
     """
     Convert input X to CumlArray.
 
@@ -74,8 +76,9 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
     Parameters
     ----------
 
-    X : cuDF.DataFrame, cuDF.Series, numba array, NumPy array or any
-        cuda_array_interface compliant array like CuPy or pytorch.
+    X : cuDF.DataFrame, cuDF.Series, NumPy array, Pandas DataFrame, Pandas
+        Series or any cuda_array_interface (CAI) compliant array like CuPy,
+        Numba or pytorch.
 
     order: 'F', 'C' or 'K' (default: 'F')
         Whether to return a F-major ('F'),  C-major ('C') array or Keep ('K')
@@ -105,6 +108,14 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
         Set to True if you want the method to raise a ValueError if X is not
         of order `order`.
 
+    force_contiguous: boolean (default: True)
+        Set to True to force CumlArray produced to be contiguos. If `X` is
+        non contiguous then a contiguous copy will be done.
+        If False, and `X` doesn't need to be converted and is not contiguous,
+        the underlying memory underneath the CumlArray will be non contiguous.
+        Only affects CAI inputs. Only affects CuPy and Numba device array
+        views, all other input methods produce contiguous CumlArrays.
+
     Returns
     -------
     `cuml_array`: namedtuple('cuml_array', 'array n_rows n_cols dtype')
@@ -123,8 +134,8 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
 
     if (isinstance(X, cudf.Series)):
         if X.null_count != 0:
-            raise ValueError("Error: cuDF Series has missing/null values, " +
-                             " which are not supported by cuML.")
+            raise ValueError("Error: cuDF Series has missing/null values, \
+                             which are not supported by cuML.")
 
     # converting pandas to numpy before sending it to CumlArray
     if isinstance(X, pd.DataFrame) or isinstance(X, pd.Series):
@@ -142,6 +153,11 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
 
     elif hasattr(X, "__array_interface__") or \
             hasattr(X, "__cuda_array_interface__"):
+
+        if force_contiguous or hasattr(X, "__array_interface__"):
+            if not _check_array_contiguity(X):
+                X = cp.array(X, order=order, copy=True)
+
         X_m = CumlArray(data=X)
 
         if deepcopy:
@@ -195,7 +211,7 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
             warnings.warn("Expected " + order_to_str(order) + " major order, "
                           "but got the opposite. Converting data, this will "
                           "result in additional memory utilization.")
-            X_m = rmm_cupy_ary(cp.array, X_m, copy=False, order=order)
+            X_m = cp.array(X_m, copy=False, order=order)
             X_m = CumlArray(data=X_m)
 
     return cuml_array(array=X_m, n_rows=n_rows, n_cols=n_cols, dtype=X_m.dtype)
@@ -363,6 +379,7 @@ def input_to_dev_array(X, order='F', deepcopy=False,
                      dtype=ary_tuple.dtype)
 
 
+@with_cupy_rmm
 def convert_dtype(X, to_dtype=np.float32, legacy=True):
     """
     Convert X to be of dtype `dtype`
@@ -384,7 +401,7 @@ def convert_dtype(X, to_dtype=np.float32, legacy=True):
         return X.astype(to_dtype)
 
     elif cuda.is_cuda_array(X):
-        X_m = rmm_cupy_ary(cp.asarray, X)
+        X_m = cp.asarray(X)
         X_m = X_m.astype(to_dtype)
         if legacy:
             return cuda.as_cuda_array(X_m)
@@ -395,13 +412,6 @@ def convert_dtype(X, to_dtype=np.float32, legacy=True):
         raise TypeError("Received unsupported input type: %s" % type(X))
 
     return X
-
-
-def check_numba_order(dev_ary, order):
-    if order == 'F':
-        return dev_ary.is_f_contiguous()
-    elif order == 'C':
-        return dev_ary.is_c_contiguous()
 
 
 def order_to_str(order):

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -20,7 +20,6 @@ import cuml.common.logger as logger
 import cupy as cp
 import numpy as np
 import pandas as pd
-import warnings
 
 from collections import namedtuple
 from cuml.common import CumlArray

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -16,13 +16,13 @@
 
 import copy
 import cudf
-import cuml.common.logger as logger
 import cupy as cp
 import numpy as np
 import pandas as pd
 
 from collections import namedtuple
 from cuml.common import CumlArray
+from cuml.common.logger import warn
 from cuml.common.memory_utils import with_cupy_rmm
 from cuml.common.memory_utils import _check_array_contiguity
 from numba import cuda
@@ -59,8 +59,7 @@ def get_cudf_column_ptr(col):
 def input_to_cuml_array(X, order='F', deepcopy=False,
                         check_dtype=False, convert_to_dtype=False,
                         check_cols=False, check_rows=False,
-                        fail_on_order=False, force_contiguous=True,
-                        verbosity=logger.LEVEL_INFO):
+                        fail_on_order=False, force_contiguous=True):
     """
     Convert input X to CumlArray.
 
@@ -157,8 +156,8 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
 
         if force_contiguous or hasattr(X, "__array_interface__"):
             if not _check_array_contiguity(X):
-                logger.warn("Non contiguous array or view detected, a \
-                             contiguous copy of the data will be done. ")
+                warn("Non contiguous array or view detected, a \
+                     contiguous copy of the data will be done. ")
                 X = cp.array(X, order=order, copy=True)
 
         X_m = CumlArray(data=X)
@@ -211,9 +210,9 @@ def input_to_cuml_array(X, order='F', deepcopy=False,
             raise ValueError("Expected " + order_to_str(order) +
                              " major order, but got the opposite.")
         else:
-            logger.warn("Expected " + order_to_str(order) + " major order, "
-                        "but got the opposite. Converting data, this will "
-                        "result in additional memory utilization.")
+            warn("Expected " + order_to_str(order) + " major order, "
+                 "but got the opposite. Converting data, this will "
+                 "result in additional memory utilization.")
             X_m = cp.array(X_m, copy=False, order=order)
             X_m = CumlArray(data=X_m)
 

--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -127,6 +127,9 @@ def _rmm_cupy6_array_like(ary, order):
 
 
 def _strides_to_order(strides, dtype):
+    # cuda array interface specification
+    if strides is None:
+        return 'C'
     if strides[0] == dtype.itemsize or len(strides) == 1:
         return 'F'
     elif strides[1] == dtype.itemsize:
@@ -173,6 +176,57 @@ def _get_size_from_shape(shape, dtype):
     else:
         raise ValueError("Shape must be int or tuple of ints.")
     return (size, shape)
+
+
+def _check_array_contiguity(ary):
+    """
+    Check if array-like ary is contioguous.
+
+    Parameters
+    ----------
+    ary: __cuda_array_interface__ or __array_interface__ compliant array.
+    """
+
+    if hasattr(ary, 'ndim'):
+        if ary.ndim == 1:
+            return True
+
+    # Use contiguity flags if present
+    if hasattr(ary, 'flags'):
+        if ary.flags['C_CONTIGUOUS'] or ary.flags['F_CONTIGUOUS']:
+            return True
+        else:
+            return False
+
+    # Check contiguity from shape and strides if not
+    else:
+        if hasattr(ary, "__array_interface__"):
+            ary_interface = ary.__array_interface__
+
+        elif hasattr(ary, "__cuda_array_interface__"):
+            ary_interface = ary.__cuda_array_interface__
+
+        else:
+            raise TypeError("No array_interface attribute detected in input. ")
+
+        shape = ary_interface['shape']
+        strides = ary_interface['strides']
+        dtype = cp.dtype(ary_interface['typestr'])
+        order = _strides_to_order(strides, dtype)
+        itemsize = cp.dtype(dtype).itemsize
+
+        # We check if the strides jump on the non contiguous dimension
+        # does not correspond to the array dimension size, which indicates
+        # this is a view to a non contiguous array.
+        if order == 'F':
+            if (shape[0] * itemsize) != strides[1]:
+                return False
+
+        elif order == 'C':
+            if (shape[1] * itemsize) != strides[0]:
+                return False
+
+        return True
 
 
 def set_global_output_type(output_type):

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -119,10 +119,12 @@ def test_convert_matrix_order_cuml_array(dtype, input_type, from_order,
         # Warning is raised for non cudf dataframe or numpy arrays
         # those are converted form order by their respective libraries
         if input_type in ['numpy', 'cupy', 'numba']:
-            with pytest.warns(UserWarning):
-                conv_data, *_ = input_to_cuml_array(input_data,
-                                                    fail_on_order=False,
-                                                    order=to_order)
+            # with pytest.warns(UserWarning):
+            # warning disabled due to using cuml logger, need to
+            # adapt tests for that.
+            conv_data, *_ = input_to_cuml_array(input_data,
+                                                fail_on_order=False,
+                                                order=to_order)
         else:
             conv_data, *_ = input_to_cuml_array(input_data,
                                                 fail_on_order=False,

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -23,7 +23,7 @@ from cuml.preprocessing.model_selection import train_test_split
 from numba import cuda
 
 test_array_input_types = [
-    'numba', 'cupy', 'rmm'
+    'numba', 'cupy'
 ]
 
 test_seeds = [
@@ -145,10 +145,6 @@ def test_array_split(type, test_size, train_size, shuffle):
     if type == 'numba':
         X = cuda.to_device(X)
         y = cuda.to_device(y)
-
-    if type == 'rmm':
-        X = rmm.to_device(X)
-        y = rmm.to_device(y)
 
     X_train, X_test, y_train, y_test = train_test_split(X, y,
                                                         train_size=train_size,

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -17,7 +17,6 @@ import cudf
 import cupy as cp
 import numpy as np
 import pytest
-import rmm
 
 from cuml.preprocessing.model_selection import train_test_split
 from numba import cuda


### PR DESCRIPTION
Closes #2273 

Main issue was that rmm DeviceBuffer is not meant to be used with non contiguous arrays, which happen with cupy/numpy views rather easily: 

```python
>>> a = cp.zeros((10, 8), order='F')
>>> a[:-3].flags
  C_CONTIGUOUS : False
  F_CONTIGUOUS : False
  OWNDATA : False
```

This can be a problem for most of our C++ based algorithms (that expect contiguous inputs) as well.

PR fixes this by introducing a new parameter to `input_to_cuml_array` (`True` by default) that will ensure a contiguous memory for the produced CumlArray. It is a parameter since some CuPy based algos might be able to avoid the need of this.

It also fixes the contiguity of `train_test_split` returned array objects. 