### PR TITLE
[REVIEW] Adding `cuml.experimental` to the Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PR #2910: Adding Support for CuPy 8.x
 - PR #2914: Add tests for XGBoost multi-class models in FIL
 - PR #2930: Pin libfaiss to <=1.6.3
+- PR #2942: Adding `cuml.experimental` to the Docs
 
 ## Bug Fixes
 - PR #2885: Changing test target for NVTX wrapper test

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -471,3 +471,32 @@ Dask Base Classes and Mixins
 
 .. autoclass:: cuml.dask.common.base.DelayedInverseTransformMixin
    :members:
+
+Experimental
+============
+
+.. warning:: The `cuml.experimental` module contains features that are still
+    under development. It is not recommended to depend on features in this
+    module as they may change in future releases.
+
+.. note:: Due to the nature of this module, it is not imported by default by
+    the root `cuml` package. Each `experimental` submodule must be imported
+    separately.
+
+Decomposition
+-------------
+.. autoclass:: cuml.experimental.decomposition.IncrementalPCA
+   :members:
+
+HyperOpt Utilities
+------------------
+.. automodule:: cuml.experimental.hyperopt_utils.plotting_utils
+   :members:
+
+Preprocessing
+-------------
+.. automodule:: cuml.experimental.preprocessing
+   :members: Binarizer, KBinsDiscretizer, MaxAbsScaler, MinMaxScaler,
+      Normalizer, RobustScaler, SimpleImputer, StandardScaler,
+      add_dummy_feature, binarize, minmax_scale, normalize,
+      PolynomialFeatures, robust_scale, scale

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -488,11 +488,6 @@ Decomposition
 .. autoclass:: cuml.experimental.decomposition.IncrementalPCA
    :members:
 
-HyperOpt Utilities
-------------------
-.. automodule:: cuml.experimental.hyperopt_utils.plotting_utils
-   :members:
-
 Preprocessing
 -------------
 .. automodule:: cuml.experimental.preprocessing

--- a/python/cuml/_thirdparty/sklearn/README.md
+++ b/python/cuml/_thirdparty/sklearn/README.md
@@ -1,6 +1,6 @@
 # GPU accelerated Scikit-Learn preprocessing
 
-This directory contains code originating from the Scikit-Learn library. The Scikit-Learn license applies accordingly (see `/thirdparty/LICENSES/LICENSE.scikit_learn`).
+This directory contains code originating from the Scikit-Learn library. The Scikit-Learn license applies accordingly (see `/thirdparty/LICENSES/LICENSE.scikit_learn`). Original authors mentioned in the code do not endorse or promote this production.
 
 This work is dedicated to providing GPU accelerated tools for preprocessing. The Scikit-Learn code is slightly modified to make it possible to take common inputs used throughout cuML such as Numpy and Cupy arrays, Pandas and cuDF dataframes and compute the results on GPU.
 

--- a/python/cuml/_thirdparty/sklearn/exceptions.py
+++ b/python/cuml/_thirdparty/sklearn/exceptions.py
@@ -1,3 +1,8 @@
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+
+
 """
 The :mod:`sklearn.exceptions` module includes all custom warnings and error
 classes used across scikit-learn.

--- a/python/cuml/_thirdparty/sklearn/preprocessing/__init__.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/__init__.py
@@ -1,3 +1,8 @@
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+
+
 """
 The :mod:`sklearn.preprocessing` module includes scaling, centering,
 normalization, binarization methods.

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -1072,41 +1072,43 @@ def maxabs_scale(X, *, axis=0, copy=True):
 
 
 class RobustScaler(TransformerMixin, BaseEstimator):
-    """Scale features using statistics that are robust to outliers.
+    """
+    Scale features using statistics that are robust to outliers.
 
-    This Scaler removes the median and scales the data according to
-    the quantile range (defaults to IQR: Interquartile Range).
-    The IQR is the range between the 1st quartile (25th quantile)
-    and the 3rd quartile (75th quantile).
+    This Scaler removes the median and scales the data according to the
+    quantile range (defaults to IQR: Interquartile Range). The IQR is the range
+    between the 1st quartile (25th quantile) and the 3rd quartile (75th
+    quantile).
 
-    Centering and scaling happen independently on each feature by
-    computing the relevant statistics on the samples in the training
-    set. Median and interquartile range are then stored to be used on
-    later data using the ``transform`` method.
+    Centering and scaling happen independently on each feature by computing the
+    relevant statistics on the samples in the training set. Median and
+    interquartile range are then stored to be used on later data using the
+    ``transform`` method.
 
-    Standardization of a dataset is a common requirement for many
-    machine learning estimators. Typically this is done by removing the mean
-    and scaling to unit variance. However, outliers can often influence the
-    sample mean / variance in a negative way. In such cases, the median and
-    the interquartile range often give better results.
+    Standardization of a dataset is a common requirement for many machine
+    learning estimators. Typically this is done by removing the mean and
+    scaling to unit variance. However, outliers can often influence the sample
+    mean / variance in a negative way. In such cases, the median and the
+    interquartile range often give better results.
 
     Parameters
     ----------
-    with_centering : boolean, True by default
+
+    with_centering : boolean, default=True
         If True, center the data before scaling.
         This will cause ``transform`` to raise an exception when attempted on
         sparse matrices, because centering them entails building a dense
         matrix which in common use cases is likely to be too large to fit in
         memory.
 
-    with_scaling : boolean, True by default
+    with_scaling : boolean, default=True
         If True, scale the data to interquartile range.
 
     quantile_range : tuple (q_min, q_max), 0.0 < q_min < q_max < 100.0
         Default: (25.0, 75.0) = (1st quantile, 3rd quantile) = IQR
         Quantile range used to calculate ``scale_``.
 
-    copy : boolean, optional, default is True
+    copy : boolean, optional, default=True
         If False, try to avoid a copy and do inplace scaling instead.
         This is not guaranteed to always work inplace; e.g. if the data is
         not a NumPy array or scipy.sparse CSR matrix, a copy may still be
