### PR TITLE
Prevent cuML from hanging when cuML RF falls back from experimental backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Bug Fixes
 - PR #2983: Fix seeding of KISS99 RNG
 - PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
+- PR #3021: Fix a hang in cuML RF experimental backend
 
 # cuML 0.16.0 (Date TBD)
 

--- a/cpp/src/decisiontree/decisiontree.cu
+++ b/cpp/src/decisiontree/decisiontree.cu
@@ -46,6 +46,35 @@ void set_tree_params(DecisionTreeParams &params, int cfg_max_depth,
                      bool cfg_quantile_per_tree,
                      bool cfg_use_experimental_backend,
                      int cfg_max_batch_size) {
+  if (cfg_use_experimental_backend) {
+    if (cfg_split_algo != SPLIT_ALGO::GLOBAL_QUANTILE) {
+      CUML_LOG_WARN(
+        "Experimental backend does not yet support histogram split algorithm");
+      CUML_LOG_WARN(
+        "To use experimental backend set split_algo = 1 (GLOBAL_QUANTILE)");
+      cfg_use_experimental_backend = false;
+    }
+    if (cfg_max_features != 1.0) {
+      CUML_LOG_WARN(
+        "Experimental backend does not yet support feature sub-sampling");
+      CUML_LOG_WARN("To use experimental backend set max_features = 1.0");
+      cfg_use_experimental_backend = false;
+    }
+    if (cfg_quantile_per_tree) {
+      CUML_LOG_WARN(
+        "Experimental backend does not yet support per tree quantile "
+        "computation");
+      CUML_LOG_WARN(
+        "To use experimental backend set quantile_per_tree = false");
+      cfg_use_experimental_backend = false;
+    }
+    if (!cfg_use_experimental_backend) {
+      CUML_LOG_WARN(
+        "Not using the experimental backend due to above mentioned reason(s)");
+      CUML_LOG_WARN("Switching back to default backend");
+    }
+  }
+
   params.max_depth = cfg_max_depth;
   params.max_leaves = cfg_max_leaves;
   params.max_features = cfg_max_features;

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -283,44 +283,7 @@ void DecisionTreeBase<T, L>::plant(
 
   total_temp_mem = tempmem->totalmem;
   MLCommon::TimerCPU timer;
-  bool use_experimental_backend = false;
-
-  if (tree_params.use_experimental_backend == true) {
-    use_experimental_backend = true;
-
-    if (tree_params.split_algo != SPLIT_ALGO::GLOBAL_QUANTILE) {
-      CUML_LOG_WARN(
-        "Experimental backend does not yet support histogram split algorithm");
-      CUML_LOG_WARN(
-        "To use experimental backend set split_algo = 1 (GLOBAL_QUANTILE)");
-      use_experimental_backend = false;
-    }
-
-    if (tree_params.max_features != 1.0) {
-      CUML_LOG_WARN(
-        "Experimental backend does not yet support feature sub-sampling");
-      CUML_LOG_WARN("To use experimental backend set max_features = 1.0");
-      use_experimental_backend = false;
-    }
-
-    if (tree_params.quantile_per_tree != false) {
-      CUML_LOG_WARN(
-        "Experimental backend does not yet support per tree quantile "
-        "computation");
-      CUML_LOG_WARN(
-        "To use experimental backend set quantile_per_tree = false");
-      use_experimental_backend = false;
-    }
-  }
-
-  if (tree_params.use_experimental_backend &&
-      use_experimental_backend == false) {
-    CUML_LOG_WARN(
-      "Not using the experimental backend due to above mentioned reason(s)");
-    CUML_LOG_WARN("Switching back to default backend");
-  }
-
-  if (use_experimental_backend) {
+  if (tree_params.use_experimental_backend) {
     if (treeid == 0) {
       CUML_LOG_WARN("Using experimental backend for growing trees\n");
     }

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -18,6 +18,8 @@ import numpy as np
 import pytest
 import random
 import json
+import io
+from contextlib import redirect_stdout
 
 from numba import cuda
 
@@ -142,8 +144,9 @@ def special_reg(request):
 @pytest.mark.parametrize('datatype', [np.float32])
 @pytest.mark.parametrize('split_algo', [0, 1])
 @pytest.mark.parametrize('max_features', [1.0, 'auto', 'log2', 'sqrt'])
+@pytest.mark.parametrize('use_experimental_backend', [True, False])
 def test_rf_classification(small_clf, datatype, split_algo,
-                           rows_sample, max_features):
+                           rows_sample, max_features, use_experimental_backend):
     use_handle = True
 
     X, y = small_clf
@@ -160,8 +163,30 @@ def test_rf_classification(small_clf, datatype, split_algo,
                        n_bins=16, split_algo=split_algo, split_criterion=0,
                        min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=40, handle=handle, max_leaves=-1,
-                       max_depth=16)
-    cuml_model.fit(X_train, y_train)
+                       max_depth=16,
+                       use_experimental_backend=use_experimental_backend)
+    f = io.StringIO()
+    with redirect_stdout(f):
+        cuml_model.fit(X_train, y_train)
+    captured_stdout = f.getvalue()
+    if use_experimental_backend:
+        is_fallback_used = False
+        if max_features != 1.0:
+            assert ('Experimental backend does not yet support feature ' +
+                    'sub-sampling' in captured_stdout)
+            is_fallback_used = True
+        if split_algo != 1:
+            assert ('Experimental backend does not yet support histogram ' +
+                    'split algorithm' in captured_stdout)
+            is_fallback_used = True
+        if is_fallback_used:
+            assert ('Not using the experimental backend due to above ' +
+                    'mentioned reason(s)' in captured_stdout)
+        else:
+            assert ('Using experimental backend for growing trees'
+                    in captured_stdout)
+    else:
+        assert captured_stdout == ''
     fil_preds = cuml_model.predict(X_test,
                                    predict_model="GPU",
                                    output_class=True,

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -146,7 +146,8 @@ def special_reg(request):
 @pytest.mark.parametrize('max_features', [1.0, 'auto', 'log2', 'sqrt'])
 @pytest.mark.parametrize('use_experimental_backend', [True, False])
 def test_rf_classification(small_clf, datatype, split_algo,
-                           rows_sample, max_features, use_experimental_backend):
+                           rows_sample, max_features,
+                           use_experimental_backend):
     use_handle = True
 
     X, y = small_clf


### PR DESCRIPTION
Closes #3020 by moving the fallback logic to `ML::DecisionTree::set_tree_params()`, where the tree parameters are set. Also add a unit test for the fallback behavior.

cc @vinaydes 