### PR TITLE
[REVIEW] Fix un-guarded sklearn import in SVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - PR #2968: Remove shuffle_features from RF param names
 - PR #2957: Fix ols test size for stability
 - PR #2972: Upgrade Treelite to 0.93
+- PR #2981: Prevent unguarded import of sklearn in SVC
 
 # cuML 0.15.0 (Date TBD)
 

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -3,7 +3,7 @@
 GIT_DESCRIBE_TAG=`git describe --tags`
 MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
-DOCKER_IMAGE="gpuci/rapidsai:${MINOR_VERSION}-cuda10.2-devel-ubuntu16.04-py3.7"
+DOCKER_IMAGE="gpuci/rapidsai:${MINOR_VERSION}-cuda10.1-devel-ubuntu16.04-py3.7"
 REPO_PATH=${PWD}
 RAPIDS_DIR_IN_CONTAINER="/rapids"
 CPP_BUILD_DIR="cuML/build"

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -3,7 +3,7 @@
 GIT_DESCRIBE_TAG=`git describe --tags`
 MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
-DOCKER_IMAGE="gpuci/rapidsai:${MINOR_VERSION}-cuda10.1-devel-ubuntu16.04-py3.7"
+DOCKER_IMAGE="gpuci/rapidsai:${MINOR_VERSION}-cuda10.2-devel-ubuntu16.04-py3.7"
 REPO_PATH=${PWD}
 RAPIDS_DIR_IN_CONTAINER="/rapids"
 CPP_BUILD_DIR="cuML/build"

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -35,7 +35,10 @@ from cuml.preprocessing import LabelEncoder
 from cuml.common.memory_utils import using_output_type
 from libcpp cimport bool, nullptr
 from cuml.svm.svm_base import SVMBase
-from sklearn.calibration import CalibratedClassifierCV
+from cuml.common.import_utils import has_sklearn
+
+if has_sklearn():
+    from sklearn.calibration import CalibratedClassifierCV
 
 cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":
     enum KernelType:
@@ -344,6 +347,10 @@ class SVC(SVMBase, ClassifierMixin):
             X, _, _, _, _ = input_to_host_array(X)
             y, _, _, _, _ = input_to_host_array(y)
             with using_output_type('numpy'):
+                if not has_sklearn():
+                    raise RuntimeError(
+                        "Scikit-learn is needed to use SVM probabilities")
+
                 self.prob_svc = CalibratedClassifierCV(SVC(**params), cv=5,
                                                        method='sigmoid')
                 self.prob_svc.fit(X, y)


### PR DESCRIPTION
We should always guard this import under has_sklearn.﻿
