### PR TITLE
[REVIEW] Add in cuML-specific dev conda dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #2770: Fix doxygen version during cmake
 - PR #2766: Update default RandomForestRegressor score function to use r2
 - PR #2783: Add pytest that will fail when GPU IDs in Dask cluster are not unique
+- PR #2785: Add in cuML-specific dev conda dependencies
 
 ## Bug Fixes
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -15,6 +15,13 @@ dependencies:
 - dask-cudf=0.16.*
 - dask-cuda=0.16.*
 - ucx-py=0.16.*
+- dask-ml
+- doxygen>=1.8.20
+- libfaiss>=1.6.3
+- faiss-proc=*=cuda
+- umap-learn
+- scikit-learn=0.23.1
+- treelite=0.92
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -15,6 +15,13 @@ dependencies:
 - dask-cudf=0.16.*
 - dask-cuda=0.16.*
 - ucx-py=0.16.*
+- dask-ml
+- doxygen>=1.8.20
+- libfaiss>=1.6.3
+- faiss-proc=*=cuda
+- umap-learn
+- scikit-learn=0.23.1
+- treelite=0.92
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -15,6 +15,13 @@ dependencies:
 - dask-cudf=0.16.*
 - dask-cuda=0.16.*
 - ucx-py=0.16.*
+- dask-ml
+- doxygen>=1.8.20
+- libfaiss>=1.6.3
+- faiss-proc=*=cuda
+- umap-learn
+- scikit-learn=0.23.1
+- treelite=0.92
 - pip
 - pip:
     - sphinx_markdown_tables


### PR DESCRIPTION
This PR adds back in a minimal set of development conda dependencies.

These dependencies overlap with the ones in the [rapids-build-env](https://github.com/rapidsai/integration/blob/branch-0.16/conda/recipes/rapids-build-env/meta.yaml) meta-package, but including them here makes it easier to create a conda environment when we can't install the meta-package.