### PR TITLE
[REVIEW] Updating Estimators Derived from Base for Consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PR #2798: Add python tests for FIL multiclass classification of lightgbm models
 - PR #2892 Update ci/local/README.md
 - PR #2910: Adding Support for CuPy 8.x
+- PR #2928: Updating Estimators Derived from Base for Consistency
 
 ## Bug Fixes
 - PR #2882: Allow import on machines without GPUs

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -65,7 +65,6 @@ Feature and Label Encoding (Single-GPU)
 
  .. autoclass:: cuml.preprocessing.LabelEncoder.LabelEncoder
     :members:
-    :inherited-members:
 
  .. autoclass:: cuml.preprocessing.LabelBinarizer
     :members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,11 +5,15 @@ cuML API Reference
 Module Configuration
 ====================
 
+.. _output-data-type-configuration:
+
 Output Data Type Configuration
 ------------------------------
 
  .. automethod:: cuml.common.memory_utils.set_global_output_type
  .. automethod:: cuml.common.memory_utils.using_output_type
+
+.. _verbosity-levels:
 
 Verbosity Levels
 ----------------
@@ -61,6 +65,7 @@ Feature and Label Encoding (Single-GPU)
 
  .. autoclass:: cuml.preprocessing.LabelEncoder.LabelEncoder
     :members:
+    :inherited-members:
 
  .. autoclass:: cuml.preprocessing.LabelBinarizer
     :members:
@@ -470,4 +475,7 @@ Dask Base Classes and Mixins
    :members:
 
 .. autoclass:: cuml.dask.common.base.DelayedInverseTransformMixin
+   :members:
+
+.. autoclass:: cuml.experimental.decomposition.IncrementalPCA
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'cuml'
-copyright = '2019, nvidia'
+copyright = '2020, nvidia'
 author = 'nvidia'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -341,10 +341,8 @@ class DBSCAN(Base):
 
     def get_param_names(self):
         return super().get_param_names() + [
-                "eps",
-                "min_samples",
-                "max_mbytes_per_batch",
-                "calc_core_sample_indices",
-            ]
-
-
+            "eps",
+            "min_samples",
+            "max_mbytes_per_batch",
+            "calc_core_sample_indices",
+        ]

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -125,12 +125,18 @@ class DBSCAN(Base):
         The maximum distance between 2 points such they reside in the same
         neighborhood.
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     min_samples : int (default = 5)
         The number of samples in a neighborhood such that this group can be
         considered as an important core point (including the point itself).
-    verbose : int or boolean (default = False)
-        Logging level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     max_mbytes_per_batch : (optional) int64
         Calculate batch size using no more than this number of megabytes for
         the pairwise distance computation. This enables the trade-off between
@@ -141,13 +147,11 @@ class DBSCAN(Base):
         Note: this option does not set the maximum total memory used in the
         DBSCAN computation and so this value will not be able to be set to
         the total memory available on the device.
-    output_type : (optional) {'input', 'cudf', 'cupy', 'numpy'} default = None
-        Use it to control output type of the results and attributes.
-        If None it'll inherit the output type set at the
-        module level, cuml.output_type. If that has not been changed, by
-        default the estimator will mirror the type of the data used for each
-        fit or predict call.
-        If set, the estimator will override the global option for its behavior.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
     calc_core_sample_indices : (optional) boolean (default = True)
         Indicates whether the indices of the core samples should be calculated.
         The the attribute `core_sample_indices_` will not be used, setting this
@@ -336,4 +340,11 @@ class DBSCAN(Base):
         return self.labels_
 
     def get_param_names(self):
-        return ["eps", "min_samples"]
+        return super().get_param_names() + [
+                "eps",
+                "min_samples",
+                "max_mbytes_per_batch",
+                "calc_core_sample_indices",
+            ]
+
+

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -177,15 +177,21 @@ class KMeans(Base):
     Parameters
     ----------
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     n_clusters : int (default = 8)
         The number of centroids or clusters you want.
     max_iter : int (default = 300)
         The more iterations of EM, the more accurate, but slower.
     tol : float64 (default = 1e-4)
         Stopping criterion when centroid means do not change much.
-    verbose : int or boolean (default = False)
-        Logging level.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     random_state : int (default = 1)
         If you want results to be the same when you restart Python, select a
         state.
@@ -218,6 +224,11 @@ class KMeans(Base):
         pairwise distance computation is max_samples_per_batch * n_clusters.
         It might become necessary to lower this number when n_clusters
         becomes prohibitively large.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -607,6 +618,7 @@ class KMeans(Base):
         return self.fit(X).transform(X, convert_dtype=convert_dtype)
 
     def get_param_names(self):
-        return ['n_init', 'oversampling_factor', 'max_samples_per_batch',
+        return super().get_param_names() + \
+            ['n_init', 'oversampling_factor', 'max_samples_per_batch',
                 'init', 'max_iter', 'n_clusters', 'random_state',
                 'tol']

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -180,7 +180,8 @@ class Base:
         else:
             self.verbose = verbose
 
-        self.output_type = _check_output_type_str(cuml.global_output_type if output_type is None else output_type)
+        self.output_type = _check_output_type_str(
+            cuml.global_output_type if output_type is None else output_type)
 
         self._mirror_input = True if self.output_type == 'input' else False
 
@@ -444,13 +445,13 @@ def _check_output_type_str(output_str):
             return output_str
         else:
             raise ValueError(("output_type must be one of "
-                             "'numpy', 'cupy', 'cudf', 'numba', or 'input'."
-                             " Got: '{}'")
-                             .format(output_str))
+                              "'numpy', 'cupy', 'cudf', 'numba', or 'input'."
+                              " Got: '{}'"
+                              ).format(output_str))
     else:
         raise ValueError(("output_type must be a string"
-                          " Got: '{}'")
-                         .format(type(output_str)))
+                          " Got: '{}'"
+                          ).format(type(output_str)))
 
 
 def _input_target_to_dtype(target):

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -108,19 +108,18 @@ class Base:
         stream that will be used for the model's computations, so users can
         run different models concurrently in different streams by creating
         handles in several streams.
-        If it is None, a new one is created just for this class.
-    verbose : int or boolean (default = False)
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
         Sets logging level. It must be one of `cuml.common.logger.level_*`.
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
-        the estimators. If None, it'll inherit the output type set at the
-        module level, cuml.output_type. If set, the estimator will override
-        the global option for its behavior.
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Examples
     --------
-
-
 
     .. code-block:: python
 
@@ -181,8 +180,7 @@ class Base:
         else:
             self.verbose = verbose
 
-        self.output_type = cuml.global_output_type if output_type is None \
-            else _check_output_type_str(output_type)
+        self.output_type = _check_output_type_str(cuml.global_output_type if output_type is None else output_type)
 
         self._mirror_input = True if self.output_type == 'input' else False
 
@@ -217,7 +215,7 @@ class Base:
         extra set of parameters that it in-turn owns. This is to simplify the
         implementation of `get_params` and `set_params` methods.
         """
-        return []
+        return ["handle", "verbose", "output_type"]
 
     def get_params(self, deep=True):
         """
@@ -442,11 +440,17 @@ def _input_to_type(input):
 def _check_output_type_str(output_str):
     if isinstance(output_str, str):
         output_type = output_str.lower()
-        if output_type in ['numpy', 'cupy', 'cudf', 'numba']:
+        if output_type in ['numpy', 'cupy', 'cudf', 'numba', 'input']:
             return output_str
         else:
-            raise ValueError("output_type must be one of " +
-                             "'numpy', 'cupy', 'cudf' or 'numba'")
+            raise ValueError(("output_type must be one of "
+                             "'numpy', 'cupy', 'cudf', 'numba', or 'input'."
+                             " Got: '{}'")
+                             .format(output_str))
+    else:
+        raise ValueError(("output_type must be a string"
+                          " Got: '{}'")
+                         .format(type(output_str)))
 
 
 def _input_target_to_dtype(target):

--- a/python/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/dask/cluster/kmeans.py
@@ -48,15 +48,21 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
     ----------
 
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     n_clusters : int (default = 8)
         The number of centroids or clusters you want.
     max_iter : int (default = 300)
         The more iterations of EM, the more accurate, but slower.
     tol : float (default = 1e-4)
         Stopping criterion when centroid means do not change much.
-    verbose : int or boolean (default = False)
-        Logging level for printing diagnostic information
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     random_state : int (default = 1)
         If you want results to be the same when you restart Python,
         select a state.

--- a/python/cuml/dask/decomposition/pca.py
+++ b/python/cuml/dask/decomposition/pca.py
@@ -98,15 +98,21 @@ class PCA(BaseDecomposition,
     Parameters
     ----------
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     n_components : int (default = 1)
         The number of top K singular vectors / values you want.
         Must be <= number(columns).
     svd_solver : 'full', 'jacobi', or 'tsqr'
         'full': run exact full SVD and select the components by postprocessing
         'jacobi': iteratively compute SVD of the covariance matrix
-    verbose : int or boolean (default = False)
-        Logging level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     whiten : boolean (default = False)
         If True, de-correlates the components. This is done by dividing them by
         the corresponding singular values then multiplying by sqrt(n_samples).

--- a/python/cuml/dask/decomposition/tsvd.py
+++ b/python/cuml/dask/decomposition/tsvd.py
@@ -88,15 +88,21 @@ class TruncatedSVD(BaseDecomposition,
     Parameters
     ----------
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     n_components : int (default = 1)
         The number of top K singular vectors / values you want.
         Must be <= number(columns).
     svd_solver : 'full'
         Only Full algorithm is supported since it's significantly faster on GPU
         then the other solvers including randomized SVD.
-    verbose : int or boolean (default = False)
-        Logging level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     Attributes
     ----------

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -67,7 +67,12 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
     n_estimators : int (default = 10)
                    total number of trees in the forest (not per-worker)
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     split_criterion : The criterion used to split nodes.
         0 for GINI, 1 for ENTROPY, 4 for CRITERION_END.
         2 and 3 not valid for classification
@@ -482,25 +487,25 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         self.datatype = data.datatype
         return self._predict_proba(X, delayed, **kwargs)
 
-    def get_params(self, deep=True):
-        """
-        Returns the value of all parameters
-        required to configure this estimator as a dictionary.
+    # def get_params(self, deep=True):
+    #     """
+    #     Returns the value of all parameters
+    #     required to configure this estimator as a dictionary.
 
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        return self._get_params(deep)
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
+    #     return self._get_params(deep)
 
-    def set_params(self, **params):
-        """
-        Sets the value of parameters required to
-        configure this estimator, it functions similar to
-        the sklearn set_params.
+    # def set_params(self, **params):
+    #     """
+    #     Sets the value of parameters required to
+    #     configure this estimator, it functions similar to
+    #     the sklearn set_params.
 
-        Parameters
-        -----------
-        params : dict of new params.
-        """
-        return self._set_params(**params)
+    #     Parameters
+    #     -----------
+    #     params : dict of new params.
+    #     """
+    #     return self._set_params(**params)

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -486,3 +486,26 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         data = DistributedDataHandler.create(X, client=self.client)
         self.datatype = data.datatype
         return self._predict_proba(X, delayed, **kwargs)
+
+    def get_params(self, deep=True):
+        """
+        Returns the value of all parameters
+        required to configure this estimator as a dictionary.
+
+        Parameters
+        -----------
+        deep : boolean (default = True)
+        """
+        return self._get_params(deep)
+
+    def set_params(self, **params):
+        """
+        Sets the value of parameters required to
+        configure this estimator, it functions similar to
+        the sklearn set_params.
+
+        Parameters
+        -----------
+        params : dict of new params.
+        """
+        return self._set_params(**params)

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -486,26 +486,3 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
         data = DistributedDataHandler.create(X, client=self.client)
         self.datatype = data.datatype
         return self._predict_proba(X, delayed, **kwargs)
-
-    # def get_params(self, deep=True):
-    #     """
-    #     Returns the value of all parameters
-    #     required to configure this estimator as a dictionary.
-
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-    #     return self._get_params(deep)
-
-    # def set_params(self, **params):
-    #     """
-    #     Sets the value of parameters required to
-    #     configure this estimator, it functions similar to
-    #     the sklearn set_params.
-
-    #     Parameters
-    #     -----------
-    #     params : dict of new params.
-    #     """
-    #     return self._set_params(**params)

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -373,26 +373,3 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
             pred.append(pred_per_worker / len(rslts))
 
         return pred
-
-    # def get_params(self, deep=True):
-    #     """
-    #     Returns the value of all parameters
-    #     required to configure this estimator as a dictionary.
-
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-    #     return self._get_params(deep)
-
-    # def set_params(self, **params):
-    #     """
-    #     Sets the value of parameters required to
-    #     configure this estimator, it functions similar to
-    #     the sklearn set_params.
-
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-    #     return self._set_params(**params)

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -373,3 +373,26 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
             pred.append(pred_per_worker / len(rslts))
 
         return pred
+
+    def get_params(self, deep=True):
+        """
+        Returns the value of all parameters
+        required to configure this estimator as a dictionary.
+
+        Parameters
+        -----------
+        deep : boolean (default = True)
+        """
+        return self._get_params(deep)
+
+    def set_params(self, **params):
+        """
+        Sets the value of parameters required to
+        configure this estimator, it functions similar to
+        the sklearn set_params.
+
+        Parameters
+        -----------
+        params : dict of new params
+        """
+        return self._set_params(**params)

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -62,7 +62,12 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
     n_estimators : int (default = 10)
         total number of trees in the forest (not per-worker)
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     split_algo : int (default = 1)
         0 for HIST, 1 for GLOBAL_QUANTILE
         The type of algorithm to be used to create the trees.
@@ -369,25 +374,25 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
 
         return pred
 
-    def get_params(self, deep=True):
-        """
-        Returns the value of all parameters
-        required to configure this estimator as a dictionary.
+    # def get_params(self, deep=True):
+    #     """
+    #     Returns the value of all parameters
+    #     required to configure this estimator as a dictionary.
 
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        return self._get_params(deep)
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
+    #     return self._get_params(deep)
 
-    def set_params(self, **params):
-        """
-        Sets the value of parameters required to
-        configure this estimator, it functions similar to
-        the sklearn set_params.
+    # def set_params(self, **params):
+    #     """
+    #     Sets the value of parameters required to
+    #     configure this estimator, it functions similar to
+    #     the sklearn set_params.
 
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        return self._set_params(**params)
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
+    #     return self._set_params(**params)

--- a/python/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/dask/linear_model/elastic_net.py
@@ -63,14 +63,17 @@ class ElasticNet(BaseEstimator):
         This (setting to ‘random’) often leads to significantly faster
         convergence especially when tol is higher than 1e-4.
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
-    output_type : (optional) {'input', 'cudf', 'cupy', 'numpy'} default = None
-        Use it to control output type of the results and attributes.
-        If None it'll inherit the output type set at the
-        module level, cuml.output_type. If that has not been changed, by
-        default the estimator will mirror the type of the data used for each
-        fit or predict call.
-        If set, the estimator will override the global option for its behavior.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     -----------

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -209,7 +209,12 @@ class PCA(Base):
         If True, then copies data then removes mean from data. False might
         cause data to be overwritten with its mean centered version.
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     iterated_power : int (default = 15)
         Used in Jacobi solver. The more iterations, the more accurate, but
         slower.
@@ -230,15 +235,20 @@ class PCA(Base):
     tol : float (default = 1e-7)
         Used if algorithm = "jacobi". Smaller tolerance can increase accuracy,
         but but will slow down the algorithm's convergence.
-    verbose : int or boolean (default = False)
-        Logging level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     whiten : boolean (default = False)
         If True, de-correlates the components. This is done by dividing them by
         the corresponding singular values then multiplying by sqrt(n_samples).
         Whitening allows each component to have unit variance and removes
         multi-collinearity. It might be beneficial for downstream
         tasks like LinearRegression where correlated features cause problems.
-
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -739,8 +749,9 @@ class PCA(Base):
         return t_input_data.to_output(out_type)
 
     def get_param_names(self):
-        return ["copy", "iterated_power", "n_components", "svd_solver", "tol",
-                "whiten"]
+        return super().get_param_names() + \
+            ["copy", "iterated_power", "n_components", "svd_solver", "tol",
+                "whiten", "random_state"]
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -182,7 +182,12 @@ class TruncatedSVD(Base):
         components.
         Jacobi is much faster as it iteratively corrects, but is less accurate.
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     n_components : int (default = 1)
         The number of top K singular vectors / values you want.
         Must be <= number(columns).
@@ -195,8 +200,14 @@ class TruncatedSVD(Base):
     tol : float (default = 1e-7)
         Used if algorithm = "jacobi". Smaller tolerance can increase accuracy,
         but but will slow down the algorithm's convergence.
-    verbose : int or boolean (default = False)
-        Logging level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     -----------
@@ -468,4 +479,5 @@ class TruncatedSVD(Base):
         return t_input_data.to_output(out_type)
 
     def get_param_names(self):
-        return ["algorithm", "n_components", "n_iter", "random_state", "tol"]
+        return super().get_param_names() + \
+            ["algorithm", "n_components", "n_iter", "random_state", "tol"]

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -42,8 +42,8 @@ class BaseRandomForestModel(Base):
                     'bootstrap', 'bootstrap_features',
                     'verbose', 'rows_sample',
                     'max_leaves', 'quantile_per_tree',
-		    'accuracy_metric', 'use_experimental_backend',
-		    'max_batch_size', 'shuffle_features']
+                    'accuracy_metric', 'use_experimental_backend',
+                    'max_batch_size', 'shuffle_features']
 
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -35,13 +35,13 @@ from cuml.common import input_to_cuml_array, with_cupy_rmm
 
 
 class BaseRandomForestModel(Base):
