### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #2931: Fix notebook error handling in gpuCI
 - PR #2943: Remove unused shuffle_features parameter
 - PR #2940: Correcting labels meta dtype for `cuml.dask.make_classification`
+- PR #2968: Remove shuffle_features from RF param names
 - PR #2957: Fix ols test size for stability
 
 # cuML 0.15.0 (Date TBD)

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -43,7 +43,7 @@ class BaseRandomForestModel(Base):
                     'verbose', 'rows_sample',
                     'max_leaves', 'quantile_per_tree',
                     'accuracy_metric', 'use_experimental_backend',
-                    'max_batch_size', 'shuffle_features']
+                    'max_batch_size']
 
     criterion_dict = {'0': GINI, '1': ENTROPY, '2': MSE,
                       '3': MAE, '4': CRITERION_END}


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.