@@ -1139,14 +1141,12 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 
     See also
     --------
+
     robust_scale: Equivalent function without the estimator API.
 
-    :class:`cuml.decomposition.PCA`
-        Further removes the linear correlation across features with
-        'whiten=True'.
+    cuml.decomposition.PCA: Further removes the linear correlation across
+        features with ``whiten=True``.
 
-    https://en.wikipedia.org/wiki/Median
-    https://en.wikipedia.org/wiki/Interquartile_range
     """
     @_deprecate_positional_args
     def __init__(self, *, with_centering=True, with_scaling=True,
@@ -1274,12 +1274,11 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 @_deprecate_positional_args
 def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
                  quantile_range=(25.0, 75.0), copy=True):
-    """Standardize a dataset along any axis
+    """
+    Standardize a dataset along any axis
 
     Center to the median and component wise scale
     according to the interquartile range.
-
-    Read more in the :ref:`User Guide <preprocessing_scaler>`.
 
     Parameters
     ----------
@@ -1325,6 +1324,7 @@ def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
     See also
     --------
     RobustScaler: Performs centering and scaling using the ``Transformer`` API
+
     """
     output_type = get_input_type(X)
     X = check_array(X, accept_sparse=('csr', 'csc'), copy=False,
@@ -2748,6 +2748,7 @@ class PowerTransformer(TransformerMixin, BaseEstimator):
 
     .. [2] G.E.P. Box and D.R. Cox, "An Analysis of Transformations", Journal
            of the Royal Statistical Society B, 26, 211-252 (1964).
+
     """
     @_deprecate_positional_args
     def __init__(self, method='yeo-johnson', *, standardize=True, copy=True):

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -1,4 +1,5 @@
-# Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
+# Original authors from Sckit-Learn:
+#          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
@@ -6,6 +7,12 @@
 #          Giorgio Patrini <giorgio.patrini@anu.edu.au>
 #          Eric Chang <ericchang2017@u.northwestern.edu>
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
 
 
 from itertools import chain, combinations
@@ -103,22 +110,21 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
         unit standard deviation).
 
     copy : boolean, optional, default True
-        set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSC matrix and if axis is 1).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Notes
     -----
-    This implementation will refuse to center scipy.sparse matrices
+    This implementation will refuse to center sparse matrices
     since it would make them non-sparse and would potentially crash the
     program with memory exhaustion problems.
 
     Instead the caller is expected to either set explicitly
     `with_mean=False` (in that case, only variance scaling will be
-    performed on the features of the CSC matrix) or to call `X.toarray()`
+    performed on the features of the sparse matrix) or to densify the matrix
     if he/she expects the materialized dense array to fit in memory.
 
-    To avoid memory copy the caller should pass a CSC matrix.
+    For optimal processing the caller should pass a CSC matrix.
 
     NaNs are treated as missing values: disregarded to compute the statistics,
     and maintained during the data transformation.
@@ -218,8 +224,8 @@ class MinMaxScaler(TransformerMixin, BaseEstimator):
         Desired range of transformed data.
 
     copy : bool, default=True
-        Set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Attributes
     ----------
@@ -455,8 +461,8 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
         otherwise (if 1) scale each sample.
 
     copy : bool, default=True
-        Set to False to perform inplace scaling and avoid a copy (if the input
-        is already a numpy array).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     See also
     --------
@@ -521,10 +527,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
     Parameters
     ----------
     copy : boolean, optional, default True
-        If False, try to avoid a copy and do inplace scaling instead.
-        This is not guaranteed to always work inplace; e.g. if the data is
-        not a NumPy array or scipy.sparse CSR matrix, a copy may still be
-        returned.
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     with_mean : boolean, True by default
         If True, center the data before scaling.
@@ -541,7 +545,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
     ----------
     scale_ : ndarray or None, shape (n_features,)
         Per feature relative scaling of the data. This is calculated using
-        `np.sqrt(var_)`. Equal to ``None`` when ``with_std=False``.
+        `sqrt(var_)`. Equal to ``None`` when ``with_std=False``.
 
     mean_ : ndarray or None, shape (n_features,)
         The mean value for each feature in the training set.
@@ -754,10 +758,11 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape [n_samples, n_features]
             The data used to scale along the features axis.
         copy : bool, optional (default: None)
-            Copy the input X or not.
+            Whether a forced copy will be triggered. If copy=False,
+            a copy might be triggered by a conversion.
         """
         check_is_fitted(self)
 
@@ -790,14 +795,15 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape [n_samples, n_features]
             The data used to scale along the features axis.
         copy : bool, optional (default: None)
-            Copy the input X or not.
+            Whether a forced copy will be triggered. If copy=False,
+            a copy might be triggered by a conversion.
 
         Returns
         -------
-        X_tr : array-like, shape [n_samples, n_features]
+        X_tr : {array-like, sparse matrix}, shape [n_samples, n_features]
             Transformed array.
         """
         check_is_fitted(self)
@@ -851,8 +857,8 @@ class MaxAbsScaler(TransformerMixin, BaseEstimator):
     Parameters
     ----------
     copy : boolean, optional, default is True
-        Set to False to perform inplace scaling and avoid a copy (if the input
-        is already a numpy array).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Attributes
     ----------
@@ -1028,7 +1034,7 @@ def maxabs_scale(X, *, axis=0, copy=True):
 
     Parameters
     ----------
-    X : array-like, shape (n_samples, n_features)
+    X : {array-like, sparse matrix}, shape (n_samples, n_features)
         The data.
 
     axis : int (0 by default)
@@ -1036,8 +1042,8 @@ def maxabs_scale(X, *, axis=0, copy=True):
         otherwise (if 1) scale each sample.
 
     copy : boolean, optional, default is True
-        Set to False to perform inplace scaling and avoid a copy (if the input
-        is already a numpy array).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     See also
     --------
@@ -1109,10 +1115,8 @@ class RobustScaler(TransformerMixin, BaseEstimator):
         Quantile range used to calculate ``scale_``.
 
     copy : boolean, optional, default=True
-        If False, try to avoid a copy and do inplace scaling instead.
-        This is not guaranteed to always work inplace; e.g. if the data is
-        not a NumPy array or scipy.sparse CSR matrix, a copy may still be
-        returned.
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Attributes
     ----------
@@ -1121,9 +1125,6 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 
     scale_ : array of floats
         The (scaled) interquartile range for each feature in the training set.
-
-        .. versionadded:: 0.17
-           *scale_* attribute.
 
     Examples
     --------
@@ -1161,7 +1162,7 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape [n_samples, n_features]
+        X : {array-like, CSC matrix}, shape [n_samples, n_features]
             The data used to compute the median and quantiles
             used for later scaling along the features axis.
         """
@@ -1247,7 +1248,7 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like
+        X : {array-like, sparse matrix}
             The data used to scale along the specified axis.
         """
         check_is_fitted(self)
@@ -1282,7 +1283,7 @@ def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
 
     Parameters
     ----------
-    X : array-like
+    X : {array-like, sparse matrix}
         The data to center and scale.
 
     axis : int (0 by default)
@@ -1301,22 +1302,19 @@ def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
         Default: (25.0, 75.0) = (1st quantile, 3rd quantile) = IQR
         Quantile range used to calculate ``scale_``.
 
-        .. versionadded:: 0.18
-
     copy : boolean, optional, default is True
-        set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSR matrix and if axis is 1).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Notes
     -----
-    This implementation will refuse to center scipy.sparse matrices
+    This implementation will refuse to center sparse matrices
     since it would make them non-sparse and would potentially crash the
     program with memory exhaustion problems.
 
     Instead the caller is expected to either set explicitly
     `with_centering=False` (in that case, only variance scaling will be
-    performed on the features of the CSR matrix) or to call `X.toarray()`
+    performed on the features of the CSR matrix) or to densify the matrix
     if he/she expects the materialized dense array to fit in memory.
 
     To avoid memory copy the caller should pass a CSR matrix.
@@ -1498,7 +1496,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like or CSR/CSC sparse matrix, shape [n_samples, n_features]
+        X : {array-like, sparse matrix}, shape [n_samples, n_features]
             The data to transform, row by row.
 
             Prefer CSR over CSC for sparse input (for speed), but CSC is
@@ -1516,7 +1514,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        XP : np.ndarray or CSR/CSC sparse matrix, shape [n_samples, NP]
+        XP : {array-like, sparse matrix}, shape [n_samples, NP]
             The matrix of features, where NP is the number of polynomial
             features generated from the combination of inputs.
         """
@@ -1633,8 +1631,8 @@ def normalize(X, norm='l2', *, axis=1, copy=True, return_norm=False):
     ----------
     X : {array-like, sparse matrix}, shape [n_samples, n_features]
         The data to normalize, element by element.
-        scipy.sparse matrices should be in CSR format to avoid an
-        un-necessary copy.
+        Please provide CSC matrix to normalize on axis 0,
+        conversely provide CSR matrix to normalize on axis 1
 
     norm : 'l1', 'l2', or 'max', optional ('l2' by default)
         The norm to use to normalize each non zero sample (or each non-zero
@@ -1645,9 +1643,8 @@ def normalize(X, norm='l2', *, axis=1, copy=True, return_norm=False):
         each sample, otherwise (if 0) normalize each feature.
 
     copy : boolean, optional, default True
-        set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSR matrix and if axis is 1).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     return_norm : boolean, default False
         whether to return the computed norms
@@ -1728,8 +1725,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
     that its norm (l1, l2 or inf) equals one.
 
     This transformer is able to work both with dense numpy arrays and
-    scipy.sparse matrix (use CSR format if you want to avoid the burden of
-    a copy / conversion).
+    sparse matrix
 
     Scaling inputs to unit norms is a common operation for text
     classification or clustering for instance. For instance the dot
@@ -1745,9 +1741,8 @@ class Normalizer(TransformerMixin, BaseEstimator):
         values.
 
     copy : boolean, optional, default True
-        set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSR matrix).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Examples
     --------
