### PR TITLE
[REVIEW] Align cuML's spdlog version with RMM's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #2783: Add pytest that will fail when GPU IDs in Dask cluster are not unique
 - PR #2785: Add in cuML-specific dev conda dependencies
 - PR #2778: Add README for FIL
+- PR #2800: Align cuML's spdlog version with RMM's
 
 ## Bug Fixes
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -122,7 +122,7 @@ set(SPDLOG_DIR ${CMAKE_CURRENT_BINARY_DIR}/spdlog CACHE STRING
   "Path to spdlog install directory")
 ExternalProject_Add(spdlog
   GIT_REPOSITORY    https://github.com/gabime/spdlog.git
-  GIT_TAG           v1.x
+  GIT_TAG           v1.7.0
   PREFIX            ${SPDLOG_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
@@ -254,4 +254,3 @@ add_dependencies(GTest::GTest spdlog)
 add_dependencies(benchmark GTest::GTest)
 add_dependencies(FAISS::FAISS benchmark)
 add_dependencies(FAISS::FAISS faiss)
-


### PR DESCRIPTION
RMM's CMakeLists.txt depends on spdlog v1.7.0. But our >=1.4.2 package version strategy is installing spdlog v1.8.0 in the conda env, causing cudf and cuML C++ build errors for me locally. I have a hunch we'll start seeing these errors in CI after tonight's rmm nightly is published.

The change in this PR will be necessary once https://github.com/rapidsai/rmm/pull/542 is merged.

Related: https://github.com/rapidsai/integration/pull/123
