### PR TITLE
[REVIEW] Add _n_features_in_ attribute to all single GPU estimators that implement fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - PR #2453: Add CumlArray to API doc
 - PR #2440: Use Treelite Conda package
 - PR #2403: Support for input and output type consistency in logistic regression predict_proba
-- PR #2410: Add `_n_features_in_` attribute to all single GPU estimators that implement fit
+- PR #2468: Add `_n_features_in_` attribute to all single GPU estimators that implement fit
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #2340: Import ARIMA in the root init file and fix the `test_fit_function` test
 - PR #2408: Install meta packages for dependencies
 - PR #2417: Move doc customization scripts to Jenkins
+- PR #2433: Add libcumlprims_mg to CMake
 - PR #2420: Add and set convert_dtype default to True in estimator fit methods
 - PR #2411: Refactor Mixin classes and use in classifier/regressor estimators
 - PR #2442: fix setting RAFT_DIR from the RAFT_PATH env var
@@ -220,7 +221,7 @@
 - PR #2305: Fixed race condition in DBScan
 - PR #2354: Fix broken links in README
 
-# cuML 0.13.0 (Date TBD)
+# cuML 0.13.0 (31 Mar 2020)
 
 ## New Features
 - PR #1777: Python bindings for entropy
@@ -337,7 +338,6 @@
 - PR #1951: Dask Random forest regression CPU predict bug fix
 - PR #1948: Adjust BatchedMargin margin and disable tests temporarily
 - PR #1950: Fix UMAP test failure
-
 
 
 # cuML 0.12.0 (04 Feb 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,10 @@
 - PR #2420: Add and set convert_dtype default to True in estimator fit methods
 - PR #2411: Refactor Mixin classes and use in classifier/regressor estimators
 - PR #2442: fix setting RAFT_DIR from the RAFT_PATH env var
-- PR #2411 Refactor Mixin classes and use in classifier/regressor estimators
 - PR #2453: Add CumlArray to API doc
 - PR #2440: Use Treelite Conda package
-- PR #2403 Support for input and output type consistency in logistic regression predict_proba
+- PR #2403: Support for input and output type consistency in logistic regression predict_proba
+- PR #2410: Add `_n_features_in_` attribute to all single GPU estimators that implement fit
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -201,7 +201,7 @@ class DBSCAN(Base):
             default: "int32". Valid values are { "int32", np.int32,
             "int64", np.int64}. When the number of samples exceed
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
 
         if self._labels_ is not None:

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -337,7 +337,7 @@ class KMeans(Base):
             are assigned equal weight.
 
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
 
         if self.init == 'preset':

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -105,6 +105,7 @@ class KMeansMG(KMeans):
             ndarray, cuda array interface compliant array like CuPy
 
         """
+        self._set_n_features_in(X)
 
         X_m, self.n_rows, self.n_cols, self.dtype = \
             input_to_cuml_array(X, order='C')

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -296,6 +296,15 @@ class Base:
         else:
             return self.output_type
 
+    def _set_n_features_in(self, X):
+        """Method to be called by the fit method of the inheriting class.
+        Sets the n_features_in_ attribute based on the data passed to fit.
+        """
+        if isinstance(X, int):
+            self.n_features_in_ = X
+        else:
+            self.n_features_in_ = X.shape[1]
+
 
 class RegressorMixin:
     """Mixin class for regression estimators in cuML"""

--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -59,6 +59,7 @@ class BaseDecompositionMG(object):
         :return: self
         """
         self._set_output_type(X[0])
+        self._set_n_features_in(n_cols)
 
         X_arys = []
         for i in range(len(X)):
@@ -80,7 +81,7 @@ class BaseDecompositionMG(object):
                                                                 rank)
 
         cdef uintptr_t part_desc = opg.build_part_descriptor(total_rows,
-                                                             n_cols,
+                                                             self.n_cols,
                                                              rank_to_sizes,
                                                              rank)
 

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -415,7 +415,7 @@ class PCA(Base):
         cluster labels
 
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
 
         if cp.sparse.issparse(X):

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -329,6 +329,7 @@ class TruncatedSVD(Base):
             Reduced version of X as a dense cuDF DataFrame
         """
         self._set_output_type(X)
+        self._set_n_features_in(X)
 
         X_m, self.n_rows, self.n_cols, self.dtype = \
             input_to_cuml_array(X, check_dtype=[np.float32, np.float64])

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -573,6 +573,7 @@ class RandomForestClassifier(Base, ClassifierMixin):
             memory used for the method.
         """
         self._set_output_type(X)
+        self._set_n_features_in(X)
 
         # Reset the old tree data for new fit call
         self._reset_forest_data()

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -550,6 +550,7 @@ class RandomForestRegressor(Base, RegressorMixin):
             memory used for the method.
         """
         self._set_output_type(X)
+        self._set_n_features_in(X)
 
         # Reset the old tree data for new fit call
         self._reset_forest_data()

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -50,6 +50,7 @@ class MGFitMixin(object):
         :return: self
         """
         self._set_output_type(input_data[0][0])
+        self._set_n_features_in(n_cols)
 
         X_arys = []
         y_arys = []

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -222,6 +222,7 @@ class ElasticNet(Base, RegressorMixin):
             convert y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
+        self._set_n_features_in(X)
 
         self.cuElasticNet.fit(X, y, convert_dtype=convert_dtype)
 

--- a/python/cuml/linear_model/lasso.pyx
+++ b/python/cuml/linear_model/lasso.pyx
@@ -186,6 +186,7 @@ class Lasso(Base, RegressorMixin):
             convert y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
