### PR TITLE
[REVIEW] Cleanup sphinx doc warnings for 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
 - PR #2616: Small test code fix for pandas dtype tests
 - PR #2625: Update Estimator notebook to resolve errors
 - PR #2634: singlegpu build option fixes
+- PR #2649: Cleanup sphinx doc warnings for 0.15
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/docs/source/_static/references.css
+++ b/docs/source/_static/references.css
@@ -1,0 +1,23 @@
+
+/* Fix references to not look like parameters */
+dl.citation > dt.label {
+  display: unset !important;
+  float: left !important;
+  border: unset !important;
+  background: unset !important;
+  padding: unset !important;
+  margin: unset !important;
+  font-size: unset !important;
+  line-height: unset !important;
+  padding-right: 0.5rem !important;
+}
+
+/* Add opening bracket */
+dl.citation > dt.label > span::before {
+  content: "[";
+}
+
+/* Add closing bracket */
+dl.citation > dt.label > span::after {
+  content: "]";
+}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -59,7 +59,7 @@ Model Selection and Data Splitting
 Feature and Label Encoding (Single-GPU)
 ---------------------------------------
 
- .. autoclass:: cuml.preprocessing.LabelEncoder
+ .. autoclass:: cuml.preprocessing.LabelEncoder.LabelEncoder
     :members:
 
  .. autoclass:: cuml.preprocessing.LabelBinarizer
@@ -248,12 +248,14 @@ Nearest Neighbors Classification
 
 .. autoclass:: cuml.neighbors.KNeighborsClassifier
     :members:
+    :noindex:
 
 Nearest Neighbors Regression
 ----------------------------
 
 .. autoclass:: cuml.neighbors.KNeighborsRegressor
     :members:
+    :noindex:
 
 Clustering
 ==========

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,4 +190,3 @@ def setup(app):
     app.add_css_file('copybutton.css')
     app.add_css_file('params.css')
     app.add_css_file('references.css')
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -187,4 +187,7 @@ numpydoc_class_members_toctree = False
 
 
 def setup(app):
+    app.add_css_file('copybutton.css')
     app.add_css_file('params.css')
+    app.add_css_file('references.css')
+

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -93,7 +93,7 @@ class DBSCAN(Base):
     neighbours.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -31,16 +31,16 @@ class CumlArray(Buffer):
     """
     Array represents an abstracted array allocation. It can be instantiated by
     itself, creating an rmm.DeviceBuffer underneath, or can be instantiated by
-    ``__cuda_array_interface__`` or ``__array_interface__`` compliant arrays, in which
-    case it'll keep a reference to that data underneath. Also can be created
-    from a pointer, specifying the characteristics of the array, in that case
-    the owner of the data referred to by the pointer should be specified
-    explicitly.
+    ``__cuda_array_interface__`` or ``__array_interface__`` compliant arrays,
+    in which case it'll keep a reference to that data underneath. Also can be
+    created from a pointer, specifying the characteristics of the array, in
+    that case the owner of the data referred to by the pointer should be
+    specified explicitly.
 
     Parameters
     ----------
 
-    data : rmm.DeviceBuffer, cudf.Buffer, array_like, int, bytes, bytearray or \
+    data : rmm.DeviceBuffer, cudf.Buffer, array_like, int, bytes, bytearray or\
            memoryview
         An array-like object or integer representing a
         device or host pointer to pre-allocated memory.

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -73,22 +73,6 @@ class CumlArray(Buffer):
     __cuda_array_interface__ : dictionary
         ``__cuda_array_interface__`` to interop with other libraries.
 
-    Object Methods
-    --------------
-
-    to_output : Convert the array to the appropriate output format.
-
-    Class Methods
-    -------------
-
-    Array.empty : Create an empty array, allocating a DeviceBuffer.
-    Array.full : Create an Array with allocated DeviceBuffer initialized with
-        a particular value.
-    Array.ones : Create an Array with allocated DeviceBuffer initialized with
-        ones.
-    Array.zeros : Create an Array with allocated DeviceBuffer initialized with
-        zeros.
-
     Notes
     -----
 
@@ -204,16 +188,19 @@ class CumlArray(Buffer):
         ----------
         output_type : string
             Format to convert the array to. Acceptable formats are:
-             - 'cupy' - to cupy array
-             - 'numpy' - to numpy (host) array
-             - 'numba' - to numba device array
-             - 'dataframe' - to cuDF DataFrame
-             - 'series' - to cuDF Series
-             - 'cudf' - to cuDF Series if array is single dimensional, to \
-                DataFrame otherwise
+
+            - 'cupy' - to cupy array
+            - 'numpy' - to numpy (host) array
+            - 'numba' - to numba device array
+            - 'dataframe' - to cuDF DataFrame
+            - 'series' - to cuDF Series
+            - 'cudf' - to cuDF Series if array is single dimensional, to
+               DataFrame otherwise
+
         output_dtype : string, optional
             Optionally cast the array to a specified dtype, creating
             a copy if necessary.
+
         """
         if output_dtype is None:
             output_dtype = self.dtype

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -31,7 +31,7 @@ class CumlArray(Buffer):
     """
     Array represents an abstracted array allocation. It can be instantiated by
     itself, creating an rmm.DeviceBuffer underneath, or can be instantiated by
-    __cuda_array_interface__ or __array_interface__ compliant arrays, in which
+    ``__cuda_array_interface__`` or ``__array_interface__`` compliant arrays, in which
     case it'll keep a reference to that data underneath. Also can be created
     from a pointer, specifying the characteristics of the array, in that case
     the owner of the data referred to by the pointer should be specified
@@ -40,7 +40,7 @@ class CumlArray(Buffer):
     Parameters
     ----------
 
-    data : rmm.DeviceBuffer, cudf.Buffer, array_like, int, bytes, bytearray or
+    data : rmm.DeviceBuffer, cudf.Buffer, array_like, int, bytes, bytearray or \
            memoryview
         An array-like object or integer representing a
         device or host pointer to pre-allocated memory.
@@ -71,7 +71,7 @@ class CumlArray(Buffer):
     strides : tuple of ints
         Strides of the data
     __cuda_array_interface__ : dictionary
-        __cuda_array_interface__ to interop with other libraries.
+        ``__cuda_array_interface__`` to interop with other libraries.
 
     Object Methods
     --------------
@@ -204,12 +204,12 @@ class CumlArray(Buffer):
         ----------
         output_type : string
             Format to convert the array to. Acceptable formats are:
-            'cupy' - to cupy array
-            'numpy' - to numpy (host) array
-            'numba' - to numba device array
-            'dataframe' - to cuDF DataFrame
-            'series' - to cuDF Series
-            'cudf' - to cuDF Series if array is single dimensional, to
+             - 'cupy' - to cupy array
+             - 'numpy' - to numpy (host) array
+             - 'numba' - to numba device array
+             - 'dataframe' - to cuDF DataFrame
+             - 'series' - to cuDF Series
+             - 'cudf' - to cuDF Series if array is single dimensional, to \
                 DataFrame otherwise
         output_dtype : string, optional
             Optionally cast the array to a specified dtype, creating

--- a/python/cuml/common/kernel_utils.py
+++ b/python/cuml/common/kernel_utils.py
@@ -66,8 +66,8 @@ def cuda_kernel_factory(nvrtc_kernel_str, dtypes, kernel_name=None):
     included in the kernel string. These will be added by this function and
     the function name will be made unique, based on the given dtypes.
 
-    Example
-    -------
+    Examples
+    --------
 
         The following kernel string with dtypes = [float, double, int]
 

--- a/python/cuml/common/logger.pyx
+++ b/python/cuml/common/logger.pyx
@@ -97,7 +97,6 @@ def set_level(level):
 
     .. code-block:: python
 
-
         # regular usage of setting a logging level for all subsequent logs
         # in this case, it will enable all logs upto and including `info()`
         logger.set_level(logger.level_info)
@@ -146,7 +145,6 @@ def set_pattern(pattern):
     --------
 
     .. code-block:: python
-
 
         # regular usage of setting a logging pattern for all subsequent logs
         logger.set_pattern("--> [%H-%M-%S] %v")

--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -63,7 +63,6 @@ def rmm_cupy_ary(cupy_fn, *args, **kwargs):
 
     Function to call CuPy functions with RMM memory management
 
-
     Parameters
     ----------
     cupy_fn : cupy function,

--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -241,30 +241,32 @@ def set_global_output_type(output_type):
     output_type : {'input', 'cudf', 'cupy', 'numpy'} (default = 'input')
         Desired output type of results and attributes of the estimators.
 
-        'input' will mean that the parameters and methods will mirror the
-        format of the data sent to the estimators/methods as much as
-        possible. Specifically:
+        * ``'input'`` will mean that the parameters and methods will mirror the
+          format of the data sent to the estimators/methods as much as
+          possible. Specifically:
 
-            Input type -> Output type
+          +---------------------------------------+--------------------------+
+          | Input type                            | Output type              |
+          +=======================================+==========================+
+          | cuDF DataFrame or Series              | cuDF DataFrame or Series |
+          +---------------------------------------+--------------------------+
+          | NumPy arrays                          | NumPy arrays             |
+          +---------------------------------------+--------------------------+
+          | Pandas DataFrame or Series            | NumPy arrays             |
+          +---------------------------------------+--------------------------+
+          | Numba device arrays                   | Numba device arrays      |
+          +---------------------------------------+--------------------------+
+          | CuPy arrays                           | CuPy arrays              |
+          +---------------------------------------+--------------------------+
+          | Other `__cuda_array_interface__` objs | CuPy arrays              |
+          +---------------------------------------+--------------------------+
 
-            cuDF DataFrame or Series -> cuDF DataFrame or Series
+        * ``'cudf'`` will return cuDF Series for single dimensional results and
+          DataFrames for the rest.
 
-            NumPy arrays -> NumPy arrays
+        * ``'cupy'`` will return CuPy arrays.
 
-            Pandas DataFrame or Series -> NumPy arrays
-
-            Numba device arrays -> Numba device arrays
-
-            CuPy arrays -> CuPy arrays
-
-            Other __cuda_array_interface__ objects -> CuPy arrays
-
-        'cudf' will return cuDF Series for single dimensional results and
-        DataFrames for the rest.
-
-        'cupy' will return CuPy arrays.
-
-        'numpy' will return NumPy arrays.
+        * ``'numpy'`` will return NumPy arrays.
 
     Examples
     --------
@@ -298,10 +300,11 @@ def set_global_output_type(output_type):
 
     Notes
     -----
-    'cupy' and 'numba' options (as well as 'input' when using Numba and CuPy
-    ndarrays for input) have the least overhead. cuDF add memory consumption
-    and processing time needed to build the Series and DataFrames. 'numpy' has
-    the biggest overhead due to the need to transfer data to CPU memory.
+    ``'cupy'`` and ``'numba'`` options (as well as ``'input'`` when using Numba
+    and CuPy ndarrays for input) have the least overhead. cuDF add memory
+    consumption and processing time needed to build the Series and DataFrames.
+    ``'numpy'`` has the biggest overhead due to the need to transfer data to
+    CPU memory.
 
     """
     if isinstance(output_type, str):
@@ -329,30 +332,32 @@ def using_output_type(output_type):
     output_type : {'input', 'cudf', 'cupy', 'numpy'} (default = 'input')
         Desired output type of results and attributes of the estimators.
 
-        'input' will mean that the parameters and methods will mirror the
-        format of the data sent to the estimators/methods as much as
-        possible. Specifically:
+        * ``'input'`` will mean that the parameters and methods will mirror the
+          format of the data sent to the estimators/methods as much as
+          possible. Specifically:
 
-            Input type -> Output type
+          +---------------------------------------+--------------------------+
+          | Input type                            | Output type              |
+          +=======================================+==========================+
+          | cuDF DataFrame or Series              | cuDF DataFrame or Series |
+          +---------------------------------------+--------------------------+
+          | NumPy arrays                          | NumPy arrays             |
+          +---------------------------------------+--------------------------+
+          | Pandas DataFrame or Series            | NumPy arrays             |
+          +---------------------------------------+--------------------------+
+          | Numba device arrays                   | Numba device arrays      |
+          +---------------------------------------+--------------------------+
+          | CuPy arrays                           | CuPy arrays              |
+          +---------------------------------------+--------------------------+
+          | Other `__cuda_array_interface__` objs | CuPy arrays              |
+          +---------------------------------------+--------------------------+
 
-            cuDF DataFrame or Series -> cuDF DataFrame or Series
+        * ``'cudf'`` will return cuDF Series for single dimensional results and
+          DataFrames for the rest.
 
-            NumPy arrays -> NumPy arrays
+        * ``'cupy'`` will return CuPy arrays.
 
-            Pandas DataFrame or Series -> NumPy arrays
-
-            Numba device arrays -> Numba device arrays
-
-            CuPy arrays -> CuPy arrays
-
-            Other __cuda_array_interface__ objects -> CuPy arrays
-
-        'cudf' will return cuDF Series for single dimensional results and
-        DataFrames for the rest.
-
-        'cupy' will return CuPy arrays.
-
-        'numpy' will return NumPy arrays.
+        * ``'numpy'`` will return NumPy arrays.
 
     Examples
     --------
@@ -369,7 +374,7 @@ def using_output_type(output_type):
             dbscan_float = cuml.DBSCAN(eps=1.0, min_samples=1)
             dbscan_float.fit(ary)
 
-            print("cuML output inside `with` context")
+            print("cuML output inside 'with' context")
             print(dbscan_float.labels_)
             print(type(dbscan_float.labels_))
 
@@ -385,13 +390,12 @@ def using_output_type(output_type):
 
     .. code-block::
 
-        cuML output inside `with` context
+        cuML output inside 'with' context
         0    0
         1    1
         2    2
         dtype: int32
         <class 'cudf.core.series.Series'>
-
 
         cuML default output
         [0 1 2]

--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -287,7 +287,7 @@ def set_global_output_type(output_type):
 
     Output:
 
-    .. code-block:: python
+    .. code-block::
 
         cuML output type
         0    0
@@ -383,7 +383,7 @@ def using_output_type(output_type):
 
     Output:
 
-    .. code-block:: python
+    .. code-block::
 
         cuML output inside `with` context
         0    0

--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -76,13 +76,13 @@ def rmm_cupy_ary(cupy_fn, *args, **kwargs):
         Keyword named arguments to pass to the CuPy function
 
 
-    Note: this function should be used if the result of cupy_fn creates
+    .. note:: this function should be used if the result of cupy_fn creates
     a new array. Functions to create a new CuPy array by reference to
     existing device array (through __cuda_array_interface__) can be used
     directly.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/common/opg_data_utils_mg.pyx
+++ b/python/cuml/common/opg_data_utils_mg.pyx
@@ -114,7 +114,7 @@ def build_rank_size_pair(parts_to_sizes, rank):
     parts_to_sizes: array of tuples in the format: [(rank,size)]
     rank: rank to be mapped
 
-    Returns:
+    Returns
     --------
     ptr: vector pointer of the RankSizePair*
     """
@@ -162,7 +162,7 @@ def build_part_descriptor(m, n, rank_size_t, rank):
         building the part descriptor
     rank: rank to be mapped
 
-    Returns:
+    Returns
     --------
     ptr: PartDescriptor object
     """

--- a/python/cuml/common/sparsefuncs.py
+++ b/python/cuml/common/sparsefuncs.py
@@ -150,7 +150,8 @@ def _insert_zeros(ary, zero_indices):
     Create a new array of len(ary + zero_indices) where zero_indices
     indicates indexes of 0s in the new array. Ary is used to fill the rest.
 
