### PR TITLE
[REVIEW] FIX Fix notebook error handling in gpuCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 - PR #2877: TSNE exception for n_components > 2
 - PR #2879: Update unit test for LabelEncoder on filtered input
 - PR #2925: Fixing Owner Bug When Slicing CumlArray Objects
+- PR #2931: Fix notebook error handling in gpuCI
+
 
 # cuML 0.15.0 (Date TBD)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -41,7 +41,7 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Activate conda env..."
-source activate gdf
+source activate rapids
 conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "cudatoolkit=${CUDA_REL}" \
       "cudf=${MINOR_VERSION}" \
@@ -107,7 +107,10 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     ################################################################################
     # TEST - Run GoogleTest and py.tests for libcuml and cuML
     ################################################################################
-
+    set +e -Eo pipefail
+    EXITCODE=0
+    trap "EXITCODE=1" ERR
+    
     if hasArg --skip-tests; then
         logger "Skipping Tests..."
         exit 0
@@ -194,6 +197,9 @@ else
     ################################################################################
     # TEST - Run notebook tests
     ################################################################################
+    set +e -Eo pipefail
+    EXITCODE=0
+    trap "EXITCODE=1" ERR
 
     ${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log
     python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
@@ -224,3 +230,5 @@ else
     $WORKSPACE/build.sh cppdocs -v
 
 fi
+
+return ${EXITCODE}


### PR DESCRIPTION
Current functionality does not actually properly handle errors in testing the notebooks.

${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log

Will only error if the last command in the pipe errors.

set +e -Eo pipefail will allow us to detect errors earlier in the pipe and hold the EXITCODE till we need it.