-    variables = ['n_estimators', 'max_depth', 'handle',
-                 'max_features', 'n_bins',
-                 'split_algo', 'split_criterion', 'min_rows_per_node',
-                 'min_impurity_decrease',
-                 'bootstrap', 'bootstrap_features',
-                 'verbose', 'rows_sample',
-                 'max_leaves', 'quantile_per_tree', 'accuracy_metric']
+    _param_names = ['n_estimators', 'max_depth', 'handle',
+                    'max_features', 'n_bins',
+                    'split_algo', 'split_criterion', 'min_rows_per_node',
+                    'min_impurity_decrease',
+                    'bootstrap', 'bootstrap_features',
+                    'verbose', 'rows_sample',
+                    'max_leaves', 'quantile_per_tree', 'accuracy_metric']
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}
 
@@ -341,12 +341,7 @@ class BaseRandomForestModel(Base):
         return preds
 
     def get_param_names(self):
-        combined = super().get_param_names() + BaseRandomForestModel.variables
-
-        if ("handle" in combined):
-            combined.remove("handle")
-
-        return combined
+        return super().get_param_names() + BaseRandomForestModel._param_names
 
     def set_params(self, **params):
         self.treelite_serialized_model = None

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -41,11 +41,11 @@ class BaseRandomForestModel(Base):
                  'min_impurity_decrease',
                  'bootstrap', 'bootstrap_features',
                  'verbose', 'rows_sample',
-                 'max_leaves', 'quantile_per_tree']
+                 'max_leaves', 'quantile_per_tree', 'accuracy_metric']
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}
 
-    def __init__(self, split_criterion, seed=None,
+    def __init__(self, *, split_criterion, seed=None,
                  n_streams=8, n_estimators=100,
                  max_depth=16, handle=None, max_features='auto',
                  n_bins=8, split_algo=1, bootstrap=True,
@@ -60,8 +60,6 @@ class BaseRandomForestModel(Base):
                  random_state=None, warm_start=None, class_weight=None,
                  quantile_per_tree=False, criterion=None):
 
-        if accuracy_metric:
-            BaseRandomForestModel.variables.append('accuracy_metric')
 
         sklearn_params = {"criterion": criterion,
                           "min_samples_leaf": min_samples_leaf,
@@ -343,26 +341,20 @@ class BaseRandomForestModel(Base):
                                         predict_proba=predict_proba)
         return preds
 
-    def _get_params(self, deep):
-        params = dict()
-        for key in BaseRandomForestModel.variables:
-            if key in ['handle']:
-                continue
-            var_value = getattr(self, key, None)
-            params[key] = var_value
-        return params
+    def get_param_names(self):
+        combined = super().get_param_names() + BaseRandomForestModel.variables
 
-    def _set_params(self, **params):
+        if ("handle" in combined):
+            combined.remove("handle")
+
+        return combined
+
+
+
+    def set_params(self, **params):
         self.treelite_serialized_model = None
 
-        if not params:
-            return self
-        for key, value in params.items():
-            if key not in BaseRandomForestModel.variables:
-                raise ValueError('Invalid parameter for estimator')
-            else:
-                setattr(self, key, value)
-        return self
+        super().set_params(**params)
 
 
 def _check_fil_parameter_validity(depth, algo, fil_sparse_format):

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -60,7 +60,6 @@ class BaseRandomForestModel(Base):
                  random_state=None, warm_start=None, class_weight=None,
                  quantile_per_tree=False, criterion=None):
 
-
         sklearn_params = {"criterion": criterion,
                           "min_samples_leaf": min_samples_leaf,
                           "min_weight_fraction_leaf": min_weight_fraction_leaf,
@@ -348,8 +347,6 @@ class BaseRandomForestModel(Base):
             combined.remove("handle")
 
         return combined
-
-
 
     def set_params(self, **params):
         self.treelite_serialized_model = None

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -880,27 +880,6 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         del(preds_m)
         return self.stats['accuracy']
 
-    # def get_params(self, deep=True):
-    #     """
-    #     Returns the value of all parameters
-    #     required to configure this estimator as a dictionary.
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-    #     return self._get_params(deep=deep)
-
-    # def set_params(self, **params):
-    #     """
-    #     Sets the value of parameters required to
-    #     configure this estimator, it functions similar to
-    #     the sklearn set_params.
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-    #     return self._set_params(**params)
-
     def print_summary(self):
         """
         Prints the summary of the forest used to train and test the model

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -171,8 +171,6 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     -----------
     n_estimators : int (default = 100)
         Number of trees in the forest. (Default changed to 100 in cuML 0.11)
-    handle : cuml.Handle
-        If it is None, a new one is created just for this class.
     split_criterion : The criterion used to split nodes.
         0 for GINI, 1 for ENTROPY
         2 and 3 not valid for classification
@@ -224,16 +222,34 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     seed : int (default = None)
         Deprecated in favor of `random_state`.
         Seed for the random number generator. Unseeded by default.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     """
 
-    def __init__(self, split_criterion=0,
-                 **kwargs):
+    def __init__(self, split_criterion=0, handle=None, verbose=False,
+                 output_type=None, **kwargs):
 
         self.RF_type = CLASSIFICATION
         self.num_classes = 2
         super(RandomForestClassifier, self).__init__(
             split_criterion=split_criterion,
+            handle=handle,
+            verbose=verbose,
+            output_type=output_type,
             **kwargs)
 
     """
@@ -864,26 +880,26 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         del(preds_m)
         return self.stats['accuracy']
 
-    def get_params(self, deep=True):
-        """
-        Returns the value of all parameters
-        required to configure this estimator as a dictionary.
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        return self._get_params(deep=deep)
+    # def get_params(self, deep=True):
+    #     """
+    #     Returns the value of all parameters
+    #     required to configure this estimator as a dictionary.
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
+    #     return self._get_params(deep=deep)
 
-    def set_params(self, **params):
-        """
-        Sets the value of parameters required to
-        configure this estimator, it functions similar to
-        the sklearn set_params.
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        return self._set_params(**params)
+    # def set_params(self, **params):
+    #     """
+    #     Sets the value of parameters required to
+    #     configure this estimator, it functions similar to
+    #     the sklearn set_params.
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
+    #     return self._set_params(**params)
 
     def print_summary(self):
         """

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -686,27 +686,6 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         del(preds_m)
         return stats
 
-    # def get_params(self, deep=True):
-    #     """
-    #     Returns the value of all parameters
-    #     required to configure this estimator as a dictionary.
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-    #     return self._get_params(deep=deep)
-
-    # def set_params(self, **params):
-    #     """
-    #     Sets the value of parameters required to
-    #     configure this estimator, it functions similar to
-    #     the sklearn set_params.
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-    #     return self._set_params(**params)
-
     def print_summary(self):
         """
         Prints the summary of the forest used to train and test the model

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -153,8 +153,6 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     -----------
     n_estimators : int (default = 100)
         Number of trees in the forest. (Default changed to 100 in cuML 0.11)
-    handle : cuml.Handle
-        If it is None, a new one is created just for this class.
     split_algo : int (default = 1)
         The algorithm to determine how nodes are split in the tree.
         0 for HIST and 1 for GLOBAL_QUANTILE. HIST curently uses a slower
@@ -217,16 +215,37 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         Deprecated in favor of `random_state`.
         Seed for the random number generator. Unseeded by default. Does not
         currently fully guarantee the exact same results.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     """
 
     def __init__(self, split_criterion=2,
                  accuracy_metric='r2',
+                 handle=None,
+                 verbose=False,
+                 output_type=None,
                  **kwargs):
         self.RF_type = REGRESSION
         super(RandomForestRegressor, self).__init__(
             split_criterion=split_criterion,
             accuracy_metric=accuracy_metric,
+            handle=handle,
+            verbose=verbose,
+            output_type=output_type,
             **kwargs)
     """
     TODO:
@@ -667,26 +686,26 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         del(preds_m)
         return stats
 
-    def get_params(self, deep=True):
-        """
-        Returns the value of all parameters
-        required to configure this estimator as a dictionary.
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        return self._get_params(deep=deep)
+    # def get_params(self, deep=True):
+    #     """
+    #     Returns the value of all parameters
+    #     required to configure this estimator as a dictionary.
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
+    #     return self._get_params(deep=deep)
 
-    def set_params(self, **params):
-        """
-        Sets the value of parameters required to
-        configure this estimator, it functions similar to
-        the sklearn set_params.
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        return self._set_params(**params)
+    # def set_params(self, **params):
+    #     """
+    #     Sets the value of parameters required to
+    #     configure this estimator, it functions similar to
+    #     the sklearn set_params.
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
+    #     return self._set_params(**params)
 
     def print_summary(self):
         """

--- a/python/cuml/experimental/decomposition/incremental_pca.py
+++ b/python/cuml/experimental/decomposition/incremental_pca.py
@@ -59,7 +59,7 @@ class IncrementalPCA(PCA):
         handles in several streams.
         If it is None, a new one is created.
     n_components : int or None, (default=None)
-        Number of components to keep. If ``n_components `` is ``None``,
+        Number of components to keep. If ``n_components`` is ``None``,
         then ``n_components`` is set to ``min(n_samples, n_features)``.
     whiten : bool, optional
         If True, de-correlates the components. This is done by dividing them by
@@ -106,9 +106,7 @@ class IncrementalPCA(PCA):
         ``partial_fit``.
     noise_variance_ : float
         The estimated noise covariance following the Probabilistic PCA model
-        from Tipping and Bishop 1999. See "Pattern Recognition and
-        Machine Learning" by C. Bishop, 12.2.1 p. 574 or
-        http://www.miketipping.com/papers/met-mppca.pdf.
+        from [4]_.
     n_components_ : int
         The estimated number of components. Relevant when
         ``n_components=None``.
@@ -121,79 +119,73 @@ class IncrementalPCA(PCA):
     Notes
     -----
 
-    Implements the incremental PCA model from:
-    *D. Ross, J. Lim, R. Lin, M. Yang, Incremental Learning for Robust Visual
-    Tracking, International Journal of Computer Vision, Volume 77, Issue 1-3,
-    pp. 125-141, May 2008.*
-    See https://www.cs.toronto.edu/~dross/ivt/RossLimLinYang_ijcv.pdf
-    This model is an extension of the Sequential Karhunen-Loeve Transform from:
-    *A. Levy and M. Lindenbaum, Sequential Karhunen-Loeve Basis Extraction and
-    its Application to Images, IEEE Transactions on Image Processing, Volume 9,
-    Number 8, pp. 1371-1374, August 2000.*
-    See https://www.cs.technion.ac.il/~mic/doc/skl-ip.pdf
-    We have specifically abstained from an optimization used by authors of both
-    papers, a QR decomposition used in specific situations to reduce the
-    algorithmic complexity of the SVD. The source for this technique is
-    *Matrix Computations, Third Edition, G. Holub and C. Van Loan, Chapter 5,
-    section 5.4.4, pp 252-253.*. This technique has been omitted because it is
-    advantageous only when decomposing a matrix with ``n_samples`` (rows)
-    >= 5/3 * ``n_features`` (columns), and hurts the readability of the
-    implemented algorithm. This would be a good opportunity for future
-    optimization, if it is deemed necessary.
+    Implements the incremental PCA model from [1]_. This model is an extension
+    of the Sequential Karhunen-Loeve Transform from [2]_. We have specifically
+    abstained from an optimization used by authors of both papers, a QR
+    decomposition used in specific situations to reduce the algorithmic
+    complexity of the SVD. The source for this technique is [3]_. This
+    technique has been omitted because it is advantageous only when decomposing
+    a matrix with ``n_samples >= 5/3 * n_features`` where ``n_samples`` and
+    ``n_features`` are the matrix rows and columns, respectively. In addition,
+    it hurts the readability of the implemented algorithm. This would be a good
+    opportunity for future optimization, if it is deemed necessary.
+
+    References
+    ----------
+    .. [1] `D. Ross, J. Lim, R. Lin, M. Yang. Incremental Learning for Robust
+        Visual Tracking, International Journal of Computer Vision, Volume 77,
+        Issue 1-3, pp. 125-141, May 2008.
+        <https://www.cs.toronto.edu/~dross/ivt/RossLimLinYang_ijcv.pdf>`_
+
+    .. [2] `A. Levy and M. Lindenbaum, Sequential Karhunen-Loeve Basis
+        Extraction and its Application to Images, IEEE Transactions on Image
+        Processing, Volume 9, Number 8, pp. 1371-1374, August 2000.
+        <https://www.cs.technion.ac.il/~mic/doc/skl-ip.pdf>`_
+
+    .. [3] G. Golub and C. Van Loan. Matrix Computations, Third Edition,
+        Chapter 5, Section 5.4.4, pp. 252-253.
+
+    .. [4] `C. Bishop, 1999. "Pattern Recognition and Machine Learning",
+        Section 12.2.1, pp. 574
+        <http://www.miketipping.com/papers/met-mppca.pdf>`_
 
     Examples
     ---------
 
     .. code-block:: python
 
-        from cuml.decomposition import IncrementalPCA
-        import cupy as cp
-        import cupyx
-
-        X = cupyx.scipy.sparse.random(1000, 5, format='csr', density=0.07)
-        ipca = IncrementalPCA(n_components=2, batch_size=200)
-        ipca.fit(X)
-
-        print("Components: \n", ipca.components_)
-
-        print("Singular Values: ", ipca.singular_values_)
-
-        print("Explained Variance: ", ipca.explained_variance_)
-
-        print("Explained Variance Ratio: ",
-            ipca.explained_variance_ratio_)
-
-        print("Mean: ", ipca.mean_)
-
-        print("Noise Variance: ", ipca.noise_variance_)
-
-    Output:
-
-    .. code-block:: python
-
-        Components:
-        [[ 0.40465797  0.70924681 -0.46980153 -0.32028596 -0.09962083]
-        [ 0.3072285  -0.31337166 -0.21010504 -0.25727659  0.83490926]]
-
-        Singular Values: [4.67710479 4.0249979 ]
-
-        Explained Variance: [0.02189721 0.01621682]
-
-        Explained Variance Ratio: [0.2084041  0.15434174]
-
-        Mean: [0.03341744 0.03796517 0.03316038 0.03825872 0.0253353 ]
-
-        Noise Variance: 0.0049539530909571425
-
-    References
-    ----------
-
-    D. Ross, J. Lim, R. Lin, M. Yang. Incremental Learning for Robust Visual
-        Tracking, International Journal of Computer Vision, Volume 77,
-        Issue 1-3, pp. 125-141, May 2008.
-
-    G. Golub and C. Van Loan. Matrix Computations, Third Edition, Chapter 5,
-        Section 5.4.4, pp. 252-253.
+        >>> from cuml.experimental.decomposition import IncrementalPCA
+        >>> import cupy as cp
+        >>> import cupyx
+        >>>
+        >>> X = cupyx.scipy.sparse.random(1000, 4, format='csr', density=0.07)
+        >>> ipca = IncrementalPCA(n_components=2, batch_size=200)
+        >>> ipca.fit(X)
+        >>>
+        >>> # Components:
+        >>> ipca.components_
+        array([[-0.02362926,  0.87328851, -0.15971988,  0.45967206],
+            [-0.14643883,  0.11414225,  0.97589354,  0.11471273]])
+        >>>
+        >>> # Singular Values:
+        >>> ipca.singular_values_
+        array([4.90298662, 4.54498226])
+        >>>
+        >>> # Explained Variance:
+        >>> ipca.explained_variance_
+        array([0.02406334, 0.02067754])
+        >>>
+        >>> # Explained Variance Ratio:
+        >>> ipca.explained_variance_ratio_
+        array([0.28018011, 0.24075775])
+        >>>
+        >>> # Mean:
+        >>> ipca.mean_
+        array([0.03249896, 0.03629852, 0.03268694, 0.03216601])
+        >>>
+        >>> # Noise Variance:
+        >>> ipca.noise_variance_.item()
+        0.003474966583315544
 
     """
     def __init__(self, handle=None, n_components=None, *, whiten=False,
@@ -413,7 +405,7 @@ class IncrementalPCA(PCA):
         -------
 
         X_new : array-like, shape (n_samples, n_components)
-            New X
+
         """
 
         if scipy.sparse.issparse(X) or cupyx.scipy.sparse.issparse(X):

--- a/python/cuml/experimental/decomposition/incremental_pca.py
+++ b/python/cuml/experimental/decomposition/incremental_pca.py
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
+import numbers
+
 import cupy as cp
 import cupyx
 import scipy
-import numbers
-
-from cuml.common import with_cupy_rmm
+from cuml import Base
 from cuml.common import input_to_cuml_array
+from cuml.common import with_cupy_rmm
 from cuml.common.array import CumlArray
-
 from cuml.decomposition import PCA
 
 
@@ -426,7 +426,8 @@ class IncrementalPCA(PCA):
             return super().transform(X)
 
     def get_param_names(self):
-        return super().get_param_names() + self._hyperparams
+        # Skip super() since we dont pass any extra parameters in __init__
+        return Base.get_param_names(self) + self._hyperparams
 
     def _cupy_to_cumlarray_attrs(self):
         self._components_ = CumlArray(self._components_.copy())

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -93,6 +93,21 @@ class TfidfTransformer(Base):
         exactly once. Prevents zero divisions.
     sublinear_tf : bool, default=False
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -102,9 +117,13 @@ class TfidfTransformer(Base):
     """
 
     def __init__(self, *, norm='l2', use_idf=True, smooth_idf=True,
-                 sublinear_tf=False):
+                 sublinear_tf=False, handle=None, verbose=False,
+                 output_type=None):
 
-        super(TfidfTransformer, self).__init__(...)
+        super(TfidfTransformer, self).__init__(
+            handle=handle,
+            verbose=verbose,
+            output_type=output_type)
         self.norm = norm
         self.use_idf = use_idf
         self.smooth_idf = smooth_idf
@@ -266,3 +285,7 @@ class TfidfTransformer(Base):
             shape=(n_features, n_features),
             dtype=cp.float32
         )
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            ["norm", "use_idf", "smooth_idf", "sublinear_tf"]

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -43,7 +43,8 @@ def _get_dtype(X):
 
 
 class TfidfTransformer(Base):
