### PR TITLE
[REVIEW] Moving some `linalg` and `stats` prims to RAFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #2906: Moving `linalg` decomp to RAFT namespaces
 - PR #2996: Removing the max_depth restriction for switching to the batched backend
 - PR #3004: Remove Single Process Multi GPU (SPMG) code
+- PR #3044: Move leftover `linalg` and `stats` to RAFT namespaces
 
 ## Bug Fixes
 - PR #2983: Fix seeding of KISS99 RNG

--- a/cpp/bench/prims/fused_l2_nn.cu
+++ b/cpp/bench/prims/fused_l2_nn.cu
@@ -47,10 +47,10 @@ struct FusedL2NN : public Fixture {
     raft::random::Rng r(123456ULL);
     r.uniform(x, params.m * params.k, T(-1.0), T(1.0), stream);
     r.uniform(y, params.n * params.k, T(-1.0), T(1.0), stream);
-    raft::linalg::rowNorm(xn, x, params.k, params.m,
-                              raft::linalg::L2Norm, true, stream);
-    raft::linalg::rowNorm(yn, y, params.k, params.n,
-                              raft::linalg::L2Norm, true, stream);
+    raft::linalg::rowNorm(xn, x, params.k, params.m, raft::linalg::L2Norm, true,
+                          stream);
+    raft::linalg::rowNorm(yn, y, params.k, params.n, raft::linalg::L2Norm, true,
+                          stream);
     auto blks = raft::ceildiv(params.m, 256);
     MLCommon::Distance::initKernel<T, cub::KeyValuePair<int, T>, int>
       <<<blks, 256, 0, stream>>>(out, params.m, std::numeric_limits<T>::max(),

--- a/cpp/bench/prims/fused_l2_nn.cu
+++ b/cpp/bench/prims/fused_l2_nn.cu
@@ -47,10 +47,10 @@ struct FusedL2NN : public Fixture {
     raft::random::Rng r(123456ULL);
     r.uniform(x, params.m * params.k, T(-1.0), T(1.0), stream);
     r.uniform(y, params.n * params.k, T(-1.0), T(1.0), stream);
-    MLCommon::LinAlg::rowNorm(xn, x, params.k, params.m,
-                              MLCommon::LinAlg::L2Norm, true, stream);
-    MLCommon::LinAlg::rowNorm(yn, y, params.k, params.n,
-                              MLCommon::LinAlg::L2Norm, true, stream);
+    raft::linalg::rowNorm(xn, x, params.k, params.m,
+                              raft::linalg::L2Norm, true, stream);
+    raft::linalg::rowNorm(yn, y, params.k, params.n,
+                              raft::linalg::L2Norm, true, stream);
     auto blks = raft::ceildiv(params.m, 256);
     MLCommon::Distance::initKernel<T, cub::KeyValuePair<int, T>, int>
       <<<blks, 256, 0, stream>>>(out, params.m, std::numeric_limits<T>::max(),

--- a/cpp/bench/prims/reduce.cu
+++ b/cpp/bench/prims/reduce.cu
@@ -46,8 +46,8 @@ struct Reduce : public Fixture {
 
   void runBenchmark(::benchmark::State& state) override {
     loopOnState(state, [this]() {
-      raft::linalg::reduce(dots, data, params.cols, params.rows, T(0.f),
-                               true, params.alongRows, stream);
+      raft::linalg::reduce(dots, data, params.cols, params.rows, T(0.f), true,
+                           params.alongRows, stream);
     });
   }
 

--- a/cpp/bench/prims/reduce.cu
+++ b/cpp/bench/prims/reduce.cu
@@ -46,7 +46,7 @@ struct Reduce : public Fixture {
 
   void runBenchmark(::benchmark::State& state) override {
     loopOnState(state, [this]() {
-      MLCommon::LinAlg::reduce(dots, data, params.cols, params.rows, T(0.f),
+      raft::linalg::reduce(dots, data, params.cols, params.rows, T(0.f),
                                true, params.alongRows, stream);
     });
   }

--- a/cpp/src/glm/preprocess.cuh
+++ b/cpp/src/glm/preprocess.cuh
@@ -52,7 +52,7 @@ void preProcessData(const raft::handle_t &handle, math_t *input, int n_rows,
                             stream);
 
     if (normalize) {
-      LinAlg::colNorm(norm2_input, input, n_cols, n_rows, LinAlg::L2Norm, false,
+      raft::linalg::colNorm(norm2_input, input, n_cols, n_rows, raft::linalg::L2Norm, false,
                       stream,
                       [] __device__(math_t v) { return raft::mySqrt(v); });
       raft::matrix::matrixVectorBinaryDivSkipZero(

--- a/cpp/src/glm/preprocess.cuh
+++ b/cpp/src/glm/preprocess.cuh
@@ -52,9 +52,9 @@ void preProcessData(const raft::handle_t &handle, math_t *input, int n_rows,
                             stream);
 
     if (normalize) {
-      raft::linalg::colNorm(norm2_input, input, n_cols, n_rows, raft::linalg::L2Norm, false,
-                      stream,
-                      [] __device__(math_t v) { return raft::mySqrt(v); });
+      raft::linalg::colNorm(
+        norm2_input, input, n_cols, n_rows, raft::linalg::L2Norm, false, stream,
+        [] __device__(math_t v) { return raft::mySqrt(v); });
       raft::matrix::matrixVectorBinaryDivSkipZero(
         input, norm2_input, n_rows, n_cols, false, true, stream, true);
     }

--- a/cpp/src/glm/qn/simple_mat.cuh
+++ b/cpp/src/glm/qn/simple_mat.cuh
@@ -245,7 +245,7 @@ inline T nrm2(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream) {
 
 template <typename T>
 inline T nrm1(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream) {
-  MLCommon::LinAlg::rowNorm(tmp_dev, u.data, u.len, 1, MLCommon::LinAlg::L1Norm,
+  raft::linalg::rowNorm(tmp_dev, u.data, u.len, 1, raft::linalg::L1Norm,
                             true, stream, raft::Nop<T>());
   T tmp_host;
   raft::update_host(&tmp_host, tmp_dev, 1, stream);

--- a/cpp/src/glm/qn/simple_mat.cuh
+++ b/cpp/src/glm/qn/simple_mat.cuh
@@ -245,8 +245,8 @@ inline T nrm2(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream) {
 
 template <typename T>
 inline T nrm1(const SimpleVec<T> &u, T *tmp_dev, cudaStream_t stream) {
-  raft::linalg::rowNorm(tmp_dev, u.data, u.len, 1, raft::linalg::L1Norm,
-                            true, stream, raft::Nop<T>());
+  raft::linalg::rowNorm(tmp_dev, u.data, u.len, 1, raft::linalg::L1Norm, true,
+                        stream, raft::Nop<T>());
   T tmp_host;
   raft::update_host(&tmp_host, tmp_dev, 1, stream);
   cudaStreamSynchronize(stream);

--- a/cpp/src/kmeans/common.cuh
+++ b/cpp/src/kmeans/common.cuh
@@ -281,9 +281,9 @@ void minClusterAndDistance(
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
     L2NormBuf_OR_DistBuf.resize(n_clusters, stream);
-    MLCommon::LinAlg::rowNorm(L2NormBuf_OR_DistBuf.data(), centroids.data(),
+    raft::linalg::rowNorm(L2NormBuf_OR_DistBuf.data(), centroids.data(),
                               centroids.getSize(1), centroids.getSize(0),
-                              MLCommon::LinAlg::L2Norm, true, stream);
+                              raft::linalg::L2Norm, true, stream);
   } else {
     L2NormBuf_OR_DistBuf.resize(dataBatchSize * centroidsBatchSize, stream);
   }
@@ -357,7 +357,7 @@ void minClusterAndDistance(
         // argmin reduction returning <index, value> pair
         // calculates the closest centroid and the distance to the closest
         // centroid
-        MLCommon::LinAlg::coalescedReduction(
+        raft::linalg::coalescedReduction(
           minClusterAndDistanceView.data(), pairwiseDistanceView.data(),
           pairwiseDistanceView.getSize(1), pairwiseDistanceView.getSize(0),
           initial_value, stream, true,
@@ -400,9 +400,9 @@ void minClusterDistance(const raft::handle_t &handle,
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
     L2NormBuf_OR_DistBuf.resize(n_clusters, stream);
-    MLCommon::LinAlg::rowNorm(L2NormBuf_OR_DistBuf.data(), centroids.data(),
+    raft::linalg::rowNorm(L2NormBuf_OR_DistBuf.data(), centroids.data(),
                               centroids.getSize(1), centroids.getSize(0),
-                              MLCommon::LinAlg::L2Norm, true, stream);
+                              raft::linalg::L2Norm, true, stream);
   } else {
     L2NormBuf_OR_DistBuf.resize(dataBatchSize * centroidsBatchSize, stream);
   }
@@ -469,7 +469,7 @@ void minClusterDistance(const raft::handle_t &handle,
                                          pairwiseDistanceView, workspace,
                                          metric, stream);
 
-        MLCommon::LinAlg::coalescedReduction(
+        raft::linalg::coalescedReduction(
           minClusterDistanceView.data(), pairwiseDistanceView.data(),
           pairwiseDistanceView.getSize(1), pairwiseDistanceView.getSize(0),
           std::numeric_limits<DataT>::max(), stream, true,
@@ -633,8 +633,8 @@ void kmeansPlusPlus(const raft::handle_t &handle, const KMeansParams &params,
 
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    MLCommon::LinAlg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), MLCommon::LinAlg::L2Norm, true,
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
+                              X.getSize(0), raft::linalg::L2Norm, true,
                               stream);
   }
 
@@ -704,7 +704,7 @@ void kmeansPlusPlus(const raft::handle_t &handle, const KMeansParams &params,
       stream);
 
     // Calculate costPerCandidate[n_trials] where costPerCandidate[i] is the cluster cost when using centroid candidate-i
-    MLCommon::LinAlg::reduce(costPerCandidate.data(), minDistBuf.data(),
+    raft::linalg::reduce(costPerCandidate.data(), minDistBuf.data(),
                              minDistBuf.getSize(1), minDistBuf.getSize(0),
                              static_cast<DataT>(0), true, true, stream);
 

--- a/cpp/src/kmeans/common.cuh
+++ b/cpp/src/kmeans/common.cuh
@@ -282,8 +282,8 @@ void minClusterAndDistance(
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
     L2NormBuf_OR_DistBuf.resize(n_clusters, stream);
     raft::linalg::rowNorm(L2NormBuf_OR_DistBuf.data(), centroids.data(),
-                              centroids.getSize(1), centroids.getSize(0),
-                              raft::linalg::L2Norm, true, stream);
+                          centroids.getSize(1), centroids.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   } else {
     L2NormBuf_OR_DistBuf.resize(dataBatchSize * centroidsBatchSize, stream);
   }
@@ -401,8 +401,8 @@ void minClusterDistance(const raft::handle_t &handle,
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
     L2NormBuf_OR_DistBuf.resize(n_clusters, stream);
     raft::linalg::rowNorm(L2NormBuf_OR_DistBuf.data(), centroids.data(),
-                              centroids.getSize(1), centroids.getSize(0),
-                              raft::linalg::L2Norm, true, stream);
+                          centroids.getSize(1), centroids.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   } else {
     L2NormBuf_OR_DistBuf.resize(dataBatchSize * centroidsBatchSize, stream);
   }
@@ -633,9 +633,8 @@ void kmeansPlusPlus(const raft::handle_t &handle, const KMeansParams &params,
 
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), raft::linalg::L2Norm, true,
-                              stream);
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1), X.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   }
 
   std::mt19937 gen(params.seed);
@@ -705,8 +704,8 @@ void kmeansPlusPlus(const raft::handle_t &handle, const KMeansParams &params,
 
     // Calculate costPerCandidate[n_trials] where costPerCandidate[i] is the cluster cost when using centroid candidate-i
     raft::linalg::reduce(costPerCandidate.data(), minDistBuf.data(),
-                             minDistBuf.getSize(1), minDistBuf.getSize(0),
-                             static_cast<DataT>(0), true, true, stream);
+                         minDistBuf.getSize(1), minDistBuf.getSize(0),
+                         static_cast<DataT>(0), true, true, stream);
 
     // Greedy Choice - Choose the candidate that has minimum cluster cost
     // ArgMin operation below identifies the index of minimum cost in costPerCandidate

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -193,9 +193,8 @@ void initKMeansPlusPlus(const raft::handle_t &handle,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), raft::linalg::L2Norm, true,
-                              stream);
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1), X.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   }
 
   Tensor<DataT, 1, IndexT> minClusterDistance(
@@ -415,9 +414,8 @@ void fit(const raft::handle_t &handle, const KMeansParams &params,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), raft::linalg::L2Norm, true,
-                              stream);
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1), X.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   }
 
   DataT priorClusteringCost = 0;

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -193,8 +193,8 @@ void initKMeansPlusPlus(const raft::handle_t &handle,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    MLCommon::LinAlg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), MLCommon::LinAlg::L2Norm, true,
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
+                              X.getSize(0), raft::linalg::L2Norm, true,
                               stream);
   }
 
@@ -415,8 +415,8 @@ void fit(const raft::handle_t &handle, const KMeansParams &params,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    MLCommon::LinAlg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), MLCommon::LinAlg::L2Norm, true,
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
+                              X.getSize(0), raft::linalg::L2Norm, true,
                               stream);
   }
 

--- a/cpp/src/kmeans/sg_impl.cuh
+++ b/cpp/src/kmeans/sg_impl.cuh
@@ -85,9 +85,8 @@ void fit(const raft::handle_t &handle, const KMeansParams &params,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), raft::linalg::L2Norm, true,
-                              stream);
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1), X.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   }
 
   ML::thrustAllocatorAdapter alloc(handle.get_device_allocator(), stream);
@@ -358,9 +357,8 @@ void initScalableKMeansPlusPlus(
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), raft::linalg::L2Norm, true,
-                              stream);
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1), X.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   }
 
   Tensor<DataT, 1, IndexT> minClusterDistance(
@@ -669,9 +667,8 @@ void predict(const raft::handle_t &handle, const KMeansParams &params,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), raft::linalg::L2Norm, true,
-                              stream);
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1), X.getSize(0),
+                          raft::linalg::L2Norm, true, stream);
   }
 
   // computes minClusterAndDistance[0:n_samples) where  minClusterAndDistance[i]

