### PR TITLE
Fix flake8 error: `W291 trailing whitespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Bug Fixes
 
+- PR #2337: Fix flake8 error: `W291 trailing whitespace`
+
 # cuML 0.14.0 (Date TBD)
 
 ## New Features

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -233,7 +233,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
 
         In the 0.15 cuML release, inference will be updated with much
         faster tree transfer. Preliminary builds with this updated approach
-        will be available from rapids.ai 
+        will be available from rapids.ai
 
         Parameters
         ----------


### PR DESCRIPTION
This cropped up for me in [this CI log]( https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fcuml%2Fprb%2Fcuml-style/detail/cuml-style/4016/pipeline ). Fixing it here.