-    """Transform a count matrix to a normalized tf or tf-idf representation
+    """
+    Transform a count matrix to a normalized tf or tf-idf representation
     Tf means term-frequency while tf-idf means term-frequency times inverse
     document-frequency. This is a common term weighting scheme in information
     retrieval, that has also found good use in document classification.
@@ -79,12 +80,13 @@ class TfidfTransformer(Base):
 
     Parameters
     ----------
+
     norm : {'l1', 'l2'}, default='l2'
         Each output row will have unit norm, either:
-        * 'l2': Sum of squares of vector elements is 1. The cosine
-        similarity between two vectors is their dot product when l2 norm has
-        been applied.
-        * 'l1': Sum of absolute values of vector elements is 1.
+         * 'l2': Sum of squares of vector elements is 1. The cosine similarity
+           between two vectors is their dot product when l2 norm has been
+           applied.
+         * 'l1': Sum of absolute values of vector elements is 1.
     use_idf : bool, default=True
         Enable inverse-document-frequency reweighting.
     smooth_idf : bool, default=True
@@ -113,7 +115,8 @@ class TfidfTransformer(Base):
     ----------
     idf_ : array of shape (n_features)
         The inverse document frequency (IDF) vector; only defined
-        if  ``use_idf`` is True.
+        if ``use_idf`` is True.
+
     """
 
     def __init__(self, *, norm='l2', use_idf=True, smooth_idf=True,

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -71,13 +71,8 @@ cdef class TreeliteModel():
     Attributes
     ----------
 
-    handle : cuml.Handle
-        Specifies the cuml.handle that holds internal CUDA state for
-        computations in this model. Most importantly, this specifies the CUDA
-        stream that will be used for the model's computations, so users can
-        run different models concurrently in different streams by creating
-        handles in several streams.
-        If it is None, a new one is created.
+    handle : ModelHandle
+        Opaque pointer to Treelite model
     """
     cpdef ModelHandle handle
     cpdef bool owns_handle

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -461,7 +461,7 @@ class ForestInference(Base):
     """
 
     def __init__(self,
-                 handle=None, 
+                 handle=None,
                  output_type=None,
                  verbose=False):
         super(ForestInference, self).__init__(handle=handle,

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -71,8 +71,13 @@ cdef class TreeliteModel():
     Attributes
     ----------
 
-    handle : ModelHandle
-        Opaque pointer to Treelite model
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     """
     cpdef ModelHandle handle
     cpdef bool owns_handle
@@ -414,7 +419,20 @@ class ForestInference(Base):
     Parameters
     ----------
     handle : cuml.Handle
-       If it is None, a new one is created just for this class.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Examples
     --------
@@ -448,9 +466,12 @@ class ForestInference(Base):
     """
 
     def __init__(self,
-                 handle=None, output_type=None):
-        super(ForestInference, self).__init__(handle,
-                                              output_type=output_type)
+                 handle=None, 
+                 output_type=None,
+                 verbose=False):
+        super(ForestInference, self).__init__(handle=handle,
+                                              output_type=output_type,
+                                              verbose=verbose)
         self._impl = ForestInference_impl(self.handle)
 
     def predict(self, X, preds=None):

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -228,42 +228,6 @@ class ElasticNet(Base, RegressorMixin):
 
         return self.solver_model.predict(X, convert_dtype=convert_dtype)
 
-    # def get_params(self, deep=True):
-    #     """
-    #     Scikit-learn style function that returns the estimator parameters.
-
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-    #     params = dict()
-    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-    #                  'selection']
-    #     for key in variables:
-    #         var_value = getattr(self, key, None)
-    #         params[key] = var_value
-    #     return params
-
-    # def set_params(self, **params):
-    #     """
-    #     Sklearn style set parameter state to dictionary of params.
-
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-    #     if not params:
-    #         return self
-    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-    #                  'selection']
-    #     for key, value in params.items():
-    #         if key not in variables:
-    #             raise ValueError('Invalid parameter for estimator')
-    #         else:
-    #             setattr(self, key, value)
-
-    #     return self
-
     def get_param_names(self):
         return super().get_param_names() + \
             [

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -229,14 +229,12 @@ class ElasticNet(Base, RegressorMixin):
         return self.solver_model.predict(X, convert_dtype=convert_dtype)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "alpha",
-                "l1_ratio",
-                "fit_intercept",
-                "normalize",
-                "max_iter",
-                "tol",
-                "selection",
-            ]
-
+        return super().get_param_names() + [
+            "alpha",
+            "l1_ratio",
+            "fit_intercept",
+            "normalize",
+            "max_iter",
+            "tol",
+            "selection",
+        ]

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -113,14 +113,20 @@ class ElasticNet(Base, RegressorMixin):
         This (setting to ‘random’) often leads to significantly faster
         convergence especially when tol is higher than 1e-4.
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
-    output_type : (optional) {'input', 'cudf', 'cupy', 'numpy'} default = None
-        Use it to control output type of the results and attributes.
-        If None it'll inherit the output type set at the
-        module level, cuml.output_type. If that has not been changed, by
-        default the estimator will mirror the type of the data used for each
-        fit or predict call.
-        If set, the estimator will override the global option for its behavior.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     Attributes
     -----------
@@ -137,7 +143,7 @@ class ElasticNet(Base, RegressorMixin):
 
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
                  normalize=False, max_iter=1000, tol=1e-3, selection='cyclic',
-                 handle=None, output_type=None):
+                 handle=None, output_type=None, verbose=False):
         """
         Initializes the elastic-net regression class.
 
@@ -157,7 +163,7 @@ class ElasticNet(Base, RegressorMixin):
 
         # Hard-code verbosity as CoordinateDescent does not have verbosity
         super(ElasticNet, self).__init__(handle=handle,
-                                         verbose=False,
+                                         verbose=verbose,
                                          output_type=output_type)
 
         self._check_alpha(alpha)
@@ -222,38 +228,51 @@ class ElasticNet(Base, RegressorMixin):
 
         return self.solver_model.predict(X, convert_dtype=convert_dtype)
 
-    def get_params(self, deep=True):
-        """
-        Scikit-learn style function that returns the estimator parameters.
+    # def get_params(self, deep=True):
+    #     """
+    #     Scikit-learn style function that returns the estimator parameters.
 
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        params = dict()
-        variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-                     'selection']
-        for key in variables:
-            var_value = getattr(self, key, None)
-            params[key] = var_value
-        return params
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
+    #     params = dict()
+    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
+    #                  'selection']
+    #     for key in variables:
+    #         var_value = getattr(self, key, None)
+    #         params[key] = var_value
+    #     return params
 
-    def set_params(self, **params):
-        """
-        Sklearn style set parameter state to dictionary of params.
+    # def set_params(self, **params):
+    #     """
+    #     Sklearn style set parameter state to dictionary of params.
 
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        if not params:
-            return self
-        variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-                     'selection']
-        for key, value in params.items():
-            if key not in variables:
-                raise ValueError('Invalid parameter for estimator')
-            else:
-                setattr(self, key, value)
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
+    #     if not params:
+    #         return self
+    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
+    #                  'selection']
+    #     for key, value in params.items():
+    #         if key not in variables:
+    #             raise ValueError('Invalid parameter for estimator')
+    #         else:
+    #             setattr(self, key, value)
 
-        return self
+    #     return self
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "alpha",
+                "l1_ratio",
+                "fit_intercept",
+                "normalize",
+                "max_iter",
+                "tol",
+                "selection",
+            ]
+

--- a/python/cuml/linear_model/lasso.pyx
+++ b/python/cuml/linear_model/lasso.pyx
@@ -109,7 +109,20 @@ class Lasso(Base, RegressorMixin):
         This (setting to ‘random’) often leads to significantly faster
         convergence especially when tol is higher than 1e-4.
     handle : cuml.Handle
-        If it is None, a new one is created just for this class.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     Attributes
     -----------
@@ -126,10 +139,10 @@ class Lasso(Base, RegressorMixin):
 
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  max_iter=1000, tol=1e-3, selection='cyclic', handle=None,
-                 output_type=None):
+                 output_type=None, verbose=False):
 
         # Hard-code verbosity as CoordinateDescent does not have verbosity
-        super(Lasso, self).__init__(handle=handle, verbose=False,
+        super(Lasso, self).__init__(handle=handle, verbose=verbose,
                                     output_type=output_type)
 
         self._check_alpha(alpha)
@@ -184,38 +197,49 @@ class Lasso(Base, RegressorMixin):
 
         return self.solver_model.predict(X, convert_dtype=convert_dtype)
 
-    def get_params(self, deep=True):
-        """
-        Scikit-learn style function that returns the estimator parameters.
+    # def get_params(self, deep=True):
+    #     """
+    #     Scikit-learn style function that returns the estimator parameters.
 
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
-        params = dict()
-        variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-                     'selection']
-        for key in variables:
-            var_value = getattr(self, key, None)
-            params[key] = var_value
-        return params
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
+    #     params = dict()
+    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
+    #                  'selection']
+    #     for key in variables:
+    #         var_value = getattr(self, key, None)
+    #         params[key] = var_value
+    #     return params
 
-    def set_params(self, **params):
-        """
-        Sklearn style set parameter state to dictionary of params.
+    # def set_params(self, **params):
+    #     """
+    #     Sklearn style set parameter state to dictionary of params.
 
-        Parameters
-        -----------
-        params : dict of new params
-        """
-        if not params:
-            return self
-        variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-                     'selection']
-        for key, value in params.items():
-            if key not in variables:
-                raise ValueError('Invalid parameter for estimator')
-            else:
-                setattr(self, key, value)
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
+    #     if not params:
+    #         return self
+    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
+    #                  'selection']
+    #     for key, value in params.items():
+    #         if key not in variables:
+    #             raise ValueError('Invalid parameter for estimator')
+    #         else:
+    #             setattr(self, key, value)
 
-        return self
+    #     return self
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "alpha",
+                "fit_intercept",
+                "normalize",
+                "max_iter",
+                "tol",
+                "selection",
+            ]

--- a/python/cuml/linear_model/lasso.pyx
+++ b/python/cuml/linear_model/lasso.pyx
@@ -197,42 +197,6 @@ class Lasso(Base, RegressorMixin):
 
         return self.solver_model.predict(X, convert_dtype=convert_dtype)
 
-    # def get_params(self, deep=True):
-    #     """
-    #     Scikit-learn style function that returns the estimator parameters.
-
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-    #     params = dict()
-    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-    #                  'selection']
-    #     for key in variables:
-    #         var_value = getattr(self, key, None)
-    #         params[key] = var_value
-    #     return params
-
-    # def set_params(self, **params):
-    #     """
-    #     Sklearn style set parameter state to dictionary of params.
-
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-    #     if not params:
-    #         return self
-    #     variables = ['alpha', 'fit_intercept', 'normalize', 'max_iter', 'tol',
-    #                  'selection']
-    #     for key, value in params.items():
-    #         if key not in variables:
-    #             raise ValueError('Invalid parameter for estimator')
-    #         else:
-    #             setattr(self, key, value)
-
-    #     return self
-
     def get_param_names(self):
         return super().get_param_names() + \
             [

--- a/python/cuml/linear_model/lasso.pyx
+++ b/python/cuml/linear_model/lasso.pyx
@@ -198,12 +198,11 @@ class Lasso(Base, RegressorMixin):
         return self.solver_model.predict(X, convert_dtype=convert_dtype)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "alpha",
-                "fit_intercept",
-                "normalize",
-                "max_iter",
-                "tol",
-                "selection",
-            ]
+        return super().get_param_names() + [
+            "alpha",
+            "fit_intercept",
+            "normalize",
+            "max_iter",
+            "tol",
+            "selection",
+        ]

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -149,6 +149,21 @@ class LinearRegression(Base, RegressorMixin):
         If True, the predictors in X will be normalized by dividing by it's
         L2 norm.
         If False, no scaling will be done.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     -----------
@@ -336,4 +351,5 @@ class LinearRegression(Base, RegressorMixin):
         return preds.to_output(out_type)
 
     def get_param_names(self):
-        return ['algorithm', 'fit_intercept', 'normalize']
+        return super().get_param_names() + \
+            ['algorithm', 'fit_intercept', 'normalize']

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -124,8 +124,9 @@ class LogisticRegression(Base, ClassifierMixin):
     linesearch_max_iter: int (default = 50)
         Max number of linesearch iterations per outer iteration used in the
         lbfgs and owl QN solvers.