-    Example:
+    Examples
+    --------
         _insert_zeros([1, 2, 3], [1, 3]) => [1, 0, 2, 0, 3]
     """
     if len(zero_indices) == 0:

--- a/python/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/dask/cluster/kmeans.py
@@ -60,7 +60,7 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
     random_state : int (default = 1)
         If you want results to be the same when you restart Python,
         select a state.
-    init : {'scalable-kmeans++', 'k-means||' , 'random' or an ndarray}
+    init : {'scalable-kmeans++', 'k-means||' , 'random' or an ndarray} \
            (default = 'scalable-k-means++')
         'scalable-k-means++' or 'k-means||': Uses fast and stable scalable
         kmeans++ intialization.

--- a/python/cuml/dask/datasets/classification.py
+++ b/python/cuml/dask/datasets/classification.py
@@ -41,16 +41,18 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
                         class_sep=1.0, hypercube=True, shift=0.0, scale=1.0,
                         shuffle=True, random_state=None, order='F',
                         dtype='float32', n_parts=None, client=None):
-    """Generate a random n-class classification problem.
+    """
+    Generate a random n-class classification problem.
 
     This initially creates clusters of points normally distributed (std=1)
-    about vertices of an ``n_informative``-dimensional hypercube with sides of
-    length ``2*class_sep`` and assigns an equal number of clusters to each
+    about vertices of an `n_informative`-dimensional hypercube with sides of
+    length ``2 * class_sep`` and assigns an equal number of clusters to each
     class. It introduces interdependence between these features and adds
     various types of further noise to the data.
+
     Without shuffling, ``X`` horizontally stacks features in the following
-    order: the primary ``n_informative`` features, followed by ``n_redundant``
-    linear combinations of the informative features, followed by ``n_repeated``
+    order: the primary `n_informative` features, followed by `n_redundant`
+    linear combinations of the informative features, followed by `n_repeated`
     duplicates, drawn randomly with replacement from the informative and
     redundant features. The remaining features are filled with random noise.
     Thus, without shuffling, all useful features are contained in the columns
@@ -99,15 +101,15 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     n_samples : int, optional (default=100)
         The number of samples.
     n_features : int, optional (default=20)
-        The total number of features. These comprise ``n_informative``
-        informative features, ``n_redundant`` redundant features,
-        ``n_repeated`` duplicated features and
+        The total number of features. These comprise `n_informative`
+        informative features, `n_redundant` redundant features,
+        `n_repeated` duplicated features and
         ``n_features-n_informative-n_redundant-n_repeated`` useless features
         drawn at random.
     n_informative : int, optional (default=2)
         The number of informative features. Each class is composed of a number
         of gaussian clusters each located around the vertices of a hypercube
-        in a subspace of dimension ``n_informative``. For each cluster,
+        in a subspace of dimension `n_informative`. For each cluster,
         informative features are drawn independently from  N(0, 1) and then
         randomly linearly combined within each cluster in order to add
         covariance. The clusters are then placed on the vertices of the
@@ -122,13 +124,13 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         The number of classes (or labels) of the classification problem.
     n_clusters_per_class : int, optional (default=2)
         The number of clusters per class.
-    weights : array-like of shape (n_classes,) or (n_classes - 1,),\
-              (default=None)
+    weights : array-like of shape ``(n_classes,)`` or ``(n_classes - 1,)``, \
+        (default=None)
         The proportions of samples assigned to each class. If None, then
         classes are balanced. Note that if ``len(weights) == n_classes - 1``,
         then the last class weight is automatically inferred.
-        More than ``n_samples`` samples may be returned if the sum of
-        ``weights`` exceeds 1.
+        More than `n_samples` samples may be returned if the sum of
+        `weights` exceeds 1.
     flip_y : float, optional (default=0.01)
         The fraction of samples whose class is assigned randomly. Larger
         values introduce noise in the labels and make the classification
@@ -171,17 +173,18 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     -----
     How we extended the dask MNMG version from the single GPU version:
 
-        1. We generate centroids of shape (n_centroids, n_informative)
-        2. We generate an informative covariance of shape
-           (n_centroids, n_informative, n_informative)
-        3. We generate a redundant covariance of shape
-           (n_informative, n_redundant)
-        4. We generate the indices for the repeated features
-        We pass along the references to the futures of the above arrays
-        with each part to the single GPU
-        `cuml.datasets.classification.make_classification` so that each
-        part (and worker) has access to the correct values to generate
-        data from the same covariances
+    1. We generate centroids of shape ``(n_centroids, n_informative)``
+    2. We generate an informative covariance of shape \
+        ``(n_centroids, n_informative, n_informative)``
+    3. We generate a redundant covariance of shape \
+        ``(n_informative, n_redundant)``
+    4. We generate the indices for the repeated features \
+    We pass along the references to the futures of the above arrays \
+    with each part to the single GPU \
+    `cuml.datasets.classification.make_classification` so that each \
+    part (and worker) has access to the correct values to generate \
+    data from the same covariances
+
     """
 
     client = get_client(client=client)

