### PR TITLE
[REVIEW] Removing unused shuffle_features parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 - PR #2932: Marking KBinsDiscretizer pytests as xfail
 - PR #2925: Fixing Owner Bug When Slicing CumlArray Objects
 - PR #2931: Fix notebook error handling in gpuCI
-
+- PR #2943: Remove unused shuffle_features parameter
 
 # cuML 0.15.0 (Date TBD)
 

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -192,8 +192,7 @@ RF_params set_rf_class_obj(int max_depth, int max_leaves, float max_features,
                            bool bootstrap, int n_trees, float rows_sample,
                            int seed, CRITERION split_criterion,
                            bool quantile_per_tree, int cfg_n_streams,
-                           bool shuffle_features, bool use_experimental_backend,
-                           int max_batch_size);
+                           bool use_experimental_backend, int max_batch_size);
 
 // ----------------------------- Regression ----------------------------------- //
 

--- a/cpp/include/cuml/tree/decisiontree.hpp
+++ b/cpp/include/cuml/tree/decisiontree.hpp
@@ -63,10 +63,6 @@ struct DecisionTreeParams {
    */
   CRITERION split_criterion;
   /**
-   * Whether to fully reshuffle the features for subsampling at each tree node. Default is one shuffle per depth with random start point in the shuffled feature list per node
-   */
-  bool shuffle_features;
-  /**
    * Minimum impurity decrease required for spliting a node. If the impurity decrease is below this value, node is leafed out. Default is 0.0
    */
   float min_impurity_decrease = 0.0f;
@@ -102,7 +98,6 @@ struct DecisionTreeParams {
  * @param[in] cfg_split_criterion: split criterion; default CRITERION_END,
  *            i.e., GINI for classification or MSE for regression
  * @param[in] cfg_quantile_per_tree: compute quantile per tree; default false
- * @param[in] cfg_shuffle_features: whether to shuffle features or not
  * @param[in] cfg_use_experimental_backend: If set to true, experimental batched
  *            backend is used (provided other conditions are met). Default is 
               false.
@@ -110,14 +105,16 @@ struct DecisionTreeParams {
               in a batch. This is used only for batched-level algo. Default 
               value 128.
  */
-void set_tree_params(
-  DecisionTreeParams &params, int cfg_max_depth = -1, int cfg_max_leaves = -1,
-  float cfg_max_features = 1.0f, int cfg_n_bins = 8,
-  int cfg_split_algo = SPLIT_ALGO::HIST, int cfg_min_rows_per_node = 2,
-  float cfg_min_impurity_decrease = 0.0f, bool cfg_bootstrap_features = false,
-  CRITERION cfg_split_criterion = CRITERION_END,
-  bool cfg_quantile_per_tree = false, bool cfg_shuffle_features = false,
-  bool cfg_use_experimental_backend = false, int cfg_max_batch_size = 128);
+void set_tree_params(DecisionTreeParams &params, int cfg_max_depth = -1,
+                     int cfg_max_leaves = -1, float cfg_max_features = 1.0f,
+                     int cfg_n_bins = 8, int cfg_split_algo = SPLIT_ALGO::HIST,
+                     int cfg_min_rows_per_node = 2,
+                     float cfg_min_impurity_decrease = 0.0f,
+                     bool cfg_bootstrap_features = false,
+                     CRITERION cfg_split_criterion = CRITERION_END,
+                     bool cfg_quantile_per_tree = false,
+                     bool cfg_use_experimental_backend = false,
+                     int cfg_max_batch_size = 128);
 
 /**
  * @brief Check validity of all decision tree hyper-parameters.

--- a/cpp/src/decisiontree/decisiontree.cu
+++ b/cpp/src/decisiontree/decisiontree.cu
@@ -34,7 +34,6 @@ namespace DecisionTree {
  * @param[in] cfg_split_criterion: split criterion; default CRITERION_END,
  *            i.e., GINI for classification or MSE for regression
  * @param[in] cfg_quantile_per_tree: compute quantile per tree; default false
- * @param[in] cfg_shuffle_features: whether to shuffle column ids or not
  * @param[in] cfg_use_experimental_backend: Switch to using experimental
               backend; default false
  * @param[in] cfg_max_batch_size: batch size for experimental backend
@@ -44,7 +43,7 @@ void set_tree_params(DecisionTreeParams &params, int cfg_max_depth,
                      int cfg_split_algo, int cfg_min_rows_per_node,
                      float cfg_min_impurity_decrease,
                      bool cfg_bootstrap_features, CRITERION cfg_split_criterion,
-                     bool cfg_quantile_per_tree, bool cfg_shuffle_features,
+                     bool cfg_quantile_per_tree,
                      bool cfg_use_experimental_backend,
                      int cfg_max_batch_size) {
   params.max_depth = cfg_max_depth;
@@ -56,7 +55,6 @@ void set_tree_params(DecisionTreeParams &params, int cfg_max_depth,
   params.bootstrap_features = cfg_bootstrap_features;
   params.split_criterion = cfg_split_criterion;
   params.quantile_per_tree = cfg_quantile_per_tree;
-  params.shuffle_features = cfg_shuffle_features;
   params.use_experimental_backend = cfg_use_experimental_backend;
   params.min_impurity_decrease = cfg_min_impurity_decrease;
   params.max_batch_size = cfg_max_batch_size;
@@ -89,7 +87,6 @@ void print(const DecisionTreeParams params) {
   CUML_LOG_DEBUG("bootstrap_features: %d", params.bootstrap_features);
   CUML_LOG_DEBUG("split_criterion: %d", params.split_criterion);
   CUML_LOG_DEBUG("quantile_per_tree: %d", params.quantile_per_tree);
-  CUML_LOG_DEBUG("shuffle_features: %d", params.shuffle_features);
   CUML_LOG_DEBUG("min_impurity_decrease: %f", params.min_impurity_decrease);
   CUML_LOG_DEBUG("use_experimental_backend: %s",
                  params.use_experimental_backend ? "True" : "False");

--- a/cpp/src/decisiontree/memory.cuh
+++ b/cpp/src/decisiontree/memory.cuh
@@ -141,25 +141,17 @@ void TemporaryMemory<T, L>::LevelMemAllocator(
   }
   d_sample_cnt =
     new MLCommon::device_buffer<unsigned int>(device_allocator, stream, nrows);
-  if (tree_params.shuffle_features == true) {
-    d_colids = new MLCommon::device_buffer<unsigned int>(
-      device_allocator, stream, ncols_sampled * gather_max_nodes);
-    h_colids = new MLCommon::host_buffer<unsigned int>(
-      host_allocator, stream, ncols_sampled * gather_max_nodes);
-    totalmem += ncols_sampled * maxnodes * sizeof(int);
-
-  } else {
-    //This buffers are also reused by gather algorithm
-    d_colids = new MLCommon::device_buffer<unsigned int>(device_allocator,
-                                                         stream, ncols);
-    d_colstart = new MLCommon::device_buffer<unsigned int>(device_allocator,
-                                                           stream, parentsz);
-    h_colids =
-      new MLCommon::host_buffer<unsigned int>(host_allocator, stream, ncols);
-    h_colstart =
-      new MLCommon::host_buffer<unsigned int>(host_allocator, stream, parentsz);
-    totalmem += ncols * sizeof(int) + parentsz * sizeof(int);
-  }
+  //This buffers are also reused by gather algorithm
+  d_colids =
+    new MLCommon::device_buffer<unsigned int>(device_allocator, stream, ncols);
+  d_colstart = new MLCommon::device_buffer<unsigned int>(device_allocator,
+                                                         stream, parentsz);
+  h_colids =
+    new MLCommon::host_buffer<unsigned int>(host_allocator, stream, ncols);
+  h_colstart =
+    new MLCommon::host_buffer<unsigned int>(host_allocator, stream, parentsz);
+  totalmem += ncols * sizeof(int) + parentsz * sizeof(int);
+  // }
   //CUB memory for gather algorithms
   size_t temp_storage_bytes = 0;
   void* cub_buffer = NULL;

--- a/cpp/src/decisiontree/memory.cuh
+++ b/cpp/src/decisiontree/memory.cuh
@@ -151,7 +151,6 @@ void TemporaryMemory<T, L>::LevelMemAllocator(
   h_colstart =
     new MLCommon::host_buffer<unsigned int>(host_allocator, stream, parentsz);
   totalmem += ncols * sizeof(int) + parentsz * sizeof(int);
-  // }
   //CUB memory for gather algorithms
   size_t temp_storage_bytes = 0;
   void* cub_buffer = NULL;

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -617,14 +617,13 @@ RF_params set_rf_class_obj(int max_depth, int max_leaves, float max_features,
                            bool bootstrap, int n_trees, float rows_sample,
                            int seed, CRITERION split_criterion,
                            bool quantile_per_tree, int cfg_n_streams,
-                           bool shuffle_features, bool use_experimental_backend,
-                           int max_batch_size) {
+                           bool use_experimental_backend, int max_batch_size) {
   DecisionTree::DecisionTreeParams tree_params;
   DecisionTree::set_tree_params(
     tree_params, max_depth, max_leaves, max_features, n_bins, split_algo,
     min_rows_per_node, min_impurity_decrease, bootstrap_features,
-    split_criterion, quantile_per_tree, shuffle_features,
-    use_experimental_backend, max_batch_size);
+    split_criterion, quantile_per_tree, use_experimental_backend,
+    max_batch_size);
   RF_params rf_params;
   set_all_rf_params(rf_params, n_trees, bootstrap, rows_sample, seed,
                     cfg_n_streams, tree_params);

--- a/cpp/test/sg/decisiontree_batchedlevel_algo.cu
+++ b/cpp/test/sg/decisiontree_batchedlevel_algo.cu
@@ -50,8 +50,8 @@ class DtBaseTest : public ::testing::TestWithParam<DtTestParams> {
     handle->set_stream(stream);
     set_tree_params(params, inparams.max_depth, 1 << inparams.max_depth, 1.f,
                     inparams.nbins, SPLIT_ALGO::GLOBAL_QUANTILE, inparams.nbins,
-                    inparams.min_gain, false, inparams.splitType, false, false,
-                    true, 128);
+                    inparams.min_gain, false, inparams.splitType, false, true,
+                    128);
     auto allocator = handle->get_device_allocator();
     data = (T*)allocator->allocate(sizeof(T) * inparams.M * inparams.N, stream);
     labels = (L*)allocator->allocate(sizeof(L) * inparams.M, stream);

--- a/cpp/test/sg/rf_accuracy_test.cu
+++ b/cpp/test/sg/rf_accuracy_test.cu
@@ -93,8 +93,7 @@ class RFClassifierAccuracyTest : public ::testing::TestWithParam<RFInputs> {
                     0.f,            /* min_impurity_decrease */
                     false,          /* bootstrap_features */
                     sc,             /* split_criterion */
-                    false,          /* quantile_per_tree */
-                    false           /* shuffle_features */
+                    false           /* quantile_per_tree */
     );
     set_all_rf_params(rfp, 1, /* n_trees */
                       true,   /* bootstrap */

--- a/cpp/test/sg/rf_batched_classification_test.cu
+++ b/cpp/test/sg/rf_batched_classification_test.cu
@@ -55,7 +55,7 @@ class RFBatchedTest : public ::testing::TestWithParam<RfInputs> {
                     params.max_features, params.n_bins, params.split_algo,
                     params.min_rows_per_node, params.min_impurity_decrease,
                     params.bootstrap_features, params.split_criterion, false,
-                    false, true);
+                    true);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
                       params.rows_sample, -1, params.n_streams, tree_params);

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -58,7 +58,7 @@ class RFBatchedRegTest : public ::testing::TestWithParam<RfInputs> {
                     params.max_features, params.n_bins, params.split_algo,
                     params.min_rows_per_node, params.min_impurity_decrease,
                     params.bootstrap_features, params.split_criterion, false,
-                    false, true);
+                    true);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
                       params.rows_sample, -1, params.n_streams, tree_params);

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -59,7 +59,6 @@ class BaseRandomForestModel(Base):
                  min_impurity_split=None, oob_score=None,
                  random_state=None, warm_start=None, class_weight=None,
                  quantile_per_tree=False, criterion=None,
