### PR TITLE
[REVIEW] Handle C++ exception thrown from FIL predict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
 - PR #3021: Fix a hang in cuML RF experimental backend
 - PR #3039: Update RF and decision tree parameter initializations in benchmark codes
+- PR #3061: Handle C++ exception thrown from FIL predict
 
 # cuML 0.16.0 (Date TBD)
 

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -186,7 +186,7 @@ cdef extern from "cuml/fil/fil.h" namespace "ML::fil":
                       float*,
                       float*,
                       size_t,
-                      bool)
+                      bool) except +
 
     cdef forest_t from_treelite(handle_t& handle,
                                 forest_t*,

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -405,6 +405,37 @@ def test_output_args(small_classifier_and_preds):
     assert array_equal(fil_preds, xgb_preds, 1e-3)
 
 
+@pytest.mark.skipif(has_lightgbm() is False, reason="need to install lightgbm")
+def test_cpp_exception(tmp_path):
+    import lightgbm as lgb
+    num_class = 3
+    X, y = simulate_data(50,
+                         5 * num_class,
+                         num_class,
+                         random_state=2020,
+                         classification=True)
+    train_data = lgb.Dataset(X, label=y)
+
+    num_round = 1
+    param = {'objective': 'ova',  # 'multiclass', would use softmax
+             'metric': 'multi_logloss',
+             'num_class': num_class}
+    bst = lgb.train(param, train_data, num_round)
+    model_path = str(os.path.join(tmp_path, 'lgb.model'))
+    bst.save_model(model_path)
+
+    fm = ForestInference.load(model_path,
+                              algo='TREE_REORG',
+                              output_class=True,
+                              model_type='lightgbm')
+
+    with pytest.raises(RuntimeError) as excinfo:
+        fil_proba = fm.predict_proba(X)
+
+    assert ('predict_proba not supported for multi-class gradient boosted ' +
+            'decision trees' in str(excinfo.value))
+
+
 @pytest.mark.parametrize('num_classes', [2, 5])
 @pytest.mark.skipif(has_lightgbm() is False, reason="need to install lightgbm")
 def test_lightgbm(tmp_path, num_classes):

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -430,7 +430,7 @@ def test_cpp_exception(tmp_path):
                               model_type='lightgbm')
 
     with pytest.raises(RuntimeError) as excinfo:
-        fil_proba = fm.predict_proba(X)
+        _ = fm.predict_proba(X)
 
     assert ('predict_proba not supported for multi-class gradient boosted ' +
             'decision trees' in str(excinfo.value))


### PR DESCRIPTION
Currently, attempting to use `predict_proba()` with a multi-class classifier will result into a segfault, because a C++ exception is not properly handled in the Python layer.

Use `except +` construct in Cython to convert C++ exceptions from the `predict()` function of FIL into Python exceptions.