### PR TITLE
[REVIEW] Pinning libcumlprims version to ease future updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #2345: make C++ logger level definition to be the same as python layer
 - PR #2329: Add short commit hash to conda package name
 - PR #2371: Updating MBSGD tests to use larger batches
+- PR #2380: Pinning libcumlprims version to ease future updates
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -48,7 +48,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
       "nvstrings=${MINOR_VERSION}" \
-      "libcumlprims=${MINOR_VERSION}" \
+      "libcumlprims=${MINOR_VERSION}a200607" \
       "lapack" \
       "cmake==3.14.3" \
       "umap-learn" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -48,7 +48,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
       "nvstrings=${MINOR_VERSION}" \
-      "libcumlprims=${MINOR_VERSION}a200607" \
+      "libcumlprims=0.15.0a200607" \
       "lapack" \
       "cmake==3.14.3" \
       "umap-learn" \

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - protobuf >=3.4.1,<4.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims=0.15.0a200607
+    - libcumlprims {{ minor_version }}a200607
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
   run:
@@ -39,7 +39,7 @@ requirements:
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims=0.15.0a200607
+    - libcumlprims {{ minor_version }}a200607
     - cupy>=7,<8.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - protobuf >=3.4.1,<4.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims=0.15.*
+    - libcumlprims=0.15.0a200607
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
   run:
@@ -39,7 +39,7 @@ requirements:
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims=0.15.*
+    - libcumlprims=0.15.0a200607
     - cupy>=7,<8.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - protobuf >=3.4.1,<4.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims {{ minor_version }}a200607
+    - libcumlprims 0.15.0a200607
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
   run:
@@ -39,7 +39,7 @@ requirements:
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims {{ minor_version }}a200607
+    - libcumlprims=0.15.0a200607
     - cupy>=7,<8.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -34,11 +34,11 @@ requirements:
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
-    - libcumlprims {{ minor_version }}a200607
+    - libcumlprims=0.15.0a200607
     - lapack
     - protobuf >=3.4.1,<4.0.0
   run:
-    - libcumlprims {{ minor_version}}a200607
+    - libcumlprims=0.15.0a200607
     - cudf {{ minor_version }}
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -34,11 +34,11 @@ requirements:
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
-    - libcumlprims {{ minor_version }}
+    - libcumlprims {{ minor_version }}a200607
     - lapack
     - protobuf >=3.4.1,<4.0.0
   run:
-    - libcumlprims=0.15.*
+    - libcumlprims {{ minor_version}}a200607
     - cudf {{ minor_version }}
     - nccl>=2.5
     - ucx-py {{ minor_version }}


### PR DESCRIPTION
We currently have a chicken and egg situation when merging in PRs from libcumlprims that required changes to both cuml and cumlprims. Unfortunately, since cuML is always pinned to the latest minor version of libcumlprims, CI fails for all existing PRs while the PR that implements the cumlprims changes runs through its own CI and gets merged. 

Pinning the libcumlprims version will stop this from happening. Each time a PR with libcumlprims updates is merged into cuML, the libcumlprims conda package version will be set to the new nightly on the cuml side. Before cuml is released, the libcumlprims will be pinned to `{{ MINOR_VERSION }}`. 