### PR TITLE
[REVIEW] Add sum operator and base operator overloader functions to cumlarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - PR #2648: Replace CNMeM with `rmm::mr::pool_memory_resource`.
 - PR #2686: Improve SVM tests
 - PR #2692: Changin LBFGS log level
+- PR #2705: Add sum operator and base operator overloader functions to cumlarray
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -175,6 +175,9 @@ class CumlArray(Buffer):
     def __add__(self, other):
         return self._operator_overload(other, operator.add)
 
+    def __sub__(self, other):
+        return self._operator_overload(other, operator.sub)
+
     @property
     def __cuda_array_interface__(self):
         output = {

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -16,6 +16,7 @@
 
 import cupy as cp
 import numpy as np
+import operator
 
 from rmm import DeviceBuffer
 from cudf.core import Buffer, Series, DataFrame
@@ -167,6 +168,12 @@ class CumlArray(Buffer):
 
     def __len__(self):
         return self.shape[0]
+
+    def _operator_overload(self, other, fn):
+        return CumlArray(fn(self.to_output('cupy'), other))
+
+    def __add__(self, other):
+        return self._operator_overload(other, operator.add)
 
     @property
     def __cuda_array_interface__(self):
@@ -337,12 +344,12 @@ class CumlArray(Buffer):
 
 
 def _check_low_level_type(data):
-    if not (
+    if isinstance(data, CumlArray):
+        return False
+    elif not (
         hasattr(data, "__array_interface__")
         or hasattr(data, "__cuda_array_interface__")
-    ):
-        return True
-    elif isinstance(data, (DeviceBuffer, Buffer)):
+    ) or isinstance(data, (DeviceBuffer, Buffer)):
         return True
     else:
         return False

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -19,8 +19,9 @@ import sys
 import pytest
 
 import cupy as cp
-import numpy as np
 import cudf
+import numpy as np
+import operator
 
 from copy import deepcopy
 from numba import cuda
@@ -463,6 +464,20 @@ def test_deepcopy(input_type):
     if input_type != 'series':
         # skipping one dimensional ary order test
         assert ary.order == b.order
+
+
+@pytest.mark.parametrize('operation', [operator.add, operator.sub])
+def test_cumlary_binops(operation):
+    a = cp.arange(5)
+    b = cp.arange(5)
+
+    ary_a = CumlArray(a)
+    ary_b = CumlArray(b)
+
+    c = operation(a, b)
+    ary_c = operation(ary_a, ary_b)
+
+    assert(cp.all(ary_c.to_output('cupy') == c))
 
 
 def create_input(input_type, dtype, shape, order):


### PR DESCRIPTION
closes #2704 

MNMG Naive Bayes was failing as reported in that issue because it needs to add 2 CumlArrays, which is a very trivial addition to the capabilities. In general it is very easy to expand the capabilities to more operations as needed, but for now just added as little as possible to fix things for 0.15 release.

Part of #2412 