### PR TITLE
[REVIEW] Fix parsing of singlegpu option in build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #2813: Fix memory access in generation of non-row-major random blobs
 - PR #2810: Update Rf MNMG threshold to prevent sporadic test failure
 - PR #2808: Relax Doxygen version required in CMake to coincide with integration repo
+- PR #2818: Fix parsing of singlegpu option in build command
 
 # cuML 0.15.0 (Date TBD)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -139,19 +139,17 @@ if not libcuml_path:
 
 class cuml_build(_build):
 
-    user_options = [
-        ("singlegpu", None, "Specifies whether to include multi-gpu or not")
-    ] + _build.user_options
-
-    boolean_options = ["singlegpu"] + _build.boolean_options
-
     def initialize_options(self):
 
         self.singlegpu = False
-
         super().initialize_options()
 
     def finalize_options(self):
+
+        # distutils plain build command override cannot be done just setting
+        # user_options and boolean options like build_ext below. Distribution
+        # object has all the args used by the user, we can check that.
+        self.singlegpu = '--singlegpu' in self.distribution.script_args
 
         libs = ['cuda', 'cuml++', 'rmm']
 


### PR DESCRIPTION
Fix for `--singlegpu` build option in Python

Due to the way the build command works, the `--singlegpu` was not being detected properly, so had to inspect the `Distribution` object, otherwise `libcumlcomms` and `libcumlprims` were being passed to be linked erroneously. 