-    verbose : int or boolean (default = False)
-        Controls verbose level of logging.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     l1_ratio: float or None, optional (default=None)
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`
     solver: 'qn', 'lbfgs', 'owl' (default='qn').
@@ -134,6 +135,18 @@ class LogisticRegression(Base, ClassifierMixin):
         depending on the conditions of the l1 regularization described
         above. Options 'lbfgs' and 'owl' are just convenience values that
         end up using the same solver following the same rules.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     -----------
@@ -388,16 +401,18 @@ class LogisticRegression(Base, ClassifierMixin):
         return proba.to_output(out_type)
 
     def get_param_names(self):
-        return [
-            "C",
-            "penalty",
-            "tol",
-            "fit_intercept",
-            "max_iter",
-            "linesearch_max_iter",
-            "l1_ratio",
-            "solver",
-        ]
+        return super().get_param_names() + \
+            [
+                "penalty",
+                "tol",
+                "C",
+                "fit_intercept",
+                "class_weight",
+                "max_iter",
+                "linesearch_max_iter",
+                "l1_ratio",
+                "solver",
+            ]
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -401,18 +401,17 @@ class LogisticRegression(Base, ClassifierMixin):
         return proba.to_output(out_type)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "penalty",
-                "tol",
-                "C",
-                "fit_intercept",
-                "class_weight",
-                "max_iter",
-                "linesearch_max_iter",
-                "l1_ratio",
-                "solver",
-            ]
+        return super().get_param_names() + [
+            "penalty",
+            "tol",
+            "C",
+            "fit_intercept",
+            "class_weight",
+            "max_iter",
+            "linesearch_max_iter",
+            "l1_ratio",
+            "solver",
+        ]
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -200,46 +200,6 @@ class MBSGDClassifier(Base, ClassifierMixin):
 
         return preds
 
-    # def get_params(self, deep=True):
-    #     """
-    #     Scikit-learn style function that returns the estimator parameters.
-
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-
-    #     params = dict()
-    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-    #     for key in variables:
-    #         var_value = getattr(self, key, None)
-    #         params[key] = var_value
-    #     return params
-
-    # def set_params(self, **params):
-    #     """
-    #     Sklearn style set parameter state to dictionary of params.
-
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-
-    #     if not params:
-    #         return self
-    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-    #     for key, value in params.items():
-    #         if key not in variables:
-    #             raise ValueError('Invalid parameter for estimator')
-    #         else:
-    #             setattr(self, key, value)
-
-    #     return self
-
     def get_param_names(self):
         return super().get_param_names() + \
             [

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -201,19 +201,18 @@ class MBSGDClassifier(Base, ClassifierMixin):
         return preds
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "loss",
-                "penalty",
-                "alpha",
-                "l1_ratio",
-                "fit_intercept",
-                "epochs",
-                "tol",
-                "shuffle",
-                "learning_rate",
-                "eta0",
-                "power_t",
-                "batch_size",
-                "n_iter_no_change",
-            ]
+        return super().get_param_names() + [
+            "loss",
+            "penalty",
+            "alpha",
+            "l1_ratio",
+            "fit_intercept",
+            "epochs",
+            "tol",
+            "shuffle",
+            "learning_rate",
+            "eta0",
+            "power_t",
+            "batch_size",
+            "n_iter_no_change",
+        ]

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -129,11 +129,21 @@ class MBSGDClassifier(Base, ClassifierMixin):
         The old learning rate is generally divided by 5
     n_iter_no_change : int (default = 5)
         the number of epochs to train without any imporvement in the model
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
-        the estimators. If None, it'll inherit the output type set at the
-        module level, cuml.output_type. If set, the estimator will override
-        the global option for its behavior.
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Notes
     ------
@@ -190,42 +200,60 @@ class MBSGDClassifier(Base, ClassifierMixin):
 
         return preds
 
-    def get_params(self, deep=True):
-        """
-        Scikit-learn style function that returns the estimator parameters.
+    # def get_params(self, deep=True):
+    #     """
+    #     Scikit-learn style function that returns the estimator parameters.
 
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
 
-        params = dict()
-        variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-                     'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-                     'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-        for key in variables:
-            var_value = getattr(self, key, None)
-            params[key] = var_value
-        return params
+    #     params = dict()
+    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
+    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
+    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
+    #     for key in variables:
+    #         var_value = getattr(self, key, None)
+    #         params[key] = var_value
+    #     return params
 
-    def set_params(self, **params):
-        """
-        Sklearn style set parameter state to dictionary of params.
+    # def set_params(self, **params):
+    #     """
+    #     Sklearn style set parameter state to dictionary of params.
 
-        Parameters
-        -----------
-        params : dict of new params
-        """
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
 
-        if not params:
-            return self
-        variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-                     'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-                     'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-        for key, value in params.items():
-            if key not in variables:
-                raise ValueError('Invalid parameter for estimator')
-            else:
-                setattr(self, key, value)
+    #     if not params:
+    #         return self
+    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
+    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
+    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
+    #     for key, value in params.items():
+    #         if key not in variables:
+    #             raise ValueError('Invalid parameter for estimator')
+    #         else:
+    #             setattr(self, key, value)
 
-        return self
+    #     return self
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "loss",
+                "penalty",
+                "alpha",
+                "l1_ratio",
+                "fit_intercept",
+                "epochs",
+                "tol",
+                "shuffle",
+                "learning_rate",
+                "eta0",
+                "power_t",
+                "batch_size",
+                "n_iter_no_change",
+            ]

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -194,46 +194,6 @@ class MBSGDRegressor(Base, RegressorMixin):
                                           convert_dtype=convert_dtype)
         return preds
 
-    # def get_params(self, deep=True):
-    #     """
-    #     Scikit-learn style function that returns the estimator parameters.
-
-    #     Parameters
-    #     -----------
-    #     deep : boolean (default = True)
-    #     """
-
-    #     params = dict()
-    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-    #     for key in variables:
-    #         var_value = getattr(self, key, None)
-    #         params[key] = var_value
-    #     return params
-
-    # def set_params(self, **params):
-    #     """
-    #     Sklearn style set parameter state to dictionary of params.
-
-    #     Parameters
-    #     -----------
-    #     params : dict of new params
-    #     """
-
-    #     if not params:
-    #         return self
-    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-    #     for key, value in params.items():
-    #         if key not in variables:
-    #             raise ValueError('Invalid parameter for estimator')
-    #         else:
-    #             setattr(self, key, value)
-
-    #     return self
-
     def get_param_names(self):
         return super().get_param_names() + \
             [

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -195,20 +195,18 @@ class MBSGDRegressor(Base, RegressorMixin):
         return preds
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "loss",
-                "penalty",
-                "alpha",
-                "l1_ratio",
-                "fit_intercept",
-                "epochs",
-                "tol",
-                "shuffle",
-                "learning_rate",
-                "eta0",
-                "power_t",
-                "batch_size",
-                "n_iter_no_change",
-            ]
-
+        return super().get_param_names() + [
+            "loss",
+            "penalty",
+            "alpha",
+            "l1_ratio",
+            "fit_intercept",
+            "epochs",
+            "tol",
+            "shuffle",
+            "learning_rate",
+            "eta0",
+            "power_t",
+            "batch_size",
+            "n_iter_no_change",
+        ]

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -120,11 +120,21 @@ class MBSGDRegressor(Base, RegressorMixin):
         The old learning rate is generally divided by 5
     n_iter_no_change : int (default = 5)
         the number of epochs to train without any imporvement in the model
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
-        the estimators. If None, it'll inherit the output type set at the
-        module level, cuml.output_type. If set, the estimator will override
-        the global option for its behavior.
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Notes
     ------
@@ -184,42 +194,61 @@ class MBSGDRegressor(Base, RegressorMixin):
                                           convert_dtype=convert_dtype)
         return preds
 
-    def get_params(self, deep=True):
-        """
-        Scikit-learn style function that returns the estimator parameters.
+    # def get_params(self, deep=True):
+    #     """
+    #     Scikit-learn style function that returns the estimator parameters.
 
-        Parameters
-        -----------
-        deep : boolean (default = True)
-        """
+    #     Parameters
+    #     -----------
+    #     deep : boolean (default = True)
+    #     """
 
-        params = dict()
-        variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-                     'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-                     'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-        for key in variables:
-            var_value = getattr(self, key, None)
-            params[key] = var_value
-        return params
+    #     params = dict()
+    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
+    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
+    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
+    #     for key in variables:
+    #         var_value = getattr(self, key, None)
+    #         params[key] = var_value
+    #     return params
 
-    def set_params(self, **params):
-        """
-        Sklearn style set parameter state to dictionary of params.
+    # def set_params(self, **params):
+    #     """
+    #     Sklearn style set parameter state to dictionary of params.
 
-        Parameters
-        -----------
-        params : dict of new params
-        """
+    #     Parameters
+    #     -----------
+    #     params : dict of new params
+    #     """
 
-        if not params:
-            return self
-        variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
-                     'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
-                     'power_t', 'batch_size', 'n_iter_no_change', 'handle']
-        for key, value in params.items():
-            if key not in variables:
-                raise ValueError('Invalid parameter for estimator')
-            else:
-                setattr(self, key, value)
+    #     if not params:
+    #         return self
+    #     variables = ['loss', 'penalty', 'alpha', 'l1_ratio', 'fit_intercept',
+    #                  'epochs', 'tol', 'shuffle', 'learning_rate', 'eta0',
+    #                  'power_t', 'batch_size', 'n_iter_no_change', 'handle']
+    #     for key, value in params.items():
+    #         if key not in variables:
+    #             raise ValueError('Invalid parameter for estimator')
+    #         else:
+    #             setattr(self, key, value)
 
-        return self
+    #     return self
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "loss",
+                "penalty",
+                "alpha",
+                "l1_ratio",
+                "fit_intercept",
+                "epochs",
+                "tol",
+                "shuffle",
+                "learning_rate",
+                "eta0",
+                "power_t",
+                "batch_size",
+                "n_iter_no_change",
+            ]
+

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -208,7 +208,8 @@ class Ridge(Base, RegressorMixin):
     """
 
     def __init__(self, alpha=1.0, solver='eig', fit_intercept=True,
-                 normalize=False, handle=None, output_type=None, verbose=False):
+                 normalize=False, handle=None, output_type=None,
+                 verbose=False):
 
         """
         Initializes the linear ridge regression class.

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -166,6 +166,21 @@ class Ridge(Base, RegressorMixin):
         If True, the predictors in X will be normalized by dividing by it's L2
         norm.
         If False, no scaling will be done.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     Attributes
     -----------
@@ -193,7 +208,7 @@ class Ridge(Base, RegressorMixin):
     """
 
     def __init__(self, alpha=1.0, solver='eig', fit_intercept=True,
-                 normalize=False, handle=None, output_type=None):
+                 normalize=False, handle=None, output_type=None, verbose=False):
 
         """
         Initializes the linear ridge regression class.
@@ -209,7 +224,7 @@ class Ridge(Base, RegressorMixin):
 
         """
         self._check_alpha(alpha)
-        super(Ridge, self).__init__(handle=handle, verbose=False,
+        super(Ridge, self).__init__(handle=handle, verbose=verbose,
                                     output_type=output_type)
 
         # internal array attributes
@@ -375,4 +390,5 @@ class Ridge(Base, RegressorMixin):
         return preds.to_output(out_type)
 
     def get_param_names(self):
-        return ['solver', 'fit_intercept', 'normalize', 'alpha']
+        return super().get_param_names() + \
+            ['solver', 'fit_intercept', 'normalize', 'alpha']

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -111,9 +111,9 @@ class TSNE(Base):
         a future release.
     init : str 'random' (default 'random')
         Currently supports random intialization.
-    verbose : int or boolean (default = False) (default logger.level_info)
-        Level of verbosity.
-        Most messages will be printed inside the Python Console.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
     random_state : int (default None)
         Setting this can allow future runs of TSNE to look mostly the same.
         It is known that TSNE tends to have vastly different outputs on
@@ -144,9 +144,18 @@ class TSNE(Base):
         During the exaggeration iteration, more forcefully apply gradients.
     post_momentum : float (default 0.8)
         During the late phases, less forcefully apply gradients.
-    handle : (cuML Handle, default None)
-        You can pass in a past handle that was initialized, or we will create
-        one for you anew!
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     References
     -----------
@@ -203,9 +212,12 @@ class TSNE(Base):
                  int exaggeration_iter=250,
                  float pre_momentum=0.5,
                  float post_momentum=0.8,
-                 handle=None):
+                 handle=None,
+                 str output_type=None):
 
-        super(TSNE, self).__init__(handle=handle, verbose=verbose)
+        super(TSNE, self).__init__(handle=handle,
+                                   verbose=verbose,
+                                   output_type=output_type)
 
         if n_components < 0:
             raise ValueError("n_components = {} should be more "
@@ -435,3 +447,26 @@ class TSNE(Base):
                                    verbose=state['verbose'])
         self.__dict__.update(state)
         return state
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "n_components",
+                "perplexity",
+                "early_exaggeration",
+                "learning_rate",
+                "n_iter",
+                "n_iter_without_progress",
+                "min_grad_norm",
+                "metric",
+                "init",
+                "random_state",
+                "method",
+                "angle",
+                "learning_rate_method",
+                "n_neighbors",
+                "perplexity_max_iter",
+                "exaggeration_iter",
+                "pre_momentum",
+                "post_momentum",
+            ]

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -449,24 +449,23 @@ class TSNE(Base):
         return state
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "n_components",
-                "perplexity",
-                "early_exaggeration",
-                "learning_rate",
-                "n_iter",
-                "n_iter_without_progress",
-                "min_grad_norm",
-                "metric",
-                "init",
-                "random_state",
-                "method",
-                "angle",
-                "learning_rate_method",
-                "n_neighbors",
-                "perplexity_max_iter",
-                "exaggeration_iter",
-                "pre_momentum",
-                "post_momentum",
-            ]
+        return super().get_param_names() + [
+            "n_components",
+            "perplexity",
+            "early_exaggeration",
+            "learning_rate",
+            "n_iter",
+            "n_iter_without_progress",
+            "min_grad_norm",
+            "metric",
+            "init",
+            "random_state",
+            "method",
+            "angle",
+            "learning_rate_method",
+            "n_neighbors",
+            "perplexity_max_iter",
+            "exaggeration_iter",
+            "pre_momentum",
+            "post_momentum",
+        ]

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -193,27 +193,27 @@ class TSNE(Base):
 
     """
     def __init__(self,
-                 int n_components=2,
-                 float perplexity=30.0,
-                 float early_exaggeration=12.0,
-                 float learning_rate=200.0,
-                 int n_iter=1000,
-                 int n_iter_without_progress=300,
-                 float min_grad_norm=1e-07,
-                 str metric='euclidean',
-                 str init='random',
-                 int verbose=False,
+                 n_components=2,
+                 perplexity=30.0,
+                 early_exaggeration=12.0,
+                 learning_rate=200.0,
+                 n_iter=1000,
+                 n_iter_without_progress=300,
+                 min_grad_norm=1e-07,
+                 metric='euclidean',
+                 init='random',
+                 verbose=False,
                  random_state=None,
-                 str method='barnes_hut',
-                 float angle=0.5,
+                 method='barnes_hut',
+                 angle=0.5,
                  learning_rate_method='adaptive',
-                 int n_neighbors=90,
-                 int perplexity_max_iter=100,
-                 int exaggeration_iter=250,
-                 float pre_momentum=0.5,
-                 float post_momentum=0.8,
+                 n_neighbors=90,
+                 perplexity_max_iter=100,
+                 exaggeration_iter=250,
+                 pre_momentum=0.5,
+                 post_momentum=0.8,
                  handle=None,
-                 str output_type=None):
+                 output_type=None):
 
         super(TSNE, self).__init__(handle=handle,
                                    verbose=verbose,
@@ -306,7 +306,15 @@ class TSNE(Base):
         if learning_rate_method is None:
             self.learning_rate_method = 'none'
         else:
-            self.learning_rate_method = learning_rate_method.lower()
+            # To support `sklearn.base.clone()`, we must minimize altering
+            # argument references unless absolutely necessary. Check to see if
+            # lowering the string results in the same value, and if so, keep
+            # the same reference that was passed in. This may seem redundant,
+            # but it allows `clone()` to function without raising an error
+            if (learning_rate_method.lower() != learning_rate_method):
+                learning_rate_method = learning_rate_method.lower()
+
+            self.learning_rate_method = learning_rate_method
         self.epssq = 0.0025
         self.perplexity_tol = 1e-5
         self.min_gain = 0.01

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -763,28 +763,26 @@ class UMAP(Base):
         return ret
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "n_neighbors",
-                "n_components",
-                "n_epochs",
-                "learning_rate",
-                "min_dist",
-                "spread",
-                "set_op_mix_ratio",
-                "local_connectivity",
-                "repulsion_strength",
-                "negative_sample_rate",
-                "transform_queue_size",
-                "init",
-                "a",
-                "b",
-                "target_n_neighbors",
-                "target_weights",
-                "target_metric",
-                "hash_input",
-                "random_state",
-                "optim_batch_size",
-                "callback",
-            ]
-
+        return super().get_param_names() + [
+            "n_neighbors",
+            "n_components",
+            "n_epochs",
+            "learning_rate",
+            "min_dist",
+            "spread",
+            "set_op_mix_ratio",
+            "local_connectivity",
+            "repulsion_strength",
+            "negative_sample_rate",
+            "transform_queue_size",
+            "init",
+            "a",
+            "b",
+            "target_n_neighbors",
+            "target_weights",
+            "target_metric",
+            "hash_input",
+            "random_state",
+            "optim_batch_size",
+            "callback",
+        ]

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -354,14 +354,23 @@ class UMAP(Base):
         self.target_weights = target_weights
 
         self.multicore_implem = random_state is None
-        if isinstance(random_state, np.random.RandomState):
-            rs = random_state
+
+        # Check to see if we are already a random_state (type==np.uint64).
+        # Reuse this if already passed (can happen from get_params() of another
+        # instance)
+        if isinstance(random_state, np.uint64):
+            self.random_state = random_state
         else:
-            rs = np.random.RandomState(random_state)
-        self.random_state = <uint64_t> rs.randint(low=0,
-                                                  high=np.iinfo(
-                                                      np.uint64).max,
-                                                  dtype=np.uint64)
+            # Otherwise create a RandomState instance to generate a new
+            # np.uint64
+            if isinstance(random_state, np.random.RandomState):
+                rs = random_state
+            else:
+                rs = np.random.RandomState(random_state)
+
+            self.random_state = rs.randint(low=0,
+                                           high=np.iinfo(np.uint64).max,
+                                           dtype=np.uint64)
 
         if target_metric == "euclidean" or target_metric == "categorical":
             self.target_metric = target_metric

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -207,6 +207,13 @@ class UMAP(Base):
         More specific parameters controlling the embedding. If None these
         values are set automatically as determined by ``min_dist`` and
         ``spread``.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     hash_input: bool, optional (default = False)
         UMAP can hash the training input so that exact embeddings
         are returned when transform is called on the same data upon
@@ -252,8 +259,14 @@ class UMAP(Base):
                 def on_train_end(self, embeddings):
                     print(embeddings.copy_to_host())
 
-    verbose : int or boolean (default = False)
-        Controls verbosity of logging.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Notes
     -----
@@ -748,3 +761,30 @@ class UMAP(Base):
         ret = embedding.to_output(out_type)
         del X_m
         return ret
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "n_neighbors",
+                "n_components",
+                "n_epochs",
+                "learning_rate",
+                "min_dist",
+                "spread",
+                "set_op_mix_ratio",
+                "local_connectivity",
+                "repulsion_strength",
+                "negative_sample_rate",
+                "transform_queue_size",
+                "init",
+                "a",
+                "b",
+                "target_n_neighbors",
+                "target_weights",
+                "target_metric",
+                "hash_input",
+                "random_state",
+                "optim_batch_size",
+                "callback",
+            ]
+

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -142,11 +142,11 @@ def pairwise_distances(X, Y=None, metric="euclidean", handle=None,
         Y to be the same data type as X if they differ. This
         will increase memory used for the method.
 
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
-        Variable to control output type of the results of the function. If
-        None, it'll inherit the output type set at the module level,
-        `cuml.output_type`. If set, the function will temporarily override
-        the global option.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Returns
     -------

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -140,7 +140,7 @@ class MultinomialNB(Base):
     fit_prior : boolean
         Whether to learn class prior probabilities or no. If false, a uniform
         prior will be used.
-    class_prior : array-like, size (n_classes) 
+    class_prior : array-like, size (n_classes)
         Prior probabilities of the classes. If specified, the priors are not
         adjusted according to the data.
     output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -126,10 +126,38 @@ class MultinomialNB(Base):
     The multinomial distribution normally requires integer feature counts.
     However, in practice, fractional counts such as tf-idf may also work.
 
-    NOTE: While cuML only provides the multinomial version currently, the
-    other variants are planned to be included soon. Refer to the
-    corresponding Github issue for updates:
-    https://github.com/rapidsai/cuml/issues/1666
+    Notes
+    -----
+    While cuML only provides the multinomial version currently, the other
+    variants are planned to be included soon. Refer to the corresponding Github
+    `issue <https://github.com/rapidsai/cuml/issues/1666>`_ for updates.
+
+    Parameters
+    ----------
+
+    alpha : float
+        Additive (Laplace/Lidstone) smoothing parameter (0 for no smoothing).
+    fit_prior : boolean
+        Whether to learn class prior probabilities or no. If false, a uniform
+        prior will be used.
+    class_prior : array-like, size (n_classes) 
+        Prior probabilities of the classes. If specified, the priors are not
+        adjusted according to the data.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     Examples
     --------
