### PR TITLE
[REVIEW] Reducing dask coordinate descent test runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #2996: Removing the max_depth restriction for switching to the batched backend
 - PR #3004: Remove Single Process Multi GPU (SPMG) code
 - PR #3044: Move leftover `linalg` and `stats` to RAFT namespaces
+- PR #3074: Reducing dask coordinate descent test runtime
 
 ## Bug Fixes
 - PR #3037: Avoid logging deadlock in multi-threaded C code

--- a/python/cuml/test/dask/test_coordinate_descent.py
+++ b/python/cuml/test/dask/test_coordinate_descent.py
@@ -26,9 +26,9 @@ import numpy as np
 
 @pytest.mark.mg
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-@pytest.mark.parametrize('alpha', [0.1, 0.001])
+@pytest.mark.parametrize('alpha', [0.001])
 @pytest.mark.parametrize('algorithm', ['cyclic', 'random'])
-@pytest.mark.parametrize('nrows', [unit_param(500),
+@pytest.mark.parametrize('nrows', [unit_param(50),
                                    quality_param(5000),
                                    stress_param(500000)])
 @pytest.mark.parametrize('column_info', [unit_param([20, 10]),
@@ -63,7 +63,7 @@ def test_lasso(dtype, alpha, algorithm,
 
 @pytest.mark.mg
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-@pytest.mark.parametrize('nrows', [unit_param(500),
+@pytest.mark.parametrize('nrows', [unit_param(50),
                                    quality_param(5000),
                                    stress_param(500000)])
 @pytest.mark.parametrize('column_info', [unit_param([20, 10]),
@@ -92,7 +92,7 @@ def test_lasso_default(dtype, nrows, column_info, n_parts, client):
 
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-@pytest.mark.parametrize('alpha', [0.2, 0.7])
+@pytest.mark.parametrize('alpha', [0.5])
 @pytest.mark.parametrize('algorithm', ['cyclic', 'random'])
 @pytest.mark.parametrize('nrows', [unit_param(500),
                                    quality_param(5000),


### PR DESCRIPTION
It already seems to be minimal, removing a few redundant values.

Runtime on my machine went from 72 seconds to 45 seconds

Closes #3043 