### PR TITLE
[REVIEW] Import treelite.sklearn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PR #2494: Set QN regularization strength consistent with scikit-learn
 - PR #2486: Fix cupy input to kmeans init
 - PR #2497: Changes to accomodate cuDF unsigned categorical changes
+- PR #2507: Import `treelite.sklearn`
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -39,7 +39,7 @@ from cuml.common.handle cimport cumlHandle
 from cuml.common import input_to_cuml_array
 
 import treelite
-import treelite.gallery.sklearn as tl_skl
+import treelite.sklearn as tl_skl
 
 cimport cuml.common.handle
 cimport cuml.common.cuda


### PR DESCRIPTION
Import `treelite.sklearn` (instead of `treelite.gallery.sklearn`).