@@ -139,43 +167,43 @@ class MultinomialNB(Base):
 
     .. code-block:: python
 
-    import cupy as cp
-    import cupyx
+        import cupy as cp
+        import cupyx
 
-    from sklearn.datasets import fetch_20newsgroups
-    from sklearn.feature_extraction.text import CountVectorizer
+        from sklearn.datasets import fetch_20newsgroups
+        from sklearn.feature_extraction.text import CountVectorizer
 
-    from cuml.naive_bayes import MultinomialNB
+        from cuml.naive_bayes import MultinomialNB
 
-    # Load corpus
+        # Load corpus
 
-    twenty_train = fetch_20newsgroups(subset='train',
-                              shuffle=True, random_state=42)
+        twenty_train = fetch_20newsgroups(subset='train',
+                                shuffle=True, random_state=42)
 
-    # Turn documents into term frequency vectors
+        # Turn documents into term frequency vectors
 
-    count_vect = CountVectorizer()
-    features = count_vect.fit_transform(twenty_train.data)
+        count_vect = CountVectorizer()
+        features = count_vect.fit_transform(twenty_train.data)
 
-    # Put feature vectors and labels on the GPU
+        # Put feature vectors and labels on the GPU
 
-    X = cupyx.scipy.sparse.csr_matrix(features.tocsr(), dtype=cp.float32)
-    y = cp.asarray(twenty_train.target, dtype=cp.int32)
+        X = cupyx.scipy.sparse.csr_matrix(features.tocsr(), dtype=cp.float32)
+        y = cp.asarray(twenty_train.target, dtype=cp.int32)
 
-    # Train model
+        # Train model
 
-    model = MultinomialNB()
-    model.fit(X, y)
+        model = MultinomialNB()
+        model.fit(X, y)
 
-    # Compute accuracy on training set
+        # Compute accuracy on training set
 
-    model.score(X, y)
+        model.score(X, y)
 
     Output:
 
     .. code-block:: python
 
-    0.9244298934936523
+        0.9244298934936523
 
     """
     @with_cupy_rmm
@@ -184,23 +212,11 @@ class MultinomialNB(Base):
                  fit_prior=True,
                  class_prior=None,
                  output_type=None,
-                 handle=None):
-        """
-        Create new multinomial Naive Bayes instance
-
-        Parameters
-        ----------
-
-        alpha : float Additive (Laplace/Lidstone) smoothing parameter (0 for
-                no smoothing).
-        fit_prior : boolean Whether to learn class prior probabilities or no.
-                    If false, a uniform prior will be used.
-        class_prior : array-like, size (n_classes) Prior probabilities of the
-                      classes. If specified, the priors are not adjusted
-                      according to the data.
-        """
+                 handle=None,
+                 verbose=False):
         super(MultinomialNB, self).__init__(handle=handle,
-                                            output_type=output_type)
+                                            output_type=output_type,
+                                            verbose=verbose)
         self.alpha = alpha
         self.fit_prior = fit_prior
 
@@ -579,3 +595,11 @@ class MultinomialNB(Base):
         ret = X.dot(cp.asarray(self._feature_log_prob_).T)
         ret += cp.asarray(self._class_log_prior_)
         return ret
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "alpha",
+                "fit_prior",
+                "class_prior",
+            ]

--- a/python/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier.pyx
@@ -83,10 +83,6 @@ class KNeighborsClassifier(NearestNeighbors, ClassifierMixin):
     ----------
     n_neighbors : int (default=5)
         Default number of neighbors to query
-    verbose : int or boolean (default = False)
-        Logging level
-    handle : handle_t
-        The handle_t resources to use
     algorithm : string (default='brute')
         The query algorithm to use. Currently, only 'brute' is supported.
     metric : string (default='euclidean').
@@ -94,6 +90,21 @@ class KNeighborsClassifier(NearestNeighbors, ClassifierMixin):
     weights : string (default='uniform')
         Sample weights to use. Currently, only the uniform strategy is
         supported.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Examples
     --------
@@ -131,8 +142,13 @@ class KNeighborsClassifier(NearestNeighbors, ClassifierMixin):
     <https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html>`_.
     """
 
-    def __init__(self, weights="uniform", **kwargs):
-        super(KNeighborsClassifier, self).__init__(**kwargs)
+    def __init__(self, weights="uniform", *, handle=None, verbose=False,
+                 output_type=None, **kwargs):
+        super(KNeighborsClassifier, self).__init__(
+            handle=handle,
+            verbose=verbose,
+            output_type=output_type,
+            **kwargs)
 
         self._y = None
         self._classes_ = None
@@ -288,5 +304,4 @@ class KNeighborsClassifier(NearestNeighbors, ClassifierMixin):
             if len(final_classes) == 1 else tuple(final_classes)
 
     def get_param_names(self):
-        return super(KNeighborsClassifier, self).get_param_names()\
-            + ["weights"]
+        return super().get_param_names() + ["weights"]

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -75,10 +75,6 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
     ----------
     n_neighbors : int (default=5)
         Default number of neighbors to query
-    verbose : int or boolean (default = False)
-        Logging level
-    handle : handle_t
-        The handle_t resources to use
     algorithm : string (default='brute')
         The query algorithm to use. Currently, only 'brute' is supported.
     metric : string (default='euclidean').
@@ -86,6 +82,21 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
     weights : string (default='uniform')
         Sample weights to use. Currently, only the uniform strategy is
         supported.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Examples
     --------
@@ -131,8 +142,13 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
     <https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html>`_.
     """
 
-    def __init__(self, weights="uniform", **kwargs):
-        super(KNeighborsRegressor, self).__init__(**kwargs)
+    def __init__(self, weights="uniform", *, handle=None, verbose=False,
+                 output_type=None, **kwargs):
+        super(KNeighborsRegressor, self).__init__(
+            handle=handle,
+            verbose=verbose,
+            output_type=output_type,
+            **kwargs)
         self._y = None
         self.weights = weights
         if weights != "uniform":
@@ -210,5 +226,4 @@ class KNeighborsRegressor(NearestNeighbors, RegressorMixin):
         return results.to_output(out_type, output_dtype=out_dtype)
 
     def get_param_names(self):
-        return super(KNeighborsRegressor, self).get_param_names() \
-            + ["weights"]
+        return super().get_param_names() + ["weights"]

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -92,10 +92,16 @@ class NearestNeighbors(Base):
     ----------
     n_neighbors : int (default=5)
         Default number of neighbors to query
-    verbose : int or boolean (default = False)
-        Logging level
-    handle : handle_t
-        The handle_t resources to use
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     algorithm : string (default='brute')
         The query algorithm to use. Currently, only 'brute' is supported.
     metric : string (default='euclidean').
@@ -109,6 +115,11 @@ class NearestNeighbors(Base):
         Can increase performance in Minkowski-based (Lp) metrics (for p > 1)
         by using the expanded form and not computing the n-th roots.
     metric_params : dict, optional (default = None) This is currently ignored.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Examples
     --------
@@ -231,7 +242,8 @@ class NearestNeighbors(Base):
         return self
 
     def get_param_names(self):
-        return ["n_neighbors", "algorithm", "metric",
+        return super().get_param_names() + \
+            ["n_neighbors", "algorithm", "metric",
                 "p", "metric_params"]
 
     @staticmethod
@@ -525,11 +537,17 @@ def kneighbors_graph(X=None, n_neighbors=5, mode='connectivity', verbose=False,
         connectivity matrix with ones and zeros, 'distance' returns the
         edges as the distances between points with the requested metric.
 
-    verbose : int or boolean (default = False)
-        Logging level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
-    handle : handle_t
-        The handle_t resources to use
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     algorithm : string (default='brute')
         The query algorithm to use. Currently, only 'brute' is supported.
@@ -550,11 +568,11 @@ def kneighbors_graph(X=None, n_neighbors=5, mode='connectivity', verbose=False,
 
     metric_params : dict, optional (default = None) This is currently ignored.
 
-    output_type : {'input', 'cupy', 'numpy'}, optional (default=None)
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
-        the estimators. If None, it'll inherit the output type set at the
-        module level, cuml.output_type. If set, the estimator will override
-        the global option for its behavior.
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Returns
     -------

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -275,7 +275,6 @@ class LabelEncoder(Base):
         return cudf.Series(reverted)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "handle_unknown",
-            ]
+        return super().get_param_names() + [
+            "handle_unknown",
+        ]

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -34,6 +34,21 @@ class LabelEncoder(Base):
         is present during transform (default is to raise). When this parameter
         is set to 'ignore' and an unknown category is encountered during
         transform or inverse transform, the resulting encoding will be null.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Examples
     --------
@@ -109,7 +124,17 @@ class LabelEncoder(Base):
 
     """
 
-    def __init__(self, handle_unknown='error'):
+    def __init__(self,
+                 handle_unknown='error',
+                 *,
+                 handle=None,
+                 verbose=False,
+                 output_type=None):
+
+        super().__init__(handle=handle,
+                         verbose=verbose,
+                         output_type=output_type)
+
         self.classes_ = None
         self.dtype = None
         self._fitted: bool = False
@@ -248,3 +273,9 @@ class LabelEncoder(Base):
         reverted = y._column.find_and_replace(ran_idx, self.classes_, False)
 
         return cudf.Series(reverted)
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "handle_unknown",
+            ]

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -328,7 +328,7 @@ class OneHotEncoder(Base):
                 if (max_value > np.iinfo(col_idx.dtype).max):
                     col_idx = col_idx.astype(np.min_scalar_type(max_value))
                     logger.debug("Upconverting column: '{}', to dtype: '{}', \
-                            to support up to {} classes"                                                                                                                .format(
+                            to support up to {} classes".format(
                         feature, np.min_scalar_type(max_value), max_value))
 
                 # increase indices to take previous features into account
@@ -461,4 +461,3 @@ class OneHotEncoder(Base):
                 "dtype",
                 "handle_unknown",
             ]
-

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -81,6 +81,21 @@ class OneHotEncoder(Base):
         transform, the resulting one-hot encoded columns for this feature
         will be all zeros. In the inverse transform, an unknown category
         will be denoted as None.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -90,8 +105,18 @@ class OneHotEncoder(Base):
         be retained.
 
     """
-    def __init__(self, categories='auto', drop=None, sparse=True,
-                 dtype=np.float, handle_unknown='error'):
+    def __init__(self,
+                 categories='auto',
+                 drop=None,
+                 sparse=True,
+                 dtype=np.float,
+                 handle_unknown='error',
+                 handle=None,
+                 verbose=False,
+                 output_type=None):
+        super().__init__(handle=handle,
+                         verbose=verbose,
+                         output_type=output_type)
         self.categories = categories
         self.sparse = sparse
         self.dtype = dtype
@@ -303,7 +328,7 @@ class OneHotEncoder(Base):
                 if (max_value > np.iinfo(col_idx.dtype).max):
                     col_idx = col_idx.astype(np.min_scalar_type(max_value))
                     logger.debug("Upconverting column: '{}', to dtype: '{}', \
-                            to support up to {} classes".format(
+                            to support up to {} classes"                                                                                                                .format(
                         feature, np.min_scalar_type(max_value), max_value))
 
                 # increase indices to take previous features into account
@@ -426,3 +451,14 @@ class OneHotEncoder(Base):
                               "values. Returning output as a DataFrame "
                               "instead.")
         return result
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "categories",
+                "drop",
+                "sparse",
+                "dtype",
+                "handle_unknown",
+            ]
+

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -111,6 +111,7 @@ class OneHotEncoder(Base):
                  sparse=True,
                  dtype=np.float,
                  handle_unknown='error',
+                 *,
                  handle=None,
                  verbose=False,
                  output_type=None):

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -149,6 +149,7 @@ class LabelBinarizer(Base):
                  neg_label=0,
                  pos_label=1,
                  sparse_output=False,
+                 *,
                  handle=None,
                  verbose=False,
                  output_type=None):
@@ -280,9 +281,8 @@ class LabelBinarizer(Base):
         return invert_labels(y_mapped, self._classes_)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "neg_label",
-                "pos_label",
-                "sparse_output",
-            ]
+        return super().get_param_names() + [
+            "neg_label",
+            "pos_label",
+            "sparse_output",
+        ]

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -74,6 +74,31 @@ class LabelBinarizer(Base):
     """
     A multi-class dummy encoder for labels.
 
+    Parameters
+    ----------
+
+    neg_label : integer
+        label to be used as the negative binary label
+    pos_label : integer
+        label to be used as the positive binary label
+    sparse_output : bool
+        whether to return sparse arrays for transformed output
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+
     Examples
     --------
 
@@ -120,19 +145,16 @@ class LabelBinarizer(Base):
          [ 0  5 10  7  2  4  1  0  0  4  3  2  1]
     """
 
-    def __init__(self, neg_label=0, pos_label=1, sparse_output=False):
-        """
-        Creates a LabelBinarizer instance
-
-        Parameters
-        ----------
-
-        neg_label : integer label to be used as the negative binary label
-        pos_label : integer label to be used as the positive binary label
-        sparse_output : bool whether to return sparse arrays for transformed
-                        output
-        """
-        super().__init__()
+    def __init__(self,
+                 neg_label=0,
+                 pos_label=1,
+                 sparse_output=False,
+                 handle=None,
+                 verbose=False,
+                 output_type=None):
+        super().__init__(handle=handle,
+                         verbose=verbose,
+                         output_type=output_type)
 
         if neg_label >= pos_label:
             raise ValueError("neg_label=%s must be less "
@@ -256,3 +278,11 @@ class LabelBinarizer(Base):
                                     axis=1).astype(y.dtype)
 
         return invert_labels(y_mapped, self._classes_)
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "neg_label",
+                "pos_label",
+                "sparse_output",
+            ]

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -416,8 +416,11 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
 
     Notes
     ------
-        Inspired by Scikit-learn's implementation :
-        https://scikit-learn.org/stable/modules/random_projection.html
+    This class is unable to be used with ``sklearn.base.clone()`` and will
+    raise an exception when called.
+
+    Inspired by Scikit-learn's implementation :
+    https://scikit-learn.org/stable/modules/random_projection.html
 
     """
 
@@ -553,6 +556,9 @@ class SparseRandomProjection(Base, BaseRandomProjection):
 
     Notes
     -----
+    This class is unable to be used with ``sklearn.base.clone()`` and will
+    raise an exception when called.
+
     Inspired by Scikit-learn's `implementation
     <https://scikit-learn.org/stable/modules/random_projection.html>`_.
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -156,8 +156,9 @@ cdef class BaseRandomProjection():
         del self.rand_matS
         del self.rand_matD
 
