### PR TITLE
[REVIEW] Remove deprecated cuDF from_gpu_matrix calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PR #2536 Update conda upload versions for new supported CUDA/Python
 - PR #2538: Remove Protobuf dependency
 - PR #2553: Test pickle protocol 5 support
+- PR #2566: Remove deprecated cuDF from_gpu_matrix calls
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/notebooks/kmeans_demo.ipynb
+++ b/notebooks/kmeans_demo.ipynb
@@ -80,7 +80,7 @@
     "                                        random_state=random_state,\n",
     "                                        cluster_std=0.1)\n",
     "\n",
-    "device_data = cudf.DataFrame.from_gpu_matrix(device_data)\n",
+    "device_data = cudf.DataFrame(device_data)\n",
     "device_labels = cudf.Series(device_labels)"
    ]
   },

--- a/notebooks/linear_regression_demo.ipynb
+++ b/notebooks/linear_regression_demo.ipynb
@@ -72,8 +72,8 @@
     "%%time\n",
     "X, y = make_regression(n_samples=n_samples, n_features=n_features, random_state=random_state)\n",
     "\n",
-    "X = cudf.DataFrame.from_gpu_matrix(X)\n",
-    "y = cudf.DataFrame.from_gpu_matrix(y)[0]\n",
+    "X = cudf.DataFrame(X)\n",
+    "y = cudf.DataFrame(y)[0]\n",
     "\n",
     "X_cudf, X_cudf_test, y_cudf, y_cudf_test = train_test_split(X, y, test_size = 0.2, random_state=random_state)"
    ]

--- a/notebooks/nearest_neighbors_demo.ipynb
+++ b/notebooks/nearest_neighbors_demo.ipynb
@@ -75,7 +75,7 @@
     "                            centers=5,\n",
     "                            random_state=random_state)\n",
     "\n",
