### PR TITLE
[REVIEW] fix setting RAFT_DIR from the RAFT_PATH env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 - PR #2340: Import ARIMA in the root init file and fix the `test_fit_function` test
 - PR #2408: Install meta packages for dependencies
 - PR #2417: Move doc customization scripts to Jenkins
-- PR #2411 Refactor Mixin classes and use in classifier/regressor estimators
+- PR #2411: Refactor Mixin classes and use in classifier/regressor estimators
+- PR #2442: fix setting RAFT_DIR from the RAFT_PATH env var
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -24,7 +24,7 @@ include(ExternalProject)
 if(DEFINED ENV{RAFT_PATH})
   message(STATUS "RAFT_PATH environment variable detected.")
   message(STATUS "RAFT_DIR set to $ENV{RAFT_PATH}")
-  set(RAFT_DIR ENV{RAFT_PATH})
+  set(RAFT_DIR "$ENV{RAFT_PATH}")
 
   ExternalProject_Add(raft
     DOWNLOAD_COMMAND  ""

--- a/python/setup.py
+++ b/python/setup.py
@@ -109,7 +109,7 @@ if clean_artifacts:
 
 # Use RAFT repository in cuml.raft
 
-use_raft_package(raft_path, libcuml_path)
+raft_include_dir = use_raft_package(raft_path, libcuml_path)
 
 # Use treelite from the libcuml build folder, otherwise clone it
 # Needed until there is a treelite distribution
@@ -131,6 +131,7 @@ include_dirs = ['../cpp/src',
                 '../cpp/include',
                 '../cpp/src_prims',
                 treelite_path,
+                raft_include_dir,
                 '../cpp/comms/std/src',
                 '../cpp/comms/std/include',
                 cuda_include_dir,

--- a/python/setuputils.py
+++ b/python/setuputils.py
@@ -84,27 +84,38 @@ def use_raft_package(raft_path, cpp_build_path,
         - Branch/git tag cloned is located in git_info_file in this case.
 
     """
-
-    if not os.path.islink('cuml/raft'):
-        if not raft_path:
-            raft_path, raft_cloned = \
-                clone_repo_if_needed('raft', cpp_build_path,
-                                     git_info_file=git_info_file)
-
-        else:
-            print("-- Using RAFT_PATH variable, RAFT found at " +
-                  str(os.environ['RAFT_PATH']))
-            raft_path = os.environ['RAFT_PATH']
-
-        try:
-            os.symlink(raft_path + '/python/raft', 'cuml/raft')
-        except FileExistsError:
-            os.remove('cuml/raft')
-            os.symlink(raft_path + '/python/raft', 'cuml/raft')
-
+    if os.path.islink('cuml/raft'):
+        raft_path = os.path.realpath('cuml/raft')
+        # walk up two dirs from `python/raft`
+        raft_path = os.path.join(raft_path, '..', '..')
+        print("-- Using existing RAFT folder")
+    elif isinstance(raft_path, (str, os.PathLike)):
+        print('-- Using RAFT_PATH argument')
+    elif os.environ.get('RAFT_PATH', False) is not False:
+        raft_path = str(os.environ['RAFT_PATH'])
+        print('-- Using RAFT_PATH environment variable')
     else:
-        print("-- Using already existing RAFT folder, source located at")
-        print(os.path.realpath('cuml/raft'))
+        raft_path, raft_cloned = \
+            clone_repo_if_needed('raft', cpp_build_path,
+                                 git_info_file=git_info_file)
+        raft_path = os.path.join('../', raft_path)
+
+    raft_path = os.path.realpath(raft_path)
+    print('-- RAFT found at: ' + str(raft_path))
+
+    try:
+        os.symlink(
+            os.path.join(raft_path, 'python/raft'),
+            os.path.join('cuml/raft')
+        )
+    except FileExistsError:
+        os.remove(os.path.join('cuml/raft'))
+        os.symlink(
+            os.path.join(raft_path, 'python/raft'),
+            os.path.join('cuml/raft')
+        )
+
+    return os.path.join(raft_path, 'cpp/include')
 
 
 def clone_repo_if_needed(name, cpp_build_path=None,


### PR DESCRIPTION
Fixes setting the RAFT_PATH env var for source builds.

Without this fix the path `-I../../../../ENV{RAFT_PATH}/cpp/include` is included in the C++ build args instead of the correct path.