### PR TITLE
[REVIEW] pin libfaiss to <=1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,10 @@
 - PR #2863: in FIL, rename leaf_value_t enums to more descriptive
 - PR #2867: improve stability of FIL benchmark measurements
 - PR #2798: Add python tests for FIL multiclass classification of lightgbm models
-- PR #2892 Update ci/local/README.md
+- PR #2892: Update ci/local/README.md
 - PR #2910: Adding Support for CuPy 8.x
 - PR #2914: Add tests for XGBoost multi-class models in FIL
+- PR #2930: Pin libfaiss to <=1.6.3
 
 ## Bug Fixes
 - PR #2882: Allow import on machines without GPUs

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - treelite=0.92
     - faiss-proc=*=cuda
     - gtest=1.10.0
-    - libfaiss>=1.6.0, <= 1.6.3
+    - libfaiss=1.6.3
   run:
     - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
@@ -49,7 +49,7 @@ requirements:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - treelite=0.92
     - faiss-proc=*=cuda
-    - libfaiss>=1.6.0, <= 1.6.3
+    - libfaiss=1.6.3
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - treelite=0.92
     - faiss-proc=*=cuda
     - gtest=1.10.0
-    - libfaiss
+    - libfaiss>=1.6.0, <= 1.6.3
   run:
     - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
@@ -49,7 +49,7 @@ requirements:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - treelite=0.92
     - faiss-proc=*=cuda
-    - libfaiss
+    - libfaiss>=1.6.0, <= 1.6.3
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
faiss had some file re-organization, so there is a good chance that the next release could be incompatible with cuML as it is right now. 