### PR TITLE
[gpuCI] Auto-merge branch-0.15 to branch-0.16 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - PR #2705: Add sum operator and base operator overloader functions to cumlarray
 - PR #2701: Updating README + Adding ref to UMAP paper
 - PR #2721: Update API docs
+- PR #2730: Unpin cumlprims in conda recipes for release
 
 ## Bug Fixes
 - PR #2369: Update RF code to fix set_params memory leak

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,7 +46,7 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "cudatoolkit=${CUDA_REL}" \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
-      "libcumlprims=0.15.0a200812" \
+      "libcumlprims=${MINOR_VERSION}" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - treelite=0.92
     - cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims 0.15.0a200812
+    - libcumlprims {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
   run:
@@ -39,7 +39,7 @@ requirements:
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims=0.15.0a200812
+    - libcumlprims {{ minor_version }}
     - treelite=0.92
     - cupy>=7,<=8.0.0dev.rapidsai0.15
     - nccl>=2.5

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -34,14 +34,14 @@ requirements:
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
-    - libcumlprims=0.15.0a200812
+    - libcumlprims {{ minor_version }}
     - lapack
     - treelite=0.92
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - libfaiss
   run:
-    - libcumlprims=0.15.0a200812
+    - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
     - nccl>=2.5
     - ucx-py {{ minor_version }}


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.15` that creates a PR to keep `branch-0.16` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.