-    "device_data = cudf.DataFrame.from_gpu_matrix(device_data)"
+    "device_data = cudf.DataFrame(device_data)"
    ]
   },
   {

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -244,7 +244,7 @@ class CumlArray(Buffer):
                 mat = cp.asarray(self, dtype=output_dtype)
                 if len(mat.shape) == 1:
                     mat = mat.reshape(mat.shape[0], 1)
-                return DataFrame.from_gpu_matrix(mat)
+                return DataFrame(mat)
             else:
                 raise ValueError('cuDF unsupported Array dtype')
 

--- a/python/cuml/dask/common/dask_arr_utils.py
+++ b/python/cuml/dask/common/dask_arr_utils.py
@@ -135,7 +135,7 @@ def to_sparse_dask_array(cudf_or_array, client=None):
             cupy_ary = rmm_cupy_ary(cp.asarray,
                                     x,
                                     dtype=x.dtype)
-            return cudf.DataFrame.from_gpu_matrix(cupy_ary)
+            return cudf.DataFrame(cupy_ary)
 
         parts = client.sync(_extract_partitions, ret)
         futures = [client.submit(_conv_np_to_df, part, workers=[w], pure=False)
@@ -174,7 +174,7 @@ def _get_meta(df):
 @dask.delayed
 def _to_cudf(arr):
     if arr.ndim == 2:
-        return cudf.DataFrame.from_gpu_matrix(arr)
+        return cudf.DataFrame(arr)
     elif arr.ndim == 1:
         return cudf.Series(arr)
 

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -137,7 +137,7 @@ class NearestNeighbors(Base):
                         n_features=10, random_state=42)
 
       # build a cudf Dataframe
-      X_cudf = cudf.DataFrame.from_gpu_matrix(X)
+      X_cudf = cudf.DataFrame(X)
 
       # fit model
       model = NearestNeighbors(n_neighbors=3)

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -178,7 +178,7 @@ class OneHotEncoder(Base):
             self._set_input_type('array')
             if is_categories:
                 X = X.transpose()
-            return DataFrame.from_gpu_matrix(X)
+            return DataFrame(X)
         else:
             self._set_input_type('df')
             return X

--- a/python/cuml/preprocessing/onehotencoder_mg.py
+++ b/python/cuml/preprocessing/onehotencoder_mg.py
@@ -44,7 +44,7 @@ class OneHotEncoderMG(OneHotEncoder):
             if is_categories:
                 X = X.transpose()
             if isinstance(X, cp.ndarray):
-                return DataFrame.from_gpu_matrix(X)
+                return DataFrame(X)
             else:
                 return to_dask_cudf(X, client=self.client)
         else:

--- a/python/cuml/test/dask/test_dask_arr_utils.py
+++ b/python/cuml/test/dask/test_dask_arr_utils.py
@@ -45,12 +45,12 @@ def test_to_sparse_dask_array(input_type, nrows, ncols, client):
 
     a = cp.sparse.random(nrows, ncols, format='csr', dtype=cp.float32)
     if input_type == "dask_dataframe":
-        df = cudf.DataFrame.from_gpu_matrix(a.todense())
+        df = cudf.DataFrame(a.todense())
         inp = dask_cudf.from_cudf(df, npartitions=2)
     elif input_type == "dask_array":
         inp = dask.array.from_array(a.todense().get())
     elif input_type == "dataframe":
-        inp = cudf.DataFrame.from_gpu_matrix(a.todense())
+        inp = cudf.DataFrame(a.todense())
     elif input_type == "scipysparse":
         inp = a.get()
     elif input_type == "cupysparse":

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -279,10 +279,9 @@ def test_output(output_type, dtype, out_dtype, order, shape):
             assert np.all(comp.to_array())
 
         elif output_type == 'dataframe':
-            mat = cuda.to_device(inp)
-            if len(mat.shape) == 1:
-                mat = mat.reshape(mat.shape[0], 1)
-            comp = cudf.DataFrame.from_gpu_matrix(mat)
+            if len(inp.shape) == 1:
+                inp = inp.reshape(inp.shape[0], 1)
+            comp = cudf.DataFrame(inp)
             comp = comp == res
             assert np.all(comp.as_gpu_matrix().copy_to_host())
 

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -190,7 +190,7 @@ def test_dtype_check(dtype, check_dtype, input_type, order):
 
     if (dtype == np.float16 or check_dtype == np.float16)\
             and input_type != 'numpy':
-        pytest.xfail("float16 not yet supported by numba/cuDF.from_gpu_matrix")
+        pytest.xfail("float16 not yet supported by numba/cuDF")
 
     if dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
         if input_type in ['cudf', 'pandas']:
@@ -223,7 +223,7 @@ def test_convert_input_dtype(from_dtype, to_dtype, input_type, num_rows,
                              num_cols, order):
 
     if from_dtype == np.float16 and input_type != 'numpy':
-        pytest.xfail("float16 not yet supported by numba/cuDF.from_gpu_matrix")
+        pytest.xfail("float16 not yet supported by numba/cuDF")
 
     if from_dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
         if input_type == 'cudf':
@@ -329,12 +329,10 @@ def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
         result = nbcuda.as_cuda_array(rand_mat)
 
     if type == 'cudf':
-        result = cudf.DataFrame()
-        result = result.from_gpu_matrix(nbcuda.as_cuda_array(rand_mat))
+        result = cudf.DataFrame(rand_mat)
 
     if type == 'pandas':
-        result = cudf.DataFrame()
-        result = result.from_gpu_matrix(nbcuda.as_cuda_array(rand_mat))
+        result = cudf.DataFrame(rand_mat)
         result = result.to_pandas()
 
     if type == 'cuml':

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -44,13 +44,13 @@ def _build_train_test_data(X, y, datatype, train_ratio=0.9):
     y_test = y[~train_selection]
 
     if datatype == "dataframe":
-        X_train = cudf.DataFrame.from_gpu_matrix(
+        X_train = cudf.DataFrame(
             rmm.to_device(X_train))
-        y_train = cudf.DataFrame.from_gpu_matrix(
+        y_train = cudf.DataFrame(
             rmm.to_device(y_train.reshape(y_train.shape[0], 1)))
-        X_test = cudf.DataFrame.from_gpu_matrix(
+        X_test = cudf.DataFrame(
             rmm.to_device(X_test))
-        y_test = cudf.DataFrame.from_gpu_matrix(
+        y_test = cudf.DataFrame(
             rmm.to_device(y_test.reshape(y_test.shape[0], 1)))
 
     return X_train, X_test, y_train, y_test
@@ -225,8 +225,8 @@ def test_predict_multioutput(input_type, output_type):
     y = np.array([[15, 2], [5, 4]]).astype(np.int32)
 
     if input_type == "cudf":
-        X = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X))
-        y = cudf.DataFrame.from_gpu_matrix(rmm.to_device(y))
+        X = cudf.DataFrame(rmm.to_device(X))
+        y = cudf.DataFrame(rmm.to_device(y))
     elif input_type == "cupy":
         X = cp.asarray(X)
         y = cp.asarray(y)
@@ -254,8 +254,8 @@ def test_predict_proba_multioutput(input_type, output_type):
     y = np.array([[15, 2], [5, 4]]).astype(np.int32)
 
     if input_type == "cudf":
-        X = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X))
-        y = cudf.DataFrame.from_gpu_matrix(rmm.to_device(y))
+        X = cudf.DataFrame(rmm.to_device(X))
+        y = cudf.DataFrame(rmm.to_device(y))
     elif input_type == "cupy":
         X = cp.asarray(X)
         y = cp.asarray(y)

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -44,14 +44,10 @@ def _build_train_test_data(X, y, datatype, train_ratio=0.9):
     y_test = y[~train_selection]
 
     if datatype == "dataframe":
-        X_train = cudf.DataFrame(
-            rmm.to_device(X_train))
-        y_train = cudf.DataFrame(
-            rmm.to_device(y_train.reshape(y_train.shape[0], 1)))
-        X_test = cudf.DataFrame(
-            rmm.to_device(X_test))
-        y_test = cudf.DataFrame(
-            rmm.to_device(y_test.reshape(y_test.shape[0], 1)))
+        X_train = cudf.DataFrame(X_train)
+        y_train = cudf.DataFrame(y_train.reshape(y_train.shape[0], 1))
+        X_test = cudf.DataFrame(X_test)
+        y_test = cudf.DataFrame(y_test.reshape(y_test.shape[0], 1))
 
     return X_train, X_test, y_train, y_test
 
@@ -225,8 +221,8 @@ def test_predict_multioutput(input_type, output_type):
     y = np.array([[15, 2], [5, 4]]).astype(np.int32)
 
     if input_type == "cudf":
-        X = cudf.DataFrame(rmm.to_device(X))
-        y = cudf.DataFrame(rmm.to_device(y))
+        X = cudf.DataFrame(X)
+        y = cudf.DataFrame(y)
     elif input_type == "cupy":
         X = cp.asarray(X)
         y = cp.asarray(y)
@@ -254,8 +250,8 @@ def test_predict_proba_multioutput(input_type, output_type):
     y = np.array([[15, 2], [5, 4]]).astype(np.int32)
 
     if input_type == "cudf":
-        X = cudf.DataFrame(rmm.to_device(X))
-        y = cudf.DataFrame(rmm.to_device(y))
+        X = cudf.DataFrame(X)
+        y = cudf.DataFrame(y)
     elif input_type == "cupy":
         X = cp.asarray(X)
         y = cp.asarray(y)

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -16,9 +16,6 @@
 
 import pytest
 
-import rmm
-
-
 import cudf
 
 from cuml.neighbors import KNeighborsClassifier as cuKNN

--- a/python/cuml/test/test_kneighbors_regressor.py
+++ b/python/cuml/test/test_kneighbors_regressor.py
@@ -17,7 +17,6 @@
 import pytest
 
 import cudf
-import rmm
 
 from cuml.neighbors import KNeighborsRegressor as cuKNN
 

--- a/python/cuml/test/test_kneighbors_regressor.py
+++ b/python/cuml/test/test_kneighbors_regressor.py
@@ -96,8 +96,8 @@ def test_score(nrows, ncols, n_neighbors, n_clusters, datatype):
     y = y.astype(np.float32)
 
     if datatype == "dataframe":
-        X = cudf.DataFrame(rmm.to_device(X))
-        y = cudf.DataFrame(rmm.to_device(y.reshape(nrows, 1)))
+        X = cudf.DataFrame(X)
+        y = cudf.DataFrame(y.reshape(nrows, 1))
 
     knn_cu = cuKNN(n_neighbors=n_neighbors)
     knn_cu.fit(X, y)
@@ -113,8 +113,8 @@ def test_predict_multioutput(input_type, output_type):
     y = np.array([[15, 2], [5, 4]]).astype(np.int32)
 
     if input_type == "cudf":
-        X = cudf.DataFrame(rmm.to_device(X))
-        y = cudf.DataFrame(rmm.to_device(y))
+        X = cudf.DataFrame(X)
+        y = cudf.DataFrame(y)
     elif input_type == "cupy":
         X = cp.asarray(X)
         y = cp.asarray(y)

--- a/python/cuml/test/test_kneighbors_regressor.py
+++ b/python/cuml/test/test_kneighbors_regressor.py
@@ -96,8 +96,8 @@ def test_score(nrows, ncols, n_neighbors, n_clusters, datatype):
     y = y.astype(np.float32)
 
     if datatype == "dataframe":
-        X = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X))
-        y = cudf.DataFrame.from_gpu_matrix(rmm.to_device(y.reshape(nrows, 1)))
+        X = cudf.DataFrame(rmm.to_device(X))
+        y = cudf.DataFrame(rmm.to_device(y.reshape(nrows, 1)))
 
     knn_cu = cuKNN(n_neighbors=n_neighbors)
     knn_cu.fit(X, y)
