### PR TITLE
[REVIEW] reenable lightgbm test with a lower (1%) proba accuracy threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #2783: Add pytest that will fail when GPU IDs in Dask cluster are not unique
 - PR #2785: Add in cuML-specific dev conda dependencies
 - PR #2778: Add README for FIL
+- PR #2799: Reenable lightgbm test with lower (1%) proba accuracy
 
 ## Bug Fixes
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -397,9 +397,6 @@ def test_output_args(small_classifier_and_preds):
 @pytest.mark.skipif(has_lightgbm() is False, reason="need to install lightgbm")
 def test_lightgbm(tmp_path):
     import lightgbm as lgb
-    from distutils.version import LooseVersion
-    if LooseVersion(lgb.__version__) >= LooseVersion('3.0.0'):
-        pytest.skip('lightgbm version 3 support is underway.')
     X, y = simulate_data(500, 10,
                          random_state=43210,
                          classification=True)
@@ -436,4 +433,4 @@ def test_lightgbm(tmp_path):
     fil_proba = np.asarray(fm.predict_proba(X))
     fil_proba = np.reshape(fil_proba, np.shape(gbm_proba))
 
-    assert np.allclose(gbm_proba, fil_proba, 1e-3)
+    assert np.allclose(gbm_proba, fil_proba, 1e-2)


### PR DESCRIPTION
as explained by @hcho3 , lightgbm uses float64 in thresholds. FIL rounds them to float32, which slightly (and unpredictably) alters the predictions.
Since the tests are deterministic, it takes a code [version] change to change the conditions and trigger the discrepancy.
By lowering the proba (not prediction!) accuracy threshold to 1%, we can pass the test until FIL adds float64 threshold support.
This should be a realistic requirement, especially given that the discrepancy shrinks with a more realistic number of input columns, as less information is derived from the exact value of each.