### PR TITLE
[REVIEW] Considering managed memory in the device type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - PR #2563: Update scipy call for arima gradient test
 - PR #2569: Fix for cuDF update
 - PR #2508: Use keyword parameters in sklearn.datasets.make_* functions
+- PR #2573: Considering managed memory as device type on checking for KMeans 
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -609,7 +609,7 @@ void fit(const ML::cumlHandle_impl &handle, const KMeansParams &params,
          "oversampling factor must be > 0 (requested %d)",
          (int)params.oversampling_factor);
 
-  ASSERT(memory_type(X) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(X),
          "input data must be device accessible");
 
   Tensor<DataT, 2, IndexT> data((DataT *)X, {n_local_samples, n_features});

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -609,8 +609,7 @@ void fit(const ML::cumlHandle_impl &handle, const KMeansParams &params,
          "oversampling factor must be > 0 (requested %d)",
          (int)params.oversampling_factor);
 
-  ASSERT(is_device_or_managed_type(X),
-         "input data must be device accessible");
+  ASSERT(is_device_or_managed_type(X), "input data must be device accessible");
 
   Tensor<DataT, 2, IndexT> data((DataT *)X, {n_local_samples, n_features});
 

--- a/cpp/src/kmeans/sg_impl.cuh
+++ b/cpp/src/kmeans/sg_impl.cuh
@@ -507,8 +507,7 @@ void fit(const ML::cumlHandle_impl &handle, const KMeansParams &km_params,
          "oversampling factor must be >= 0 (requested %f)",
          km_params.oversampling_factor);
 
-  ASSERT(is_device_or_managed_type(X),
-         "input data must be device accessible");
+  ASSERT(is_device_or_managed_type(X), "input data must be device accessible");
 
   Tensor<DataT, 2, IndexT> data((DataT *)X, {n_samples, n_features});
 

--- a/cpp/src/kmeans/sg_impl.cuh
+++ b/cpp/src/kmeans/sg_impl.cuh
@@ -507,7 +507,7 @@ void fit(const ML::cumlHandle_impl &handle, const KMeansParams &km_params,
          "oversampling factor must be >= 0 (requested %f)",
          km_params.oversampling_factor);
 
-  ASSERT(memory_type(X) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(X),
          "input data must be device accessible");
 
   Tensor<DataT, 2, IndexT> data((DataT *)X, {n_samples, n_features});
@@ -624,10 +624,10 @@ void predict(const ML::cumlHandle_impl &handle, const KMeansParams &params,
 
   ASSERT(n_clusters > 0 && cptr != nullptr, "no clusters exist");
 
-  ASSERT(memory_type(Xptr) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(Xptr),
          "input data must be device accessible");
 
-  ASSERT(memory_type(cptr) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(cptr),
          "centroid data must be device accessible");
 
   MLCommon::Distance::DistanceType metric =
@@ -737,13 +737,13 @@ void transform(const ML::cumlHandle_impl &handle, const KMeansParams &params,
 
   ASSERT(n_clusters > 0 && cptr != nullptr, "no clusters exist");
 
-  ASSERT(memory_type(Xptr) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(Xptr),
          "input data must be device accessible");
 
-  ASSERT(memory_type(cptr) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(cptr),
          "centroid data must be device accessible");
 
-  ASSERT(memory_type(X_new) == cudaMemoryTypeDevice,
+  ASSERT(is_device_or_managed_type(X_new),
          "output data storage must be device accessible");
 
   Tensor<DataT, 2, IndexT> dataset((DataT *)Xptr, {n_samples, n_features});

--- a/cpp/src/ml_cuda_utils.h
+++ b/cpp/src/ml_cuda_utils.h
@@ -44,4 +44,10 @@ inline cudaMemoryType memory_type(const void *p) {
   return att.memoryType;
 #endif
 }
+
+inline bool is_device_or_managed_type(const void *p) {
+  cudaMemoryType p_memory_type = memory_type(p);
+  return p_memory_type == cudaMemoryTypeDevice ||
+         p_memory_type == cudaMemoryTypeManaged;
+}
 }  // namespace ML


### PR DESCRIPTION
Fixes #2572 

I understand that the intent of these assertions is to verify that the memory buffers must be accessible by the device, and since managed memory can be considered device memory, my proposal is to consider it too.