### PR TITLE
[REVIEW] Add sklearn GBDT support (without predict_proba)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #2638: Improve cython build with custom `build_ext`
 - PR #2866: Support XGBoost-style multiclass models (gradient boosted decision trees) in FIL C++
 - PR #2874: Issue warning for degraded accuracy with float64 models in Treelite
+- PR #2916: Add SKLearn multi-class GBDT model support in FIL
 
 ## Improvements
 - PR #2873: Remove empty marker kernel code for NVTX markers

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -689,11 +689,11 @@ void tl2fil_common(forest_params_t* params, const tl::Model& model,
       ASSERT(tl_params->output_class,
              "output_class==true is required for multi-class models");
       ASSERT(pred_transform == "sigmoid" || pred_transform == "identity" ||
-               pred_transform == "max_index" ||
+               pred_transform == "max_index" || pred_transform == "softmax" ||
                pred_transform == "multiclass_ova",
-             "only sigmoid, identity, max_index and multiclass_ova values of "
-             "pred_transform are supported for xgboost-style multi-class "
-             "classification models.");
+             "only sigmoid, identity, max_index, multiclass_ova and softmax "
+             "values of pred_transform are supported for xgboost-style "
+             "multi-class classification models.");
       // this function should not know how many threads per block will be used
       params->leaf_algo = leaf_algo_t::GROVE_PER_CLASS;
     } else {

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -191,10 +191,10 @@ def test_fil_regression(n_rows, n_columns, num_rounds, tmp_path, max_depth):
 
 
 @pytest.mark.parametrize('n_rows', [1000])
-@pytest.mark.parametrize('n_columns', [20])
+@pytest.mark.parametrize('n_columns', [30])
 @pytest.mark.parametrize('n_estimators', [1, 10])
 @pytest.mark.parametrize('max_depth', [2, 10, 20])
-@pytest.mark.parametrize('n_classes', [2, 5])
+@pytest.mark.parametrize('n_classes', [2, 5, 25])
 @pytest.mark.parametrize('storage_type', [False, True])
 @pytest.mark.parametrize('model_class',
                          [GradientBoostingClassifier, RandomForestClassifier])


### PR DESCRIPTION
This is mostly just adding tests, and it also adds "softmax" as an allowed pred_transform for `GROVE_PER_CLASS` multi-class models (since only class label prediction is supported for such models, it doesn't affect the result).

See below, there are differences due to FIL not supporting float64 thresholds, however, they are random and not consistently in sklearn's favor. This is a similar situation as lightgbm, and will be fixed in the future.

Can we merge the accuracy thresholds as-is?
The accuracy threshold chosen (0.04 for multiclass, kept existing for binary) is not small, but is hard to reduce. Although the test results with the fixed seed should reproduce on any machine, there may be a possibility of sklearn changing the algorithm with a new release.

> why this threshold?
```
FAILED cuml/test/test_fil.py::test_fil_skl_classification[GradientBoostingClassifier-True-5-10-1-20-1000] - assert 0.53 == 0.515 ± 1.0e-05
FAILED cuml/test/test_fil.py::test_fil_skl_classification[GradientBoostingClassifier-True-5-20-1-20-1000] - assert 0.53 == 0.5 ± 1.0e-05
FAILED cuml/test/test_fil.py::test_fil_skl_classification[GradientBoostingClassifier-True-5-20-10-20-1000] - assert 0.56 == 0.545 ± 1.0e-05
FAILED cuml/test/test_fil.py::test_fil_skl_classification[GradientBoostingClassifier-False-5-10-1-20-1000] - assert 0.53 == 0.515 ± 1.0e-05
```

> hard to reduce

using 10K rows instead of 1K did not improve the issue for deep trees, especially with only 1 estimator.

> a possibility of sklearn changing the algorithm with a new release

They haven't promised otherwise and I've seen someone observe it.


Below is the proof that FIL is not worse than skl in inferring its models, by using a floating sklearn seed (current main branch of cuml).
These are the results (collection of accuracies from failed asserts):

  | fill_acc | skl_acc | delta
-- | -- | -- | --
  | 0.585 | 0.595 | −0.01
  | 0.575 | 0.58 | −0.005
  | 0.58 | 0.585 | −0.005
  | 0.575 | 0.57 | 0.005
  | 0.495 | 0.485 | 0.01
  | 0.51 | 0.5 | 0.01
  | 0.525 | 0.515 | 0.01
  | 0.535 | 0.525 | 0.01
  | 0.545 | 0.535 | 0.01
  | 0.56 | 0.55 | 0.01
  | 0.585 | 0.575 | 0.01
  | 0.59 | 0.58 | 0.01
  | 0.54 | 0.525 | 0.015
  | 0.54 | 0.525 | 0.015
  | 0.545 | 0.53 | 0.015
  | 0.58 | 0.565 | 0.015
  | 0.51 | 0.49 | 0.02
  | 0.53 | 0.51 | 0.02
  | 0.545 | 0.525 | 0.02
  | 0.585 | 0.565 | 0.02
  | 0.595 | 0.575 | 0.02
  | 0.575 | 0.55 | 0.025
  | 0.52 | 0.495 | 0.025
  | 0.555 | 0.53 | 0.025
  | 0.515 | 0.485 | 0.03
  | 0.52 | 0.49 | 0.03
  | 0.53 | 0.5 | 0.03
  | 0.555 | 0.525 | 0.03
  | 0.525 | 0.49 | 0.035
  | 0.54 | 0.5 | 0.04
  |   |   |  
avg | 0.549 | 0.532 | 0.017
std | 0.028 | 0.035 | 0.012

