### PR TITLE
[REVIEW] Install meta packages for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #2363: Update threshold and make other changes for stress tests
 - PR #2371: Updating MBSGD tests to use larger batches
 - PR #2380: Pinning libcumlprims version to ease future updates
+- PR #2408: Install meta packages for dependencies
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -43,30 +43,21 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      "cupy>=7,<8.0.0a0" \
       "cudatoolkit=${CUDA_REL}" \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
       "nvstrings=${MINOR_VERSION}" \
       "libcumlprims=0.15.0a200607" \
-      "lapack" \
-      "cmake==3.14.3" \
-      "umap-learn" \
-      "protobuf>=3.4.1,<4.0.0" \
-      "nccl>=2.5" \
-      "dask>=2.12.0" \
-      "distributed>=2.12.0" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
-      "statsmodels" \
       "xgboost==1.0.2dev.rapidsai0.13" \
-      "psutil" \
-      "lightgbm" \
-      "matplotlib" \
-      "ipython=7.3*" \
-      "jupyterlab"
-      
+      "rapids-build-env=$MINOR_VERSION.*" \
+      "rapids-notebook-env=$MINOR_VERSION.*"
+
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env rapids-notebook-env
+# conda install "your-pkg=1.0.0"
 
 
 # Install contextvars on Python 3.6


### PR DESCRIPTION
Install dependencies via `rapids-build-env` and `rapids-notebook-env` (which are pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/