### PR TITLE
[REVIEW] removing shuffle_features from RF param names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #2931: Fix notebook error handling in gpuCI
 - PR #2943: Remove unused shuffle_features parameter
 - PR #2940: Correcting labels meta dtype for `cuml.dask.make_classification`
+- PR #2968: Remove shuffle_features from RF param names
 
 # cuML 0.15.0 (Date TBD)
 

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -43,7 +43,7 @@ class BaseRandomForestModel(Base):
                     'verbose', 'rows_sample',
                     'max_leaves', 'quantile_per_tree',
                     'accuracy_metric', 'use_experimental_backend',
-                    'max_batch_size', 'shuffle_features']
+                    'max_batch_size']
 
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}


### PR DESCRIPTION
This will unblock CI for branch-0.16 and solve failing `test_unfit_clone` in `test_pickle.py`