### PR TITLE
[REVIEW] Small test code fix for pandas dtype tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - PR #2593: Fix inconsistency in train_test_split
 - PR #2609: Fix small doxygen issues
 - PR #2610: Remove cuDF tolist call
+- PR #2616: Small test code fix for pandas dtype tests
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/dask/test_kmeans.py
+++ b/python/cuml/test/dask/test_kmeans.py
@@ -73,8 +73,8 @@ def test_end_to_end(nrows, ncols, nclusters, n_parts,
 
     if input_type == "dataframe":
         assert cumlLabels.npartitions == parts_len
-        cumlPred = cp.array(cumlLabels.compute().to_pandas().values)
-        labels = cp.squeeze(y_train.compute().to_pandas().values)
+        cumlPred = cumlLabels.compute().values
+        labels = y_train.compute().values
     elif input_type == "array":
         assert len(cumlLabels.chunks[0]) == parts_len
         cumlPred = cp.array(cumlLabels.compute())
@@ -118,7 +118,7 @@ def test_transform(nrows, ncols, nclusters, n_parts, input_type, client):
     if input_type == "dataframe":
         X_train = to_dask_cudf(X)
         y_train = to_dask_cudf(y)
-        labels = cp.squeeze(y_train.compute().to_pandas().values)
+        labels = y_train.compute().values
     elif input_type == "array":
         X_train, y_train = X, y
         labels = cp.squeeze(y_train.compute())

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -132,8 +132,10 @@ def test_convert_matrix_order_cuml_array(dtype, input_type, from_order,
                                                 order=to_order)
 
     if to_order == 'K':
-        if input_type in ['cudf', 'pandas']:
+        if input_type in ['cudf']:
             assert conv_data.order == 'F'
+        elif input_type in ['pandas']:
+            assert conv_data.order == 'C'
         else:
             assert conv_data.order == from_order
     else:

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -19,6 +19,7 @@ import pytest
 import cudf
 import cupy as cp
 import numpy as np
+from pandas import DataFrame as pdDF
 
 from cuml.common import input_to_cuml_array, CumlArray
 from cuml.common import input_to_dev_array
@@ -332,8 +333,7 @@ def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
         result = cudf.DataFrame(rand_mat)
 
     if type == 'pandas':
-        result = cudf.DataFrame(rand_mat)
-        result = result.to_pandas()
+        result = pdDF(cp.asnumpy(rand_mat))
 
     if type == 'cuml':
         result = CumlArray(data=rand_mat,


### PR DESCRIPTION
The recent change of cuDF support for nullable objects in the to_pandas method caused a small issue in integral pandas dataframes, this fixes CI for those tests