### PR TITLE
[REVIEW] Removing the max_depth restriction for switching to the batched backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #2903: Moving linalg's gemm, gemv, transpose to RAFT namespaces
 - PR #2905: `stats` prims `mean_center`, `sum` to RAFT namespaces
 - PR #2904: Moving `linalg` basic math ops to RAFT namespaces
+- PR #2996: Removing the max_depth restriction for switching to the batched backend
 
 ## Bug Fixes
 - PR #2983: Fix seeding of KISS99 RNG

--- a/cpp/include/cuml/tree/decisiontree.hpp
+++ b/cpp/include/cuml/tree/decisiontree.hpp
@@ -76,7 +76,6 @@ struct DecisionTreeParams {
   * If set to true and following conditions are also met, experimental decision
   *  tree training implementation would be used:
   *     split_algo = 1 (GLOBAL_QUANTILE)
-  *     0 < max_depth < 14
   *     max_features = 1.0 (Feature sub-sampling disabled)
   *     quantile_per_tree = false (No per tree quantile computation)
   */

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -55,15 +55,15 @@ void grow_tree(std::shared_ptr<MLCommon::deviceAllocator> d_allocator,
                         rowids, colids, unique_labels, quantiles);
   MLCommon::device_buffer<char> d_buff(d_allocator, stream, d_wsize);
   MLCommon::host_buffer<char> h_buff(h_allocator, stream, h_wsize);
-  MLCommon::host_buffer<Node<DataT, LabelT, IdxT>> h_nodes(h_allocator, stream,
-                                                           builder.maxNodes);
+
+  std::vector<Node<DataT, LabelT, IdxT>> h_nodes;
+  h_nodes.reserve(builder.maxNodes);
   builder.assignWorkspace(d_buff.data(), h_buff.data());
-  builder.train(h_nodes.data(), num_leaves, depth, stream);
+  builder.train(h_nodes, num_leaves, depth, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
   d_buff.release(stream);
   h_buff.release(stream);
   convertToSparse<Traits>(builder, h_nodes.data(), sparsetree);
-  h_nodes.release(stream);
 }
 
 /**

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -161,8 +161,8 @@ struct Builder {
       // Start with allocation for a dense tree for depth < 13
       maxNodes = pow(2, (params.max_depth + 1)) - 1;
     } else {
-       // Start with fixed size allocation for depth >= 13
-       maxNodes = 8191;
+      // Start with fixed size allocation for depth >= 13
+      maxNodes = 8191;
     }
 
     if (isRegression() && params.split_criterion == CRITERION::MAE) {
@@ -254,7 +254,8 @@ struct Builder {
    * @param[out] depth      max depth of the built tree
    * @param[in]  s          cuda steam
    */
-  void train(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes, IdxT& num_leaves, IdxT& depth, cudaStream_t s) {
+  void train(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes, IdxT& num_leaves,
+             IdxT& depth, cudaStream_t s) {
     init(h_nodes, s);
     while (true) {
       IdxT new_nodes = doSplit(h_nodes, s);
@@ -316,7 +317,8 @@ struct Builder {
    * @param[in]  s cuda stream
    * @return the number of newly created nodes
    */
-  IdxT doSplit(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes, cudaStream_t s) {
+  IdxT doSplit(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes,
+               cudaStream_t s) {
     auto batchSize = node_end - node_start;
     // start fresh on the number of *new* nodes created in this batch
     CUDA_CHECK(cudaMemsetAsync(n_nodes, 0, sizeof(IdxT), s));
@@ -344,7 +346,8 @@ struct Builder {
     CUDA_CHECK(cudaStreamSynchronize(s));
     h_nodes.resize(h_nodes.size() + batchSize + *h_n_nodes);
     raft::update_host(h_nodes.data() + node_start, curr_nodes, batchSize, s);
-    raft::update_host(h_nodes.data() + h_total_nodes, next_nodes, *h_n_nodes, s);
+    raft::update_host(h_nodes.data() + h_total_nodes, next_nodes, *h_n_nodes,
+                      s);
     return *h_n_nodes;
   }
 };  // end Builder

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -157,7 +157,13 @@ struct Builder {
     nHistBins = 2 * max_batch * params.n_bins * n_col_blks * nclasses;
     // x2 for mean and mean-of-square
     nPredCounts = max_batch * params.n_bins * n_col_blks;
-    maxNodes = pow(2, (params.max_depth + 1)) - 1;
+    if (params.max_depth < 13) {
+      // Start with allocation for a dense tree for depth < 13
+      maxNodes = pow(2, (params.max_depth + 1)) - 1;
+    } else {
+       // Start with fixed size allocation for depth >= 13
+       maxNodes = 8191;
+    }
 
     if (isRegression() && params.split_criterion == CRITERION::MAE) {
       dim3 grid(n_blks_for_rows, n_col_blks, max_batch);
@@ -248,7 +254,7 @@ struct Builder {
    * @param[out] depth      max depth of the built tree
    * @param[in]  s          cuda steam
    */
-  void train(NodeT* h_nodes, IdxT& num_leaves, IdxT& depth, cudaStream_t s) {
+  void train(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes, IdxT& num_leaves, IdxT& depth, cudaStream_t s) {
     init(h_nodes, s);
     while (true) {
       IdxT new_nodes = doSplit(h_nodes, s);
@@ -267,7 +273,7 @@ struct Builder {
    * @param[out] h_nodes list of nodes (must be allocated using cudaMallocHost!)
    * @param[in]  s       cuda stream
    */
-  void init(NodeT* h_nodes, cudaStream_t s) {
+  void init(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes, cudaStream_t s) {
     *h_n_nodes = 0;
     auto max_batch = params.max_batch_size;
     auto n_col_blks = n_blks_for_cols;
@@ -282,6 +288,7 @@ struct Builder {
     }
     node_start = 0;
     node_end = h_total_nodes = 1;  // start with root node
+    h_nodes.resize(1);
     h_nodes[0].initSpNode();
     h_nodes[0].start = 0;
     h_nodes[0].count = input.nSampledRows;
@@ -309,13 +316,13 @@ struct Builder {
    * @param[in]  s cuda stream
    * @return the number of newly created nodes
    */
-  IdxT doSplit(NodeT* h_nodes, cudaStream_t s) {
+  IdxT doSplit(std::vector<Node<DataT, LabelT, IdxT>>& h_nodes, cudaStream_t s) {
     auto batchSize = node_end - node_start;
     // start fresh on the number of *new* nodes created in this batch
     CUDA_CHECK(cudaMemsetAsync(n_nodes, 0, sizeof(IdxT), s));
     initSplit<DataT, IdxT, Traits::TPB_DEFAULT>(splits, batchSize, s);
     // get the current set of nodes to be worked upon
-    raft::update_device(curr_nodes, h_nodes + node_start, batchSize, s);
+    raft::update_device(curr_nodes, h_nodes.data() + node_start, batchSize, s);
     // iterate through a batch of columns (to reduce the memory pressure) and
     // compute the best split at the end
     auto n_col_blks = n_blks_for_cols;
@@ -333,10 +340,11 @@ struct Builder {
         splits, n_leaves, h_total_nodes, n_depth);
     CUDA_CHECK(cudaGetLastError());
     // copy the updated (due to leaf creation) and newly created child nodes
-    raft::update_host(h_nodes + node_start, curr_nodes, batchSize, s);
     raft::update_host(h_n_nodes, n_nodes, 1, s);
     CUDA_CHECK(cudaStreamSynchronize(s));
-    raft::update_host(h_nodes + h_total_nodes, next_nodes, *h_n_nodes, s);
+    h_nodes.resize(h_nodes.size() + batchSize + *h_n_nodes);
+    raft::update_host(h_nodes.data() + node_start, curr_nodes, batchSize, s);
+    raft::update_host(h_nodes.data() + h_total_nodes, next_nodes, *h_n_nodes, s);
     return *h_n_nodes;
   }
 };  // end Builder

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -296,13 +296,6 @@ void DecisionTreeBase<T, L>::plant(
       use_experimental_backend = false;
     }
 
-    if (tree_params.max_depth <= 0 || tree_params.max_depth >= 14) {
-      CUML_LOG_WARN(
-        "Experimental backend does not yet support arbitrary depth trees");
-      CUML_LOG_WARN("To use experimental backend set 0 < max_depth < 14");
-      use_experimental_backend = false;
-    }
-
     if (tree_params.max_features != 1.0) {
       CUML_LOG_WARN(
         "Experimental backend does not yet support feature sub-sampling");

--- a/cpp/test/sg/rf_batched_classification_test.cu
+++ b/cpp/test/sg/rf_batched_classification_test.cu
@@ -45,7 +45,7 @@ struct RfInputs {
 };
 
 template <typename T>
-class RFBatchedTest : public ::testing::TestWithParam<RfInputs> {
+class RFBatchedClsTest : public ::testing::TestWithParam<RfInputs> {
  protected:
   void basicTest() {
     params = ::testing::TestWithParam<RfInputs>::GetParam();
@@ -72,17 +72,13 @@ class RFBatchedTest : public ::testing::TestWithParam<RfInputs> {
       (int*)allocator->allocate(params.n_rows * sizeof(int), stream);
 
     Datasets::make_blobs(*handle, data, labels, params.n_rows, params.n_cols, 5,
-                         false, nullptr, nullptr, T(0.1), false, T(-1.0),
-                         T(1.0), 3536699ULL);
+                         false, nullptr, nullptr, T(0.1), false, T(-0.5),
+                         T(0.5), 3536699ULL);
 
     labels_h.resize(params.n_rows);
     raft::update_host(labels_h.data(), labels, params.n_rows, stream);
     preprocess_labels(params.n_rows, labels_h, labels_map);
     raft::update_device(labels, labels_h.data(), params.n_rows, stream);
-
-    T* data_h;
-    data_h = (T*)malloc(data_len * sizeof(T));
-    raft::update_host(data_h, data, data_len, stream);
 
     // Training part
     forest = new typename ML::RandomForestMetaData<T, int>;
@@ -147,13 +143,13 @@ class RFBatchedTest : public ::testing::TestWithParam<RfInputs> {
 
 //-------------------------------------------------------------------------------------------------------------------------------------
 const std::vector<RfInputs> inputsf2_clf = {
-  {20000, 10, 25, 1.0f, 0.4f, 12, -1, true, false, 10,
+  {20000, 10, 25, 1.0f, 0.4f, 16, -1, true, false, 10,
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::GINI},
   {20000, 10, 5, 1.0f, 0.4f, 14, -1, true, false, 10,
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::ENTROPY}};
 
-typedef RFBatchedTest<float> RFBatchedTestF;
-TEST_P(RFBatchedTestF, Fit) {
+typedef RFBatchedClsTest<float> RFBatchedClsTestF;
+TEST_P(RFBatchedClsTestF, Fit) {
   if (!params.bootstrap && (params.max_features == 1.0f)) {
     ASSERT_TRUE(accuracy == 1.0f);
   } else {
@@ -161,11 +157,11 @@ TEST_P(RFBatchedTestF, Fit) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(RFBatchedTests, RFBatchedTestF,
+INSTANTIATE_TEST_CASE_P(RFBatchedClsTests, RFBatchedClsTestF,
                         ::testing::ValuesIn(inputsf2_clf));
 
-typedef RFBatchedTest<double> RFBatchedTestD;
-TEST_P(RFBatchedTestD, Fit) {
+typedef RFBatchedClsTest<double> RFBatchedClsTestD;
+TEST_P(RFBatchedClsTestD, Fit) {
   if (!params.bootstrap && (params.max_features == 1.0f)) {
     ASSERT_TRUE(accuracy == 1.0f);
   } else {
@@ -173,7 +169,7 @@ TEST_P(RFBatchedTestD, Fit) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(RFBatchedTests, RFBatchedTestD,
+INSTANTIATE_TEST_CASE_P(RFBatchedClsTests, RFBatchedClsTestD,
                         ::testing::ValuesIn(inputsf2_clf));
 
 }  // end namespace ML

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -221,7 +221,6 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         If set to true and  following conditions are also met, experimental
          decision tree training implementation would be used:
             split_algo = 1 (GLOBAL_QUANTILE)
-            0 < max_depth < 14
             max_features = 1.0 (Feature sub-sampling disabled)
             quantile_per_tree = false (No per tree quantile computation)
     max_batch_size: int (default = 128)

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -212,7 +212,6 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         If set to true and  following conditions are also met, experimental
          decision tree training implementation would be used:
             split_algo = 1 (GLOBAL_QUANTILE)
-            0 < max_depth < 14
             max_features = 1.0 (Feature sub-sampling disabled)
             quantile_per_tree = false (No per tree quantile computation)
     max_batch_size: int (default = 128)


### PR DESCRIPTION
This PR removes the `max_depth` restriction for switching to the batched backend. It changes the way tree nodes are allocated on host. It is now stored in a `std::vector` of `Node`. I have evaluated the performance penalty of dynamically growing the vector and found it to be negligible.
The RF models produced by multiple runs of `fit` function are not exactly same thus it is not easily possible to compare tree produced by old way of allocation against the new allocation. I kept both new and old allocation side-by-side in the code and compared the trees produced in same run. Found them to be matching exactly. Side-by-side comparison code is removed from the final committed code.