### PR TITLE
[REVIEW]Hashing Vectorizer and general vectorizer improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuML 0.15.0 (Date TBD)
 
 ## New Features
+- PR #2554: Hashing Vectorizer and general vectorizer improvements
 - PR #2240: Making Dask models pickleable
 - PR #2267: CountVectorizer estimator
 - PR #2261: Exposing new FAISS metrics through Python API

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -81,7 +81,14 @@ Feature and Label Encoding (Dask-based Multi-GPU)
 
 Feature Extraction (Single-GPU)
 -------------------------------
- .. autoclass:: cuml.feature_extraction.text.CountVectorizer
+
+  .. autoclass:: cuml.feature_extraction.text.CountVectorizer
+    :members:
+
+  .. autoclass:: cuml.feature_extraction.text.HashingVectorizer
+    :members:
+
+  .. autoclass:: cuml.feature_extraction.text.TfidfVectorizer
     :members:
 
 Dataset Generation (Single-GPU)

--- a/python/cuml/common/sparsefuncs.py
+++ b/python/cuml/common/sparsefuncs.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import math
-
+import cupy as cp
 from cuml.common import with_cupy_rmm
 from cuml.common.kernel_utils import cuda_kernel_factory
 
@@ -97,3 +97,59 @@ def csr_row_normalize_l2(X, inplace=True):
            (X.data, X.indices, X.indptr, X.shape[0]))
 
     return X
+
+
+def create_csr_matrix_from_count_df(count_df, empty_doc_ids, n_doc, n_features,
+                                    dtype=cp.float32):
+    """
+    Create a sparse matrix from the count of tokens by document
+
+    Parameters
+    ----------
+        count_df = cudf.DataFrame({'count':..., 'doc_id':.., 'token':.. })
+                    sorted by doc_id and token
+        empty_doc_ids = cupy array containing doc_ids with no tokens
+        n_doc: Total number of documents
+        n_features: Number of features
+        dtype: Output dtype
+    """
+    data = count_df["count"].values
+    indices = count_df["token"].values
+
+    doc_token_counts = count_df["doc_id"].value_counts().reset_index()
+    del count_df
+    doc_token_counts = doc_token_counts.rename(
+        {"doc_id": "token_counts", "index": "doc_id"}, axis=1
+    ).sort_values(by="doc_id")
+
+    token_counts = _insert_zeros(
+        doc_token_counts["token_counts"], empty_doc_ids
+    )
+    indptr = token_counts.cumsum()
+    indptr = cp.pad(indptr, (1, 0), "constant")
+
+    return cp.sparse.csr_matrix(
+        arg1=(data, indices, indptr), dtype=dtype,
+        shape=(n_doc, n_features)
+    )
+
+
+def _insert_zeros(ary, zero_indices):
+    """
+    Create a new array of len(ary + zero_indices) where zero_indices
+    indicates indexes of 0s in the new array. Ary is used to fill the rest.
+
+    Example:
+        _insert_zeros([1, 2, 3], [1, 3]) => [1, 0, 2, 0, 3]
+    """
+    if len(zero_indices) == 0:
+        return ary.values
+
+    new_ary = cp.zeros((len(ary) + len(zero_indices)), dtype=cp.int32)
+
+    # getting mask of non-zeros
+    data_mask = ~cp.in1d(cp.arange(0, len(new_ary), dtype=cp.int32),
+                         zero_indices)
+
+    new_ary[data_mask] = ary
+    return new_ary

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -17,8 +17,7 @@ from sklearn.utils.validation import FLOAT_DTYPES
 from sklearn.exceptions import NotFittedError
 import cupy as cp
 from cuml.common import with_cupy_rmm
-from cuml.common.sparsefuncs import csr_row_normalize_l1
-from cuml.common.sparsefuncs import csr_row_normalize_l2
+from cuml.common.sparsefuncs import csr_row_normalize_l1, csr_row_normalize_l2
 
 
 def _sparse_document_frequency(X):

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -95,6 +95,9 @@ class TfidfTransformer:
         self.smooth_idf = smooth_idf
         self.sublinear_tf = sublinear_tf
 
+        if self.norm not in ('l1', 'l2'):
+            raise ValueError(f"{self.norm} is not a supported norm")
+
     @with_cupy_rmm
     def fit(self, X):
         """Learn the idf vector (global term weights).

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -95,9 +95,6 @@ class TfidfTransformer:
         self.smooth_idf = smooth_idf
         self.sublinear_tf = sublinear_tf
 
-        if self.norm not in ('l1', 'l2'):
-            raise ValueError(f"{self.norm} is not a supported norm")
-
     @with_cupy_rmm
     def fit(self, X):
         """Learn the idf vector (global term weights).

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -51,14 +51,15 @@ def _preprocess(doc, lower=False, remove_non_alphanumeric=False, delimiter=" ",
     if remove_non_alphanumeric:
         if keep_underscore_char:
             # why: sklearn by default keeps `_` char along with  alphanumerics
-            # currently we dont have a easy way of removing all chars but x in cudf.Series[str]
-            # below works around it
-            temp_string = 'cumlCh'
+            # currently we dont have a easy way of removing
+            # all chars but `_`
+            # in cudf.Series[str] below works around it
+            temp_string = 'cumlSt'
             doc = doc.str.replace('_', temp_string, regex=False)
             doc = doc.str.filter_alphanum(' ', keep=True)
             doc = doc.str.replace(temp_string, '_', regex=False)
         else:
-            doc = doc.str.filter_alphanum(' ', keep=True)      
+            doc = doc.str.filter_alphanum(' ', keep=True)
     return doc
 
 
@@ -93,7 +94,6 @@ class _VectorizerMixin:
                                  remove_non_alphanumeric=remove_non_alpha,
                                  delimiter=self.delimiter)
         return lambda doc: self._remove_stop_words(preprocess(doc))
-
 
     def _get_stop_words(self):
         """Build or fetch the effective stop words list.
@@ -257,7 +257,8 @@ class _VectorizerMixin:
         indptr = cp.pad(indptr, (1, 0), "constant")
 
         return cp.sparse.csr_matrix(
-            arg1=(data, indices, indptr), dtype=self.dtype, shape=(n_doc, n_features)
+            arg1=(data, indices, indptr), dtype=self.dtype,
+            shape=(n_doc, n_features)
         )
 
     def _validate_params(self):
@@ -275,7 +276,8 @@ class _VectorizerMixin:
         if hasattr(self, "n_features"):
             if not isinstance(self.n_features, numbers.Integral):
                 raise TypeError(
-                    f"n_features must be integral, got {self.n_features} ({type(self.n_features)})."
+                    f"n_features must be integral, got {self.n_features}\
+                    ({type(self.n_features)})."
                 )
 
     def _warn_for_unused_params(self):
@@ -322,6 +324,7 @@ def _term_frequency(X):
         .sum()
     )
     return term_freq["count"].values
+
 
 class CountVectorizer(_VectorizerMixin):
     """Convert a collection of text documents to a matrix of token counts
@@ -575,7 +578,7 @@ class CountVectorizer(_VectorizerMixin):
         empty_doc_ids = self._compute_empty_doc_ids(count_df, n_doc)
 
         X = self._create_csr_matrix_from_count_df(count_df, empty_doc_ids,
-                                                  n_doc,len(self.vocabulary_))
+                                                  n_doc, len(self.vocabulary_))
         if self.binary:
             X.data.fill(1)
         return X
@@ -652,7 +655,8 @@ class HashingVectorizer(_VectorizerMixin):
     token string name to feature integer index mapping.
     This strategy has several advantages:
     - it is very low memory scalable to large datasets as there is no need to
-      store a vocabulary dictionary in memory which even more important as GPU's are often memory constrained
+      store a vocabulary dictionary in memory which is even more important
+      as GPU's that are often memory constrained
     - it is fast to pickle and un-pickle as it holds no state besides the
       constructor parameters
     - it can be used in a streaming (partial fit) or parallel pipeline as there

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -29,8 +29,8 @@ from cudf.utils.dtypes import min_signed_type
 
 def _get_non_alphanumeric_characters(docs):
     characters = docs.str.character_tokenize().unique()
-    non_alpha = characters.str.extract(r"([^\w])", expand=False).dropna()
-    return non_alpha.tolist() + ["\n"]
+    non_alpha = characters.str.extract(r'([^\w])', expand=False).dropna()
+    return non_alpha.tolist() + ['\n']
 
 
 def _preprocess(doc, lower=False, remove_non_alphanumeric=False, delimiter=" "):
