### PR TITLE
[REVIEW] Adjust cuml.dask kmeans score test margin to avoid failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - PR #2569: Fix for cuDF update
 - PR #2508: Use keyword parameters in sklearn.datasets.make_* functions
 - PR #2574: Fixing include path in `tsvd_mg.pyx`
+- PR #2578: Adjust cuml.dask kmeans score test margin to avoid failures
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/dask/test_kmeans.py
+++ b/python/cuml/test/dask/test_kmeans.py
@@ -159,7 +159,7 @@ def test_transform(nrows, ncols, nclusters, n_parts, input_type, client):
                                        stress_param(50)])
 @pytest.mark.parametrize("n_parts", [unit_param(None), quality_param(7),
                                      stress_param(50)])
-@pytest.mark.parametrize("score_eps", [unit_param(0.06), stress_param(35.0)])
+@pytest.mark.parametrize("score_eps", [unit_param(0.071), stress_param(35.0)])
 @pytest.mark.parametrize("input_type", ["dataframe", "array"])
 def test_score(nrows, ncols, nclusters, n_parts,
                input_type, score_eps, client):
@@ -216,3 +216,8 @@ def test_score(nrows, ncols, nclusters, n_parts,
     assert actual_score + score_eps \
         >= (-1 * expected_score) \
         >= actual_score - score_eps
+
+    with open("kmeans_results.txt", 'a') as f:
+        f.write(str((actual_score + score_eps) - (-1 * expected_score)))
+        f.write(str((-1 * expected_score) - (actual_score - score_eps)))
+        f.write("\n")


### PR DESCRIPTION
closes #2534 

After a (not so) small number of runs of the test in my machine, this value was the smallest to guarantee no failures in 100000 runs (well technically it was 0.7089), so barring differences between my machines and CI, this should avoid the sporadic fail in CI. 