@@ -113,8 +113,8 @@ def test_predict_multioutput(input_type, output_type):
     y = np.array([[15, 2], [5, 4]]).astype(np.int32)
 
     if input_type == "cudf":
-        X = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X))
-        y = cudf.DataFrame.from_gpu_matrix(rmm.to_device(y))
+        X = cudf.DataFrame(rmm.to_device(X))
+        y = cudf.DataFrame(rmm.to_device(y))
     elif input_type == "cupy":
         X = cp.asarray(X)
         y = cp.asarray(y)

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -99,7 +99,7 @@ def test_sklearn_search():
     assert getattr(cu_clf, 'score', False)
     sk_cu_grid = GridSearchCV(cu_clf, params, cv=5, iid=False)
 
-    gdf_data = cudf.DataFrame(cuda.to_device(X_train))
+    gdf_data = cudf.DataFrame(X_train)
     gdf_train = cudf.DataFrame(dict(train=y_train))
 
     sk_cu_grid.fit(gdf_data, gdf_train.train)

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -99,7 +99,7 @@ def test_sklearn_search():
     assert getattr(cu_clf, 'score', False)
     sk_cu_grid = GridSearchCV(cu_clf, params, cv=5, iid=False)
 
-    gdf_data = cudf.DataFrame.from_gpu_matrix(cuda.to_device(X_train))
+    gdf_data = cudf.DataFrame(cuda.to_device(X_train))
     gdf_train = cudf.DataFrame(dict(train=y_train))
 
     sk_cu_grid.fit(gdf_data, gdf_train.train)