@@ -65,11 +65,11 @@ class _VectorizerMixin:
 
     def _remove_stop_words(self, doc):
         """Remove stop words only if needed."""
-        if self.analyzer == "word" and self.stop_words is not None:
+        if self.analyzer == 'word' and self.stop_words is not None:
             stop_words = Series(self._get_stop_words())
-            doc = doc.str.replace_tokens(
-                stop_words, replacements=self.delimiter, delimiter=self.delimiter
-            )
+            doc = doc.str.replace_tokens(stop_words,
+                                         replacements=self.delimiter,
+                                         delimiter=self.delimiter)
         return doc
 
     def build_preprocessor(self):
@@ -86,14 +86,12 @@ class _VectorizerMixin:
         if self.preprocessor is not None:
             preprocess = self.preprocessor
         else:
-            remove_non_alpha = self.analyzer == "word"
-            preprocess = partial(
-                _preprocess,
-                lower=self.lowercase,
-                remove_non_alphanumeric=remove_non_alpha,
-                delimiter=self.delimiter,
-            )
+            remove_non_alpha = self.analyzer == 'word'
+            preprocess = partial(_preprocess, lower=self.lowercase,
+                                 remove_non_alphanumeric=remove_non_alpha,
+                                 delimiter=self.delimiter)
         return lambda doc: self._remove_stop_words(preprocess(doc))
+
 
     def _get_stop_words(self):
         """Build or fetch the effective stop words list.
@@ -118,7 +116,7 @@ class _VectorizerMixin:
         When analyzer is 'char_wb', we generate ngrams within word boundaries,
         meaning we need to first tokenize and pad each token with a delimiter.
         """
-        if self.analyzer == "char_wb" and ngram_size != 1:
+        if self.analyzer == 'char_wb' and ngram_size != 1:
             tokens = str_series.str.tokenize(self.delimiter)
 
             padding = Series(self.delimiter).repeat(len(tokens))
@@ -128,20 +126,18 @@ class _VectorizerMixin:
             ngram_sr = tokens.str.character_ngrams(n=ngram_size)
 
             token_count = str_series.str.token_count(self.delimiter)
-            doc_id_df = cudf.DataFrame(
-                {
-                    "doc_id": doc_id_sr.repeat(token_count).reset_index(drop=True),
-                    # formula to count ngrams given number of letters per token:
-                    "ngram_count": tokens.str.len() - (ngram_size - 1),
-                }
-            )
-            ngram_count = doc_id_df.groupby("doc_id").sum()["ngram_count"]
+            doc_id_df = cudf.DataFrame({
+                'doc_id': doc_id_sr.repeat(token_count).reset_index(drop=True),
+                # formula to count ngrams given number of letters per token:
+                'ngram_count': tokens.str.len() - (ngram_size - 1)
+            })
+            ngram_count = doc_id_df.groupby('doc_id').sum()['ngram_count']
             return ngram_sr, ngram_count, token_count
 
         if ngram_size == 1:
             token_count = str_series.str.len()
             ngram_sr = str_series.str.character_tokenize()
-        elif self.analyzer == "char":
+        elif self.analyzer == 'char':
             token_count = str_series.str.len()
             ngram_sr = str_series.str.character_ngrams(n=ngram_size)
 
@@ -161,11 +157,11 @@ class _VectorizerMixin:
         doc_id_sr : cudf.Series
             Int series containing documents ids
         """
-        if self.analyzer == "word":
+        if self.analyzer == 'word':
             token_count_sr = str_series.str.token_count(self.delimiter)
-            ngram_sr = str_series.str.ngrams_tokenize(
-                n=ngram_size, separator=" ", delimiter=self.delimiter
-            )
+            ngram_sr = str_series.str.ngrams_tokenize(n=ngram_size,
+                                                      separator=" ",
+                                                      delimiter=self.delimiter)
             # formula to count ngrams given number of tokens x per doc: x-(n-1)
             ngram_count = token_count_sr - (ngram_size - 1)
         else:
@@ -194,7 +190,8 @@ class _VectorizerMixin:
         doc_id = Series(doc_id)
 
         tokenized_df_ls = [
-            self.get_ngrams(docs, n, doc_id) for n in range(min_n, max_n + 1)
+            self.get_ngrams(docs, n, doc_id)
+            for n in range(min_n, max_n + 1)
         ]
 
         tokenized_df = cudf.concat(tokenized_df_ls)
@@ -225,14 +222,14 @@ class _VectorizerMixin:
         Compute empty docs ids using the remaining docs, given the total number
         of documents.
         """
-        remaining_docs = count_df["doc_id"].unique()
+        remaining_docs = count_df['doc_id'].unique()
         dtype = min_signed_type(n_doc)
-        doc_ids = cudf.DataFrame(
-            data={"all_ids": cp.arange(0, n_doc, dtype=dtype)}, dtype=dtype
-        )
+        doc_ids = cudf.DataFrame(data={'all_ids': cp.arange(0, n_doc,
+                                                            dtype=dtype)},
+                                 dtype=dtype)
 
         empty_docs = doc_ids - doc_ids.iloc[remaining_docs]
-        empty_ids = empty_docs[empty_docs["all_ids"].isnull()].index.values
+        empty_ids = empty_docs[empty_docs['all_ids'].isnull()].index.values
         return empty_ids
 
     def _create_csr_matrix_from_count_df(
@@ -303,15 +300,22 @@ class _VectorizerMixin:
 
 def _document_frequency(X):
     """Count the number of non-zero values for each feature in X."""
-    doc_freq = X[["token", "doc_id"]].groupby(["token"]).count()
+    doc_freq = (
+        X[["token", "doc_id"]]
+        .groupby(["token"])
+        .count()
+    )
     return doc_freq["doc_id"].values
 
 
 def _term_frequency(X):
     """Count the number of occurrences of each term in X."""
-    term_freq = X[["token", "count"]].groupby(["token"]).sum()
+    term_freq = (
+        X[["token", "count"]]
+        .groupby(["token"])
+        .sum()
+    )
     return term_freq["count"].values
-
 
 class CountVectorizer(_VectorizerMixin):
     """Convert a collection of text documents to a matrix of token counts
@@ -386,27 +390,12 @@ class CountVectorizer(_VectorizerMixin):
         This is only available if no vocabulary was given.
     """
 
-    def __init__(
-        self,
-        input=None,
-        encoding=None,
-        decode_error=None,
-        strip_accents=None,
-        lowercase=True,
-        preprocessor=None,
-        tokenizer=None,
-        stop_words=None,
-        token_pattern=None,
-        ngram_range=(1, 1),
-        analyzer="word",
-        max_df=1.0,
-        min_df=1,
-        max_features=None,
-        vocabulary=None,
-        binary=False,
-        dtype=cp.float32,
-        delimiter=" ",
-    ):
+    def __init__(self, input=None, encoding=None, decode_error=None,
+                 strip_accents=None, lowercase=True, preprocessor=None,
+                 tokenizer=None, stop_words=None, token_pattern=None,
+                 ngram_range=(1, 1), analyzer='word', max_df=1.0, min_df=1,
+                 max_features=None, vocabulary=None, binary=False,
+                 dtype=cp.float32, delimiter=' '):
         self.preprocessor = preprocessor
         self.analyzer = analyzer
         self.lowercase = lowercase
@@ -420,8 +409,7 @@ class CountVectorizer(_VectorizerMixin):
             if not isinstance(max_features, int) or max_features <= 0:
                 raise ValueError(
                     "max_features=%r, neither a positive integer nor None"
-                    % max_features
-                )
+                    % max_features)
         self.ngram_range = ngram_range
         self.vocabulary = vocabulary
         self.binary = binary
@@ -431,24 +419,22 @@ class CountVectorizer(_VectorizerMixin):
             msg = f"Expected dtype in {CUPY_SPARSE_DTYPES}, got {dtype}"
             raise ValueError(msg)
 
