### PR TITLE
[REVIEW] Update seed to random_state in random forest and associated tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #2735: Update seed to random_state in random forest and associated tests
 
 ## Bug Fixes
 

--- a/python/cuml/dask/ensemble/base.py
+++ b/python/cuml/dask/ensemble/base.py
@@ -64,7 +64,7 @@ class BaseRandomForestModel(object):
             worker: self.client.submit(
                 model_func,
                 n_estimators=self.n_estimators_per_worker[n],
-                seed=seeds[n],
+                random_state=seeds[n],
                 **kwargs,
                 pure=False,
                 workers=[worker],

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -105,7 +105,10 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
     workers : optional, list of strings
         Dask addresses of workers to use for computation.
         If None, all available Dask workers will be used.
+    random_state : int (default = None)
+        Seed for the random number generator. Unseeded by default.
     seed : int (default = None)
+        Deprecated in favor of `random_state`.
         Base seed for the random number generator. Unseeded by default. Does
         not currently fully guarantee the exact same results.
     ignore_empty_partitions: Boolean (default = False)
@@ -136,25 +139,37 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         super(RandomForestClassifier, self).__init__(client=client,
                                                      verbose=verbose,
                                                      **kwargs)
+        if seed is not None:
+            if random_state is None:
+                warnings.warn("Parameter 'seed' is deprecated and will be"
+                              " removed in 0.17. Please use 'random_state'"
+                              " instead.",
+                              DeprecationWarning)
+                random_state = seed
+            else:
+                warnings.warn("Both 'seed' and 'random_state' parameters were"
+                              " set. Using 'random_state' since 'seed' is"
+                              " deprecated and will be removed in 0.17.",
+                              DeprecationWarning)
 
         self._create_model(
             model_func=RandomForestClassifier._construct_rf,
             client=client,
             workers=workers,
             n_estimators=n_estimators,
-            base_seed=seed,
+            base_seed=random_state,
             ignore_empty_partitions=ignore_empty_partitions,
             **kwargs)
 
     @staticmethod
     def _construct_rf(
         n_estimators,
-        seed,
+        random_state,
         **kwargs
     ):
         return cuRFC(
             n_estimators=n_estimators,
-            seed=seed,
+            random_state=random_state,
             **kwargs
         )
 

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -146,7 +146,8 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
             if random_state is None:
                 warnings.warn("Parameter 'seed' is deprecated and will be"
                               " removed in 0.17. Please use 'random_state'"
-                              " instead.",
+                              " instead. Setting 'random_state' as the"
+                              " curent 'seed' value",
                               DeprecationWarning)
                 random_state = seed
             else:

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+import warnings
+
 import numpy as np
 
 from cuml.dask.common.base import BaseEstimator
@@ -131,6 +133,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         client=None,
         verbose=False,
         n_estimators=10,
+        random_state=None,
         seed=None,
         ignore_empty_partitions=False,
         **kwargs

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+import warnings
+
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.ensemble import RandomForestRegressor as cuRFR
 from cuml.dask.ensemble.base import \

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -145,7 +145,8 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
             if random_state is None:
                 warnings.warn("Parameter 'seed' is deprecated and will be"
                               " removed in 0.17. Please use 'random_state'"
-                              " instead.",
+                              " instead. Setting 'random_state' as the"
+                              " curent 'seed' value",
                               DeprecationWarning)
                 random_state = seed
             else:

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -45,7 +45,7 @@ class BaseRandomForestModel(Base):
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}
 
-    def __init__(self, split_criterion, random_state=None,
+    def __init__(self, split_criterion, seed=None,
                  n_streams=8, n_estimators=100,
                  max_depth=16, handle=None, max_features='auto',
                  n_bins=8, split_algo=1, bootstrap=True,
@@ -57,7 +57,7 @@ class BaseRandomForestModel(Base):
                  min_weight_fraction_leaf=None, n_jobs=None,
                  max_leaf_nodes=None, min_impurity_decrease=0.0,
                  min_impurity_split=None, oob_score=None,
-                 warm_start=None, class_weight=None,
+                 random_state=None, warm_start=None, class_weight=None,
                  quantile_per_tree=False, criterion=None):
 
         if accuracy_metric:
@@ -69,7 +69,6 @@ class BaseRandomForestModel(Base):
                           "max_leaf_nodes": max_leaf_nodes,
                           "min_impurity_split": min_impurity_split,
                           "oob_score": oob_score, "n_jobs": n_jobs,
-#                           "random_state": random_state,
                           "warm_start": warm_start,
                           "class_weight": class_weight}
 
