### PR TITLE
[REVIEW] Updating LBFGS warnings log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - PR #2629: Add naive_bayes api docs
 - PR #2643: 'dense' and 'sparse' values of `storage_type` for FIL
 - PR #2686: Improve SVM tests
+- PR #2692: Changin LBFGS log level
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/cpp/src/glm/qn/qn_util.cuh
+++ b/cpp/src/glm/qn/qn_util.cuh
@@ -179,7 +179,7 @@ inline int lbfgs_search_dir(const LBFGSParam<T> &param, int *n_vec,
     // "L-BFGS-B Fortran subroutines for large-scale bound constrained
     // optimization" Ciyou Zhu, Richard H. Byrd, Peihuang Lu and Jorge Nocedal
     // (1994).
-    CUML_LOG_INFO("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
+    CUML_LOG_DEBUG("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
     return end;
   }
   (*n_vec)++;

--- a/cpp/src/glm/qn/qn_util.cuh
+++ b/cpp/src/glm/qn/qn_util.cuh
@@ -179,7 +179,7 @@ inline int lbfgs_search_dir(const LBFGSParam<T> &param, int *n_vec,
     // "L-BFGS-B Fortran subroutines for large-scale bound constrained
     // optimization" Ciyou Zhu, Richard H. Byrd, Peihuang Lu and Jorge Nocedal
     // (1994).
-    CUML_LOG_DEBUG("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
+    CUML_LOG_WARN("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
     return end;
   }
   (*n_vec)++;

--- a/cpp/src/glm/qn/qn_util.cuh
+++ b/cpp/src/glm/qn/qn_util.cuh
@@ -179,7 +179,7 @@ inline int lbfgs_search_dir(const LBFGSParam<T> &param, int *n_vec,
     // "L-BFGS-B Fortran subroutines for large-scale bound constrained
     // optimization" Ciyou Zhu, Richard H. Byrd, Peihuang Lu and Jorge Nocedal
     // (1994).
-    CUML_LOG_WARN("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
+    CUML_LOG_DEBUG("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
     return end;
   }
   (*n_vec)++;


### PR DESCRIPTION
L-BFGS prints more warning than necessary in tests. Changing the log level to debug from info.

Closes https://github.com/rapidsai/cuml/issues/2680