### PR TITLE
[REVIEW] Fixing indentation for simulate_data in test_fil.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PR #2454: Mark RF memleak test as XFAIL, because we can't detect memleak reliably
 - PR #2455: Use correct field to store data type in `LabelEncoder.fit_transform`
 - PR #2475: Fix typo in build.sh
+- PR #2496: Fixing indentation for simulate_data in test_fil.py
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -32,23 +32,23 @@ from sklearn.model_selection import train_test_split
 if has_xgboost():
     import xgboost as xgb
 
-    def simulate_data(m, n, k=2, random_state=None, classification=True,
-                      bias=0.0):
-        if classification:
-            features, labels = make_classification(n_samples=m,
-                                                   n_features=n,
-                                                   n_informative=int(n/5),
-                                                   n_classes=k,
-                                                   random_state=random_state)
-        else:
-            features, labels = make_regression(n_samples=m,
+def simulate_data(m, n, k=2, random_state=None, classification=True,
+                  bias=0.0):
+    if classification:
+        features, labels = make_classification(n_samples=m,
                                                n_features=n,
                                                n_informative=int(n/5),
-                                               n_targets=1,
-                                               bias=bias,
+                                               n_classes=k,
                                                random_state=random_state)
-        return np.c_[features].astype(np.float32), \
-            np.c_[labels].astype(np.float32).flatten()
+    else:
+        features, labels = make_regression(n_samples=m,
+                                           n_features=n,
+                                           n_informative=int(n/5),
+                                           n_targets=1,
+                                           bias=bias,
+                                           random_state=random_state)
+    return np.c_[features].astype(np.float32), \
+        np.c_[labels].astype(np.float32).flatten()
 
 
 def _build_and_save_xgboost(model_path,

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -32,6 +32,7 @@ from sklearn.model_selection import train_test_split
 if has_xgboost():
     import xgboost as xgb
 
+
 def simulate_data(m, n, k=2, random_state=None, classification=True,
                   bias=0.0):
     if classification:


### PR DESCRIPTION
Closes https://github.com/rapidsai/cuml/issues/2482 

Correcting the indentation of `simulate_data` as it does not have to be defined only if xgboost if installed.