### PR TITLE
--singlegpu flag fix and calling script with only flags defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #2373: Use Treelite Pip package in GPU testing
 - PR #2376: Update documentation Links
 - PR #2413: CumlArray and related methods updates to account for cuDF.Buffer contiguity update
+- PR #2424: --singlegpu flag fix on build.sh script
 
 # cuML 0.14.0 (03 Jun 2020)
 


### PR DESCRIPTION
Fixed issue with --singlegpu flag as it was not parsed correctly and as a result cuML didn't build properly for it.

Build script didn't run if only flags were specified. It should build the libraries and install them. Added check to see if complete build should be done (no arguments specified or then all arguments are flags).