### PR TITLE
[WIP] Redirect spdlogs to Python stdout/stderr when necessary

### DIFF
--- a/cpp/include/cuml/common/logger.hpp
+++ b/cpp/include/cuml/common/logger.hpp
@@ -105,6 +105,13 @@ class Logger {
   void setPattern(const std::string& pattern);
 
   /**
+   * @brief Register a callback function to be run in place of usual log call
+   *
+   * @param[in] callback the function to be run on all logged messages
+   */
+  void registerCallback(void (*callback)(int, const char*));
+
+  /**
    * @brief Tells whether messages will be logged for the given log level
    *
    * @param[in] level log level to be checked for
@@ -133,12 +140,26 @@ class Logger {
    */
   void log(int level, const char* fmt, ...);
 
+  /**
+   * @brief Logging method for pre-formatted messages
+   *
+   * This method is publicly exposed primarily to facilitate logging callbacks
+   * which may have difficulty dealing with the variable-length arguments of
+   * the log method.
+   *
+   * @param[in] spd_level SPD logging level of this message
+   * @param[in] msg       a C-style string message to be logged
+   */
+  void logFormatted(int spd_level, const char* msg);
+
  private:
   Logger();
   ~Logger() {}
 
   std::shared_ptr<spdlog::logger> logger;
   std::string currPattern;
+
+  void (*logCallback)(int, const char*);
   static const std::string DefaultPattern;
 };  // class Logger
 

--- a/python/cuml/test/test_logger.py
+++ b/python/cuml/test/test_logger.py
@@ -39,11 +39,8 @@ def test_redirected_logger():
     new_stdout = StringIO()
 
     with logger.set_level(logger.level_trace):
-        test_msg = "This is a trace message"
-        with redirect_stdout(new_stdout):
-            logger.trace(test_msg)
-        assert test_msg in new_stdout.getvalue()
-
+        # We do not test trace because CUML_LOG_TRACE is not compiled by
+        # default
         test_msg = "This is a debug message"
         with redirect_stdout(new_stdout):
             logger.debug(test_msg)

--- a/python/cuml/test/test_logger.py
+++ b/python/cuml/test/test_logger.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
+from contextlib import redirect_stdout
 import cuml.common.logger as logger
+from io import StringIO
 
 
 def test_logger():
@@ -31,3 +33,38 @@ def test_logger():
 
     with logger.set_pattern("%v"):
         logger.info("This is an info message")
+
+
+def test_redirected_logger():
+    new_stdout = StringIO()
+
+    with logger.set_level(logger.level_trace):
+        test_msg = "This is a trace message"
+        with redirect_stdout(new_stdout):
+            logger.trace(test_msg)
+        assert test_msg in new_stdout.getvalue()
+
+        test_msg = "This is a debug message"
+        with redirect_stdout(new_stdout):
+            logger.debug(test_msg)
+        assert test_msg in new_stdout.getvalue()
+
+        test_msg = "This is an info message"
+        with redirect_stdout(new_stdout):
+            logger.info(test_msg)
+        assert test_msg in new_stdout.getvalue()
+
+        test_msg = "This is a warn message"
+        with redirect_stdout(new_stdout):
+            logger.warn(test_msg)
+        assert test_msg in new_stdout.getvalue()
+
+        test_msg = "This is an error message"
+        with redirect_stdout(new_stdout):
+            logger.error(test_msg)
+        assert test_msg in new_stdout.getvalue()
+
+        test_msg = "This is a critical message"
+        with redirect_stdout(new_stdout):
+            logger.critical(test_msg)
+        assert test_msg in new_stdout.getvalue()


### PR DESCRIPTION
When Python has redefined stdout or stderr (as in a Jupyter Notebook), ensure that messages logged to the OS-defined stdout/stderr from spdlogs are redirected to the Python-defined stdout/stderr