### PR TITLE
[REVIEW] Fix debug build issue due to incorrect host/device method setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 - PR #2668: Order conversion improvements to account for cupy behavior changes
 - PR #2669: Revert PR 2655 Revert "Fixes C++ RF predict function"
 - PR #2683: Fix incorrect "Bad CumlArray Use" error messages on test failures
+- PR #2695: Fix debug build issue due to incorrect host/device method setup
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/cpp/src/arima/batched_kalman.cu
+++ b/cpp/src/arima/batched_kalman.cu
@@ -838,6 +838,8 @@ void init_batched_kalman_matrices(cumlHandle& handle, const double* d_ar,
   int r = order.r();
 
   auto counting = thrust::make_counting_iterator(0);
+  auto n_theta = order.n_theta();
+  auto n_phi = order.n_phi();
   thrust::for_each(
     thrust::cuda::par.on(stream), counting, counting + nb,
     [=] __device__(int bid) {
@@ -859,7 +861,7 @@ void init_batched_kalman_matrices(cumlHandle& handle, const double* d_ar,
       //     |theta_{r-1}|
       //
       d_R_b[bid * rd + n_diff] = 1.0;
-      for (int i = 0; i < order.n_theta(); i++) {
+      for (int i = 0; i < n_theta; i++) {
         d_R_b[bid * rd + n_diff + i + 1] =
           MLCommon::TimeSeries::reduced_polynomial<false>(
             bid, d_ma, order.q, d_sma, order.Q, order.s, i + 1);
@@ -908,7 +910,7 @@ void init_batched_kalman_matrices(cumlHandle& handle, const double* d_ar,
         batch_T[(n_diff - 1) * rd + order.d] = 1.0;
       }
       // 3. Auto-Regressive component
-      for (int i = 0; i < order.n_phi(); i++) {
+      for (int i = 0; i < n_phi; i++) {
         batch_T[n_diff * (rd + 1) + i] =
           MLCommon::TimeSeries::reduced_polynomial<true>(
             bid, d_ar, order.p, d_sar, order.P, order.s, i + 1);


### PR DESCRIPTION
This was observed by @vinaydes while compiling with `DCMAKE_BUILD_TYPE=Debug`. The exact error seen was:
```
/home/vinayd/nwork/git-repos/cuml/cpp/src/arima/batched_kalman.cu(862): error: calling a __host__ function("ML::ARIMAOrder::n_theta const") from a __device__ function(" const") is not allowed/home/vinayd/nwork/git-repos/cuml/cpp/src/arima/batched_kalman.cu(862): error: identifier "ML::ARIMAOrder::n_theta const" is undefined in device code/home/vinayd/nwork/git-repos/cuml/cpp/src/arima/batched_kalman.cu(911): error: calling a __host__ function("ML::ARIMAOrder::n_phi const") from a __device__ function(" const") is not allowed/home/vinayd/nwork/git-repos/cuml/cpp/src/arima/batched_kalman.cu(911): error: identifier "ML::ARIMAOrder::n_phi const" is undefined in device code4 errors detected in the compilation of "/tmp/tmpxft_00004fea_00000000-6_batched_kalman.cpp1.ii".
CMakeFiles/cuml++.dir/build.make:75: recipe for target 'CMakeFiles/cuml++.dir/src/arima/batched_kalman.cu.o' failed
make[2]: *** [CMakeFiles/cuml++.dir/src/arima/batched_kalman.cu.o] Error 1
CMakeFiles/Makefile2:294: recipe for target 'CMakeFiles/cuml++.di
```

One way to fix this was to make all the method in `ARIMAOrder` to be `__host__ __device__`. But that would then mean this header to be renamed to `.cuh`, which in turn would have had ripple effects! So, I chose an approach to minimize the amount of code change by storing the necessary variables by calling the host methods before the kernel call.

My hypothesis for the error: (citation needed!)
I guess during `Release` build compiler is able to successfully inline these methods and thus host/device distinction wouldn't have mattered. However during `Debug` build as compiler will not inline the above methods, this distinction matters, thereby leading to compilation error.