--- a/python/cuml/test/test_module_config.py
+++ b/python/cuml/test/test_module_config.py
@@ -134,7 +134,7 @@ def get_small_dataset(output_type):
         return cp.asnumpy(ary)
 
     elif output_type == 'pandas':
-        return cudf.DataFrame.from_gpu_matrix(as_cuda_array(ary)).to_pandas()
+        return cudf.DataFrame(as_cuda_array(ary)).to_pandas()
 
     else:
-        return cudf.DataFrame.from_gpu_matrix(as_cuda_array(ary))
+        return cudf.DataFrame(as_cuda_array(ary))

--- a/python/cuml/test/test_module_config.py
+++ b/python/cuml/test/test_module_config.py
@@ -134,7 +134,7 @@ def get_small_dataset(output_type):
         return cp.asnumpy(ary)
 
     elif output_type == 'pandas':
-        return cudf.DataFrame(as_cuda_array(ary)).to_pandas()
+        return cudf.DataFrame(ary).to_pandas()
 
     else:
-        return cudf.DataFrame(as_cuda_array(ary))
+        return cudf.DataFrame(ary)

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -65,7 +65,7 @@ def test_neighborhood_predictions(nrows, ncols, n_neighbors, n_clusters,
     X = X.astype(np.float32)
 
     if datatype == "dataframe":
-        X = cudf.DataFrame(rmm.to_device(X))
+        X = cudf.DataFrame(X)
 
     knn_cu = cuKNN()
     knn_cu.fit(X)
@@ -124,7 +124,7 @@ def test_cuml_against_sklearn(input_type, nrows, n_feats, k, metric):
     X_orig = X
 
     if input_type == "dataframe":
-        X = cudf.DataFrame(rmm.to_device(X))
+        X = cudf.DataFrame(X)
 
     knn_cu = cuKNN(metric=metric, p=p)
     knn_cu.fit(X)

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -16,8 +16,6 @@
 
 import pytest
 
-import rmm
-
 from cuml.test.utils import array_equal, unit_param, quality_param, \
     stress_param
 from cuml.neighbors import NearestNeighbors as cuKNN

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -65,7 +65,7 @@ def test_neighborhood_predictions(nrows, ncols, n_neighbors, n_clusters,
     X = X.astype(np.float32)
 
     if datatype == "dataframe":
-        X = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X))
+        X = cudf.DataFrame(rmm.to_device(X))
 
     knn_cu = cuKNN()
     knn_cu.fit(X)
