### PR TITLE
[REVIEW] Getting cuML covariance passing w/ Cupy 7.8 & CUDA 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@
 - PR #2711: Fix Dask RF failure intermittently
 - PR #2718: Fix temp directory for py.test
 - PR #2720: Updates to outdated links
+- PR #2722: Getting cuML covariance test passing w/ Cupy 7.8 & CUDA 11
 
 # cuML 0.14.0 (03 Jun 2020)
 

--- a/python/cuml/test/test_stats.py
+++ b/python/cuml/test/test_stats.py
@@ -26,7 +26,8 @@ from cuml.test.utils import array_equal
 @pytest.mark.parametrize("dtype", [cp.float32, cp.float64])
 def test_cov(nrows, ncols, sparse, dtype):
     if sparse:
-        x = cp.sparse.random(nrows, ncols, density=0.07, format='csr', dtype=dtype)
+        x = cp.sparse.random(nrows, ncols, density=0.07,
+                             format='csr', dtype=dtype)
     else:
         x = cp.random.random((nrows, ncols), dtype=dtype)
 

--- a/python/cuml/test/test_stats.py
+++ b/python/cuml/test/test_stats.py
@@ -26,9 +26,9 @@ from cuml.test.utils import array_equal
 @pytest.mark.parametrize("dtype", [cp.float32, cp.float64])
 def test_cov(nrows, ncols, sparse, dtype):
     if sparse:
-        x = cp.sparse.random(nrows, ncols, density=0.07)
+        x = cp.sparse.random(nrows, ncols, density=0.07, format='csr', dtype=dtype)
     else:
-        x = cp.random.random((nrows, ncols))
+        x = cp.random.random((nrows, ncols), dtype=dtype)
 
     cov_result = cov(x, x)
 
@@ -38,4 +38,4 @@ def test_cov(nrows, ncols, sparse, dtype):
         x = x.todense()
     local_cov = cp.cov(x, rowvar=False, ddof=0)
 
-    assert array_equal(cov_result, local_cov, 1e-7, with_sign=True)
+    assert array_equal(cov_result, local_cov, 1e-6, with_sign=True)


### PR DESCRIPTION
This is a very subtle bug and I'm root causing the exact place where using a COO, rather than a CSR, is causing differences in outputs (my current guess is there's a bug in only one of the arithmetic / conversion ops.). This should fix CI in the meantime. 

Closes #2724 