@@ -1787,7 +1782,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like
+        X : {array-like, CSR matrix}
         """
         self._validate_data(X, accept_sparse='csr')
         return self
@@ -1797,11 +1792,11 @@ class Normalizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape [n_samples, n_features]
-            The data to normalize, row by row. scipy.sparse matrices should be
-            in CSR format to avoid an un-necessary copy.
+        X : {array-like, CSR matrix}, shape [n_samples, n_features]
+            The data to normalize, row by row.
         copy : bool, optional (default: None)
-            Copy the input X or not.
+            Whether a forced copy will be triggered. If copy=False,
+            a copy might be triggered by a conversion.
         """
         output_type = get_input_type(X)
         copy = copy if copy is not None else self.copy
@@ -1815,23 +1810,20 @@ class Normalizer(TransformerMixin, BaseEstimator):
 
 @_deprecate_positional_args
 def binarize(X, *, threshold=0.0, copy=True):
-    """Boolean thresholding of array-like or scipy.sparse matrix
+    """Boolean thresholding of array-like or sparse matrix
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape [n_samples, n_features]
         The data to binarize, element by element.
-        scipy.sparse matrices should be in CSR or CSC format to avoid an
-        un-necessary copy.
 
     threshold : float, optional (0.0 by default)
         Feature values below or equal to this are replaced by 0, above it by 1.
         Threshold may not be less than 0 for operations on sparse matrices.
 
     copy : boolean, optional, default True
-        set to False to perform inplace binarization and avoid a copy
-        (if the input is already a numpy array or a scipy.sparse CSR / CSC
-        matrix and if axis is 1).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     See also
     --------
@@ -1878,8 +1870,8 @@ class Binarizer(TransformerMixin, BaseEstimator):
         Threshold may not be less than 0 for operations on sparse matrices.
 
     copy : boolean, optional, default True
