### PR TITLE
[REVIEW] Fixing Owner Bug When Slicing CumlArray Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - PR #2880: Fix bugs in Auto-ARIMA when s==None
 - PR #2877: TSNE exception for n_components > 2
 - PR #2879: Update unit test for LabelEncoder on filtered input
+- PR #2925: Fixing Owner Bug When Slicing CumlArray Objects
 
 # cuML 0.15.0 (Date TBD)
 

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -113,6 +113,12 @@ class CumlArray(Buffer):
         elif dtype is not None and shape is not None and order is not None:
             detailed_construction = True
         else:
+            # Catch a likely developer error if CumlArray is created
+            # incorrectly
+            assert dtype is None and shape is None and order is None, \
+                ("Creating array from array-like object. The arguments "
+                 "`dtype`, `shape` and `order` should be None.")
+
             detailed_construction = False
 
         ary_interface = False
@@ -121,17 +127,21 @@ class CumlArray(Buffer):
         size, shape = _get_size_from_shape(shape, dtype)
 
         if not memview_construction and not detailed_construction:
-            flattened_data = cp.asarray(data).ravel(order='A').view('u1')
+            # Convert to cupy array and manually specify the ptr, size and
+            # owner. This is to avoid the restriction on Buffer that requires
+            # all data be u8
+            cupy_data = cp.asarray(data)
+            flattened_data = cupy_data.data.ptr
+
+            # Size for Buffer is not the same as for cupy. Use nbytes
+            size = cupy_data.nbytes
+            owner = cupy_data if cupy_data.flags.owndata else data
         else:
             flattened_data = data
 
         super(CumlArray, self).__init__(data=flattened_data,
                                         owner=owner,
                                         size=size)
-
-        if owner is None and not isinstance(data, np.ndarray):
-            # need to reference original owner instead of flattened_data
-            self._owner = data
 
         # Post processing of meta data
         if detailed_construction:

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -117,7 +117,7 @@ class CumlArray(Buffer):
             # incorrectly
             assert dtype is None and shape is None and order is None, \
                 ("Creating array from array-like object. The arguments "
-                 "`dtype`, `shape` and `order` should be None.")
+                 "`dtype`, `shape` and `order` should be `None`.")
 
             detailed_construction = False
 

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -198,7 +198,7 @@ def test_array_init_bad(input_type, dtype, shape, order):
     else:
         inp = create_input(input_type, dtype, shape, order)
 
-    # Ensure the array is creatible
+    # Ensure the array is creatable
     cuml_ary = CumlArray(inp)
 
     with pytest.raises(AssertionError):

--- a/python/cuml/test/test_array.py
+++ b/python/cuml/test/test_array.py
@@ -15,6 +15,7 @@
 #
 
 import sys
+import gc
 
 import pytest
 
@@ -27,8 +28,8 @@ from copy import deepcopy
 from numba import cuda
 from cudf.core.buffer import Buffer
 from cuml.common.array import CumlArray
-from cuml.common.memory_utils import _get_size_from_shape
-from rmm import DeviceBuffer
+from cuml.common.memory_utils import _get_size_from_shape, _strides_to_order
+import rmm
 
 if sys.version_info < (3, 8):
     try:
@@ -99,7 +100,7 @@ def test_array_init(input_type, dtype, shape, order):
 
     if shape == 10:
         assert ary.shape == (10,)
-        len(ary) == 10
+        assert len(ary) == 10
     elif input_type == 'series':
         # cudf Series make their shape (10,) from (10, 1)
         if shape == (10, 1):
@@ -109,15 +110,7 @@ def test_array_init(input_type, dtype, shape, order):
 
     assert ary.dtype == np.dtype(dtype)
 
-    if input_type in ['cupy', 'numba', 'series']:
-        assert ary._owner is inp
-        inp_copy = deepcopy(cp.asarray(inp))
-
-        # testing owner reference keeps data of ary alive
-        del inp
-        assert cp.all(cp.asarray(ary._owner) == cp.asarray(inp_copy))
-
-    else:
+    if (input_type == "numpy"):
         assert isinstance(ary._owner, cp.ndarray)
 
         truth = cp.asnumpy(inp)
@@ -127,6 +120,38 @@ def test_array_init(input_type, dtype, shape, order):
         data = ary.to_output('numpy')
 
         assert np.array_equal(truth, data)
+    else:
+        found_owner = False
+
+        def get_owner(curr):
+            if (isinstance(curr, CumlArray)):
+                return curr._owner
+            elif (isinstance(curr, cp.ndarray)):
+                return curr.data.mem._owner
+            else:
+                return None
+
+        # Make sure the input array is in the ownership chain
+        curr_owner = ary
+
+        while (curr_owner is not None):
+            if (curr_owner is inp):
+                found_owner = True
+                break
+
+            curr_owner = get_owner(curr_owner)
+
+        assert found_owner, "GPU input arrays must be in the owner chain"
+
+        inp_copy = deepcopy(cp.asarray(inp))
+
+        # testing owner reference keeps data of ary alive
+        del inp
+
+        # Force GC just in case it lingers
+        gc.collect()
+
+        assert cp.all(cp.asarray(ary._owner) == cp.asarray(inp_copy))
 
     return True
 
