### PR TITLE
Revert "Fixes C++ RF predict function "

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,6 @@
 - PR #2634: singlegpu build option fixes
 - PR #2651: AutoARIMA Python bug fix
 - PR #2654: Fix for vectorizer concatenations
-- PR #2655: Fix C++ RF predict function access of rows/samples array
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 - PR #2634: singlegpu build option fixes
 - PR #2651: AutoARIMA Python bug fix
 - PR #2654: Fix for vectorizer concatenations
+- PR #2669: Revert PR 2655 Revert "Fixes C++ RF predict function"
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -270,15 +270,14 @@ void DecisionTreeBase<T, L>::predict_all(const TreeMetaDataNode<T, L> *tree,
                                          const T *rows, const int n_rows,
                                          const int n_cols, L *preds) const {
   for (int row_id = 0; row_id < n_rows; row_id++) {
-    preds[row_id] =
-      predict_one(rows, row_id, n_rows, n_cols, tree->sparsetree, 0);
+    preds[row_id] = predict_one(&rows[row_id * n_cols], tree->sparsetree, 0);
   }
 }
 
 template <typename T, typename L>
 L DecisionTreeBase<T, L>::predict_one(
-  const T *rows, const int row_id, const int n_rows, const int n_cols,
-  const std::vector<SparseTreeNode<T, L>> sparsetree, int idx) const {
+  const T *row, const std::vector<SparseTreeNode<T, L>> sparsetree,
+  int idx) const {
   int colid = sparsetree[idx].colid;
   T quesval = sparsetree[idx].quesval;
   int leftchild = sparsetree[idx].left_child_id;
@@ -286,14 +285,14 @@ L DecisionTreeBase<T, L>::predict_one(
     CUML_LOG_DEBUG("Leaf node. Predicting %f",
                    (float)sparsetree[idx].prediction);
     return sparsetree[idx].prediction;
-  } else if (rows[colid * n_rows + row_id] <= quesval) {
+  } else if (row[colid] <= quesval) {
     CUML_LOG_DEBUG("Classifying Left @ node w/ column %d and value %f", colid,
                    (float)quesval);
-    return predict_one(rows, row_id, n_rows, n_cols, sparsetree, leftchild);
+    return predict_one(row, sparsetree, leftchild);
   } else {
     CUML_LOG_DEBUG("Classifying Right @ node w/ column %d and value %f", colid,
                    (float)quesval);
-    return predict_one(rows, row_id, n_rows, n_cols, sparsetree, leftchild + 1);
+    return predict_one(row, sparsetree, leftchild + 1);
   }
 }
 

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -110,8 +110,7 @@ class DecisionTreeBase {
                L *predictions, int verbosity = -1) const;
   void predict_all(const TreeMetaDataNode<T, L> *tree, const T *rows,
                    const int n_rows, const int n_cols, L *preds) const;
-  L predict_one(const T *rows, const int row_id, const int n_rows,
-                const int n_cols,
+  L predict_one(const T *row,
                 const std::vector<SparseTreeNode<T, L>> sparsetree,
                 int idx) const;
 


### PR DESCRIPTION
Reverts rapidsai/cuml#2655. The changes made here are not as per the design. Prediction function expects row-major layout by design, which is consistent with FIL.

CC: @teju85 @JohnZed @hcho3 @dantegd