-    def __init__(self, *, bool gaussian_method, double density, n_components='auto', eps=0.1,
-                 dense_output=True, random_state=None, ):
+    def __init__(self, *, bool gaussian_method, double density,
+                 n_components='auto', eps=0.1, dense_output=True,
+                 random_state=None):
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
         cdef _DevAlloc alloc = <_DevAlloc>handle_.get_device_allocator()
@@ -428,9 +429,6 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
                       verbose=verbose,
                       output_type=output_type)
 
-        # self.gaussian_method = True
-        # self.density = -1.0  # not used
-
         BaseRandomProjection.__init__(
             self,
             gaussian_method=True,
@@ -537,9 +535,11 @@ class SparseRandomProjection(Base, BaseRandomProjection):
 
     random_state : int (default = None)
         Seed used to initilize random generator
+
     verbose : int or boolean, default=False
         Sets logging level. It must be one of `cuml.common.logger.level_*`.
         See :ref:`verbosity-levels` for more info.
+
     output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
         the estimator. If None, it'll inherit the output type set at the
@@ -567,9 +567,6 @@ class SparseRandomProjection(Base, BaseRandomProjection):
                       handle=handle,
                       verbose=verbose,
                       output_type=output_type)
-
-        # self.gaussian_method = False
-        # self.density = density if density != 'auto' else -1.0
 
         BaseRandomProjection.__init__(
             self,

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -156,8 +156,8 @@ cdef class BaseRandomProjection():
         del self.rand_matS
         del self.rand_matD
 
-    def __init__(self, n_components='auto', eps=0.1,
-                 dense_output=True, random_state=None):
+    def __init__(self, *, bool gaussian_method, double density, n_components='auto', eps=0.1,
+                 dense_output=True, random_state=None, ):
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
         cdef _DevAlloc alloc = <_DevAlloc>handle_.get_device_allocator()
@@ -172,8 +172,56 @@ cdef class BaseRandomProjection():
         if random_state is not None:
             self.params.random_state = random_state
 
-        self.params.gaussian_method = self.gaussian_method
-        self.params.density = self.density
+        self.params.gaussian_method = gaussian_method
+        self.params.density = density
+
+    @property
+    def n_components(self):
+        return self.params.n_components
+
+    @n_components.setter
+    def n_components(self, value):
+        self.params.n_components = value
+
+    @property
+    def eps(self):
+        return self.params.eps
+
+    @eps.setter
+    def eps(self, value):
+        self.params.eps = value
+
+    @property
+    def dense_output(self):
+        return self.params.dense_output
+
+    @dense_output.setter
+    def dense_output(self, value):
+        self.params.dense_output = value
+
+    @property
+    def random_state(self):
+        return self.params.random_state
+
+    @random_state.setter
+    def random_state(self, value):
+        self.params.random_state = value
+
+    @property
+    def gaussian_method(self):
+        return self.params.gaussian_method
+
+    @gaussian_method.setter
+    def gaussian_method(self, value):
+        self.params.gaussian_method = value
+
+    @property
+    def density(self):
+        return self.params.density
+
+    @density.setter
+    def density(self, value):
+        self.params.density = value
 
     def fit(self, X, y=None):
         """
@@ -328,7 +376,12 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
     ----------
 
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     n_components : int (default = 'auto')
         Dimensionality of the target projection space. If set to 'auto',
@@ -345,6 +398,14 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
 
     random_state : int (default = None)
         Seed used to initilize random generator
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -360,17 +421,32 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
     """
 
     def __init__(self, handle=None, n_components='auto', eps=0.1,
-                 random_state=None, verbose=False):
-        Base.__init__(self, handle, verbose)
-        self.gaussian_method = True
-        self.density = -1.0  # not used
+                 random_state=None, verbose=False, output_type=None):
+
+        Base.__init__(self,
+                      handle=handle,
+                      verbose=verbose,
+                      output_type=output_type)
+
+        # self.gaussian_method = True
+        # self.density = -1.0  # not used
 
         BaseRandomProjection.__init__(
             self,
+            gaussian_method=True,
+            density=-1.0,
             n_components=n_components,
             eps=eps,
             dense_output=True,
             random_state=random_state)
+    
+    def get_param_names(self):
+        return Base.get_param_names(self) + \
+            [
+                "n_components",
+                "eps",
+                "random_state"
+            ]
 
 
 class SparseRandomProjection(Base, BaseRandomProjection):
@@ -432,7 +508,12 @@ class SparseRandomProjection(Base, BaseRandomProjection):
     Parameters
     ----------
     handle : cuml.Handle
-        If it is None, a new one is created just for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     n_components : int (default = 'auto')
         Dimensionality of the target projection space. If set to 'auto',
@@ -456,6 +537,14 @@ class SparseRandomProjection(Base, BaseRandomProjection):
 
     random_state : int (default = None)
         Seed used to initilize random generator
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -472,14 +561,31 @@ class SparseRandomProjection(Base, BaseRandomProjection):
 
     def __init__(self, handle=None, n_components='auto', density='auto',
                  eps=0.1, dense_output=True, random_state=None,
-                 verbose=False):
-        Base.__init__(self, handle, verbose)
-        self.gaussian_method = False
-        self.density = density if density != 'auto' else -1.0
+                 verbose=False, output_type=None):
+
+        Base.__init__(self,
+                      handle=handle,
+                      verbose=verbose,
+                      output_type=output_type)
+
+        # self.gaussian_method = False
+        # self.density = density if density != 'auto' else -1.0
 
         BaseRandomProjection.__init__(
             self,
+            gaussian_method=False,
+            density=(density if density != 'auto' else -1.0),
             n_components=n_components,
             eps=eps,
             dense_output=dense_output,
             random_state=random_state)
+
+    def get_param_names(self):
+        return Base.get_param_names(self) + \
+            [
+                "n_components",
+                "density",
+                "eps",
+                "dense_output",
+                "random_state"
+            ]

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -437,14 +437,13 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
             eps=eps,
             dense_output=True,
             random_state=random_state)
-    
+
     def get_param_names(self):
-        return Base.get_param_names(self) + \
-            [
-                "n_components",
-                "eps",
-                "random_state"
-            ]
+        return Base.get_param_names(self) + [
+            "n_components",
+            "eps",
+            "random_state"
+        ]
 
 
 class SparseRandomProjection(Base, BaseRandomProjection):
@@ -578,11 +577,10 @@ class SparseRandomProjection(Base, BaseRandomProjection):
             random_state=random_state)
 
     def get_param_names(self):
-        return Base.get_param_names(self) + \
-            [
-                "n_components",
-                "density",
-                "eps",
-                "dense_output",
-                "random_state"
-            ]
+        return Base.get_param_names(self) + [
+            "n_components",
+            "density",
+            "eps",
+            "dense_output",
+            "random_state"
+        ]

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -169,21 +169,36 @@ class CD(Base):
        than looping over features sequentially by default.
        This (setting to ‘True’) often leads to significantly faster convergence
        especially when tol is higher than 1e-4.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     """
 
     def __init__(self, loss='squared_loss', alpha=0.0001, l1_ratio=0.15,
                  fit_intercept=True, normalize=False, max_iter=1000, tol=1e-3,
-                 shuffle=True, handle=None, output_type=None):
+                 shuffle=True, handle=None, output_type=None, verbose=False):
 
-        if loss in ['squared_loss']:
-            self.loss = self._get_loss_int(loss)
-        else:
+        if loss not in ['squared_loss']:
             msg = "loss {!r} is not supported"
             raise NotImplementedError(msg.format(loss))
 
-        super(CD, self).__init__(handle=handle, verbose=False,
+        super(CD, self).__init__(handle=handle, verbose=verbose,
                                  output_type=output_type)
+        
+        self.loss = loss
         self.alpha = alpha
         self.l1_ratio = l1_ratio
         self.fit_intercept = fit_intercept
@@ -201,10 +216,10 @@ class CD(Base):
                 msg = "alpha values have to be positive"
                 raise TypeError(msg.format(alpha))
 
-    def _get_loss_int(self, loss):
+    def _get_loss_int(self):
         return {
             'squared_loss': 0,
-        }[loss]
+        }[self.loss]
 
     @generate_docstring()
     def fit(self, X, y, convert_dtype=False):
@@ -247,7 +262,7 @@ class CD(Base):
                   <bool>self.fit_intercept,
                   <bool>self.normalize,
                   <int>self.max_iter,
-                  <int>self.loss,
+                  <int>self._get_loss_int(),
                   <float>self.alpha,
                   <float>self.l1_ratio,
                   <bool>self.shuffle,
@@ -265,7 +280,7 @@ class CD(Base):
                   <bool>self.fit_intercept,
                   <bool>self.normalize,
                   <int>self.max_iter,
-                  <int>self.loss,
+                  <int>self._get_loss_int(),
                   <double>self.alpha,
                   <double>self.l1_ratio,
                   <bool>self.shuffle,
@@ -310,7 +325,7 @@ class CD(Base):
                       <float*>coef_ptr,
                       <float>self.intercept_,
                       <float*>preds_ptr,
-                      <int>self.loss)
+                      <int>self._get_loss_int())
         else:
             cdPredict(handle_[0],
                       <double*>X_ptr,
@@ -319,10 +334,23 @@ class CD(Base):
                       <double*>coef_ptr,
                       <double>self.intercept_,
                       <double*>preds_ptr,
-                      <int>self.loss)
+                      <int>self._get_loss_int())
 
         self.handle.sync()
 
         del(X_m)
 
         return preds.to_output(out_type)
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "loss",
+                "alpha",
+                "l1_ratio",
+                "fit_intercept",
+                "normalize",
+                "max_iter",
+                "tol",
+                "shuffle",
+            ]

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -197,7 +197,7 @@ class CD(Base):
 
         super(CD, self).__init__(handle=handle, verbose=verbose,
                                  output_type=output_type)
-        
+
         self.loss = loss
         self.alpha = alpha
         self.l1_ratio = l1_ratio
@@ -343,14 +343,13 @@ class CD(Base):
         return preds.to_output(out_type)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "loss",
-                "alpha",
-                "l1_ratio",
-                "fit_intercept",
-                "normalize",
-                "max_iter",
-                "tol",
-                "shuffle",
-            ]
+        return super().get_param_names() + [
+            "loss",
+            "alpha",
+            "l1_ratio",
+            "fit_intercept",
+            "normalize",
+            "max_iter",
+            "tol",
+            "shuffle",
+        ]

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -209,8 +209,21 @@ class QN(Base):
     lbfgs_memory: int (default = 5)
         Rank of the lbfgs inverse-Hessian approximation. Method will use
         O(lbfgs_memory * D) memory.
-    verbose : int or boolean (default = False)
-        Controls verbose level of logging.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     -----------
@@ -507,5 +520,6 @@ class QN(Base):
             return super().__getattr__(attr)
 
     def get_param_names(self):
-        return ['loss', 'fit_intercept', 'l1_strength', 'l2_strength',
+        return super().get_param_names() + \
+            ['loss', 'fit_intercept', 'l1_strength', 'l2_strength',
                 'max_iter', 'tol', 'linesearch_max_iter', 'lbfgs_memory']

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -491,19 +491,18 @@ class SGD(Base):
         return preds.to_output(output_type=output_type, output_dtype=out_dtype)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "loss",
-                "penalty",
-                "alpha",
-                "l1_ratio",
-                "fit_intercept",
-                "epochs",
-                "tol",
-                "shuffle",
-                "learning_rate",
-                "eta0",
-                "power_t",
-                "batch_size",
-                "n_iter_no_change",
-            ]
+        return super().get_param_names() + [
+            "loss",
+            "penalty",
+            "alpha",
+            "l1_ratio",
+            "fit_intercept",
+            "epochs",
+            "tol",
+            "shuffle",
+            "learning_rate",
+            "eta0",
+            "power_t",
+            "batch_size",
+            "n_iter_no_change",
+        ]

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -199,11 +199,21 @@ class SGD(Base):
         The old learning rate is generally divide by 5
     n_iter_no_change : int (default = 5)
         the number of epochs to train without any imporvement in the model
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
-        the estimators. If None, it'll inherit the output type set at the
-        module level, cuml.output_type. If set, the estimator will override
-        the global option for its behavior.
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     """
 
@@ -211,21 +221,21 @@ class SGD(Base):
                  l1_ratio=0.15, fit_intercept=True, epochs=1000, tol=1e-3,
                  shuffle=True, learning_rate='constant', eta0=0.001,
                  power_t=0.5, batch_size=32, n_iter_no_change=5, handle=None,
-                 output_type=None):
+                 output_type=None, verbose=False):
 
         if loss in ['hinge', 'log', 'squared_loss']:
