### PR TITLE
[REVIEW] Use correct field to store data type in LabelEncoder.fit_transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #2441: Change p2p_enabled definition to work without ucx
 - PR #2447: Drop `nvstrings`
 - PR #2450: Update local build to use new gpuCI image
+- PR #2455: Use correct field to store data type in `LabelEncoder.fit_transform`
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -193,7 +193,7 @@ class LabelEncoder(object):
         This is functionally equivalent to (but faster than)
         `LabelEncoder().fit(y).transform(y)`
         """
-        self._dtype = y.dtype
+        self.dtype = y.dtype if y.dtype != cp.dtype('O') else str
 
         y = y.astype('category')
         self.classes_ = y._column.categories

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -79,6 +79,7 @@ def test_labelencoder_unfitted():
         le.transform(df)
 
 
+@pytest.mark.parametrize("use_fit_transform", [False, True])
 @pytest.mark.parametrize(
         "orig_label, ord_label, expected_reverted, bad_ord_label",
         [(cudf.Series(['a', 'b', 'c']),
@@ -98,10 +99,14 @@ def test_labelencoder_unfitted():
           cudf.Series(['.09', '0.09', '09', '1.09']),
           cudf.Series([0, 1, 2, 3, 4]))])
 def test_inverse_transform(orig_label, ord_label,
-                           expected_reverted, bad_ord_label):
+                           expected_reverted, bad_ord_label,
+                           use_fit_transform):
     # prepare LabelEncoder
     le = LabelEncoder()
-    le.fit(orig_label)
+    if use_fit_transform:
+        le.fit_transform(orig_label)
+    else:
+        le.fit(orig_label)
     assert(le._fitted is True)
 
     # test if inverse_transform is correct


### PR DESCRIPTION
Fixes #2451 by correctly setting `self.dtype` field for `LabelEncoder.fit_transform()` method. Previously, the method was setting a wrong field `self._dtype`.