### PR TITLE
[REVIEW] Remove unnecessary norm_add1 array from tSNE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - PR #2548: Fix limitation on number of rows usable with tSNE and refactor memory allocation
 - PR #2589: including cuda-11 build fixes into raft
 - PR #2487: Set classes_ attribute during classifier fit
+- PR #2605: Reduce memory usage in tSNE
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/cpp/src/tsne/barnes_hut.cuh
+++ b/cpp/src/tsne/barnes_hut.cuh
@@ -114,7 +114,6 @@ void Barnes_Hut(float *VAL, const int *COL, const int *ROW, const int NNZ,
   MLCommon::device_buffer<float> attr_forces(
     d_alloc, stream, n * 2);  // n*2 double for reduction sum
 
-  MLCommon::device_buffer<float> norm_add1(d_alloc, stream, n);
   MLCommon::device_buffer<float> norm(d_alloc, stream, n);
   MLCommon::device_buffer<float> Z_norm(d_alloc, stream, 1);
 
@@ -240,7 +239,7 @@ void Barnes_Hut(float *VAL, const int *COL, const int *ROW, const int NNZ,
 
     START_TIMER;
     TSNE::get_norm<<<MLCommon::ceildiv(n, 1024), 1024, 0, stream>>>(
-      YY.data(), YY.data() + nnodes + 1, norm.data(), norm_add1.data(), n);
+      YY.data(), YY.data() + nnodes + 1, norm.data(), n);
     CUDA_CHECK(cudaPeekAtLastError());
 
     // TODO: Calculate Kullback-Leibler divergence
@@ -248,7 +247,7 @@ void Barnes_Hut(float *VAL, const int *COL, const int *ROW, const int NNZ,
     TSNE::
       attractive_kernel_bh<<<MLCommon::ceildiv(NNZ, 1024), 1024, 0, stream>>>(
         VAL, COL, ROW, YY.data(), YY.data() + nnodes + 1, norm.data(),
-        norm_add1.data(), attr_forces.data(), attr_forces.data() + n, NNZ);
+        attr_forces.data(), attr_forces.data() + n, NNZ);
     CUDA_CHECK(cudaPeekAtLastError());
     END_TIMER(attractive_time);
 

--- a/cpp/src/tsne/bh_kernels.cuh
+++ b/cpp/src/tsne/bh_kernels.cuh
@@ -622,12 +622,10 @@ __global__ __launch_bounds__(
  * Find the norm(Y)
  */
 __global__ void get_norm(const float *restrict Y1, const float *restrict Y2,
-                         float *restrict norm, float *restrict norm_add1,
-                         const int N) {
+                         float *restrict norm, const int N) {
   const int i = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (i >= N) return;
   norm[i] = Y1[i] * Y1[i] + Y2[i] * Y2[i];
-  norm_add1[i] = norm[i] + 1.0f;
 }
 
 /**
@@ -636,8 +634,8 @@ __global__ void get_norm(const float *restrict Y1, const float *restrict Y2,
 __global__ void attractive_kernel_bh(
   const float *restrict VAL, const int *restrict COL, const int *restrict ROW,
   const float *restrict Y1, const float *restrict Y2,
-  const float *restrict norm, const float *restrict norm_add1,
-  float *restrict attract1, float *restrict attract2, const int NNZ) {
+  const float *restrict norm, float *restrict attract1,
+  float *restrict attract2, const int NNZ) {
   const int index = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (index >= NNZ) return;
   const int i = ROW[index];
@@ -647,7 +645,7 @@ __global__ void attractive_kernel_bh(
   // TODO: Convert attractive forces to CSR format
   const float PQ = __fdividef(
     VAL[index],
-    norm_add1[i] + norm[j] - 2.0f * (Y1[i] * Y1[j] + Y2[i] * Y2[j]));  // P*Q
+    norm[i] + 1.0f + norm[j] - 2.0f * (Y1[i] * Y1[j] + Y2[i] * Y2[j]));  // P*Q
 
   // Apply forces
   atomicAdd(&attract1[i], PQ * (Y1[i] - Y1[j]));


### PR DESCRIPTION
Reduces memory usage by sizeof(float)*nRows, reduces global loads/stores and fixes an FP error.

@drobison00 I think we can actually fold this `get_norm` kernel into `attractive_kernel_bh` and get rid of the `norms` array also. AFAICT the denominator just works out to

```c
      Y1[i] * Y1[i] + Y2[i] * Y2[i] + 1.0f   // norm_add1[i]
    + Y1[j] * Y1[j] + Y2[j] * Y2[j]   // norm[j]
    - 2.0f * (Y1[i] * Y1[j] + Y2[i] * Y2[j])   // the other terms
```

Then it'll be easier to deal with FP error in a single place because we can reorder intermediates, etc.

Did that in a separate branch for consideration: https://github.com/rapidsai/cuml/commit/4fa9e89d51db22aa7a7e5e1eab423800dfad4dcd

It's these norm values that get to be huge, and I'm seeing lots of cases where `norm[i] + 1 != norm_add1[i]` because of insufficient precision.