### PR TITLE
[REVIEW] Fix memory leak and unnecessary allocs in TSNE::get_distances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - PR #2497: Changes to accomodate cuDF unsigned categorical changes
 - PR #2507: Import `treelite.sklearn`
 - PR #2515: Increase tolerance for LogisticRegression test
+- PR #2542: Fix small memory leak in TSNE
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/cpp/src/tsne/distances.cuh
+++ b/cpp/src/tsne/distances.cuh
@@ -41,15 +41,9 @@ void get_distances(const float *X, const int n, const int p, long *indices,
                    cudaStream_t stream) {
   // TODO: for TSNE transform first fit some points then transform with 1/(1+d^2)
   // #861
-  float **knn_input = new float *[1];
-  int *sizes = new int[1];
-  knn_input[0] = (float *)X;
-  sizes[0] = n;
 
-  std::vector<float *> input_vec(1);
-  std::vector<int> sizes_vec(1);
-  input_vec.push_back(knn_input[0]);
-  sizes_vec.push_back(sizes[0]);
+  std::vector<float *> input_vec = {const_cast<float *>(X)};
+  std::vector<int> sizes_vec = {n};
 
   /**
  * std::vector<float *> &input, std::vector<int> &sizes,
@@ -62,7 +56,6 @@ void get_distances(const float *X, const int n, const int p, long *indices,
   MLCommon::Selection::brute_force_knn(input_vec, sizes_vec, p,
                                        const_cast<float *>(X), n, indices,
                                        distances, n_neighbors, d_alloc, stream);
-  delete knn_input, sizes;
 }
 
 /**


### PR DESCRIPTION
c3ab759e289d18fbf3b470fcd8ee469a751043a7 left behind two extra allocations. Those allocations also leaked because `delete knn_input, sizes` only deletes `knn_input`. (It should also be `delete[]`.)

Finally, modernizes the vector initialization syntax.