### PR TITLE
[WIP] Split row among blocks

### DIFF
--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -209,6 +209,7 @@ struct predict_params {
 
   // Other parameters.
   int max_shm;
+  int blocks_per_row;
 };
 
 // infer() calls the inference kernel with the parameters on the stream

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -233,10 +233,12 @@ struct tree_aggregator_t<NITEMS, INT_CLASS_LABEL> {
   }
 };
 
+#define FIL_NBLOCKS 256
+
 template <int NITEMS, leaf_value_t leaf_payload_type, class storage_type>
 __global__ void infer_k(storage_type forest, predict_params params) {
 
-  for(int row0 = 0; row0 < params.num_rows; row0 += NITEMS * 128 / params.blocks_per_row) {
+  for(int row0 = 0; row0 < params.num_rows; row0 += NITEMS * FIL_NBLOCKS / params.blocks_per_row) {
   // cache the row for all threads to reuse
   extern __shared__ char smem[];
   float* sdata = (float*)smem;
@@ -330,7 +332,7 @@ void infer_k_launcher(storage_type forest, predict_params params,
              ? " (accounting for shared class vote histogram)"
              : "");
   }
-  int num_blocks = 128;//ceildiv(int(params.num_rows), num_items);
+  int num_blocks = FIL_NBLOCKS;//ceildiv(int(params.num_rows), num_items);
   switch (num_items) {
     case 1:
       infer_k<1, leaf_payload_type>

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -329,7 +329,7 @@ void infer_k_launcher(storage_type forest, predict_params params,
              ? " (accounting for shared class vote histogram)"
              : "");
   }
-  int num_blocks = ceildiv(int(params.num_rows), num_items);
+  int num_blocks = ceildiv(int(params.num_rows), num_items) * params.blocks_per_row;
   switch (num_items) {
     case 1:
       infer_k<1, leaf_payload_type>


### PR DESCRIPTION
Use multiple blocks to infer same row (set of rows).
Right now, in prototype stage.
On internal models, achieved 18-34% speedup.
This simulates bandwidth impact properly, but does not have final reduction. That does not require synchronization, but needs some extra code.
This would require a tuning framework.