-        set to False to perform inplace binarization and avoid a copy (if
-        the input is already a numpy array or a scipy.sparse CSR matrix).
+        Whether a forced copy will be triggered. If copy=False, a copy might
+        be triggered by a conversion.
 
     Examples
     --------
@@ -1921,7 +1913,7 @@ class Binarizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like
+        X : {array-like, sparse matrix}
         """
         self._validate_data(X, accept_sparse=['csr', 'csc'])
         return self
@@ -1933,11 +1925,10 @@ class Binarizer(TransformerMixin, BaseEstimator):
         ----------
         X : {array-like, sparse matrix}, shape [n_samples, n_features]
             The data to binarize, element by element.
-            scipy.sparse matrices should be in CSR format to avoid an
-            un-necessary copy.
 
         copy : bool
-            Copy the input X or not.
+            Whether a forced copy will be triggered. If copy=False,
+            a copy might be triggered by a conversion.
         """
         copy = copy if copy is not None else self.copy
         return binarize(X, threshold=self.threshold, copy=copy)
@@ -2024,7 +2015,8 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
             Kernel matrix.
 
         copy : boolean, optional, default True
-            Set to False to perform inplace computation.
+            Whether a forced copy will be triggered. If copy=False,
+            a copy might be triggered by a conversion.
 
         Returns
         -------

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -843,7 +843,6 @@ class StandardScaler(TransformerMixin, BaseEstimator):
         return {'allow_nan': True}
 
 
-@check_cupy8()
 class MaxAbsScaler(TransformerMixin, BaseEstimator):
     """Scale each feature by its maximum absolute value.
 
@@ -896,6 +895,7 @@ class MaxAbsScaler(TransformerMixin, BaseEstimator):
     transform.
     """
 
+    @check_cupy8()
     @_deprecate_positional_args
     def __init__(self, *, copy=True):
         self.copy = copy
@@ -1345,7 +1345,6 @@ def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
     return to_output_type(X, output_type)
 
 
-@check_cupy8()
 class PolynomialFeatures(TransformerMixin, BaseEstimator):
     """Generate polynomial and interaction features.
 
@@ -1412,6 +1411,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     polynomially in the number of features of the input array, and
     exponentially in the degree. High degrees can cause overfitting.
     """
+    @check_cupy8()
     @_deprecate_positional_args
     def __init__(self, degree=2, *, interaction_only=False, include_bias=True,
                  order='C'):
@@ -1421,6 +1421,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
         self.order = order
 
     @staticmethod
+    @check_cupy8()
     def _combinations(n_features, degree, interaction_only, include_bias):
         comb = (combinations if interaction_only else combinations_w_r)
         start = int(not include_bias)
@@ -1715,7 +1716,6 @@ def normalize(X, norm='l2', *, axis=1, copy=True, return_norm=False):
         return X
 
 
-@check_cupy8()
 class Normalizer(TransformerMixin, BaseEstimator):
     """Normalize samples individually to unit norm.
 
@@ -1768,6 +1768,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
     normalize: Equivalent function without the estimator API.
     """
 
+    @check_cupy8()
     @_deprecate_positional_args
     def __init__(self, norm='l2', *, copy=True):
         self.norm = norm

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -1078,8 +1078,7 @@ def maxabs_scale(X, *, axis=0, copy=True):
 
 
 class RobustScaler(TransformerMixin, BaseEstimator):
-    """
-    Scale features using statistics that are robust to outliers.
+    """Scale features using statistics that are robust to outliers.
 
     This Scaler removes the median and scales the data according to the
     quantile range (defaults to IQR: Interquartile Range). The IQR is the range

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -42,10 +42,6 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
     """
     Bin continuous data into intervals.
 
-    Read more in the :ref:`User Guide <preprocessing_discretization>`.
-
-    .. versionadded:: 0.20
-
     Parameters
     ----------
     n_bins : int or array-like, shape (n_features,) (default=5)

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -44,7 +44,6 @@ def digitize(x, bins):
     return out
 
 
-@check_cupy8()
 class KBinsDiscretizer(TransformerMixin, BaseEstimator):
     """
     Bin continuous data into intervals.
@@ -141,6 +140,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     """
 
+    @check_cupy8()
     @_deprecate_positional_args
     def __init__(self, n_bins=5, *, encode='onehot', strategy='quantile'):
         self.n_bins = n_bins

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
 
-# Author: Henry Lin <hlin117@gmail.com>
+# Original authors from Sckit-Learn:
+#         Henry Lin <hlin117@gmail.com>
 #         Tom Dupré la Tour
 
 # License: BSD
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
 
 
 import numbers
@@ -84,7 +91,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     See Also
     --------
-     sklearn.preprocessing.Binarizer : Class used to bin values as ``0`` or
+     cuml.preprocessing.Binarizer : Class used to bin values as ``0`` or
         ``1`` based on a parameter ``threshold``.
 
     Notes

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_encoders.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_encoders.py
@@ -1,6 +1,14 @@
-# Authors: Andreas Mueller <amueller@ais.uni-bonn.de>
+# Original authors from Sckit-Learn:
+#          Andreas Mueller <amueller@ais.uni-bonn.de>
 #          Joris Van den Bossche <jorisvandenbossche@gmail.com>
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
+
 
 import numpy as np
 from scipy import sparse

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -1,3 +1,8 @@
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+
+
 import warnings
 
 from ..utils.skl_dependencies import BaseEstimator, TransformerMixin

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -80,17 +80,13 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
 
     Examples
     --------
-
-    .. code-block:: python
-
-        >>> import numpy as np
-        >>> from sklearn.preprocessing import FunctionTransformer
-        >>> transformer = FunctionTransformer(np.log1p)
-        >>> X = np.array([[0, 1], [2, 3]])
-        >>> transformer.transform(X)
-        array([[0.       , 0.6931...],
-            [1.0986..., 1.3862...]])
-
+    >>> import numpy as np
+    >>> from sklearn.preprocessing import FunctionTransformer
+    >>> transformer = FunctionTransformer(np.log1p)
+    >>> X = np.array([[0, 1], [2, 3]])
+    >>> transformer.transform(X)
+    array([[0.       , 0.6931...],
+           [1.0986..., 1.3862...]])
     """
 
     @_deprecate_positional_args

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -75,13 +75,17 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
 
     Examples
     --------
