### PR TITLE
[REVIEW]Speed up TfidfTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PR #2538: Remove Protobuf dependency
 - PR #2553: Test pickle protocol 5 support
 - PR #2566: Remove deprecated cuDF from_gpu_matrix calls
+- PR #2575: Speed up TfidfTransformer
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/python/cuml/common/sparsefuncs.py
+++ b/python/cuml/common/sparsefuncs.py
@@ -73,23 +73,6 @@ def _map_l2_norm_kernel(dtype):
     return cuda_kernel_factory(map_kernel_str, dtype, "map_l2_norm_kernel")
 
 
-def _map_mul_sparse_array(dtype):
-    """Creates cupy RawKernel for multiplying sparse array with a dense ar """
-
-    map_kernel_str = r'''
-    ({0} *data, {1} *indices, {2} *indptr, {3} *dense_ar, int data_size) {
-
-      int tid = blockDim.x * blockIdx.x + threadIdx.x;
-
-      if(tid >= data_size) return;
-
-      int index = indices[tid];
-      data[tid] =  data[tid] * dense_ar[index];
-    }
-    '''
-    return cuda_kernel_factory(map_kernel_str, dtype, "_map_mul_sparse_array")
-
-
 @with_cupy_rmm
 def csr_row_normalize_l1(X, inplace=True):
     """Row normalize for csr matrix using the l1 norm"""
@@ -121,12 +104,9 @@ def csr_diag_mul(X, y, inplace=True):
     """Multiply a sparse X matrix with diagonal matrix y"""
     if not inplace:
         X = X.copy()
-    y = y.data
-    kernel = _map_mul_sparse_array((X.dtype, X.indices.dtype,
-                                   X.indptr.dtype, y.dtype))
-    kernel((math.ceil(X.indices.shape[0] / 32),), (32,),
-           (X.data, X.indices, X.indptr, y, X.indices.shape[0]))
-
+    # grab underlying dense ar from y
+    y = y.data[0]
+    X.data *= y[X.indices]
     return X
 
 

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -18,6 +18,7 @@ from sklearn.exceptions import NotFittedError
 import cupy as cp
 from cuml.common import with_cupy_rmm
 from cuml.common.sparsefuncs import csr_row_normalize_l1, csr_row_normalize_l2
+from cuml.common.sparsefuncs import csr_diag_mul
 
 
 def _sparse_document_frequency(X):
@@ -165,7 +166,8 @@ class TfidfTransformer:
                 raise ValueError("Input has n_features=%d while the model"
                                  " has been trained with n_features=%d" % (
                                      n_features, expected_n_features))
-            X *= self._idf_diag
+
+            csr_diag_mul(X, self._idf_diag, inplace=True)
 
         if self.norm:
             if self.norm == 'l1':


### PR DESCRIPTION
This pr speeds up tf_idf transformer by around 36x by switching sparse and dense multiplication to a custom kernel.   

All benchmarks on a `Tesla T4`  and dataset used is the one used in the [blog](https://medium.com/rapids-ai/natural-language-processing-text-preprocessing-and-vectorizing-at-rocking-speed-with-rapids-cuml-74b8d751812e)


- [x] [Sanity check the results on a larger dataset](https://gist.github.com/VibhuJawa/e8cefb11cafcd9f176891465988d7f71
)
- [x] Verify Tests run locally
- [x] Benchmarking

#### Performance Delta
[Master](https://gist.github.com/VibhuJawa/104f52c6abdb5a7f17473356c150b758)  10.9 s 
[PR](https://gist.github.com/VibhuJawa/8e300456f24be167ae1b95ffe43259e5) 289 ms
