### PR TITLE
[REVIEW] Adding `power_t` param to SGD failing pytests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug Fixes
 - PR #2983: Fix seeding of KISS99 RNG
+- PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
 
 # cuML 0.16.0 (Date TBD)
 

--- a/python/cuml/test/test_sgd.py
+++ b/python/cuml/test/test_sgd.py
@@ -65,11 +65,8 @@ def test_sgd(dtype, lrate, penalty, loss, datatype):
         assert isinstance(cu_pred, np.ndarray)
 
     if loss == "log":
-        print(cu_pred)
         cu_pred[cu_pred < 0.5] = 0
         cu_pred[cu_pred >= 0.5] = 1
-        print(cu_pred)
-        print(y_test)
     elif loss == "squared_loss":
         cu_pred[cu_pred < 0] = -1
         cu_pred[cu_pred >= 0] = 1

--- a/python/cuml/test/test_sgd.py
+++ b/python/cuml/test/test_sgd.py
@@ -51,7 +51,8 @@ def test_sgd(dtype, lrate, penalty, loss, datatype):
 
     cu_sgd = cumlSGD(learning_rate=lrate, eta0=0.005, epochs=2000,
                      fit_intercept=True, batch_size=4096,
-                     tol=0.0, penalty=penalty, loss=loss)
+                     tol=0.0, penalty=penalty, loss=loss,
+                     power_t=0.4)
 
     cu_sgd.fit(X_train, y_train)
     cu_pred = cu_sgd.predict(X_test)
@@ -64,8 +65,11 @@ def test_sgd(dtype, lrate, penalty, loss, datatype):
         assert isinstance(cu_pred, np.ndarray)
 
     if loss == "log":
+        print(cu_pred)
         cu_pred[cu_pred < 0.5] = 0
         cu_pred[cu_pred >= 0.5] = 1
+        print(cu_pred)
+        print(y_test)
     elif loss == "squared_loss":
         cu_pred[cu_pred < 0] = -1
         cu_pred[cu_pred >= 0] = 1


### PR DESCRIPTION
`SGDClassifier` pytests were failing in CI for the specific test params, `lrate=invscaling` and `loss=log`. This was occurring due to floating point errors where values like `0.50xx` would cause a misclassification. To resolve this, I simply increased the learning rate of the problem. For `invscaling`, `lrate = eta0 / (pow(t, power_t)`, where `eta0` and `power_t` are configurable parameters. Reducing `power_t` to `0.4` from its default of `0.5` was enough for the solution to converge for these pytests.