### PR TITLE
[REVIEW]Remove tokens of length 1 by default for text vectorizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - PR #2698: Distributed TF-IDF transformer
 
 ## Improvements
+- PR #2796: Remove tokens of length 1 by default for text vectorizers
 - PR #2741: Use rapids build packages in conda environments
 - PR #2735: Update seed to random_state in random forest and associated tests
 - PR #2739: Use cusparse_wrappers.h from RAFT

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -28,7 +28,7 @@ import cuml.common.logger as logger
 
 
 def _preprocess(doc, lower=False, remove_non_alphanumeric=False, delimiter=" ",
-                keep_underscore_char=True):
+                keep_underscore_char=True, remove_single_token_len=True):
     """
     Chain together an optional series of text preprocessing steps to
     apply to a document.
@@ -63,6 +63,12 @@ def _preprocess(doc, lower=False, remove_non_alphanumeric=False, delimiter=" ",
             doc = doc.str.replace(temp_string, '_', regex=False)
         else:
             doc = doc.str.filter_alphanum(' ', keep=True)
+
+        # sklearn by default only keeps
+        # single length tokens if its remove alphanums
+        if remove_single_token_len:
+            doc = doc.str.filter_tokens(2)
+
     return doc
 
 

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -64,8 +64,8 @@ def _preprocess(doc, lower=False, remove_non_alphanumeric=False, delimiter=" ",
         else:
             doc = doc.str.filter_alphanum(' ', keep=True)
 
-        # sklearn by default only keeps
-        # single length tokens if its remove alphanums
+        # sklearn by default removes tokens of
+        # length 1, if its remove alphanumerics
         if remove_single_token_len:
             doc = doc.str.filter_tokens(2)
 

--- a/python/cuml/test/test_text_feature_extraction.py
+++ b/python/cuml/test/test_text_feature_extraction.py
@@ -275,6 +275,17 @@ def test_non_ascii():
     cp.testing.assert_array_equal(res.todense(), ref.toarray())
 
 
+def test_sngle_len():
+    single_token_ser = ['S I N G L E T 0 K E N Example', '1 2 3 4 5 eg']
+    single_token_gpu = Series(single_token_ser)
+
+    cv = CountVectorizer()
+    res = cv.fit_transform(single_token_gpu)
+    ref = SkCountVect().fit_transform(single_token_ser)
+
+    cp.testing.assert_array_equal(res.todense(), ref.toarray())
+
+
 def test_only_delimiters():
     data = ['abc def. 123',
             '   ',


### PR DESCRIPTION
This PR closes https://github.com/rapidsai/cuml/issues/2588