### PR TITLE
[REVIEW] Additional pytest assertions to help verify distributed nearest neighbors results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - PR #2440: Use Treelite Conda package
 - PR #2403: Support for input and output type consistency in logistic regression predict_proba
 - PR #2468: Add `_n_features_in_` attribute to all single GPU estimators that implement fit
-
+- PR #2492: Adding additional assertions to mnmg nearest neighbors pytests
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak
 - PR #2364: Fix for random projection

--- a/cpp/src_prims/selection/knn.cuh
+++ b/cpp/src_prims/selection/knn.cuh
@@ -312,6 +312,7 @@ void brute_force_knn(std::vector<float *> &input, std::vector<int> &sizes,
     CUDA_CHECK(cudaStreamSynchronize(internalStreams[i]));
   }
 
+  // This is necessary for proper index translations
   knn_merge_parts(out_D, out_I, res_D, res_I, n, input.size(), k, userStream,
 	  			  trans.data());
 

--- a/cpp/src_prims/selection/knn.cuh
+++ b/cpp/src_prims/selection/knn.cuh
@@ -312,10 +312,8 @@ void brute_force_knn(std::vector<float *> &input, std::vector<int> &sizes,
     CUDA_CHECK(cudaStreamSynchronize(internalStreams[i]));
   }
 
-  if (input.size() > 1) {
-    knn_merge_parts(out_D, out_I, res_D, res_I, n, input.size(), k, userStream,
-                    trans.data());
-  }
+  knn_merge_parts(out_D, out_I, res_D, res_I, n, input.size(), k, userStream,
+	  			  trans.data());
 
   // Perform necessary post-processing
   if ((m == faiss::MetricType::METRIC_L2 ||

--- a/python/cuml/test/dask/test_nearest_neighbors.py
+++ b/python/cuml/test/dask/test_nearest_neighbors.py
@@ -68,7 +68,9 @@ def _scale_rows(client, nrows):
     return n_workers * nrows
 
 
-@pytest.mark.parametrize("nrows", [unit_param(100), unit_param(1e4),
+@pytest.mark.parametrize("nrows", [unit_param(100),
+                                   unit_param(1e3),
+                                   unit_param(1e4),
                                    quality_param(1e6),
                                    stress_param(5e8)])
 @pytest.mark.parametrize("ncols", [10, 30])

--- a/python/cuml/test/dask/test_nearest_neighbors.py
+++ b/python/cuml/test/dask/test_nearest_neighbors.py
@@ -100,7 +100,9 @@ def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
 
     wait(X_cudf)
 
-    print(str(client.has_what()))
+    dist = np.array([len(v) for v in client.has_what().values()])
+
+    assert np.all(dist == dist[0])
 
     cumlModel = daskNN(n_neighbors=n_neighbors,
                        streams_per_handle=streams_per_handle)
@@ -118,12 +120,10 @@ def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
 
     sk_i = sk_i.astype("int64")
 
-    print(str(sk_i[:,0]))
-    print(str(local_i[:,0]))
+    assert array_equal(local_i[:, 0], np.arange(nrows))
 
     diff = sk_i-local_i
-
-    n_diff = len(diff[diff>0])
+    n_diff = len(diff[diff > 0])
 
     perc_diff = n_diff / (nrows * n_neighbors)
 

--- a/python/cuml/test/dask/test_nearest_neighbors.py
+++ b/python/cuml/test/dask/test_nearest_neighbors.py
@@ -64,7 +64,7 @@ def _scale_rows(client, nrows):
     return n_workers * nrows
 
 
-@pytest.mark.parametrize("nrows", [unit_param(1e3), unit_param(1e4),
+@pytest.mark.parametrize("nrows", [unit_param(100), unit_param(1e4),
                                    quality_param(1e6),
                                    stress_param(5e8)])
 @pytest.mark.parametrize("ncols", [10, 30])
@@ -113,8 +113,8 @@ def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
 
     sk_i = sk_i.astype("int64")
 
-    print(str(sk_i))
-    print(str(local_i))
+    print(str(sk_i[:,0]))
+    print(str(local_i[:,0]))
 
     diff = sk_i-local_i
 

--- a/python/cuml/test/dask/test_nearest_neighbors.py
+++ b/python/cuml/test/dask/test_nearest_neighbors.py
@@ -16,6 +16,7 @@ import pytest
 
 import cudf
 import dask_cudf
+
 import pandas as pd
 
 import numpy as np
@@ -90,18 +91,38 @@ def test_compare_skl(nrows, ncols, nclusters, n_parts, n_neighbors,
 
     X_cudf = _prep_training_data(client, X, n_parts)
 
+    from dask.distributed import wait
+
+    wait(X_cudf)
+
+    print(str(client.has_what()))
+
     cumlModel = daskNN(n_neighbors=n_neighbors,
                        streams_per_handle=streams_per_handle)
     cumlModel.fit(X_cudf)
 
     out_d, out_i = cumlModel.kneighbors(X_cudf)
 
-    local_i = np.array(out_i.compute().as_gpu_matrix())
+    local_i = np.array(out_i.compute().as_gpu_matrix(), dtype="int64")
 
     sklModel = KNeighborsClassifier(n_neighbors=n_neighbors).fit(X, y)
     skl_y_hat = sklModel.predict(X)
-
     y_hat, _ = predict(local_i, y, n_neighbors)
+
+    sk_d, sk_i = sklModel.kneighbors(X)
+
+    sk_i = sk_i.astype("int64")
+
+    print(str(sk_i))
+    print(str(local_i))
+
+    diff = sk_i-local_i
+
+    n_diff = len(diff[diff>0])
+
+    perc_diff = n_diff / (nrows * n_neighbors)
+
+    assert perc_diff < 1e-3
 
     assert array_equal(y_hat, skl_y_hat)
 


### PR DESCRIPTION
Some new assertions:

- Reversing the order of worker partition assignment
- Validating first column of resulting array of indices always matches the row number. 
- Validating low percentage of mismatched indices from small numerical errors when compared to scikit-learn
- Explicitly performing a `dask.distributed.wait` after data generation to guarantee partitions are at rest when query begins
- Verifying equal number of partitions end up on each worker. 