### PR TITLE
Replace CNMeM with `rmm::mr::pool_memory_resource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - PR #2611: Adding building doxygen docs to gpu ci
 - PR #2629: Add naive_bayes api docs
 - PR #2643: 'dense' and 'sparse' values of `storage_type` for FIL
+- PR #2648: Replace CNMeM with `rmm::mr::pool_memory_resource`.
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/cpp/include/cuml/common/rmmAllocatorAdapter.hpp
+++ b/cpp/include/cuml/common/rmmAllocatorAdapter.hpp
@@ -43,7 +43,7 @@ class rmmAllocatorAdapter : public ML::deviceAllocator {
    */
   virtual void* allocate(std::size_t n, cudaStream_t stream) {
     void* ptr = 0;
-    ptr = rmm::mr::get_per_device_resource()->allocate(n, stream);
+    ptr = rmm::mr::get_current_device_resource()->allocate(n, stream);
     return ptr;
   }
 
@@ -56,7 +56,7 @@ class rmmAllocatorAdapter : public ML::deviceAllocator {
    * @param[in] stream    the stream to use for the asynchronous free
    */
   virtual void deallocate(void* p, std::size_t n, cudaStream_t stream) {
-    rmm::mr::get_per_device_resource()->deallocate(p, n, stream);
+    rmm::mr::get_current_device_resource()->deallocate(p, n, stream);
   }
 
   virtual ~rmmAllocatorAdapter() {}

--- a/cpp/include/cuml/common/rmmAllocatorAdapter.hpp
+++ b/cpp/include/cuml/common/rmmAllocatorAdapter.hpp
@@ -19,7 +19,7 @@
 #include <cuml/common/logger.hpp>
 #include <cuml/common/utils.hpp>
 #include <cuml/cuml.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace ML {
 
@@ -43,7 +43,7 @@ class rmmAllocatorAdapter : public ML::deviceAllocator {
    */
   virtual void* allocate(std::size_t n, cudaStream_t stream) {
     void* ptr = 0;
-    ptr = rmm::mr::get_default_resource()->allocate(n, stream);
+    ptr = rmm::mr::get_per_device_resource()->allocate(n, stream);
     return ptr;
   }
 
@@ -56,7 +56,7 @@ class rmmAllocatorAdapter : public ML::deviceAllocator {
    * @param[in] stream    the stream to use for the asynchronous free
    */
   virtual void deallocate(void* p, std::size_t n, cudaStream_t stream) {
-    rmm::mr::get_default_resource()->deallocate(p, n, stream);
+    rmm::mr::get_per_device_resource()->deallocate(p, n, stream);
   }
 
   virtual ~rmmAllocatorAdapter() {}

--- a/cpp/include/cuml/common/rmmPoolAllocatorAdapter.hpp
+++ b/cpp/include/cuml/common/rmmPoolAllocatorAdapter.hpp
@@ -51,12 +51,12 @@ inline auto make_pool() {
 class rmmPoolAllocatorAdapter : public rmmAllocatorAdapter {
  public:
   rmmPoolAllocatorAdapter() : mr_(make_pool()) {
-    prev_mr_ = rmm::mr::set_default_resource(mr_.get());
+    prev_mr_ = rmm::mr::set_current_device_resource(mr_.get());
   }
 
   ~rmmPoolAllocatorAdapter() {
     // restore the previous memory resource when this object goes out-of-scope
-    rmm::mr::set_default_resource(prev_mr_);
+    rmm::mr::set_current_device_resource(prev_mr_);
   }
 
  private:

--- a/cpp/include/cuml/common/rmmPoolAllocatorAdapter.hpp
+++ b/cpp/include/cuml/common/rmmPoolAllocatorAdapter.hpp
@@ -16,24 +16,42 @@
 
 #pragma once
 
+#include "rmmAllocatorAdapter.hpp"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/common/utils.hpp>
 #include <cuml/cuml.hpp>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
-#include "rmmAllocatorAdapter.hpp"
+
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+
+#include <memory>
 
 namespace ML {
+
+namespace {
+// simple helpers for creating RMM MRs
+inline auto make_cuda() {
+  return std::make_shared<rmm::mr::cuda_memory_resource>();
+}
+
+inline auto make_pool() {
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
+    make_cuda());
+}
+}  // namespace
 
 /**
  * @brief Implemententation of ML::deviceAllocator using the RMM pool
  *
  * @todo rmmPoolAllocatorAdapter currently only uses the default ctor of the
- *       underlying pool allocator (ie cnmem).
+ *       underlying device_memory_resource.
  */
 class rmmPoolAllocatorAdapter : public rmmAllocatorAdapter {
  public:
-  rmmPoolAllocatorAdapter() : cnmem_mr_() {
-    prev_mr_ = rmm::mr::set_default_resource(&cnmem_mr_);
+  rmmPoolAllocatorAdapter() : mr_(make_pool()) {
+    prev_mr_ = rmm::mr::set_default_resource(mr_.get());
   }
 
   ~rmmPoolAllocatorAdapter() {
@@ -42,7 +60,7 @@ class rmmPoolAllocatorAdapter : public rmmAllocatorAdapter {
   }
 
  private:
-  rmm::mr::cnmem_memory_resource cnmem_mr_;
+  std::shared_ptr<rmm::mr::device_memory_resource> mr_;
   rmm::mr::device_memory_resource* prev_mr_;
 };
 


### PR DESCRIPTION
As of 0.15, RMM deprecates CNMeM, so this PR replaces the use of `cnmem_memory_resource` with `pool_memory_resource`.﻿
