### PR TITLE
Bugfix for 2767 - fix rf path trying to sample 0 columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,7 +369,7 @@
 - PR #2305: Fixed race condition in DBScan
 - PR #2354: Fix broken links in README
 - PR #2619: Explicitly skip raft test folder for pytest 6.0.0
-- PR #2767: Set the minimum number of columns that can be sampled to 1 to fix 0 mem allocation error
+- PR #2788: Set the minimum number of columns that can be sampled to 1 to fix 0 mem allocation error
 
 # cuML 0.13.0 (31 Mar 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,7 @@
 - PR #2305: Fixed race condition in DBScan
 - PR #2354: Fix broken links in README
 - PR #2619: Explicitly skip raft test folder for pytest 6.0.0
+- PR #2767: Set the minimum number of columns that can be sampled to 1 to fix 0 mem allocation error
 
 # cuML 0.13.0 (31 Mar 2020)
 

--- a/cpp/src/decisiontree/memory.cuh
+++ b/cpp/src/decisiontree/memory.cuh
@@ -83,6 +83,7 @@ void TemporaryMemory<T, L>::LevelMemAllocator(
   }
   size_t maxnodes = max_nodes_per_level;
   size_t ncols_sampled = (size_t)(ncols * tree_params.max_features);
+  ncols_sampled = ncols_sampled > 0 ? ncols_sampled : 1;
   if (depth < 64) {
     gather_max_nodes = std::min((size_t)(nrows + 1),
                                 (size_t)(pow((size_t)2, (size_t)depth) + 1));


### PR DESCRIPTION
In some situations, the number of sampled columns, multiplied by max features would result in a number that rounded to 0, which in turn caused a memory block of size zero to be allocated, and CudaMemsetAsync to throw an invalid argument exception.

This sets a floor of 1 for ncols_sampled, which resolves the issue. 

Closes #2767 