+        self._set_n_features_in(X)
 
         self.culasso.fit(X, y, convert_dtype=convert_dtype)
 

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -232,7 +232,7 @@ class LinearRegression(Base, RegressorMixin):
             y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
 
         cdef uintptr_t X_ptr, y_ptr

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -268,6 +268,7 @@ class LogisticRegression(Base, ClassifierMixin):
             will increase memory used for the method.
         """
         self._set_output_type(X)
+        self._set_n_features_in(X)
 
         # Converting y to device array here to use `unique` function
         # since calling input_to_dev_array again in QN has no cost

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -171,7 +171,7 @@ class MBSGDClassifier(Base, ClassifierMixin):
             y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
-
+        self._set_n_features_in(X)
         self.cu_mbsgd_classifier.fit(X, y, convert_dtype=convert_dtype)
         self.coef_ = self.cu_mbsgd_classifier.coef_
         self.intercept_ = self.cu_mbsgd_classifier.intercept_

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -167,7 +167,7 @@ class MBSGDRegressor(Base, RegressorMixin):
             y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
-
+        self._set_n_features_in(X)
         self.cu_mbsgd_classifier.fit(X, y, convert_dtype=convert_dtype)
         self.coef_ = self.cu_mbsgd_classifier.coef_
         self.intercept_ = self.cu_mbsgd_classifier.intercept_

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -264,6 +264,7 @@ class Ridge(Base, RegressorMixin):
             will increase memory used for the method.
         """
         self._set_output_type(X)
+        self._set_n_features_in(X)
 
         cdef uintptr_t X_ptr, y_ptr
         X_m, n_rows, self.n_cols, self.dtype = \

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -311,7 +311,7 @@ class TSNE(Base):
             When set to True, the fit method will automatically
             convert the inputs to np.float32.
         """
-
+        self._set_n_features_in(X)
         cdef int n, p
         cdef cumlHandle* handle_ = <cumlHandle*><size_t>self.handle.getHandle()
         if handle_ == NULL:

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -510,6 +510,8 @@ class UMAP(Base):
             Acceptable formats: sparse SciPy ndarray, CuPy device ndarray,
             CSR/COO preferred other formats will go through conversion to CSR
         """
+        self._set_n_features_in(X)
+
         if len(X.shape) != 2:
             raise ValueError("data should be two dimensional")
 

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -235,6 +235,7 @@ class MultinomialNB(Base):
         sample_weight : array-like of shape (n_samples)
             Weights applied to individial samples (1. for unweighted).
         """
+        self._set_n_features_in(X)
         return self.partial_fit(X, y, sample_weight)
 
     @cp.prof.TimeRangeDecorator(message="fit()", color_id=0)

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -233,7 +233,7 @@ class NearestNeighbors(Base):
             When set to True, the fit method will automatically
             convert the inputs to np.float32.
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
 
         if len(X.shape) != 2:

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -195,7 +195,7 @@ cdef class BaseRandomProjection():
             generated random matrix as attributes
 
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
 
         _, n_samples, n_features, self.dtype = \

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -234,6 +234,7 @@ class SVC(SVMBase, ClassifierMixin):
             y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
+        self._set_n_features_in(X)
         self._set_output_type(X)
         X_m, self.n_rows, self.n_cols, self.dtype = \
             input_to_cuml_array(X, order='F')

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -235,7 +235,7 @@ class SVR(SVMBase, RegressorMixin):
             y to be the same data type as X if they differ. This
             will increase memory used for the method.
         """
-
+        self._set_n_features_in(X)
         self._set_output_type(X)
         cdef uintptr_t X_ptr, y_ptr
 

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
+import pytest
 import cuml
+from cuml.test.utils import small_classification_dataset
 
 
 def test_base_class_usage():
@@ -39,3 +41,18 @@ def test_base_hasattr():
     # True only for valid attributes
     assert hasattr(base, "handle")
     assert not hasattr(base, "somefakeattr")
+
+
+@pytest.mark.parametrize('datatype', ["float32", "float64"])
+@pytest.mark.parametrize('use_integer_n_features', [True, False])
+def test_base_n_features_in(datatype, use_integer_n_features):
+    X_train, _, _, _ = small_classification_dataset(datatype)
+    integer_n_features = 8
+    clf = cuml.Base()
+
+    if use_integer_n_features:
+        clf._set_n_features_in(integer_n_features)
+        assert clf.n_features_in_ == integer_n_features
+    else:
+        clf._set_n_features_in(X_train)
+        assert clf.n_features_in_ == X_train.shape[1]


### PR DESCRIPTION
This PR:
- Adds a `_set_n_features_in` method to the `Base` estimator class. This is part of scikit-learn's data validation [implementation](https://github.com/scikit-learn/scikit-learn/blob/332aaa112b1ed02bcf0ce38e0901d3ea5eaf6e3a/sklearn/base.py#L350-L365) on their base class, but less feature-rich
- Calls `_set_n_features_in` in the `fit` method of all estimators that subclass `Base` and are available in sklearn (i.e., not the time series analysis estimators). This includes the `*_mg.pyx` estimators for single-GPU dask, where appropriate
- Adds a test to `test_base.py` to assert that the setter does actually set `n_features_in_`

Setting a `n_features_in_` attribute while fitting an estimator is useful for API consistency with sklearn (see #2401 ).

This closes #2395 

This PR is a clean version of #2410 , which has tags pointing to 0.14 commits due to a mixup