-        sklearn_params = {
-            "input": input,
-            "encoding": encoding,
-            "decode_error": decode_error,
-            "strip_accents": strip_accents,
-            "tokenizer": tokenizer,
-            "token_pattern": token_pattern,
-        }
+        sklearn_params = {"input": input,
+                          "encoding": encoding,
+                          "decode_error": decode_error,
+                          "strip_accents": strip_accents,
+                          "tokenizer": tokenizer,
+                          "token_pattern": token_pattern}
         self._check_sklearn_params(analyzer, sklearn_params)
 
     def _count_vocab(self, tokenized_df):
         """Count occurrences of tokens in each document."""
         # Transform string tokens into token indexes from 0 to len(vocab)
         # The indexes are based on lexicographical ordering.
-        tokenized_df["token"] = tokenized_df["token"].astype("category")
-        tokenized_df["token"] = (
-            tokenized_df["token"].cat.set_categories(self.vocabulary_)._column.codes
-        )
+        tokenized_df['token'] = tokenized_df['token'].astype('category')
+        tokenized_df['token'] = tokenized_df['token'].cat.set_categories(
+            self.vocabulary_
+        )._column.codes
 
         # Count of each token in each document
         count_df = (
@@ -465,7 +451,9 @@ class CountVectorizer(_VectorizerMixin):
         """Filter dataframe to keep only values from column matching
         keep_values."""
         df[column] = (
-            df[column].astype("category").cat.set_categories(keep_values)._column.codes
+            df[column].astype('category')
+            .cat.set_categories(keep_values)
+            ._column.codes
         )
         df = df.dropna(subset=column)
         return df
@@ -501,13 +489,11 @@ class CountVectorizer(_VectorizerMixin):
         keep_num = keep_idx.shape[0]
 
         if keep_num == 0:
-            raise ValueError(
-                "After pruning, no terms remain. Try a lower"
-                " min_df or a higher max_df."
-            )
+            raise ValueError("After pruning, no terms remain. Try a lower"
+                             " min_df or a higher max_df.")
 
         if len(vocab) - keep_num != 0:
-            count_df = self._filter_and_renumber(count_df, keep_idx, "token")
+            count_df = self._filter_and_renumber(count_df, keep_idx, 'token')
 
         self.stop_words_ = vocab[~mask].reset_index(drop=True)
         self.vocabulary_ = vocab[mask].reset_index(drop=True)
@@ -566,31 +552,24 @@ class CountVectorizer(_VectorizerMixin):
         count_df = self._count_vocab(tokenized_df)
 
         if not self._fixed_vocabulary:
-            max_doc_count = (
-                self.max_df
-                if isinstance(self.max_df, numbers.Integral)
-                else self.max_df * n_doc
-            )
-            min_doc_count = (
-                self.min_df
-                if isinstance(self.min_df, numbers.Integral)
-                else self.min_df * n_doc
-            )
+            max_doc_count = (self.max_df
+                             if isinstance(self.max_df, numbers.Integral)
+                             else self.max_df * n_doc)
+            min_doc_count = (self.min_df
+                             if isinstance(self.min_df, numbers.Integral)
+                             else self.min_df * n_doc)
             if max_doc_count < min_doc_count:
-                raise ValueError("max_df corresponds to < documents than min_df")
-            count_df = self._limit_features(
-                count_df,
-                self.vocabulary_,
-                max_doc_count,
-                min_doc_count,
-                self.max_features,
-            )
+                raise ValueError(
+                    "max_df corresponds to < documents than min_df")
+            count_df = self._limit_features(count_df, self.vocabulary_,
+                                            max_doc_count,
+                                            min_doc_count,
+                                            self.max_features)
 
         empty_doc_ids = self._compute_empty_doc_ids(count_df, n_doc)
 
-        X = self._create_csr_matrix_from_count_df(
-            count_df, empty_doc_ids, n_doc, len(self.vocabulary_)
-        )
+        X = self._create_csr_matrix_from_count_df(count_df, empty_doc_ids,
+                                                  n_doc,len(self.vocabulary_))
         if self.binary:
             X.data.fill(1)
         return X

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -660,15 +660,14 @@ class HashingVectorizer(_VectorizerMixin):
       feature index. However in practice this is rarely an issue if n_features
       is large enough (e.g. 2 ** 18 for text classification problems).
     - no IDF weighting as this would render the transformer stateful.
-    he hash function employed is the signed 32-bit version of Murmurhash3.
+    The hash function employed is the signed 32-bit version of Murmurhash3.
     Parameters
     ----------
     lowercase : bool, default=True
         Convert all characters to lowercase before tokenizing.
-    preprocessor : callable, default=None
+    preprocessor : callable or None (default)
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
-        Only applies if ``analyzer is not callable``.
     stop_words : string {'english'}, list, default=None
         If 'english', a built-in stop word list for English is used.
         There are several known issues with 'english' and you should
@@ -678,11 +677,10 @@ class HashingVectorizer(_VectorizerMixin):
         Only applies if ``analyzer == 'word'``.
     ngram_range : tuple (min_n, max_n), default=(1, 1)
         The lower and upper boundary of the range of n-values for different
-        n-grams to be extracted. All values of n such that min_n <= n <= max_n
-        will be used. For example an ``ngram_range`` of ``(1, 1)`` means only
-        unigrams, ``(1, 2)`` means unigrams and bigrams, and ``(2, 2)`` means
-        only bigrams.
-        Only applies if ``analyzer is not callable``.
+        word n-grams or char n-grams to be extracted. All values of n such
+        such that min_n <= n <= max_n will be used. For example an
+        ``ngram_range`` of ``(1, 1)`` means only unigrams, ``(1, 2)`` means
+        unigrams and bigrams, and ``(2, 2)`` means only bigrams.
     analyzer : string, {'word', 'char', 'char_wb'}
         Whether the feature should be made of word n-gram or character
         n-grams.
@@ -704,7 +702,6 @@ class HashingVectorizer(_VectorizerMixin):
         small n_features. This approach is similar to sparse random projection.
     dtype : type, optional
         Type of the matrix returned by fit_transform() or transform().
-
     delimiter : str, whitespace by default
         String used as a replacement for stop words if stop_words is not None.
         Typically the delimiting character between words is a good choice.

--- a/python/cuml/feature_extraction/text.py
+++ b/python/cuml/feature_extraction/text.py
@@ -21,3 +21,4 @@ from cuml.feature_extraction.text just like scikit-learn. Do not remove.
 from cuml.feature_extraction._tfidf import TfidfTransformer  # noqa # pylint: disable=unused-import
 from cuml.feature_extraction._tfidf_vectorizer import TfidfVectorizer  # noqa # pylint: disable=unused-import
 from cuml.feature_extraction._vectorizers import CountVectorizer  # noqa # pylint: disable=unused-import
+from cuml.feature_extraction._vectorizers import HashingVectorizer # noqa # pylint: disable=unused-import

--- a/python/cuml/test/test_text_feature_extraction.py
+++ b/python/cuml/test/test_text_feature_extraction.py
@@ -29,10 +29,10 @@ import numpy as np
 
 def test_count_vectorizer():
     corpus = [
-        'This is the first document.',
-        'This document is the second document.',
-        'And this is the third one.',
-        'Is this the first document?',
+        "This is the first document.",
+        "This document is the second document.",
+        "And this is the third one.",
+        "Is this the first document?",
     ]
 
     res = CountVectorizer().fit_transform(Series(corpus))
@@ -63,10 +63,10 @@ DOCS = JUNK_FOOD_DOCS + EMPTY_DOCS + NOTJUNK_FOOD_DOCS + EMPTY_DOCS
 DOCS_GPU = Series(DOCS)
 
 NGRAM_RANGES = [(1, 1), (1, 2), (2, 3)]
-NGRAM_IDS = [f'ngram_range={str(r)}' for r in NGRAM_RANGES]
+NGRAM_IDS = [f"ngram_range={str(r)}" for r in NGRAM_RANGES]
 
 
-@pytest.mark.parametrize('ngram_range', NGRAM_RANGES, ids=NGRAM_IDS)
+@pytest.mark.parametrize("ngram_range", NGRAM_RANGES, ids=NGRAM_IDS)
 def test_word_analyzer(ngram_range):
     vec = CountVectorizer(ngram_range=ngram_range).fit(DOCS_GPU)
     ref = SkCountVect(ngram_range=ngram_range).fit(DOCS)
@@ -83,8 +83,8 @@ def test_countvectorizer_custom_vocabulary():
 
 
 def test_countvectorizer_stop_words():
-    ref = SkCountVect(stop_words='english').fit_transform(DOCS)
-    X = CountVectorizer(stop_words='english').fit_transform(DOCS_GPU)
+    ref = SkCountVect(stop_words="english").fit_transform(DOCS)
+    X = CountVectorizer(stop_words="english").fit_transform(DOCS_GPU)
     cp.testing.assert_array_equal(X.todense(), ref.toarray())
 
 
@@ -99,16 +99,23 @@ def test_countvectorizer_stop_words_ngrams():
     stop_words_doc = Series(["and me too andy andy too"])
     expected_vocabulary = ["andy andy"]
 
-    vec = CountVectorizer(ngram_range=(2, 2), stop_words='english')
+    vec = CountVectorizer(ngram_range=(2, 2), stop_words="english")
     vec.fit(stop_words_doc)
 
     assert expected_vocabulary == vec.get_feature_names().tolist()
 
 
 def test_countvectorizer_max_features():
-    expected_vocabulary = {'burger', 'beer', 'salad', 'pizza'}
-    expected_stop_words = {'celeri', 'tomato', 'copyright', 'coke',
-                           'sparkling', 'water', 'the'}
+    expected_vocabulary = {"burger", "beer", "salad", "pizza"}
+    expected_stop_words = {
+        "celeri",
+        "tomato",
+        "copyright",
+        "coke",
+        "sparkling",
+        "water",
+        "the",
+    }
 
     # test bounded number of extracted features
     vec = CountVectorizer(max_df=0.6, max_features=4)
@@ -138,78 +145,76 @@ def test_countvectorizer_max_features_counts():
     assert 7 == counts_None.max()
 
     # The most common feature should be the same
-    def as_index(x): return x.astype(cp.int32).item()
+    def as_index(x):
+        return x.astype(cp.int32).item()
+
     assert "the" == features_1[as_index(cp.argmax(counts_1))]
     assert "the" == features_3[as_index(cp.argmax(counts_3))]
     assert "the" == features_None[as_index(cp.argmax(counts_None))]
 
 
 def test_countvectorizer_max_df():
-    test_data = Series(['abc', 'dea', 'eat'])
-    vect = CountVectorizer(analyzer='char', max_df=1.0)
+    test_data = Series(["abc", "dea", "eat"])
+    vect = CountVectorizer(analyzer="char", max_df=1.0)
     vect.fit(test_data)
-    assert 'a' in vect.vocabulary_.tolist()
+    assert "a" in vect.vocabulary_.tolist()
     assert len(vect.vocabulary_.tolist()) == 6
     assert len(vect.stop_words_) == 0
 
     vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
     vect.fit(test_data)
-    assert 'a' not in vect.vocabulary_.tolist()  # {ae} ignored
-    assert len(vect.vocabulary_.tolist()) == 4    # {bcdt} remain
-    assert 'a' in vect.stop_words_.tolist()
+    assert "a" not in vect.vocabulary_.tolist()  # {ae} ignored
+    assert len(vect.vocabulary_.tolist()) == 4  # {bcdt} remain
+    assert "a" in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 2
 
     vect.max_df = 1
     vect.fit(test_data)
-    assert 'a' not in vect.vocabulary_.tolist()  # {ae} ignored
-    assert len(vect.vocabulary_.tolist()) == 4    # {bcdt} remain
-    assert 'a' in vect.stop_words_.tolist()
+    assert "a" not in vect.vocabulary_.tolist()  # {ae} ignored
+    assert len(vect.vocabulary_.tolist()) == 4  # {bcdt} remain
+    assert "a" in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 2
 
 
 def test_vectorizer_min_df():
-    test_data = Series(['abc', 'dea', 'eat'])
-    vect = CountVectorizer(analyzer='char', min_df=1)
+    test_data = Series(["abc", "dea", "eat"])
+    vect = CountVectorizer(analyzer="char", min_df=1)
     vect.fit(test_data)
-    assert 'a' in vect.vocabulary_.tolist()
+    assert "a" in vect.vocabulary_.tolist()
     assert len(vect.vocabulary_.tolist()) == 6
     assert len(vect.stop_words_) == 0
 
     vect.min_df = 2
     vect.fit(test_data)
-    assert 'c' not in vect.vocabulary_.tolist()  # {bcdt} ignored
-    assert len(vect.vocabulary_.tolist()) == 2    # {ae} remain
-    assert 'c' in vect.stop_words_.tolist()
+    assert "c" not in vect.vocabulary_.tolist()  # {bcdt} ignored
+    assert len(vect.vocabulary_.tolist()) == 2  # {ae} remain
+    assert "c" in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 4
 
     vect.min_df = 0.8  # 0.8 * 3 documents -> min_doc_count == 2.4
     vect.fit(test_data)
-    assert 'c' not in vect.vocabulary_.tolist()  # {bcdet} ignored
-    assert len(vect.vocabulary_.tolist()) == 1    # {a} remains
-    assert 'c' in vect.stop_words_.tolist()
+    assert "c" not in vect.vocabulary_.tolist()  # {bcdet} ignored
+    assert len(vect.vocabulary_.tolist()) == 1  # {a} remains
+    assert "c" in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 5
 
 
 def test_count_binary_occurrences():
     # by default multiple occurrences are counted as longs
-    test_data = Series(['aaabc', 'abbde'])
-    vect = CountVectorizer(analyzer='char', max_df=1.0)
+    test_data = Series(["aaabc", "abbde"])
+    vect = CountVectorizer(analyzer="char", max_df=1.0)
     X = cp.asnumpy(vect.fit_transform(test_data).todense())
-    assert_array_equal(['a', 'b', 'c', 'd', 'e'],
-                       vect.get_feature_names().tolist())
-    assert_array_equal([[3, 1, 1, 0, 0],
-                        [1, 2, 0, 1, 1]], X)
+    assert_array_equal(["a", "b", "c", "d", "e"], vect.get_feature_names().tolist())
+    assert_array_equal([[3, 1, 1, 0, 0], [1, 2, 0, 1, 1]], X)
 
     # using boolean features, we can fetch the binary occurrence info
     # instead.
-    vect = CountVectorizer(analyzer='char', max_df=1.0, binary=True)
+    vect = CountVectorizer(analyzer="char", max_df=1.0, binary=True)
     X = cp.asnumpy(vect.fit_transform(test_data).todense())
-    assert_array_equal([[1, 1, 1, 0, 0],
-                        [1, 1, 0, 1, 1]], X)
+    assert_array_equal([[1, 1, 1, 0, 0], [1, 1, 0, 1, 1]], X)
 
     # check the ability to change the dtype
-    vect = CountVectorizer(analyzer='char', max_df=1.0,
-                           binary=True, dtype=cp.float32)
+    vect = CountVectorizer(analyzer="char", max_df=1.0, binary=True, dtype=cp.float32)
     X = vect.fit_transform(test_data)
     assert X.dtype == cp.float32
 
@@ -231,9 +236,9 @@ def test_vectorizer_inverse_transform():
         assert_array_equal(doc, sk_doc)
 
 
-@pytest.mark.parametrize('ngram_range', NGRAM_RANGES, ids=NGRAM_IDS)
+@pytest.mark.parametrize("ngram_range", NGRAM_RANGES, ids=NGRAM_IDS)
 def test_space_ngrams(ngram_range):
-    data = ['abc      def. 123 456    789']
+    data = ["abc      def. 123 456    789"]
     data_gpu = Series(data)
     vec = CountVectorizer(ngram_range=ngram_range).fit(data_gpu)
     ref = SkCountVect(ngram_range=ngram_range).fit(data)
@@ -241,9 +246,7 @@ def test_space_ngrams(ngram_range):
 
 
 def test_empty_doc_after_limit_features():
-    data = ['abc abc def',
-            'def abc',
-            'ghi']
+    data = ["abc abc def", "def abc", "ghi"]
     data_gpu = Series(data)
     count = CountVectorizer(min_df=2).fit_transform(data_gpu)
     ref = SkCountVect(min_df=2).fit_transform(data)
@@ -257,34 +260,29 @@ def test_countvectorizer_separate_fit_transform():
 
 
 def test_non_ascii():
-    non_ascii = ('This is ascii,',
-                 'but not this Αγγλικά.')
+    non_ascii = ("This is ascii,", "but not this Αγγλικά.")
     non_ascii_gpu = Series(non_ascii)
 
     cv = CountVectorizer()
     res = cv.fit_transform(non_ascii_gpu)
     ref = SkCountVect().fit_transform(non_ascii)
 
-    assert 'αγγλικά' in set(cv.get_feature_names().tolist())
+    assert "αγγλικά" in set(cv.get_feature_names().tolist())
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
 
 def test_only_delimiters():
-    data = ['abc def. 123',
-            '   ',
-            '456 789']
+    data = ["abc def. 123", "   ", "456 789"]
     data_gpu = Series(data)
     res = CountVectorizer().fit_transform(data_gpu)
     ref = SkCountVect().fit_transform(data)
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
 
-@pytest.mark.parametrize('analyzer', ['char', 'char_wb'])
-@pytest.mark.parametrize('ngram_range', NGRAM_RANGES, ids=NGRAM_IDS)
+@pytest.mark.parametrize("analyzer", ["char", "char_wb"])
+@pytest.mark.parametrize("ngram_range", NGRAM_RANGES, ids=NGRAM_IDS)
 def test_character_ngrams(analyzer, ngram_range):
-    data = ['ab c',
-            ''
-            'edf gh']
+    data = ["ab c", "" "edf gh"]
 
     res = CountVectorizer(analyzer=analyzer, ngram_range=ngram_range)
     res.fit(Series(data))
@@ -294,16 +292,21 @@ def test_character_ngrams(analyzer, ngram_range):
     assert ref.get_feature_names() == res.get_feature_names().tolist()
 
 
-@pytest.mark.parametrize('query', [Series(['science aa', '', 'a aa aaa']),
-                                   Series(['science aa', '']),
-                                   Series(['science'])])
+@pytest.mark.parametrize(
+    "query",
+    [
+        Series(["science aa", "", "a aa aaa"]),
+        Series(["science aa", ""]),
+        Series(["science"]),
+    ],
+)
 def test_transform_unsigned_categories(query):
-    token = 'a'
+    token = "a"
     thousand_tokens = list()
     for i in range(1000):
         thousand_tokens.append(token)
-        token += 'a'
-    thousand_tokens[128] = 'science'
+        token += "a"
+    thousand_tokens[128] = "science"
 
     vec = CountVectorizer().fit(Series(thousand_tokens))
     res = vec.transform(query)
@@ -316,11 +319,11 @@ def test_transform_unsigned_categories(query):
 # TfidfTransformer so we only do the bare minimum tests here
 # ----------------------------------------------------------------
 
+
 def test_tfidf_vectorizer_setters():
-    tv = TfidfVectorizer(norm='l2', use_idf=False, smooth_idf=False,
-                         sublinear_tf=False)
-    tv.norm = 'l1'
-    assert tv._tfidf.norm == 'l1'
+    tv = TfidfVectorizer(norm="l2", use_idf=False, smooth_idf=False, sublinear_tf=False)
+    tv.norm = "l1"
+    assert tv._tfidf.norm == "l1"
     tv.use_idf = True
     assert tv._tfidf.use_idf
     tv.smooth_idf = True
@@ -334,34 +337,31 @@ def test_tfidf_vectorizer_idf_setter():
     orig.fit(DOCS_GPU)
     copy = TfidfVectorizer(vocabulary=orig.vocabulary_, use_idf=True)
     copy.idf_ = orig.idf_[0]
-    cp.testing.assert_array_almost_equal(copy.transform(DOCS_GPU).todense(),
-                                         orig.transform(DOCS_GPU).todense())
+    cp.testing.assert_array_almost_equal(
+        copy.transform(DOCS_GPU).todense(), orig.transform(DOCS_GPU).todense()
+    )
 
 
-@pytest.mark.parametrize('norm', ['l1', 'l2', None])
-@pytest.mark.parametrize('use_idf', [True, False])
-@pytest.mark.parametrize('smooth_idf', [True, False])
-@pytest.mark.parametrize('sublinear_tf', [True, False])
+@pytest.mark.parametrize("norm", ["l1", "l2", None])
+@pytest.mark.parametrize("use_idf", [True, False])
+@pytest.mark.parametrize("smooth_idf", [True, False])
+@pytest.mark.parametrize("sublinear_tf", [True, False])
 def test_tfidf_vectorizer(norm, use_idf, smooth_idf, sublinear_tf):
     tfidf_mat = TfidfVectorizer(
-        norm=norm, use_idf=use_idf,
-        smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
+        norm=norm, use_idf=use_idf, smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
     ).fit_transform(DOCS_GPU)
 
     ref = SkTfidfVect(
-        norm=norm, use_idf=use_idf,
-        smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
+        norm=norm, use_idf=use_idf, smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
     ).fit_transform(DOCS)
 
     cp.testing.assert_array_almost_equal(tfidf_mat.todense(), ref.toarray())
 
 
-
 # ----------------------------------------------------------------
-# HashingVectorizer tests 
+# HashingVectorizer tests
 # ----------------------------------------------------------------
-
-def test_almost_equal_hash_matrices(mat_1,mat_2,ignore_sign=True):
+def test_almost_equal_hash_matrices(mat_1, mat_2, ignore_sign=True):
     """
     Currently if all the sorted values in the row is equal we assume equality 
     TODO: Find better way to test ig hash matrices are equal
@@ -370,8 +370,8 @@ def test_almost_equal_hash_matrices(mat_1,mat_2,ignore_sign=True):
     for row_id in range(mat_1.shape[0]):
         row_m1 = mat_1[row_id]
         row_m2 = mat_2[row_id]
-        nz_row_m1  = np.sort(row_m1[row_m1!=0])
-        nz_row_m2  = np.sort(row_m2[row_m2!=0])
+        nz_row_m1 = np.sort(row_m1[row_m1 != 0])
+        nz_row_m2 = np.sort(row_m2[row_m2 != 0])
         # print(nz_row_m1)
         # print(nz_row_m2)
         if ignore_sign:
@@ -381,17 +381,19 @@ def test_almost_equal_hash_matrices(mat_1,mat_2,ignore_sign=True):
         nz_row_m2.sort()
         np.testing.assert_almost_equal(nz_row_m1, nz_row_m2)
 
+
 def test_hashingvectorizer():
     corpus = [
-        'This is the first document.',
-        'This document is the second document.',
-        'And this is the third one.',
-        'Is this the first document?',
+        "This is the first document.",
+        "This document is the second document.",
+        "And this is the third one.",
+        "Is this the first document?",
     ]
 
     res = HashingVectorizer().fit_transform(Series(corpus))
     ref = SkHashVect().fit_transform(corpus)
     test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+
 
 @pytest.mark.xfail
 def test_vectorizer_empty_token_case():
@@ -400,28 +402,31 @@ def test_vectorizer_empty_token_case():
     we might want to look into this more but this should not be a concern for most piplines
     """
     corpus = [
-        'a b ',
+        "a b ",
     ]
 
-    preprocessor = lambda s:s
-    sklearn_tokenizer = lambda s:s.split(' ')
-    ## we have extra null token here
-    ## we slightly diverge from sklearn here as not treating it as a token
-    res = CountVectorizer(preprocessor=preprocessor).fit_transform(Series(corpus))
-    ref = SkCountVect(preprocessor=preprocessor, tokenizer=sklearn_tokenizer).fit_transform(corpus)
+    # we have extra null token here
+    # we slightly diverge from sklearn here as not treating it as a token
+    res = CountVectorizer(preprocessor=lambda s: s).fit_transform(Series(corpus))
+    ref = SkCountVect(
+        preprocessor=lambda s: s, tokenizer=lambda s: s.split(" ")
+    ).fit_transform(corpus)
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
-    res = HashingVectorizer(preprocessor=preprocessor).fit_transform(Series(corpus))
-    ref = SkHashVect(preprocessor=preprocessor, tokenizer=sklearn_tokenizer).fit_transform(corpus)
+    res = HashingVectorizer(preprocessor=lambda s: s).fit_transform(Series(corpus))
+    ref = SkHashVect(
+        preprocessor=lambda s: s, tokenizer=lambda s: s.split(" ")
+    ).fit_transform(corpus)
     test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
-@pytest.mark.parametrize('lowercase', [False,True])
+
+@pytest.mark.parametrize("lowercase", [False, True])
 def test_hashingvectorizer_lowercase(lowercase):
     corpus = [
-        'This Is DoC',
-        'this DoC is the second DoC.',
-        'And this document is the third one.',
-        'and Is this the first document?',
+        "This Is DoC",
+        "this DoC is the second DoC.",
+        "And this document is the third one.",
+        "and Is this the first document?",
     ]
     res = HashingVectorizer(lowercase=lowercase).fit_transform(Series(corpus))
     ref = SkHashVect(lowercase=lowercase).fit_transform(corpus)
@@ -429,21 +434,23 @@ def test_hashingvectorizer_lowercase(lowercase):
 
 
 def test_hashingvectorizer_stop_word():
-    ref = SkHashVect(stop_words='english').fit_transform(DOCS)
-    res = HashingVectorizer(stop_words='english').fit_transform(DOCS_GPU)
+    ref = SkHashVect(stop_words="english").fit_transform(DOCS)
+    res = HashingVectorizer(stop_words="english").fit_transform(DOCS_GPU)
     test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
 
 def test_hashingvectorizer_n_features():
     n_features = 10
-    res = HashingVectorizer(n_features=n_features).fit_transform(DOCS_GPU).todense().get()
+    res = (
+        HashingVectorizer(n_features=n_features).fit_transform(DOCS_GPU).todense().get()
+    )
     ref = SkHashVect(n_features=n_features).fit_transform(DOCS).toarray()
     assert res.shape == ref.shape
 
 
-@pytest.mark.parametrize('norm', ['l1', 'l2', None, 'max'])
+@pytest.mark.parametrize("norm", ["l1", "l2", None, "max"])
 def test_hashingvectorizer_norm(norm):
-    if norm not in ['l1','l2',None]:
+    if norm not in ["l1", "l2", None]:
         with pytest.raises(ValueError):
             res = HashingVectorizer(norm=norm).fit_transform(DOCS_GPU)
     else:
@@ -458,7 +465,7 @@ def test_hashingvectorizer_alternate_sign():
     res = HashingVectorizer(alternate_sign=True).fit_transform(DOCS_GPU)
     res_f_array = res.todense().get().flatten()
     assert np.sum(res_f_array > 0, axis=0) > 0
-    assert np.sum(res_f_array < 0, axis=0) > 0  
+    assert np.sum(res_f_array < 0, axis=0) > 0
 
     # if alternate_sign = False
     # we should have no negative values and some positive values
@@ -467,15 +474,23 @@ def test_hashingvectorizer_alternate_sign():
     assert np.sum(res_f_array > 0, axis=0) > 0
     assert np.sum(res_f_array < 0, axis=0) == 0
 
-@pytest.mark.parametrize('dtype', [np.float32, np.float64,cp.float64])
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, cp.float64])
 def test_hashingvectorizer_dtype(dtype):
     res = HashingVectorizer(dtype=dtype).fit_transform(DOCS_GPU)
     assert res.dtype == dtype
 
 
 def test_hashingvectorizer_delimiter():
