### PR TITLE
[REVIEW] Fix memory access in non-row_major blob creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier
 - PR #2769: Remove outdated doxygen options for 1.8.20
 - PR #2787: Skip lightgbm test for version 3 and above temporarily
+- PR #2787: Skip lightgbm test for version 3 and above temporarily
+- PR #2813: Fix memory access in generation of non-row-major random blobs
 
 # cuML 0.15.0 (Date TBD)
 

--- a/cpp/src_prims/random/make_blobs.cuh
+++ b/cpp/src_prims/random/make_blobs.cuh
@@ -70,6 +70,11 @@ DI void get_mu_sigma(DataT& mu, DataT& sigma, IdxT idx, const IdxT* labels,
   } else {
     center_id = 0;
   }
+
+  if (fid >= n_cols) {
+    fid = 0;
+  }
+
   if (row_major) {
     center_id = center_id * n_cols + fid;
   } else {


### PR DESCRIPTION
Avoid memory access beyond space allocated for centers while generating random blobs
Resolve #2786