-            self.loss = self._get_loss_int(loss)
+            self.loss = loss
         else:
             msg = "loss {!r} is not supported"
             raise TypeError(msg.format(loss))
 
         if penalty in ['none', 'l1', 'l2', 'elasticnet']:
-            self.penalty = self._get_penalty_int(penalty)
+            self.penalty = penalty
         else:
             msg = "penalty {!r} is not supported"
             raise TypeError(msg.format(penalty))
 
-        super(SGD, self).__init__(handle=handle, verbose=False,
+        super(SGD, self).__init__(handle=handle, verbose=verbose,
                                   output_type=output_type)
         self.alpha = alpha
         self.l1_ratio = l1_ratio
@@ -277,20 +287,20 @@ class SGD(Base):
                 msg = "alpha values have to be positive"
                 raise TypeError(msg.format(alpha))
 
-    def _get_loss_int(self, loss):
+    def _get_loss_int(self):
         return {
             'squared_loss': 0,
             'log': 1,
             'hinge': 2,
-        }[loss]
+        }[self.loss]
 
-    def _get_penalty_int(self, penalty):
+    def _get_penalty_int(self):
         return {
             'none': 0,
             'l1': 1,
             'l2': 2,
             'elasticnet': 3
-        }[penalty]
+        }[self.penalty]
 
     @generate_docstring()
     @with_cupy_rmm
@@ -341,8 +351,8 @@ class SGD(Base):
                    <int>self.lr_type,
                    <float>self.eta0,
                    <float>self.power_t,
-                   <int>self.loss,
-                   <int>self.penalty,
+                   <int>self._get_loss_int(),
+                   <int>self._get_penalty_int(),
                    <float>self.alpha,
                    <float>self.l1_ratio,
                    <bool>self.shuffle,
@@ -364,8 +374,8 @@ class SGD(Base):
                    <int>self.lr_type,
                    <double>self.eta0,
                    <double>self.power_t,
-                   <int>self.loss,
-                   <int>self.penalty,
+                   <int>self._get_loss_int(),
+                   <int>self._get_penalty_int(),
                    <double>self.alpha,
                    <double>self.l1_ratio,
                    <bool>self.shuffle,
@@ -414,7 +424,7 @@ class SGD(Base):
                        <float*>coef_ptr,
                        <float>self.intercept_,
                        <float*>preds_ptr,
-                       <int>self.loss)
+                       <int>self._get_loss_int())
         else:
             sgdPredict(handle_[0],
                        <double*>X_ptr,
@@ -423,7 +433,7 @@ class SGD(Base):
                        <double*>coef_ptr,
                        <double>self.intercept_,
                        <double*>preds_ptr,
-                       <int>self.loss)
+                       <int>self._get_loss_int())
 
         self.handle.sync()
 
@@ -463,7 +473,7 @@ class SGD(Base):
                                   <float*>coef_ptr,
                                   <float>self.intercept_,
                                   <float*>preds_ptr,
-                                  <int>self.loss)
+                                  <int>self._get_loss_int())
         else:
             sgdPredictBinaryClass(handle_[0],
                                   <double*>X_ptr,
@@ -472,10 +482,28 @@ class SGD(Base):
                                   <double*>coef_ptr,
                                   <double>self.intercept_,
                                   <double*>preds_ptr,
-                                  <int>self.loss)
+                                  <int>self._get_loss_int())
 
         self.handle.sync()
 
         del(X_m)
 
         return preds.to_output(output_type=output_type, output_dtype=out_dtype)
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            [
+                "loss",
+                "penalty",
+                "alpha",
+                "l1_ratio",
+                "fit_intercept",
+                "epochs",
+                "tol",
+                "shuffle",
+                "learning_rate",
+                "eta0",
+                "power_t",
+                "batch_size",
+                "n_iter_no_change",
+            ]

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -149,7 +149,12 @@ class SVC(SVMBase, ClassifierMixin):
     Parameters
     ----------
     handle : cuml.Handle
-        If it is None, a new one is created for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     C : float (default = 1.0)
         Penalty parameter C
     kernel : string (default='rbf')
@@ -186,14 +191,20 @@ class SVC(SVMBase, ClassifierMixin):
         We monitor how much our stopping criteria changes during outer
         iterations. If it does not change (changes less then 1e-3*tol)
         for nochange_steps consecutive steps, then we stop training.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
     probability: bool (default = False)
         Enable or disable probability estimates.
     random_state: int (default = None)
         Seed for random number generator (used only when probability = True).
         Currently this argument is not used and a waring will be printed if the
         user provides it.
-    verbose : int or boolean (default = False)
-        verbosity level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
 
     Attributes
     ----------
@@ -490,5 +501,5 @@ class SVC(SVMBase, ClassifierMixin):
             return super(SVC, self).predict(X, False)
 
     def get_param_names(self):
-        return super(SVC, self).get_param_names() + \
+        return super().get_param_names() + \
             ["probability", "random_state", "class_weight"]

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -503,7 +503,7 @@ class SVC(SVMBase, ClassifierMixin):
     def get_param_names(self):
         params = super().get_param_names() + \
             ["probability", "random_state", "class_weight"]
-        
+
         # Ignore "epsilon" since its not used in the constructor
         if ("epsilon" in params):
             params.remove("epsilon")

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -501,5 +501,11 @@ class SVC(SVMBase, ClassifierMixin):
             return super(SVC, self).predict(X, False)
 
     def get_param_names(self):
-        return super().get_param_names() + \
+        params = super().get_param_names() + \
             ["probability", "random_state", "class_weight"]
+        
+        # Ignore "epsilon" since its not used in the constructor
+        if ("epsilon" in params):
+            params.remove("epsilon")
+
+        return params

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -531,19 +531,18 @@ class SVMBase(Base):
         return preds.to_output(output_type=out_type, output_dtype=out_dtype)
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            [
-                "C",
-                "kernel",
-                "degree",
-                "gamma",
-                "coef0",
-                "tol",
-                "cache_size",
-                "max_iter",
-                "nochange_steps",
-                "epsilon",
-            ]
+        return super().get_param_names() + [
+            "C",
+            "kernel",
+            "degree",
+            "gamma",
+            "coef0",
+            "tol",
+            "cache_size",
+            "max_iter",
+            "nochange_steps",
+            "epsilon",
+        ]
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -102,6 +102,88 @@ class SVMBase(Base):
     The solver uses the SMO method to fit the classifier. We use the Optimized
     Hierarchical Decomposition [1] variant of the SMO algorithm, similar to [2]
 
+    Parameters
+    ----------
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    C : float (default = 1.0)
+        Penalty parameter C
+    kernel : string (default='rbf')
+        Specifies the kernel function. Possible options: 'linear', 'poly',
+        'rbf', 'sigmoid'. Currently precomputed kernels are not supported.
+    degree : int (default=3)
+        Degree of polynomial kernel function.
+    gamma : float or string (default = 'scale')
+        Coefficient for rbf, poly, and sigmoid kernels. You can specify the
+        numeric value, or use one of the following options:
+
+        - 'auto': gamma will be set to ``1 / n_features``
+        - 'scale': gamma will be se to ``1 / (n_features * X.var())``
+
+    coef0 : float (default = 0.0)
+        Independent term in kernel function, only signifficant for poly and
+        sigmoid
+    tol : float (default = 1e-3)
+        Tolerance for stopping criterion.
+    cache_size : float (default = 200.0)
+        Size of the kernel cache during training in MiB. The default is a
+        conservative value, increase it to improve the training time, at
+        the cost of higher memory footprint. After training the kernel
+        cache is deallocated.
+        During prediction, we also need a temporary space to store kernel
+        matrix elements (this can be signifficant if n_support is large).
+        The cache_size variable sets an upper limit to the prediction
+        buffer as well.
+    max_iter : int (default = 100*n_samples)
+        Limit the number of outer iterations in the solver
+    nochange_steps : int (default = 1000)
+        We monitor how much our stopping criteria changes during outer
+        iterations. If it does not change (changes less then 1e-3*tol)
+        for nochange_steps consecutive steps, then we stop training.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    epsilon: float (default = 0.1)
+        epsilon parameter of the epsiron-SVR model. There is no penalty
+        associated to points that are predicted within the epsilon-tube
+        around the target values.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
+
+    Attributes
+    ----------
+    n_support_ : int
+        The total number of support vectors. Note: this will change in the
+        future to represent number support vectors for each class (like
+        in Sklearn, see Issue #956)
+    support_ : int, shape = [n_support]
+        Device array of suppurt vector indices
+    support_vectors_ : float, shape [n_support, n_cols]
+        Device array of support vectors
+    dual_coef_ : float, shape = [1, n_support]
+        Device array of coefficients for support vectors
+    intercept_ : int
+        The constant in the decision function
+    fit_status_ : int
+        0 if SVM is correctly fitted
+    coef_ : float, shape [1, n_cols]
+        Only available for linear kernels. It is the normal of the
+        hyperplane.
+        ``coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]``
+
+    Notes
+    -----
+    For additional docs, see `scikitlearn's SVC
+    <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_.
+
     References
     ----------
     [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical Decomposition
@@ -116,72 +198,6 @@ class SVMBase(Base):
                  gamma='auto', coef0=0.0, tol=1e-3, cache_size=200.0,
                  max_iter=-1, nochange_steps=1000, verbose=False,
                  epsilon=0.1, output_type=None):
-        """
-        Construct an SVC classifier for training and predictions.
-
-        Parameters
-        ----------
-        handle : cuml.Handle
-            If it is None, a new one is created for this class
-        C : float (default = 1.0)
-            Penalty parameter C
-        kernel : string (default='rbf')
-            Specifies the kernel function. Possible options: 'linear', 'poly',
-            'rbf', 'sigmoid'. Currently precomputed kernels are not supported.
-        degree : int (default=3)
-            Degree of polynomial kernel function.
-        gamma : float or string (default = 'auto')
-            Coefficient for rbf, poly, and sigmoid kernels. You can specify the
-            numeric value, or use one of the following options:
-            - 'auto': gamma will be set to 1 / n_features
-            - 'scale': gamma will be se to 1 / (n_features * X.var())
-        coef0 : float (default = 0.0)
-            Independent term in kernel function, only signifficant for poly and
-            sigmoid
-        tol : float (default = 1e-3)
-            Tolerance for stopping criterion.
-        cache_size : float (default = 200 MiB)
-            Size of the kernel cache during training in MiB. The default is a
-            conservative value, increase it to improve the training time, at
-            the cost of higher memory footprint. After training the kernel
-            cache is deallocated.
-            During prediction, we also need a temporary space to store kernel
-            matrix elements (this can be signifficant if n_support is large).
-            The cache_size variable sets an upper limit to the prediction
-            buffer as well.
-        max_iter : int (default = 100*n_samples)
-            Limit the number of outer iterations in the solver
-        nochange_steps : int (default = 1000)
-            We monitor how much our stopping criteria changes during outer
-            iterations. If it does not change (changes less then 1e-3*tol)
-            for nochange_steps consecutive steps, then we stop training.
-        verbose : int or boolean (default = False)
-            verbosity level
-
-        Attributes
-        ----------
-        n_support_ : int
-            The total number of support vectors. Note: this will change in the
-            future to represent number support vectors for each class (like
-            in Sklearn, see Issue #956)
-        support_ : int, shape = [n_support]
-            Device array of suppurt vector indices
-        support_vectors_ : float, shape [n_support, n_cols]
-            Device array of support vectors
-        dual_coef_ : float, shape = [1, n_support]
-            Device array of coefficients for support vectors
-        intercept_ : int
-            The constant in the decision function
-        fit_status_ : int
-            0 if SVM is correctly fitted
-        coef_ : float, shape [1, n_cols]
-            Only available for linear kernels. It is the normal of the
-            hyperplane.
-            coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]
-
-        For additional docs, see `scikitlearn's SVC
-        <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_.
-        """
         super(SVMBase, self).__init__(handle=handle, verbose=verbose,
                                       output_type=output_type)
         # Input parameters for training
@@ -513,8 +529,19 @@ class SVMBase(Base):
         return preds.to_output(output_type=out_type, output_dtype=out_dtype)
 
     def get_param_names(self):
-        return ["C", "kernel", "degree", "gamma", "coef0", "cache_size",
-                "max_iter", "nochange_steps", "tol"]
+        return super().get_param_names() + \
+            [
+                "C",
+                "kernel",
+                "degree",
+                "gamma",
+                "coef0",
+                "tol",
+                "cache_size",
+                "max_iter",
+                "nochange_steps",
+                "epsilon",
+            ]
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -528,3 +555,4 @@ class SVMBase(Base):
         self.__dict__.update(state)
         self._model = self._get_svm_model()
         self._freeSvmBuffers = False
+

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -100,7 +100,8 @@ class SVMBase(Base):
     Currently only binary classification is supported.
 
     The solver uses the SMO method to fit the classifier. We use the Optimized
-    Hierarchical Decomposition [1] variant of the SMO algorithm, similar to [2]
+    Hierarchical Decomposition [1]_ variant of the SMO algorithm, similar to
+    [2]_
 
     Parameters
     ----------
@@ -186,12 +187,13 @@ class SVMBase(Base):
 
     References
     ----------
-    [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical Decomposition
-         Algorithm for Support VectorMachine Training, IEEE Transactions on
-         Parallel and Distributed Systems, vol 28, no 12, 3330, (2017)
-    [2] Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs, Journal
-    *      of Machine Learning Research, 19, 1-5 (2018)
-        https://github.com/Xtra-Computing/thundersvm
+    .. [1] J. Vanek et al. A GPU-Architecture Optimized Hierarchical
+        Decomposition Algorithm for Support VectorMachine Training, IEEE
+        Transactions on Parallel and Distributed Systems, vol 28, no 12, 3330,
+        (2017)
+    .. [2] `Z. Wen et al. ThunderSVM: A Fast SVM Library on GPUs and CPUs,
+        Journal of Machine Learning Research, 19, 1-5 (2018)
+        <https://github.com/Xtra-Computing/thundersvm>`_
 
     """
     def __init__(self, handle=None, C=1, kernel='rbf', degree=3,
@@ -555,4 +557,3 @@ class SVMBase(Base):
         self.__dict__.update(state)
         self._model = self._get_svm_model()
         self._freeSvmBuffers = False
-

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -108,7 +108,12 @@ class SVR(SVMBase, RegressorMixin):
     Parameters
     ----------
     handle : cuml.Handle
-        If it is None, a new one is created for this class
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     C : float (default = 1.0)
         Penalty parameter C
     kernel : string (default='rbf')
@@ -147,8 +152,14 @@ class SVR(SVMBase, RegressorMixin):
         We monitor how much our stopping criteria changes during outer
         iterations. If it does not change (changes less then 1e-3*tol)
         for nochange_steps consecutive steps, then we stop training.
-    verbose : int or boolean (default = False)
-        verbosity level
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -216,10 +227,10 @@ class SVR(SVMBase, RegressorMixin):
     def __init__(self, handle=None, C=1, kernel='rbf', degree=3,
                  gamma='scale', coef0=0.0, tol=1e-3, epsilon=0.1,
                  cache_size=200.0, max_iter=-1, nochange_steps=1000,
-                 verbose=False):
+                 verbose=False, output_type=None):
         super(SVR, self).__init__(handle, C, kernel, degree, gamma, coef0, tol,
                                   cache_size, max_iter, nochange_steps,
-                                  verbose, epsilon)
+                                  verbose, epsilon, output_type=output_type)
         self.svmType = EPSILON_SVR
 
     @generate_docstring()

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -25,10 +25,15 @@ all_base_children = get_classes_from_package(cuml, import_sub_packages=True)
 
 
 def test_base_class_usage():
+    # Ensure base class returns the 3 main properties needed by all classes
     base = cuml.Base()
     base.handle.sync()
     base_params = base.get_param_names()
-    assert base_params == []
+
+    assert "handle" in base_params
+    assert "verbose" in base_params
+    assert "output_type" in base_params
+
     del base
 
 
@@ -69,6 +74,8 @@ def test_base_children_init(child_class: str):
 
     # Regex for find and replace:
     # output_type: `^[ ]{4}output_type :.*\n(^(?![ ]{0,4}(?![ ]{4,})).*(\n))+`
