### PR TITLE
[REVIEW] Support larger numbers of classes in KNeighborsClassifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Bug Fixes
 
+- PR #2744: Supporting larger number of classes in KNeighborsClassifier
+
 # cuML 0.15.0 (Date TBD)
 
 ## New Features

--- a/cpp/src/knn/knn.cu
+++ b/cpp/src/knn/knn.cu
@@ -59,7 +59,7 @@ void knn_classify(cumlHandle &handle, int *out, int64_t *knn_indices,
   std::vector<int> n_unique(y.size());
 
   for (int i = 0; i < y.size(); i++) {
-    MLCommon::Label::getUniqueLabels(y[i], n_query_rows, &(uniq_labels[i]),
+    MLCommon::Label::getUniqueLabels(y[i], n_index_rows, &(uniq_labels[i]),
                                      &(n_unique[i]), stream, d_alloc);
   }
 
@@ -85,7 +85,7 @@ void knn_class_proba(cumlHandle &handle, std::vector<float *> &out,
   std::vector<int> n_unique(y.size());
 
   for (int i = 0; i < y.size(); i++) {
-    MLCommon::Label::getUniqueLabels(y[i], n_query_rows, &(uniq_labels[i]),
+    MLCommon::Label::getUniqueLabels(y[i], n_index_rows, &(uniq_labels[i]),
                                      &(n_unique[i]), stream, d_alloc);
   }
 

--- a/cpp/src_prims/selection/knn.cuh
+++ b/cpp/src_prims/selection/knn.cuh
@@ -375,16 +375,18 @@ template <typename OutType = int>
 __global__ void class_vote_kernel(OutType *out, const float *class_proba,
                                   int *unique_labels, int n_uniq_labels,
                                   size_t n_samples, int n_outputs,
-                                  int output_offset) {
+                                  int output_offset, bool use_shared_mem) {
   int row = (blockIdx.x * blockDim.x) + threadIdx.x;
   int i = row * n_uniq_labels;
 
   extern __shared__ int label_cache[];
-  for (int j = threadIdx.x; j < n_uniq_labels; j += blockDim.x) {
-    label_cache[j] = unique_labels[j];
-  }
+  if(use_shared_mem) {
+	  for (int j = threadIdx.x; j < n_uniq_labels; j += blockDim.x) {
+	    label_cache[j] = unique_labels[j];
+	  }
 
-  __syncthreads();
+	  __syncthreads();
+  }
 
   if (row >= n_samples) return;
   float cur_max = -1.0;
@@ -396,7 +398,10 @@ __global__ void class_vote_kernel(OutType *out, const float *class_proba,
       cur_label = j;
     }
   }
-  out[row * n_outputs + output_offset] = label_cache[cur_label];
+
+  int val = use_shared_mem ? label_cache[cur_label] : unique_labels[cur_label];
+
+  out[row * n_outputs + output_offset] = val;
 }
 
 template <typename LabelType, bool precomp_lbls = false>
@@ -409,7 +414,6 @@ __global__ void regress_avg_kernel(LabelType *out, const int64_t *knn_indices,
 
   if (row >= n_samples) return;
 
-  // should work for moderately small number of classes
   LabelType pred = 0;
   for (int j = 0; j < n_neighbors; j++) {
     pred += get_lbls<precomp_lbls>(labels, knn_indices, i + j);
@@ -550,11 +554,13 @@ void knn_classify(int *out, const int64_t *knn_indices, std::vector<int *> &y,
     /**
      * Choose max probability
      */
-
+    // Use shared memory for label lookups if the number of classes is small enough
     int smem = sizeof(int) * n_unique_labels;
-    class_vote_kernel<<<grid, blk, smem, stream>>>(
+    bool use_shared_mem = smem < MLCommon::getSharedMemPerBlock();
+
+    class_vote_kernel<<<grid, blk, use_shared_mem ? smem : 0, stream>>>(
       out, probs[i], uniq_labels[i], n_unique_labels, n_query_rows, y.size(),
-      i);
+      i, use_shared_mem);
     CUDA_CHECK(cudaPeekAtLastError());
 
     delete tmp_probs[i];

--- a/cpp/src_prims/selection/knn.cuh
+++ b/cpp/src_prims/selection/knn.cuh
@@ -380,12 +380,12 @@ __global__ void class_vote_kernel(OutType *out, const float *class_proba,
   int i = row * n_uniq_labels;
 
   extern __shared__ int label_cache[];
-  if(use_shared_mem) {
-	  for (int j = threadIdx.x; j < n_uniq_labels; j += blockDim.x) {
-	    label_cache[j] = unique_labels[j];
-	  }
+  if (use_shared_mem) {
+    for (int j = threadIdx.x; j < n_uniq_labels; j += blockDim.x) {
+      label_cache[j] = unique_labels[j];
+    }
 
-	  __syncthreads();
+    __syncthreads();
   }
 
   if (row >= n_samples) return;
@@ -559,8 +559,8 @@ void knn_classify(int *out, const int64_t *knn_indices, std::vector<int *> &y,
     bool use_shared_mem = smem < MLCommon::getSharedMemPerBlock();
 
     class_vote_kernel<<<grid, blk, use_shared_mem ? smem : 0, stream>>>(
-      out, probs[i], uniq_labels[i], n_unique_labels, n_query_rows, y.size(),
-      i, use_shared_mem);
+      out, probs[i], uniq_labels[i], n_unique_labels, n_query_rows, y.size(), i,
+      use_shared_mem);
     CUDA_CHECK(cudaPeekAtLastError());
 
     delete tmp_probs[i];

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -191,8 +191,8 @@ def test_predict_large_n_classes(datatype):
     y_hat = knn_cu.predict(X_test)
 
     if datatype == "dataframe":
-        y_hat = y_hat.to_gpu_array().copy_to_host()
-        y_test = y_test.as_gpu_matrix().copy_to_host().ravel()
+        y_hat = y_hat.as_matrix()
+        y_test = y_test.as_matrix().ravel()
 
     assert array_equal(y_hat.astype(np.int32), y_test.astype(np.int32))
 

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -263,9 +263,6 @@ def test_nonmonotonic_labels(n_classes, n_rows, n_cols,
         p = p.to_frame().as_gpu_matrix().copy_to_host().reshape(p.shape[0])
         y_test = y_test.as_gpu_matrix().copy_to_host().reshape(y_test.shape[0])
 
-    print(str(p))
-    print(str(y_test))
-
     assert array_equal(p.astype(np.int32), y_test.astype(np.int32))
 
 

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -138,6 +138,65 @@ def test_predict_proba(nrows, ncols, n_neighbors, n_clusters, datatype):
     assert array_equal(predictions.sum(axis=1), np.ones(y_test.shape[0]))
 
 
+@pytest.mark.parametrize("datatype", ["dataframe", "numpy"])
+def test_predict_proba_large_n_classes(datatype):
+
+    nrows = 10000
+    ncols = 100
+    n_neighbors = 10
+    n_clusters = 10000
+
+    X, y = make_blobs(n_samples=nrows,
+                      centers=n_clusters,
+                      n_features=ncols,
+                      cluster_std=0.01,
+                      random_state=0)
+
+    X = X.astype(np.float32)
+
+    X_train, X_test, y_train, y_test = _build_train_test_data(X, y, datatype)
+
+    knn_cu = cuKNN(n_neighbors=n_neighbors)
+    knn_cu.fit(X_train, y_train)
+
+    predictions = knn_cu.predict_proba(X_test)
+
+    if datatype == "dataframe":
+        predictions = predictions.as_gpu_matrix().copy_to_host()
+
+    assert np.rint(np.sum(predictions)) == len(y_test)
+
+
+@pytest.mark.parametrize("datatype", ["dataframe", "numpy"])
+def test_predict_large_n_classes(datatype):
+
+    nrows = 10000
+    ncols = 100
+    n_neighbors = 2
+    n_clusters = 1000
+
+    X, y = make_blobs(n_samples=nrows,
+                      centers=n_clusters,
+                      n_features=ncols,
+                      cluster_std=0.01,
+                      random_state=0)
+
+    X = X.astype(np.float32)
+
+    X_train, X_test, y_train, y_test = _build_train_test_data(X, y, datatype)
+
+    knn_cu = cuKNN(n_neighbors=n_neighbors)
+    knn_cu.fit(X_train, y_train)
+
+    y_hat = knn_cu.predict(X_test)
+
+    if datatype == "dataframe":
+        y_hat = y_hat.to_gpu_array().copy_to_host()
+        y_test = y_test.as_gpu_matrix().copy_to_host().ravel()
+
+    assert array_equal(y_hat.astype(np.int32), y_test.astype(np.int32))
+
+
 @pytest.mark.parametrize("n_samples", [100])
 @pytest.mark.parametrize("n_features", [40])
 @pytest.mark.parametrize("n_neighbors", [4])

--- a/python/cuml/test/test_kneighbors_classifier.py
+++ b/python/cuml/test/test_kneighbors_classifier.py
@@ -191,8 +191,8 @@ def test_predict_large_n_classes(datatype):
     y_hat = knn_cu.predict(X_test)
 
     if datatype == "dataframe":
-        y_hat = y_hat.as_matrix()
-        y_test = y_test.as_matrix().ravel()
+        y_hat = y_hat.to_gpu_array().copy_to_host()
+        y_test = y_test.as_gpu_matrix().copy_to_host().ravel()
 
     assert array_equal(y_hat.astype(np.int32), y_test.astype(np.int32))
 


### PR DESCRIPTION
Enabling support for extremely large number of classes in `KNeighborsClassifier`. This also fixes a small bug in `predic_proba` where the unique classes were being computed from the number of search samples instead of the index samples. 

Closes #2743