### PR TITLE
[gpuCI] Auto-merge branch-0.15 to branch-0.16 [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/cuml/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/cuml/blob/main/README.md)
     to learn how to setup the development environment.
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/cuml/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/cuml/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels
@@ -62,12 +62,12 @@ implementation of the issue, ask them in the issue instead of the PR.
 
 The cuML repository has two main branches: 
 
-1. `master` branch: it contains the last released version. Only hotfixes are targeted and merged into it.  
+1. `main` branch: it contains the last released version. Only hotfixes are targeted and merged into it.  
 2. `branch-x.y`: it is the development branch which contains the upcoming release. All the new features should be based on this branch and Merge/Pull request should target this branch (with the exception of hotfixes).
     
 ### Additional details
 
-For every new version `x.y` of cuML there is a corresponding branch called `branch-x.y`, from where new feature development starts and PRs will be targeted and merged before its release. The exceptions to this are the 'hotfixes' that target the `master` branch, which target critical issues raised by Github users and are directly merged to `master` branch, and create a new subversion of the project. While trying to patch an issue which requires a 'hotfix', please state the intent in the PR. 
+For every new version `x.y` of cuML there is a corresponding branch called `branch-x.y`, from where new feature development starts and PRs will be targeted and merged before its release. The exceptions to this are the 'hotfixes' that target the `main` branch, which target critical issues raised by Github users and are directly merged to `main` branch, and create a new subversion of the project. While trying to patch an issue which requires a 'hotfix', please state the intent in the PR. 
 
 For all development, your changes should be pushed into a branch (created using the naming instructions below) in your own fork of cuML and then create a pull request when the code is ready. 
 

--- a/ci/cpu/cuml/upload-anaconda.sh
+++ b/ci/cpu/cuml/upload-anaconda.sh
@@ -9,7 +9,6 @@ if [ "$BUILD_CUML" == "1" ]; then
 
   export UPLOADFILE=`conda build conda/recipes/cuml -c conda-forge -c numba -c conda-forge/label/rc_ucx -c rapidsai -c nvidia -c pytorch -c defaults --python=${PYTHON} --output`
 
-  SOURCE_BRANCH=master
 
   LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
@@ -17,7 +16,7 @@ if [ "$BUILD_CUML" == "1" ]; then
   test -e ${UPLOADFILE}
 
   # Restrict uploads to master branch
-  if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+  if [ ${BUILD_MODE} != "branch" ]; then
     echo "Skipping upload"
     return 0
   fi

--- a/ci/cpu/libcuml/upload-anaconda.sh
+++ b/ci/cpu/libcuml/upload-anaconda.sh
@@ -9,7 +9,6 @@ if [ "$BUILD_LIBCUML" == "1" ]; then
 
   export UPLOADFILE=`conda build conda/recipes/libcuml -c conda-forge -c numba -c conda-forge/label/rc_ucx -c nvidia -c rapidsai -c pytorch -c defaults --python=${PYTHON} --output`
 
-  SOURCE_BRANCH=master
 
   LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
@@ -17,7 +16,7 @@ if [ "$BUILD_LIBCUML" == "1" ]; then
   test -e ${UPLOADFILE}
 
   # Restrict uploads to master branch
-  if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+  if [ ${BUILD_MODE} != "branch" ]; then
     echo "Skipping upload"
     return 0
   fi


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.15` that creates a PR to keep `branch-0.16` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.