### PR TITLE
[REVIEW] SVM class and sample weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #2211: MNMG KNN Classifier & Regressor
 - PR #2461: Add KNN Sparse Output Functionality
 - PR #2607: Add support for probability estimates in SVC
+- PR #2618: SVM class and sample weights
 
 ## Improvements
 - PR #2336: Eliminate `rmm.device_array` usage

--- a/cpp/include/cuml/svm/svc.hpp
+++ b/cpp/include/cuml/svm/svc.hpp
@@ -44,6 +44,7 @@ namespace SVM {
  * @param [in] param parameters for training
  * @param [in] kernel_params parameters for the kernel function
  * @param [out] model parameters of the trained model
+ * @param [in] sample_weight optional sample weights, size [n_rows]
  */
 template <typename math_t>
 void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
@@ -151,6 +152,7 @@ class SVC {
    * @param n_rows number of rows
    * @param n_cols number of columns
    * @param labels device pointer for the labels. Size n_rows.
+   * @param [in] sample_weight optional sample weights, size [n_rows]
    */
   void fit(math_t *input, int n_rows, int n_cols, math_t *labels,
            const math_t *sample_weight = nullptr);

--- a/cpp/include/cuml/svm/svc.hpp
+++ b/cpp/include/cuml/svm/svc.hpp
@@ -49,7 +49,7 @@ template <typename math_t>
 void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
             math_t *labels, const svmParameter &param,
             MLCommon::Matrix::KernelParams &kernel_params,
-            svmModel<math_t> &model);
+            svmModel<math_t> &model, const math_t *sample_weight = nullptr);
 
 /**
  * @brief Predict classes or decision function value for samples in input.
@@ -152,7 +152,8 @@ class SVC {
    * @param n_cols number of columns
    * @param labels device pointer for the labels. Size n_rows.
    */
-  void fit(math_t *input, int n_rows, int n_cols, math_t *labels);
+  void fit(math_t *input, int n_rows, int n_cols, math_t *labels,
+           const math_t *sample_weight = nullptr);
 
   /**
    * @brief Predict classes for samples in input.

--- a/cpp/include/cuml/svm/svr.hpp
+++ b/cpp/include/cuml/svm/svr.hpp
@@ -43,6 +43,7 @@ namespace SVM {
  * @param [in] param parameters for training
  * @param [in] kernel_params parameters for the kernel function
  * @param [out] model parameters of the trained model
+ * @param [in] sample_weight optional sample weights, size [n_rows]
  */
 template <typename math_t>
 void svrFit(const cumlHandle &handle, math_t *X, int n_rows, int n_cols,

--- a/cpp/include/cuml/svm/svr.hpp
+++ b/cpp/include/cuml/svm/svr.hpp
@@ -48,7 +48,7 @@ template <typename math_t>
 void svrFit(const cumlHandle &handle, math_t *X, int n_rows, int n_cols,
             math_t *y, const svmParameter &param,
             MLCommon::Matrix::KernelParams &kernel_params,
-            svmModel<math_t> &model);
+            svmModel<math_t> &model, const math_t *sample_weight = nullptr);
 
 // For prediction we use svcPredict
 

--- a/cpp/src/svm/results.cuh
+++ b/cpp/src/svm/results.cuh
@@ -60,7 +60,7 @@ class Results {
    * @param C penalty parameter
    */
   Results(const cumlHandle_impl &handle, const math_t *x, const math_t *y,
-          int n_rows, int n_cols, math_t C, SvmType svmType)
+          int n_rows, int n_cols, const math_t *C, SvmType svmType)
     : allocator(handle.getDeviceAllocator()),
       stream(handle.getStream()),
       handle(handle),
