### PR TITLE
Update mathjax CDN URL to prevent mixed content warnings [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
 - PR #3021: Fix a hang in cuML RF experimental backend
 - PR #3039: Update RF and decision tree parameter initializations in benchmark codes
+- PR #3073: Update mathjax CDN URL for documentation
 
 # cuML 0.16.0 (Date TBD)
 

--- a/cpp/Doxyfile.in
+++ b/cpp/Doxyfile.in
@@ -1478,10 +1478,10 @@ MATHJAX_FORMAT         = HTML-CSS
 # Content Delivery Network so you can quickly see the result without installing
 # MathJax. However, it is strongly recommended to install a local copy of
 # MathJax from http://www.mathjax.org before deployment.
-# The default value is: http://cdn.mathjax.org/mathjax/latest.
+# The default value is: https://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
This PR updates the mathjax CDN URL to prevent mixed content warnings that appear in Chrome dev tools when visiting `libcuml` documentation pages like this one: https://docs.rapids.ai/api/libcuml/stable/

![image](https://user-images.githubusercontent.com/7400326/97445480-ae9c3080-1903-11eb-8048-3bc38a6efe80.png)