-    corpus = ['a0b0c','a 0 b0e','c0d0f']
-    res = HashingVectorizer(delimiter='0',norm=None,preprocessor=lambda s:s).fit_transform(Series(corpus))
+    corpus = ["a0b0c", "a 0 b0e", "c0d0f"]
+    res = HashingVectorizer(
+        delimiter="0", norm=None, preprocessor=lambda s: s
+    ).fit_transform(Series(corpus))
     # equivalent logic for sklearn
-    ref = SkHashVect(tokenizer=lambda s:s.split('0'), norm=None, token_pattern=None, preprocessor=lambda s:s).fit_transform(corpus)
+    ref = SkHashVect(
+        tokenizer=lambda s: s.split("0"),
+        norm=None,
+        token_pattern=None,
+        preprocessor=lambda s: s,
+    ).fit_transform(corpus)
     test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())

--- a/python/cuml/test/test_text_feature_extraction.py
+++ b/python/cuml/test/test_text_feature_extraction.py
@@ -361,7 +361,8 @@ def test_tfidf_vectorizer(norm, use_idf, smooth_idf, sublinear_tf):
 # ----------------------------------------------------------------
 def assert_almost_equal_hash_matrices(mat_1, mat_2, ignore_sign=True):
     """
-    Currently if all the sorted values in the row is equal we assume equality 
+    Currently if all the sorted values in the row is equal we
+    assume equality
     TODO: Find better way to test ig hash matrices are equal
     """
     assert mat_1.shape == mat_2.shape
