### PR TITLE
[REVIEW] fix doxygen version during cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #2762: Fix broken links and provide minor edits to docs
 - PR #2723: Support and enable convert_dtype in estimator predict
 - PR #2758: Match sklearn's default n_components behavior for PCA
+- PR #2770: Fix doxygen version during cmake
 
 ## Bug Fixes
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier

--- a/cpp/cmake/doxygen.cmake
+++ b/cpp/cmake/doxygen.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/cmake/doxygen.cmake
+++ b/cpp/cmake/doxygen.cmake
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-find_package(Doxygen 1.8.11)
+find_package(Doxygen 1.8.20 REQUIRED)
 
 function(add_doxygen_target)
   if(Doxygen_FOUND)


### PR DESCRIPTION
As per `rapids-doc-env` meta package, we are now at doxygen version `1.8.20`. This PR tries to keep this version-match fixed/mandatory in order to avoid issues like the one here: #2769 .