### PR TITLE
UPDATE masked label encoder unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PR #2848: Fix typo in Python docstring for UMAP
 - PR #2856: Fix LabelEncoder for filtered input
 - PR #2855: Updates for RMM being header only
+- PR #2879: Update unit test for LabelEncoder on filtered input
 
 # cuML 0.15.0 (Date TBD)
 

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -150,14 +150,16 @@ def test_empty_input(empty, ord_label):
 
 
 def test_masked_encode():
-    df = cudf.DataFrame({"filter_col": [1, 1, 2, 3, 1, 1, 1, 1, 6, 5],
-                         "cat_col": ['a', 'b', 'c', 'd', 'a',
-                                     'a', 'a', 'c', 'b', 'c']})
+    int_values = [3, 1, 1, 2, 1, 1, 1, 1, 6, 5]
+    cat_values = ['a', 'd', 'b', 'c', 'd', 'd', 'd', 'c', 'b', 'c']
+    df = cudf.DataFrame({"filter_col": int_values, "cat_col": cat_values})
 
     df_filter = df[df["filter_col"] == 1]
     df_filter["cat_col"] = LabelEncoder().fit_transform(df_filter["cat_col"])
 
-    df["cat_col"] = LabelEncoder().fit_transform(df["cat_col"])
-    df = df[df["filter_col"] == 1]
+    filtered_int_values = [int_values[i] for i in range(len(int_values)) if int_values[i] == 1]
+    filtered_cat_values = [cat_values[i] for i in range(len(int_values)) if int_values[i] == 1]
+    df_test = cudf.DataFrame({"filter_col": filtered_int_values, "cat_col": filtered_cat_values})
+    df_test["cat_col"] = LabelEncoder().fit_transform(df_test["cat_col"])
 
-    assert(df_filter["cat_col"] == df["cat_col"]).all()
+    assert(df_filter["cat_col"] == df_test["cat_col"]).all()

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -166,4 +166,4 @@ def test_masked_encode():
                               "cat_col": filtered_cat_values})
     df_test["cat_col"] = LabelEncoder().fit_transform(df_test["cat_col"])
 
-    assert(df_filter["cat_col"] == df_test["cat_col"]).all()
+    assert(df_filter["cat_col"].values == df_test["cat_col"].values).all()

--- a/python/cuml/test/test_label_encoder.py
+++ b/python/cuml/test/test_label_encoder.py
@@ -152,14 +152,18 @@ def test_empty_input(empty, ord_label):
 def test_masked_encode():
     int_values = [3, 1, 1, 2, 1, 1, 1, 1, 6, 5]
     cat_values = ['a', 'd', 'b', 'c', 'd', 'd', 'd', 'c', 'b', 'c']
-    df = cudf.DataFrame({"filter_col": int_values, "cat_col": cat_values})
+    df = cudf.DataFrame({"filter_col": int_values,
+                         "cat_col": cat_values})
 
     df_filter = df[df["filter_col"] == 1]
     df_filter["cat_col"] = LabelEncoder().fit_transform(df_filter["cat_col"])
 
-    filtered_int_values = [int_values[i] for i in range(len(int_values)) if int_values[i] == 1]
-    filtered_cat_values = [cat_values[i] for i in range(len(int_values)) if int_values[i] == 1]
-    df_test = cudf.DataFrame({"filter_col": filtered_int_values, "cat_col": filtered_cat_values})
+    filtered_int_values = [int_values[i] for i in range(len(int_values))
+                           if int_values[i] == 1]
+    filtered_cat_values = [cat_values[i] for i in range(len(int_values))
+                           if int_values[i] == 1]
+    df_test = cudf.DataFrame({"filter_col": filtered_int_values,
+                              "cat_col": filtered_cat_values})
     df_test["cat_col"] = LabelEncoder().fit_transform(df_test["cat_col"])
 
     assert(df_filter["cat_col"] == df_test["cat_col"]).all()


### PR DESCRIPTION
Previous test was assuming that generated category values should be the same when encoding is applied before the filtering and after the filtering. It didn't fail for the given example but that assumption can fail for the new example I have created. Same category can be mapped to different integers based on order. Therefore I have updated the unit test. Now it only checks if a filtered dataframe's encoded values are the same with non-filtered but identical dataframe.