### PR TITLE
Use Numba to allocate the array directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #2336: Eliminate `rmm.device_array` usage
 - PR #2262: Using fully shared PartDescriptor in MNMG decomposiition, linear models, and solvers
 
 - PR #2310: Pinning ucx-py to 0.14 to make 0.15 CI pass

--- a/python/cuml/common/numba_utils.py
+++ b/python/cuml/common/numba_utils.py
@@ -35,7 +35,7 @@ def gpu_zeros_2d(out):
         out[i][j] = 0
 
 
-def zeros(size, dtype, order='F'):
+def zeros(size, dtype, order="F"):
     """
     Return device array of zeros generated on device.
     """

--- a/python/cuml/common/numba_utils.py
+++ b/python/cuml/common/numba_utils.py
@@ -17,8 +17,6 @@
 # DEPRECATED: to be removed once full migration to CumlArray is done
 # remaining usages: blobs.pyx, regression.pyx
 
-import rmm
-
 from numba import cuda
 from numba.cuda.cudadrv.driver import driver
 
@@ -41,7 +39,7 @@ def zeros(size, dtype, order='F'):
     """
     Return device array of zeros generated on device.
     """
-    out = rmm.device_array(size, dtype=dtype, order=order)
+    out = cuda.device_array(size, dtype=dtype, order=order)
     if isinstance(size, tuple):
         tpb = driver.get_device().MAX_THREADS_PER_BLOCK
         nrows = size[0]


### PR DESCRIPTION
Since Numba has added support for external memory managers (EMM) and cuDF configures Numba to use RMM on import, we can just use Numba directly here. This should eliminate the last usage of `device_array` in cuML :)

xref: https://github.com/rapidsai/rmm/issues/180