### PR TITLE
[REVIEW] Fix AutoARIMA Python bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - PR #2616: Small test code fix for pandas dtype tests
 - PR #2625: Update Estimator notebook to resolve errors
 - PR #2634: singlegpu build option fixes
+- PR #2651: AutoARIMA Python bug fix
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -306,7 +306,7 @@ class AutoARIMA(Base):
                         break
                 else:  # (when the for loop reaches its end naturally)
                     # The remaining series are assigned the max possible d
-                    data_dD[d_options[-1]] = (data_temp, id_temp)
+                    data_dD[(d_options[-1], D_)] = (data_temp, id_temp)
                 del data_temp, id_temp, mask, out0, index0, out1, index1
         del data_D
 


### PR DESCRIPTION
@KeertiBafna reported a Python exception occuring in `AutoARIMA`.
I managed to reproduce the bug which is due to a trivial error (in some cases the key written in a dictionary was `d` instead of `(d, D)`).