### PR TITLE
[REVIEW] Support Pandas 1.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #2289: QR SVD solver for MNMG PCA
 - PR #2312: column-major support for make_blobs
 - PR #2392: PCA can accept sparse inputs, and sparse prim for computing covariance
+- PR #2465: Support pandas 1.0+
 
 ## Improvements
 - PR #2336: Eliminate `rmm.device_array` usage

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -309,8 +309,8 @@ def check_ptr(a, b, input_type):
                 return x.__array_interface__['data'][0]
 
         if input_type == 'pandas':
-            a = a.as_matrix()
-            b = b.as_matrix()
+            a = a.values
+            b = b.values
 
         assert get_ptr(a) == get_ptr(b)
 


### PR DESCRIPTION
Small change to fix a few cuML tests when Pandas 1.0+ is used. 

xref https://github.com/rapidsai/cudf/pull/4546