-    >>> import numpy as np
-    >>> from sklearn.preprocessing import FunctionTransformer
-    >>> transformer = FunctionTransformer(np.log1p)
-    >>> X = np.array([[0, 1], [2, 3]])
-    >>> transformer.transform(X)
-    array([[0.       , 0.6931...],
-           [1.0986..., 1.3862...]])
+
+    .. code-block:: python
+
+        >>> import numpy as np
+        >>> from sklearn.preprocessing import FunctionTransformer
+        >>> transformer = FunctionTransformer(np.log1p)
+        >>> X = np.array([[0, 1], [2, 3]])
+        >>> transformer.transform(X)
+        array([[0.       , 0.6931...],
+            [1.0986..., 1.3862...]])
+
     """
 
     @_deprecate_positional_args

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -144,7 +144,6 @@ class _BaseImputer(TransformerMixin, BaseEstimator):
         return {'allow_nan': is_scalar_nan(self.missing_values)}
 
 
-@check_cupy8()
 class SimpleImputer(_BaseImputer):
     """Imputation transformer for completing missing values.
 
@@ -227,6 +226,7 @@ class SimpleImputer(_BaseImputer):
     upon :meth:`transform` if strategy is not "constant".
 
     """
+    @check_cupy8()
     @_deprecate_positional_args
     def __init__(self, *, missing_values=np.nan, strategy="mean",
                  fill_value=None, verbose=0, copy=True, add_indicator=False):

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -1,6 +1,14 @@
-# Authors: Nicolas Tresegnie <nicolas.tresegnie@gmail.com>
+# Original authors from Sckit-Learn:
+#          Nicolas Tresegnie <nicolas.tresegnie@gmail.com>
 #          Sergey Feldman <sergeyfeldman@gmail.com>
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
+
 
 import numbers
 import warnings
@@ -160,8 +168,7 @@ class SimpleImputer(_BaseImputer):
         - If "constant", then replace missing values with fill_value. Can be
           used with strings or numeric data.
 
-        .. versionadded:: 0.20
-           strategy="constant" for fixed value imputation.
+        strategy="constant" for fixed value imputation.
 
     fill_value : string or numerical value, default=None
         When strategy == "constant", fill_value is used to replace all

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_label.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_label.py
@@ -1,10 +1,18 @@
-# Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
+# Original authors from Sckit-Learn:
+#          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Mathieu Blondel <mathieu@mblondel.org>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 #          Andreas Mueller <amueller@ais.uni-bonn.de>
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Hamzeh Alsalhi <ha258@cornell.edu>
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
+
 
 from collections import defaultdict
 import itertools

--- a/python/cuml/_thirdparty/sklearn/utils/__init__.py
+++ b/python/cuml/_thirdparty/sklearn/utils/__init__.py
@@ -1,2 +1,7 @@
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+
+
 from . import validation
 from . import extmath

--- a/python/cuml/_thirdparty/sklearn/utils/extmath.py
+++ b/python/cuml/_thirdparty/sklearn/utils/extmath.py
@@ -1,7 +1,8 @@
 """
 Extended math utilities.
 """
-# Authors: Gael Varoquaux
+# Original authors from Sckit-Learn:
+#          Gael Varoquaux
 #          Alexandre Gramfort
 #          Alexandre T. Passos
 #          Olivier Grisel
@@ -10,6 +11,12 @@ Extended math utilities.
 #          Kyle Kastner
 #          Giorgio Patrini
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
 
 
 import cupy as np

--- a/python/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
+++ b/python/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
@@ -3,8 +3,16 @@ This file gathers Scikit-Learn code that would otherwise
 require a version-dependent import from the sklearn library
 """
 
-# Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
+# Original authors from Sckit-Learn:
+#         Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
+
 
 import warnings
 from collections import defaultdict

--- a/python/cuml/_thirdparty/sklearn/utils/sparsefuncs.py
+++ b/python/cuml/_thirdparty/sklearn/utils/sparsefuncs.py
@@ -1,8 +1,17 @@
-# Authors: Manoj Kumar
+# Original authors from Sckit-Learn:
+#          Manoj Kumar
 #          Thomas Unterthiner
 #          Giorgio Patrini
 #
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
+
+
 from scipy import sparse as cpu_sp
 from cupy import sparse as gpu_sp
 import cupy as np

--- a/python/cuml/_thirdparty/sklearn/utils/validation.py
+++ b/python/cuml/_thirdparty/sklearn/utils/validation.py
@@ -1,6 +1,7 @@
 """Utilities for input validation"""
 
-# Authors: Olivier Grisel
+# Original authors from Sckit-Learn:
+#          Olivier Grisel
 #          Gael Varoquaux
 #          Andreas Mueller
 #          Lars Buitinck
@@ -8,6 +9,13 @@
 #          Nicolas Tresegnie
 #          Sylvain Marie
 # License: BSD 3 clause
+
+
+# This code originates from the Scikit-Learn library,
+# it was since modified to allow GPU acceleration.
+# This code is under BSD 3 clause license.
+# Authors mentioned above do not endorse or promote this production.
+
 
 from functools import wraps
 import warnings

--- a/python/cuml/common/import_utils.py
+++ b/python/cuml/common/import_utils.py
@@ -149,7 +149,7 @@ def check_cupy8(conf=None):
 
         # If this is a class, we dont want to wrap the class which will turn it
         # into a function. Instead, wrap __new__ to have the same effect
-        if (inspect.isclass(func)):
+        if inspect.isclass(func):
 
             func.__new__ = get_inner(func.__new__)
 

