### PR TITLE
[DO NOT MERGE] Enable rmm pool in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #2871: Add timing function to utils
 - PR #2863: in FIL, rename leaf_value_t enums to more descriptive
 - PR #2892 Update ci/local/README.md
+- PR #2899: Enable RMM pool tests
 
 ## Bug Fixes
 - PR #2882: Allow import on machines without GPUs

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -187,9 +187,9 @@ else
     logger "Python pytest for cuml..."
     cd $WORKSPACE/python
 
-    pytest --cache-clear --basetemp=${WORKSPACE}/cuml-cuda-tmp --junitxml=${WORKSPACE}/junit-cuml.xml -v -s -m "not memleak" --durations=50 --timeout=300 --ignore=cuml/test/dask --ignore=cuml/raft
+    pytest --cache-clear --basetemp=${WORKSPACE}/cuml-cuda-tmp --junitxml=${WORKSPACE}/junit-cuml.xml -v -s -m "not memleak" --durations=50 --timeout=300 --ignore=cuml/test/dask --ignore=cuml/raft --use-rmm-pool
 
-    timeout 7200 sh -c "pytest cuml/test/dask --cache-clear --basetemp=${WORKSPACE}/cuml-mg-cuda-tmp --junitxml=${WORKSPACE}/junit-cuml-mg.xml -v -s -m 'not memleak' --durations=50 --timeout=300"
+    timeout 7200 sh -c "pytest cuml/test/dask --cache-clear --basetemp=${WORKSPACE}/cuml-mg-cuda-tmp --junitxml=${WORKSPACE}/junit-cuml-mg.xml -v -s -m 'not memleak' --use-rmm-pool --durations=50 --timeout=300"
 
     ################################################################################
     # TEST - Run notebook tests

--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -239,7 +239,7 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_stress)
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True, scope="session")
 def setup_rmm(request, pytestconfig):
     """Enable RMM pool if --use-rmm-pool flag is set."""
     # Strongly inspired by https://github.com/dmlc/xgboost/pull/5873/files

--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -185,9 +185,11 @@ def pytest_addoption(parser):
                      action="store_true",
                      default=False,
                      help="run unit tests")
+
     parser.addoption('--use-rmm-pool',
                      action='store_true',
                      default=False, help='Use RMM pool')
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--run_quality"):

--- a/python/cuml/test/dask/conftest.py
+++ b/python/cuml/test/dask/conftest.py
@@ -10,9 +10,11 @@ enable_infiniband = False
 
 
 @pytest.fixture(scope="module")
-def cluster():
-
-    cluster = LocalCUDACluster(protocol="tcp", scheduler_port=0)
+def cluster(pytestconfig):
+    args = {'protocol': 'tcp', 'scheduler_port': 0}
+    if pytestconfig.getoption('--use-rmm-pool'):
+        args["rmm_pool_size"] = "2GB"
+    cluster = LocalCUDACluster(**args)
     yield cluster
     cluster.close()
 


### PR DESCRIPTION
Replaces PR #2713, which got garbled history a bit.
This currently enables RMM pool testing in CI to help in debugging - will not be merged like this.