### PR TITLE
[REVIEW] Clean up paramsPCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PR #2799: Reenable lightgbm test with lower (1%) proba accuracy
 - PR #2800: Align cuML's spdlog version with RMM's
 - PR #2824: Make data conversions warnings be debug level
+- PR #2850: Clean up unused params in paramsPCA
 
 ## Bug Fixes
 - PR #2744: Supporting larger number of classes in KNeighborsClassifier

--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -67,7 +67,7 @@ class paramsTSVDTemplate : public paramsSolver {
 template <typename enum_solver = solver>
 class paramsPCATemplate : public paramsTSVDTemplate<enum_solver> {
  public:
-  bool copy = true;
+  bool copy = true;  // TODO unused, see #2830 and #2833
   bool whiten = false;
 };
 

--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -19,19 +19,12 @@
 namespace ML {
 
 /**
- * @defgroup pcaSolver: enumeration for pca solvers.
- * @param AUTO: Fastest solver will be used based on input shape and n_components.
- * @param FULL: All the eigenvectors and singular values (or eigenvalues) will be generated.
- * @param ARPACK: tsvd using power method. Lanczos will be included in the future.
- * @param RANDOMIZED: randomized svd
  * @param COV_EIG_DQ: covariance of input will be used along with eigen decomposition using divide and conquer method for symmetric matrices
  * @param COV_EIG_JACOBI: covariance of input will be used along with eigen decomposition using jacobi method for symmetric matrices
- * @{
  */
 enum class solver : int {
   COV_EIG_DQ,
   COV_EIG_JACOBI,
-  RANDOMIZED,
 };
 
 class params {
@@ -48,7 +41,6 @@ class paramsSolver : public params {
   //math_t tol = 0.0;
   float tol = 0.0;
   int n_iterations = 15;
-  int random_state;
   int verbose = 0;
 };
 
@@ -72,7 +64,6 @@ class paramsTSVDTemplate : public paramsSolver {
  * @param tol: Tolerance for singular values computed by svd_solver == ‘arpack’ or svd_solver == ‘COV_EIG_JACOBI’
  * @param iterated_power: Number of iterations for the power method computed by svd_solver == ‘randomized’ or
  *                        jacobi method by svd_solver == 'COV_EIG_JACOBI'.
- * @param random_state: RandomState instance or None, optional (default None)
  * @param verbose: 0: no error message printing, 1: print error messages
  * @param max_sweeps: number of sweeps jacobi method uses. The more the better accuracy.
  */

--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -48,7 +48,6 @@ template <typename enum_solver = solver>
 class paramsTSVDTemplate : public paramsSolver {
  public:
   int n_components = 1;
-  int max_sweeps = 15;
   enum_solver algorithm = enum_solver::COV_EIG_DQ;
 };
 
@@ -59,12 +58,10 @@ class paramsTSVDTemplate : public paramsSolver {
  *              use fit_transform(X) instead.
  * @param whiten: When True (False by default) the components_ vectors are multiplied by the square root of n_samples and
  *                then divided by the singular values to ensure uncorrelated outputs with unit component-wise variances.
- * @param svd_solver: the solver to be used in PCA.
+ * @param algorithm: the solver to be used in PCA.
  * @param tol: Tolerance for singular values computed by svd_solver == ‘arpack’ or svd_solver == ‘COV_EIG_JACOBI’
- * @param iterated_power: Number of iterations for the power method computed by svd_solver == ‘randomized’ or
- *                        jacobi method by svd_solver == 'COV_EIG_JACOBI'.
+ * @param n_iterations: Number of iterations for the power method computed by jacobi method (svd_solver == 'COV_EIG_JACOBI').
  * @param verbose: 0: no error message printing, 1: print error messages
- * @param max_sweeps: number of sweeps jacobi method uses. The more the better accuracy.
  */
 
 template <typename enum_solver = solver>

--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -50,7 +50,6 @@ class paramsTSVDTemplate : public paramsSolver {
   int n_components = 1;
   int max_sweeps = 15;
   enum_solver algorithm = enum_solver::COV_EIG_DQ;
-  bool trans_input = false;
 };
 
 /**

--- a/cpp/test/sg/tsvd_test.cu
+++ b/cpp/test/sg/tsvd_test.cu
@@ -96,10 +96,8 @@ class TsvdTest : public ::testing::TestWithParam<TsvdInputs<T>> {
       prms.algorithm = solver::COV_EIG_DQ;
     else if (params.algo == 1)
       prms.algorithm = solver::COV_EIG_JACOBI;
-    else if (params.algo == 2) {
-      prms.algorithm = solver::RANDOMIZED;
+    else
       prms.n_components = params.n_col2 - 15;
-    }
 
     allocate(data2, len);
     r.uniform(data2, len, T(-1.0), T(1.0), stream);

--- a/python/cuml/decomposition/utils.pxd
+++ b/python/cuml/decomposition/utils.pxd
@@ -23,7 +23,6 @@ cdef extern from "cuml/decomposition/params.hpp" namespace "ML" nogil:
     ctypedef enum solver "ML::solver":
         COV_EIG_DQ "ML::solver::COV_EIG_DQ"
         COV_EIG_JACOBI "ML::solver::COV_EIG_JACOBI"
-        RANDOMIZED "ML::solver::RANDOMIZED"
 
     cdef cppclass params:
         int n_rows


### PR DESCRIPTION
See commit messages and #2833:

* Finish removing `RANDOMIZED` solver. (I wasn't positive what to do in cpp/test/sg/tsvd_test.cu.)
* Remove unused `bool trans_input`
* Remove unused `max_sweeps` and `iterated_power`
* Add TODO for unused `copy` param, possibly related to #2830