--- a/cpp/src/kmeans/sg_impl.cuh
+++ b/cpp/src/kmeans/sg_impl.cuh
@@ -85,8 +85,8 @@ void fit(const raft::handle_t &handle, const KMeansParams &params,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    MLCommon::LinAlg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), MLCommon::LinAlg::L2Norm, true,
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
+                              X.getSize(0), raft::linalg::L2Norm, true,
                               stream);
   }
 
@@ -358,8 +358,8 @@ void initScalableKMeansPlusPlus(
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    MLCommon::LinAlg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), MLCommon::LinAlg::L2Norm, true,
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
+                              X.getSize(0), raft::linalg::L2Norm, true,
                               stream);
   }
 
@@ -669,8 +669,8 @@ void predict(const raft::handle_t &handle, const KMeansParams &params,
   Tensor<DataT, 1> L2NormX({n_samples}, handle.get_device_allocator(), stream);
   if (metric == ML::Distance::DistanceType::EucExpandedL2 ||
       metric == ML::Distance::DistanceType::EucExpandedL2Sqrt) {
-    MLCommon::LinAlg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
-                              X.getSize(0), MLCommon::LinAlg::L2Norm, true,
+    raft::linalg::rowNorm(L2NormX.data(), X.data(), X.getSize(1),
+                              X.getSize(0), raft::linalg::L2Norm, true,
                               stream);
   }
 

--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -126,8 +126,8 @@ void cdFit(const raft::handle_t &handle, math_t *input, int n_rows, int n_cols,
     raft::matrix::setValue(squared.data(), squared.data(), scalar, n_cols,
                            stream);
   } else {
-    raft::linalg::colNorm(squared.data(), input, n_cols, n_rows, raft::linalg::L2Norm,
-                    false, stream);
+    raft::linalg::colNorm(squared.data(), input, n_cols, n_rows,
+                          raft::linalg::L2Norm, false, stream);
     raft::linalg::addScalar(squared.data(), squared.data(), l2_alpha, n_cols,
                             stream);
   }

--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -126,7 +126,7 @@ void cdFit(const raft::handle_t &handle, math_t *input, int n_rows, int n_cols,
     raft::matrix::setValue(squared.data(), squared.data(), scalar, n_cols,
                            stream);
   } else {
-    LinAlg::colNorm(squared.data(), input, n_cols, n_rows, LinAlg::L2Norm,
+    raft::linalg::colNorm(squared.data(), input, n_cols, n_rows, raft::linalg::L2Norm,
                     false, stream);
     raft::linalg::addScalar(squared.data(), squared.data(), l2_alpha, n_cols,
                             stream);

--- a/cpp/src/tsne/exact_tsne.cuh
+++ b/cpp/src/tsne/exact_tsne.cuh
@@ -107,7 +107,7 @@ void Exact_TSNE(float *VAL, const int *COL, const int *ROW, const int NNZ,
     }
 
     // Get row norm of Y
-    MLCommon::LinAlg::rowNorm(norm.data(), Y, dim, n, MLCommon::LinAlg::L2Norm,
+    raft::linalg::rowNorm(norm.data(), Y, dim, n, raft::linalg::L2Norm,
                               false, stream);
 
     // Compute attractive forces

--- a/cpp/src/tsne/exact_tsne.cuh
+++ b/cpp/src/tsne/exact_tsne.cuh
@@ -107,8 +107,8 @@ void Exact_TSNE(float *VAL, const int *COL, const int *ROW, const int NNZ,
     }
 
     // Get row norm of Y
-    raft::linalg::rowNorm(norm.data(), Y, dim, n, raft::linalg::L2Norm,
-                              false, stream);
+    raft::linalg::rowNorm(norm.data(), Y, dim, n, raft::linalg::L2Norm, false,
+                          stream);
 
     // Compute attractive forces
     TSNE::attractive_forces(VAL, COL, ROW, Y, norm.data(), attract.data(), NNZ,

--- a/cpp/src/tsvd/tsvd.cuh
+++ b/cpp/src/tsvd/tsvd.cuh
@@ -245,7 +245,7 @@ void tsvdFitTransform(const raft::handle_t &handle, math_t *input,
                     true, false, stream);
 
   device_buffer<math_t> total_vars(allocator, stream, 1);
-  Stats::sum(total_vars.data(), vars.data(), 1, prms.n_cols, false, stream);
+  raft::stats::sum(total_vars.data(), vars.data(), 1, prms.n_cols, false, stream);
 
   math_t total_vars_h;
   raft::update_host(&total_vars_h, total_vars.data(), 1, stream);

--- a/cpp/src/tsvd/tsvd.cuh
+++ b/cpp/src/tsvd/tsvd.cuh
@@ -245,7 +245,8 @@ void tsvdFitTransform(const raft::handle_t &handle, math_t *input,
                     true, false, stream);
 
   device_buffer<math_t> total_vars(allocator, stream, 1);
-  raft::stats::sum(total_vars.data(), vars.data(), 1, prms.n_cols, false, stream);
+  raft::stats::sum(total_vars.data(), vars.data(), 1, prms.n_cols, false,
+                   stream);
 
   math_t total_vars_h;
   raft::update_host(&total_vars_h, total_vars.data(), 1, stream);

--- a/cpp/src/tsvd/tsvd_mg.cu
+++ b/cpp/src/tsvd/tsvd_mg.cu
@@ -337,7 +337,7 @@ void fit_transform_impl(raft::handle_t &handle,
                   n_streams, handle.get_cublas_handle());
 
   device_buffer<T> total_vars(handle.get_device_allocator(), streams[0], 1);
-  Stats::sum(total_vars.data(), var_input_data.ptr, 1, prms.n_cols, false,
+  raft::stats::sum(total_vars.data(), var_input_data.ptr, 1, prms.n_cols, false,
              streams[0]);
 
   T total_vars_h;

--- a/cpp/src/tsvd/tsvd_mg.cu
+++ b/cpp/src/tsvd/tsvd_mg.cu
@@ -338,7 +338,7 @@ void fit_transform_impl(raft::handle_t &handle,
 
   device_buffer<T> total_vars(handle.get_device_allocator(), streams[0], 1);
   raft::stats::sum(total_vars.data(), var_input_data.ptr, 1, prms.n_cols, false,
-             streams[0]);
+                   streams[0]);
 
   T total_vars_h;
   raft::update_host(&total_vars_h, total_vars.data(), 1, streams[0]);

--- a/cpp/src_prims/distance/algo1.cuh
+++ b/cpp/src_prims/distance/algo1.cuh
@@ -82,13 +82,13 @@ void distanceAlgo1(Index_ m, Index_ n, Index_ k, const InType *pA,
   InType *row_vec = workspace;
   if (pA != pB) {
     row_vec += m;
-    raft::linalg::rowNorm(col_vec, pA, k, m, raft::linalg::L2Norm, isRowMajor, stream,
-                    norm_op);
-    raft::linalg::rowNorm(row_vec, pB, k, n, raft::linalg::L2Norm, isRowMajor, stream,
-                    norm_op);
+    raft::linalg::rowNorm(col_vec, pA, k, m, raft::linalg::L2Norm, isRowMajor,
+                          stream, norm_op);
+    raft::linalg::rowNorm(row_vec, pB, k, n, raft::linalg::L2Norm, isRowMajor,
+                          stream, norm_op);
   } else {
-    raft::linalg::rowNorm(col_vec, pA, k, m, raft::linalg::L2Norm, isRowMajor, stream,
-                    norm_op);
+    raft::linalg::rowNorm(col_vec, pA, k, m, raft::linalg::L2Norm, isRowMajor,
+                          stream, norm_op);
   }
 
   typedef typename cutlass::Shape<8, 8, 8> AccumulatorsPerThread_;

--- a/cpp/src_prims/distance/algo1.cuh
+++ b/cpp/src_prims/distance/algo1.cuh
@@ -82,12 +82,12 @@ void distanceAlgo1(Index_ m, Index_ n, Index_ k, const InType *pA,
   InType *row_vec = workspace;
   if (pA != pB) {
     row_vec += m;
-    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, isRowMajor, stream,
+    raft::linalg::rowNorm(col_vec, pA, k, m, raft::linalg::L2Norm, isRowMajor, stream,
                     norm_op);
-    LinAlg::rowNorm(row_vec, pB, k, n, LinAlg::L2Norm, isRowMajor, stream,
+    raft::linalg::rowNorm(row_vec, pB, k, n, raft::linalg::L2Norm, isRowMajor, stream,
                     norm_op);
   } else {
-    LinAlg::rowNorm(col_vec, pA, k, m, LinAlg::L2Norm, isRowMajor, stream,
+    raft::linalg::rowNorm(col_vec, pA, k, m, raft::linalg::L2Norm, isRowMajor, stream,
                     norm_op);
   }
 

--- a/cpp/src_prims/functions/hinge.cuh
+++ b/cpp/src_prims/functions/hinge.cuh
@@ -131,7 +131,7 @@ void hingeLoss(const raft::handle_t &handle, math_t *input, int n_rows,
   hingeLossSubtract(labels_pred.data(), labels_pred.data(), math_t(1), n_rows,
                     stream);
 
-  Stats::sum(loss, labels_pred.data(), 1, n_rows, false, stream);
+  raft::stats::sum(loss, labels_pred.data(), 1, n_rows, false, stream);
 
   raft::mr::device::buffer<math_t> pen_val(allocator, stream, 0);
 

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -38,7 +38,7 @@ enum penalty {
 template <typename math_t>
 void lasso(math_t *out, const math_t *coef, const int len, const math_t alpha,
            cudaStream_t stream) {
-  LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L1Norm, true, stream);
+  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L1Norm, true, stream);
   raft::linalg::scalarMultiply(out, out, alpha, 1, stream);
 }
 
@@ -51,7 +51,7 @@ void lassoGrad(math_t *grad, const math_t *coef, const int len,
 template <typename math_t>
 void ridge(math_t *out, const math_t *coef, const int len, const math_t alpha,
            cudaStream_t stream) {
-  LinAlg::rowNorm(out, coef, len, 1, LinAlg::NormType::L2Norm, true, stream);
+  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L2Norm, true, stream);
   raft::linalg::scalarMultiply(out, out, alpha, 1, stream);
 }
 

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -38,7 +38,8 @@ enum penalty {
 template <typename math_t>
 void lasso(math_t *out, const math_t *coef, const int len, const math_t alpha,
            cudaStream_t stream) {
-  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L1Norm, true, stream);
+  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L1Norm, true,
+                        stream);
   raft::linalg::scalarMultiply(out, out, alpha, 1, stream);
 }
 
@@ -51,7 +52,8 @@ void lassoGrad(math_t *grad, const math_t *coef, const int len,
 template <typename math_t>
 void ridge(math_t *out, const math_t *coef, const int len, const math_t alpha,
            cudaStream_t stream) {
-  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L2Norm, true, stream);
+  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L2Norm, true,
+                        stream);
   raft::linalg::scalarMultiply(out, out, alpha, 1, stream);
 }
 

--- a/cpp/src_prims/linalg/coalesced_reduction.cuh
+++ b/cpp/src_prims/linalg/coalesced_reduction.cuh
@@ -19,8 +19,8 @@
 #include <cub/cub.cuh>
 #include <cuda_utils.cuh>
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 // Kernel (based on norm.cuh) to perform reductions along the coalesced dimension
 // of the matrix, i.e. reduce along rows for row major or reduce along columns
@@ -110,5 +110,5 @@ void coalescedReduction(OutType *dots, const InType *data, int D, int N,
   CUDA_CHECK(cudaPeekAtLastError());
 }
 
-};  // end namespace LinAlg
-};  // end namespace MLCommon
+};  // end namespace linalg
+};  // end namespace raft

--- a/cpp/src_prims/linalg/norm.cuh
+++ b/cpp/src_prims/linalg/norm.cuh
@@ -52,11 +52,11 @@ void rowNorm(Type *dots, const Type *data, IdxType D, IdxType N, NormType type,
   switch (type) {
     case L1Norm:
       reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
-                     raft::L1Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
+             raft::L1Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
       break;
     case L2Norm:
       reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
-                     raft::L2Op<Type>(), raft::Sum<Type>(), fin_op);
+             raft::L2Op<Type>(), raft::Sum<Type>(), fin_op);
       break;
     default:
       ASSERT(false, "Invalid norm type passed! [%d]", type);
@@ -85,11 +85,11 @@ void colNorm(Type *dots, const Type *data, IdxType D, IdxType N, NormType type,
   switch (type) {
     case L1Norm:
       reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
-                     raft::L1Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
+             raft::L1Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
       break;
     case L2Norm:
       reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
-                     raft::L2Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
+             raft::L2Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
       break;
     default:
       ASSERT(false, "Invalid norm type passed! [%d]", type);

--- a/cpp/src_prims/linalg/norm.cuh
+++ b/cpp/src_prims/linalg/norm.cuh
@@ -18,8 +18,8 @@
 
 #include "reduce.cuh"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 /** different types of norms supported on the input buffers */
 enum NormType { L1Norm = 0, L2Norm };
@@ -51,11 +51,11 @@ void rowNorm(Type *dots, const Type *data, IdxType D, IdxType N, NormType type,
              Lambda fin_op = raft::Nop<Type, IdxType>()) {
   switch (type) {
     case L1Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
+      reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
                      raft::L1Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
       break;
     case L2Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
+      reduce(dots, data, D, N, (Type)0, rowMajor, true, stream, false,
                      raft::L2Op<Type>(), raft::Sum<Type>(), fin_op);
       break;
     default:
@@ -84,11 +84,11 @@ void colNorm(Type *dots, const Type *data, IdxType D, IdxType N, NormType type,
              Lambda fin_op = raft::Nop<Type, IdxType>()) {
   switch (type) {
     case L1Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
+      reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
                      raft::L1Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
       break;
     case L2Norm:
-      LinAlg::reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
+      reduce(dots, data, D, N, (Type)0, rowMajor, false, stream, false,
                      raft::L2Op<Type, IdxType>(), raft::Sum<Type>(), fin_op);
       break;
     default:
@@ -96,5 +96,5 @@ void colNorm(Type *dots, const Type *data, IdxType D, IdxType N, NormType type,
   };
 }
 
-};  // end namespace LinAlg
-};  // end namespace MLCommon
+};  // end namespace linalg
+};  // end namespace raft

--- a/cpp/src_prims/linalg/reduce.cuh
+++ b/cpp/src_prims/linalg/reduce.cuh
@@ -20,8 +20,8 @@
 #include "coalesced_reduction.cuh"
 #include "strided_reduction.cuh"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 /**
  * @brief Compute reduction of the input matrix along the requested dimension
@@ -77,5 +77,5 @@ void reduce(OutType *dots, const InType *data, int D, int N, OutType init,
   }
 }
 
-};  // end namespace LinAlg
-};  // end namespace MLCommon
+};  // end namespace linalg
+};  // end namespace raft

