### PR TITLE
[REVIEW] Increase tolerance for LogisticRegression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - PR #2486: Fix cupy input to kmeans init
 - PR #2497: Changes to accomodate cuDF unsigned categorical changes
 - PR #2507: Import `treelite.sklearn`
+- PR #2515: Increase tolerance for LogisticRegression test
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/test_linear_model.py
+++ b/python/cuml/test/test_linear_model.py
@@ -257,8 +257,8 @@ def test_logistic_regression(
     cu_preds = culog.predict(X_test)
 
     assert culog.score(X_train, y_train) >= sklog.score(X_train, y_train) - \
-        0.003
-    assert culog.score(X_test, y_test) >= sklog.score(X_test, y_test) - 0.006
+        0.006
+    assert culog.score(X_test, y_test) >= sklog.score(X_test, y_test) - 0.012
     assert len(np.unique(cu_preds)) == len(np.unique(y_test))
 
 


### PR DESCRIPTION
This PR increases the tolerance for logistic regression tests by a factor of two. 

The tolerance of logistic regression tests were recently decreased in #2494 by a factor of 10 to catch differences due to incorrect interpretation of the regularization strength parameter. The new value turns out to be too tight on some platforms, hence this PR increases the tolerance. 