@@ -81,6 +80,19 @@ class BaseRandomForestModel(Base):
                     " please read the cuML documentation at "
                     "(https://docs.rapids.ai/api/cuml/nightly/"
                     "api.html#random-forest) for more information")
+
+        if seed is not None:
+            if random_state is None:
+                warnings.warn("Parameter 'seed' is deprecated and will be"
+                              "removed in 0.17. Please use 'random_state'"
+                              " instead.",
+                              DeprecationWarning)
+                random_state = seed
+            else:
+                warnings.warn("Both 'seed' and 'random_state' parameters were"
+                              " set. Using 'random_state' since 'seed' is"
+                              " deprecated and will be removed in 0.17.",
+                              DeprecationWarning)
 
         if ((random_state is not None) and (n_streams != 1)):
             warnings.warn("For reproducible results in Random Forest"

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -84,7 +84,7 @@ class BaseRandomForestModel(Base):
         if seed is not None:
             if random_state is None:
                 warnings.warn("Parameter 'seed' is deprecated and will be"
-                              "removed in 0.17. Please use 'random_state'"
+                              " removed in 0.17. Please use 'random_state'"
                               " instead.",
                               DeprecationWarning)
                 random_state = seed

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -45,7 +45,7 @@ class BaseRandomForestModel(Base):
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}
 
-    def __init__(self, split_criterion, seed=None,
+    def __init__(self, split_criterion, random_state=None,
                  n_streams=8, n_estimators=100,
                  max_depth=16, handle=None, max_features='auto',
                  n_bins=8, split_algo=1, bootstrap=True,
@@ -57,7 +57,7 @@ class BaseRandomForestModel(Base):
                  min_weight_fraction_leaf=None, n_jobs=None,
                  max_leaf_nodes=None, min_impurity_decrease=0.0,
                  min_impurity_split=None, oob_score=None,
-                 random_state=None, warm_start=None, class_weight=None,
+                 warm_start=None, class_weight=None,
                  quantile_per_tree=False, criterion=None):
 
         if accuracy_metric:
@@ -69,7 +69,7 @@ class BaseRandomForestModel(Base):
                           "max_leaf_nodes": max_leaf_nodes,
                           "min_impurity_split": min_impurity_split,
                           "oob_score": oob_score, "n_jobs": n_jobs,
-                          "random_state": random_state,
+#                           "random_state": random_state,
                           "warm_start": warm_start,
                           "class_weight": class_weight}
 
@@ -82,13 +82,13 @@ class BaseRandomForestModel(Base):
                     "(https://docs.rapids.ai/api/cuml/nightly/"
                     "api.html#random-forest) for more information")
 
-        if ((seed is not None) and (n_streams != 1)):
+        if ((random_state is not None) and (n_streams != 1)):
             warnings.warn("For reproducible results in Random Forest"
                           " Classifier or for almost reproducible results"
                           " in Random Forest Regressor, n_streams==1 is "
                           "recommended. If n_streams is > 1, results may vary "
                           "due to stream/thread timing differences, even when "
-                          "random_seed is set")
+                          "random_state is set")
         if handle is None:
             handle = Handle(n_streams)
 
@@ -126,7 +126,7 @@ class BaseRandomForestModel(Base):
         self.accuracy_metric = accuracy_metric
         self.quantile_per_tree = quantile_per_tree
         self.n_streams = handle.getNumInternalStreams()
-        self.seed = seed
+        self.random_state = random_state
         self.rf_forest = 0
         self.rf_forest64 = 0
         self.model_pbuf_bytes = bytearray()

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -85,7 +85,8 @@ class BaseRandomForestModel(Base):
             if random_state is None:
                 warnings.warn("Parameter 'seed' is deprecated and will be"
                               " removed in 0.17. Please use 'random_state'"
-                              " instead.",
+                              " instead. Setting 'random_state' as the"
+                              " curent 'seed' value",
                               DeprecationWarning)
                 random_state = seed
             else:

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -225,6 +225,9 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         Only relevant for GLOBAL_QUANTILE split_algo.
     random_state : int (default = None)
         Seed for the random number generator. Unseeded by default.
+    seed : int (default = None)
+        Deprecated in favor of `random_state`.
+        Seed for the random number generator. Unseeded by default.
 
     """
 

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -219,7 +219,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     quantile_per_tree : boolean (default = False)
         Whether quantile is computed for individal trees in RF.
         Only relevant for GLOBAL_QUANTILE split_algo.
-    seed : int (default = None)
+    random_state : int (default = None)
         Seed for the random number generator. Unseeded by default.
 
     """
