### PR TITLE
[CI] Use Treelite Pip package in GPU testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak
+- PR #2373: Use Treelite Pip package in GPU testing
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -105,17 +105,8 @@ logger "Resetting LD_LIBRARY_PATH..."
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
 export LD_LIBRARY_PATH_CACHED=""
 
-logger "Build treelite for GPU testing..."
-# Buildint treelite Python for testing is temporary while there is a pip/conda
-# treelite package
-
-cd $WORKSPACE/cpp/build/treelite/src/treelite
-mkdir build
-cd build
-cmake ..
-make -j${PARALLEL_LEVEL}
-cd ../python
-python setup.py install
+logger "Install Treelite for GPU testing..."
+python -m pip install -v treelite==0.90
 
 cd $WORKSPACE
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -106,7 +106,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
 export LD_LIBRARY_PATH_CACHED=""
 
 logger "Install Treelite for GPU testing..."
-python -m pip install -v treelite==0.90
+python -m pip install -v treelite==0.91
 
 cd $WORKSPACE
 


### PR DESCRIPTION
**Motivation**. I published latest Treelite (0.90) to PyPI 2 days ago. I found that one of the unit tests failed when I installed Treelite from PyPI:
```
========================================================================= FAILURES =========================================================================
________________________________________ test_fil_skl_classification[GradientBoostingClassifier-DENSE-2-1-20-1000]
       fm = ForestInference.load_from_sklearn(skl_model,
                                               algo=algo,
                                               output_class=True,
                                               threshold=0.50,
>                                              storage_type=storage_type)
python/cuml/test/test_fil.py:245:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cuml/fil/fil.pyx:585: in cuml.fil.fil.ForestInference.load_from_sklearn
    ???
cuml/fil/fil.pyx:529: in cuml.fil.fil.ForestInference.load_from_treelite_model
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
>   ???
E   RuntimeError: Exception occured! file=/home/phcho/tmp2/cuml/cpp/src/fil/fil.cu line=620: sigmoid_alpha not supported. sigmoid_alpha = 0.000000
...
```
The gpuCI didn't catch this error because it was building Treelite from the source.

**Diagnosis**. The C++ class `ModelParam` got corrupted when it crossed the library boundary, because the PyPI wheel was built with CentOS 6 whereas cuML is built with Ubuntu 18.04, leading to incompatible C++ binary interface. I fixed the problem by releasing a source distribution to PyPI, ensuring that users will always install Treelite using the native C++ compiler.

**Solution**. This PR ensures that all tests pass when the latest PyPI release of Treelite is installed. Moving forward, I am writing a Conda package for Treelite, so that cuML can pull the native libs (`libtreelite.a`) in addition to the Python package.