@@ -220,10 +220,7 @@ class Results {
     // For unbound support vectors f_i = -b.
 
     // Select f for unbound support vectors (0 < alpha < C)
-    math_t C = this->C;
-    auto select = [C] __device__(math_t a) -> bool { return 0 < a && a < C; };
-
-    int n_free = SelectByCoef(alpha, n_train, f, select, val_selected.data());
+    int n_free = SelectUnboundSV(alpha, n_train, f, val_selected.data());
     if (n_free > 0) {
       cub::DeviceReduce::Sum(cub_storage.data(), cub_bytes, val_selected.data(),
                              d_val_reduced.data(), n_free, stream);
@@ -242,6 +239,30 @@ class Results {
     }
   }
 
+  /**
+  * @brief Select values for unbound support vectors (not bound by C).
+  * @tparam valType type of values that will be selected
+  * @param [in] alpha dual coefficients, size [n]
+  * @param [in] n number of dual coefficients
+  * @param [in] val values to filter, size [n]
+  * @param [out] out buffer size [n]
+  * @return number of selected elements
+  */
+  template <typename valType>
+  int SelectUnboundSV(const math_t *alpha, int n, const valType *val,
+                      valType *out) {
+    auto select = [] __device__(math_t a, math_t C) -> bool {
+      return 0 < a && a < C;
+    };
+    MLCommon::LinAlg::binaryOp(flag.data(), alpha, C, n, select, stream);
+    cub::DeviceSelect::Flagged(cub_storage.data(), cub_bytes, val, flag.data(),
+                               out, d_num_selected.data(), n, stream);
+    int n_selected;
+    MLCommon::updateHost(&n_selected, d_num_selected.data(), 1, stream);
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+    return n_selected;
+  }
+
   std::shared_ptr<deviceAllocator> allocator;
 
  private:
@@ -252,7 +273,7 @@ class Results {
   int n_cols;       //!< number of features
   const math_t *x;  //!< training vectors
   const math_t *y;  //!< labels
-  math_t C;         //!< penalty parameter
+  const math_t *C;  //!< penalty parameter
   SvmType svmType;  //!< SVM problem type: SVC or SVR
   int n_train;  //!< number of training vectors (including duplicates for SVR)
 
@@ -323,7 +344,7 @@ class Results {
    */
   math_t SelectReduce(const math_t *alpha, const math_t *f, bool min,
                       void (*flag_op)(bool *, int, const math_t *,
-                                      const math_t *, math_t)) {
+                                      const math_t *, const math_t *)) {
     flag_op<<<MLCommon::ceildiv(n_train, TPB), TPB, 0, stream>>>(
       flag.data(), n_train, alpha, y, C);
     CUDA_CHECK(cudaPeekAtLastError());

--- a/cpp/src/svm/smoblocksolve.cuh
+++ b/cpp/src/svm/smoblocksolve.cuh
@@ -132,7 +132,8 @@ namespace SVM {
  * @param [in] kernel kernel function calculated between the working set and all
  *   other training vectors, size [n_rows * n_ws]
  * @param [in] ws_idx indices of traning vectors in the working set, size [n_ws]
- * @param [in] C penalty parameter
+ * @param [in] C_vec penalty parameter vector including class and sample weights
+ *   size [n_train]
  * @param [in] eps tolerance, iterations will stop if the duality gap is smaller
  *  than this value (or if the gap is smaller than 0.1 times the initial gap)
  * @param [out] return_buff, two valies are returned: duality gap and the number
@@ -144,7 +145,7 @@ namespace SVM {
 template <typename math_t, int WSIZE>
 __global__ __launch_bounds__(WSIZE) void SmoBlockSolve(
   math_t *y_array, int n_train, math_t *alpha, int n_ws, math_t *delta_alpha,
-  math_t *f_array, const math_t *kernel, const int *ws_idx, math_t C,
+  math_t *f_array, const math_t *kernel, const int *ws_idx, const math_t *C_vec,
   math_t eps, math_t *return_buff, int max_iter = 10000,
   SvmType svmType = C_SVC, const int *kColIdx = nullptr) {
   typedef MLCommon::Selection::KVPair<math_t, int> Pair;
@@ -190,6 +191,8 @@ __global__ __launch_bounds__(WSIZE) void SmoBlockSolve(
   math_t f = f_array[idx];
   math_t a = alpha[idx];
   math_t a_save = a;
+  math_t C = C_vec[idx];
+
   __shared__ math_t diff_end;
   __shared__ math_t diff;
 

--- a/cpp/src/svm/smosolver.cuh
+++ b/cpp/src/svm/smosolver.cuh
@@ -18,6 +18,8 @@
 
 #include <common/cudart_utils.h>
 #include <math.h>
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
 #include <cuda_utils.cuh>
 #include <iostream>
 #include <limits>
@@ -86,6 +88,7 @@ class SmoSolver {
       stream(handle.getStream()),
       return_buff(handle.getDeviceAllocator(), stream, 2),
       alpha(handle.getDeviceAllocator(), stream),
+      C_vec(handle.getDeviceAllocator(), stream),
       delta_alpha(handle.getDeviceAllocator(), stream),
       f(handle.getDeviceAllocator(), stream),
       y_label(handle.getDeviceAllocator(), stream) {
@@ -103,6 +106,8 @@ class SmoSolver {
    * @param [in] n_rows number of rows (training vectors)
    * @param [in] n_cols number of columns (features)
    * @param [in] y labels (values +/-1), size [n_rows]
+   * @param [in] sample_weight device array of sample weights (or nullptr if not
+   *     applicable)
    * @param [out] dual_coefs size [n_support] on exit
    * @param [out] n_support number of support vectors
    * @param [out] x_support support vectors in column major format, size [n_support, n_cols]
@@ -111,13 +116,14 @@ class SmoSolver {
    * @param [in] max_outer_iter maximum number of outer iteration (default 100 * n_rows)
    * @param [in] max_inner_iter maximum number of inner iterations (default 10000)
    */
-  void Solve(math_t *x, int n_rows, int n_cols, math_t *y, math_t **dual_coefs,
-             int *n_support, math_t **x_support, int **idx, math_t *b,
-             int max_outer_iter = -1, int max_inner_iter = 10000) {
+  void Solve(math_t *x, int n_rows, int n_cols, math_t *y,
+             const math_t *sample_weight, math_t **dual_coefs, int *n_support,
+             math_t **x_support, int **idx, math_t *b, int max_outer_iter = -1,
+             int max_inner_iter = 10000) {
     // Prepare data structures for SMO
     WorkingSet<math_t> ws(handle, stream, n_rows, SMO_WS_SIZE, svmType);
     n_ws = ws.GetSize();
-    Initialize(&y, n_rows, n_cols);
+    Initialize(&y, sample_weight, n_rows, n_cols);
     KernelCache<math_t> cache(handle, x, n_rows, n_cols, n_ws, kernel,
                               cache_size, svmType);
     // Init counters
@@ -131,13 +137,13 @@ class SmoSolver {
     while (n_iter < max_outer_iter && keep_going) {
       CUDA_CHECK(
         cudaMemsetAsync(delta_alpha.data(), 0, n_ws * sizeof(math_t), stream));
-      ws.Select(f.data(), alpha.data(), y, C);
+      ws.Select(f.data(), alpha.data(), y, C_vec.data());
 
       math_t *cacheTile = cache.GetTile(ws.GetIndices());
       SmoBlockSolve<math_t, SMO_WS_SIZE><<<1, n_ws, 0, stream>>>(
         y, n_train, alpha.data(), n_ws, delta_alpha.data(), f.data(), cacheTile,
-        cache.GetWsIndices(), C, tol, return_buff.data(), max_inner_iter,
-        svmType, cache.GetColIdxMap());
+        cache.GetWsIndices(), C_vec.data(), tol, return_buff.data(),
+        max_inner_iter, svmType, cache.GetColIdxMap());
 
       CUDA_CHECK(cudaPeekAtLastError());
 
@@ -162,7 +168,7 @@ class SmoSolver {
       "SMO solver finished after %d outer iterations, total inner"
       " iterations, and diff %lf",
       n_iter, n_inner_iter, diff_prev);
-    Results<math_t> res(handle, x, y, n_rows, n_cols, C, svmType);
+    Results<math_t> res(handle, x, y, n_rows, n_cols, C_vec.data(), svmType);
     res.Get(alpha.data(), f.data(), dual_coefs, n_support, idx, x_support, b);
     ReleaseBuffers();
   }
@@ -213,10 +219,13 @@ class SmoSolver {
    *
    * @param[inout] y on entry class labels or target values,
    *    on exit device pointer to class labels
+   * @param[in] sample_weight sample weights (can be nullptr, otherwise device
+   *    array of size [n_rows])
    * @param[in] n_rows
    * @param[in] n_cols
    */
-  void Initialize(math_t **y, int n_rows, int n_cols) {
+  void Initialize(math_t **y, const math_t *sample_weight, int n_rows,
+                  int n_cols) {
     this->n_rows = n_rows;
     this->n_cols = n_cols;
     n_train = (svmType == EPSILON_SVR) ? n_rows * 2 : n_rows;
@@ -224,6 +233,7 @@ class SmoSolver {
     // Zero init alpha
     CUDA_CHECK(
       cudaMemsetAsync(alpha.data(), 0, n_train * sizeof(math_t), stream));
+    InitPenalty(C_vec.data(), sample_weight, n_rows);
     // Init f (and also class labels for SVR)
     switch (svmType) {
       case C_SVC:
@@ -240,6 +250,23 @@ class SmoSolver {
     }
   }
 
+  void InitPenalty(math_t *C_vec, const math_t *sample_weight, int n_rows) {
+    if (sample_weight == nullptr) {
+      thrust::device_ptr<math_t> c_ptr(C_vec);
+      thrust::fill(thrust::cuda::par.on(stream), c_ptr, c_ptr + n_train, C);
+    } else {
+      math_t C = this->C;
+      MLCommon::LinAlg::unaryOp(
+        C_vec, sample_weight, n_rows,
+        [C] __device__(math_t w) { return C * w; }, stream);
+      if (n_train > n_rows) {
+        // Set the same penalty parameter for the duplicate set of vectors
+        MLCommon::LinAlg::unaryOp(
+          C_vec + n_rows, sample_weight, n_rows,
+          [C] __device__(math_t w) { return C * w; }, stream);
+      }
+    }
+  }
   /** @brief Initialize Support Vector Classification
    *
    * We would like to maximize the following quantity
@@ -326,6 +353,8 @@ class SmoSolver {
   MLCommon::device_buffer<math_t> f;        //!< optimality indicator vector
   MLCommon::device_buffer<math_t> y_label;  //!< extra label for regression
 
+  MLCommon::device_buffer<math_t> C_vec;  //!< penalty parameter vector
+
   // Buffers for the working set [n_ws]
   //! change in alpha parameter during a blocksolve step
   MLCommon::device_buffer<math_t> delta_alpha;
@@ -392,8 +421,9 @@ class SmoSolver {
   }
 
   void ResizeBuffers(int n_train, int n_cols) {
-    // This needs to know n_rows, therefore it can be only called during solve
+    // This needs to know n_train, therefore it can be only called during solve
     alpha.resize(n_train, stream);
+    C_vec.resize(n_train, stream);
     f.resize(n_train, stream);
     delta_alpha.resize(n_ws, stream);
     if (svmType == EPSILON_SVR) y_label.resize(n_train, stream);

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -82,8 +82,8 @@ SVC<math_t>::~SVC() {
 }
 
 template <typename math_t>
-void SVC<math_t>::fit(math_t *input, int n_rows, int n_cols,
-                      math_t *labels, const math_t *sample_weight) {
+void SVC<math_t>::fit(math_t *input, int n_rows, int n_cols, math_t *labels,
+                      const math_t *sample_weight) {
   model.n_cols = n_cols;
   if (model.dual_coefs) svmFreeBuffers(handle, model);
   svcFit(handle, input, n_rows, n_cols, labels, param, kernel_params, model,

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -36,13 +36,14 @@ template void svcFit<float>(const cumlHandle &handle, float *input, int n_rows,
                             int n_cols, float *labels,
                             const svmParameter &param,
                             MLCommon::Matrix::KernelParams &kernel_params,
-                            svmModel<float> &model);
+                            svmModel<float> &model, const float *sample_weight);
 
 template void svcFit<double>(const cumlHandle &handle, double *input,
                              int n_rows, int n_cols, double *labels,
                              const svmParameter &param,
                              MLCommon::Matrix::KernelParams &kernel_params,
-                             svmModel<double> &model);
+                             svmModel<double> &model,
+                             const double *sample_weight);
 
 template void svcPredict<float>(const cumlHandle &handle, float *input,
                                 int n_rows, int n_cols,
@@ -81,10 +82,12 @@ SVC<math_t>::~SVC() {
 }
 
 template <typename math_t>
-void SVC<math_t>::fit(math_t *input, int n_rows, int n_cols, math_t *labels) {
+void SVC<math_t>::fit(math_t *input, int n_rows, int n_cols,
+                      math_t *labels, const math_t *sample_weight) {
   model.n_cols = n_cols;
   if (model.dual_coefs) svmFreeBuffers(handle, model);
-  svcFit(handle, input, n_rows, n_cols, labels, param, kernel_params, model);
+  svcFit(handle, input, n_rows, n_cols, labels, param, kernel_params, model,
+         sample_weight);
 }
 
 template <typename math_t>

--- a/cpp/src/svm/svc_impl.cuh
+++ b/cpp/src/svm/svc_impl.cuh
@@ -46,7 +46,7 @@ template <typename math_t>
 void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
             math_t *labels, const svmParameter &param,
             MLCommon::Matrix::KernelParams &kernel_params,
-            svmModel<math_t> &model) {
+            svmModel<math_t> &model, const math_t *sample_weight) {
   ASSERT(n_cols > 0,
          "Parameter n_cols: number of columns cannot be less than one");
   ASSERT(n_rows > 0,
@@ -74,7 +74,7 @@ void svcFit(const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
     MLCommon::Matrix::KernelFactory<math_t>::create(
       kernel_params, handle_impl.getCublasHandle());
   SmoSolver<math_t> smo(handle_impl, param, kernel);
-  smo.Solve(input, n_rows, n_cols, y.data(), &(model.dual_coefs),
+  smo.Solve(input, n_rows, n_cols, y.data(), sample_weight, &(model.dual_coefs),
             &(model.n_support), &(model.x_support), &(model.support_idx),
             &(model.b), param.max_iter);
   model.n_cols = n_cols;

--- a/cpp/src/svm/svr.cu
+++ b/cpp/src/svm/svr.cu
@@ -33,12 +33,13 @@ namespace SVM {
 template void svrFit<float>(const cumlHandle &handle, float *X, int n_rows,
                             int n_cols, float *y, const svmParameter &param,
                             MLCommon::Matrix::KernelParams &kernel_params,
-                            svmModel<float> &model);
+                            svmModel<float> &model, const float *sample_weight);
 
 template void svrFit<double>(const cumlHandle &handle, double *X, int n_rows,
                              int n_cols, double *y, const svmParameter &param,
                              MLCommon::Matrix::KernelParams &kernel_params,
-                             svmModel<double> &model);
+                             svmModel<double> &model,
+                             const double *sample_weight);
 
 };  // namespace SVM
 };  // end namespace ML

--- a/cpp/src/svm/svr_impl.cuh
+++ b/cpp/src/svm/svr_impl.cuh
@@ -58,15 +58,15 @@ void svrFit(const cumlHandle &handle, math_t *X, int n_rows, int n_cols,
   const cumlHandle_impl &handle_impl = handle.getImpl();
 
   cudaStream_t stream = handle_impl.getStream();
-
+  math_t *sample_weight = nullptr;
   MLCommon::Matrix::GramMatrixBase<math_t> *kernel =
     MLCommon::Matrix::KernelFactory<math_t>::create(
       kernel_params, handle_impl.getCublasHandle());
 
   SmoSolver<math_t> smo(handle_impl, param, kernel);
-  smo.Solve(X, n_rows, n_cols, y, &(model.dual_coefs), &(model.n_support),
-            &(model.x_support), &(model.support_idx), &(model.b),
-            param.max_iter);
+  smo.Solve(X, n_rows, n_cols, y, sample_weight, &(model.dual_coefs),
+            &(model.n_support), &(model.x_support), &(model.support_idx),
+            &(model.b), param.max_iter);
   model.n_cols = n_cols;
   delete kernel;
 }

--- a/cpp/src/svm/svr_impl.cuh
+++ b/cpp/src/svm/svr_impl.cuh
@@ -46,7 +46,7 @@ template <typename math_t>
 void svrFit(const cumlHandle &handle, math_t *X, int n_rows, int n_cols,
             math_t *y, const svmParameter &param,
             MLCommon::Matrix::KernelParams &kernel_params,
-            svmModel<math_t> &model) {
+            svmModel<math_t> &model, const math_t *sample_weight) {
   ASSERT(n_cols > 0,
          "Parameter n_cols: number of columns cannot be less than one");
   ASSERT(n_rows > 0,
@@ -58,7 +58,6 @@ void svrFit(const cumlHandle &handle, math_t *X, int n_rows, int n_cols,
   const cumlHandle_impl &handle_impl = handle.getImpl();
 
   cudaStream_t stream = handle_impl.getStream();
-  math_t *sample_weight = nullptr;
   MLCommon::Matrix::GramMatrixBase<math_t> *kernel =
     MLCommon::Matrix::KernelFactory<math_t>::create(
       kernel_params, handle_impl.getCublasHandle());

--- a/cpp/src/svm/workingset.cuh
+++ b/cpp/src/svm/workingset.cuh
@@ -138,11 +138,11 @@ class WorkingSet {
    * @param f optimality indicator vector, size [n_train]
    * @param alpha dual coefficients, size [n_train]
    * @param y target labels (+/- 1)
-   * @param C penalty parameter
+   * @param C penalty parameter vector size [n_train]
    * @param n_already_selected
    */
 
-  void SimpleSelect(math_t *f, math_t *alpha, math_t *y, math_t C,
+  void SimpleSelect(math_t *f, math_t *alpha, math_t *y, const math_t *C,
                     int n_already_selected = 0) {
     // We are not using the topK kernel, because of the additional lower/upper
     // constraint
@@ -204,8 +204,12 @@ class WorkingSet {
   * [1] Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs, Journal
   *     of Machine Learning Research, 19, 1-5 (2018)
   *
+  * @param f
+  * @param alpha dual coefficients, size [n_train]
+  * @param y class labels, size [n_train]
+  * @param C penalty parameter vector, size [n_train]
   */
-  void Select(math_t *f, math_t *alpha, math_t *y, math_t C) {
+  void Select(math_t *f, math_t *alpha, math_t *y, const math_t *C) {
     if (n_ws >= n_train) {
       // All elements are selected, we have initialized idx to cover this case
       return;
@@ -252,10 +256,11 @@ class WorkingSet {
    *     DOI: 10.1080/10556780500140714
    *
    * @param [in] alpha device vector of dual coefficients, size [n_train]
-   * @param [in] C penalty parameter
+   * @param [in] C_vec penalty parameter
    * @param [in] nc number of elements to select
    */
-  int PrioritySelect(math_t *alpha, math_t C, int nc) {
+  int PrioritySelect(math_t *alpha, const math_t *C_vec, int nc) {
+    math_t C = 1;  // TODO remove this and use C_vec
     int n_selected = 0;
 
     cub::DeviceRadixSort::SortPairs(

--- a/cpp/src/svm/ws_util.cuh
+++ b/cpp/src/svm/ws_util.cuh
@@ -39,9 +39,9 @@ __global__ void set_unavailable(bool *available, int n_rows, const int *idx,
  */
 template <typename math_t>
 __global__ void set_upper(bool *available, int n, const math_t *alpha,
-                          const math_t *y, math_t C) {
+                          const math_t *y, const math_t *C) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (tid < n) available[tid] = in_upper(alpha[tid], y[tid], C);
+  if (tid < n) available[tid] = in_upper(alpha[tid], y[tid], C[tid]);
 }
 
 /** Set availability to true for elements in the lower set, otherwise false.
@@ -53,9 +53,9 @@ __global__ void set_upper(bool *available, int n, const math_t *alpha,
  */
 template <typename math_t>
 __global__ void set_lower(bool *available, int n, const math_t *alpha,
-                          const math_t *y, math_t C) {
+                          const math_t *y, const math_t *C) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if (tid < n) available[tid] = in_lower(alpha[tid], y[tid], C);
+  if (tid < n) available[tid] = in_lower(alpha[tid], y[tid], C[tid]);
 }
 /**
 * Get the priority of the elements that are selected by new_idx.

--- a/cpp/src_prims/linalg/init.h
+++ b/cpp/src_prims/linalg/init.h
@@ -39,7 +39,7 @@ template <typename T>
 void range(T *out, int start, int end, cudaStream_t stream) {
   thrust::counting_iterator<int> first(start);
   thrust::counting_iterator<int> last = first + (end - start);
-  thrust::device_ptr<int> ptr(out);
+  thrust::device_ptr<T> ptr(out);
   thrust::copy(thrust::cuda::par.on(stream), first, last, ptr);
 }
 

--- a/cpp/src_prims/vectorized.cuh
+++ b/cpp/src_prims/vectorized.cuh
@@ -26,6 +26,8 @@ struct IOType {};
 
 template <>
 struct IOType<bool, 1> {
+  static_assert(sizeof(bool) == sizeof(int8_t),
+                "IOType bool size assumption failed");
   typedef int8_t Type;
 };
 template <>

--- a/cpp/src_prims/vectorized.cuh
+++ b/cpp/src_prims/vectorized.cuh
@@ -25,6 +25,27 @@ template <typename math_, int VecLen>
 struct IOType {};
 
 template <>
+struct IOType<bool, 1> {
+  typedef int8_t Type;
+};
+template <>
+struct IOType<bool, 2> {
+  typedef int16_t Type;
+};
+template <>
+struct IOType<bool, 4> {
+  typedef int32_t Type;
+};
+template <>
+struct IOType<bool, 8> {
+  typedef int2 Type;
+};
+template <>
+struct IOType<bool, 16> {
+  typedef int4 Type;
+};
+
+template <>
 struct IOType<int8_t, 1> {
   typedef int8_t Type;
 };

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -51,6 +51,13 @@ namespace SVM {
 using namespace MLCommon;
 using namespace Matrix;
 
+// Initialize device vector C_vec with scalar C
+template <typename math_t>
+void init_C(math_t C, math_t *C_vec, int n, cudaStream_t stream) {
+  thrust::device_ptr<math_t> c_ptr(C_vec);
+  thrust::fill(thrust::cuda::par.on(stream), c_ptr, c_ptr + n, C);
+}
+
 template <typename math_t>
 class WorkingSetTest : public ::testing::Test {
  protected:
@@ -59,13 +66,21 @@ class WorkingSetTest : public ::testing::Test {
     handle.setStream(stream);
     allocate(f_dev, 10);
     allocate(y_dev, 10);
+    allocate(C_dev, 10);
     allocate(alpha_dev, 10);
+    init_C(C, C_dev, 10, stream);
     updateDevice(f_dev, f_host, 10, stream);
     updateDevice(y_dev, y_host, 10, stream);
     updateDevice(alpha_dev, alpha_host, 10, stream);
   }
 
-  void TearDown() override { CUDA_CHECK(cudaStreamDestroy(stream)); }
+  void TearDown() override {
+    CUDA_CHECK(cudaStreamDestroy(stream));
+    CUDA_CHECK(cudaFree(f_dev));
+    CUDA_CHECK(cudaFree(y_dev));
+    CUDA_CHECK(cudaFree(C_dev));
+    CUDA_CHECK(cudaFree(alpha_dev));
+  }
   cumlHandle handle;
   cudaStream_t stream;
   WorkingSet<math_t> *ws;
@@ -76,6 +91,7 @@ class WorkingSetTest : public ::testing::Test {
   math_t y_host[10] = {-1, -1, -1, -1, -1, 1, 1, 1, 1, 1};
   math_t *y_dev;
 
+  math_t *C_dev;
   math_t C = 1.5;
 
   math_t alpha_host[10] = {0, 0, 0.1, 0.2, 1.5, 0, 0.2, 0.4, 1.5, 1.5};
@@ -105,14 +121,15 @@ TYPED_TEST(WorkingSetTest, Select) {
   this->ws =
     new WorkingSet<TypeParam>(this->handle.getImpl(), this->stream, 10, 4);
   EXPECT_EQ(this->ws->GetSize(), 4);
-  this->ws->SimpleSelect(this->f_dev, this->alpha_dev, this->y_dev, this->C);
+  this->ws->SimpleSelect(this->f_dev, this->alpha_dev, this->y_dev,
+                         this->C_dev);
   ASSERT_TRUE(devArrMatchHost(this->expected_idx, this->ws->GetIndices(),
                               this->ws->GetSize(), Compare<int>()));
 
-  this->ws->Select(this->f_dev, this->alpha_dev, this->y_dev, this->C);
+  this->ws->Select(this->f_dev, this->alpha_dev, this->y_dev, this->C_dev);
   ASSERT_TRUE(devArrMatchHost(this->expected_idx, this->ws->GetIndices(),
                               this->ws->GetSize(), Compare<int>()));
-  this->ws->Select(this->f_dev, this->alpha_dev, this->y_dev, this->C);
+  this->ws->Select(this->f_dev, this->alpha_dev, this->y_dev, this->C_dev);
 
   ASSERT_TRUE(devArrMatchHost(this->expected_idx2, this->ws->GetIndices(),
                               this->ws->GetSize(), Compare<int>()));
@@ -309,9 +326,10 @@ class GetResultsTest : public ::testing::Test {
     updateDevice(y_dev.data(), y_host, n_rows, stream);
     device_buffer<math_t> alpha_dev(allocator, stream, n_rows);
     updateDevice(alpha_dev.data(), alpha_host, n_rows, stream);
-
+    device_buffer<math_t> C_dev(allocator, stream, n_rows);
+    init_C(C, C_dev.data(), n_rows, stream);
     Results<math_t> res(handle.getImpl(), x_dev.data(), y_dev.data(), n_rows,
-                        n_cols, C, C_SVC);
+                        n_cols, C_dev.data(), C_SVC);
     res.Get(alpha_dev.data(), f_dev.data(), &dual_coefs, &n_coefs, &idx,
             &x_support, &b);
 
@@ -430,12 +448,14 @@ class SmoBlockSolverTest : public ::testing::Test {
     cublas_handle = handle.getImpl().getCublasHandle();
     allocate(ws_idx_dev, n_ws);
     allocate(y_dev, n_rows);
+    allocate(C_dev, n_rows);
     allocate(f_dev, n_rows);
     allocate(alpha_dev, n_rows, true);
     allocate(delta_alpha_dev, n_ws, true);
     allocate(kernel_dev, n_ws * n_rows);
     allocate(return_buff_dev, 2);
 
+    init_C(C, C_dev, n_rows, stream);
     updateDevice(ws_idx_dev, ws_idx_host, n_ws, stream);
     updateDevice(y_dev, y_host, n_rows, stream);
     updateDevice(f_dev, f_host, n_rows, stream);
@@ -446,7 +466,7 @@ class SmoBlockSolverTest : public ::testing::Test {
   void testBlockSolve() {
     SmoBlockSolve<math_t, 1024><<<1, n_ws, 0, stream>>>(
       y_dev, n_rows, alpha_dev, n_ws, delta_alpha_dev, f_dev, kernel_dev,
-      ws_idx_dev, 1.5f, 1e-3f, return_buff_dev, 1);
+      ws_idx_dev, C_dev, 1e-3f, return_buff_dev, 1);
     CUDA_CHECK(cudaPeekAtLastError());
 
     math_t return_buff_exp[2] = {0.2, 1};
@@ -469,6 +489,7 @@ class SmoBlockSolverTest : public ::testing::Test {
   void TearDown() override {
     CUDA_CHECK(cudaStreamDestroy(stream));
     CUDA_CHECK(cudaFree(y_dev));
+    CUDA_CHECK(cudaFree(C_dev));
     CUDA_CHECK(cudaFree(f_dev));
     CUDA_CHECK(cudaFree(ws_idx_dev));
     CUDA_CHECK(cudaFree(alpha_dev));
@@ -488,6 +509,7 @@ class SmoBlockSolverTest : public ::testing::Test {
   int *ws_idx_dev;
   math_t *y_dev;
   math_t *f_dev;
+  math_t *C_dev;
   math_t *alpha_dev;
   math_t *delta_alpha_dev;
   math_t *kernel_dev;
@@ -495,6 +517,7 @@ class SmoBlockSolverTest : public ::testing::Test {
 
   int ws_idx_host[4] = {0, 1, 2, 3};
   math_t y_host[4] = {1, 1, -1, -1};
+  math_t C = 1.5;
   math_t f_host[4] = {0.4, 0.3, 0.5, 0.1};
   math_t kernel_host[16] = {26, 32, 38, 44, 32, 40, 48, 56,
                             38, 48, 58, 68, 44, 56, 68, 80};
@@ -643,18 +666,21 @@ class SmoSolverTest : public ::testing::Test {
     allocate(x_dev, n_rows * n_cols);
     allocate(ws_idx_dev, n_ws);
     allocate(y_dev, n_rows);
+    allocate(C_dev, n_rows);
     allocate(y_pred, n_rows);
     allocate(f_dev, n_rows);
     allocate(alpha_dev, n_rows, true);
     allocate(delta_alpha_dev, n_ws, true);
     allocate(kernel_dev, n_ws * n_rows);
     allocate(return_buff_dev, 2);
-
+    allocate(sample_weights_dev, n_rows);
+    LinAlg::range(sample_weights_dev, 1, n_rows + 1, stream);
     cublas_handle = handle.getImpl().getCublasHandle();
 
     updateDevice(x_dev, x_host, n_rows * n_cols, stream);
     updateDevice(ws_idx_dev, ws_idx_host, n_ws, stream);
     updateDevice(y_dev, y_host, n_rows, stream);
+    init_C(C, C_dev, n_rows, stream);
     updateDevice(f_dev, f_host, n_rows, stream);
     updateDevice(kernel_dev, kernel_host, n_ws * n_rows, stream);
     CUDA_CHECK(
@@ -676,6 +702,7 @@ class SmoSolverTest : public ::testing::Test {
     CUDA_CHECK(cudaStreamDestroy(stream));
     CUDA_CHECK(cudaFree(x_dev));
     CUDA_CHECK(cudaFree(y_dev));
+    CUDA_CHECK(cudaFree(C_dev));
     CUDA_CHECK(cudaFree(y_pred));
     CUDA_CHECK(cudaFree(f_dev));
     CUDA_CHECK(cudaFree(ws_idx_dev));
@@ -683,6 +710,7 @@ class SmoSolverTest : public ::testing::Test {
     CUDA_CHECK(cudaFree(delta_alpha_dev));
     CUDA_CHECK(cudaFree(kernel_dev));
     CUDA_CHECK(cudaFree(return_buff_dev));
+    CUDA_CHECK(cudaFree(sample_weights_dev));
     FreeResultBuffers();
   }
 
@@ -690,7 +718,7 @@ class SmoSolverTest : public ::testing::Test {
   void blockSolveTest() {
     SmoBlockSolve<math_t, 1024><<<1, n_ws, 0, stream>>>(
       y_dev, n_rows, alpha_dev, n_ws, delta_alpha_dev, f_dev, kernel_dev,
-      ws_idx_dev, 1.0, 1e-3, return_buff_dev);
+      ws_idx_dev, C_dev, 1e-3, return_buff_dev);
     CUDA_CHECK(cudaPeekAtLastError());
 
     math_t return_buff[2];
@@ -748,7 +776,7 @@ class SmoSolverTest : public ::testing::Test {
     updateDevice(kColIdx_dev.data(), kColIdx, 4, stream);
     SmoBlockSolve<math_t, 1024><<<1, n_ws, 0, stream>>>(
       y_dev, 2 * n_rows, alpha_dev, n_ws, delta_alpha_dev, f_dev, kernel_dev,
-      ws_idx_dev, 1.0, 1e-3, return_buff_dev, 10, EPSILON_SVR,
+      ws_idx_dev, C_dev, 1e-3, return_buff_dev, 10, EPSILON_SVR,
       kColIdx_dev.data());
     CUDA_CHECK(cudaPeekAtLastError());
 
@@ -775,17 +803,19 @@ class SmoSolverTest : public ::testing::Test {
   math_t *x_dev;
   int *ws_idx_dev;
   math_t *y_dev;
+  math_t *C_dev;
   math_t *y_pred;
   math_t *f_dev;
   math_t *alpha_dev;
   math_t *delta_alpha_dev;
   math_t *kernel_dev;
   math_t *return_buff_dev;
+  math_t *sample_weights_dev;
 
   math_t x_host[12] = {1, 2, 1, 2, 1, 2, 1, 1, 2, 2, 3, 3};
   int ws_idx_host[6] = {0, 1, 2, 3, 4, 5};
   math_t y_host[6] = {-1, -1, 1, -1, 1, 1};
-
+  math_t C = 1;
   math_t f_host[6] = {1, 1, -1, 1, -1, -1};
 
   math_t kernel_host[36] = {2, 3, 3, 4, 4,  5,  3, 5, 4, 6,  5,  7,
@@ -848,7 +878,7 @@ TYPED_TEST(SmoSolverTest, SmoSolveTest) {
     SmoSolver<TypeParam> smo(this->handle.getImpl(), param, kernel);
     svmModel<TypeParam> model{0,       this->n_cols, 0, nullptr,
                               nullptr, nullptr,      0, nullptr};
-    smo.Solve(this->x_dev, this->n_rows, this->n_cols, this->y_dev,
+    smo.Solve(this->x_dev, this->n_rows, this->n_cols, this->y_dev, nullptr,
               &model.dual_coefs, &model.n_support, &model.x_support,
               &model.support_idx, &model.b, p.max_iter, p.max_inner_iter);
     checkResults(model, exp, this->stream);
@@ -867,6 +897,16 @@ TYPED_TEST(SmoSolverTest, SvcTest) {
                            {1, 1, 2, 2, 1, 2, 2, 3},
                            {0, 2, 3, 5},
                            {-1.0, -1.4, 0.2, -0.2, 1.4, 1.0}}},
+    {// C == 0 marks a special tast case with sample weights
+     svcInput<TypeParam>{0, 0.001, KernelParams{LINEAR, 3, 1, 0}, this->n_rows,
+                         this->n_cols, this->x_dev, this->y_dev, true},
+     smoOutput2<TypeParam>{4,
+                           {},
+                           -1.0f,
+                           {-2, 2},
+                           {1, 1, 2, 2, 1, 2, 2, 3},
+                           {0, 2, 3, 5},
+                           {-1.0, -3.0, 1.0, -1.0, 3.0, 1.0}}},
     {svcInput<TypeParam>{1, 1e-6, KernelParams{POLYNOMIAL, 3, 1, 0},
                          this->n_rows, this->n_cols, this->x_dev, this->y_dev,
                          true},
@@ -904,8 +944,13 @@ TYPED_TEST(SmoSolverTest, SvcTest) {
     auto p = d.first;
     auto exp = d.second;
     SCOPED_TRACE(kernelName(p.kernel_params));
+    TypeParam *sample_weights = nullptr;
+    if (p.C == 0) {
+      p.C = 1;
+      sample_weights = this->sample_weights_dev;
+    }
     SVC<TypeParam> svc(this->handle, p.C, p.tol, p.kernel_params);
-    svc.fit(p.x_dev, p.n_rows, p.n_cols, p.y_dev);
+    svc.fit(p.x_dev, p.n_rows, p.n_cols, p.y_dev, sample_weights);
     checkResults(svc.model, toSmoOutput(exp), this->stream);
     device_buffer<TypeParam> y_pred(this->handle.getDeviceAllocator(),
                                     this->stream, p.n_rows);
@@ -1121,6 +1166,7 @@ class SvrTest : public ::testing::Test {
     allocator = handle.getDeviceAllocator();
     allocate(x_dev, n_rows * n_cols);
     allocate(y_dev, n_rows);
+    allocate(C_dev, 2 * n_rows);
     allocate(y_pred, n_rows);
 
     allocate(yc, n_train);
@@ -1142,6 +1188,7 @@ class SvrTest : public ::testing::Test {
     CUDA_CHECK(cudaStreamDestroy(stream));
     CUDA_CHECK(cudaFree(x_dev));
     CUDA_CHECK(cudaFree(y_dev));
+    CUDA_CHECK(cudaFree(C_dev));
     CUDA_CHECK(cudaFree(y_pred));
     CUDA_CHECK(cudaFree(yc));
     CUDA_CHECK(cudaFree(f));
@@ -1162,7 +1209,7 @@ class SvrTest : public ::testing::Test {
   }
 
   void TestSvrWorkingSet() {
-    math_t C = 1;
+    init_C((math_t)1.0, C_dev, 2 * n_rows, stream);
     WorkingSet<math_t> *ws;
     ws =
       new WorkingSet<math_t>(handle.getImpl(), stream, n_rows, 20, EPSILON_SVR);
@@ -1172,7 +1219,7 @@ class SvrTest : public ::testing::Test {
     updateDevice(f, f_exp, n_train, stream);
     updateDevice(yc, yc_exp, n_train, stream);
 
-    ws->Select(f, alpha, yc, C);
+    ws->Select(f, alpha, yc, C_dev);
     int exp_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
     ASSERT_TRUE(devArrMatchHost(exp_idx, ws->GetIndices(), ws->GetSize(),
                                 Compare<int>()));
@@ -1182,7 +1229,7 @@ class SvrTest : public ::testing::Test {
     ws =
       new WorkingSet<math_t>(handle.getImpl(), stream, n_rows, 10, EPSILON_SVR);
     EXPECT_EQ(ws->GetSize(), 10);
-    ws->Select(f, alpha, yc, C);
+    ws->Select(f, alpha, yc, C_dev);
     int exp_idx2[] = {6, 12, 5, 11, 3, 9, 8, 1, 7, 0};
     ASSERT_TRUE(devArrMatchHost(exp_idx2, ws->GetIndices(), ws->GetSize(),
                                 Compare<int>()));
@@ -1191,8 +1238,9 @@ class SvrTest : public ::testing::Test {
 
   void TestSvrResults() {
     updateDevice(yc, yc_exp, n_train, stream);
-    Results<math_t> res(handle.getImpl(), x_dev, yc, n_rows, n_cols,
-                        (math_t)0.001, EPSILON_SVR);
+    init_C((math_t)0.001, C_dev, n_rows * 2, stream);
+    Results<math_t> res(handle.getImpl(), x_dev, yc, n_rows, n_cols, C_dev,
+                        EPSILON_SVR);
     model.n_cols = n_cols;
     updateDevice(alpha, alpha_host, n_train, stream);
     updateDevice(f, f_exp, n_train, stream);
@@ -1295,6 +1343,7 @@ class SvrTest : public ::testing::Test {
   svmModel<math_t> model;
   math_t *x_dev;
   math_t *y_dev;
+  math_t *C_dev;
   math_t *y_pred;
   math_t *yc;
   math_t *f;

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -299,7 +299,7 @@ class SVC(SVMBase, ClassifierMixin):
         else:
             keys = self.class_weight.keys()
             keys_series = cudf.Series(keys)
-            encoded_keys = le.transform(cudf.Series(keys))
+            encoded_keys = le.transform(cudf.Series(keys)).values_host
             class_weight = {enc_key: self.class_weight[key]
                             for enc_key, key in zip(encoded_keys, keys)}
 

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -20,6 +20,7 @@
 
 import ctypes
 import cudf
+import cupy as cp
 import numpy as np
 
 from numba import cuda
@@ -32,8 +33,9 @@ from cuml.common.base import Base, ClassifierMixin
 from cuml.common.logger import warn
 from cuml.common.handle cimport cumlHandle
 from cuml.common import input_to_cuml_array, input_to_host_array, with_cupy_rmm
+from cuml.preprocessing import LabelEncoder
 from cuml.common.memory_utils import using_output_type
-from libcpp cimport bool
+from libcpp cimport bool, nullptr
 from cuml.svm.svm_base import SVMBase
 from sklearn.calibration import CalibratedClassifierCV
 
@@ -86,7 +88,8 @@ cdef extern from "cuml/svm/svc.hpp" namespace "ML::SVM":
                              int n_rows, int n_cols, math_t *labels,
                              const svmParameter &param,
                              KernelParams &kernel_params,
-                             svmModel[math_t] &model) except+
+                             svmModel[math_t] &model,
+                             const math_t *sample_weight) except+
 
     cdef void svcPredict[math_t](
         const cumlHandle &handle, math_t *input, int n_rows, int n_cols,
@@ -175,6 +178,10 @@ class SVC(SVMBase, ClassifierMixin):
         matrix elements (this can be signifficant if n_support is large).
         The cache_size variable sets an upper limit to the prediction
         buffer as well.
+    class_weight : dict or string (default=None)
+        Weights to modify the parameter C for class i to class_weight[i]*C. The
+        string 'balanced' is also accepted, in which case class_weight[i] =
+        n_samples / (n_classes * n_samples_of_class[i])
     max_iter : int (default = 100*n_samples)
         Limit the number of outer iterations in the solver
     nochange_steps : int (default = 1000)
@@ -235,7 +242,8 @@ class SVC(SVMBase, ClassifierMixin):
     def __init__(self, handle=None, C=1, kernel='rbf', degree=3,
                  gamma='scale', coef0=0.0, tol=1e-3, cache_size=200.0,
                  max_iter=-1, nochange_steps=1000, verbose=False,
-                 output_type=None, probability=False, random_state=None):
+                 output_type=None, probability=False, random_state=None,
+                 class_weight=None):
         super(SVC, self).__init__(handle, C, kernel, degree, gamma, coef0, tol,
                                   cache_size, max_iter, nochange_steps,
                                   verbose, output_type=output_type)
@@ -243,6 +251,7 @@ class SVC(SVMBase, ClassifierMixin):
         self.random_state = random_state
         if probability and random_state is not None:
             warn("Random state is currently ignored by probabilistic SVC")
+        self.class_weight = class_weight
         self.svmType = C_SVC
 
     @property
@@ -253,7 +262,62 @@ class SVC(SVMBase, ClassifierMixin):
             return self.unique_labels
 
     @with_cupy_rmm
-    def fit(self, X, y, convert_dtype=True):
+    def _apply_class_weight(self, sample_weight, y_m):
+        """
+        Scale the sample weights with the class weights.
+
+        Returns the modified sample weights, or None if neither class weights
+        nor sample weights are defined. The returned weights are defined as
+
+        sample_weight[i] = class_weight[y[i]] * sample_weight[i].
+
+        Parameters:
+        -----------
+        sample_weight: array-like (device or host), shape = (n_samples, 1)
+            sample weights or None if not given
+        y_m: device array of floats or doubles, shape = (n_samples, 1)
+            Array of target labels already copied to the device.
+
+        Returns:
+        --------
+        sample_weight: device array shape = (n_samples, 1) or None
+        """
+        if self.class_weight is None:
+            return sample_weight
+
+        le = LabelEncoder()
+        labels = y_m.to_output(output_type='series')
+        encoded_labels = cp.asarray(le.fit_transform(labels))
+
+        # Define class weights for the encoded labels
+        if self.class_weight == 'balanced':
+            counts = cp.asnumpy(cp.bincount(encoded_labels))
+            n_classes = len(counts)
+            n_samples = y_m.shape[0]
+            weights = n_samples / (n_classes * counts)
+            class_weight = {i: weights[i] for i in range(n_classes)}
+        else:
+            keys = self.class_weight.keys()
+            keys_series = cudf.Series(keys)
+            encoded_keys = le.transform(cudf.Series(keys))
+            class_weight = {enc_key: self.class_weight[key]
+                            for enc_key, key in zip(encoded_keys, keys)}
+
+        if sample_weight is None:
+            sample_weight = cp.ones(y_m.shape, dtype=self.dtype)
+        else:
+            sample_weight_m, _, _, _ = \
+                input_to_cuml_array(sample_weight, convert_to_dtype=self.dtype,
+                                    check_rows=self.n_rows, check_cols=1)
+            sample_weight = sample_weight_m.to_output(output_type='cupy')
+
+        for label, weight in class_weight.items():
+            sample_weight[encoded_labels==label] *= weight
+
+        return sample_weight
+
+    @with_cupy_rmm
+    def fit(self, X, y, sample_weight=None, convert_dtype=True):
         """
         Fit the model with X and y.
 
@@ -296,13 +360,23 @@ class SVC(SVMBase, ClassifierMixin):
             input_to_cuml_array(X, order='F')
 
         cdef uintptr_t X_ptr = X_m.ptr
+        convert_to_dtype = self.dtype if convert_dtype else None
         y_m, _, _, _ = \
             input_to_cuml_array(y, check_dtype=self.dtype,
-                                convert_to_dtype=(self.dtype if convert_dtype
-                                                  else None),
+                                convert_to_dtype=convert_to_dtype,
                                 check_rows=self.n_rows, check_cols=1)
 
         cdef uintptr_t y_ptr = y_m.ptr
+
+        sample_weight = self._apply_class_weight(sample_weight, y_m)
+        cdef uintptr_t sample_weight_ptr = <uintptr_t> nullptr
+        if sample_weight is not None:
+            sample_weight_m, _, _, _ = \
+                input_to_cuml_array(sample_weight, check_dtype=self.dtype,
+                                    convert_to_dtype=convert_to_dtype,
+                                    check_rows=self.n_rows, check_cols=1)
+            sample_weight_ptr = sample_weight_m.ptr
+
         self._dealloc()  # delete any previously fitted model
         self._coef_ = None
 
@@ -316,13 +390,13 @@ class SVC(SVMBase, ClassifierMixin):
             model_f = new svmModel[float]()
             svcFit(handle_[0], <float*>X_ptr, <int>self.n_rows,
                    <int>self.n_cols, <float*>y_ptr, param, _kernel_params,
-                   model_f[0])
+                   model_f[0], <float*>sample_weight_ptr)
             self._model = <uintptr_t>model_f
         elif self.dtype == np.float64:
             model_d = new svmModel[double]()
             svcFit(handle_[0], <double*>X_ptr, <int>self.n_rows,
                    <int>self.n_cols, <double*>y_ptr, param, _kernel_params,
-                   model_d[0])
+                   model_d[0], <double*>sample_weight_ptr)
             self._model = <uintptr_t>model_d
         else:
             raise TypeError('Input data type should be float32 or float64')
@@ -459,4 +533,4 @@ class SVC(SVMBase, ClassifierMixin):
 
     def get_param_names(self):
         return super(SVC, self).get_param_names() + \
-            ["probability", "random_state"]
+            ["probability", "random_state", "class_weight"]

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -84,7 +84,8 @@ cdef extern from "cuml/svm/svc.hpp" namespace "ML::SVM":
                              int n_rows, int n_cols, math_t *labels,
                              const svmParameter &param,
                              KernelParams &kernel_params,
-                             svmModel[math_t] &model) except+
+                             svmModel[math_t] &model,
+                             const math_t *sample_weight) except+
 
     cdef void svcPredict[math_t](
         const cumlHandle &handle, math_t *input, int n_rows, int n_cols,

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -357,7 +357,7 @@ def test_svc_weights(class_weight, sample_weight):
     if class_weight is not None or sample_weight is not None:
         # Standalone test: check if smaller blob is correctly classified in the
         # presence of class weights
-        X_1 = X[y==1, :]
+        X_1 = X[y == 1, :]
         y_1 = np.ones(X_1.shape[0])
         cu_score = cuSVC.score(X_1, y_1)
         assert cu_score > 0.9

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -600,3 +600,20 @@ def test_svr_skl_cmp(params, dataset, n_rows, n_cols):
     sklSVR.fit(X_train, y_train)
 
     compare_svr(cuSVR, sklSVR, X_test, y_test)
+
+
+def test_svr_skl_cmp_weighted():
+    """ Compare to Sklearn SVR, use sample weights"""
+    X, y = make_regression(
+        n_samples=100, n_features=5, n_informative=2, n_targets=1,
+        random_state=137, noise=10)
+    sample_weights = 10*np.sin(np.linspace(0, 2*np.pi, len(y))) + 10.1
+
+    params = {'kernel': 'linear', 'C': 10, 'gamma': 1}
+    cuSVR = cu_svm.SVR(**params)
+    cuSVR.fit(X, y, sample_weights)
+
+    sklSVR = svm.SVR(**params)
+    sklSVR.fit(X, y, sample_weights)
+
+    compare_svr(cuSVR, sklSVR, X, y)


### PR DESCRIPTION
This PR adds SVM class and sample weights, and closes issue #2222.

- The Python layer accepts both sample and class weights.
- The C++ layer accepts only sample weights. Class weight can be included by setting sample weights based on the class label (as it is done [here](https://github.com/tfeher/cuml/blob/71ea6a37590ed804859e9b7cab48dc3ed3e0d95b/python/cuml/svm/svc.pyx#L265)).

The weights scale the penalty parameter C for each sample individually. The essence of this PR is the two code lines change in SmoBlockSolver, the rest just makes sure that the correctly weighted penalty parameter reaches that point, and the results are correctly processed afterwards. 

Additional unrelated change: the unused fit method from SVMBase was removed (#2409).