### PR TITLE
FIX Update conda recipes to support CUDA 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #2618: SVM class and sample weights
 - PR #2661: CUDA-11 support for single-gpu code
 - PR #2322: Sparse FIL forests with 8-byte nodes
+- PR #2675: Update conda recipes to support CUDA 11
 
 ## Improvements
 - PR #2336: Eliminate `rmm.device_array` usage

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -42,7 +42,7 @@ nvidia-smi
 
 # Set xgboost version based on CUDA_VERSION
 XGBOOST_VERSION=1.1.0dev.rapidsai0.15
-if [[ "$CUDA_VERSION" == "11.0" ]] ; then
+if [[ "$CUDA_REL" == "11.0" ]] ; then
   XGBOOST_VERSION=1.2.0dev.rapidsai0.15
 fi
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -40,6 +40,12 @@ env
 logger "Check GPU usage..."
 nvidia-smi
 
+# Set xgboost version based on CUDA_VERSION
+XGBOOST_VERSION=1.1.0dev.rapidsai0.15
+if [[ "$CUDA_VERSION" == "11.0" ]] ; then
+  XGBOOST_VERSION=1.2.0dev.rapidsai0.15
+fi
+
 logger "Activate conda env..."
 source activate gdf
 conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
@@ -50,7 +56,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
-      "xgboost==1.1.0dev.rapidsai0.15" \
+      "xgboost=${XGBOOST_VERSION}" \
       "rapids-build-env=$MINOR_VERSION.*" \
       "rapids-notebook-env=$MINOR_VERSION.*" \
       "rapids-doc-env=$MINOR_VERSION.*"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -52,7 +52,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "cudatoolkit=${CUDA_REL}" \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
-      "libcumlprims=0.15.0a200720" \
+      "libcumlprims=0.15.0a200812" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - treelite=0.92
     - cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims 0.15.0a200720
+    - libcumlprims 0.15.0a200812
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
   run:
@@ -39,7 +39,7 @@ requirements:
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims=0.15.0a200720
+    - libcumlprims=0.15.0a200812
     - treelite=0.92
     - cupy>=7,<=8.0.0dev.rapidsai0.15
     - nccl>=2.5

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims=0.15.0a200720
     - treelite=0.92
-    - cupy>=7,<8.0.0a0
+    - cupy>=7,<=8.0.0dev.rapidsai0.15
     - nccl>=2.5
     - ucx-py {{ minor_version }}
     - dask>=2.12.0

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - clang=8.0.1
     - clang-tools=8.0.1
   host:
-    - nccl 2.5.*
+    - nccl >=2.5
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -34,13 +34,13 @@ requirements:
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
-    - libcumlprims=0.15.0a200720
+    - libcumlprims=0.15.0a200812
     - lapack
     - treelite=0.92
     - faiss-proc=*=cuda
     - libfaiss
   run:
-    - libcumlprims=0.15.0a200720
+    - libcumlprims=0.15.0a200812
     - cudf {{ minor_version }}
     - nccl>=2.5
     - ucx-py {{ minor_version }}


### PR DESCRIPTION
Update pinned versions to pull newer versions with support for CUDA 11.

These packages need to be updated:
- `cupy`
- `libcumlprims`
- `nccl`