### PR TITLE
[Review] Add additional warnings for float64 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #2916: Add SKLearn multi-class GBDT model support in FIL
 
 ## Improvements
+- PR #2947: Add more warnings for accuracy degradation with 64-bit models
 - PR #2873: Remove empty marker kernel code for NVTX markers
 - PR #2796: Remove tokens of length 1 by default for text vectorizers
 - PR #2741: Use rapids build packages in conda environments

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -410,6 +410,11 @@ class ForestInference(Base):
      * Inference uses a dense matrix format, which is efficient for many
        problems but can be suboptimal for sparse datasets.
      * Only binary classification and regression are supported.
+     * Many other random forest implementations including LightGBM, and SKLearn
+       GBDTs make use of 64-bit floating point parameters, but the underlying
+       library for ForestInference uses only 32-bit parameters. Because of the
+       truncation that will occur when loading such models into
+       ForestInference, you may observe a slight degradation in accuracy.
 
     Parameters
     ----------
@@ -612,6 +617,9 @@ class ForestInference(Base):
 
         """
         cuml_fm = ForestInference(handle=handle)
+        logger.warn("Treelite currently does not support float64 model"
+                    " parameters. Accuracy may degrade relative to"
+                    " native sklearn invocation.")
         tl_model = tl_skl.import_model(skl_model)
         cuml_fm.load_from_treelite_model(
             tl_model, algo=algo, output_class=output_class,

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -134,8 +134,8 @@ cdef class TreeliteModel():
                 raise RuntimeError("Failed to load %s (%s)" % (filename, err))
         elif model_type == "lightgbm":
             logger.warn("Treelite currently does not support float64 model"
-                        " parameters. Accuracy may degrade relative to"
-                        " native LightGBM invocation.")
+                        " parameters. Accuracy may degrade slightly relative"
+                        " to native LightGBM invocation.")
             res = TreeliteLoadLightGBMModel(filename_bytes, &handle)
             if res < 0:
                 err = TreeliteGetLastError()
@@ -618,7 +618,7 @@ class ForestInference(Base):
         """
         cuml_fm = ForestInference(handle=handle)
         logger.warn("Treelite currently does not support float64 model"
-                    " parameters. Accuracy may degrade relative to"
+                    " parameters. Accuracy may degrade slightly relative to"
                     " native sklearn invocation.")
         tl_model = tl_skl.import_model(skl_model)
         cuml_fm.load_from_treelite_model(


### PR DESCRIPTION
Add in-line and documentation warning about accuracy degradation when loading models with 64-bit parameters using Treelite/FIL

Closes #2944 