### PR TITLE
[REVIEW] Bumping xgboost version to match cuml version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
 - PR #3021: Fix a hang in cuML RF experimental backend
 - PR #3039: Update RF and decision tree parameter initializations in benchmark codes
+- PR #3062: Bumping xgboost version to match cuml version
 
 # cuML 0.16.0 (Date TBD)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,7 +53,7 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
-      "xgboost=1.2.0dev.rapidsai0.16" \
+      "xgboost=1.2.0dev.rapidsai${MINOR_VERSION}" \
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*"

--- a/ci/gpu/test-notebooks.sh
+++ b/ci/gpu/test-notebooks.sh
@@ -10,7 +10,9 @@ TOPLEVEL_NB_FOLDERS=$(find . -name *.ipynb |cut -d'/' -f2|sort -u)
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
 
-SKIPNBS="cuml_benchmarks.ipynb"
+# TODO: (MDD) Temporarily adding forest_inference_demo.ipynb since xgboost is broken in 0.17
+#       Remove once xgboost is working again.
+SKIPNBS="cuml_benchmarks.ipynb forest_inference_demo.ipynb"
 
 ## Check env
 env

--- a/python/cuml/common/import_utils.py
+++ b/python/cuml/common/import_utils.py
@@ -70,6 +70,13 @@ def has_xgboost():
         return True
     except ImportError:
         return False
+    except Exception as ex:
+        import warnings
+        warnings.warn(
+            ("The XGBoost library was found but raised an exception during "
+             "import. Importing xgboost will be skipped. "
+             "Error message:\n{}").format(str(ex)))
+        return False
 
 
 def has_pytest_benchmark():


### PR DESCRIPTION
Upgrading the xgboost version used in the build script to match the cuML version (since its a custom build of xgboost).

This follows a similar PR for integration: https://github.com/rapidsai/integration/pull/166

However, unlike the integration change, we will match the xgboost version to the cuml version to avoid hitting this issue in the future.