### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuML 0.16.0 (Date TBD)
 
 ## New Features
+- PR #2909: Update allgatherv for compatibility with latest RAFT
 - PR #2677: Ability to export RF trees as JSON
 - PR #2698: Distributed TF-IDF transformer
 - PR #2476: Porter Stemmer

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -39,7 +39,7 @@ else(DEFINED ENV{RAFT_PATH})
 
   ExternalProject_Add(raft
     GIT_REPOSITORY    https://github.com/rapidsai/raft.git
-    GIT_TAG           516106e3b515b25c863776fcc51fb12df6c0a186
+    GIT_TAG           3f8a4bf6f81289f1fdaae9a5bd4a10de8674aa5c
     PREFIX            ${RAFT_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -76,7 +76,7 @@ void initRandom(const raft::handle_t &handle, const KMeansParams &params,
                                    nCentroidsSampledInRank, params.seed,
                                    stream);
 
-  std::vector<int> displs(n_ranks);
+  std::vector<size_t> displs(n_ranks);
   thrust::exclusive_scan(
     thrust::host, nCentroidsElementsToReceiveFromRank.begin(),
     nCentroidsElementsToReceiveFromRank.end(), displs.begin());
@@ -292,7 +292,7 @@ void initKMeansPlusPlus(const raft::handle_t &handle,
                       nPtsSampledByRank.end(), sizes.begin(),
                       [&](int val) { return val * n_features; });
 
-    std::vector<int> displs(n_rank);
+    std::vector<size_t> displs(n_rank);
     thrust::exclusive_scan(thrust::host, sizes.begin(), sizes.end(),
                            displs.begin());
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.