--- a/python/cuml/dask/datasets/regression.py
+++ b/python/cuml/dask/datasets/regression.py
@@ -223,7 +223,7 @@ def make_low_rank_matrix(n_samples=100, n_features=100,
     tail_strength : float between 0.0 and 1.0, optional (default=0.5)
         The relative importance of the fat noisy tail of the singular values
         profile.
-    random_state : int, CuPy RandomState instance, Dask RandomState instance
+    random_state : int, CuPy RandomState instance, Dask RandomState instance \
                    or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
@@ -236,6 +236,7 @@ def make_low_rank_matrix(n_samples=100, n_features=100,
     -------
     X : Dask-CuPy array of shape [n_samples, n_features]
         The matrix.
+
     """
 
     rs = _create_rs_generator(random_state)
@@ -276,7 +277,9 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
                     random_state=None, n_parts=1, n_samples_per_part=None,
                     order='F', dtype='float32', client=None,
                     use_full_low_rank=True):
-    """Generate a random regression problem.
+    """
+    Generate a random regression problem.
+    
     The input set can either be well conditioned (by default) or have a low
     rank-fat tail singular profile.
 
@@ -305,9 +308,11 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
             of the input data by linear combinations. Using this kind of
             singular spectrum in the input allows the generator to reproduce
             the correlations often observed in practice.
+
         if None:
             The input set is well conditioned, centered and gaussian with
             unit variance.
+
     tail_strength : float between 0.0 and 1.0, optional (default=0.5)
         The relative importance of the fat noisy tail of the singular values
         profile if "effective_rank" is not None.
@@ -317,7 +322,7 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
         Shuffle the samples and the features.
     coef : boolean, optional (default=False)
         If True, the coefficients of the underlying linear model are returned.
-    random_state : int, CuPy RandomState instance, Dask RandomState instance
+    random_state : int, CuPy RandomState instance, Dask RandomState instance \
                    or None (default)
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
@@ -339,26 +344,26 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
         The input samples.
     y : Dask-CuPy array of shape [n_samples] or [n_samples, n_targets]
         The output values.
-    coef : Dask-CuPy array of shape [n_features]
+    coef : Dask-CuPy array of shape [n_features] \
            or [n_features, n_targets], optional
         The coefficient of the underlying linear model. It is returned only if
         coef is True.
 
     Notes
     -----
-    - Known Performance Limitations:
-        1. When `effective_rank` is set and `use_full_low_rank` is True,
-           we cannot generate order `F` by construction, and an explicit
-           transpose is performed on each part. This may cause memory to spike
-           (other parameters make order `F` by construction)
-        2. When `n_targets > 1` and `order = 'F'` as above, we have to
-           explicity transpose the `y` array. If `coef = True`, then we also
-           explicity transpose the `ground_truth` array
-        3. When `shuffle = True` and `order = F`, there are memory spikes to
-           shuffle the `F` order arrays
+    Known Performance Limitations:
+     1. When `effective_rank` is set and `use_full_low_rank` is True, \
+        we cannot generate order `F` by construction, and an explicit \
+        transpose is performed on each part. This may cause memory to spike \
+        (other parameters make order `F` by construction)
+     2. When `n_targets > 1` and `order = 'F'` as above, we have to \
+        explicity transpose the `y` array. If `coef = True`, then we also \
+        explicity transpose the `ground_truth` array
+     3. When `shuffle = True` and `order = F`, there are memory spikes to \
+        shuffle the `F` order arrays
 
-    - NOTE: If out-of-memory errors are encountered in any of the above \
-          configurations, try increasing the `n_parts` parameter.
+    .. note:: If out-of-memory errors are encountered in any of the above 
+        configurations, try increasing the `n_parts` parameter.
     """
 
     client = get_client(client=client)

--- a/python/cuml/dask/datasets/regression.py
+++ b/python/cuml/dask/datasets/regression.py
@@ -279,7 +279,7 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
                     use_full_low_rank=True):
     """
     Generate a random regression problem.
-    
+
     The input set can either be well conditioned (by default) or have a low
     rank-fat tail singular profile.
 
@@ -362,7 +362,7 @@ def make_regression(n_samples=100, n_features=100, n_informative=10,
      3. When `shuffle = True` and `order = F`, there are memory spikes to \
         shuffle the `F` order arrays
 
-    .. note:: If out-of-memory errors are encountered in any of the above 
+    .. note:: If out-of-memory errors are encountered in any of the above
         configurations, try increasing the `n_parts` parameter.
     """
 

--- a/python/cuml/dask/decomposition/pca.py
+++ b/python/cuml/dask/decomposition/pca.py
@@ -37,7 +37,7 @@ class PCA(BaseDecomposition,
     then selects the top K eigenvectors.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 
@@ -92,8 +92,8 @@ class PCA(BaseDecomposition,
                     1  0.011454
                     2 -0.008182
 
-    Note: Everytime this code is run, the output will be different because
-          "make_blobs" function generates random matrices.
+    .. note:: Everytime this code is run, the output will be different because
+        "make_blobs" function generates random matrices.
 
     Parameters
     ----------

--- a/python/cuml/dask/decomposition/tsvd.py
+++ b/python/cuml/dask/decomposition/tsvd.py
@@ -27,7 +27,7 @@ class TruncatedSVD(BaseDecomposition,
                    DecompositionSyncFitMixin):
     """
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 
@@ -64,25 +64,26 @@ class TruncatedSVD(BaseDecomposition,
 
     .. code-block:: python
 
-          Input Matrix:
-                              0         1          2
-                    0 -8.519647 -8.519222  -8.865648
-                    1 -6.107700 -8.350124 -10.351215
-                    2 -8.026635 -9.442240  -7.561770
-                    0 -8.519647 -8.519222  -8.865648
-                    1 -6.107700 -8.350124 -10.351215
-                    2 -8.026635 -9.442240  -7.561770
+        Input Matrix:
+                            0         1          2
+                  0 -8.519647 -8.519222  -8.865648
+                  1 -6.107700 -8.350124 -10.351215
+                  2 -8.026635 -9.442240  -7.561770
+                  0 -8.519647 -8.519222  -8.865648
+                  1 -6.107700 -8.350124 -10.351215
+                  2 -8.026635 -9.442240  -7.561770
 
-          Transformed Input Matrix:
-                               0
-                    0  14.928891
-                    1  14.487295
-                    2  14.431235
-                    0  14.928891
-                    1  14.487295
-                    2  14.431235
-    Note: Everytime this code is run, the output will be different because
-          "make_blobs" function generates random matrices.
+        Transformed Input Matrix:
+                             0
+                  0  14.928891
+                  1  14.487295
+                  2  14.431235
+                  0  14.928891
+                  1  14.487295
+                  2  14.431235
+
+    .. note:: Everytime this code is run, the output will be different because
+        "make_blobs" function generates random matrices.
 
     Parameters
     ----------
@@ -107,6 +108,7 @@ class TruncatedSVD(BaseDecomposition,
         How much in % the variance is explained given by S**2/sum(S**2)
     singular_values_ : array
         The top K singular values. Remember all singular values >= 0
+
     """
 
     def __init__(self, client=None, **kwargs):
@@ -151,9 +153,9 @@ class TruncatedSVD(BaseDecomposition,
 
     def transform(self, X, delayed=True):
         """
-        Apply dimensionality reduction to X.
+        Apply dimensionality reduction to `X`.
 
-        X is projected on the first principal components previously extracted
+        `X` is projected on the first principal components previously extracted
         from a training set.
 
         Parameters

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -36,12 +36,12 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
     (possibly on different nodes).
 
     Currently, this API makes the following assumptions:
-    * The set of Dask workers used between instantiation, fit,
-    and predict are all consistent
-    * Training data comes in the form of cuDF dataframes or Dask Arrays
-    distributed so that each worker has at least one partition.
-    * The print_summary and print_detailed functions print the
-    information of the forest on the worker.
+     * The set of Dask workers used between instantiation, fit, \
+        and predict are all consistent
+     * Training data comes in the form of cuDF dataframes or Dask Arrays \
+        distributed so that each worker has at least one partition.
+     * The print_summary and print_detailed functions print the \
+        information of the forest on the worker.
 
     Future versions of the API will support more flexible data
     distribution and additional input types.
@@ -70,8 +70,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         0 for GINI, 1 for ENTROPY, 4 for CRITERION_END.
         2 and 3 not valid for classification
         (default = 0)
-    split_algo : 0 for HIST and 1 for GLOBAL_QUANTILE
-        (default = 1)
+    split_algo : 0 for HIST and 1 for GLOBAL_QUANTILE (default = 1)
         the algorithm to determine how nodes are split in the tree.
     split_criterion : The criterion used to split nodes.
         0 for GINI, 1 for ENTROPY, 4 for CRITERION_END.
@@ -111,7 +110,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         not currently fully guarantee the exact same results.
 
     Examples
-    ---------
+    --------
     For usage examples, please see the RAPIDS notebooks repository:
     https://github.com/rapidsai/notebooks/blob/branch-0.12/cuml/random_forest_mnmg_demo.ipynb
     """
@@ -182,7 +181,9 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         memory consumption, ensure that each worker has exactly one partition.
 
         When persisting data, you can use
-        cuml.dask.common.utils.persist_across_workers to simplify this::
+        `cuml.dask.common.utils.persist_across_workers` to simplify this:
+
+        .. code-block:: python
 
             X_dask_cudf = dask_cudf.from_cudf(X_cudf, npartitions=n_workers)
             y_dask_cudf = dask_cudf.from_cudf(y_cudf, npartitions=n_workers)
@@ -190,7 +191,10 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
                                                               [X_dask_cudf,
                                                                y_dask_cudf])
 
-        (this is equivalent to calling `persist` with the data and workers)::
+        This is equivalent to calling `persist` with the data and workers:
+
+        .. code-block:: python
+
             X_dask_cudf, y_dask_cudf = dask_client.persist([X_dask_cudf,
                                                             y_dask_cudf],
                                                            workers={
@@ -265,7 +269,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
             coalescing-friendly
             'batch_tree_reorg' - similar to tree_reorg but predicting
             multiple rows per thread block
-            `algo` - choose the algorithm automatically. Currently
+            'algo' - choose the algorithm automatically. Currently
             'batch_tree_reorg' is used for dense storage
             and 'naive' for sparse storage
         threshold : float (default = 0.5)
@@ -391,7 +395,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         """
         Predicts the probability of each class for X.
 
-        See documentation of `predict' for notes on performance.
+        See documentation of `predict` for notes on performance.
 
         Parameters
         ----------
@@ -417,7 +421,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
             coalescing-friendly
             'batch_tree_reorg' - similar to tree_reorg but predicting
             multiple rows per thread block
-            `auto` - choose the algorithm automatically. Currently
+            'auto' - choose the algorithm automatically. Currently
             'batch_tree_reorg' is used for dense storage
             and 'naive' for sparse storage
         threshold : float (default = 0.5)
@@ -439,9 +443,10 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
             or algo='auto'
 
         Returns
-        ----------
+        -------
         y : NumPy
            Dask cuDF dataframe or CuPy backed Dask Array (n_rows, n_classes)
+
         """
         if self._get_internal_model() is None:
             self._set_internal_model(self._concat_treelite_models())

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -30,12 +30,12 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
     (possibly on different nodes).
 
     Currently, this API makes the following assumptions:
-    * The set of Dask workers used between instantiation, fit,
-    and predict are all consistent
-    * Training data comes in the form of cuDF dataframes or Dask Arrays
-    distributed so that each worker has at least one partition.
-    * The print_summary and print_detailed functions print the
-    information of the forest on the worker.
+     * The set of Dask workers used between instantiation, fit,
+       and predict are all consistent
+     * Training data comes in the form of cuDF dataframes or Dask Arrays
+       distributed so that each worker has at least one partition.
+     * The print_summary and print_detailed functions print the
+       information of the forest on the worker.
 
     Future versions of the API will support more flexible data
     distribution and additional input types. User-facing APIs are
@@ -174,7 +174,9 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
         on each Dask worker being used by the forest (self.workers).
 
         When persisting data, you can use
-        cuml.dask.common.utils.persist_across_workers to simplify this::
+        `cuml.dask.common.utils.persist_across_workers` to simplify this:
+
+        .. code-block:: python
 
             X_dask_cudf = dask_cudf.from_cudf(X_cudf, npartitions=n_workers)
             y_dask_cudf = dask_cudf.from_cudf(y_cudf, npartitions=n_workers)
@@ -182,7 +184,10 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
                                                               [X_dask_cudf,
                                                                y_dask_cudf])
 
-        (this is equivalent to calling `persist` with the data and workers)::
+        This is equivalent to calling `persist` with the data and workers):
+
+        .. code-block:: python
+
             X_dask_cudf, y_dask_cudf = dask_client.persist([X_dask_cudf,
                                                             y_dask_cudf],
                                                            workers={
@@ -202,6 +207,7 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
             When set to True, the fit method will, when necessary, convert
             y to be the same data type as X if they differ. This will increase
             memory used for the method.
+
         """
         self.internal_model = None
         self._fit(model=self.rfs,
@@ -274,8 +280,9 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
             eagerly executed one.
 
         Returns
-        ----------
-        y : Dask cuDF dataframe  or CuPy backed Dask Array (n_rows, 1)
+        -------
+        y : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, 1)
+
         """
         if predict_model == "CPU":
             preds = self.predict_model_on_cpu(X, convert_dtype=convert_dtype)

--- a/python/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/dask/linear_model/elastic_net.py
@@ -82,7 +82,7 @@ class ElasticNet(BaseEstimator):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If `fit_intercept_` is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
 
     For additional docs, see `scikitlearn's ElasticNet

--- a/python/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/dask/linear_model/elastic_net.py
@@ -82,7 +82,7 @@ class ElasticNet(BaseEstimator):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept_` is False, will be 0.
 
 
     For additional docs, see `scikitlearn's ElasticNet

--- a/python/cuml/dask/linear_model/lasso.py
+++ b/python/cuml/dask/linear_model/lasso.py
@@ -67,7 +67,7 @@ class Lasso(BaseEstimator):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept_` is False, will be 0.
 
     For additional docs, see `scikitlearn's Lasso
     <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html>`_.

--- a/python/cuml/dask/linear_model/lasso.py
+++ b/python/cuml/dask/linear_model/lasso.py
@@ -67,7 +67,7 @@ class Lasso(BaseEstimator):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If `fit_intercept_` is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     For additional docs, see `scikitlearn's Lasso
     <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html>`_.

--- a/python/cuml/dask/linear_model/linear_regression.py
+++ b/python/cuml/dask/linear_model/linear_regression.py
@@ -59,7 +59,7 @@ class LinearRegression(BaseEstimator,
     coef_ : cuDF series, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept_` is False, will be 0.
     """
 
     def __init__(self, client=None, verbose=False, **kwargs):

--- a/python/cuml/dask/linear_model/linear_regression.py
+++ b/python/cuml/dask/linear_model/linear_regression.py
@@ -59,7 +59,7 @@ class LinearRegression(BaseEstimator,
     coef_ : cuDF series, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If `fit_intercept_` is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
     """
 
     def __init__(self, client=None, verbose=False, **kwargs):

--- a/python/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/dask/linear_model/ridge.py
@@ -65,7 +65,7 @@ class Ridge(BaseEstimator,
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If `fit_intercept_` is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     """
 

--- a/python/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/dask/linear_model/ridge.py
@@ -65,7 +65,8 @@ class Ridge(BaseEstimator,
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept_` is False, will be 0.
+
     """
 
     def __init__(self, client=None, verbose=False, **kwargs):

--- a/python/cuml/dask/manifold/umap.py
+++ b/python/cuml/dask/manifold/umap.py
@@ -19,7 +19,7 @@ from cuml.dask.common.input_utils import DistributedDataHandler
 
 class UMAP(BaseEstimator,
            DelayedTransformMixin):
-    r"""
+    """
     Uniform Manifold Approximation and Projection
 
     Finds a low dimensional embedding of the data that approximates
@@ -98,7 +98,7 @@ class UMAP(BaseEstimator,
         self._set_internal_model(model)
 
     def transform(self, X, convert_dtype=True):
-        r"""
+        """
         Transform X into the existing embedded space and return that
         transformed output.
 

--- a/python/cuml/dask/manifold/umap.py
+++ b/python/cuml/dask/manifold/umap.py
@@ -67,13 +67,15 @@ class UMAP(BaseEstimator,
     -----
     This module is heavily based on Leland McInnes' reference UMAP package
     [1]_.
+
     However, there are a number of differences and features that are
-        not yet implemented in `cuml.umap`:
-     * Using a non-Euclidean distance metric (support for a fixed set
-       of non-Euclidean metrics is planned for an upcoming release).
-     * Using a pre-computed pairwise distance matrix (under consideration
-       for future releases)
-     * Manual initialization of initial embedding positions
+    not yet implemented in `cuml.umap`:
+
+    * Using a non-Euclidean distance metric (support for a fixed set
+      of non-Euclidean metrics is planned for an upcoming release).
+    * Using a pre-computed pairwise distance matrix (under consideration
+      for future releases)
+    * Manual initialization of initial embedding positions
 
     In addition to these missing features, you should expect to see
     the final embeddings differing between `cuml.umap` and the reference
@@ -85,11 +87,9 @@ class UMAP(BaseEstimator,
 
     References
     ----------
-
     .. [1] `Leland McInnes, John Healy, James Melville
-           UMAP: Uniform Manifold Approximation and Projection for Dimension
-           Reduction.
-           <https://arxiv.org/abs/1802.03426>`_
+       UMAP: Uniform Manifold Approximation and Projection for Dimension
+       Reduction. <https://arxiv.org/abs/1802.03426>`_
 
     """
     def __init__(self, model, client=None, **kwargs):

--- a/python/cuml/dask/manifold/umap.py
+++ b/python/cuml/dask/manifold/umap.py
@@ -19,15 +19,16 @@ from cuml.dask.common.input_utils import DistributedDataHandler
 
 class UMAP(BaseEstimator,
            DelayedTransformMixin):
-    """
+    r"""
     Uniform Manifold Approximation and Projection
+
     Finds a low dimensional embedding of the data that approximates
     an underlying manifold.
 
     Adapted from https://github.com/lmcinnes/umap/blob/master/umap/umap_.py
 
     Examples
-    ----------
+    --------
 
     .. code-block:: python
 
@@ -59,34 +60,35 @@ class UMAP(BaseEstimator,
         distributed_model = MNMG_UMAP(local_model)
         embedding = distributed_model.transform(X)
 
-    Note: Everytime this code is run, the output will be different because
+    .. note:: Everytime this code is run, the output will be different because
         "make_blobs" function generates random matrices.
 
     Notes
     -----
-    This module is heavily based on Leland McInnes' reference UMAP package.
+    This module is heavily based on Leland McInnes' reference UMAP package [1]_.
     However, there are a number of differences and features that are
-    not yet implemented in cuml.umap:
-    * Using a non-Euclidean distance metric (support for a fixed set
-        of non-Euclidean metrics is planned for an upcoming release).
-    * Using a pre-computed pairwise distance matrix (under consideration
-        for future releases)
-    * Manual initialization of initial embedding positions
+    not yet implemented in `cuml.umap`:
+     * Using a non-Euclidean distance metric (support for a fixed set
+       of non-Euclidean metrics is planned for an upcoming release).
+     * Using a pre-computed pairwise distance matrix (under consideration
+       for future releases)
+     * Manual initialization of initial embedding positions
 
     In addition to these missing features, you should expect to see
-    the final embeddings differing between cuml.umap and the reference
+    the final embeddings differing between `cuml.umap` and the reference
     UMAP. In particular, the reference UMAP uses an approximate kNN
     algorithm for large data sizes while cuml.umap always uses exact
     kNN.
 
-    Known issue: If a UMAP model has not yet been fit, it cannot be pickled
+    **Known issue:** If a UMAP model has not yet been fit, it cannot be pickled
 
     References
     ----------
-    * Leland McInnes, John Healy, James Melville
-    UMAP: Uniform Manifold Approximation and Projection for Dimension
-    Reduction
-    https://arxiv.org/abs/1802.03426
+
+    .. [1] `Leland McInnes, John Healy, James Melville
+           UMAP: Uniform Manifold Approximation and Projection for Dimension
+           Reduction.
+           <https://arxiv.org/abs/1802.03426>`_
 
     """
     def __init__(self, model, client=None, **kwargs):
@@ -95,7 +97,7 @@ class UMAP(BaseEstimator,
         self._set_internal_model(model)
 
     def transform(self, X, convert_dtype=True):
-        """
+        r"""
         Transform X into the existing embedded space and return that
         transformed output.
 

--- a/python/cuml/dask/manifold/umap.py
+++ b/python/cuml/dask/manifold/umap.py
@@ -65,9 +65,10 @@ class UMAP(BaseEstimator,
 
     Notes
     -----
-    This module is heavily based on Leland McInnes' reference UMAP package [1]_.
+    This module is heavily based on Leland McInnes' reference UMAP package
+    [1]_.
     However, there are a number of differences and features that are
-    not yet implemented in `cuml.umap`:
+        not yet implemented in `cuml.umap`:
      * Using a non-Euclidean distance metric (support for a fixed set
        of non-Euclidean metrics is planned for an upcoming release).
      * Using a pre-computed pairwise distance matrix (under consideration

--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -70,7 +70,7 @@ def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
                seasonal_order=(0, 0, 0, 0), intercept=False,
                random_state=None, dtype='double', output_type='cupy',
                handle=None):
-    r"""Generates a dataset of time series by simulating an ARIMA process
+    """Generates a dataset of time series by simulating an ARIMA process
     of a given order.
 
     Examples

--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -73,8 +73,8 @@ def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
     r"""Generates a dataset of time series by simulating an ARIMA process
     of a given order.
 
-    Example
-    -------
+    Examples
+    --------
     .. code-block:: python
 
         from cuml.datasets import make_arima
@@ -102,7 +102,7 @@ def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
     handle: cuml.Handle
         If it is None, a new one is created just for this function call
 
-    Returns:
+    Returns
     --------
     out: array-like, shape (n_obs, batch_size)
         Array of the requested type containing the generated dataset

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -80,8 +80,8 @@ def make_regression(n_samples=100, n_features=2, n_informative=2, n_targets=1,
 
     See https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_regression.html
 
-    Example
-    -------
+    Examples
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -122,7 +122,7 @@ class PCA(Base):
     less accurate.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -115,7 +115,7 @@ class TruncatedSVD(Base):
     might be less accurate.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 
@@ -221,14 +221,15 @@ class TruncatedSVD(Base):
 
     **Applications of TruncatedSVD**
 
-        TruncatedSVD is also known as Latent Semantic Indexing (LSI) which
-        tries to find topics of a word count matrix. If X previously was
-        centered with mean removal, TruncatedSVD is the same as TruncatedPCA.
-        TruncatedSVD is also used in information retrieval tasks,
-        recommendation systems and data compression.
+    TruncatedSVD is also known as Latent Semantic Indexing (LSI) which
+    tries to find topics of a word count matrix. If X previously was
+    centered with mean removal, TruncatedSVD is the same as TruncatedPCA.
+    TruncatedSVD is also used in information retrieval tasks,
+    recommendation systems and data compression.
 
     For additional documentation, see `scikitlearn's TruncatedSVD docs
     <http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html>`_.
+
     """
 
     def __init__(self, algorithm='full', handle=None, n_components=1,
@@ -449,12 +450,14 @@ class TruncatedSVD(Base):
     def transform(self, X, convert_dtype=False):
         """
         Perform dimensionality reduction on X.
+
         Parameters
         ----------
         X : array-like (device or host) shape = (n_samples, n_features)
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
             ndarray, cuda array interface compliant array like CuPy
+
         convert_dtype : bool, optional (default = False)
             When set to True, the transform method will automatically
             convert the input to the data type which was used to train the
@@ -464,6 +467,7 @@ class TruncatedSVD(Base):
         -------
         X_new : cuDF DataFrame, shape (n_samples, n_components)
             Reduced version of X. This will always be a dense DataFrame.
+
         """
         input, n_rows, _, dtype = \
             input_to_cuml_array(X, check_dtype=self.dtype,

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -144,7 +144,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
          reduce memory consumption.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
             import numpy as np
@@ -332,6 +332,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
 
         Parameters
         ----------
+
         output_class : boolean (default = True)
             This is optional and required only while performing the
             predict operation on the GPU.
@@ -364,10 +365,12 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             or algo='auto'
 
         Returns
-        ----------
-        fil_model :
+        -------
+
+        fil_model
             A Forest Inference model which can be used to perform
             inferencing on the random forest model.
+
         """
         treelite_handle = self._obtain_treelite_handle()
         return _obtain_fil_model(treelite_handle=treelite_handle,

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -133,15 +133,15 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     histogram-based algorithms to determine splits, rather than an exact
     count. You can tune the size of the histograms with the n_bins parameter.
 
-    **Known Limitations**: This is an early release of the cuML
-    Random Forest code. It contains a few known limitations:
+    .. note:: This is an early release of the cuML
+        Random Forest code. It contains a few known limitations:
 
-       * GPU-based inference is only supported if the model was trained
-         with 32-bit (float32) datatypes. CPU-based inference may be used
-         in this case as a slower fallback.
-       * Very deep / very wide models may exhaust available GPU memory.
-         Future versions of cuML will provide an alternative algorithm to
-         reduce memory consumption.
+        * GPU-based inference is only supported if the model was trained
+          with 32-bit (float32) datatypes. CPU-based inference may be used
+          in this case as a slower fallback.
+        * Very deep / very wide models may exhaust available GPU memory.
+          Future versions of cuML will provide an alternative algorithm to
+          reduce memory consumption.
 
     Examples
     --------
@@ -221,6 +221,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         Only relevant for GLOBAL_QUANTILE split_algo.
     seed : int (default = None)
         Seed for the random number generator. Unseeded by default.
+
     """
 
     def __init__(self, split_criterion=0,

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -110,11 +110,12 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     """
     Implements a Random Forest regressor model which fits multiple decision
     trees in an ensemble.
-    
-    .. note:: that the underlying algorithm for tree node splits differs from that
-        used in scikit-learn. By default, the cuML Random Forest uses a
+
+    .. note:: that the underlying algorithm for tree node splits differs from
+        that used in scikit-learn. By default, the cuML Random Forest uses a
         histogram-based algorithm to determine splits, rather than an exact
-        count. You can tune the size of the histograms with the n_bins parameter.
+        count. You can tune the size of the histograms with the n_bins
+        parameter.
 
     **Known Limitations**: This is an early release of the cuML
     Random Forest code. It contains a few known limitations:

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -110,43 +110,45 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     """
     Implements a Random Forest regressor model which fits multiple decision
     trees in an ensemble.
-    Note that the underlying algorithm for tree node splits differs from that
-    used in scikit-learn. By default, the cuML Random Forest uses a
-    histogram-based algorithm to determine splits, rather than an exact
-    count. You can tune the size of the histograms with the n_bins parameter.
+    
+    .. note:: that the underlying algorithm for tree node splits differs from that
+        used in scikit-learn. By default, the cuML Random Forest uses a
+        histogram-based algorithm to determine splits, rather than an exact
+        count. You can tune the size of the histograms with the n_bins parameter.
 
     **Known Limitations**: This is an early release of the cuML
     Random Forest code. It contains a few known limitations:
 
-       * GPU-based inference is only supported if the model was trained
-         with 32-bit (float32) datatypes. CPU-based inference may be used
-         in this case as a slower fallback.
-       * Very deep / very wide models may exhaust available GPU memory.
-         Future versions of cuML will provide an alternative algorithm to
-         reduce memory consumption.
+     * GPU-based inference is only supported if the model was trained
+       with 32-bit (float32) datatypes. CPU-based inference may be used
+       in this case as a slower fallback.
+     * Very deep / very wide models may exhaust available GPU memory.
+       Future versions of cuML will provide an alternative algorithm to
+       reduce memory consumption.
 
     Examples
-    ---------
+    --------
+
     .. code-block:: python
 
-            import numpy as np
-            from cuml.test.utils import get_handle
-            from cuml.ensemble import RandomForestRegressor as curfc
-            from cuml.test.utils import get_handle
-            X = np.asarray([[0,10],[0,20],[0,30],[0,40]], dtype=np.float32)
-            y = np.asarray([0.0,1.0,2.0,3.0], dtype=np.float32)
-            cuml_model = curfc(max_features=1.0, n_bins=8,
-                               split_algo=0, min_rows_per_node=2,
-                               n_estimators=40, accuracy_metric='mse')
-            cuml_model.fit(X,y)
-            cuml_score = cuml_model.score(X,y)
-            print("MSE score of cuml : ", cuml_score)
+        import numpy as np
+        from cuml.test.utils import get_handle
+        from cuml.ensemble import RandomForestRegressor as curfc
+        from cuml.test.utils import get_handle
+        X = np.asarray([[0,10],[0,20],[0,30],[0,40]], dtype=np.float32)
+        y = np.asarray([0.0,1.0,2.0,3.0], dtype=np.float32)
+        cuml_model = curfc(max_features=1.0, n_bins=8,
+                            split_algo=0, min_rows_per_node=2,
+                            n_estimators=40, accuracy_metric='mse')
+        cuml_model.fit(X,y)
+        cuml_score = cuml_model.score(X,y)
+        print("MSE score of cuml : ", cuml_score)
 
     Output:
 
     .. code-block:: python
 
-            MSE score of cuml :  0.1123437201231765
+        MSE score of cuml :  0.1123437201231765
 
     Parameters
     -----------
@@ -165,7 +167,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         2 for MSE, or 3 for MAE
         0 and 1 not valid for regression
     bootstrap : boolean (default = True)
-       Control bootstrapping.
+        Control bootstrapping.
         If True, each tree in the forest is built
         on a bootstrapped sample with replacement.
         If False, sampling without replacement is done.
@@ -182,7 +184,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited,
         if -1.
-     max_features : int, float, or string (default = 'auto')
+    max_features : int, float, or string (default = 'auto')
         Ratio of number of features (columns) to consider
         per node split.
         If int then max_features/n_features.
@@ -315,6 +317,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         """
         Create a Forest Inference (FIL) model from the trained cuML
         Random Forest model.
+
         Parameters
         ----------
         output_class : boolean (default = False)
@@ -323,6 +326,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             If true, return a 1 or 0 depending on whether the raw
             prediction exceeds the threshold. If False, just return
             the raw prediction.
+
         algo : string (default = 'auto')
             This is optional and required only while performing the
             predict operation on the GPU.
@@ -334,6 +338,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             `auto` - choose the algorithm automatically. Currently
             'batch_tree_reorg' is used for dense storage
             and 'naive' for sparse storage
+
         fil_sparse_format : boolean or string (default = 'auto')
             This variable is used to choose the type of forest that will be
             created in the Forest Inference Library. It is not required
@@ -343,11 +348,14 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             False - create a dense forest
             True - create a sparse forest, requires algo='naive'
             or algo='auto'
+
         Returns
-        ----------
-        fil_model :
+        -------
+
+        fil_model
             A Forest Inference model which can be used to perform
             inferencing on the random forest model.
+
         """
         treelite_handle = self._obtain_treelite_handle()
         return _obtain_fil_model(treelite_handle=treelite_handle,

--- a/python/cuml/feature_extraction/_tfidf_vectorizer.py
+++ b/python/cuml/feature_extraction/_tfidf_vectorizer.py
@@ -94,10 +94,11 @@ class TfidfVectorizer(CountVectorizer):
         Typically the delimiting character between words is a good choice.
     norm : {'l1', 'l2'}, default='l2'
         Each output row will have unit norm, either:
-        * 'l2': Sum of squares of vector elements is 1. The cosine
-        similarity between two vectors is their dot product when l2 norm has
-        been applied.
-        * 'l1': Sum of absolute values of vector elements is 1.
+         * 'l2': Sum of squares of vector elements is 1. The cosine \
+            similarity between two vectors is their dot product when l2 norm has \
+            been applied.
+         * 'l1': Sum of absolute values of vector elements is 1.
+
     use_idf : bool, default=True
         Enable inverse-document-frequency reweighting.
     smooth_idf : bool, default=True
@@ -119,6 +120,7 @@ class TfidfVectorizer(CountVectorizer):
           - occurred in too many documents (`max_df`)
           - occurred in too few documents (`min_df`)
           - were cut off by feature selection (`max_features`).
+
         This is only available if no vocabulary was given.
 
     Notes

--- a/python/cuml/feature_extraction/_tfidf_vectorizer.py
+++ b/python/cuml/feature_extraction/_tfidf_vectorizer.py
@@ -94,9 +94,9 @@ class TfidfVectorizer(CountVectorizer):
         Typically the delimiting character between words is a good choice.
     norm : {'l1', 'l2'}, default='l2'
         Each output row will have unit norm, either:
-         * 'l2': Sum of squares of vector elements is 1. The cosine \
-            similarity between two vectors is their dot product when l2 norm has \
-            been applied.
+         * 'l2': Sum of squares of vector elements is 1. The cosine similarity
+           between two vectors is their dot product when l2 norm has been
+           applied.
          * 'l1': Sum of absolute values of vector elements is 1.
 
     use_idf : bool, default=True

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -506,7 +506,7 @@ class CountVectorizer(_VectorizerMixin):
 
         raw_documents : cudf.Series
             A Series of string documents
- 
+
         Returns
         -------
         self
@@ -519,7 +519,8 @@ class CountVectorizer(_VectorizerMixin):
         """
         Build the vocabulary and return document-term matrix.
 
-        Equivalent to ``self.fit(X).transform(X)`` but preprocess `X` only once.
+        Equivalent to ``self.fit(X).transform(X)`` but preprocess `X` only
+        once.
 
         Parameters
         ----------
@@ -653,22 +654,22 @@ class HashingVectorizer(_VectorizerMixin):
 
     This strategy has several advantages:
 
-     - it is very low memory scalable to large datasets as there is no need to\
-       store a vocabulary dictionary in memory which is even more important \
+     - it is very low memory scalable to large datasets as there is no need to
+       store a vocabulary dictionary in memory which is even more important
        as GPU's that are often memory constrained
-     - it is fast to pickle and un-pickle as it holds no state besides the \
+     - it is fast to pickle and un-pickle as it holds no state besides the
        constructor parameters
-     - it can be used in a streaming (partial fit) or parallel pipeline as there \
-       is no state computed during fit.
+     - it can be used in a streaming (partial fit) or parallel pipeline as
+       there is no state computed during fit.
 
     There are also a couple of cons (vs using a CountVectorizer with an
     in-memory vocabulary):
 
-     - there is no way to compute the inverse transform (from feature indices to \
-       string feature names) which can be a problem when trying to introspect \
-       which features are most important to a model.
-     - there can be collisions: distinct tokens can be mapped to the same \
-       feature index. However in practice this is rarely an issue if n_features \
+     - there is no way to compute the inverse transform (from feature indices
+       to string feature names) which can be a problem when trying to
+       introspect which features are most important to a model.
+     - there can be collisions: distinct tokens can be mapped to the same
+       feature index. However in practice this is rarely an issue if n_features
        is large enough (e.g. 2 ** 18 for text classification problems).
      - no IDF weighting as this would render the transformer stateful.
 
@@ -716,8 +717,9 @@ class HashingVectorizer(_VectorizerMixin):
     dtype : type, optional
         Type of the matrix returned by fit_transform() or transform().
     delimiter : str, whitespace by default
-        String used as a replacement for stop words if `stop_words` is not None.
-        Typically the delimiting character between words is a good choice.
+        String used as a replacement for stop words if `stop_words` is not
+        None. Typically the delimiting character between words is a good
+        choice.
 
     Examples
     --------

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -687,7 +687,7 @@ class HashingVectorizer(_VectorizerMixin):
     stop_words : string {'english'}, list, default=None
         If 'english', a built-in stop word list for English is used.
         There are several known issues with 'english' and you should
-        consider an alternative (see :ref:`stop_words`).
+        consider an alternative.
         If a list, that list is assumed to contain stop words, all of which
         will be removed from the resulting tokens.
         Only applies if ``analyzer == 'word'``.

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -373,7 +373,9 @@ class CountVectorizer(_VectorizerMixin):
           - occurred in too many documents (`max_df`)
           - occurred in too few documents (`min_df`)
           - were cut off by feature selection (`max_features`).
+
         This is only available if no vocabulary was given.
+
     """
 
     def __init__(self, input=None, encoding=None, decode_error=None,
@@ -456,7 +458,7 @@ class CountVectorizer(_VectorizerMixin):
         documents than low, modifying the vocabulary, and restricting it to
         at most the limit most frequent.
 
-        Sets self.vocabulary_ and self.stop_words_ with the new values.
+        Sets `self.vocabulary_` and `self.stop_words_` with the new values.
         """
         if high is None and low is None and limit is None:
             self.stop_words_ = None
@@ -499,15 +501,17 @@ class CountVectorizer(_VectorizerMixin):
         """
         Build a vocabulary of all tokens in the raw documents.
 
-       Parameters
-       ----------
-       raw_documents : cudf.Series
-           A Series of string documents
+        Parameters
+        ----------
 
-       Returns
-       -------
-       self
-       """
+        raw_documents : cudf.Series
+            A Series of string documents
+ 
+        Returns
+        -------
+        self
+
+        """
         self.fit_transform(raw_documents)
         return self
 
@@ -515,7 +519,7 @@ class CountVectorizer(_VectorizerMixin):
         """
         Build the vocabulary and return document-term matrix.
 
-        Equivalent to .fit(X).transform(X) but preprocess X only once.
+        Equivalent to ``self.fit(X).transform(X)`` but preprocess `X` only once.
 
         Parameters
         ----------
@@ -624,10 +628,13 @@ class CountVectorizer(_VectorizerMixin):
     def get_feature_names(self):
         """
         Array mapping from feature integer indices to feature name.
+
         Returns
         -------
+
         feature_names : Series
             A list of feature names.
+
         """
         return self.vocabulary_
 
@@ -646,24 +653,24 @@ class HashingVectorizer(_VectorizerMixin):
 
     This strategy has several advantages:
 
-    - it is very low memory scalable to large datasets as there is no need to
-      store a vocabulary dictionary in memory which is even more important
-      as GPU's that are often memory constrained
-    - it is fast to pickle and un-pickle as it holds no state besides the
-      constructor parameters
-    - it can be used in a streaming (partial fit) or parallel pipeline as there
-      is no state computed during fit.
+     - it is very low memory scalable to large datasets as there is no need to\
+       store a vocabulary dictionary in memory which is even more important \
+       as GPU's that are often memory constrained
+     - it is fast to pickle and un-pickle as it holds no state besides the \
+       constructor parameters
+     - it can be used in a streaming (partial fit) or parallel pipeline as there \
+       is no state computed during fit.
 
     There are also a couple of cons (vs using a CountVectorizer with an
     in-memory vocabulary):
 
-    - there is no way to compute the inverse transform (from feature indices to
-      string feature names) which can be a problem when trying to introspect
-      which features are most important to a model.
-    - there can be collisions: distinct tokens can be mapped to the same
-      feature index. However in practice this is rarely an issue if n_features
-      is large enough (e.g. 2 ** 18 for text classification problems).
-    - no IDF weighting as this would render the transformer stateful.
+     - there is no way to compute the inverse transform (from feature indices to \
+       string feature names) which can be a problem when trying to introspect \
+       which features are most important to a model.
+     - there can be collisions: distinct tokens can be mapped to the same \
+       feature index. However in practice this is rarely an issue if n_features \
+       is large enough (e.g. 2 ** 18 for text classification problems).
+     - no IDF weighting as this would render the transformer stateful.
 
     The hash function employed is the signed 32-bit version of Murmurhash3.
 
@@ -709,7 +716,7 @@ class HashingVectorizer(_VectorizerMixin):
     dtype : type, optional
         Type of the matrix returned by fit_transform() or transform().
     delimiter : str, whitespace by default
-        String used as a replacement for stop words if stop_words is not None.
+        String used as a replacement for stop words if `stop_words` is not None.
         Typically the delimiting character between words is a good choice.
 
     Examples

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -256,7 +256,7 @@ cdef class ForestInference_impl():
         -------
 
         Predicted results of type as defined by the output_type variable
-        
+
         """
         if (not self.output_class) and predict_proba:
             raise NotImplementedError("Predict_proba function is not available"
@@ -522,24 +522,24 @@ class ForestInference(Base):
             For a Regression model output_class must be False.
         algo : string (default='auto')
             name of the algo from (from algo_t enum) :
-             - 'AUTO' or 'auto' - choose the algorithm automatically; \
-                currently 'BATCH_TREE_REORG' is used for dense storage, \
-                and 'NAIVE' for sparse storage
+             - 'AUTO' or 'auto' - choose the algorithm automatically;
+               currently 'BATCH_TREE_REORG' is used for dense storage,
+               and 'NAIVE' for sparse storage
              - 'NAIVE' or 'naive' - simple inference using shared memory
-             - 'TREE_REORG' or 'tree_reorg' - similar to naive but trees \
-                rearranged to be more coalescing-friendly
-             - 'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG \
-                but predicting multiple rows per thread block
+             - 'TREE_REORG' or 'tree_reorg' - similar to naive but trees
+               rearranged to be more coalescing-friendly
+             - 'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG
+               but predicting multiple rows per thread block
         threshold : float (default=0.5)
             Threshold is used to for classification. It is applied
             only if output_class == True, else it is ignored.
         storage_type : string or boolean (default='auto')
             In-memory storage format to be used for the FIL model:
-             - 'auto' - choose the storage type automatically \
-                (currently DENSE is always used)
+             - 'auto' - choose the storage type automatically
+               (currently DENSE is always used)
              - False - create a dense forest
-             - True - create a sparse forest; \
-                requires algo='NAIVE' or algo='AUTO'
+             - True - create a sparse forest;
+               requires algo='NAIVE' or algo='AUTO'
 
         Returns
         ----------
@@ -577,24 +577,24 @@ class ForestInference(Base):
             For a Regression model output_class must be False.
         algo : string (default='auto')
             name of the algo from (from algo_t enum):
-             - 'AUTO' or 'auto' - choose the algorithm automatically; \
-                currently 'BATCH_TREE_REORG' is used for dense storage, \
-                and 'NAIVE' for sparse storage
+             - 'AUTO' or 'auto' - choose the algorithm automatically;
+               currently 'BATCH_TREE_REORG' is used for dense storage,
+               and 'NAIVE' for sparse storage
              - 'NAIVE' or 'naive' - simple inference using shared memory
-             - 'TREE_REORG' or 'tree_reorg' - similar to naive but trees \
-                rearranged to be more coalescing-friendly
-             - 'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG \
-                but predicting multiple rows per thread block
+             - 'TREE_REORG' or 'tree_reorg' - similar to naive but trees
+               rearranged to be more coalescing-friendly
+             - 'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG
+               but predicting multiple rows per thread block
         threshold : float (default=0.5)
             Threshold is used to for classification. It is applied
             only if ``output_class == True``, else it is ignored.
         storage_type : string or boolean (default='auto')
             In-memory storage format to be used for the FIL model:
-             - 'auto' - choose the storage type automatically \
-                      (currently DENSE is always used)
+             - 'auto' - choose the storage type automatically
+               (currently DENSE is always used)
              - False - create a dense forest
-             - True - create a sparse forest; \
-                      requires algo='NAIVE' or algo='AUTO'
+             - True - create a sparse forest;
+               requires algo='NAIVE' or algo='AUTO'
 
         Returns
         ----------

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -68,7 +68,7 @@ cdef class TreeliteModel():
     """
     Wrapper for Treelite-loaded forest
 
-    Note: This is only used for loading saved models into ForestInference,
+    .. note:: This is only used for loading saved models into ForestInference,
     it does not actually perform inference. Users typically do
     not need to access TreeliteModel instances directly.
 
@@ -253,8 +253,10 @@ cdef class ForestInference_impl():
             matches sklearn
 
         Returns
-        ----------
+        -------
+
         Predicted results of type as defined by the output_type variable
+        
         """
         if (not self.output_class) and predict_proba:
             raise NotImplementedError("Predict_proba function is not available"
@@ -379,7 +381,8 @@ cdef class ForestInference_impl():
 
 
 class ForestInference(Base):
-    """ForestInference provides GPU-accelerated inference (prediction)
+    """
+    ForestInference provides GPU-accelerated inference (prediction)
     for random forest and boosted decision tree models.
 
     This module does not support training models. Rather, users should
@@ -440,6 +443,7 @@ class ForestInference(Base):
     https://github.com/rapidsai/cuml/blob/branch-0.14/notebooks/forest_inference_demo.ipynb
 
     """
+
     def __init__(self,
                  handle=None, output_type=None):
         super(ForestInference, self).__init__(handle,
@@ -509,37 +513,37 @@ class ForestInference(Base):
 
         Parameters
         ----------
-        model : the trained model information in the treelite format
-           loaded from a saved model using the treelite API
-           https://treelite.readthedocs.io/en/latest/treelite-api.html
+        model
+            the trained model information in the treelite format
+            loaded from a saved model using the treelite API
+            https://treelite.readthedocs.io/en/latest/treelite-api.html
         output_class: boolean (default=False)
-           For a Classification model output_class must be True.
-           For a Regression model output_class must be False.
+            For a Classification model output_class must be True.
+            For a Regression model output_class must be False.
         algo : string (default='auto')
-            name of the algo from (from algo_t enum)
-             'AUTO' or 'auto' - choose the algorithm automatically;
-                   currently 'BATCH_TREE_REORG' is used for dense storage,
-                   and 'NAIVE' for sparse storage
-             'NAIVE' or 'naive' - simple inference using shared memory
-             'TREE_REORG' or 'tree_reorg' - similar to naive but trees
-                              rearranged to be more coalescing-friendly
-             'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG
-                                    but predicting multiple rows
-                                    per thread block
+            name of the algo from (from algo_t enum) :
+             - 'AUTO' or 'auto' - choose the algorithm automatically; \
+                currently 'BATCH_TREE_REORG' is used for dense storage, \
+                and 'NAIVE' for sparse storage
+             - 'NAIVE' or 'naive' - simple inference using shared memory
+             - 'TREE_REORG' or 'tree_reorg' - similar to naive but trees \
+                rearranged to be more coalescing-friendly
+             - 'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG \
+                but predicting multiple rows per thread block
         threshold : float (default=0.5)
             Threshold is used to for classification. It is applied
             only if output_class == True, else it is ignored.
         storage_type : string or boolean (default='auto')
-            In-memory storage format to be used for the FIL model.
-             'auto' - choose the storage type automatically
-                      (currently DENSE is always used)
-             False - create a dense forest
-             True - create a sparse forest;
-                      requires algo='NAIVE' or algo='AUTO'
+            In-memory storage format to be used for the FIL model:
+             - 'auto' - choose the storage type automatically \
+                (currently DENSE is always used)
+             - False - create a dense forest
+             - True - create a sparse forest; \
+                requires algo='NAIVE' or algo='AUTO'
 
         Returns
         ----------
-        fil_model :
+        fil_model
             A Forest Inference model which can be used to perform
             inferencing on the random forest/ XGBoost model.
         """
@@ -566,35 +570,35 @@ class ForestInference(Base):
 
         Parameters
         ----------
-        skl_model : The scikit-learn model from which to build the FIL version.
+        skl_model
+            The scikit-learn model from which to build the FIL version.
         output_class: boolean (default=False)
-           For a Classification model output_class must be True.
-           For a Regression model output_class must be False.
+            For a Classification model output_class must be True.
+            For a Regression model output_class must be False.
         algo : string (default='auto')
-            name of the algo from (from algo_t enum)
-             'AUTO' or 'auto' - choose the algorithm automatically;
-                   currently 'BATCH_TREE_REORG' is used for dense storage,
-                   and 'NAIVE' for sparse storage
-             'NAIVE' or 'naive' - simple inference using shared memory
-             'TREE_REORG' or 'tree_reorg' - similar to naive but trees
-                              rearranged to be more coalescing-friendly
-             'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG
-                                    but predicting multiple rows
-                                    per thread block
+            name of the algo from (from algo_t enum):
+             - 'AUTO' or 'auto' - choose the algorithm automatically; \
+                currently 'BATCH_TREE_REORG' is used for dense storage, \
+                and 'NAIVE' for sparse storage
+             - 'NAIVE' or 'naive' - simple inference using shared memory
+             - 'TREE_REORG' or 'tree_reorg' - similar to naive but trees \
+                rearranged to be more coalescing-friendly
+             - 'BATCH_TREE_REORG' or 'batch_tree_reorg' - similar to TREE_REORG \
+                but predicting multiple rows per thread block
         threshold : float (default=0.5)
             Threshold is used to for classification. It is applied
-            only if output_class == True, else it is ignored.
+            only if ``output_class == True``, else it is ignored.
         storage_type : string or boolean (default='auto')
-            In-memory storage format to be used for the FIL model.
-             'auto' - choose the storage type automatically
+            In-memory storage format to be used for the FIL model:
+             - 'auto' - choose the storage type automatically \
                       (currently DENSE is always used)
-             False - create a dense forest
-             True - create a sparse forest;
+             - False - create a dense forest
+             - True - create a sparse forest; \
                       requires algo='NAIVE' or algo='AUTO'
 
         Returns
         ----------
-        fil_model :
+        fil_model
             A Forest Inference model created from the scikit-learn
             model passed.
 
@@ -615,36 +619,37 @@ class ForestInference(Base):
              model_type="xgboost",
              handle=None):
         """
-        Returns a FIL instance containing the forest saved in 'filename'
+        Returns a FIL instance containing the forest saved in `filename`
         This uses Treelite to load the saved model.
 
         Parameters
         ----------
         filename : string
-           Path to saved model file in a treelite-compatible format
-           (See https://treelite.readthedocs.io/en/latest/treelite-api.html
+            Path to saved model file in a treelite-compatible format
+            (See https://treelite.readthedocs.io/en/latest/treelite-api.html
             for more information)
         output_class: boolean (default=False)
-           For a Classification model output_class must be True.
-           For a Regression model output_class must be False.
+            For a Classification model `output_class` must be True.
+            For a Regression model `output_class` must be False.
         threshold : float (default=0.5)
-           Cutoff value above which a prediction is set to 1.0
-           Only used if the model is classification and output_class is True
+            Cutoff value above which a prediction is set to 1.0
+            Only used if the model is classification and `output_class` is True
         algo : string (default='auto')
-           Which inference algorithm to use.
-           See documentation in FIL.load_from_treelite_model
+            Which inference algorithm to use.
+            See documentation in `FIL.load_from_treelite_model`
         storage_type : string (default='auto')
             In-memory storage format to be used for the FIL model.
-            See documentation in FIL.load_from_treelite_model
+            See documentation in `FIL.load_from_treelite_model`
         model_type : string (default="xgboost")
             Format of the saved treelite model to be load.
             It can be 'xgboost', 'lightgbm'.
 
         Returns
         ----------
-        fil_model :
+        fil_model
             A Forest Inference model which can be used to perform
             inferencing on the model read from the file.
+
         """
         cuml_fm = ForestInference(handle=handle)
         tl_model = TreeliteModel.from_filename(filename, model_type=model_type)
@@ -671,21 +676,21 @@ class ForestInference(Base):
             (See https://treelite.readthedocs.io/en/latest/treelite-api.html
             for more information)
         output_class: boolean (default=False)
-           For a Classification model output_class must be True.
-           For a Regression model output_class must be False.
+            For a Classification model `output_class` must be True.
+            For a Regression model `output_class` must be False.
         threshold : float (default=0.5)
-           Cutoff value above which a prediction is set to 1.0
-           Only used if the model is classification and output_class is True
+            Cutoff value above which a prediction is set to 1.0
+            Only used if the model is classification and output_class is True
         algo : string (default='auto')
-           Which inference algorithm to use.
-           See documentation in FIL.load_from_treelite_model
+            Which inference algorithm to use.
+            See documentation in `FIL.load_from_treelite_model`
         storage_type : string (default='auto')
             In-memory storage format to be used for the FIL model.
-            See documentation in FIL.load_from_treelite_model
+            See documentation in `FIL.load_from_treelite_model`
 
         Returns
         ----------
-        fil_model :
+        fil_model
             A Forest Inference model which can be used to perform
             inferencing on the random forest model.
         """

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -129,7 +129,7 @@ class ElasticNet(Base, RegressorMixin):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     Notes
     -----

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -36,7 +36,7 @@ class ElasticNet(Base, RegressorMixin):
     descent to fit a linear model.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/linear_model/lasso.pyx
+++ b/python/cuml/linear_model/lasso.pyx
@@ -118,7 +118,7 @@ class Lasso(Base, RegressorMixin):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     Notes
     -----

--- a/python/cuml/linear_model/lasso.pyx
+++ b/python/cuml/linear_model/lasso.pyx
@@ -37,7 +37,7 @@ class Lasso(Base, RegressorMixin):
     a linear model.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -157,7 +157,7 @@ class LinearRegression(Base, RegressorMixin):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If `fit_intercept_` is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     Notes
     ------

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -86,7 +86,7 @@ class LinearRegression(Base, RegressorMixin):
     stable, but Eig (default) is much faster.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -59,7 +59,7 @@ class LogisticRegression(Base, ClassifierMixin):
     Note that, just like in Scikit-learn, the bias will not be regularized.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
         import cudf

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -144,7 +144,7 @@ class LogisticRegression(Base, ClassifierMixin):
         Note: this includes the intercept as the last column if fit_intercept
         is True
     intercept_: device array (n_classes, 1)
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     Notes
     ------

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -28,7 +28,7 @@ class MBSGDClassifier(Base, ClassifierMixin):
     fitted by minimizing a regularized empirical loss with mini-batch SGD.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
         import numpy as np

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -28,7 +28,7 @@ class MBSGDRegressor(Base, RegressorMixin):
     regularized empirical loss with mini-batch SGD.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
         import numpy as np

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -174,7 +174,7 @@ class Ridge(Base, RegressorMixin):
     coef_ : array, shape (n_features)
         The estimated coefficients for the linear regression model.
     intercept_ : array
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     Notes
     ------

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -98,7 +98,7 @@ class Ridge(Base, RegressorMixin):
     Coordinate Descent and can be faster when data is large.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -150,38 +150,37 @@ class TSNE(Base):
 
     References
     -----------
-    *   van der Maaten, L.J.P.
-        t-Distributed Stochastic Neighbor Embedding
-        https://lvdmaaten.github.io/tsne/
+    .. [1] `van der Maaten, L.J.P.
+       t-Distributed Stochastic Neighbor Embedding
+       <https://lvdmaaten.github.io/tsne/>`_
 
-    *   van der Maaten, L.J.P.; Hinton, G.E.
+    .. [2] van der Maaten, L.J.P.; Hinton, G.E.
         Visualizing High-Dimensional Data
         Using t-SNE. Journal of Machine Learning Research 9:2579-2605, 2008.
 
-    *   George C. Linderman, Manas Rachh, Jeremy G. Hoskins,
+    .. [3] George C. Linderman, Manas Rachh, Jeremy G. Hoskins,
         Stefan Steinerberger, Yuval Kluger Efficient Algorithms for
         t-distributed Stochastic Neighborhood Embedding
 
-    Tips
-    -----
-    Maaten and Linderman showcased how TSNE can be very sensitive to both the
-    starting conditions (ie random initialization), and how parallel versions
-    of TSNE can generate vastly different results. It has been suggested that
-    you run TSNE a few times to settle on the best configuration. Notice
-    specifying random_state and fixing it across runs can help, but TSNE does
-    not guarantee similar results each time.
+    .. tip::
+        Maaten and Linderman showcased how TSNE can be very sensitive to both the
+        starting conditions (ie random initialization), and how parallel versions
+        of TSNE can generate vastly different results. It has been suggested that
+        you run TSNE a few times to settle on the best configuration. Notice
+        specifying random_state and fixing it across runs can help, but TSNE does
+        not guarantee similar results each time.
 
-    As suggested, PCA (upcoming with change #1098) can also help to alleviate
-    this issue.
+        As suggested, PCA (upcoming with change #1098) can also help to alleviate
+        this issue.
 
-    Reference Implementation
-    -------------------------
-    The CUDA implementation is derived from the excellent CannyLabs open source
-    implementation here: https://github.com/CannyLab/tsne-cuda/. The CannyLabs
-    code is licensed according to the conditions in cuml/cpp/src/tsne/
-    cannylabs_tsne_license.txt. A full description of their approach is
-    available in their article t-SNE-CUDA: GPU-Accelerated t-SNE and its
-    Applications to Modern Data (https://arxiv.org/abs/1807.11824).
+    .. note::
+        The CUDA implementation is derived from the excellent CannyLabs open source
+        implementation here: https://github.com/CannyLab/tsne-cuda/. The CannyLabs
+        code is licensed according to the conditions in cuml/cpp/src/tsne/
+        cannylabs_tsne_license.txt. A full description of their approach is
+        available in their article t-SNE-CUDA: GPU-Accelerated t-SNE and its
+        Applications to Modern Data (https://arxiv.org/abs/1807.11824).
+
     """
     def __init__(self,
                  int n_components=2,

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -155,31 +155,32 @@ class TSNE(Base):
        <https://lvdmaaten.github.io/tsne/>`_
 
     .. [2] van der Maaten, L.J.P.; Hinton, G.E.
-        Visualizing High-Dimensional Data
-        Using t-SNE. Journal of Machine Learning Research 9:2579-2605, 2008.
+       Visualizing High-Dimensional Data
+       Using t-SNE. Journal of Machine Learning Research 9:2579-2605, 2008.
 
     .. [3] George C. Linderman, Manas Rachh, Jeremy G. Hoskins,
         Stefan Steinerberger, Yuval Kluger Efficient Algorithms for
         t-distributed Stochastic Neighborhood Embedding
 
     .. tip::
-        Maaten and Linderman showcased how TSNE can be very sensitive to both the
-        starting conditions (ie random initialization), and how parallel versions
-        of TSNE can generate vastly different results. It has been suggested that
-        you run TSNE a few times to settle on the best configuration. Notice
-        specifying random_state and fixing it across runs can help, but TSNE does
-        not guarantee similar results each time.
+        Maaten and Linderman showcased how TSNE can be very sensitive to both
+        the starting conditions (ie random initialization), and how parallel
+        versions of TSNE can generate vastly different results. It has been
+        suggested that you run TSNE a few times to settle on the best
+        configuration. Notice specifying random_state and fixing it across runs
+        can help, but TSNE does not guarantee similar results each time.
 
-        As suggested, PCA (upcoming with change #1098) can also help to alleviate
-        this issue.
+        As suggested, PCA (upcoming with change #1098) can also help to
+        alleviate this issue.
 
     .. note::
-        The CUDA implementation is derived from the excellent CannyLabs open source
-        implementation here: https://github.com/CannyLab/tsne-cuda/. The CannyLabs
-        code is licensed according to the conditions in cuml/cpp/src/tsne/
-        cannylabs_tsne_license.txt. A full description of their approach is
-        available in their article t-SNE-CUDA: GPU-Accelerated t-SNE and its
-        Applications to Modern Data (https://arxiv.org/abs/1807.11824).
+        The CUDA implementation is derived from the excellent CannyLabs open
+        source implementation here: https://github.com/CannyLab/tsne-cuda/. The
+        CannyLabs code is licensed according to the conditions in
+        cuml/cpp/src/tsne/ cannylabs_tsne_license.txt. A full description of
+        their approach is available in their article t-SNE-CUDA:
+        GPU-Accelerated t-SNE and its Applications to Modern Data
+        (https://arxiv.org/abs/1807.11824).
 
     """
     def __init__(self,

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -231,8 +231,8 @@ class UMAP(Base):
         edges at once preventing inconsistencies. A lower batch size will yield
         more consistently repeatable embeddings at the cost of speed.
     callback: An instance of GraphBasedDimRedCallback class
-        Used to intercept the internal state of embeddings while they are being trained.
-        Example of callback usage:
+        Used to intercept the internal state of embeddings while they are being
+        trained. Example of callback usage:
 
         .. code-block:: python
 
@@ -268,8 +268,8 @@ class UMAP(Base):
     algorithm for large data sizes while cuml.umap always uses exact
     kNN.
 
-    **Known issue:** If a UMAP model has not yet been fit, it cannot be pickled.
-    However, after fitting, a UMAP mode.
+    **Known issue:** If a UMAP model has not yet been fit, it cannot be
+    pickled. However, after fitting, a UMAP mode.
 
     References
     ----------

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -128,7 +128,7 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML":
 
 
 class UMAP(Base):
-    """Uniform Manifold Approximation and Projection
+    r"""Uniform Manifold Approximation and Projection
     Finds a low dimensional embedding of the data that approximates
     an underlying manifold.
 
@@ -154,8 +154,9 @@ class UMAP(Base):
         The initial learning rate for the embedding optimization.
     init: string (optional, default 'spectral')
         How to initialize the low dimensional embedding. Options are:
-            * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
-            * 'random': assign initial embedding positions at random.
+         * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
+         * 'random': assign initial embedding positions at random.
+
     min_dist: float (optional, default 0.1)
         The effective minimum distance between embedded points. Smaller values
         will result in a more clustered/clumped embedding where nearby points
@@ -202,15 +203,16 @@ class UMAP(Base):
         More specific parameters controlling the embedding. If None these
         values are set automatically as determined by ``min_dist`` and
         ``spread``.
-    hash_input: UMAP can hash the training input so that exact embeddings
-                are returned when transform is called on the same data upon
-                which the model was trained. This enables consistent
-                behavior between calling model.fit_transform(X) and
-                calling model.fit(X).transform(X). Not that the CPU-based
-                UMAP reference implementation does this by default. This
-                feature is made optional in the GPU version due to the
-                significant overhead in copying memory to the host for
-                computing the hash. (default = False)
+    hash_input: bool, optional (default = False)
+        UMAP can hash the training input so that exact embeddings
+        are returned when transform is called on the same data upon
+        which the model was trained. This enables consistent
+        behavior between calling ``model.fit_transform(X)`` and
+        calling ``model.fit(X).transform(X)``. Not that the CPU-based
+        UMAP reference implementation does this by default. This
+        feature is made optional in the GPU version due to the
+        significant overhead in copying memory to the host for
+        computing the hash.
     random_state : int, RandomState instance or None, optional (default=None)
         random_state is the seed used by the random number generator during
         embedding initialization and during sampling used by the optimizer.
@@ -228,19 +230,24 @@ class UMAP(Base):
         The optimization step will be processed with at most optim_batch_size
         edges at once preventing inconsistencies. A lower batch size will yield
         more consistently repeatable embeddings at the cost of speed.
-    callback: An instance of GraphBasedDimRedCallback class to intercept
-              the internal state of embeddings while they are being trained.
-              Example of callback usage:
-                  from cuml.internals import GraphBasedDimRedCallback
-                  class CustomCallback(GraphBasedDimRedCallback):
-                    def on_preprocess_end(self, embeddings):
-                        print(embeddings.copy_to_host())
+    callback: An instance of GraphBasedDimRedCallback class
+        Used to intercept the internal state of embeddings while they are being trained.
+        Example of callback usage:
 
-                    def on_epoch_end(self, embeddings):
-                        print(embeddings.copy_to_host())
+        .. code-block:: python
 
-                    def on_train_end(self, embeddings):
-                        print(embeddings.copy_to_host())
+            from cuml.internals import GraphBasedDimRedCallback
+
+            class CustomCallback(GraphBasedDimRedCallback):
+                def on_preprocess_end(self, embeddings):
+                    print(embeddings.copy_to_host())
+
+                def on_epoch_end(self, embeddings):
+                    print(embeddings.copy_to_host())
+
+                def on_train_end(self, embeddings):
+                    print(embeddings.copy_to_host())
+
     verbose : int or boolean (default = False)
         Controls verbosity of logging.
 
@@ -249,11 +256,11 @@ class UMAP(Base):
     This module is heavily based on Leland McInnes' reference UMAP package.
     However, there are a number of differences and features that are not yet
     implemented in cuml.umap:
-      * Using a non-Euclidean distance metric (support for a fixed set
-        of non-Euclidean metrics is planned for an upcoming release).
-      * Using a pre-computed pairwise distance matrix (under consideration
-        for future releases)
-      * Manual initialization of initial embedding positions
+     * Using a non-Euclidean distance metric (support for a fixed set
+       of non-Euclidean metrics is planned for an upcoming release).
+     * Using a pre-computed pairwise distance matrix (under consideration
+       for future releases)
+     * Manual initialization of initial embedding positions
 
     In addition to these missing features, you should expect to see
     the final embeddings differing between cuml.umap and the reference
@@ -261,15 +268,15 @@ class UMAP(Base):
     algorithm for large data sizes while cuml.umap always uses exact
     kNN.
 
-    Known issue: If a UMAP model has not yet been fit, it cannot be pickled.
+    **Known issue:** If a UMAP model has not yet been fit, it cannot be pickled.
     However, after fitting, a UMAP mode.
 
     References
     ----------
-    * Leland McInnes, John Healy, James Melville
-      UMAP: Uniform Manifold Approximation and Projection for Dimension
-      Reduction
-      https://arxiv.org/abs/1802.03426
+    .. [1] `Leland McInnes, John Healy, James Melville
+           UMAP: Uniform Manifold Approximation and Projection for Dimension
+           Reduction
+           <https://arxiv.org/abs/1802.03426>`_
 
     """
 

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -128,7 +128,7 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML":
 
 
 class UMAP(Base):
-    r"""
+    """
     Uniform Manifold Approximation and Projection
 
     Finds a low dimensional embedding of the data that approximates

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -128,7 +128,9 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML":
 
 
 class UMAP(Base):
-    r"""Uniform Manifold Approximation and Projection
+    r"""
+    Uniform Manifold Approximation and Projection
+
     Finds a low dimensional embedding of the data that approximates
     an underlying manifold.
 
@@ -154,8 +156,9 @@ class UMAP(Base):
         The initial learning rate for the embedding optimization.
     init: string (optional, default 'spectral')
         How to initialize the low dimensional embedding. Options are:
-         * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
-         * 'random': assign initial embedding positions at random.
+
+        * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
+        * 'random': assign initial embedding positions at random.
 
     min_dist: float (optional, default 0.1)
         The effective minimum distance between embedded points. Smaller values
@@ -191,7 +194,7 @@ class UMAP(Base):
         in greater repulsive force being applied, greater optimization
         cost, but slightly more accuracy.
     transform_queue_size: float (optional, default 4.0)
-        For transform operations (embedding new points using a trained model_
+        For transform operations (embedding new points using a trained model
         this will control how aggressively to search for nearest neighbors.
         Larger values will result in slower performance but more accurate
         nearest neighbor evaluation.
@@ -255,12 +258,13 @@ class UMAP(Base):
     -----
     This module is heavily based on Leland McInnes' reference UMAP package.
     However, there are a number of differences and features that are not yet
-    implemented in cuml.umap:
-     * Using a non-Euclidean distance metric (support for a fixed set
-       of non-Euclidean metrics is planned for an upcoming release).
-     * Using a pre-computed pairwise distance matrix (under consideration
-       for future releases)
-     * Manual initialization of initial embedding positions
+    implemented in `cuml.umap`:
+
+    * Using a non-Euclidean distance metric (support for a fixed set
+      of non-Euclidean metrics is planned for an upcoming release).
+    * Using a pre-computed pairwise distance matrix (under consideration
+      for future releases)
+    * Manual initialization of initial embedding positions
 
     In addition to these missing features, you should expect to see
     the final embeddings differing between cuml.umap and the reference
@@ -274,9 +278,8 @@ class UMAP(Base):
     References
     ----------
     .. [1] `Leland McInnes, John Healy, James Melville
-           UMAP: Uniform Manifold Approximation and Projection for Dimension
-           Reduction
-           <https://arxiv.org/abs/1802.03426>`_
+       UMAP: Uniform Manifold Approximation and Projection for Dimension
+       Reduction <https://arxiv.org/abs/1802.03426>`_
 
     """
 

--- a/python/cuml/metrics/_classification.py
+++ b/python/cuml/metrics/_classification.py
@@ -46,6 +46,7 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     Returns
     -------
     loss : float
+
     Examples
     --------
     >>> from cuml.metrics import log_loss
@@ -53,13 +54,16 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None):
     >>> log_loss(np.array([1, 0, 0, 1]),
     ...          np.array([[.1, .9], [.9, .1], [.8, .2], [.35, .65]]))
     0.21616...
+
     References
     ----------
     C.M. Bishop (2006). Pattern Recognition and Machine Learning. Springer,
     p. 209.
+
     Notes
     -----
     The logarithm used is the natural logarithm (base-e).
+
     """
     y_true, n_rows, n_cols, ytype = \
         input_to_cuml_array(y_true, check_dtype=[np.int32, np.int64,

--- a/python/cuml/metrics/_ranking.py
+++ b/python/cuml/metrics/_ranking.py
@@ -26,20 +26,21 @@ def precision_recall_curve(y_true, probs_pred):
     """
     Compute precision-recall pairs for different probability thresholds
 
-    .. note:: this implementation is restricted to the binary classification task.
-        The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
-        true positives and ``fp`` the number of false positives. The precision is
-        intuitively the ability of the classifier not to label as positive a sample
-        that is negative.
+    .. note:: this implementation is restricted to the binary classification
+        task. The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the
+        number of true positives and ``fp`` the number of false positives. The
+        precision is intuitively the ability of the classifier not to label as
+        positive a sample that is negative.
 
-        The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
-        true positives and ``fn`` the number of false negatives. The recall is
-        intuitively the ability of the classifier to find all the positive samples.
-        The last precision and recall values are 1. and 0. respectively and do not
-        have a corresponding threshold.  This ensures that the graph starts on the
-        y axis.
+        The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number
+        of true positives and ``fn`` the number of false negatives. The recall
+        is intuitively the ability of the classifier to find all the positive
+        samples. The last precision and recall values are 1. and 0.
+        respectively and do not have a corresponding threshold. This ensures
+        that the graph starts on the y axis.
 
-        Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+        Read more in the
+        :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters
     ----------

--- a/python/cuml/metrics/_ranking.py
+++ b/python/cuml/metrics/_ranking.py
@@ -26,20 +26,20 @@ def precision_recall_curve(y_true, probs_pred):
     """
     Compute precision-recall pairs for different probability thresholds
 
-    Note: this implementation is restricted to the binary classification task.
-    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
-    true positives and ``fp`` the number of false positives. The precision is
-    intuitively the ability of the classifier not to label as positive a sample
-    that is negative.
+    .. note:: this implementation is restricted to the binary classification task.
+        The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
+        true positives and ``fp`` the number of false positives. The precision is
+        intuitively the ability of the classifier not to label as positive a sample
+        that is negative.
 
-    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
-    true positives and ``fn`` the number of false negatives. The recall is
-    intuitively the ability of the classifier to find all the positive samples.
-    The last precision and recall values are 1. and 0. respectively and do not
-    have a corresponding threshold.  This ensures that the graph starts on the
-    y axis.
+        The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
+        true positives and ``fn`` the number of false negatives. The recall is
+        intuitively the ability of the classifier to find all the positive samples.
+        The last precision and recall values are 1. and 0. respectively and do not
+        have a corresponding threshold.  This ensures that the graph starts on the
+        y axis.
 
-    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+        Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def roc_auc_score(y_true, y_score):
     Compute Area Under the Receiver Operating Characteristic Curve (ROC AUC)
     from prediction scores.
 
-    Note: this implementation can only be used with binary classification.
+    .. note:: this implementation can only be used with binary classification.
 
     Parameters
     ----------
@@ -140,18 +140,13 @@ def roc_auc_score(y_true, y_score):
 
     Examples
     --------
-    .. code-block:: python
+    >>> import numpy as np
+    >>> from cuml.metrics import roc_auc_score
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
+    >>> print(roc_auc_score(y_true, y_scores))
+    0.75
 
-            import numpy as np
-            from cuml.metrics import roc_auc_score
-            y_true = np.array([0, 0, 1, 1])
-            y_scores = np.array([0.1, 0.4, 0.35, 0.8])
-            print(roc_auc_score(y_true, y_scores))
-
-    Output:
-    .. code-block:: python
-
-            0.75
     """
     y_true, n_rows, n_cols, ytype = \
         input_to_cuml_array(y_true, check_dtype=[np.int32, np.int64,

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -160,7 +160,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", handle=None,
         array from `X` and the jth array from `Y`.
 
     Examples
-    ---------
+    --------
         >>> import cupy as cp
         >>> from cuml.metrics import pairwise_distances
         >>>

--- a/python/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier.pyx
@@ -99,7 +99,7 @@ class KNeighborsClassifier(NearestNeighbors, ClassifierMixin):
         supported.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
       from cuml.neighbors import KNeighborsClassifier
@@ -121,7 +121,6 @@ class KNeighborsClassifier(NearestNeighbors, ClassifierMixin):
 
 
     Output:
-    -------
 
     .. code-block:: python
 

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -101,7 +101,7 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
         supported.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
       from cuml.neighbors import KNeighborsRegressor

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -124,7 +124,7 @@ class NearestNeighbors(Base):
     metric_params : dict, optional (default = None) This is currently ignored.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
       import cudf

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -140,6 +140,7 @@ class LabelEncoder(object):
         -------
         self : LabelEncoder
             A fitted instance of itself to allow method chaining
+
         """
         self._validate_keywords()
         self.dtype = y.dtype if y.dtype != cp.dtype('O') else str

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -37,7 +37,7 @@ class OneHotEncoder(Base):
     By default, the encoder derives the categories based on the unique values
     in each feature. Alternatively, you can also specify the `categories`
     manually.
-    
+
     .. note:: a one-hot encoding of y labels should use a LabelBinarizer
         instead.
 

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -37,8 +37,9 @@ class OneHotEncoder(Base):
     By default, the encoder derives the categories based on the unique values
     in each feature. Alternatively, you can also specify the `categories`
     manually.
-    Note: a one-hot encoding of y labels should use a LabelBinarizer
-    instead.
+    
+    .. note:: a one-hot encoding of y labels should use a LabelBinarizer
+        instead.
 
     Parameters
     ----------

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -68,14 +68,13 @@ def _stratify_split(X, y, n_train, n_test, x_numba, y_numba, random_state):
     class_counts = cp.bincount(y_indices)
     if n_train < n_classes:
         raise ValueError('The train_size = %d should be greater or '
-                         'equal to the number of classes = %d' %
-                         (n_train, n_classes))
+                         'equal to the number of classes = %d' % (n_train,
+                                                                  n_classes))
     if n_test < n_classes:
         raise ValueError('The test_size = %d should be greater or '
-                         'equal to the number of classes = %d' %
-                         (n_test, n_classes))
-    class_indices = cp.array_split(cp.argsort(y_indices),
-                                   n_classes)
+                         'equal to the number of classes = %d' % (n_test,
+                                                                  n_classes))
+    class_indices = cp.array_split(cp.argsort(y_indices), n_classes)
 
     X_train = None
 
@@ -175,17 +174,20 @@ def _approximate_mode(class_counts, n_draws, rng):
     return floored.astype(cp.int)
 
 
-def train_test_split(
-    X,
-    y=None,
-    test_size: Union[float, int] = None,
-    train_size: Union[float, int] = None,
-    shuffle: bool = True,
-    random_state: Union[int, cp.random.RandomState,
-                        np.random.RandomState] = None,
-    seed: Union[int, cp.random.RandomState, np.random.RandomState] = None,
-    stratify=None
-):
+def train_test_split(X,
+                     y=None,
+                     test_size: Union[float,
+                                      int] = None,
+                     train_size: Union[float,
+                                       int] = None,
+                     shuffle: bool = True,
+                     random_state: Union[int,
+                                         cp.random.RandomState,
+                                         np.random.RandomState] = None,
+                     seed: Union[int,
+                                 cp.random.RandomState,
+                                 np.random.RandomState] = None,
+                     stratify=None):
     """
     Partitions device data into four collated objects, mimicking
     Scikit-learn's `train_test_split`
@@ -215,6 +217,7 @@ def train_test_split(
 
     Examples
     --------
+
     .. code-block:: python
 
         import cudf
@@ -253,11 +256,13 @@ def train_test_split(
 
     Returns
     -------
+
     X_train, X_test, y_train, y_test : cudf.DataFrame or array-like objects
         Partitioned dataframes if X and y were cuDF objects. If `y` was
         provided as a column name, the column was dropped from the `X`s
         Partitioned numba device arrays if X and y were Numba device arrays.
         Partitioned CuPy arrays for any other input.
+
     """
     if isinstance(y, str):
         # Use the column with name `str` as y
@@ -284,10 +289,10 @@ def train_test_split(
                             a cuda_array_interface compliant array.")
 
         if X.shape[0] != y.shape[0]:
-            raise ValueError(
-                "X and y must have the same first dimension"
-                "(found {} and {})".format(X.shape[0], y.shape[0])
-            )
+            raise ValueError("X and y must have the same first dimension"
+                             "(found {} and {})".format(
+                                 X.shape[0],
+                                 y.shape[0]))
     else:
         if not hasattr(X, "__cuda_array_interface__") and not \
                 isinstance(X, cudf.DataFrame):
@@ -296,31 +301,25 @@ def train_test_split(
 
     if isinstance(train_size, float):
         if not 0 <= train_size <= 1:
-            raise ValueError(
-                "proportion train_size should be between"
-                "0 and 1 (found {})".format(train_size)
-            )
+            raise ValueError("proportion train_size should be between"
+                             "0 and 1 (found {})".format(train_size))
 
     if isinstance(train_size, int):
         if not 0 <= train_size <= X.shape[0]:
             raise ValueError(
                 "Number of instances train_size should be between 0 and the"
-                "first dimension of X (found {})".format(train_size)
-            )
+                "first dimension of X (found {})".format(train_size))
 
     if isinstance(test_size, float):
         if not 0 <= test_size <= 1:
-            raise ValueError(
-                "proportion test_size should be between"
-                "0 and 1 (found {})".format(train_size)
-            )
+            raise ValueError("proportion test_size should be between"
+                             "0 and 1 (found {})".format(train_size))
 
     if isinstance(test_size, int):
         if not 0 <= test_size <= X.shape[0]:
             raise ValueError(
                 "Number of instances test_size should be between 0 and the"
-                "first dimension of X (found {})".format(test_size)
-            )
+                "first dimension of X (found {})".format(test_size))
 
     x_numba = cuda.devicearray.is_cuda_ndarray(X)
     y_numba = cuda.devicearray.is_cuda_ndarray(y)
@@ -387,8 +386,13 @@ def train_test_split(
             y = cp.asarray(y)[idxs]
 
         if stratify is not None:
-            split_return = _stratify_split(X, y, train_size, test_size,
-                                           x_numba, y_numba, random_state)
+            split_return = _stratify_split(X,
+                                           y,
+                                           train_size,
+                                           test_size,
+                                           x_numba,
+                                           y_numba,
+                                           random_state)
             return split_return
 
     # If not stratified, perform train_test_split splicing

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -190,7 +190,7 @@ def train_test_split(X,
                      stratify=None):
     """
     Partitions device data into four collated objects, mimicking
-    Scikit-learn's `train_test_split`
+    Scikit-learn's `train_test_split`.
 
     Parameters
     ----------
@@ -259,7 +259,7 @@ def train_test_split(X,
 
     X_train, X_test, y_train, y_test : cudf.DataFrame or array-like objects
         Partitioned dataframes if X and y were cuDF objects. If `y` was
-        provided as a column name, the column was dropped from the `X`s
+        provided as a column name, the column was dropped from `X`.
         Partitioned numba device arrays if X and y were Numba device arrays.
         Partitioned CuPy arrays for any other input.
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -293,10 +293,11 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
 
     The components of the random matrix are drawn from N(0, 1 / n_components).
 
-    Example
-    ---------
+    Examples
+    --------
 
     .. code-block:: python
+
         from cuml.random_projection import GaussianRandomProjection
         from sklearn.datasets.samples_generator import make_blobs
         from sklearn.svm import SVC
@@ -324,6 +325,7 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
     Output:
 
     .. code-block:: python
+
         Score: 1.0
 
     Parameters
@@ -389,16 +391,17 @@ class SparseRandomProjection(Base, BaseRandomProjection):
     (e.g. Gaussian) that guarantees similar embedding quality while being much
     more memory efficient and allowing faster computation of the projected data
     (with sparse enough matrices).
-    If we note 's = 1 / density' the components of the random matrix are
+    If we note ``s = 1 / density`` the components of the random matrix are
     drawn from:
-      - -sqrt(s) / sqrt(n_components)   with probability 1 / 2s
-      -  0                              with probability 1 - 1 / s
-      - +sqrt(s) / sqrt(n_components)   with probability 1 / 2s
+     - ``-sqrt(s) / sqrt(n_components)`` - with probability ``1 / 2s``
+     - ``0`` - with probability ``1 - 1 / s``
+     - ``+sqrt(s) / sqrt(n_components)`` - with probability ``1 / 2s``
 
-    Example
-    ---------
+    Examples
+    --------
 
     .. code-block:: python
+
         from cuml.random_projection import SparseRandomProjection
         from sklearn.datasets.samples_generator import make_blobs
         from sklearn.svm import SVC
@@ -426,11 +429,11 @@ class SparseRandomProjection(Base, BaseRandomProjection):
     Output:
 
     .. code-block:: python
+
         Score: 1.0
 
     Parameters
     ----------
-
     handle : cuml.Handle
         If it is None, a new one is created just for this class
 
@@ -439,13 +442,11 @@ class SparseRandomProjection(Base, BaseRandomProjection):
         the parameter is deducted thanks to Johnson–Lindenstrauss lemma.
         The automatic deduction make use of the number of samples and
         the eps parameter.
-
         The Johnson–Lindenstrauss lemma can produce very conservative
         n_components parameter as it makes no assumption on dataset structure.
 
     density : float in range (0, 1] (default = 'auto')
         Ratio of non-zero component in the random projection matrix.
-
         If density = 'auto', the value is set to the minimum density
         as recommended by Ping Li et al.: 1 / sqrt(n_features).
 
@@ -461,14 +462,14 @@ class SparseRandomProjection(Base, BaseRandomProjection):
 
     Attributes
     ----------
-        gaussian_method : boolean
-            To be passed to base class in order to determine
-            random matrix generation method
+    gaussian_method : boolean
+        To be passed to base class in order to determine
+        random matrix generation method
 
     Notes
-    ------
-        Inspired by Scikit-learn's implementation :
-        https://scikit-learn.org/stable/modules/random_projection.html
+    -----
+        Inspired by Scikit-learn's `implementation
+        <https://scikit-learn.org/stable/modules/random_projection.html>`_
 
     """
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -393,9 +393,10 @@ class SparseRandomProjection(Base, BaseRandomProjection):
     (with sparse enough matrices).
     If we note ``s = 1 / density`` the components of the random matrix are
     drawn from:
-     - ``-sqrt(s) / sqrt(n_components)`` - with probability ``1 / 2s``
-     - ``0`` - with probability ``1 - 1 / s``
-     - ``+sqrt(s) / sqrt(n_components)`` - with probability ``1 / 2s``
+
+    - ``-sqrt(s) / sqrt(n_components)`` - with probability ``1 / 2s``
+    - ``0`` - with probability ``1 - 1 / s``
+    - ``+sqrt(s) / sqrt(n_components)`` - with probability ``1 / 2s``
 
     Examples
     --------
@@ -468,8 +469,8 @@ class SparseRandomProjection(Base, BaseRandomProjection):
 
     Notes
     -----
-        Inspired by Scikit-learn's `implementation
-        <https://scikit-learn.org/stable/modules/random_projection.html>`_
+    Inspired by Scikit-learn's `implementation
+    <https://scikit-learn.org/stable/modules/random_projection.html>`_.
 
     """
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -219,7 +219,7 @@ class QN(Base):
         The estimated coefficients for the linear regression model.
         Note: shape is (n_classes, n_features + 1) if fit_intercept = True.
     intercept_ : array (n_classes, 1)
-        The independent term. If fit_intercept_ is False, will be 0.
+        The independent term. If `fit_intercept` is False, will be 0.
 
     Notes
     ------

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -137,7 +137,7 @@ class QN(Base):
     NumPy arrays or in device (as Numba or __cuda_array_interface__ compliant).
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
         import cudf

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -127,7 +127,7 @@ class SGD(Base):
     ridge regression and SVM models.
 
     Examples
-    ---------
+    --------
 
     .. code-block:: python
 
@@ -164,35 +164,35 @@ class SGD(Base):
     Parameters
     -----------
     loss : 'hinge', 'log', 'squared_loss' (default = 'squared_loss')
-       'hinge' uses linear SVM
-       'log' uses logistic regression
-       'squared_loss' uses linear regression
+        'hinge' uses linear SVM
+        'log' uses logistic regression
+        'squared_loss' uses linear regression
     penalty: 'none', 'l1', 'l2', 'elasticnet' (default = 'none')
-       'none' does not perform any regularization
-       'l1' performs L1 norm (Lasso) which minimizes the sum of the abs value
-       of coefficients
-       'l2' performs L2 norm (Ridge) which minimizes the sum of the square of
-       the coefficients
-       'elasticnet' performs Elastic Net regularization which is a weighted
-       average of L1 and L2 norms
+        'none' does not perform any regularization
+        'l1' performs L1 norm (Lasso) which minimizes the sum of the abs value
+        of coefficients
+        'l2' performs L2 norm (Ridge) which minimizes the sum of the square of
+        the coefficients
+        'elasticnet' performs Elastic Net regularization which is a weighted
+        average of L1 and L2 norms
     alpha: float (default = 0.0001)
         The constant value which decides the degree of regularization
     fit_intercept : boolean (default = True)
-       If True, the model tries to correct for the global mean of y.
-       If False, the model expects that you have centered the data.
+        If True, the model tries to correct for the global mean of y.
+        If False, the model expects that you have centered the data.
     epochs : int (default = 1000)
         The number of times the model should iterate through the entire dataset
         during training (default = 1000)
     tol : float (default = 1e-3)
-       The training process will stop if current_loss > previous_loss - tol
+        The training process will stop if current_loss > previous_loss - tol
     shuffle : boolean (default = True)
-       True, shuffles the training data after each epoch
-       False, does not shuffle the training data after each epoch
+        True, shuffles the training data after each epoch
+        False, does not shuffle the training data after each epoch
     eta0 : float (default = 0.001)
         Initial learning rate
     power_t : float (default = 0.5)
         The exponent used for calculating the invscaling learning rate
-    learning_rate : 'optimal', 'constant', 'invscaling',
+    learning_rate : 'optimal', 'constant', 'invscaling', \
                     'adaptive' (default = 'constant')
         optimal option supported in the next version
         constant keeps the learning rate constant

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -124,10 +124,11 @@ class SVC(SVMBase, ClassifierMixin):
 
     Construct an SVC classifier for training and predictions.
 
-    Known limitations
-    -----------------
-    - Currently only binary classification is supported.
-    - predict_proba is not yet supported
+    .. note::
+        This implementation has the following known limitations:
+
+        - Currently only binary classification is supported.
+        - predict_proba is not yet supported
 
     Examples
     --------
@@ -220,23 +221,25 @@ class SVC(SVMBase, ClassifierMixin):
     classes_: shape (n_classes_,)
         Array of class labels.
 
-    For additional docs, see `scikitlearn's SVC
-    <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_.
-
     Notes
     -----
     The solver uses the SMO method to fit the classifier. We use the Optimized
-    Hierarchical Decomposition [1] variant of the SMO algorithm, similar to [2]
+    Hierarchical Decomposition [1]_ variant of the SMO algorithm, similar to
+    [2]_.
+
+    For additional docs, see `scikitlearn's SVC
+    <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_.
 
     References
     ----------
-    [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical Decomposition
-    Algorithm for Support VectorMachine Training, IEEE Transactions on
-    Parallel and Distributed Systems, vol 28, no 12, 3330, (2017)
+    .. [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical
+       Decomposition Algorithm for Support VectorMachine Training, IEEE
+       Transactions on Parallel and Distributed Systems, vol 28, no 12, 3330,
+       (2017)
 
-    [2] Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs, Journal
-    of Machine Learning Research, 19, 1-5 (2018)
-    https://github.com/Xtra-Computing/thundersvm
+    .. [2] `Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs,
+       Journal of Machine Learning Research, 19, 1-5 (2018)
+       <https://github.com/Xtra-Computing/thundersvm>`_
 
     """
     def __init__(self, handle=None, C=1, kernel='rbf', degree=3,

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -130,7 +130,7 @@ class SVC(SVMBase, ClassifierMixin):
     - predict_proba is not yet supported
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
             import numpy as np
@@ -278,7 +278,7 @@ class SVC(SVMBase, ClassifierMixin):
         y_m: device array of floats or doubles, shape = (n_samples, 1)
             Array of target labels already copied to the device.
 
-        Returns:
+        Returns
         --------
         sample_weight: device array shape = (n_samples, 1) or None
         """

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -178,17 +178,19 @@ class SVR(SVMBase, RegressorMixin):
     <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html>`_.
 
     The solver uses the SMO method to fit the regressor. We use the Optimized
-    Hierarchical Decomposition [1]_ variant of the SMO algorithm, similar to [2]_
+    Hierarchical Decomposition [1]_ variant of the SMO algorithm, similar to
+    [2]_
 
     References
     ----------
 
-    .. [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical Decomposition
-           Algorithm for Support VectorMachine Training, IEEE Transactions on
-           Parallel and Distributed Systems, vol 28, no 12, 3330, (2017)
+    .. [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical
+           Decomposition Algorithm for Support VectorMachine Training, IEEE
+           Transactions on Parallel and Distributed Systems, vol 28, no 12,
+           3330, (2017)
 
-    .. [2] `Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs, Journal
-           of Machine Learning Research, 19, 1-5 (2018)
+    .. [2] `Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs,
+           Journal of Machine Learning Research, 19, 1-5 (2018)
            <https://github.com/Xtra-Computing/thundersvm>`_
 
     Examples

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -120,8 +120,9 @@ class SVR(SVMBase, RegressorMixin):
     gamma : float or string (default = 'scale')
         Coefficient for rbf, poly, and sigmoid kernels. You can specify the
         numeric value, or use one of the following options:
-         - 'auto': gamma will be set to ``1 / n_features``
-         - 'scale': gamma will be se to ``1 / (n_features * X.var())``
+
+        - 'auto': gamma will be set to ``1 / n_features``
+        - 'scale': gamma will be se to ``1 / (n_features * X.var())``
 
     coef0 : float (default = 0.0)
         Independent term in kernel function, only signifficant for poly and

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -106,24 +106,6 @@ class SVR(SVMBase, RegressorMixin):
 
     Construct an SVC classifier for training and predictions.
 
-    Examples
-    ---------
-    .. code-block:: python
-
-            import numpy as np
-            from cuml.svm import SVR
-            X = np.array([[1], [2], [3], [4], [5]], dtype=np.float32)
-            y = np.array([1.1, 4, 5, 3.9, 1.], dtype = np.float32)
-            reg = SVR(kernel='rbf', gamma='scale', C=10, epsilon=0.1)
-            reg.fit(X, y)
-            print("Predicted values:", reg.predict(X))
-
-    Output:
-
-    .. code-block:: none
-
-            Predicted values: [1.200474 3.8999617 5.100488 3.7995374 1.0995375]
-
     Parameters
     ----------
     handle : cuml.Handle
@@ -138,8 +120,9 @@ class SVR(SVMBase, RegressorMixin):
     gamma : float or string (default = 'scale')
         Coefficient for rbf, poly, and sigmoid kernels. You can specify the
         numeric value, or use one of the following options:
-        - 'auto': gamma will be set to 1 / n_features
-        - 'scale': gamma will be se to 1 / (n_features * X.var())
+         - 'auto': gamma will be set to ``1 / n_features``
+         - 'scale': gamma will be se to ``1 / (n_features * X.var())``
+
     coef0 : float (default = 0.0)
         Independent term in kernel function, only signifficant for poly and
         sigmoid
@@ -186,25 +169,46 @@ class SVR(SVMBase, RegressorMixin):
     coef_ : float, shape [1, n_cols]
         Only available for linear kernels. It is the normal of the
         hyperplane.
-        coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]
-
+        ``coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]``
 
     Notes
     -----
+
     For additional docs, see `Scikit-learn's SVR
     <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html>`_.
 
     The solver uses the SMO method to fit the regressor. We use the Optimized
-    Hierarchical Decomposition [1] variant of the SMO algorithm, similar to [2]
+    Hierarchical Decomposition [1]_ variant of the SMO algorithm, similar to [2]_
 
     References
     ----------
-    [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical Decomposition
-         Algorithm for Support VectorMachine Training, IEEE Transactions on
-         Parallel and Distributed Systems, vol 28, no 12, 3330, (2017)
-    [2] Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs, Journal
-    *      of Machine Learning Research, 19, 1-5 (2018)
-        https://github.com/Xtra-Computing/thundersvm
+
+    .. [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical Decomposition
+           Algorithm for Support VectorMachine Training, IEEE Transactions on
+           Parallel and Distributed Systems, vol 28, no 12, 3330, (2017)
+
+    .. [2] `Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs, Journal
+           of Machine Learning Research, 19, 1-5 (2018)
+           <https://github.com/Xtra-Computing/thundersvm>`_
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        import numpy as np
+        from cuml.svm import SVR
+        X = np.array([[1], [2], [3], [4], [5]], dtype=np.float32)
+        y = np.array([1.1, 4, 5, 3.9, 1.], dtype = np.float32)
+        reg = SVR(kernel='rbf', gamma='scale', C=10, epsilon=0.1)
+        reg.fit(X, y)
+        print("Predicted values:", reg.predict(X))
+
+    Output:
+
+    .. code-block:: python
+
+        Predicted values: [1.200474 3.8999617 5.100488 3.7995374 1.0995375]
 
     """
     def __init__(self, handle=None, C=1, kernel='rbf', degree=3,

--- a/python/cuml/test/test_arima.py
+++ b/python/cuml/test/test_arima.py
@@ -365,7 +365,7 @@ def test_gradient(key, data, dtype):
     """
     Test batched gradient implementation against scipy non-batched
     gradient.
-    
+
     .. note:: it doesn't test that the loglikelihood is correct!
     """
     order, seasonal_order, intercept = extract_order(key)

--- a/python/cuml/test/test_arima.py
+++ b/python/cuml/test/test_arima.py
@@ -261,9 +261,12 @@ def _statsmodels_to_cuml(ref_fits, cuml_model, order, seasonal_order,
                          intercept, dtype):
     """Utility function to transfer the parameters from a statsmodels'
     SARIMAXResults object to a cuML ARIMA object.
-    Note: be cautious with the intercept, it is not always equivalent
-    in statsmodels and cuML models (it depends on the order).
+
+    .. note:: be cautious with the intercept, it is not always equivalent
+        in statsmodels and cuML models (it depends on the order).
+
     """
+
     nb = cuml_model.batch_size
     N = cuml_model.complexity
     x = np.zeros(nb * N, dtype=np.float64)
@@ -359,8 +362,11 @@ def test_loglikelihood(key, data, dtype):
 @pytest.mark.parametrize('key, data', test_data)
 @pytest.mark.parametrize('dtype', [np.float64])
 def test_gradient(key, data, dtype):
-    """Test batched gradient implementation against scipy non-batched
-    gradient. Note: it doesn't test that the loglikelihood is correct!
+    """
+    Test batched gradient implementation against scipy non-batched
+    gradient.
+    
+    .. note:: it doesn't test that the loglikelihood is correct!
     """
     order, seasonal_order, intercept = extract_order(key)
     p, _, q = order

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -417,7 +417,7 @@ def test_k_neighbors_classifier_pickle(tmpdir, datatype, data_info, keys):
 def test_neighbors_pickle_nofit(tmpdir, datatype, data_info):
     result = {}
     """
-    Note: This test digs down a bit far into the
+    .. note:: This test digs down a bit far into the
     internals of the implementation, but it's
     important that regressions do not occur
     from changes to the class.

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -461,8 +461,8 @@ def get_memsize(svc):
 def test_svm_memleak(params, n_rows, n_iter, n_cols,
                      use_handle, dataset='blobs'):
     """
-    Test whether there is any memory leak. 
-    
+    Test whether there is any memory leak.
+
     .. note:: small `n_rows`, and `n_cols` values will result in small model
         size, that will not be measured by get_memory_info.
 

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -461,9 +461,11 @@ def get_memsize(svc):
 def test_svm_memleak(params, n_rows, n_iter, n_cols,
                      use_handle, dataset='blobs'):
     """
-    Test whether there is any memory leak. Note: small n_rows, and n_cols
-    values will result in small model size, that will not be measured by
-    get_memory_info.
+    Test whether there is any memory leak. 
+    
+    .. note:: small `n_rows`, and `n_cols` values will result in small model
+        size, that will not be measured by get_memory_info.
+
     """
     X_train, X_test, y_train, y_test = make_dataset(dataset, n_rows, n_cols)
     stream = cuml.cuda.Stream()

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -191,12 +191,12 @@ class ARIMA(Base):
         After fitting, contains the number of iterations before convergence
         for each time series.
 
-    Performance
-    -----------
-    Let ``r=max(p+s*P, q+s*Q+1)``. The device memory used for most operations
-    is ``O(batch_size*n_obs + batch_size*r^2)``. The execution time is a linear
-    function of `n_obs` and `batch_size` (if `batch_size` is large), but grows
-    very fast with `r`.
+    Notes
+    -----
+    *Performance:* Let ``r=max(p+s*P, q+s*Q+1)``. The device memory used for
+    most operations is ``O(batch_size*n_obs + batch_size*r^2)``. The execution
+    time is a linear function of `n_obs` and `batch_size` (if `batch_size` is
+    large), but grows very fast with `r`.
 
     The performance is optimized for very large batch sizes (e.g thousands of
     series).
@@ -205,7 +205,7 @@ class ARIMA(Base):
     ----------
     This class is heavily influenced by the Python library `statsmodels`,
     particularly `statsmodels.tsa.statespace.sarimax.SARIMAX`.
-    See https://www.statsmodels.org/stable/statespace.html
+    See https://www.statsmodels.org/stable/statespace.html.
 
     Additionally the following book is a useful reference:
     "Time Series Analysis by State Space Methods",
@@ -656,7 +656,7 @@ class ARIMA(Base):
             maxiter: int = 1000,
             method="ml",
             truncate: int = 0):
-        """Fit the ARIMA model to each time series.
+        r"""Fit the ARIMA model to each time series.
 
         Parameters
         ----------
@@ -667,18 +667,19 @@ class ARIMA(Base):
             (n, batch_size) for any other type, where n is the corresponding
             number of parameters of this type.
             Pass None for automatic estimation (recommended)
+
         opt_disp : int
-            Fit diagnostic level (for L-BFGS solver) :
-             * `-1` for no output (default)
-             * `0<n<100` for output every `n` steps
-             * `n>100` for more detailed output
+            Fit diagnostic level (for L-BFGS solver):
+
+            * `-1` for no output (default)
+            * `0<n<100` for output every `n` steps
+            * `n>100` for more detailed output
+
         h : float
             Finite-differencing step size. The gradient is computed using
             forward finite differencing:
-            .. code-block:: none
-                    f(x+h) - f(x)
-                g = ------------- + O(h)
-                          h
+            :math:`g = \frac{f(x + \mathtt{h}) - f(x)}{\mathtt{h}} + O(\mathtt{h})`
+
         maxiter : int
             Maximum number of iterations of L-BFGS-B
         method : str

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -101,7 +101,7 @@ class ARIMA(Base):
     large batches of time series.
 
     Examples
-    ---------
+    --------
     .. code-block:: python
 
         import numpy as np
@@ -183,8 +183,8 @@ class ARIMA(Base):
 
     Performance
     -----------
-    Let `r=max(p+s*P, q+s*Q+1)`. The device memory used for most operations
-    is `O(batch_size*n_obs + batch_size*r^2)`. The execution time is a linear
+    Let ``r=max(p+s*P, q+s*Q+1)``. The device memory used for most operations
+    is ``O(batch_size*n_obs + batch_size*r^2)``. The execution time is a linear
     function of `n_obs` and `batch_size` (if `batch_size` is large), but grows
     very fast with `r`.
 
@@ -200,6 +200,7 @@ class ARIMA(Base):
     Additionally the following book is a useful reference:
     "Time Series Analysis by State Space Methods",
     J. Durbin, S.J. Koopman, 2nd Edition (2012).
+
     """
 
     def __init__(self,
@@ -369,7 +370,7 @@ class ARIMA(Base):
     def get_params(self) -> Dict[str, np.ndarray]:
         """Get the parameters of the model
 
-        Returns:
+        Returns
         --------
         params: Dict[str, np.ndarray]
             A dictionary of parameter names and associated arrays
@@ -390,8 +391,8 @@ class ARIMA(Base):
     def set_params(self, params: Mapping[str, object]):
         """Set the parameters of the model
 
-        Parameters:
-        --------
+        Parameters
+        ----------
         params: Mapping[str, np.ndarray]
             A mapping (e.g dictionary) of parameter names and associated arrays
             The key names are in {"mu", "ar", "ma", "sar", "sma", "sigma2"}
@@ -408,23 +409,24 @@ class ARIMA(Base):
     def predict(self, start=0, end=None):
         """Compute in-sample and/or out-of-sample prediction for each series
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         start: int
             Index where to start the predictions (0 <= start <= num_samples)
         end:
             Index where to end the predictions, excluded (end > start)
 
-        Returns:
+        Returns
         --------
         y_p : array-like (device)
             Predictions. Shape = (end - start, batch_size)
 
-        Example:
+        Examples
         --------
         .. code-block:: python
+
             from cuml.tsa.arima import ARIMA
-            ...
+
             model = ARIMA(ys, (1,1,1))
             model.fit()
             y_pred = model.predict()
@@ -505,19 +507,20 @@ class ARIMA(Base):
     def forecast(self, nsteps: int):
         """Forecast the given model `nsteps` into the future.
 
-        Parameters:
+        Parameters
         ----------
         nsteps : int
             The number of steps to forecast beyond end of the given series
 
-        Returns:
+        Returns
         --------
         y_fc : array-like
                Forecasts. Shape = (nsteps, batch_size)
 
-        Example:
+        Examples
         --------
         .. code-block:: python
+
             from cuml.tsa.arima import ARIMA
             ...
             model = ARIMA(ys, (1,1,1))
@@ -611,16 +614,21 @@ class ARIMA(Base):
             number of parameters of this type.
             Pass None for automatic estimation (recommended)
         opt_disp : int
-            Fit diagnostic level (for L-BFGS solver):
+            Fit diagnostic level (for L-BFGS solver) :
              * `-1` for no output (default)
              * `0<n<100` for output every `n` steps
              * `n>100` for more detailed output
+
         h : float
             Finite-differencing step size. The gradient is computed
             using second-order differencing:
+
+            .. code-block
+
                     f(x+h) - f(x - h)
                 g = ----------------- + O(h^2)
                           2 * h
+
         maxiter : int
             Maximum number of iterations of L-BFGS-B
         method : str
@@ -688,7 +696,7 @@ class ARIMA(Base):
     def _loglike(self, x, trans=True, method="ml", truncate=0):
         """Compute the batched log-likelihood for the given parameters.
 
-        Parameters:
+        Parameters
         ----------
         x : array-like
             Packed parameter array, grouped by series
@@ -702,8 +710,8 @@ class ARIMA(Base):
             When using CSS, start the sum of squares after a given number of
             observations
 
-        Returns:
-        --------
+        Returns
+        -------
         loglike : numpy.ndarray
             Batched log-likelihood. Shape: (batch_size,)
         """
@@ -738,7 +746,7 @@ class ARIMA(Base):
         """Compute the gradient (via finite differencing) of the batched
         log-likelihood.
 
-        Parameters:
+        Parameters
         ----------
         x : array-like
             Packed parameter array, grouped by series.
@@ -755,8 +763,8 @@ class ARIMA(Base):
             When using CSS, start the sum of squares after a given number of
             observations
 
-        Returns:
-        --------
+        Returns
+        -------
         grad : numpy.ndarray
             Batched log-likelihood gradient. Shape: (n_params * batch_size,)
             where n_params is the complexity of the model
@@ -797,8 +805,8 @@ class ARIMA(Base):
         """Unpack linearized parameter vector `x` into the separate
         parameter arrays of the model
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x : array-like
             Packed parameter array, grouped by series.
             Shape: (n_params * batch_size,)
@@ -833,8 +841,8 @@ class ARIMA(Base):
     def pack(self) -> np.ndarray:
         """Pack parameters of the model into a linearized vector `x`
 
-        Returns:
-        -----------
+        Returns
+        -------
         x : array-like
             Packed parameter array, grouped by series.
             Shape: (n_params * batch_size,)
@@ -866,14 +874,14 @@ class ARIMA(Base):
     def _batched_transform(self, x, isInv=False):
         """Applies Jones transform or inverse transform to a parameter vector
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         x : array-like
             Packed parameter array, grouped by series.
             Shape: (n_params * batch_size,)
 
-        Returns:
-        -----------
+        Returns
+        -------
         Tx : array-like
             Packed transformed parameter array, grouped by series.
             Shape: (n_params * batch_size,)

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -193,10 +193,11 @@ class ARIMA(Base):
 
     Notes
     -----
-    *Performance:* Let ``r=max(p+s*P, q+s*Q+1)``. The device memory used for
-    most operations is ``O(batch_size*n_obs + batch_size*r^2)``. The execution
-    time is a linear function of `n_obs` and `batch_size` (if `batch_size` is
-    large), but grows very fast with `r`.
+    *Performance:* Let :math:`r=max(p+s*P, q+s*Q+1)`. The device memory used
+    for most operations is
+    :math:`O(\mathtt{batch\_size}*\mathtt{n\_obs} + \mathtt{batch\_size}*r^2)`.
+    The execution time is a linear function of `n_obs` and `batch_size`
+    (if `batch_size` is large), but grows very fast with `r`.
 
     The performance is optimized for very large batch sizes (e.g thousands of
     series).

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -678,7 +678,7 @@ class ARIMA(Base):
         h : float
             Finite-differencing step size. The gradient is computed using
             forward finite differencing:
-            :math:`g = \frac{f(x + \mathtt{h}) - f(x)}{\mathtt{h}} + O(\mathtt{h})`
+            :math:`g = \frac{f(x + \mathtt{h}) - f(x)}{\mathtt{h}} + O(\mathtt{h})` # noqa
 
         maxiter : int
             Maximum number of iterations of L-BFGS-B

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -112,8 +112,8 @@ class AutoARIMA(Base):
     It provides an abstraction around the underlying ARIMA models to predict
     and forecast as if using a single model.
 
-    Example
-    -------
+    Examples
+    --------
     .. code-block:: python
 
         from cuml.tsa.auto_arima import AutoARIMA
@@ -410,7 +410,7 @@ class AutoARIMA(Base):
         end:
             Index where to end the predictions, excluded (end > start)
 
-        Returns:
+        Returns
         --------
         y_p : array-like (device)
             Predictions. Shape = (end - start, batch_size)
@@ -433,7 +433,7 @@ class AutoARIMA(Base):
         nsteps : int
             The number of steps to forecast beyond end of the given series
 
-        Returns:
+        Returns
         --------
         y_fc : array-like
                Forecasts. Shape = (nsteps, batch_size)
@@ -467,8 +467,9 @@ def _parse_sequence(name, seq_in, min_accepted, max_accepted):
 
 def _divide_by_mask(original, mask, batch_id, handle=None):
     """Divide a given batch into two sub-batches according to a boolean mask
-    Note: in case the mask contains only False or only True, one sub-batch
-    will be the original batch (not a copy!) and the other None
+
+    .. note:: in case the mask contains only False or only True, one sub-batch
+        will be the original batch (not a copy!) and the other None
 
     Parameters:
     ----------
@@ -481,7 +482,7 @@ def _divide_by_mask(original, mask, batch_id, handle=None):
     handle : cuml.Handle
         If it is None, a new one is created just for this call
 
-    Returns:
+    Returns
     --------
     out0 : cumlArray (float32 or float64)
         Sub-batch 0, or None if empty
@@ -600,7 +601,7 @@ def _divide_by_min(original, metrics, batch_id, handle=None):
     handle : cuml.Handle
         If it is None, a new one is created just for this call
 
-    Returns:
+    Returns
     --------
     sub_batches : List[cumlArray] (float32 or float64)
         List of arrays containing each sub-batch, or None if empty
@@ -715,7 +716,7 @@ def _build_division_map(id_tracker, batch_size, handle=None):
     batch_size : int
         Size of the initial batch
 
-    Returns:
+    Returns
     --------
     id_to_model : cumlArray (int)
         Associates each batch member with a model
@@ -771,7 +772,7 @@ def _merge_series(data_in, id_to_sub, id_to_pos, batch_size, handle=None):
     batch_size : int
         Size of the initial batch
 
-    Returns:
+    Returns
     --------
     data_out : cumlArray (float32 or float64)
         Merged batch

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -103,7 +103,7 @@ tests_map = {
 
 
 class AutoARIMA(Base):
-    r"""Implements a batched auto-ARIMA model for in- and out-of-sample
+    """Implements a batched auto-ARIMA model for in- and out-of-sample
     times-series prediction.
 
     This interface offers a highly customizable search, with functionality

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -80,13 +80,13 @@ class ExponentialSmoothing(Base):
 
      * predict : no support for in-sample prediction.
         * https://github.com/rapidsai/cuml/issues/875
- 
+
      * hessian : no support for returning Hessian matrix.
         * https://github.com/rapidsai/cuml/issues/880
- 
+
      * information : no support for returning Fisher matrix.
         * https://github.com/rapidsai/cuml/issues/880
- 
+
      * loglike : no support for returning Log-likelihood.
         * https://github.com/rapidsai/cuml/issues/880
 

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -72,32 +72,30 @@ class ExponentialSmoothing(Base):
     data with exponentially decreasing impact. This is done by analyzing
     three components of the data: level, trend, and seasonality.
 
-    Known Limitations
-    -----------------
-    This version of ExponentialSmoothing currently provides only a limited
-    number of features when compared to the
+    Notes
+    -----
+    *Known Limitations:* This version of ExponentialSmoothing currently
+    provides only a limited number of features when compared to the
     `statsmodels.holtwinters.ExponentialSmoothing` model. Noticeably, it lacks:
 
-     * predict : no support for in-sample prediction.
+    * predict : no support for in-sample prediction.
         * https://github.com/rapidsai/cuml/issues/875
 
-     * hessian : no support for returning Hessian matrix.
+    * hessian : no support for returning Hessian matrix.
         * https://github.com/rapidsai/cuml/issues/880
 
-     * information : no support for returning Fisher matrix.
+    * information : no support for returning Fisher matrix.
         * https://github.com/rapidsai/cuml/issues/880
 
-     * loglike : no support for returning Log-likelihood.
+    * loglike : no support for returning Log-likelihood.
         * https://github.com/rapidsai/cuml/issues/880
 
     Additionally, be warned that there may exist floating point instability
     issues in this model. Small values in endog may lead to faulty results.
     See https://github.com/rapidsai/cuml/issues/888 for more information.
 
-    Known Differences
-    -----------------
-    This version of ExponentialSmoothing differs from statsmodels in some
-    other minor ways:
+    *Known Differences:* This version of ExponentialSmoothing differs from
+    statsmodels in some other minor ways:
 
     * Cannot pass trend component or damped trend component
     * this version can take additional parameters `eps`,
@@ -108,6 +106,7 @@ class ExponentialSmoothing(Base):
 
     Examples
     --------
+
     .. code-block:: python
 
         from cuml import ExponentialSmoothing

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -76,19 +76,19 @@ class ExponentialSmoothing(Base):
     -----------------
     This version of ExponentialSmoothing currently provides only a limited
     number of features when compared to the
-    statsmodels.holtwinters.ExponentialSmoothing model. Noticeably, it lacks:
+    `statsmodels.holtwinters.ExponentialSmoothing` model. Noticeably, it lacks:
 
-        * predict : no support for in-sample prediction.
-                       https://github.com/rapidsai/cuml/issues/875
-
-        * hessian : no support for returning Hessian matrix.
-                       https://github.com/rapidsai/cuml/issues/880
-
-        * information : no support for returning Fisher matrix.
-                           https://github.com/rapidsai/cuml/issues/880
-
-        * loglike : no support for returning Log-likelihood.
-                       https://github.com/rapidsai/cuml/issues/880
+     * predict : no support for in-sample prediction.
+        * https://github.com/rapidsai/cuml/issues/875
+ 
+     * hessian : no support for returning Hessian matrix.
+        * https://github.com/rapidsai/cuml/issues/880
+ 
+     * information : no support for returning Fisher matrix.
+        * https://github.com/rapidsai/cuml/issues/880
+ 
+     * loglike : no support for returning Log-likelihood.
+        * https://github.com/rapidsai/cuml/issues/880
 
     Additionally, be warned that there may exist floating point instability
     issues in this model. Small values in endog may lead to faulty results.
@@ -101,39 +101,39 @@ class ExponentialSmoothing(Base):
 
     * Cannot pass trend component or damped trend component
     * this version can take additional parameters `eps`,
-                    `start_periods`, `ts_num`, and `handle`
+      `start_periods`, `ts_num`, and `handle`
     * Score returns SSE rather than gradient logL
-                 https://github.com/rapidsai/cuml/issues/876
+      https://github.com/rapidsai/cuml/issues/876
     * This version provides get_level(), get_trend(), get_season()
 
     Examples
     --------
     .. code-block:: python
 
-            from cuml import ExponentialSmoothing
-            import cudf
-            import numpy as np
-            data = cudf.Series([1, 2, 3, 4, 5, 6,
-                               7, 8, 9, 10, 11, 12,
-                               2, 3, 4, 5, 6, 7,
-                               8, 9, 10, 11, 12, 13,
-                               3, 4, 5, 6, 7, 8, 9,
-                               10, 11, 12, 13, 14],
-                               dtype=np.float64)
-            cu_hw = ExponentialSmoothing(data, seasonal_periods=12)
-            cu_hw.fit()
-            cu_pred = cu_hw.forecast(4)
-            print('Forecasted points:', cu_pred)
-    Output
+        from cuml import ExponentialSmoothing
+        import cudf
+        import numpy as np
+        data = cudf.Series([1, 2, 3, 4, 5, 6,
+                            7, 8, 9, 10, 11, 12,
+                            2, 3, 4, 5, 6, 7,
+                            8, 9, 10, 11, 12, 13,
+                            3, 4, 5, 6, 7, 8, 9,
+                            10, 11, 12, 13, 14],
+                            dtype=np.float64)
+        cu_hw = ExponentialSmoothing(data, seasonal_periods=12)
+        cu_hw.fit()
+        cu_pred = cu_hw.forecast(4)
+        print('Forecasted points:', cu_pred)
 
+    Output:
 
     .. code-block:: python
 
-            Forecasted points :
-            0    4.000143766093652
-            1    5.000000163513641
-            2    6.000000000174092
-            3    7.000000000000178
+        Forecasted points :
+        0    4.000143766093652
+        1    5.000000163513641
+        2    6.000000000174092
+        3    7.000000000000178
 
     Parameters
     ----------
@@ -144,7 +144,8 @@ class ExponentialSmoothing(Base):
         Note: cuDF.DataFrame types assumes data is in columns,
         while all other datatypes assume data is in rows.
         The endogenous dataset to be operated on.
-    seasonal : 'additive', 'add', 'multiplicative', 'mul' (default = 'additive')  # noqa
+    seasonal : 'additive', 'add', 'multiplicative', 'mul' \
+        (default = 'additive')
         Whether the seasonal trend should be calculated
         additively or multiplicatively.
     seasonal_periods : int (default=2)
@@ -435,8 +436,8 @@ class ExponentialSmoothing(Base):
         """
         Returns the score of the model.
 
-        **Note: Currently returns the SSE, rather than the gradient of the
-                LogLikelihood. https://github.com/rapidsai/cuml/issues/876
+        .. note:: Currently returns the SSE, rather than the gradient of the
+            LogLikelihood. https://github.com/rapidsai/cuml/issues/876
 
         Parameters
         ----------


### PR DESCRIPTION
This PR pulls warnings cleanup from `mdemoret-nv:fea-improve-doc-examples-source` which was completed as part of the documentation source improvement. Since that PR is blocked until 0.16, the warning cleanup was cherry picked into a separate PR.

While there are still outstanding warnings, this does clean up the majority of the basic warnings and improves the documentation. This includes the following types of fixes:

- Normalization of section headers
- Fixing References styling to be consistent and look different from attributes/parameters
- Distinction between single backticks, used for referencing members/functions/classes/modules, and double backticks, for inline code
- Addition of `.. note::` sections to replace "Note: "
- Cleanup of indentation errors common with lists and parameters
- Addition of `\` where needed for parameter types
- General fixing of indentation and newlines

Remaining warnings that were not cleaned up:

1. Uncommon section names (such as Known Limitations, Performance, Tips, etc.). These require input from the author on the correct section to move them into.
2. Autosummary failed imports. It's unclear why this is happening.
3. Odd, `WARNING: Unexpected indentation.` messages. The cause is unclear for these warnings.
4. `WARNING: duplicate object description...` seem to be caused by very similar documentation for different objects. Need author input on whether the docs can be tweaked to show the difference between the objects.
5. `WARNING: Unknown target name`. The following [link](https://numpydoc.readthedocs.io/en/latest/format.html#other-points-to-keep-in-mind) suggests this may be due to hyperlinks, however removing all links did not cause the messages to disappear. Need further research.

@dantegd This should hopefully work well with #2635. I would appreciate any feedback you have on these changes