### PR TITLE
Removing empty marker kernel code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #2638: Improve cython build with custom `build_ext`
 
 ## Improvements
+- PR #2873: Remove empty marker kernel code for NVTX markers
 - PR #2796: Remove tokens of length 1 by default for text vectorizers
 - PR #2741: Use rapids build packages in conda environments
 - PR #2735: Update seed to random_state in random forest and associated tests

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -74,8 +74,6 @@ option(DISABLE_OPENMP "Disable OpenMP" OFF)
 
 option(ENABLE_CUMLPRIMS_MG "Enable algorithms that use libcumlprims_mg" ON)
 
-option(EMPTY_MARKER_KERNEL "Enable empty marker kernel after nvtxRangePop" OFF)
-
 option(KERNEL_INFO "Enable kernel resource usage info" OFF)
 
 option(LINE_INFO "Enable lineinfo in nvcc" OFF)
@@ -268,9 +266,7 @@ endif(KERNEL_INFO)
 if(NVTX)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DNVTX_ENABLED")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNVTX_ENABLED")
-  if(EMPTY_MARKER_KERNEL)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DENABLE_EMPTY_MARKER_KERNEL")
-  endif(EMPTY_MARKER_KERNEL)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
 endif(NVTX)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -147,15 +147,8 @@ void PUSH_RANGE(const char *name) {
   nvtxRangePushEx(&eventAttrib);
 }
 
-#ifdef ENABLE_EMPTY_MARKER_KERNEL
-__global__ void emptyMarkerKernel() {}
-#endif  // ENABLE_EMPTY_MARKER_KERNEL
-
 void POP_RANGE() {
   nvtxRangePop();
-#ifdef ENABLE_EMPTY_MARKER_KERNEL
-  emptyMarkerKernel<<<1, 1>>>();
-#endif
 }
 
 #else  // NVTX_ENABLED

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -147,9 +147,7 @@ void PUSH_RANGE(const char *name) {
   nvtxRangePushEx(&eventAttrib);
 }
 
-void POP_RANGE() {
-  nvtxRangePop();
-}
+void POP_RANGE() { nvtxRangePop(); }
 
 #else  // NVTX_ENABLED
 


### PR DESCRIPTION
* This mini-PR is to remove the redundancy of `EMPTY_MARKER_KERNEL` variables in cuml.
* NVTX Markers do not require explicit empty-marker-kernels management for correct range detection, this has been added as a functionality in the Nsight Systems tools internally.