@@ -425,10 +425,10 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             new RandomForestMetaData[double, int]()
         self.rf_forest64 = <uintptr_t> rf_forest64
 
-        if self.seed is None:
+        if self.random_state is None:
             seed_val = <uintptr_t>NULL
         else:
-            seed_val = <uintptr_t>self.seed
+            seed_val = <uintptr_t>self.random_state
 
         rf_params = set_rf_class_obj(<int> self.max_depth,
                                      <int> self.max_leaves,

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -214,6 +214,10 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     random_state : int (default = None)
         Seed for the random number generator. Unseeded by default. Does not
         currently fully guarantee the exact same results.
+    seed : int (default = None)
+        Deprecated in favor of `random_state`.
+        Seed for the random number generator. Unseeded by default. Does not
+        currently fully guarantee the exact same results.
 
     """
 

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -209,7 +209,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     quantile_per_tree : boolean (default = False)
         Whether quantile is computed for individal trees in RF.
         Only relevant for GLOBAL_QUANTILE split_algo.
-    seed : int (default = None)
+    random_state : int (default = None)
         Seed for the random number generator. Unseeded by default. Does not
         currently fully guarantee the exact same results.
 
@@ -407,10 +407,10 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         cdef RandomForestMetaData[double, double] *rf_forest64 = \
             new RandomForestMetaData[double, double]()
         self.rf_forest64 = <uintptr_t> rf_forest64
-        if self.seed is None:
+        if self.random_state is None:
             seed_val = <uintptr_t>NULL
         else:
-            seed_val = <uintptr_t>self.seed
+            seed_val = <uintptr_t>self.random_state
 
         rf_params = set_rf_class_obj(<int> self.max_depth,
                                      <int> self.max_leaves,

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -326,13 +326,17 @@ def train_test_split(X,
 
     if seed is not None:
         if random_state is None:
-            warnings.warn("Parameter 'seed' is deprecated, please use \
-                          'random_state' instead.")
+            warnings.warn("Parameter 'seed' is deprecated and will be"
+                          " removed in 0.17. Please use 'random_state'"
+                          " instead. Setting 'random_state' as the"
+                          " curent 'seed' value",
+                          DeprecationWarning)
             random_state = seed
         else:
-            warnings.warn("Both 'seed' and 'random_state' parameters were \
-                          set, using 'random_state' since 'seed' is \
-                          deprecated. ")
+            warnings.warn("Both 'seed' and 'random_state' parameters were"
+                          " set. Using 'random_state' since 'seed' is"
+                          " deprecated and will be removed in 0.17.",
+                          DeprecationWarning)
 
     # Determining sizes of splits
     if isinstance(train_size, float):

--- a/python/cuml/test/dask/test_random_forest.py
+++ b/python/cuml/test/dask/test_random_forest.py
@@ -91,7 +91,7 @@ def test_rf_classification_multi_class(partitions_per_worker, cluster):
             'n_estimators': 25,
             'max_depth': 16,
             'n_bins': 256,
-            'seed': 10,
+            'random_state': 10,
         }
 
         X_train_df, y_train_df = _prep_training_data(c, X_train, y_train,

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -632,7 +632,7 @@ def test_small_rf(tmpdir, key, datatype, nrows, ncols, n_info):
                                                                n_info,
                                                                n_classes=2)
         model = rf_models[key](n_estimators=1, max_depth=1,
-                               max_features=1.0, seed=10)
+                               max_features=1.0, random_state=10)
         model.fit(X_train, y_train)
         result['rf_res'] = model.predict(X_test)
         return model, X_test

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -157,7 +157,7 @@ def test_rf_classification(small_clf, datatype, split_algo,
     # random forest classification model
     cuml_model = curfc(max_features=max_features, rows_sample=rows_sample,
                        n_bins=16, split_algo=split_algo, split_criterion=0,
-                       min_rows_per_node=2, seed=123, n_streams=1,
+                       min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=40, handle=handle, max_leaves=-1,
                        max_depth=16)
     cuml_model.fit(X_train, y_train)
@@ -204,7 +204,7 @@ def test_rf_regression(special_reg, datatype, split_algo, max_features,
     # Initialize and fit using cuML's random forest regression model
     cuml_model = curfr(max_features=max_features, rows_sample=rows_sample,
                        n_bins=16, split_algo=split_algo, split_criterion=2,
-                       min_rows_per_node=2, seed=123, n_streams=1,
+                       min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=50, handle=handle, max_leaves=-1,
                        max_depth=16, accuracy_metric='mse')
     cuml_model.fit(X_train, y_train)
@@ -241,7 +241,7 @@ def test_rf_classification_seed(small_clf, datatype):
         seed = random.randint(100, 1e5)
         # Initialize, fit and predict using cuML's
         # random forest classification model
-        cu_class = curfc(seed=seed, n_streams=1)
+        cu_class = curfc(random_state=seed, n_streams=1)
         cu_class.fit(X_train, y_train)
 
         # predict using FIL
@@ -256,7 +256,7 @@ def test_rf_classification_seed(small_clf, datatype):
 
         # Initialize, fit and predict using cuML's
         # random forest classification model
-        cu_class2 = curfc(seed=seed, n_streams=1)
+        cu_class2 = curfc(random_state=seed, n_streams=1)
         cu_class2.fit(X_train, y_train)
 
         # predict using FIL
@@ -383,7 +383,7 @@ def rf_classification(datatype, array_type, max_features, rows_sample,
     # random forest classification model
     cuml_model = curfc(max_features=max_features, rows_sample=rows_sample,
                        n_bins=16, split_criterion=0,
-                       min_rows_per_node=2, seed=123,
+                       min_rows_per_node=2, random_state=123,
                        n_estimators=40, handle=handle, max_leaves=-1,
                        max_depth=16)
     if array_type == 'dataframe':
@@ -463,7 +463,7 @@ def test_rf_classification_sparse(small_clf, datatype,
     # Initialize, fit and predict using cuML's
     # random forest classification model
     cuml_model = curfc(n_bins=16, split_criterion=0,
-                       min_rows_per_node=2, seed=123, n_streams=1,
+                       min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=num_treees, handle=handle, max_leaves=-1,
                        max_depth=40)
     cuml_model.fit(X_train, y_train)
@@ -530,7 +530,7 @@ def test_rf_regression_sparse(special_reg, datatype, fil_sparse_format, algo):
 
     # Initialize and fit using cuML's random forest regression model
     cuml_model = curfr(n_bins=16, split_criterion=2,
-                       min_rows_per_node=2, seed=123, n_streams=1,
+                       min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=num_treees, handle=handle, max_leaves=-1,
                        max_depth=40, accuracy_metric='mse')
     cuml_model.fit(X_train, y_train)
@@ -715,7 +715,7 @@ def test_rf_printing(capfd, n_estimators, detailed_printing):
     # Initialize cuML Random Forest classification model
     cuml_model = curfc(handle=handle, max_features=1.0, rows_sample=1.0,
                        n_bins=16, split_algo=0, split_criterion=0,
-                       min_rows_per_node=2, seed=23707, n_streams=1,
+                       min_rows_per_node=2, random_state=23707, n_streams=1,
                        n_estimators=n_estimators, max_leaves=-1,
                        max_depth=16)
 
@@ -762,12 +762,12 @@ def test_rf_host_memory_leak(large_clf, estimator_type):
     if estimator_type == 'classification':
         base_model = curfc(max_depth=10,
                            n_estimators=100,
-                           seed=123)
+                           random_state=123)
         y = y.astype(np.int32)
     else:
         base_model = curfr(max_depth=10,
                            n_estimators=100,
-                           seed=123)
+                           random_state=123)
         y = y.astype(np.float32)
 
     # Pre-fit once - this is our baseline and memory usage
@@ -808,12 +808,12 @@ def test_concat_memory_leak(large_clf, estimator_type):
     if estimator_type == 'classification':
         base_models = [curfc(max_depth=10,
                              n_estimators=100,
-                             seed=123) for i in range(n_models)]
+                             random_state=123) for i in range(n_models)]
         y = y.astype(np.int32)
     elif estimator_type == 'regression':
         base_models = [curfr(max_depth=10,
                              n_estimators=100,
-                             seed=123) for i in range(n_models)]
+                             random_state=123) for i in range(n_models)]
         y = y.astype(np.float32)
     else:
         assert False


### PR DESCRIPTION
This PR:
- Deprecates the user-facing seed argument in Random Forest (regression/classification) in favor of `random_state` and updates the associated tests accordingly.
- Follows the general logic in `model_selection.train_test_split` for the `seed` deprecation, but specifically calls out removal in the following release (i.e., 0.17), adds a DeprecationWarning, and fixes the whitespace issues.

- [x] Single GPU RF passing local tests
- [x] Dask RF passing local tests (intermittent accuracy related failures I suspect are unrelated)

This closes #1995 