### PR TITLE
Fixes C++ RF predict function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - PR #2616: Small test code fix for pandas dtype tests
 - PR #2625: Update Estimator notebook to resolve errors
 - PR #2634: singlegpu build option fixes
+- PR #2655: Fix C++ RF predict function access of rows/samples array
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -110,7 +110,8 @@ class DecisionTreeBase {
                L *predictions, int verbosity = -1) const;
   void predict_all(const TreeMetaDataNode<T, L> *tree, const T *rows,
                    const int n_rows, const int n_cols, L *preds) const;
-  L predict_one(const T *row,
+  L predict_one(const T *rows, const int row_id, const int n_rows,
+                const int n_cols,
                 const std::vector<SparseTreeNode<T, L>> sparsetree,
                 int idx) const;
 


### PR DESCRIPTION
The C++ RF `predict` function expects array containing rows/samples in row-major fashion. However, RF `fit` function (and most of the other cuML functions) default to column-major. This PR corrects the way in which RF `predict` accesses rows/samples array.