### PR TITLE
[REVIEW] Restore access to coef_ property of Lasso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #2413: CumlArray and related methods updates to account for cuDF.Buffer contiguity update
 - PR #2424: --singlegpu flag fix on build.sh script
 - PR #2432: Using correct algo_name for UMAP in benchmark tests
+- PR #2445: Restore access to coef_ property of Lasso
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -194,7 +194,7 @@ class CD(Base):
         self.tol = tol
         self.shuffle = shuffle
         self.intercept_value = 0.0
-        self.coef_ = None
+        self._coef_ = None   # accessed via estimator.coef_
         self.intercept_ = None
 
     def _check_alpha(self, alpha):

--- a/python/cuml/test/test_coordinate_descent.py
+++ b/python/cuml/test/test_coordinate_descent.py
@@ -49,6 +49,7 @@ def test_lasso(datatype, X_type, alpha, algorithm,
                        selection=algorithm, tol=1e-10)
 
     cu_lasso.fit(X_train, y_train)
+    assert cu_lasso.coef_ is not None
     cu_predict = cu_lasso.predict(X_test)
 
     cu_r2 = r2_score(y_test, cu_predict)
@@ -82,6 +83,7 @@ def test_lasso_default(datatype, nrows, column_info):
     cu_lasso = cuLasso()
 
     cu_lasso.fit(X_train, y_train)
+    assert cu_lasso.coef_ is not None
     cu_predict = cu_lasso.predict(X_test)
     cu_r2 = r2_score(y_test, cu_predict)
 


### PR DESCRIPTION
Fixes #2438.

Diagnosis of the bug: When the user requests the `coef_` property of a Lasso object, the `__getattr__` method from `Base` should have been invoked in order to correctly convert `_coef_` cuML array into a NumPy array. That did not happen because the constructor of `Lasso` was setting `self.coef_ = None`, so `__getattr__` method was never invoked.

Fix. Set `self._coef_ = None` in the constructor, in accordance with the usage guideline of cuML arrays.

I also updated the Lasso unit tests to check whether `coef_` could be fetchted.