### PR TITLE
[REVIEW] Update default RandomForestRegressor score function to use r2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - PR #2723: Support and enable convert_dtype in estimator predict
 - PR #2766: Updates default RandomForestRegressor score function to use r2
 
-
 ## Bug Fixes
 
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - PR #2729: Replace `cupy.sparse` with `cupyx.scipy.sparse`
 - PR #2749: Correct docs for python version used in cuml_dev conda environment
 - PR #2723: Support and enable convert_dtype in estimator predict
+- PR #2766: Updates default RandomForestRegressor score function to use r2
+
 
 ## Bug Fixes
 

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -102,6 +102,8 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
         If float the min_rows_per_sample*n_rows
     accuracy_metric : string (default = 'r2')
         Decides the metric used to evaluate the performance of the model.
+        In the 0.16 release, the default scoring metric was changed
+        from mean squared error to r-squared.
         for r-squared : 'r2'
         for median of abs error : 'median_ae'
         for mean of abs error : 'mean_ae'

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -100,8 +100,9 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
         The minimum number of samples (rows) needed to split a node.
         If int then number of sample rows
         If float the min_rows_per_sample*n_rows
-    accuracy_metric : string (default = 'mse')
+    accuracy_metric : string (default = 'r2')
         Decides the metric used to evaluate the performance of the model.
+        for r-squared : 'r2'
         for median of abs error : 'median_ae'
         for mean of abs error : 'mean_ae'
         for mean square error' : 'mse'

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -205,6 +205,8 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         The minimum decrease in impurity required for node to be split
     accuracy_metric : string (default = 'r2')
         Decides the metric used to evaluate the performance of the model.
+        In the 0.16 release, the default scoring metric was changed
+        from mean squared error to r-squared.
         for r-squared : 'r2'
         for median of abs error : 'median_ae'
         for mean of abs error : 'mean_ae'
@@ -562,6 +564,8 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
               fil_sparse_format='auto', predict_model="GPU"):
         """
         Calculates the accuracy metric score of the model for X.
+        In the 0.16 release, the default scoring metric was changed
+        from mean squared error to r-squared.
 
         Parameters
         ----------

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -142,7 +142,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         y = np.asarray([0.0,1.0,2.0,3.0], dtype=np.float32)
         cuml_model = curfc(max_features=1.0, n_bins=8,
                             split_algo=0, min_rows_per_node=2,
-                            n_estimators=40, accuracy_metric='mse')
+                            n_estimators=40, accuracy_metric='r2')
         cuml_model.fit(X,y)
         cuml_score = cuml_model.score(X,y)
         print("MSE score of cuml : ", cuml_score)
@@ -203,8 +203,9 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         If float the min_rows_per_sample*n_rows
     min_impurity_decrease : float (default = 0.0)
         The minimum decrease in impurity required for node to be split
-    accuracy_metric : string (default = 'mse')
+    accuracy_metric : string (default = 'r2')
         Decides the metric used to evaluate the performance of the model.
+        for r-squared : 'r2'
         for median of abs error : 'median_ae'
         for mean of abs error : 'mean_ae'
         for mean square error' : 'mse'
@@ -222,7 +223,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     """
 
     def __init__(self, split_criterion=2,
-                 accuracy_metric='mse',
+                 accuracy_metric='r2',
                  **kwargs):
         self.RF_type = REGRESSION
         super(RandomForestRegressor, self).__init__(
@@ -599,6 +600,8 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         median_abs_error : float or
         mean_abs_error : float
         """
+        from cuml.metrics.regression import r2_score
+
         cdef uintptr_t y_ptr
         _, n_rows, _, dtype = \
             input_to_cuml_array(X,
@@ -619,37 +622,41 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             input_to_cuml_array(preds, convert_to_dtype=dtype)
         preds_ptr = preds_m.ptr
 
-        cdef cumlHandle* handle_ =\
-            <cumlHandle*><uintptr_t>self.handle.getHandle()
-
-        cdef RandomForestMetaData[float, float] *rf_forest = \
-            <RandomForestMetaData[float, float]*><uintptr_t> self.rf_forest
-
-        cdef RandomForestMetaData[double, double] *rf_forest64 = \
-            <RandomForestMetaData[double, double]*><uintptr_t> self.rf_forest64
-
-        if self.dtype == np.float32:
-            self.temp_stats = score(handle_[0],
-                                    rf_forest,
-                                    <float*> y_ptr,
-                                    <int> n_rows,
-                                    <float*> preds_ptr,
-                                    <int> self.verbose)
-
-        elif self.dtype == np.float64:
-            self.temp_stats = score(handle_[0],
-                                    rf_forest64,
-                                    <double*> y_ptr,
-                                    <int> n_rows,
-                                    <double*> preds_ptr,
-                                    <int> self.verbose)
-
-        if self.accuracy_metric == 'median_ae':
-            stats = self.temp_stats['median_abs_error']
-        if self.accuracy_metric == 'mean_ae':
-            stats = self.temp_stats['mean_abs_error']
+        # shortcut for default accuracy metric of r^2
+        if self.accuracy_metric == "r2":
+            stats = r2_score(y_test, preds, handle=self.handle)
         else:
-            stats = self.temp_stats['mean_squared_error']
+            cdef cumlHandle* handle_ =\
+                <cumlHandle*><uintptr_t>self.handle.getHandle()
+
+            cdef RandomForestMetaData[float, float] *rf_forest = \
+                <RandomForestMetaData[float, float]*><uintptr_t> self.rf_forest
+
+            cdef RandomForestMetaData[double, double] *rf_forest64 = \
+                <RandomForestMetaData[double, double]*><uintptr_t> self.rf_forest64
+
+            if self.dtype == np.float32:
+                self.temp_stats = score(handle_[0],
+                                        rf_forest,
+                                        <float*> y_ptr,
+                                        <int> n_rows,
+                                        <float*> preds_ptr,
+                                        <int> self.verbose)
+
+            elif self.dtype == np.float64:
+                self.temp_stats = score(handle_[0],
+                                        rf_forest64,
+                                        <double*> y_ptr,
+                                        <int> n_rows,
+                                        <double*> preds_ptr,
+                                        <int> self.verbose)
+
+            if self.accuracy_metric == 'median_ae':
+                stats = self.temp_stats['median_abs_error']
+            if self.accuracy_metric == 'mean_ae':
+                stats = self.temp_stats['mean_abs_error']
+            else:
+                stats = self.temp_stats['mean_squared_error']
 
         self.handle.sync()
         del(y_m)


### PR DESCRIPTION
This PR:
- Updates the default score function for RandomForestRegressor to use r^2 rather than mean-squared error, consistent with other cuML and scikit-learn regressors

This closes #2765