--- a/python/cuml/common/import_utils.py
+++ b/python/cuml/common/import_utils.py
@@ -127,14 +127,17 @@ def check_cupy8(conf=None):
     Will otherwise raise an error in case CuPy 8.0+ is unavailable.
 
     """
+    def check_cupy8_dec(func):
 
-    def get_inner(f):
+        assert not inspect.isclass(func), \
+            ("Do not use this decorator on classes. Instead decorate "
+             "__init__  and any static or class methods.")
 
-        @wraps(f)
+        @wraps(func)
         def inner(*args, **kwargs):
             import cupy as cp
             if LooseVersion(str(cp.__version__)) >= LooseVersion('8.0'):
-                return f(*args, **kwargs)
+                return func(*args, **kwargs)
             else:
                 err_msg = 'Could not import required module CuPy 8.0+'
                 if conf == 'pytest':
@@ -142,18 +145,5 @@ def check_cupy8(conf=None):
                     pytest.skip(err_msg)
                 else:
                     raise ImportError(err_msg)
-
         return inner
-
-    def check_cupy8_dec(func):
-
-        # If this is a class, we dont want to wrap the class which will turn it
-        # into a function. Instead, wrap __new__ to have the same effect
-        if inspect.isclass(func):
-
-            func.__new__ = get_inner(func.__new__)
-
-            return func
-
-        return get_inner(func)
     return check_cupy8_dec

--- a/python/cuml/experimental/decomposition/incremental_pca.py
+++ b/python/cuml/experimental/decomposition/incremental_pca.py
@@ -48,55 +48,12 @@ class IncrementalPCA(PCA):
     SVD computations to get the principal components, versus 1 large SVD
     of complexity ``O(n_samples * n_features ** 2)`` for PCA.
 
-
-    Examples
-    ---------
-
-    .. code-block:: python
-        from cuml.decomposition import IncrementalPCA
-        import cupy as cp
-        import cupyx
-
-        X = cupyx.scipy.sparse.random(1000, 5, format='csr', density=0.07)
-        ipca = IncrementalPCA(n_components=2, batch_size=200)
-        ipca.fit(X)
-
-        print("Components: \n", ipca.components_)
-
-        print("Singular Values: ", ipca.singular_values_)
-
-        print("Explained Variance: ", ipca.explained_variance_)
-
-        print("Explained Variance Ratio: ",
-            ipca.explained_variance_ratio_)
-
-        print("Mean: ", ipca.mean_)
-
-        print("Noise Variance: ", ipca.noise_variance_)
-
-    Output:
-
-    .. code-block:: python
-        Components:
-        [[ 0.40465797  0.70924681 -0.46980153 -0.32028596 -0.09962083]
-        [ 0.3072285  -0.31337166 -0.21010504 -0.25727659  0.83490926]]
-
-        Singular Values: [4.67710479 4.0249979 ]
-
-        Explained Variance: [0.02189721 0.01621682]
-
-        Explained Variance Ratio: [0.2084041  0.15434174]
-
-        Mean: [0.03341744 0.03796517 0.03316038 0.03825872 0.0253353 ]
-
-        Noise Variance: 0.0049539530909571425
-
     Parameters
     ----------
     handle : cuml.Handle
         If it is None, a new one is created just for this class
     n_components : int or None, (default=None)
-        Number of components to keep. If ``n_components `` is ``None``,
+        Number of components to keep. If ``n_components`` is ``None``,
         then ``n_components`` is set to ``min(n_samples, n_features)``.
     whiten : bool, optional
         If True, de-correlates the components. This is done by dividing them by
@@ -135,9 +92,7 @@ class IncrementalPCA(PCA):
         ``partial_fit``.
     noise_variance_ : float
         The estimated noise covariance following the Probabilistic PCA model
-        from Tipping and Bishop 1999. See "Pattern Recognition and
-        Machine Learning" by C. Bishop, 12.2.1 p. 574 or
-        http://www.miketipping.com/papers/met-mppca.pdf.
+        from [4]_.
     n_components_ : int
         The estimated number of components. Relevant when
         ``n_components=None``.
@@ -146,34 +101,78 @@ class IncrementalPCA(PCA):
         new calls to fit, but increments across ``partial_fit`` calls.
     batch_size_ : int
         Inferred batch size from ``batch_size``.
+
     Notes
     -----
-    Implements the incremental PCA model from:
-    *D. Ross, J. Lim, R. Lin, M. Yang, Incremental Learning for Robust Visual
-    Tracking, International Journal of Computer Vision, Volume 77, Issue 1-3,
-    pp. 125-141, May 2008.*
-    See https://www.cs.toronto.edu/~dross/ivt/RossLimLinYang_ijcv.pdf
-    This model is an extension of the Sequential Karhunen-Loeve Transform from:
-    *A. Levy and M. Lindenbaum, Sequential Karhunen-Loeve Basis Extraction and
-    its Application to Images, IEEE Transactions on Image Processing, Volume 9,
-    Number 8, pp. 1371-1374, August 2000.*
-    See https://www.cs.technion.ac.il/~mic/doc/skl-ip.pdf
-    We have specifically abstained from an optimization used by authors of both
-    papers, a QR decomposition used in specific situations to reduce the
-    algorithmic complexity of the SVD. The source for this technique is
-    *Matrix Computations, Third Edition, G. Holub and C. Van Loan, Chapter 5,
-    section 5.4.4, pp 252-253.*. This technique has been omitted because it is
-    advantageous only when decomposing a matrix with ``n_samples`` (rows)
-    >= 5/3 * ``n_features`` (columns), and hurts the readability of the
-    implemented algorithm. This would be a good opportunity for future
-    optimization, if it is deemed necessary.
+
+    Implements the incremental PCA model from [1]_. This model is an extension
+    of the Sequential Karhunen-Loeve Transform from [2]_. We have specifically
+    abstained from an optimization used by authors of both papers, a QR
+    decomposition used in specific situations to reduce the algorithmic
+    complexity of the SVD. The source for this technique is [3]_. This
+    technique has been omitted because it is advantageous only when decomposing
+    a matrix with ``n_samples >= 5/3 * n_features`` where ``n_samples`` and
+    ``n_features`` are the matrix rows and columns, respectively. In addition,
+    it hurts the readability of the implemented algorithm. This would be a good
+    opportunity for future optimization, if it is deemed necessary.
+
     References
     ----------
-    D. Ross, J. Lim, R. Lin, M. Yang. Incremental Learning for Robust Visual
-    Tracking, International Journal of Computer Vision, Volume 77,
-    Issue 1-3, pp. 125-141, May 2008.
-    G. Golub and C. Van Loan. Matrix Computations, Third Edition, Chapter 5,
-    Section 5.4.4, pp. 252-253.
+    .. [1] `D. Ross, J. Lim, R. Lin, M. Yang. Incremental Learning for Robust
+        Visual Tracking, International Journal of Computer Vision, Volume 77,
+        Issue 1-3, pp. 125-141, May 2008.
+        <https://www.cs.toronto.edu/~dross/ivt/RossLimLinYang_ijcv.pdf>`_
+
+    .. [2] `A. Levy and M. Lindenbaum, Sequential Karhunen-Loeve Basis
+        Extraction and its Application to Images, IEEE Transactions on Image
+        Processing, Volume 9, Number 8, pp. 1371-1374, August 2000.
+        <https://www.cs.technion.ac.il/~mic/doc/skl-ip.pdf>`_
+
+    .. [3] G. Golub and C. Van Loan. Matrix Computations, Third Edition,
+        Chapter 5, Section 5.4.4, pp. 252-253.
+
+    .. [4] `C. Bishop, 1999. "Pattern Recognition and Machine Learning",
+        Section 12.2.1, pp. 574
+        <http://www.miketipping.com/papers/met-mppca.pdf>`_
+
+    Examples
+    ---------
+
+    .. code-block:: python
+
+        >>> from cuml.experimental.decomposition import IncrementalPCA
+        >>> import cupy as cp
+        >>> import cupyx
+        >>>
+        >>> X = cupyx.scipy.sparse.random(1000, 4, format='csr', density=0.07)
+        >>> ipca = IncrementalPCA(n_components=2, batch_size=200)
+        >>> ipca.fit(X)
+        >>>
+        >>> # Components:
+        >>> ipca.components_
+        array([[-0.02362926,  0.87328851, -0.15971988,  0.45967206],
+            [-0.14643883,  0.11414225,  0.97589354,  0.11471273]])
+        >>>
+        >>> # Singular Values:
+        >>> ipca.singular_values_
+        array([4.90298662, 4.54498226])
+        >>>
+        >>> # Explained Variance:
+        >>> ipca.explained_variance_
+        array([0.02406334, 0.02067754])
+        >>>
+        >>> # Explained Variance Ratio:
+        >>> ipca.explained_variance_ratio_
+        array([0.28018011, 0.24075775])
+        >>>
+        >>> # Mean:
+        >>> ipca.mean_
+        array([0.03249896, 0.03629852, 0.03268694, 0.03216601])
+        >>>
+        >>> # Noise Variance:
+        >>> ipca.noise_variance_.item()
+        0.003474966583315544
+
     """
     def __init__(self, handle=None, n_components=None, *, whiten=False,
                  copy=True, batch_size=None, verbose=None,
@@ -191,17 +190,22 @@ class IncrementalPCA(PCA):
 
     @with_cupy_rmm
     def fit(self, X, y=None):
-        """Fit the model with X, using minibatches of size batch_size.
+        """
+        Fit the model with X, using minibatches of size batch_size.
+
         Parameters
         ----------
         X : array-like or sparse matrix, shape (n_samples, n_features)
             Training data, where n_samples is the number of samples and
             n_features is the number of features.
         y : Ignored
+
         Returns
         -------
+
         self : object
             Returns the instance itself.
+
         """
 
         self._set_base_attributes(output_type=X)
@@ -243,19 +247,25 @@ class IncrementalPCA(PCA):
 
     @with_cupy_rmm
     def partial_fit(self, X, y=None, check_input=True):
-        """Incremental fit with X. All of X is processed as a single batch.
+        """
+        Incremental fit with X. All of X is processed as a single batch.
+
         Parameters
         ----------
+
         X : array-like or sparse matrix, shape (n_samples, n_features)
             Training data, where n_samples is the number of samples and
             n_features is the number of features.
         check_input : bool
             Run check_array on X.
         y : Ignored
+
         Returns
         -------
+
         self : object
             Returns the instance itself.
+
         """
         if check_input:
             if scipy.sparse.issparse(X) or cupyx.scipy.sparse.issparse(X):
@@ -358,12 +368,16 @@ class IncrementalPCA(PCA):
 
     @with_cupy_rmm
     def transform(self, X, convert_dtype=False):
-        """Apply dimensionality reduction to X.
+        """
+        Apply dimensionality reduction to X.
+
         X is projected on the first principal components previously extracted
         from a training set, using minibatches of size batch_size if X is
         sparse.
+
         Parameters
         ----------
+
         X : array-like or sparse matrix, shape (n_samples, n_features)
             New data, where n_samples is the number of samples
             and n_features is the number of features.
@@ -375,7 +389,9 @@ class IncrementalPCA(PCA):
 
         Returns
         -------
+
         X_new : array-like, shape (n_samples, n_components)
+
         """
 
         if scipy.sparse.issparse(X) or cupyx.scipy.sparse.issparse(X):
@@ -426,11 +442,15 @@ def _validate_sparse_input(X):
 
     Parameters
     ----------
+
     X : scipy.sparse or cupyx.scipy.sparse object
         A sparse input
+
     Returns
     -------
+
     X : The input converted to a cupyx.scipy.sparse.csr_matrix object
+
     """
 
     acceptable_dtypes = ('float32', 'float64')
@@ -463,14 +483,18 @@ def _gen_batches(n, batch_size, min_batch_size=0):
 
     Parameters
     ----------
+
     n : int
     batch_size : int
         Number of element in each batch
     min_batch_size : int, default=0
         Minimum batch size to produce.
+
     Yields
     ------
+
     slice of batch_size elements
+
     """
 
     if not isinstance(batch_size, numbers.Integral):
@@ -495,8 +519,10 @@ def _safe_accumulator_op(op, x, *args, **kwargs):
     This function provides numpy accumulator functions with a float64 dtype
     when used on a floating point input. This prevents accumulator overflow on
     smaller floating point dtypes.
+
     Parameters
     ----------
+
     op : function
         A cupy accumulator function such as cp.mean or cp.sum
     x : cupy array
@@ -506,9 +532,12 @@ def _safe_accumulator_op(op, x, *args, **kwargs):
         input x
     **kwargs : keyword arguments
         Keyword arguments passed to the accumulator function
+
     Returns
     -------
+
     result : The output of the accumulator function passed to this function
+
     """
 
     if cp.issubdtype(x.dtype, cp.floating) and x.dtype.itemsize < 8:
@@ -519,7 +548,8 @@ def _safe_accumulator_op(op, x, *args, **kwargs):
 
 
 def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
-    """Calculate mean update and a Youngs and Cramer variance update.
+    """
+    Calculate mean update and a Youngs and Cramer variance update.
     last_mean and last_variance are statistics computed at the last step by the
     function. Both must be initialized to 0.0. In case no scaling is required
     last_variance can be None. The mean is always required and returned because
@@ -527,27 +557,34 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
     number of samples encountered until now.
     From the paper "Algorithms for computing the sample variance: analysis and
     recommendations", by Chan, Golub, and LeVeque.
+
     Parameters
     ----------
+
     X : array-like, shape (n_samples, n_features)
         Data to use for variance update
     last_mean : array-like, shape: (n_features,)
     last_variance : array-like, shape: (n_features,)
     last_sample_count : array-like, shape (n_features,)
+
     Returns
     -------
+
     updated_mean : array, shape (n_features,)
     updated_variance : array, shape (n_features,)
         If None, only mean is computed
     updated_sample_count : array, shape (n_features,)
+
     Notes
     -----
     NaNs are ignored during the algorithm.
+
     References
     ----------
     T. Chan, G. Golub, R. LeVeque. Algorithms for computing the sample
         variance: recommendations, The American Statistician, Vol. 37, No. 3,
         pp. 242-247
+
     """
 
     # old = stats until now
@@ -585,11 +622,14 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
 
 
 def _svd_flip(u, v, u_based_decision=True):
-    """Sign correction to ensure deterministic output from SVD.
+    """
+    Sign correction to ensure deterministic output from SVD.
     Adjusts the columns of u and the rows of v such that the loadings in the
     columns in u that are largest in absolute value are always positive.
+
     Parameters
     ----------
+
     u : cupy.ndarray
         u and v are the output of `cupy.linalg.svd`
     v : cupy.ndarray
@@ -598,9 +638,11 @@ def _svd_flip(u, v, u_based_decision=True):
         If True, use the columns of u as the basis for sign flipping.
         Otherwise, use the rows of v. The choice of which variable to base the
         decision on is generally algorithm dependent.
+
     Returns
     -------
     u_adjusted, v_adjusted : arrays with the same dimensions as the input.
+
     """
     if u_based_decision:
         # columns of u, rows of v

--- a/python/cuml/experimental/hyperopt_utils/plotting_utils.py
+++ b/python/cuml/experimental/hyperopt_utils/plotting_utils.py
@@ -22,8 +22,8 @@ import seaborn as sns
 
 def plot_heatmap(df, col1, col2):
     """
-    Generates a heatmap to highlight interactions
-    of two parameters specified in col1 and col2.
+    Generates a heatmap to highlight interactions of two parameters specified
+    in col1 and col2.
 
     Parameters
     ----------
@@ -32,9 +32,6 @@ def plot_heatmap(df, col1, col2):
     col1 : string; Name of the first parameter
     col2: string; Name of the second parameter
 
-    Output
-    ----------
-    A heatmap using seaborn
     """
     max_scores = df.groupby([col1, col2]).max()
     max_scores = max_scores.unstack()[['mean_test_score']]
@@ -43,8 +40,8 @@ def plot_heatmap(df, col1, col2):
 
 def plot_search_results(res):
     """
-    Plots by fixing all paramters except one parameter to
-    its best value using matplotlib.
+    Plots by fixing all paramters except one parameter to its best value using
+    matplotlib.
 
     Accepts results from grid or random search from dask-ml.
 
@@ -52,9 +49,6 @@ def plot_search_results(res):
     ----------
     res : results from Grid or Random Search
 
-    Output
-    ----------
-    As many plots as the parameters that were tuned
     """
     # Results from grid search
     results = res.cv_results_

--- a/python/cuml/experimental/preprocessing/__init__.py
+++ b/python/cuml/experimental/preprocessing/__init__.py
@@ -19,3 +19,23 @@ from cuml._thirdparty.sklearn.preprocessing import StandardScaler, \
     SimpleImputer, RobustScaler, KBinsDiscretizer
 from cuml._thirdparty.sklearn.preprocessing import scale, minmax_scale, \
     normalize, add_dummy_feature, binarize, robust_scale
+
+__all__ = [
+    # Classes
+    'Binarizer',
+    'KBinsDiscretizer',
+    'MaxAbsScaler',
+    'MinMaxScaler',
+    'Normalizer',
+    'PolynomialFeatures',
+    'RobustScaler',
+    'SimpleImputer',
+    'StandardScaler',
+    # Functions
+    'add_dummy_feature',
+    'binarize',
+    'minmax_scale',
+    'normalize',
+    'robust_scale',
+    'scale',
+]


### PR DESCRIPTION
This PR adds the classes and modules in `cuml.experimental` into the documentation. Was a little more difficult than expected because the `check_cupy8` decorator turned classes into functions which Sphinx did not like and refused to autodoc.

@viclafargue Can you look over the docstrings and make sure they are all correct? There are a few things that are obviously copied from sklearn (such as "added in version 0.20") which need to be cleaned up.

@JohnZed Can you look over the notices I put at the top of the Experimental section? Its just 2 quick warnings that could use a second pair of eyes.

(You are both added as contributors to my repo so you can push changes)