### PR TITLE
[REVIEW] Change p2p_enabled definition to work without ucx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #2413: CumlArray and related methods updates to account for cuDF.Buffer contiguity update
 - PR #2424: --singlegpu flag fix on build.sh script
 - PR #2432: Using correct algo_name for UMAP in benchmark tests
+- PR #2441: Change p2p_enabled definition to work without ucx
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/cpp/comms/std/src/cuML_std_comms_impl.hpp
+++ b/cpp/comms/std/src/cuML_std_comms_impl.hpp
@@ -124,9 +124,9 @@ class cumlStdCommunicator_impl : public MLCommon::cumlCommunicator_iface {
 
   void initialize();
   void get_request_id(request_t* req) const;
+  bool p2p_enabled = false;
 
 #ifdef WITH_UCX
-  bool p2p_enabled = false;
   comms_ucp_handler _ucp_handler;
   ucp_worker_h _ucp_worker;
   std::shared_ptr<ucp_ep_h*> _ucp_eps;


### PR DESCRIPTION
Small bugfix in comms to work for ucx-less mnmg build