### PR TITLE
[BUG] [Review] Set KNeighborsRegressor output dtype according to training target dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@
 - PR #2709: Fixing OneHotEncoder Overflow Error
 - PR #2710: Fix SVC doc statement about predic_proba
 - PR #2718: Fix temp directory for py.test
+- PR #2719: Set KNeighborsRegressor output dtype according to training target dtype
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -159,6 +159,7 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
         Fit a GPU index for k-nearest neighbors regression model.
 
         """
+        self._set_target_dtype(y)
         super(KNeighborsRegressor, self).fit(X, convert_dtype=convert_dtype)
         self._y, _, _, _ = \
             input_to_cuml_array(y, order='F', check_dtype=np.float32,
@@ -180,6 +181,7 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
         """
 
         out_type = self._get_output_type(X)
+        out_dtype = self._get_target_dtype() if convert_dtype else None
 
         knn_indices = self.kneighbors(X, return_distance=False,
                                       convert_dtype=convert_dtype)
@@ -219,7 +221,7 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
 
         self.handle.sync()
 
-        return results.to_output(out_type)
+        return results.to_output(out_type, output_dtype=out_dtype)
 
     def get_param_names(self):
         return super(KNeighborsRegressor, self).get_param_names() \

--- a/python/cuml/test/test_kneighbors_regressor.py
+++ b/python/cuml/test/test_kneighbors_regressor.py
@@ -104,6 +104,23 @@ def test_score(nrows, ncols, n_neighbors, n_clusters, datatype):
     assert knn_cu.score(X, y) >= 0.9999
 
 
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_score_dtype(dtype):
+    # Using make_blobs here to check averages and neighborhoods
+    X, y = make_blobs(n_samples=1000, centers=2,
+                      cluster_std=0.01,
+                      n_features=50, random_state=0)
+
+    X = X.astype(dtype)
+    y = y.astype(dtype)
+
+    knn_cu = cuKNN(n_neighbors=5)
+    knn_cu.fit(X, y)
+    pred = knn_cu.predict(X)
+    assert pred.dtype == dtype
+    assert knn_cu.score(X, y) >= 0.9999
+
+
 @pytest.mark.parametrize("input_type", ["cudf", "numpy", "cupy"])
 @pytest.mark.parametrize("output_type", ["cudf", "numpy", "cupy"])
 def test_predict_multioutput(input_type, output_type):


### PR DESCRIPTION
KNN works with fp32 under the hood. This PR sets the prediction output dtype for KNNRegressor to be equal with the training target dtype.

Without this PR, the following code

```python
import numpy as np
from sklearn.datasets import make_blobs
from cuml.neighbors import KNeighborsRegressor as KNN

X, y = make_blobs(n_samples=1000, centers=2, cluster_std=0.01, n_features=50, random_state=0)
X = X.astype(np.float64)
y = y.astype(X.dtype)

knn = KNN()
knn.fit(X, y)
knn.score(X, y)
```
produces the following error
```
TypeError: Expected input to be of type in [dtype('float64')] but got float32
```

A test is added to check if the score method works for both fp32 and fp64 input types.

Tagging @JohnZed to decide whether this should be included for 0.15.