### PR TITLE
[REVIEW] cpp logger level update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## Improvements
 - PR #2262: Using fully shared PartDescriptor in MNMG decomposiition, linear models, and solvers
-
 - PR #2310: Pinning ucx-py to 0.14 to make 0.15 CI pass
 - PR #1945: enable clang tidy
+- PR #2345: make C++ logger level definition to be the same as python layer
 
 ## Bug Fixes
 

--- a/cpp/include/cuml/common/logger.hpp
+++ b/cpp/include/cuml/common/logger.hpp
@@ -45,17 +45,18 @@ std::string format(const char* fmt, ...);
 /**
  * @defgroup CumlLogLevels Logging levels used in cuML
  *
- * @note exactly match the corresponding ones in spdlog for wrapping purposes
+ * @note exactly match the corresponding ones (but reverse in terms of value)
+ *       in spdlog for wrapping purposes
  *
  * @{
  */
-#define CUML_LEVEL_TRACE 0
-#define CUML_LEVEL_DEBUG 1
-#define CUML_LEVEL_INFO 2
+#define CUML_LEVEL_TRACE 6
+#define CUML_LEVEL_DEBUG 5
+#define CUML_LEVEL_INFO 4
 #define CUML_LEVEL_WARN 3
-#define CUML_LEVEL_ERROR 4
-#define CUML_LEVEL_CRITICAL 5
-#define CUML_LEVEL_OFF 6
+#define CUML_LEVEL_ERROR 2
+#define CUML_LEVEL_CRITICAL 1
+#define CUML_LEVEL_OFF 0
 /** @} */
 
 #if !defined(CUML_ACTIVE_LEVEL)