@@ -124,7 +124,7 @@ def test_cuml_against_sklearn(input_type, nrows, n_feats, k, metric):
     X_orig = X
 
     if input_type == "dataframe":
-        X = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X))
+        X = cudf.DataFrame(rmm.to_device(X))
 
     knn_cu = cuKNN(metric=metric, p=p)
     knn_cu.fit(X)

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -17,7 +17,6 @@ import cudf
 import numpy as np
 import pytest
 import random
-import rmm
 
 from numba import cuda
 

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -366,9 +366,9 @@ def test_rf_classification_multi_class(datatype, column_info, nrows,
     # random forest classification model
     cuml_model = curfc()
     if type == 'dataframe':
-        X_train_df = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X_train))
+        X_train_df = cudf.DataFrame(rmm.to_device(X_train))
         y_train_df = cudf.Series(y_train)
-        X_test_df = cudf.DataFrame.from_gpu_matrix(rmm.to_device(X_test))
+        X_test_df = cudf.DataFrame(rmm.to_device(X_test))
         cuml_model.fit(X_train_df, y_train_df)
         cu_preds = cuml_model.predict(X_test_df,
                                       predict_model="CPU").to_array()

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -366,9 +366,9 @@ def test_rf_classification_multi_class(datatype, column_info, nrows,
     # random forest classification model
     cuml_model = curfc()
     if type == 'dataframe':
-        X_train_df = cudf.DataFrame(rmm.to_device(X_train))
+        X_train_df = cudf.DataFrame(X_train)
         y_train_df = cudf.Series(y_train)
-        X_test_df = cudf.DataFrame(rmm.to_device(X_test))
+        X_test_df = cudf.DataFrame(X_test)
         cuml_model.fit(X_train_df, y_train_df)
         cu_preds = cuml_model.predict(X_test_df,
                                       predict_model="CPU").to_array()

--- a/python/cuml/test/test_sgd.py
+++ b/python/cuml/test/test_sgd.py
@@ -45,8 +45,8 @@ def test_sgd(dtype, lrate, penalty, loss, datatype):
                                                         train_size=0.8)
 
     if datatype == "dataframe":
-        X_train = cudf.DataFrame.from_gpu_matrix(X_train)
-        X_test = cudf.DataFrame.from_gpu_matrix(X_test)
+        X_train = cudf.DataFrame(X_train)
+        X_test = cudf.DataFrame(X_test)
         y_train = cudf.Series(y_train)
 
     cu_sgd = cumlSGD(learning_rate=lrate, eta0=0.005, epochs=2000,
@@ -93,8 +93,8 @@ def test_sgd_default(dtype, datatype):
                                                         train_size=0.8)
 
     if datatype == "dataframe":
-        X_train = cudf.DataFrame.from_gpu_matrix(X_train)
-        X_test = cudf.DataFrame.from_gpu_matrix(X_test)
+        X_train = cudf.DataFrame(X_train)
+        X_test = cudf.DataFrame(X_test)
         y_train = cudf.Series(y_train)
 
     cu_sgd = cumlSGD()

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -300,8 +300,7 @@ def test_svm_gamma(params):
                       centers=centers)
     X = X.astype(np.float32)
     if x_arraytype == 'dataframe':
-        X_df = cudf.DataFrame()
-        X = X_df.from_gpu_matrix(cuda.to_device(X))
+        X_df = cudf.DataFrame(X)
         y = cudf.Series(y)
     elif x_arraytype == 'numba':
         X = cuda.to_device(X)
@@ -311,7 +310,10 @@ def test_svm_gamma(params):
     cuSVC = cu_svm.SVC(**params)
     cuSVC.fit(X, y)
     y_pred = cuSVC.predict(X)
