### PR TITLE
[REVIEW] Mark RF memleak test as XFAIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #2441: Change p2p_enabled definition to work without ucx
 - PR #2447: Drop `nvstrings`
 - PR #2450: Update local build to use new gpuCI image
+- PR #2454: Mark RF memleak test as XFAIL, because we can't detect memleak reliably
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -522,6 +522,7 @@ def test_rf_regression_sparse(special_reg, datatype, fil_sparse_format, algo):
             assert fil_r2 >= (sk_r2 - 0.07)
 
 
+@pytest.xfail(reason='Need rapidsai/rmm#415 to detect memleak robustly')
 @pytest.mark.memleak
 @pytest.mark.parametrize('fil_sparse_format', [True, False, 'auto'])
 @pytest.mark.parametrize('n_iter', [unit_param(5), quality_param(30),

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -522,7 +522,7 @@ def test_rf_regression_sparse(special_reg, datatype, fil_sparse_format, algo):
             assert fil_r2 >= (sk_r2 - 0.07)
 
 
-@pytest.xfail(reason='Need rapidsai/rmm#415 to detect memleak robustly')
+@pytest.mark.xfail(reason='Need rapidsai/rmm#415 to detect memleak robustly')
 @pytest.mark.memleak
 @pytest.mark.parametrize('fil_sparse_format', [True, False, 'auto'])
 @pytest.mark.parametrize('n_iter', [unit_param(5), quality_param(30),

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -352,6 +352,7 @@ def get_memsize(svc):
     return ms
 
 
+@pytest.mark.xfail(reason='Need rapidsai/rmm#415 to detect memleak robustly')
 @pytest.mark.memleak
 @pytest.mark.parametrize('params', [
     {'kernel': 'rbf', 'C': 1, 'gamma': 1}
@@ -405,6 +406,7 @@ def test_svm_memleak(params, n_rows, n_iter, n_cols,
     assert delta_mem == 0
 
 
+@pytest.mark.xfail(reason='Need rapidsai/rmm#415 to detect memleak robustly')
 @pytest.mark.memleak
 @pytest.mark.parametrize('params', [
     {'kernel': 'poly', 'degree': 30, 'C': 1, 'gamma': 1}


### PR DESCRIPTION
See discussion in #2448. We need rapidsai/rmm#415 to measure memory leak properly. For now, we mark the RF memleak test as XFAIL.