+    # verbose: `^[ ]{4}verbose :.*\n(^(?![ ]{0,4}(?![ ]{4,})).*(\n))+`
+    # handle: `^[ ]{4}handle :.*\n(^(?![ ]{0,4}(?![ ]{4,})).*(\n))+`
 
     def get_param_doc(param_doc_obj, name: str):
         found_doc = next((x for x in param_doc_obj if x.name == name), None)

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -404,14 +404,16 @@ def modified_clone(estimator, *, safe=True):
 
         if (isinstance(param1, numbers.Number) or isinstance(param1, str)):
             if (param1 != param2):
-                raise RuntimeError('Cannot clone object %s, as the constructor '
-                               'either does not set or modifies parameter %s' %
-                               (estimator, name))
+                raise RuntimeError(
+                    'Cannot clone object %s, as the constructor'
+                    ' either does not set or modifies parameter %s'
+                    % (estimator, name))
         elif param1 is not param2:
             raise RuntimeError('Cannot clone object %s, as the constructor '
                                'either does not set or modifies parameter %s' %
                                (estimator, name))
     return new_object
+
 
 @pytest.mark.parametrize('model_name',
                          all_models.keys())

--- a/python/cuml/test/test_pickle.py
+++ b/python/cuml/test/test_pickle.py
@@ -402,6 +402,9 @@ def modified_clone(estimator, *, safe=True):
         param1 = new_object_params[name]
         param2 = params_set[name]
 
+        # For simple values, use equality comparison. This is due to weird
+        # inconsistencies for `id()` with basic types such as float, int, str,
+        # etc.
         if (isinstance(param1, numbers.Number) or isinstance(param1, str)):
             if (param1 != param2):
                 raise RuntimeError(

--- a/python/cuml/test/utils.py
+++ b/python/cuml/test/utils.py
@@ -187,7 +187,11 @@ class ClassEnumerator:
         Custom constructors to use instead of the default one.
         ex: {'LogisticRegression': lambda: cuml.LogisticRegression(handle=1)}
     """
-    def __init__(self, module, exclude_classes=None, custom_constructors=None, recursive=False):
+    def __init__(self,
+                 module,
+                 exclude_classes=None,
+                 custom_constructors=None,
+                 recursive=False):
         self.module = module
         self.exclude_classes = exclude_classes or []
         self.custom_constructors = custom_constructors or []
@@ -216,7 +220,8 @@ class ClassEnumerator:
 
             return classes
 
-        return [(val.__name__, val) for key, val in recurse_module(self.module).items()]
+        return [(val.__name__, val) for key,
+                val in recurse_module(self.module).items()]
 
     def get_models(self):
         """Picks up every models classes from self.module.
@@ -261,9 +266,6 @@ def get_classes_from_package(package, import_sub_packages=False):
 
                 importlib.import_module(module_name)
 
-    # modules = [m for name, m in inspect.getmembers(package, inspect.ismodule)]
-    # classes = [ClassEnumerator(module).get_models() for module in modules]
-    # return {k: v for dictionary in classes for k, v in dictionary.items()}
     return ClassEnumerator(module=package, recursive=True).get_models()
 
 

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -87,7 +87,7 @@ cdef extern from "cuml/tsa/batched_kalman.hpp" namespace "ML":
 
 
 class ARIMA(Base):
-    """
+    r"""
     Implements a batched ARIMA model for in- and out-of-sample
     time-series prediction, with support for seasonality (SARIMA)
 

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -160,13 +160,20 @@ class ARIMA(Base):
         statsmodels computes forecasts for the differenced series when
         simple_differencing is True.
     handle : cuml.Handle
-        If it is None, a new one is created just for this instance
-    verbose : int or boolean (default = False)
-        Controls verbose level of logging.
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
-        Variable to control output type of the results and attributes.
-        If None, it'll inherit the output type set at the module level,
-        cuml.output_type. If set, it will override the global option.
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -87,7 +87,8 @@ cdef extern from "cuml/tsa/batched_kalman.hpp" namespace "ML":
 
 
 class ARIMA(Base):
-    r"""Implements a batched ARIMA model for in- and out-of-sample
+    """
+    Implements a batched ARIMA model for in- and out-of-sample
     time-series prediction, with support for seasonality (SARIMA)
 
     ARIMA stands for Auto-Regressive Integrated Moving Average.
@@ -97,46 +98,6 @@ class ARIMA(Base):
     batch of time series of the same length with no missing values.
     The implementation is designed to give the best performance when using
     large batches of time series.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        import numpy as np
-        from cuml.tsa.arima import ARIMA
-
-        # Create seasonal data with a trend, a seasonal pattern and noise
-        n_obs = 100
-        np.random.seed(12)
-        x = np.linspace(0, 1, n_obs)
-        pattern = np.array([[0.05, 0.0], [0.07, 0.03],
-                            [-0.03, 0.05], [0.02, 0.025]])
-        noise = np.random.normal(scale=0.01, size=(n_obs, 2))
-        y = (np.column_stack((0.5*x, -0.25*x)) + noise
-             + np.tile(pattern, (25, 1)))
-
-        # Fit a seasonal ARIMA model
-        model = ARIMA(y, (0,1,1), (0,1,1,4), fit_intercept=False)
-        model.fit()
-
-        # Forecast
-        fc = model.forecast(10)
-        print(fc)
-
-    Output:
-
-    .. code-block:: python
-
-        [[ 0.55204599 -0.25681163]
-         [ 0.57430705 -0.2262438 ]
-         [ 0.48120315 -0.20583011]
-         [ 0.535594   -0.24060046]
-         [ 0.57207541 -0.26695497]
-         [ 0.59433647 -0.23638713]
-         [ 0.50123257 -0.21597344]
-         [ 0.55562342 -0.25074379]
-         [ 0.59210483 -0.27709831]
-         [ 0.61436589 -0.24653047]]
 
     Parameters
     ----------
@@ -215,6 +176,46 @@ class ARIMA(Base):
     Additionally the following book is a useful reference:
     "Time Series Analysis by State Space Methods",
     J. Durbin, S.J. Koopman, 2nd Edition (2012).
+
+    Examples
+    --------
+    .. code-block:: python
+
+            import numpy as np
+            from cuml.tsa.arima import ARIMA
+
+            # Create seasonal data with a trend, a seasonal pattern and noise
+            n_obs = 100
+            np.random.seed(12)
+            x = np.linspace(0, 1, n_obs)
+            pattern = np.array([[0.05, 0.0], [0.07, 0.03],
+                                [-0.03, 0.05], [0.02, 0.025]])
+            noise = np.random.normal(scale=0.01, size=(n_obs, 2))
+            y = (np.column_stack((0.5*x, -0.25*x)) + noise
+                + np.tile(pattern, (25, 1)))
+
+            # Fit a seasonal ARIMA model
+            model = ARIMA(y, (0,1,1), (0,1,1,4), fit_intercept=False)
+            model.fit()
+
+            # Forecast
+            fc = model.forecast(10)
+            print(fc)
+
+    Output:
+
+    .. code-block:: python
+
+            [[ 0.55204599 -0.25681163]
+            [ 0.57430705 -0.2262438 ]
+            [ 0.48120315 -0.20583011]
+            [ 0.535594   -0.24060046]
+            [ 0.57207541 -0.26695497]
+            [ 0.59433647 -0.23638713]
+            [ 0.50123257 -0.21597344]
+            [ 0.55562342 -0.25074379]
+            [ 0.59210483 -0.27709831]
+            [ 0.61436589 -0.24653047]]
 
     """
 

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -129,17 +129,24 @@ class AutoARIMA(Base):
         Acceptable formats: cuDF DataFrame, cuDF Series, NumPy ndarray,
         Numba device ndarray, cuda array interface compliant array like CuPy.
     handle : cuml.Handle
-        If it is None, a new one is created just for this instance
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
     simple_differencing: bool or int (default = True)
         If True, the data is differenced before being passed to the Kalman
         filter. If False, differencing is part of the state-space model.
         See additional notes in the ARIMA docs
-    verbose : int
-        Logging level. It must be one of `cuml.common.logger.level_*`
-    output_type : {'input', 'cudf', 'cupy', 'numpy'}, optional
-        Variable to control output type of the results and attributes.
-        If None, it'll inherit the output type set at the module level,
-        cuml.output_type. If set, it will override the global option.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     References
     ----------
@@ -156,10 +163,13 @@ class AutoARIMA(Base):
                  endog,
                  handle=None,
                  simple_differencing=True,
-                 verbose=logger.level_info,
+                 verbose=False,
                  output_type=None):
         # Initialize base class
-        super().__init__(handle, output_type=output_type, verbose=verbose)
+        super().__init__(
+            handle=handle,
+            output_type=output_type,
+            verbose=verbose)
         self._set_base_attributes(output_type=endog)
 
         # Get device array. Float64 only for now.
@@ -521,7 +531,12 @@ def _divide_by_mask(original, mask, batch_id, handle=None):
     batch_id : cumlArray (int)
         Integer array to track the id of each member in the initial batch
     handle : cuml.Handle
-        If it is None, a new one is created just for this call
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     Returns
     -------
@@ -640,7 +655,12 @@ def _divide_by_min(original, metrics, batch_id, handle=None):
     batch_id : cumlArray (int)
         Integer array to track the id of each member in the initial batch
     handle : cuml.Handle
-        If it is None, a new one is created just for this call
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     Returns
     -------

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -101,29 +101,18 @@ tests_map = {
 
 
 class AutoARIMA(Base):
-    """Implements a batched auto-ARIMA model for in- and out-of-sample
+    """
+    Implements a batched auto-ARIMA model for in- and out-of-sample
     times-series prediction.
 
     This interface offers a highly customizable search, with functionality
-    similar to the `forecast` and `fable` packages in R.
-    It provides an abstraction around the underlying ARIMA models to predict
-    and forecast as if using a single model.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        from cuml.tsa.auto_arima import AutoARIMA
-
-        model = AutoARIMA(y)
-        model.search(s=12, d=(0, 1), D=(0, 1), p=(0, 2, 4), q=(0, 2, 4),
-                     P=range(2), Q=range(2), method="css", truncate=100)
-        model.fit(method="css-ml")
-        fc = model.forecast(20)
-
+    similar to the `forecast` and `fable` packages in R. It provides an
+    abstraction around the underlying ARIMA models to predict and forecast as
+    if using a single model.
 
     Parameters
     ----------
+
     endog : dataframe or array-like (device or host)
         The time series data, assumed to have each time series in columns.
         Acceptable formats: cuDF DataFrame, cuDF Series, NumPy ndarray,
@@ -135,7 +124,7 @@ class AutoARIMA(Base):
         run different models concurrently in different streams by creating
         handles in several streams.
         If it is None, a new one is created.
-    simple_differencing: bool or int (default = True)
+    simple_differencing: bool or int, default=True
         If True, the data is differenced before being passed to the Kalman
         filter. If False, differencing is part of the state-space model.
         See additional notes in the ARIMA docs
@@ -148,15 +137,35 @@ class AutoARIMA(Base):
         module level, `cuml.global_output_type`.
         See :ref:`output-data-type-configuration` for more info.
 
-    References
-    ----------
+    Notes
+    -----
+
     The interface was influenced by the R `fable` package:
     See https://fable.tidyverts.org/reference/ARIMA.html
 
+    References
+    ----------
+
     A useful (though outdated) reference is the paper:
-    "Automatic Time Series Forecasting: The `forecast` Package for R",
-    Rob J. Hyndman & Yeasmin Khandakar (2008),
-    Journal of Statistical Software 27, https://doi.org/10.18637/jss.v027.i03
+
+    .. [1] Rob J. Hyndman, Yeasmin Khandakar, 2008. "Automatic Time Series
+        Forecasting: The 'forecast' Package for R", Journal of Statistical
+        Software 27
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+            from cuml.tsa.auto_arima import AutoARIMA
+
+            model = AutoARIMA(y)
+            model.search(s=12, d=(0, 1), D=(0, 1), p=(0, 2, 4), q=(0, 2, 4),
+                         P=range(2), Q=range(2), method="css", truncate=100)
+            model.fit(method="css-ml")
+            fc = model.forecast(20)
+
+
     """
 
     def __init__(self,

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -156,15 +156,29 @@ class ExponentialSmoothing(Base):
     eps : np.number > 0 (default=2.24e-3)
         The accuracy to which gradient descent should achieve.
         Note that changing this value may affect the forecasted results.
-    handle : cuml.Handle (default=None)
-        If it is None, a new one is created just for this class.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
+    verbose : int or boolean, default=False
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
+        Variable to control output type of the results and attributes of
+        the estimator. If None, it'll inherit the output type set at the
+        module level, `cuml.global_output_type`.
+        See :ref:`output-data-type-configuration` for more info.
 
     """
     def __init__(self, endog, seasonal="additive",
                  seasonal_periods=2, start_periods=2,
-                 ts_num=1, eps=2.24e-3, handle=None):
+                 ts_num=1, eps=2.24e-3, handle=None,
+                 verbose=False, output_type=None):
 
-        super(ExponentialSmoothing, self).__init__(handle)
+        super(ExponentialSmoothing, self).__init__(handle=handle, verbose=verbose, output_type=output_type)
 
         # Total number of Time Series for forecasting
         if type(ts_num) != int:
@@ -551,3 +565,8 @@ class ExponentialSmoothing(Base):
                     return cudf.Series(cp.asarray(self.season[index]))
         else:
             raise ValueError("Fit() the model to get season values")
+
+    def get_param_names(self):
+        return super().get_param_names() + \
+            ["endog", "seasonal", "seasonal_periods",
+             "start_periods", "ts_num", "eps"]

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -568,6 +568,11 @@ class ExponentialSmoothing(Base):
             raise ValueError("Fit() the model to get season values")
 
     def get_param_names(self):
-        return super().get_param_names() + \
-            ["endog", "seasonal", "seasonal_periods",
-             "start_periods", "ts_num", "eps"]
+        return super().get_param_names() + [
+            "endog",
+            "seasonal",
+            "seasonal_periods",
+            "start_periods",
+            "ts_num",
+            "eps",
+        ]

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -178,7 +178,8 @@ class ExponentialSmoothing(Base):
                  ts_num=1, eps=2.24e-3, handle=None,
                  verbose=False, output_type=None):
 
-        super(ExponentialSmoothing, self).__init__(handle=handle, verbose=verbose, output_type=output_type)
+        super(ExponentialSmoothing, self).__init__(
+            handle=handle, verbose=verbose, output_type=output_type)
 
         # Total number of Time Series for forecasting
         if type(ts_num) != int:

--- a/python/cuml/tsa/seasonality.pyx
+++ b/python/cuml/tsa/seasonality.pyx
@@ -60,8 +60,13 @@ def seas_test(y, s, output_type="input", handle=None):
         Numba device ndarray, cuda array interface compliant array like CuPy.
     s: integer
         Seasonal period (s > 1)
-    handle : cuml.Handle (default=None)
-        If it is None, a new one is created just for this function call.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     Returns
     -------

--- a/python/cuml/tsa/stationarity.pyx
+++ b/python/cuml/tsa/stationarity.pyx
@@ -69,8 +69,13 @@ def kpss_test(y, d=0, D=0, s=0, pval_threshold=0.05, output_type="input",
         Seasonal period if D > 0
     pval_threshold : float
         The p-value threshold above which a series is considered stationary.
-    handle : cuml.Handle (default=None)
-        If it is None, a new one is created just for this function call.
+    handle : cuml.Handle
+        Specifies the cuml.handle that holds internal CUDA state for
+        computations in this model. Most importantly, this specifies the CUDA
+        stream that will be used for the model's computations, so users can
+        run different models concurrently in different streams by creating
+        handles in several streams.
+        If it is None, a new one is created.
 
     Returns
     -------


### PR DESCRIPTION
This PR's goal is to make classes that derive from `cuml.common.Base` consistent in functionality and documentation. While the number of code changes is large, functionally there are few differences. Mainly this PR can be boiled down to:

- Ensuring all `__init__` methods can accept `handle`, `verbose` and `output_type` arguments
- Ensuring the above arguments are passed to `Base.__init__` correctly
- Making the documentation for the above arguments consistent
- Ensuring all classes properly implement `get_param_names()`
- Creating tests to ensure this consistency moving forward
