### PR TITLE
[REVIEW] Improve SVM tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #2611: Adding building doxygen docs to gpu ci
 - PR #2629: Add naive_bayes api docs
 - PR #2643: 'dense' and 'sparse' values of `storage_type` for FIL
+- PR #2686: Improve SVM tests
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -535,8 +535,7 @@ def test_svc_pickle(tmpdir, datatype, params):
                                       data[1], 0, 0)
         else:
             print("comparing base svc")
-            compare_svm(result["model"], pickled_model, data[0], data[1],
-                        cmp_sv=0, dcoef_tol=0)
+            compare_svm(result["model"], pickled_model, data[0], data[1])
 
     pickle_save_load(tmpdir, create_mod, assert_model)
 

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -52,54 +52,65 @@ def array_equal(a, b, tol=1e-6, relative_diff=True, report_summary=False):
     return equal
 
 
-def compare_svm(svm1, svm2, X, y, n_sv_tol=None, b_tol=None, coef_tol=None,
-                cmp_sv=False, dcoef_tol=None, accuracy_tol=None,
+def compare_svm(svm1, svm2, X, y, b_tol=None, coef_tol=None,
                 report_summary=False, cmp_decision_func=False):
     """ Compares two svm classifiers
     Parameters:
     -----------
-    svm1 : svm classifier
-    svm2 : svm classifier
-    accuracy_tol : float, default 0.1%
-        tolerance while comparing the prediction accuracy
+    svm1 : svm classifier to be tested
+    svm2 : svm classifier, the correct model
     b_tol : float
         tolerance while comparing the constant in the decision functions
     coef_tol: float
         tolerance used while comparing coef_ attribute for linear SVM
-    cmp_idx : boolean, default false
-        whether to compare SVs and their indices
-    dcoef_tol: float, default: do not compare dual coefficients
-        tolerance used to compare dual coefs
+
+    Support vector machines have a decision function:
+
+    F(x) = sum_{i=1}^{n_sv} d_i K(x_i, x) + b,
+
+    where n_sv is the number of support vectors, K is the kernel function, x_i
+    are the support vectors, d_i are the dual coefficients (more precisely
+    d = alpha_i * y_i, where alpha_i is the dual coef), and b is the intercept.
+
+    For linear svms K(x_i, x) = x_i * x, and we can simplify F by introducing
+    w = sum_{i=1}^{n_sv} d_i x_i, the normal vector of the separating
+    hyperplane:
+
+    F(x) = w * x + b.
+
+    Mathematically the solution of the optimization should be unique, which
+    means w and b should be unique.
+
+    There could be multiple set of vectors that lead to the same w, therefore
+    comparing parameters d_k, n_sv or the support vector indices can lead to
+    false positives.
+
+    We can only evaluate w for linear models, for nonlinear models we can only
+    test model accuracy and intercept.
     """
 
     n = X.shape[0]
-    svm1_y_hat = svm1.predict(X)
-    svm1_n_wrong = np.sum(np.abs(y - svm1_y_hat))
-    accuracy1 = (n-svm1_n_wrong)*100/n
-    svm2_y_hat = svm2.predict(X)
-    if type(svm2_y_hat) != np.ndarray:
-        svm2_y_hat = svm2_y_hat
-    svm2_n_wrong = np.sum(np.abs(y - svm2_y_hat))
-    accuracy2 = (n-svm2_n_wrong)*100/n
+    accuracy1 = svm1.score(X, y)
+    accuracy2 = svm2.score(X, y)
 
-    if accuracy_tol is None:
-        if n >= 250 and (accuracy1 + accuracy2)/2 <= 75:
-            # 1% accuracy tolerance for not so accurate SVM on "large" dataset
-            accuracy_tol = 1
-        else:
-            accuracy_tol = 0.1
+    # We use at least 0.1% tolerance for accuracy comparison
+    accuracy_tol_min = 0.001
+    if accuracy2 < 1:
+        # Set tolerance to include the 95% confidence interval of svm2's
+        # accuracy. In practice this gives 0.9% tolerance for a 90% accurate
+        # model (assuming n_test = 4000).
+        accuracy_tol = 1.96 * np.sqrt(accuracy2 * (1-accuracy2) / n)
+        if accuracy_tol < accuracy_tol_min:
+            accuracy_tol = accuracy_tol_min
+    else:
+        accuracy_tol = accuracy_tol_min
 
-    assert abs(accuracy1 - accuracy2) <= accuracy_tol
+    assert accuracy1 >= accuracy2 - accuracy_tol
 
-    n_support1 = np.sum(svm1.n_support_)
-    n_support2 = np.sum(svm2.n_support_)
-
-    if n_sv_tol is None:
-        n_sv_tol = max(2, n_support1*0.02)
     if b_tol is None:
         b_tol = 30*svm1.tol
 
-    if accuracy1 < 50:
+    if accuracy2 < 0.5:
         # Increase error margin for classifiers that are not accurate.
         # Although analytically the classifier should always be the same,
         # we fit only until we reach a certain numerical tolerance, and
@@ -110,46 +121,33 @@ def compare_svm(svm1, svm2, X, y, n_sv_tol=None, b_tol=None, coef_tol=None,
         # the classes are concentric blobs, and we cannot separate that with a
         # straight line. When we have a large number of data points, then
         # any separating hyperplane that goes through the center would be good.
-        n_sv_tol *= 10
         b_tol *= 10
         if n >= 250:
             coef_tol = 2  # allow any direction
         else:
             coef_tol *= 10
 
-    assert abs(n_support1-n_support2) <= n_sv_tol
-
+    # Compare model parameter b (intercept). In practice sigmoid models can
+    # have larger differences in the model parameters (while still being within
+    # the accuracy tolerance). We increase b_tol for SVMs with sigmoid kernel.
+    if svm1.kernel == 'sigmoid':
+        b_tol = 0.1
     if abs(svm2.intercept_) > 1e-6:
         assert abs((svm1.intercept_-svm2.intercept_)/svm2.intercept_) <= b_tol
     else:
         assert abs((svm1.intercept_-svm2.intercept_)) <= b_tol
 
-    if coef_tol is None:
-        coef_tol = 1e-5
+    # For linear kernels we can compare the normal vector of the separating
+    # hyperplane w, which is stored in the coef_ attribute.
     if svm1.kernel == 'linear':
+        if coef_tol is None:
+            coef_tol = 1e-5
         cs = np.dot(svm1.coef_, svm2.coef_.T) / \
             (np.linalg.norm(svm1.coef_) * np.linalg.norm(svm2.coef_))
         assert cs > 1 - coef_tol
 
-    if cmp_sv or (dcoef_tol is not None):
-        sidx1 = np.argsort((svm1.support_))
-        sidx2 = np.argsort((svm2.support_))
-
-    if cmp_sv:
-        support_idx1 = ((svm1.support_))[sidx1]
-        support_idx2 = ((svm2.support_))[sidx2]
-        assert np.all(support_idx1-support_idx2) == 0
-        sv1 = ((svm1.support_vectors_))[sidx1, :]
-        sv2 = ((svm2.support_vectors_))[sidx2, :]
-        assert np.all(sv1-sv2 == 0)
-
-    if dcoef_tol is not None:
-        dcoef1 = ((svm1.dual_coef_))[0, sidx1]
-        dcoef2 = ((svm2.dual_coef_))[0, sidx2]
-        assert np.all(np.abs(dcoef1-dcoef2) <= dcoef_tol)
-
     if cmp_decision_func:
-        if accuracy2 > 90:
+        if accuracy2 > 0.9 and svm1.kernel != 'sigmoid':
             df1 = svm1.decision_function(X)
             df2 = svm2.decision_function(X)
             # For classification, the class is determined by
@@ -164,6 +162,16 @@ def compare_svm(svm1, svm2, X, y, n_sv_tol=None, b_tol=None, coef_tol=None,
 
 def make_dataset(dataset, n_rows, n_cols, n_classes=2):
     np.random.seed(137)
+    if n_rows*0.25 < 4000:
+        # Use at least 4000 test samples
+        n_test = 4000
+        if n_rows > 1000:
+            # To avoid a large increase in test time (which is between
+            # O(n_rows^2) and O(n_rows^3)).
+            n_rows = int(n_rows * 0.75)
+        n_rows += n_test
+    else:
+        n_test = n_rows * 0.25
     if dataset == 'classification1':
         X, y = make_classification(
             n_rows, n_cols, n_informative=2, n_redundant=0,
@@ -178,7 +186,7 @@ def make_dataset(dataset, n_rows, n_cols, n_classes=2):
     elif dataset == 'blobs':
         X, y = make_blobs(n_samples=n_rows, n_features=n_cols,
                           centers=n_classes)
-    X_train, X_test, y_train, y_test = train_test_split(X, y)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=n_test)
     # correct case when not all classes made it into the training set
     if np.unique(y_train).size < n_classes:
         for i in range(n_classes):
@@ -252,8 +260,7 @@ def test_svm_skl_cmp_datasets(params, dataset, n_rows, n_cols):
         sklSVC = svm.SVC(**params)
         sklSVC.fit(X_train, y_train)
 
-        compare_svm(cuSVC, sklSVC, X_test, y_test,
-                    n_sv_tol=max(2, 0.02*n_rows), coef_tol=1e-5,
+        compare_svm(cuSVC, sklSVC, X_test, y_test, coef_tol=1e-5,
                     report_summary=True)
 
 
@@ -402,12 +409,7 @@ def test_svm_gamma(params):
     # gamma = 1/(n_cols*X.var())
     cuSVC = cu_svm.SVC(**params)
     cuSVC.fit(X, y)
-    y_pred = cuSVC.predict(X)
-    if x_arraytype == 'dataframe':
-        n_correct = np.sum(y.to_array() == y_pred)
-    else:
-        n_correct = np.sum(y == y_pred)
-    accuracy = n_correct * 100 / n_rows
+    accuracy = cuSVC.score(X, y) * 100
     assert accuracy > 70
 
 

--- a/python/cuml/test/test_svm.py
+++ b/python/cuml/test/test_svm.py
@@ -108,7 +108,7 @@ def compare_svm(svm1, svm2, X, y, b_tol=None, coef_tol=None,
     assert accuracy1 >= accuracy2 - accuracy_tol
 
     if b_tol is None:
-        b_tol = 30*svm1.tol
+        b_tol = 100*svm1.tol  # Using the deafult tol=1e-3 leads to b_tol=0.1
 
     if accuracy2 < 0.5:
         # Increase error margin for classifiers that are not accurate.
@@ -127,11 +127,9 @@ def compare_svm(svm1, svm2, X, y, b_tol=None, coef_tol=None,
         else:
             coef_tol *= 10
 
-    # Compare model parameter b (intercept). In practice sigmoid models can
-    # have larger differences in the model parameters (while still being within
-    # the accuracy tolerance). We increase b_tol for SVMs with sigmoid kernel.
-    if svm1.kernel == 'sigmoid':
-        b_tol = 0.1
+    # Compare model parameter b (intercept). In practice some models can have
+    # same differences in the model parameters while still being within
+    # the accuracy tolerance.
     if abs(svm2.intercept_) > 1e-6:
         assert abs((svm1.intercept_-svm2.intercept_)/svm2.intercept_) <= b_tol
     else:


### PR DESCRIPTION
This PR fixes the SVM testing issue discussed in #2674, and also reported in #2673. Tested with CUDA11 on V100.

- Removed comparison of actual support vector, it was not used
- Removed comparison of dual coefficient, it was not used
- Removed comparison of number of support vectors: it is not robust to compare this, equivalent model can have different number of support vectors.
- Explained in the docstring why these parameters are not tested.
- Increased the tolerance for intercept comparison ~~when kernel is 'sigmoid'~~ for all kernels
- Turned off decision function comparison for sigmoid kernel (it was only enabled in test_svm_skl_cmp_kernels, but it was too strict).
- Set accuracy tolerance based on confidence interval of the expected test accuracy. 
- Increased number of test samples to 4000 to have a reasonable tight tolerance limit. 
