### PR TITLE
[REVIEW] Update umap n_epochs default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - PR #2507: Import `treelite.sklearn`
 - PR #2521: Fixing invalid smem calculation in KNeighborsCLassifier
 - PR #2515: Increase tolerance for LogisticRegression test
+- PR #2540: Update default value for n_epochs in UMAP to match documentation & sklearn API
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -276,7 +276,7 @@ class UMAP(Base):
     def __init__(self,
                  n_neighbors=15,
                  n_components=2,
-                 n_epochs=0,
+                 n_epochs=None,
                  learning_rate=1.0,
                  min_dist=0.1,
                  spread=1.0,
@@ -306,7 +306,7 @@ class UMAP(Base):
 
         self.n_neighbors = n_neighbors
         self.n_components = n_components
-        self.n_epochs = n_epochs
+        self.n_epochs = n_epochs if n_epochs else 0
 
         if init == "spectral" or init == "random":
             self.init = init


### PR DESCRIPTION
Update UMAP to pass `None` as the default value for `n_epochs` to match the cuml documentation and to match sklearn's API