### PR TITLE
[REVIEW] Fixing OneHotEncoder Overflow Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
 - PR #2669: Revert PR 2655 Revert "Fixes C++ RF predict function"
 - PR #2683: Fix incorrect "Bad CumlArray Use" error messages on test failures
 - PR #2695: Fix debug build issue due to incorrect host/device method setup
+- PR #2709: Fixing OneHotEncoder Overflow Error
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/test_one_hot_encoder.py
+++ b/python/cuml/test/test_one_hot_encoder.py
@@ -11,18 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
+
+import cupy as cp
+import numpy as np
+import pandas as pd
 import pytest
 from cudf import DataFrame
 from cuml.preprocessing import OneHotEncoder
-
-import cupy as cp
-import pandas as pd
-import numpy as np
-
-from sklearn.preprocessing import OneHotEncoder as SkOneHotEncoder
-
 from cuml.test.utils import stress_param
 from pandas.util.testing import assert_frame_equal
+from sklearn.preprocessing import OneHotEncoder as SkOneHotEncoder
 
 
 def from_df_to_array(df):
@@ -307,9 +306,21 @@ def test_onehot_categories_shape_mismatch(as_array):
         OneHotEncoder(categories=categories, sparse=False).fit(X)
 
 
-@pytest.mark.xfail(strict=True, raises=TypeError)
-def test_onehot_category_overflow():
+def test_onehot_category_specific_cases():
     # See this for reasoning: https://github.com/rapidsai/cuml/issues/2690
+
+    # All of these cases use sparse=False, where
+    # test_onehot_category_class_count uses sparse=True
+
+    # ==== 2 Rows (Low before High) ====
+    example_df = DataFrame()
+    example_df["low_cardinality_column"] = ["A"] * 200 + ["B"] * 56
+    example_df["high_cardinality_column"] = cp.linspace(0, 255, 256)
+
+    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
+    encoder.fit_transform(example_df)
+
+    # ==== 2 Rows (High before Low, used to fail) ====
     example_df = DataFrame()
     example_df["high_cardinality_column"] = cp.linspace(0, 255, 256)
     example_df["low_cardinality_column"] = ["A"] * 200 + ["B"] * 56
@@ -318,22 +329,45 @@ def test_onehot_category_overflow():
     encoder.fit_transform(example_df)
 
 
-def test_onehot_category_force_uint64():
+@pytest.mark.parametrize('total_classes',
+                         [np.iinfo(np.uint8).max, np.iinfo(np.uint16).max],
+                         ids=['uint8', 'uint16'])
+def test_onehot_category_class_count(total_classes: int):
     # See this for reasoning: https://github.com/rapidsai/cuml/issues/2690
+    # All tests use sparse=True to avoid memory errors
 
-    # Doesnt fail (low before high)
+    encoder = OneHotEncoder(handle_unknown="ignore", sparse=True)
+
+    # ==== 2 Rows ====
     example_df = DataFrame()
-    example_df["low_cardinality_column"] = ["A"] * 200 + ["B"] * 56
-    example_df["high_cardinality_column"] = cp.linspace(0, 255, 256)
+    example_df["high_cardinality_column"] = cp.linspace(
+        0, total_classes - 1, total_classes)
+    example_df["low_cardinality_column"] = ["A"] * 200 + ["B"] * (
+        total_classes - 200)
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False)
-    encoder.fit_transform(example_df)
+    assert (encoder.fit_transform(example_df).shape[1] == total_classes + 2)
 
-    # Should fail without force_uint64_cols
+    # ==== 3 Rows ====
     example_df = DataFrame()
-    example_df["high_cardinality_column"] = cp.linspace(0, 255, 256)
-    example_df["low_cardinality_column"] = ["A"] * 200 + ["B"] * 56
+    example_df["high_cardinality_column"] = cp.linspace(
+        0, total_classes - 1, total_classes)
+    example_df["low_cardinality_column"] = ["A"] * total_classes
+    example_df["med_cardinality_column"] = ["B"] * total_classes
 
-    encoder = OneHotEncoder(handle_unknown="ignore", sparse=False,
-                            force_uint64_cols=True)
-    encoder.fit_transform(example_df)
+    assert (encoder.fit_transform(example_df).shape[1] == total_classes + 2)
+
+    # ==== N Rows (Even Split) ====
+    num_rows = [3, 10, 100]
+
+    for row_count in num_rows:
+
+        class_per_row = int(math.ceil(total_classes / float(row_count))) + 1
+        example_df = DataFrame()
+
+        for row_idx in range(row_count):
+            example_df[str(row_idx)] = cp.linspace(
+                row_idx * class_per_row, ((row_idx + 1) * class_per_row) - 1,
+                class_per_row)
+
+        assert (encoder.fit_transform(example_df).shape[1] == class_per_row *
+                row_count)


### PR DESCRIPTION
Fixes #2690 

Originally, the plan was to add a better error message to inform the user why this was occurring, and then add an option to the encoder to force using `uint64` dtype to prevent the issue altogether at the expense of memory usage. These have both been added with tests to exercise the options.

However, after this, I was able to come up with a simple alternative fix which only increases the column code dtype when it calculates there will be an overflow. I believe this will work in all scenarios, but I can't be certain.

@JohnZed Can you review these changes? Would appreciate feedback on the following:
1. Is my improved workaround (lines 306-312 of `python/cuml/preprocessing/encoders.py`) sufficient to remove the improved error message and extra option? Or should we keep them in there? (They aren't hurting anything but I cant make tests to exercise them anymore)
2. If we keep them in there, is the option name `force_uint64_cols` descriptive enough?
3. If we keep them in there, is the error message descriptive enough?

Thanks.