### PR TITLE
[REVIEW] Adding Support for CuPy 8.x and Fixing Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,9 @@
 - PR #2856: Fix LabelEncoder for filtered input
 - PR #2855: Updates for RMM being header only
 - PR #2880: Fix bugs in Auto-ARIMA when s==None
-- PR #2877:  TSNE exception for n_components > 2
+- PR #2877: TSNE exception for n_components > 2
 - PR #2879: Update unit test for LabelEncoder on filtered input
+- PR #2910: Increasing tolerance of test_kbinsdiscretizer
 
 # cuML 0.15.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #2871: Add timing function to utils
 - PR #2863: in FIL, rename leaf_value_t enums to more descriptive
 - PR #2892 Update ci/local/README.md
+- PR #2910: Adding Support for CuPy 8.x
 
 ## Bug Fixes
 - PR #2882: Allow import on machines without GPUs
@@ -66,7 +67,6 @@
 - PR #2880: Fix bugs in Auto-ARIMA when s==None
 - PR #2877: TSNE exception for n_components > 2
 - PR #2879: Update unit test for LabelEncoder on filtered input
-- PR #2910: Increasing tolerance of test_kbinsdiscretizer
 
 # cuML 0.15.0 (Date TBD)
 

--- a/ci/mg/build.sh
+++ b/ci/mg/build.sh
@@ -43,7 +43,7 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      "cupy>=7,<8.0.0a0" \
+      "cupy>7.1.0,<9.0.0a0" \
       "cudatoolkit=${CUDA_REL}" \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - treelite=0.92
-    - cupy>=7,<=8.0.0dev.rapidsai0.15
+    - cupy>7.1.0,<9.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}
     - dask>=2.12.0

--- a/python/README.md
+++ b/python/README.md
@@ -4,9 +4,11 @@ This folder contains the Python and Cython code of the algorithms and ML primiti
 
 Contents:
 
-- [Build Configuration](#build-configuration)
-- [RAFT Integration in cuml.raft](#raft-integration-in-cumlraft)
-- [Running Unit Tests](#build-requirements)
+- [cuML Python Package](#cuml-python-package)
+    - [Build Configuration](#build-configuration)
+    - [RAFT Integration in cuml.raft](#raft-integration-in-cumlraft)
+    - [Build Requirements](#build-requirements)
+    - [Python Tests](#python-tests)
 
 ### Build Configuration
 
@@ -60,7 +62,7 @@ To build cuML's Python package, the following dependencies are required:
 - cudf version matching the cuML version
 - libcuml version matching the cuML version
 - libcuml={{ version }}
-- cupy>=7,<8.0.0a0
+- cupy>7.1.0,<9.0.0a0
 - joblib >=0.11
 
 Packages required for multigpu algorithms*:

--- a/python/cuml/test/test_preprocessing.py
+++ b/python/cuml/test/test_preprocessing.py
@@ -574,7 +574,7 @@ def test_kbinsdiscretizer(blobs_dataset, n_bins,  # noqa: F811
     sk_r_X = transformer.inverse_transform(sk_t_X)
 
     if strategy == 'kmeans':
-        assert_allclose(t_X, sk_t_X, ratio_tol=0.1)
+        assert_allclose(t_X, sk_t_X, ratio_tol=0.2)
     else:
         assert_allclose(t_X, sk_t_X)
         assert_allclose(r_X, sk_r_X)


### PR DESCRIPTION
Increasing the ratio tolerance of the `test_kbinsdiscretizer` test to 0.2. Per internal discussions, the tests were failing "due to the fact that each of the KBinsDiscretizer (cuML and sklearn) call their respective versions of KMeans. It seems that even with similar KMeans initialization some differences can still be found."

This will allow the tests from experimental features to pass.