### PR TITLE
Test pickle protocol 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PR #2099: Raise an error when float64 data is used with dask RF
 - PR #2526: Removing PCA TSQR as a solver due to scalability issues
 - PR #2538: Remove Protobuf dependency
+- PR #2553: Test pickle protocol 5 support
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -19,7 +19,6 @@ import pytest
 import cupy as cp
 import numpy as np
 import cudf
-import pickle
 
 from copy import deepcopy
 from numba import cuda
@@ -27,6 +26,15 @@ from cudf.core.buffer import Buffer
 from cuml.common.array import CumlArray
 from cuml.common.memory_utils import _get_size_from_shape
 from rmm import DeviceBuffer
+
+if sys.version_info < (3, 8):
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
+
 
 test_input_types = [
     'numpy', 'numba', 'cupy', 'series', None

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+import sys
+
 import pytest
 
 import cupy as cp

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -407,9 +407,9 @@ def test_pickle(input_type, protocol):
     else:
         inp = create_input(input_type, np.float32, (10, 5), 'F')
     ary = CumlArray(data=inp)
-    f = []
     dumps_kwargs = {"protocol": protocol}
     loads_kwargs = {}
+    f = []
     len_f = 0
     if protocol >= 5:
         dumps_kwargs["buffer_callback"] = f.append


### PR DESCRIPTION
Requires PR ( https://github.com/rapidsai/integration/pull/72 )

Adds a test using pickle protocol 5 support to `CumlArray`. Uses `pickle5` for older Python versions that lack builtin pickle protocol 5 support.