@@ -397,7 +398,8 @@ def test_hashingvectorizer():
 def test_vectorizer_empty_token_case():
     """
     We ignore empty tokens right now but sklearn treats them as a character
-    we might want to look into this more but this should not be a concern for most piplines
+    we might want to look into this more but
+    this should not be a concern for most piplines
     """
     corpus = [
         "a b ",
@@ -405,13 +407,15 @@ def test_vectorizer_empty_token_case():
 
     # we have extra null token here
     # we slightly diverge from sklearn here as not treating it as a token
-    res = CountVectorizer(preprocessor=lambda s: s).fit_transform(Series(corpus))
+    res = CountVectorizer(preprocessor=lambda s: s).\
+        fit_transform(Series(corpus))
     ref = SkCountVect(
         preprocessor=lambda s: s, tokenizer=lambda s: s.split(" ")
     ).fit_transform(corpus)
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
-    res = HashingVectorizer(preprocessor=lambda s: s).fit_transform(Series(corpus))
+    res = HashingVectorizer(preprocessor=lambda s: s).\
+        fit_transform(Series(corpus))
     ref = SkHashVect(
         preprocessor=lambda s: s, tokenizer=lambda s: s.split(" ")
     ).fit_transform(corpus)
@@ -440,7 +444,8 @@ def test_hashingvectorizer_stop_word():
 def test_hashingvectorizer_n_features():
     n_features = 10
     res = (
-        HashingVectorizer(n_features=n_features).fit_transform(DOCS_GPU).todense().get()
+        HashingVectorizer(n_features=n_features)
+        .fit_transform(DOCS_GPU).todense().get()
     )
     ref = SkHashVect(n_features=n_features).fit_transform(DOCS).toarray()
     assert res.shape == ref.shape

--- a/python/cuml/test/test_text_feature_extraction.py
+++ b/python/cuml/test/test_text_feature_extraction.py
@@ -361,7 +361,7 @@ def test_tfidf_vectorizer(norm, use_idf, smooth_idf, sublinear_tf):
 # ----------------------------------------------------------------
 # HashingVectorizer tests
 # ----------------------------------------------------------------
-def test_almost_equal_hash_matrices(mat_1, mat_2, ignore_sign=True):
+def assert_almost_equal_hash_matrices(mat_1, mat_2, ignore_sign=True):
     """
     Currently if all the sorted values in the row is equal we assume equality 
     TODO: Find better way to test ig hash matrices are equal
@@ -392,7 +392,7 @@ def test_hashingvectorizer():
 
     res = HashingVectorizer().fit_transform(Series(corpus))
     ref = SkHashVect().fit_transform(corpus)
-    test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+    assert_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
 
 @pytest.mark.xfail
@@ -417,7 +417,7 @@ def test_vectorizer_empty_token_case():
     ref = SkHashVect(
         preprocessor=lambda s: s, tokenizer=lambda s: s.split(" ")
     ).fit_transform(corpus)
-    test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+    assert_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
 
 @pytest.mark.parametrize("lowercase", [False, True])
@@ -430,13 +430,13 @@ def test_hashingvectorizer_lowercase(lowercase):
     ]
     res = HashingVectorizer(lowercase=lowercase).fit_transform(Series(corpus))
     ref = SkHashVect(lowercase=lowercase).fit_transform(corpus)
-    test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+    assert_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
 
 def test_hashingvectorizer_stop_word():
     ref = SkHashVect(stop_words="english").fit_transform(DOCS)
     res = HashingVectorizer(stop_words="english").fit_transform(DOCS_GPU)
-    test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+    assert_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
 
 def test_hashingvectorizer_n_features():
@@ -456,7 +456,7 @@ def test_hashingvectorizer_norm(norm):
     else:
         res = HashingVectorizer(norm=norm).fit_transform(DOCS_GPU)
         ref = SkHashVect(norm=norm).fit_transform(DOCS)
-        test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+        assert_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
 
 
 def test_hashingvectorizer_alternate_sign():
@@ -493,4 +493,4 @@ def test_hashingvectorizer_delimiter():
         token_pattern=None,
         preprocessor=lambda s: s,
     ).fit_transform(corpus)
-    test_almost_equal_hash_matrices(res.todense().get(), ref.toarray())
+    assert_almost_equal_hash_matrices(res.todense().get(), ref.toarray())

--- a/python/cuml/test/test_text_feature_extraction.py
+++ b/python/cuml/test/test_text_feature_extraction.py
@@ -29,10 +29,10 @@ import numpy as np
 
 def test_count_vectorizer():
     corpus = [
-        "This is the first document.",
-        "This document is the second document.",
-        "And this is the third one.",
-        "Is this the first document?",
+        'This is the first document.',
+        'This document is the second document.',
+        'And this is the third one.',
+        'Is this the first document?',
     ]
 
     res = CountVectorizer().fit_transform(Series(corpus))
@@ -63,10 +63,10 @@ DOCS = JUNK_FOOD_DOCS + EMPTY_DOCS + NOTJUNK_FOOD_DOCS + EMPTY_DOCS
 DOCS_GPU = Series(DOCS)
 
 NGRAM_RANGES = [(1, 1), (1, 2), (2, 3)]
-NGRAM_IDS = [f"ngram_range={str(r)}" for r in NGRAM_RANGES]
+NGRAM_IDS = [f'ngram_range={str(r)}' for r in NGRAM_RANGES]
 
 
-@pytest.mark.parametrize("ngram_range", NGRAM_RANGES, ids=NGRAM_IDS)
+@pytest.mark.parametrize('ngram_range', NGRAM_RANGES, ids=NGRAM_IDS)
 def test_word_analyzer(ngram_range):
     vec = CountVectorizer(ngram_range=ngram_range).fit(DOCS_GPU)
     ref = SkCountVect(ngram_range=ngram_range).fit(DOCS)
@@ -83,8 +83,8 @@ def test_countvectorizer_custom_vocabulary():
 
 
 def test_countvectorizer_stop_words():
-    ref = SkCountVect(stop_words="english").fit_transform(DOCS)
-    X = CountVectorizer(stop_words="english").fit_transform(DOCS_GPU)
+    ref = SkCountVect(stop_words='english').fit_transform(DOCS)
+    X = CountVectorizer(stop_words='english').fit_transform(DOCS_GPU)
     cp.testing.assert_array_equal(X.todense(), ref.toarray())
 
 
@@ -99,23 +99,16 @@ def test_countvectorizer_stop_words_ngrams():
     stop_words_doc = Series(["and me too andy andy too"])
     expected_vocabulary = ["andy andy"]
 
-    vec = CountVectorizer(ngram_range=(2, 2), stop_words="english")
+    vec = CountVectorizer(ngram_range=(2, 2), stop_words='english')
     vec.fit(stop_words_doc)
 
     assert expected_vocabulary == vec.get_feature_names().tolist()
 
 
 def test_countvectorizer_max_features():
-    expected_vocabulary = {"burger", "beer", "salad", "pizza"}
-    expected_stop_words = {
-        "celeri",
-        "tomato",
-        "copyright",
-        "coke",
-        "sparkling",
-        "water",
-        "the",
-    }
+    expected_vocabulary = {'burger', 'beer', 'salad', 'pizza'}
+    expected_stop_words = {'celeri', 'tomato', 'copyright', 'coke',
+                           'sparkling', 'water', 'the'}
 
     # test bounded number of extracted features
     vec = CountVectorizer(max_df=0.6, max_features=4)
@@ -145,76 +138,78 @@ def test_countvectorizer_max_features_counts():
     assert 7 == counts_None.max()
 
     # The most common feature should be the same
-    def as_index(x):
-        return x.astype(cp.int32).item()
-
+    def as_index(x): return x.astype(cp.int32).item()
     assert "the" == features_1[as_index(cp.argmax(counts_1))]
     assert "the" == features_3[as_index(cp.argmax(counts_3))]
     assert "the" == features_None[as_index(cp.argmax(counts_None))]
 
 
 def test_countvectorizer_max_df():
-    test_data = Series(["abc", "dea", "eat"])
-    vect = CountVectorizer(analyzer="char", max_df=1.0)
+    test_data = Series(['abc', 'dea', 'eat'])
+    vect = CountVectorizer(analyzer='char', max_df=1.0)
     vect.fit(test_data)
-    assert "a" in vect.vocabulary_.tolist()
+    assert 'a' in vect.vocabulary_.tolist()
     assert len(vect.vocabulary_.tolist()) == 6
     assert len(vect.stop_words_) == 0
 
     vect.max_df = 0.5  # 0.5 * 3 documents -> max_doc_count == 1.5
     vect.fit(test_data)
-    assert "a" not in vect.vocabulary_.tolist()  # {ae} ignored
-    assert len(vect.vocabulary_.tolist()) == 4  # {bcdt} remain
-    assert "a" in vect.stop_words_.tolist()
+    assert 'a' not in vect.vocabulary_.tolist()  # {ae} ignored
+    assert len(vect.vocabulary_.tolist()) == 4    # {bcdt} remain
+    assert 'a' in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 2
 
     vect.max_df = 1
     vect.fit(test_data)
-    assert "a" not in vect.vocabulary_.tolist()  # {ae} ignored
-    assert len(vect.vocabulary_.tolist()) == 4  # {bcdt} remain
-    assert "a" in vect.stop_words_.tolist()
+    assert 'a' not in vect.vocabulary_.tolist()  # {ae} ignored
+    assert len(vect.vocabulary_.tolist()) == 4    # {bcdt} remain
+    assert 'a' in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 2
 
 
 def test_vectorizer_min_df():
-    test_data = Series(["abc", "dea", "eat"])
-    vect = CountVectorizer(analyzer="char", min_df=1)
+    test_data = Series(['abc', 'dea', 'eat'])
+    vect = CountVectorizer(analyzer='char', min_df=1)
     vect.fit(test_data)
-    assert "a" in vect.vocabulary_.tolist()
+    assert 'a' in vect.vocabulary_.tolist()
     assert len(vect.vocabulary_.tolist()) == 6
     assert len(vect.stop_words_) == 0
 
     vect.min_df = 2
     vect.fit(test_data)
-    assert "c" not in vect.vocabulary_.tolist()  # {bcdt} ignored
-    assert len(vect.vocabulary_.tolist()) == 2  # {ae} remain
-    assert "c" in vect.stop_words_.tolist()
+    assert 'c' not in vect.vocabulary_.tolist()  # {bcdt} ignored
+    assert len(vect.vocabulary_.tolist()) == 2    # {ae} remain
+    assert 'c' in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 4
 
     vect.min_df = 0.8  # 0.8 * 3 documents -> min_doc_count == 2.4
     vect.fit(test_data)
-    assert "c" not in vect.vocabulary_.tolist()  # {bcdet} ignored
-    assert len(vect.vocabulary_.tolist()) == 1  # {a} remains
-    assert "c" in vect.stop_words_.tolist()
+    assert 'c' not in vect.vocabulary_.tolist()  # {bcdet} ignored
+    assert len(vect.vocabulary_.tolist()) == 1    # {a} remains
+    assert 'c' in vect.stop_words_.tolist()
     assert len(vect.stop_words_) == 5
 
 
 def test_count_binary_occurrences():
     # by default multiple occurrences are counted as longs
-    test_data = Series(["aaabc", "abbde"])
-    vect = CountVectorizer(analyzer="char", max_df=1.0)
+    test_data = Series(['aaabc', 'abbde'])
+    vect = CountVectorizer(analyzer='char', max_df=1.0)
     X = cp.asnumpy(vect.fit_transform(test_data).todense())
-    assert_array_equal(["a", "b", "c", "d", "e"], vect.get_feature_names().tolist())
-    assert_array_equal([[3, 1, 1, 0, 0], [1, 2, 0, 1, 1]], X)
+    assert_array_equal(['a', 'b', 'c', 'd', 'e'],
+                       vect.get_feature_names().tolist())
+    assert_array_equal([[3, 1, 1, 0, 0],
+                        [1, 2, 0, 1, 1]], X)
 
     # using boolean features, we can fetch the binary occurrence info
     # instead.
-    vect = CountVectorizer(analyzer="char", max_df=1.0, binary=True)
+    vect = CountVectorizer(analyzer='char', max_df=1.0, binary=True)
     X = cp.asnumpy(vect.fit_transform(test_data).todense())
-    assert_array_equal([[1, 1, 1, 0, 0], [1, 1, 0, 1, 1]], X)
+    assert_array_equal([[1, 1, 1, 0, 0],
+                        [1, 1, 0, 1, 1]], X)
 
     # check the ability to change the dtype
-    vect = CountVectorizer(analyzer="char", max_df=1.0, binary=True, dtype=cp.float32)
+    vect = CountVectorizer(analyzer='char', max_df=1.0,
+                           binary=True, dtype=cp.float32)
     X = vect.fit_transform(test_data)
     assert X.dtype == cp.float32
 
@@ -236,9 +231,9 @@ def test_vectorizer_inverse_transform():
         assert_array_equal(doc, sk_doc)
 
 
-@pytest.mark.parametrize("ngram_range", NGRAM_RANGES, ids=NGRAM_IDS)
+@pytest.mark.parametrize('ngram_range', NGRAM_RANGES, ids=NGRAM_IDS)
 def test_space_ngrams(ngram_range):
-    data = ["abc      def. 123 456    789"]
+    data = ['abc      def. 123 456    789']
     data_gpu = Series(data)
     vec = CountVectorizer(ngram_range=ngram_range).fit(data_gpu)
     ref = SkCountVect(ngram_range=ngram_range).fit(data)
@@ -246,7 +241,9 @@ def test_space_ngrams(ngram_range):
 
 
 def test_empty_doc_after_limit_features():
-    data = ["abc abc def", "def abc", "ghi"]
+    data = ['abc abc def',
+            'def abc',
+            'ghi']
     data_gpu = Series(data)
     count = CountVectorizer(min_df=2).fit_transform(data_gpu)
     ref = SkCountVect(min_df=2).fit_transform(data)
@@ -260,29 +257,34 @@ def test_countvectorizer_separate_fit_transform():
 
 
 def test_non_ascii():
-    non_ascii = ("This is ascii,", "but not this Αγγλικά.")
+    non_ascii = ('This is ascii,',
+                 'but not this Αγγλικά.')
     non_ascii_gpu = Series(non_ascii)
 
     cv = CountVectorizer()
     res = cv.fit_transform(non_ascii_gpu)
     ref = SkCountVect().fit_transform(non_ascii)
 
-    assert "αγγλικά" in set(cv.get_feature_names().tolist())
+    assert 'αγγλικά' in set(cv.get_feature_names().tolist())
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
 
 def test_only_delimiters():
-    data = ["abc def. 123", "   ", "456 789"]
+    data = ['abc def. 123',
+            '   ',
+            '456 789']
     data_gpu = Series(data)
     res = CountVectorizer().fit_transform(data_gpu)
     ref = SkCountVect().fit_transform(data)
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
 
-@pytest.mark.parametrize("analyzer", ["char", "char_wb"])
-@pytest.mark.parametrize("ngram_range", NGRAM_RANGES, ids=NGRAM_IDS)
+@pytest.mark.parametrize('analyzer', ['char', 'char_wb'])
+@pytest.mark.parametrize('ngram_range', NGRAM_RANGES, ids=NGRAM_IDS)
 def test_character_ngrams(analyzer, ngram_range):
-    data = ["ab c", "" "edf gh"]
+    data = ['ab c',
+            ''
+            'edf gh']
 
     res = CountVectorizer(analyzer=analyzer, ngram_range=ngram_range)
     res.fit(Series(data))
@@ -292,21 +294,16 @@ def test_character_ngrams(analyzer, ngram_range):
     assert ref.get_feature_names() == res.get_feature_names().tolist()
 
 
-@pytest.mark.parametrize(
-    "query",
-    [
-        Series(["science aa", "", "a aa aaa"]),
-        Series(["science aa", ""]),
-        Series(["science"]),
-    ],
-)
+@pytest.mark.parametrize('query', [Series(['science aa', '', 'a aa aaa']),
+                                   Series(['science aa', '']),
+                                   Series(['science'])])
 def test_transform_unsigned_categories(query):
-    token = "a"
+    token = 'a'
     thousand_tokens = list()
     for i in range(1000):
         thousand_tokens.append(token)
-        token += "a"
-    thousand_tokens[128] = "science"
+        token += 'a'
+    thousand_tokens[128] = 'science'
 
     vec = CountVectorizer().fit(Series(thousand_tokens))
     res = vec.transform(query)
@@ -319,11 +316,11 @@ def test_transform_unsigned_categories(query):
 # TfidfTransformer so we only do the bare minimum tests here
 # ----------------------------------------------------------------
 
-
 def test_tfidf_vectorizer_setters():
-    tv = TfidfVectorizer(norm="l2", use_idf=False, smooth_idf=False, sublinear_tf=False)
-    tv.norm = "l1"
-    assert tv._tfidf.norm == "l1"
+    tv = TfidfVectorizer(norm='l2', use_idf=False, smooth_idf=False,
+                         sublinear_tf=False)
+    tv.norm = 'l1'
+    assert tv._tfidf.norm == 'l1'
     tv.use_idf = True
     assert tv._tfidf.use_idf
     tv.smooth_idf = True
@@ -337,22 +334,23 @@ def test_tfidf_vectorizer_idf_setter():
     orig.fit(DOCS_GPU)
     copy = TfidfVectorizer(vocabulary=orig.vocabulary_, use_idf=True)
     copy.idf_ = orig.idf_[0]
-    cp.testing.assert_array_almost_equal(
-        copy.transform(DOCS_GPU).todense(), orig.transform(DOCS_GPU).todense()
-    )
+    cp.testing.assert_array_almost_equal(copy.transform(DOCS_GPU).todense(),
+                                         orig.transform(DOCS_GPU).todense())
 
 
-@pytest.mark.parametrize("norm", ["l1", "l2", None])
-@pytest.mark.parametrize("use_idf", [True, False])
-@pytest.mark.parametrize("smooth_idf", [True, False])
-@pytest.mark.parametrize("sublinear_tf", [True, False])
+@pytest.mark.parametrize('norm', ['l1', 'l2', None])
+@pytest.mark.parametrize('use_idf', [True, False])
+@pytest.mark.parametrize('smooth_idf', [True, False])
+@pytest.mark.parametrize('sublinear_tf', [True, False])
 def test_tfidf_vectorizer(norm, use_idf, smooth_idf, sublinear_tf):
     tfidf_mat = TfidfVectorizer(
-        norm=norm, use_idf=use_idf, smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
+        norm=norm, use_idf=use_idf,
+        smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
     ).fit_transform(DOCS_GPU)
 
     ref = SkTfidfVect(
-        norm=norm, use_idf=use_idf, smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
+        norm=norm, use_idf=use_idf,
+        smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
     ).fit_transform(DOCS)
 
     cp.testing.assert_array_almost_equal(tfidf_mat.todense(), ref.toarray())


### PR DESCRIPTION
This pr adds `Hashing Vectorizer` and improves `CountVectorizer`
- [x] Add Support for alternate sign parameter
- [x] Add  tests for all parameters
- [x] Benchmark and Update pre-processing logic here once https://github.com/rapidsai/cudf/pull/5666 lands. 

### Count Vectorizer Improvements

All benchmarks on a `Tesla T4`  and dataset used is the one used in the [blog](https://medium.com/rapids-ai/natural-language-processing-text-preprocessing-and-vectorizing-at-rocking-speed-with-rapids-cuml-74b8d751812e)

#### Improves memory pressures
```
2x improvement
PR: 4192 MB (1500 MB is dataset) 
Master: 9712 MB (1500 MB is dataset) 
```

##### Improves Run Time(3x improvement)
```
Master: 25.4 s 
Pr: 8.8 s
Sklearn: 1 Min
```

### Hash Vectorizer: Benchmarks  (9.5x speed up) 
```
Half Dataset:
CUML: 4.37 s
Sklearn: 41.1 s


Full dataset:
7.83 s
1min 14s
```

Known Divergence (NOT INTRODUCED BY THIS PR): https://gist.github.com/VibhuJawa/5f8e2666da9ecbb63d0398277fc93ac5



#### Just linking the test/benchmarking notebooks here:

- Doc Search using [Hash-Vectorizer](https://gist.github.com/VibhuJawa/d14dc19dec549cb00499920b6c0ece84) (Gets relevant same results as count-vectorizer as on the blog) 

- [PR performance Notebook](https://gist.github.com/VibhuJawa/34185c74605e918a958d999efefd807d)

- [Master Performance Notebook](https://gist.github.com/VibhuJawa/cdeedbf80bfa8dc68b1138e786d6ed6b) 