-                 shuffle_features=False,
                  use_experimental_backend=False, max_batch_size=128):
 
         if accuracy_metric:
@@ -140,7 +139,6 @@ class BaseRandomForestModel(Base):
         self.dtype = dtype
         self.accuracy_metric = accuracy_metric
         self.quantile_per_tree = quantile_per_tree
-        self.shuffle_features = shuffle_features
         self.use_experimental_backend = use_experimental_backend
         self.max_batch_size = max_batch_size
         self.n_streams = handle.getNumInternalStreams()

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -119,7 +119,6 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
                                     bool,
                                     int,
                                     bool,
-                                    bool,
                                     int) except +
 
     cdef vector[unsigned char] save_model(ModelHandle)

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -219,9 +219,6 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     quantile_per_tree : boolean (default = False)
         Whether quantile is computed for individal trees in RF.
         Only relevant for GLOBAL_QUANTILE split_algo.
-    shuffle_features : boolean (default = False)
-        Whether to fully reshuffle the features for subsampling at each tree
-        node (instead of only shuffling once globally)
     use_experimental_backend : boolean (default = False)
         If set to true and  following conditions are also met, experimental
          decision tree training implementation would be used:
@@ -450,7 +447,6 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
                                      <CRITERION> self.split_criterion,
                                      <bool> self.quantile_per_tree,
                                      <int> self.n_streams,
-                                     <bool> self.shuffle_features,
                                      <bool> self.use_experimental_backend,
                                      <int> self.max_batch_size)
 

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -210,9 +210,6 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     quantile_per_tree : boolean (default = False)
         Whether quantile is computed for individal trees in RF.
         Only relevant for GLOBAL_QUANTILE split_algo.
-    shuffle_features : boolean (default = False)
-        Whether to fully reshuffle the features for subsampling at each tree
-        node (instead of only shuffling once globally)
     use_experimental_backend : boolean (default = False)
         If set to true and  following conditions are also met, experimental
          decision tree training implementation would be used:
@@ -426,7 +423,6 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
                                      <CRITERION> self.split_criterion,
                                      <bool> self.quantile_per_tree,
                                      <int> self.n_streams,
-                                     <bool> self.shuffle_features,
                                      <bool> self.use_experimental_backend,
                                      <int> self.max_batch_size)
 


### PR DESCRIPTION
PR #2881 accidentally reintroduced `shuffle_features` as a RF training parameter. The parameter is unused in the implementation. It is also inconsistent with scikit-learn RF. Removing it with this PR.