--- a/cpp/src_prims/linalg/strided_reduction.cuh
+++ b/cpp/src_prims/linalg/strided_reduction.cuh
@@ -21,8 +21,8 @@
 #include <type_traits>
 #include "unary_op.cuh"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 // Kernel to perform reductions along the strided dimension
 // of the matrix, i.e. reduce along columns for row major or reduce along rows
@@ -163,5 +163,5 @@ void stridedReduction(OutType *dots, const InType *data, IdxType D, IdxType N,
     raft::linalg::unaryOp(dots, dots, D, final_op, stream);
 }
 
-};  // end namespace LinAlg
-};  // end namespace MLCommon
+};  // end namespace linalg
+};  // end namespace raft

--- a/cpp/src_prims/metrics/adjustedRandIndex.cuh
+++ b/cpp/src_prims/metrics/adjustedRandIndex.cuh
@@ -163,12 +163,12 @@ double computeAdjustedRandIndex(const T* firstClusterArray,
     dContingencyMatrix.data(), dContingencyMatrix.data());
   //calculating the row-wise sums
   raft::linalg::reduce<MathT, MathT>(a.data(), dContingencyMatrix.data(),
-                               nUniqClasses, nUniqClasses, 0, true, true,
-                               stream);
+                                     nUniqClasses, nUniqClasses, 0, true, true,
+                                     stream);
   //calculating the column-wise sums
   raft::linalg::reduce<MathT, MathT>(b.data(), dContingencyMatrix.data(),
-                               nUniqClasses, nUniqClasses, 0, true, false,
-                               stream);
+                                     nUniqClasses, nUniqClasses, 0, true, false,
+                                     stream);
   //calculating the sum of number of unordered pairs for every element in a
   raft::linalg::mapThenSumReduce<MathT, nCTwo<MathT>>(
     d_aCTwoSum.data(), nUniqClasses, nCTwo<MathT>(), stream, a.data(),

--- a/cpp/src_prims/metrics/adjustedRandIndex.cuh
+++ b/cpp/src_prims/metrics/adjustedRandIndex.cuh
@@ -162,11 +162,11 @@ double computeAdjustedRandIndex(const T* firstClusterArray,
     d_nChooseTwoSum.data(), nUniqClasses * nUniqClasses, nCTwo<MathT>(), stream,
     dContingencyMatrix.data(), dContingencyMatrix.data());
   //calculating the row-wise sums
-  LinAlg::reduce<MathT, MathT>(a.data(), dContingencyMatrix.data(),
+  raft::linalg::reduce<MathT, MathT>(a.data(), dContingencyMatrix.data(),
                                nUniqClasses, nUniqClasses, 0, true, true,
                                stream);
   //calculating the column-wise sums
-  LinAlg::reduce<MathT, MathT>(b.data(), dContingencyMatrix.data(),
+  raft::linalg::reduce<MathT, MathT>(b.data(), dContingencyMatrix.data(),
                                nUniqClasses, nUniqClasses, 0, true, false,
                                stream);
   //calculating the sum of number of unordered pairs for every element in a

--- a/cpp/src_prims/metrics/mutualInfoScore.cuh
+++ b/cpp/src_prims/metrics/mutualInfoScore.cuh
@@ -136,12 +136,12 @@ double mutualInfoScore(const T *firstClusterArray, const T *secondClusterArray,
   CUDA_CHECK(cudaMemsetAsync(d_MI.data(), 0, sizeof(double), stream));
 
   //calculating the row-wise sums
-  MLCommon::LinAlg::reduce<int, int, int>(a.data(), dContingencyMatrix.data(),
+  raft::linalg::reduce<int, int, int>(a.data(), dContingencyMatrix.data(),
                                           numUniqueClasses, numUniqueClasses, 0,
                                           true, true, stream);
 
   //calculating the column-wise sums
-  MLCommon::LinAlg::reduce<int, int, int>(b.data(), dContingencyMatrix.data(),
+  raft::linalg::reduce<int, int, int>(b.data(), dContingencyMatrix.data(),
                                           numUniqueClasses, numUniqueClasses, 0,
                                           true, false, stream);
 

--- a/cpp/src_prims/metrics/mutualInfoScore.cuh
+++ b/cpp/src_prims/metrics/mutualInfoScore.cuh
@@ -137,13 +137,13 @@ double mutualInfoScore(const T *firstClusterArray, const T *secondClusterArray,
 
   //calculating the row-wise sums
   raft::linalg::reduce<int, int, int>(a.data(), dContingencyMatrix.data(),
-                                          numUniqueClasses, numUniqueClasses, 0,
-                                          true, true, stream);
+                                      numUniqueClasses, numUniqueClasses, 0,
+                                      true, true, stream);
 
   //calculating the column-wise sums
   raft::linalg::reduce<int, int, int>(b.data(), dContingencyMatrix.data(),
-                                          numUniqueClasses, numUniqueClasses, 0,
-                                          true, false, stream);
+                                      numUniqueClasses, numUniqueClasses, 0,
+                                      true, false, stream);
 
   //kernel configuration
   static const int BLOCK_DIM_Y = 16, BLOCK_DIM_X = 16;

--- a/cpp/src_prims/metrics/silhouetteScore.cuh
+++ b/cpp/src_prims/metrics/silhouetteScore.cuh
@@ -214,8 +214,8 @@ DataT silhouetteScore(DataT *X_in, int nRows, int nCols, LabelT *labels,
   CUDA_CHECK(cudaMemsetAsync(sampleToClusterSumOfDistances.data(), 0,
                              nRows * nLabels * sizeof(DataT), stream));
   MLCommon::LinAlg::reduce_cols_by_key(distanceMatrix.data(), labels,
-                             sampleToClusterSumOfDistances.data(), nRows, nRows,
-                             nLabels, stream);
+                                       sampleToClusterSumOfDistances.data(),
+                                       nRows, nRows, nLabels, stream);
 
   //creating the a array and b array
   device_buffer<DataT> d_aArray(allocator, stream, nRows);

--- a/cpp/src_prims/metrics/silhouetteScore.cuh
+++ b/cpp/src_prims/metrics/silhouetteScore.cuh
@@ -213,7 +213,7 @@ DataT silhouetteScore(DataT *X_in, int nRows, int nCols, LabelT *labels,
                                                      nRows * nLabels);
   CUDA_CHECK(cudaMemsetAsync(sampleToClusterSumOfDistances.data(), 0,
                              nRows * nLabels * sizeof(DataT), stream));
-  LinAlg::reduce_cols_by_key(distanceMatrix.data(), labels,
+  MLCommon::LinAlg::reduce_cols_by_key(distanceMatrix.data(), labels,
                              sampleToClusterSumOfDistances.data(), nRows, nRows,
                              nLabels, stream);
 
@@ -247,7 +247,7 @@ DataT silhouetteScore(DataT *X_in, int nRows, int nCols, LabelT *labels,
     binCountArray.data(), nLabels, nRows, true, true, DivOp<DataT>(), stream);
 
   //calculating row-wise minimum
-  LinAlg::reduce<DataT, DataT, int, raft::Nop<DataT>, MinOp<DataT>>(
+  raft::linalg::reduce<DataT, DataT, int, raft::Nop<DataT>, MinOp<DataT>>(
     d_bArray.data(), averageDistanceBetweenSampleAndCluster.data(), nLabels,
     nRows, std::numeric_limits<DataT>::max(), true, true, stream, false,
     raft::Nop<DataT>(), MinOp<DataT>());

--- a/cpp/src_prims/selection/processing.cuh
+++ b/cpp/src_prims/selection/processing.cuh
@@ -74,8 +74,8 @@ class CosineMetricProcessor : public MetricProcessor<math_t> {
       k_(k) {}
 
   void preprocess(math_t *data) {
-    LinAlg::rowNorm(colsums_.data(), data, n_cols_, n_rows_,
-                    LinAlg::NormType::L2Norm, row_major_, stream_,
+    raft::linalg::rowNorm(colsums_.data(), data, n_cols_, n_rows_,
+                    raft::linalg::NormType::L2Norm, row_major_, stream_,
                     [] __device__(math_t in) { return sqrtf(in); });
 
     raft::linalg::matrixVectorOp(
@@ -115,7 +115,7 @@ class CorrelationMetricProcessor : public CosineMetricProcessor<math_t> {
   void preprocess(math_t *data) {
     math_t normalizer_const = 1.0 / (math_t)cosine::n_cols_;
 
-    LinAlg::reduce(means_.data(), data, cosine::n_cols_, cosine::n_rows_,
+    raft::linalg::reduce(means_.data(), data, cosine::n_cols_, cosine::n_rows_,
                    (math_t)0.0, cosine::row_major_, true, cosine::stream_);
 
     raft::linalg::unaryOp(

--- a/cpp/src_prims/selection/processing.cuh
+++ b/cpp/src_prims/selection/processing.cuh
@@ -75,8 +75,8 @@ class CosineMetricProcessor : public MetricProcessor<math_t> {
 
   void preprocess(math_t *data) {
     raft::linalg::rowNorm(colsums_.data(), data, n_cols_, n_rows_,
-                    raft::linalg::NormType::L2Norm, row_major_, stream_,
-                    [] __device__(math_t in) { return sqrtf(in); });
+                          raft::linalg::NormType::L2Norm, row_major_, stream_,
+                          [] __device__(math_t in) { return sqrtf(in); });
 
     raft::linalg::matrixVectorOp(
       data, data, colsums_.data(), n_cols_, n_rows_, row_major_, false,
@@ -116,7 +116,8 @@ class CorrelationMetricProcessor : public CosineMetricProcessor<math_t> {
     math_t normalizer_const = 1.0 / (math_t)cosine::n_cols_;
 
     raft::linalg::reduce(means_.data(), data, cosine::n_cols_, cosine::n_rows_,
-                   (math_t)0.0, cosine::row_major_, true, cosine::stream_);
+                         (math_t)0.0, cosine::row_major_, true,
+                         cosine::stream_);
 
     raft::linalg::unaryOp(
       means_.data(), means_.data(), cosine::n_rows_,

--- a/cpp/src_prims/stats/sum.cuh
+++ b/cpp/src_prims/stats/sum.cuh
@@ -20,8 +20,8 @@
 #include <cuda_utils.cuh>
 #include <linalg/eltwise.cuh>
 
-namespace MLCommon {
-namespace Stats {
+namespace raft {
+namespace stats {
 
 ///@todo: ColsPerBlk has been tested only for 32!
 template <typename Type, typename IdxType, int TPB, int ColsPerBlk = 32>
@@ -95,5 +95,5 @@ void sum(Type *output, const Type *input, IdxType D, IdxType N, bool rowMajor,
   CUDA_CHECK(cudaPeekAtLastError());
 }
 
-};  // end namespace Stats
-};  // end namespace MLCommon
+};  // end namespace stats
+};  // end namespace raft

--- a/cpp/src_prims/stats/weighted_mean.cuh
+++ b/cpp/src_prims/stats/weighted_mean.cuh
@@ -39,10 +39,10 @@ void rowWeightedMean(Type *mu, const Type *data, const Type *weights, int D,
                      int N, cudaStream_t stream) {
   //sum the weights & copy back to CPU
   Type WS = 0;
-  LinAlg::coalescedReduction(mu, weights, D, 1, (Type)0, stream, false);
+  raft::linalg::coalescedReduction(mu, weights, D, 1, (Type)0, stream, false);
   raft::update_host(&WS, mu, 1, stream);
 
-  LinAlg::coalescedReduction(
+  raft::linalg::coalescedReduction(
     mu, data, D, N, (Type)0, stream, false,
     [weights] __device__(Type v, int i) { return v * weights[i]; },
     [] __device__(Type a, Type b) { return a + b; },
@@ -65,10 +65,10 @@ void colWeightedMean(Type *mu, const Type *data, const Type *weights, int D,
                      int N, cudaStream_t stream) {
   //sum the weights & copy back to CPU
   Type WS = 0;
-  LinAlg::stridedReduction(mu, weights, 1, N, (Type)0, stream, false);
+  raft::linalg::stridedReduction(mu, weights, 1, N, (Type)0, stream, false);
   raft::update_host(&WS, mu, 1, stream);
 
-  LinAlg::stridedReduction(
+  raft::linalg::stridedReduction(
     mu, data, D, N, (Type)0, stream, false,
     [weights] __device__(Type v, int i) { return v * weights[i]; },
     [] __device__(Type a, Type b) { return a + b; },

--- a/cpp/src_prims/timeSeries/stationarity.cuh
+++ b/cpp/src_prims/timeSeries/stationarity.cuh
@@ -217,8 +217,8 @@ static void _kpss_test(const DataT* d_y, bool* results, IdxT batch_size,
   // This calculates the first sum in eq. 10 (first part of s^2)
   device_buffer<DataT> s2A(allocator, stream, batch_size);
   raft::linalg::reduce(s2A.data(), y_cent.data(), batch_size, n_obs,
-                 static_cast<DataT>(0.0), false, false, stream, false,
-                 raft::L2Op<DataT>(), raft::Sum<DataT>());
+                       static_cast<DataT>(0.0), false, false, stream, false,
+                       raft::L2Op<DataT>(), raft::Sum<DataT>());
 
   // From Kwiatkowski et al. referencing Schwert (1989)
   DataT lags_f = ceil(12.0 * pow(n_obs_f / 100.0, 0.25));
@@ -236,7 +236,7 @@ static void _kpss_test(const DataT* d_y, bool* results, IdxT batch_size,
   CUDA_CHECK(cudaPeekAtLastError());
   device_buffer<DataT> s2B(allocator, stream, batch_size);
   raft::linalg::reduce(s2B.data(), accumulator.data(), batch_size, n_obs,
-                 static_cast<DataT>(0.0), false, false, stream, false);
+                       static_cast<DataT>(0.0), false, false, stream, false);
 
   // Cumulative sum (inclusive scan with + operator)
   thrust::counting_iterator<IdxT> c_first(0);
@@ -249,8 +249,8 @@ static void _kpss_test(const DataT* d_y, bool* results, IdxT batch_size,
   // Eq. 11 (eta)
   device_buffer<DataT> eta(allocator, stream, batch_size);
   raft::linalg::reduce(eta.data(), accumulator.data(), batch_size, n_obs,
-                 static_cast<DataT>(0.0), false, false, stream, false,
-                 raft::L2Op<DataT>(), raft::Sum<DataT>());
+                       static_cast<DataT>(0.0), false, false, stream, false,
+                       raft::L2Op<DataT>(), raft::Sum<DataT>());
 
   /* The following kernel will decide whether each series is stationary based on
    * s^2 and eta */

--- a/cpp/src_prims/timeSeries/stationarity.cuh
+++ b/cpp/src_prims/timeSeries/stationarity.cuh
@@ -216,7 +216,7 @@ static void _kpss_test(const DataT* d_y, bool* results, IdxT batch_size,
 
   // This calculates the first sum in eq. 10 (first part of s^2)
   device_buffer<DataT> s2A(allocator, stream, batch_size);
-  LinAlg::reduce(s2A.data(), y_cent.data(), batch_size, n_obs,
+  raft::linalg::reduce(s2A.data(), y_cent.data(), batch_size, n_obs,
                  static_cast<DataT>(0.0), false, false, stream, false,
                  raft::L2Op<DataT>(), raft::Sum<DataT>());
 
@@ -235,7 +235,7 @@ static void _kpss_test(const DataT* d_y, bool* results, IdxT batch_size,
     -coeff_base / (lags_f + static_cast<DataT>(1.0)), coeff_base);
   CUDA_CHECK(cudaPeekAtLastError());
   device_buffer<DataT> s2B(allocator, stream, batch_size);
-  LinAlg::reduce(s2B.data(), accumulator.data(), batch_size, n_obs,
+  raft::linalg::reduce(s2B.data(), accumulator.data(), batch_size, n_obs,
                  static_cast<DataT>(0.0), false, false, stream, false);
 
   // Cumulative sum (inclusive scan with + operator)
@@ -248,7 +248,7 @@ static void _kpss_test(const DataT* d_y, bool* results, IdxT batch_size,
 
   // Eq. 11 (eta)
   device_buffer<DataT> eta(allocator, stream, batch_size);
-  LinAlg::reduce(eta.data(), accumulator.data(), batch_size, n_obs,
+  raft::linalg::reduce(eta.data(), accumulator.data(), batch_size, n_obs,
                  static_cast<DataT>(0.0), false, false, stream, false,
                  raft::L2Op<DataT>(), raft::Sum<DataT>());
 

--- a/cpp/test/prims/coalesced_reduction.cu
+++ b/cpp/test/prims/coalesced_reduction.cu
@@ -22,8 +22,8 @@
 #include "reduce.cuh"
 #include "test_utils.h"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 template <typename T>
 struct coalescedReductionInputs {
@@ -114,5 +114,5 @@ INSTANTIATE_TEST_CASE_P(coalescedReductionTests, coalescedReductionTestF,
 INSTANTIATE_TEST_CASE_P(coalescedReductionTests, coalescedReductionTestD,
                         ::testing::ValuesIn(inputsd));
 
-}  // end namespace LinAlg
-}  // end namespace MLCommon
+}  // end namespace linalg
+}  // end namespace raft

--- a/cpp/test/prims/fused_l2_nn.cu
+++ b/cpp/test/prims/fused_l2_nn.cu
@@ -103,8 +103,8 @@ class FusedL2NNTest : public ::testing::TestWithParam<Inputs<DataT>> {
     r.uniform(x, m * k, DataT(-1.0), DataT(1.0), stream);
     r.uniform(y, n * k, DataT(-1.0), DataT(1.0), stream);
     generateGoldenResult();
-    LinAlg::rowNorm(xn, x, k, m, LinAlg::L2Norm, true, stream);
-    LinAlg::rowNorm(yn, y, k, n, LinAlg::L2Norm, true, stream);
+    raft::linalg::rowNorm(xn, x, k, m, raft::linalg::L2Norm, true, stream);
+    raft::linalg::rowNorm(yn, y, k, n, raft::linalg::L2Norm, true, stream);
   }
 
   void TearDown() override {

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -50,7 +50,7 @@ void generate_data(float *out_samples, float *out_labels, int n_rows,
     out_samples, out_samples, n_rows,
     [=] __device__(float input) { return 2 * input - 1; }, stream);
 
-  MLCommon::LinAlg::reduce(
+  raft::linalg::reduce(
     out_labels, out_samples, n_cols, n_rows, 0.0f, true, true, stream, false,
     [=] __device__(float in, int n) { return in * in; }, raft::Sum<float>(),
     [=] __device__(float in) { return sqrt(in); });

--- a/cpp/test/prims/norm.cu
+++ b/cpp/test/prims/norm.cu
@@ -20,8 +20,8 @@
 #include <random/rng.cuh>
 #include "test_utils.h"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 template <typename T>
 struct NormInputs {
@@ -286,5 +286,5 @@ INSTANTIATE_TEST_CASE_P(ColNormTests, ColNormTestF,
 INSTANTIATE_TEST_CASE_P(ColNormTests, ColNormTestD,
                         ::testing::ValuesIn(inputscd));
 
-}  // end namespace LinAlg
-}  // end namespace MLCommon
+}  // end namespace linalg
+}  // end namespace raft

--- a/cpp/test/prims/reduce.cu
+++ b/cpp/test/prims/reduce.cu
@@ -22,8 +22,8 @@
 #include "reduce.cuh"
 #include "test_utils.h"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 template <typename T>
 struct ReduceInputs {
@@ -142,5 +142,5 @@ INSTANTIATE_TEST_CASE_P(ReduceTests, ReduceTestF, ::testing::ValuesIn(inputsf));
 
 INSTANTIATE_TEST_CASE_P(ReduceTests, ReduceTestD, ::testing::ValuesIn(inputsd));
 
-}  // end namespace LinAlg
-}  // end namespace MLCommon
+}  // end namespace linalg
+}  // end namespace raft

--- a/cpp/test/prims/reduce.cuh
+++ b/cpp/test/prims/reduce.cuh
@@ -20,8 +20,8 @@
 #include <cuda_utils.cuh>
 #include <linalg/unary_op.cuh>
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 template <typename Type>
 __global__ void naiveCoalescedReductionKernel(Type *dots, const Type *data,
@@ -81,5 +81,5 @@ void naiveReduction(Type *dots, const Type *data, int D, int N, bool rowMajor,
   CUDA_CHECK(cudaDeviceSynchronize());
 }
 
-}  // end namespace LinAlg
-}  // end namespace MLCommon
+}  // end namespace linalg
+}  // end namespace raft

--- a/cpp/test/prims/strided_reduction.cu
+++ b/cpp/test/prims/strided_reduction.cu
@@ -21,8 +21,8 @@
 #include "reduce.cuh"
 #include "test_utils.h"
 
-namespace MLCommon {
-namespace LinAlg {
+namespace raft {
+namespace linalg {
 
 template <typename T>
 struct stridedReductionInputs {
@@ -102,5 +102,5 @@ INSTANTIATE_TEST_CASE_P(stridedReductionTests, stridedReductionTestF,
 INSTANTIATE_TEST_CASE_P(stridedReductionTests, stridedReductionTestD,
                         ::testing::ValuesIn(inputsd));
 
-}  // end namespace LinAlg
-}  // end namespace MLCommon
+}  // end namespace linalg
+}  // end namespace raft

--- a/cpp/test/prims/sum.cu
+++ b/cpp/test/prims/sum.cu
@@ -21,8 +21,8 @@
 #include <stats/sum.cuh>
 #include "test_utils.h"
 
-namespace MLCommon {
-namespace Stats {
+namespace raft {
+namespace stats {
 
 template <typename T>
 struct SumInputs {
@@ -91,5 +91,5 @@ INSTANTIATE_TEST_CASE_P(SumTests, SumTestF, ::testing::ValuesIn(inputsf));
 
 INSTANTIATE_TEST_CASE_P(SumTests, SumTestD, ::testing::ValuesIn(inputsd));
 
-}  // end namespace Stats
-}  // end namespace MLCommon
+}  // end namespace stats
+}  // end namespace raft


### PR DESCRIPTION
This PR moves some primes that I mistakenly left out from moving before, which include:

1.  `linalg/norm.cuh`
1.  `linalg/reduce.cuh`
1.  `linalg/coalesced_reduction.cuh`
1.  `linalg/strided_reduction.cuh`
1.  `stats/sum.cuh`

There are no API changes in this PR, and there is only a switch of namespaces