### PR TITLE
[REVIEW] Fix incorrect "Bad CumlArray Use" error messages on test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - PR #2649: Cleanup sphinx doc warnings for 0.15
 - PR #2668: Order conversion improvements to account for cupy behavior changes
 - PR #2669: Revert PR 2655 Revert "Fixes C++ RF predict function"
+- PR #2683: Fix incorrect "Bad CumlArray Use" error messages on test failures
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -27,6 +27,10 @@ def pytest_runtest_makereport(item: Item, call):
 
     if (report.failed):
 
+        # Save the abs path to this file. We will only mark bad CumlArray uses
+        # if the assertion failure comes from this file
+        conf_test_path = os.path.abspath(__file__)
+
         found_assert = False
 
         # Ensure these attributes exist. They can be missing if something else
@@ -36,8 +40,10 @@ def pytest_runtest_makereport(item: Item, call):
 
             for entry in reversed(report.longrepr.reprtraceback.reprentries):
 
-                if (not found_assert and entry.reprfileloc.message.startswith(
-                        "AssertionError")):
+                if (not found_assert and
+                        entry.reprfileloc.message.startswith("AssertionError")
+                        and os.path.abspath(
+                            entry.reprfileloc.path) == conf_test_path):
                     found_assert = True
                 elif (found_assert):
                     true_path = "{}:{}".format(entry.reprfileloc.path,


### PR DESCRIPTION
This came up from #2674 where several tests were reporting the following message at the bottom of the test log:
```
Incorrect CumlArray uses in class derived from cuml.common.base.Base:
../code/rapidsai/cuml/python/cuml/test/test_svm.py:225
../code/rapidsai/cuml/python/cuml/test/test_nearest_neighbors.py:187
```
The issue that caused the failed test has nothing to do with bad CumlArray usage, but was getting reported this way. The code in `conftest.py` that determines whether it was a bad CumlArray use was not restrictive enough and was flagging any AssertionError as a bad CumlArray use.

This fix is simple, limiting bad CumlArray uses by requiring the assertion failure to happen in `conftest.py`. AssertionErrors in other files will be handled normally.