@@ -173,7 +174,7 @@ class PatternSetter {
  * @defgroup LoggerMacros Helper macros for dealing with logging
  * @{
  */
-#if (CUML_ACTIVE_LEVEL <= CUML_LEVEL_TRACE)
+#if (CUML_ACTIVE_LEVEL >= CUML_LEVEL_TRACE)
 #define CUML_LOG_TRACE(fmt, ...)                               \
   do {                                                         \
     std::stringstream ss;                                      \
@@ -185,7 +186,7 @@ class PatternSetter {
 #define CUML_LOG_TRACE(fmt, ...) void(0)
 #endif
 
-#if (CUML_ACTIVE_LEVEL <= CUML_LEVEL_DEBUG)
+#if (CUML_ACTIVE_LEVEL >= CUML_LEVEL_DEBUG)
 #define CUML_LOG_DEBUG(fmt, ...)                               \
   do {                                                         \
     std::stringstream ss;                                      \
@@ -197,28 +198,28 @@ class PatternSetter {
 #define CUML_LOG_DEBUG(fmt, ...) void(0)
 #endif
 
-#if (CUML_ACTIVE_LEVEL <= CUML_LEVEL_INFO)
+#if (CUML_ACTIVE_LEVEL >= CUML_LEVEL_INFO)
 #define CUML_LOG_INFO(fmt, ...) \
   ML::Logger::get().log(CUML_LEVEL_INFO, fmt, ##__VA_ARGS__)
 #else
 #define CUML_LOG_INFO(fmt, ...) void(0)
 #endif
 
-#if (CUML_ACTIVE_LEVEL <= CUML_LEVEL_WARN)
+#if (CUML_ACTIVE_LEVEL >= CUML_LEVEL_WARN)
 #define CUML_LOG_WARN(fmt, ...) \
   ML::Logger::get().log(CUML_LEVEL_WARN, fmt, ##__VA_ARGS__)
 #else
 #define CUML_LOG_WARN(fmt, ...) void(0)
 #endif
 
-#if (CUML_ACTIVE_LEVEL <= CUML_LEVEL_ERROR)
+#if (CUML_ACTIVE_LEVEL >= CUML_LEVEL_ERROR)
 #define CUML_LOG_ERROR(fmt, ...) \
   ML::Logger::get().log(CUML_LEVEL_ERROR, fmt, ##__VA_ARGS__)
 #else
 #define CUML_LOG_ERROR(fmt, ...) void(0)
 #endif
 
-#if (CUML_ACTIVE_LEVEL <= CUML_LEVEL_CRITICAL)
+#if (CUML_ACTIVE_LEVEL >= CUML_LEVEL_CRITICAL)
 #define CUML_LOG_CRITICAL(fmt, ...) \
   ML::Logger::get().log(CUML_LEVEL_CRITICAL, fmt, ##__VA_ARGS__)
 #else

--- a/cpp/src/common/logger.cpp
+++ b/cpp/src/common/logger.cpp
@@ -17,6 +17,7 @@
 #include <spdlog/sinks/stdout_color_sinks.h>  // NOLINT
 #include <spdlog/spdlog.h>                    // NOLINT
 
+#include <algorithm>
 #include <cuml/common/logger.hpp>
 
 namespace ML {
@@ -35,6 +36,11 @@ std::string format(const char* fmt, ...) {
   return str;
 }
 
+int convert_level_to_spdlog(int level) {
+  level = std::max(CUML_LEVEL_OFF, std::min(CUML_LEVEL_TRACE, level));
+  return CUML_LEVEL_TRACE - level;
+}
+
 const std::string Logger::DefaultPattern("[%L] [%H:%M:%S.%f] %v");
 
 Logger& Logger::get() {
@@ -48,9 +54,8 @@ Logger::Logger() : logger{spdlog::stdout_color_mt("cuml")}, currPattern() {
 }
 
 void Logger::setLevel(int level) {
-  if (CUML_LEVEL_TRACE <= level && level <= CUML_LEVEL_OFF) {
-    logger->set_level(static_cast<spdlog::level::level_enum>(level));
-  }
+  level = convert_level_to_spdlog(level);
+  logger->set_level(static_cast<spdlog::level::level_enum>(level));
 }
 
 void Logger::setPattern(const std::string& pattern) {
@@ -59,16 +64,18 @@ void Logger::setPattern(const std::string& pattern) {
 }
 
 bool Logger::shouldLogFor(int level) const {
+  level = convert_level_to_spdlog(level);
   auto level_e = static_cast<spdlog::level::level_enum>(level);
   return logger->should_log(level_e);
 }
 
 int Logger::getLevel() const {
   auto level_e = logger->level();
-  return static_cast<int>(level_e);
+  return CUML_LEVEL_TRACE - static_cast<int>(level_e);
 }
 
 void Logger::log(int level, const char* fmt, ...) {
+  level = convert_level_to_spdlog(level);
   auto level_e = static_cast<spdlog::level::level_enum>(level);
   // explicit check to make sure that we only expand messages when required
   if (logger->should_log(level_e)) {

--- a/cpp/test/sg/logger.cpp
+++ b/cpp/test/sg/logger.cpp
@@ -29,6 +29,11 @@ TEST(Logger, Test) {
   ASSERT_EQ(CUML_LEVEL_WARN, Logger::get().getLevel());
   Logger::get().setLevel(CUML_LEVEL_INFO);
   ASSERT_EQ(CUML_LEVEL_INFO, Logger::get().getLevel());
+
+  ASSERT_FALSE(Logger::get().shouldLogFor(CUML_LEVEL_TRACE));
+  ASSERT_FALSE(Logger::get().shouldLogFor(CUML_LEVEL_DEBUG));
+  ASSERT_TRUE(Logger::get().shouldLogFor(CUML_LEVEL_INFO));
+  ASSERT_TRUE(Logger::get().shouldLogFor(CUML_LEVEL_WARN));
 }
 
 }  // namespace ML

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -178,8 +178,7 @@ class Base:
         elif verbose is False:
             self.verbose = logger.level_info
         else:
-            # Using max in case user gives a verbosity value greater than 6
-            self.verbose = max(6 - verbose, 0)
+            self.verbose = verbose
 
         self.output_type = cuml.global_output_type if output_type is None \
             else _check_output_type_str(output_type)


### PR DESCRIPTION
In lieu of the corresponding changes to the python layer, this PR updates C++ layer too, in order to keep the definition of logger-level the same at both these layers. This should close #2327 .