-    n_correct = np.sum(y == y_pred)
+    if x_arraytype == 'dataframe':
+        n_correct = np.sum(y.to_array() == y_pred)
+    else:
+        n_correct = np.sum(y == y_pred)
     accuracy = n_correct * 100 / n_rows
     assert accuracy > 70
 

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -300,7 +300,6 @@ def test_svm_gamma(params):
                       centers=centers)
     X = X.astype(np.float32)
     if x_arraytype == 'dataframe':
-        X_df = cudf.DataFrame(X)
         y = cudf.Series(y)
     elif x_arraytype == 'numba':
         X = cuda.to_device(X)

--- a/python/cuml/test/test_trustworthiness.py
+++ b/python/cuml/test/test_trustworthiness.py
@@ -43,10 +43,10 @@ def test_trustworthiness(input_type, n_samples, n_features, n_components,
     sk_score = sklearn_trustworthiness(X, X_embedded)
 
     if input_type == 'dataframe':
-        X = cudf.DataFrame.from_gpu_matrix(
+        X = cudf.DataFrame(
             numba.cuda.to_device(X))
 
-        X_embedded = cudf.DataFrame.from_gpu_matrix(
+        X_embedded = cudf.DataFrame(
             numba.cuda.to_device(X_embedded))
 
     score = cuml_trustworthiness(X, X_embedded, batch_size=batch_size)

--- a/python/cuml/test/test_trustworthiness.py
+++ b/python/cuml/test/test_trustworthiness.py
@@ -43,11 +43,9 @@ def test_trustworthiness(input_type, n_samples, n_features, n_components,
     sk_score = sklearn_trustworthiness(X, X_embedded)
 
     if input_type == 'dataframe':
-        X = cudf.DataFrame(
-            numba.cuda.to_device(X))
+        X = cudf.DataFrame(X)
 
-        X_embedded = cudf.DataFrame(
-            numba.cuda.to_device(X_embedded))
+        X_embedded = cudf.DataFrame(X_embedded)
 
     score = cuml_trustworthiness(X, X_embedded, batch_size=batch_size)
 

--- a/python/cuml/test/test_trustworthiness.py
+++ b/python/cuml/test/test_trustworthiness.py
@@ -20,7 +20,6 @@ from sklearn.datasets import make_blobs
 from umap import UMAP
 
 import cudf
-import numba.cuda
 import numpy as np
 
 

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -419,7 +419,7 @@ class ExponentialSmoothing(Base):
                     return cudf.Series(
                         self.forecasted_points.ravel(order='F')[:h])
                 else:
-                    return cudf.DataFrame.from_gpu_matrix(
+                    return cudf.DataFrame(
                         self.forecasted_points[:, :h].T)
             else:
                 if index < 0 or index >= self.ts_num:
@@ -483,7 +483,7 @@ class ExponentialSmoothing(Base):
                 if self.ts_num == 1:
                     return cudf.Series(self.level.ravel(order='F'))
                 else:
-                    return cudf.DataFrame.from_gpu_matrix(self.level.T)
+                    return cudf.DataFrame(self.level.T)
             else:
                 if index < 0 or index >= self.ts_num:
                     raise IndexError("Index input: " + str(index) + " outside "
@@ -514,7 +514,7 @@ class ExponentialSmoothing(Base):
                 if self.ts_num == 1:
                     return cudf.Series(self.trend.ravel(order='F'))
                 else:
-                    return cudf.DataFrame.from_gpu_matrix(self.trend.T)
+                    return cudf.DataFrame(self.trend.T)
             else:
                 if index < 0 or index >= self.ts_num:
                     raise IndexError("Index input: " + str(index) + " outside "
@@ -545,7 +545,7 @@ class ExponentialSmoothing(Base):
                 if self.ts_num == 1:
                     return cudf.Series(self.season.ravel(order='F'))
                 else:
-                    return cudf.DataFrame.from_gpu_matrix(self.season.T)
+                    return cudf.DataFrame(self.season.T)
             else:
                 if index < 0 or index >= self.ts_num:
                     raise IndexError("Index input: " + str(index) + " outside "


### PR DESCRIPTION
cuDF 0.16 will dro `from_gpu_matrix`, so this PR removes that call from our codebase. 

Depends on https://github.com/rapidsai/cudf/pull/5703