### PR TITLE
[REVIEW] Fixes issues with benchmark codes due to improper initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #3008: Check number of columns in check_array validator
 - PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
 - PR #3021: Fix a hang in cuML RF experimental backend
+- PR #3039: Update RF and decision tree parameter initializations in benchmark codes
 
 # cuML 0.16.0 (Date TBD)
 

--- a/cpp/bench/sg/fil.cu
+++ b/cpp/bench/sg/fil.cu
@@ -134,25 +134,37 @@ std::vector<Params> getInputs() {
   std::vector<Params> out;
   Params p;
   p.data.rowMajor = true;
-  // see src_prims/random/make_regression.h
-  p.blobs = {.n_informative = -1,
-             .effective_rank = -1,
-             .bias = 0.f,
-             .tail_strength = 0.1,
-             .noise = 0.01,
-             .shuffle = false,
-             .seed = 12345ULL};
-  p.rf.bootstrap = true;
-  p.rf.rows_sample = 1.f;
-  p.rf.tree_params.max_leaves = 1 << 20;
-  p.rf.tree_params.min_rows_per_node = 3;
-  p.rf.tree_params.n_bins = 32;
-  p.rf.tree_params.bootstrap_features = true;
-  p.rf.tree_params.quantile_per_tree = false;
-  p.rf.tree_params.split_algo = 1;
-  p.rf.tree_params.split_criterion = ML::CRITERION::MSE;
-  p.rf.n_streams = 8;
-  p.rf.tree_params.max_features = 1.f;
+  p.blobs = {
+    .n_informative = -1,   // Just a placeholder value, anyway changed below
+    .effective_rank = -1,  // Just a placeholder value, anyway changed below
+    .bias = 0.f,
+    .tail_strength = 0.1,
+    .noise = 0.01,
+    .shuffle = false,
+    .seed = 12345ULL};
+
+  set_rf_params(p.rf,  // Output RF parameters
+                1,  // n_trees, just a placeholder value, anyway changed below
+                true,  // bootstrap
+                1.f,   // rows_sample
+                1234,  // seed
+                8);    // n_streams
+
+  set_tree_params(p.rf.tree_params,    // Output tree parameters
+                  10,                  // max_depth, just a placeholder value,
+                                       //   anyway changed below
+                  (1 << 20),           // max_leaves
+                  1,                   // max_features
+                  32,                  // n_bins
+                  1,                   // split_algo
+                  3,                   // min_rows_per_node
+                  0.0f,                // min_impurity_decrease
+                  true,                // bootstrap_features
+                  ML::CRITERION::MSE,  // split_criterion
+                  false,               // quantile_per_tree
+                  false,               // use_experimental_backend
+                  128);                // max_batch_size
+
   using ML::fil::algo_t;
   using ML::fil::storage_type_t;
   std::vector<FilBenchParams> var_params = {

--- a/cpp/bench/sg/rf_classifier.cu
+++ b/cpp/bench/sg/rf_classifier.cu
@@ -77,22 +77,34 @@ std::vector<Params> getInputs() {
   std::vector<Params> out;
   Params p;
   p.data.rowMajor = false;
-  p.blobs.cluster_std = 10.0;
-  p.blobs.shuffle = false;
-  p.blobs.center_box_min = -10.0;
-  p.blobs.center_box_max = 10.0;
-  p.blobs.seed = 12345ULL;
-  p.rf.bootstrap = true;
-  p.rf.rows_sample = 1.f;
-  p.rf.tree_params.max_leaves = 1 << 20;
-  p.rf.tree_params.min_rows_per_node = 3;
-  p.rf.tree_params.n_bins = 32;
-  p.rf.tree_params.bootstrap_features = true;
-  p.rf.tree_params.quantile_per_tree = false;
-  p.rf.tree_params.split_algo = 1;
-  p.rf.tree_params.split_criterion = (ML::CRITERION)0;
-  p.rf.n_trees = 500;
-  p.rf.n_streams = 8;
+  p.blobs = {.cluster_std = 10.0,
+             .shuffle = false,
+             .center_box_min = -10.0,
+             .center_box_max = 10.0,
+             .seed = 2152953ULL};
+
+  set_rf_params(p.rf,  // Output RF parameters
+                500,   // n_trees
+                true,  // bootstrap
+                1.f,   // rows_sample
+                1234,  // seed
+                8);    // n_streams
+
+  set_tree_params(p.rf.tree_params,  // Output tree parameters
+                  10,                // max_depth, this is anyway changed below
+                  (1 << 20),         // max_leaves
+                  0.3,               // max_features, just a placeholder value,
+                                     //   anyway changed below
+                  32,                // n_bins
+                  1,                 // split_algo
+                  3,                 // min_rows_per_node
+                  0.0f,              // min_impurity_decrease
+                  true,              // bootstrap_features
+                  ML::CRITERION::GINI,  // split_criterion
+                  false,                // quantile_per_tree
+                  false,                // use_experimental_backend
+                  128);                 // max_batch_size
+
   std::vector<Triplets> rowcols = {
     {160000, 64, 2},
     {640000, 64, 8},

--- a/cpp/bench/sg/rf_classifier.cu
+++ b/cpp/bench/sg/rf_classifier.cu
@@ -77,11 +77,11 @@ std::vector<Params> getInputs() {
   std::vector<Params> out;
   Params p;
   p.data.rowMajor = false;
-  p.blobs = {.cluster_std = 10.0,
-             .shuffle = false,
-             .center_box_min = -10.0,
-             .center_box_max = 10.0,
-             .seed = 2152953ULL};
+  p.blobs = {10.0,         // cluster_std
+             false,        // shuffle
+             -10.0,        // center_box_min
+             10.0,         // center_box_max
+             2152953ULL};  //seed
 
   set_rf_params(p.rf,  // Output RF parameters
                 500,   // n_trees

--- a/cpp/bench/sg/rf_regressor.cu
+++ b/cpp/bench/sg/rf_regressor.cu
@@ -77,23 +77,37 @@ std::vector<RegParams> getInputs() {
   struct std::vector<RegParams> out;
   RegParams p;
   p.data.rowMajor = false;
-  p.regression.shuffle = true;  // better to shuffle when n_informative < ncols
-  p.regression.seed = 12345ULL;
-  p.regression.effective_rank = -1;  // dataset generation will be faster
-  p.regression.bias = 4.5;
-  p.regression.tail_strength = 0.5;  // unused when effective_rank = -1
-  p.regression.noise = 1.;
-  p.rf.bootstrap = true;
-  p.rf.rows_sample = 1.f;
-  p.rf.tree_params.max_leaves = 1 << 20;
-  p.rf.tree_params.min_rows_per_node = 3;
-  p.rf.tree_params.n_bins = 32;
-  p.rf.tree_params.bootstrap_features = true;
-  p.rf.tree_params.quantile_per_tree = false;
-  p.rf.tree_params.split_algo = 1;
-  p.rf.tree_params.split_criterion = ML::CRITERION::MSE;
-  p.rf.n_trees = 500;
-  p.rf.n_streams = 8;
+  p.regression = {
+    .shuffle = true,       // Better to shuffle when n_informative < ncols
+    .effective_rank = -1,  // dataset generation will be faster
+    .bias = 4.5,
+    .tail_strength = 0.5,  // unused when effective_rank = -1
+    .noise = 1.0,
+    .seed = 12345ULL};
+
+  set_rf_params(p.rf,  // Output RF parameters
+                500,   // n_trees
+                true,  // bootstrap
+                1.f,   // rows_sample
+                1234,  // seed
+                8);    // n_streams
+
+  set_tree_params(p.rf.tree_params,  // Output tree parameters
+                  10,                // max_depth, just a place holder value,
+                                     //   anyway changed below
+                  (1 << 20),         // max_leaves
+                  0.3,               // max_features, just a place holder value,
+                                     //   anyway changed below
+                  32,                // n_bins
+                  1,                 // split_algo
+                  3,                 // min_rows_per_node
+                  0.0f,              // min_impurity_decrease
+                  true,              // bootstrap_features
+                  ML::CRITERION::MSE,  // split_criterion
+                  false,               // quantile_per_tree
+                  false,               // use_experimental_backend
+                  128);                // max_batch_size
+
   std::vector<DimInfo> dim_info = {{500000, 500, 400}};
   for (auto& di : dim_info) {
     // Let's run Bosch only for float type


### PR DESCRIPTION
With new bckend couple of new parameters got introduced to decision tree parameter structure. Initializing those new parameters with this PR. Also instead of initialization by assignment, I have used the APIs for RF and decision tree parameters. This way, we would not miss changing the benchmark codes when RF or decision tree parameters are changed.