### PR TITLE
Fix RF memleak test to use pynvml to query free memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PR #2413: CumlArray and related methods updates to account for cuDF.Buffer contiguity update
 - PR #2424: --singlegpu flag fix on build.sh script
 - PR #2432: Using correct algo_name for UMAP in benchmark tests
+- PR #2448: Fix RF memleak test to use pynvml to query free memory
 
 # cuML 0.14.0 (03 Jun 2020)
 


### PR DESCRIPTION
Fixes #2422. The `get_memory_info()` API was removed in the latest RMM. So use pynvml instead to query the amount of free GPU memory.

Thanks @jakirkham for suggesting pynvml.

Pynvml is a dependency of dask-cuda, so we already have access to Pynvml.