@@ -157,6 +182,36 @@ def test_array_init_from_bytes(data_type, dtype, shape, order):
     cp_ary = cp.zeros(shape, dtype=dtype)
 
     assert cp.all(cp.asarray(cp_ary) == cp_ary)
+
+
+@pytest.mark.parametrize('input_type', test_input_types)
+@pytest.mark.parametrize('dtype', test_dtypes_all)
+@pytest.mark.parametrize('shape', test_shapes)
+@pytest.mark.parametrize('order', ['F', 'C'])
+def test_array_init_bad(input_type, dtype, shape, order):
+    """
+    This test ensures that we assert on incorrect combinations of arguments
+    when creating CumlArray
+    """
+    if input_type == 'series':
+        inp = create_input(input_type, dtype, shape, 'C')
+    else:
+        inp = create_input(input_type, dtype, shape, order)
+
+    # Ensure the array is creatible
+    cuml_ary = CumlArray(inp)
+
+    with pytest.raises(AssertionError):
+        CumlArray(inp, dtype=cuml_ary.dtype)
+
+    with pytest.raises(AssertionError):
+        CumlArray(inp, shape=cuml_ary.shape)
+
+    with pytest.raises(AssertionError):
+        CumlArray(inp,
+                  order=_strides_to_order(cuml_ary.strides, cuml_ary.dtype))
+
+    assert cp.all(cp.asarray(inp) == cp.asarray(cuml_ary))
 
 
 @pytest.mark.parametrize('slice', test_slices)
@@ -205,7 +260,7 @@ def test_create_empty(shape, dtype, order):
     else:
         assert ary.shape == shape
     assert ary.dtype == np.dtype(dtype)
-    assert isinstance(ary._owner, DeviceBuffer)
+    assert isinstance(ary._owner, rmm.DeviceBuffer)
 
 
 @pytest.mark.parametrize('shape', test_shapes)
@@ -478,6 +533,43 @@ def test_cumlary_binops(operation):
     ary_c = operation(ary_a, ary_b)
 
     assert(cp.all(ary_c.to_output('cupy') == c))
+
+
+def test_sliced_array_owner():
+    """
+    When slicing a CumlArray, a new object can be created created which
+    previously had an incorrect owner. This was due to the requirement by
+    `cudf.core.Buffer` that all data be in "u1" form. CumlArray would satisfy
+    this requirement by calling
+    `cp.asarray(data).ravel(order='A').view('u1')`. If the slice is not
+    contiguous, this would create an intermediate object with no references
+    that would be cleaned up by GC causing an error when using the memory
+    """
+
+    # Create 2 copies of a random array
+    random_cp = cp.array(cp.random.random((500, 4)), dtype=np.float32)
+    cupy_array = cp.array(random_cp, copy=True)
+    cuml_array = CumlArray(random_cp)
+
+    # Make sure we have 2 pieces of data
+    assert cupy_array.data.ptr != cuml_array.ptr
+
+    # Since these are C arrays, slice off the first column to ensure they are
+    # non-contiguous
+    cuml_slice = cuml_array[:, 1:]
+    cupy_slice = cupy_array[:, 1:]
+
+    # Delete the input object just to be sure
+    del random_cp
+
+    # Make sure to cleanup any objects. Forces deletion of intermediate owner
+    # object
+    gc.collect()
+
+    # Calling `to_output` forces use of the pointer. This can fail with a cuda
+    # error on `cupy.cuda.runtime.pointerGetAttributes(cuml_slice.ptr)` in CUDA
+    # < 11.0 or cudaErrorInvalidDevice in CUDA > 11.0 (unclear why it changed)
+    assert (cp.all(cuml_slice.to_output('cupy') == cupy_slice))
 
 
 def create_input(input_type, dtype, shape, order):

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -320,7 +320,7 @@ def check_ptr(a, b, input_type):
 
 def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
     rand_mat = (cp.random.rand(nrows, ncols) * 10)
-    rand_mat = cp.array(rand_mat, order=order).astype(dtype)
+    rand_mat = cp.array(rand_mat, dtype=dtype, order=order)
 
     if type == 'numpy':
         result = np.array(cp.asnumpy(rand_mat), order=order)
@@ -338,8 +338,7 @@ def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
         result = pdDF(cp.asnumpy(rand_mat))
 
     if type == 'cuml':
-        result = CumlArray(data=rand_mat,
-                           order=order if order != 'K' else None)
+        result = CumlArray(data=rand_mat)
 
     if out_dtype:
         return result, np.array(cp.asnumpy(rand_mat).astype(out_dtype),


### PR DESCRIPTION
This bug can occur when slicing a CumlArray that results in a non-contiguous memory layout (i.e. changing columns for C-type arrays or changing rows for F-type). For example:

```python
ary = CumlArray.zeros((500,4))

# Remove last column
ary = ary[:, 1:]

# Need to force intermediate objects to be deleted
gc.collect()

# Force memory access
print(ary.to_output("cupy")
```

This PR fixes this issue, adds a test to detect it, and cleans up the owner creation in `CumlArray` to prevent unnecessary array creation.