### PR TITLE
[REVIEW] Update scipy call for arima gradient test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #2535: Fix issue with incorrect docker image being used in local build script
 - PR #2542: Fix small memory leak in TSNE
 - PR #2552: Fixed the length argument of updateDevice calls in RF test
+- PR #2563: Update scipy call for arima gradient test
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/test_arima.py
+++ b/python/cuml/test/test_arima.py
@@ -40,7 +40,7 @@ import os
 import warnings
 
 import pandas as pd
-from scipy.optimize.optimize import _approx_fprime_helper
+from scipy.optimize.optimize import approx_fprime
 import statsmodels.api as sm
 
 import cudf
@@ -392,7 +392,7 @@ def test_gradient(key, data, dtype):
             return model_i._loglike(x)
 
         scipy_grad[N * i: N * (i + 1)] = \
-            _approx_fprime_helper(x[N * i: N * (i + 1)], f, h)
+            approx_fprime(x[N * i: N * (i + 1)], f, h)
 
     # Compare
     np.testing.assert_allclose(batched_grad, scipy_grad, rtol=0.001, atol=0.01)


### PR DESCRIPTION
Scipy 1.5 drops the function `_approx_fprime_helper`, so this PR changes that to call `approx_fprime` directly. Tested on 1.3, 1.4 and 1.5 locally without any issues. 