### PR TITLE
Fix artifacts in t-SNE results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #3039: Update RF and decision tree parameter initializations in benchmark codes
 - PR #3073: Update mathjax CDN URL for documentation
 - PR #3062: Bumping xgboost version to match cuml version
+- PR #3084: Fix artifacts in t-SNE results
 
 # cuML 0.16.0 (Date TBD)
 

--- a/cpp/src/tsne/barnes_hut.cuh
+++ b/cpp/src/tsne/barnes_hut.cuh
@@ -149,8 +149,8 @@ void Barnes_Hut(float *VAL, const int *COL, const int *ROW, const int NNZ,
     cudaFuncSetCacheConfig(TSNE::TreeBuildingKernel, cudaFuncCachePreferL1));
   CUDA_CHECK(cudaFuncSetCacheConfig(TSNE::ClearKernel1, cudaFuncCachePreferL1));
   CUDA_CHECK(cudaFuncSetCacheConfig(TSNE::ClearKernel2, cudaFuncCachePreferL1));
-  CUDA_CHECK(
-    cudaFuncSetCacheConfig(TSNE::SummarizationKernel, cudaFuncCachePreferL1));
+  CUDA_CHECK(cudaFuncSetCacheConfig(TSNE::SummarizationKernel,
+                                    cudaFuncCachePreferShared));
   CUDA_CHECK(cudaFuncSetCacheConfig(TSNE::SortKernel, cudaFuncCachePreferL1));
   CUDA_CHECK(
     cudaFuncSetCacheConfig(TSNE::RepulsionKernel, cudaFuncCachePreferL1));

--- a/cpp/src/tsne/bh_kernels.cuh
+++ b/cpp/src/tsne/bh_kernels.cuh
@@ -449,7 +449,7 @@ __global__ __launch_bounds__(THREADS3, FACTOR3) void SummarizationKernel(
     }
 
   SKIP_LOOP:
-    __syncthreads();
+    __threadfence();
     if (flag != 0) {
       massd[k] = cm;
       k += inc;


### PR DESCRIPTION
Fixes #3057

I suspect that 6a93762b155b5e1f6eacf01875ed6524dab97541 only masked a thread synchronization bug but didn't actually fix the lockup. In turn, I suspect the effect that commit had on timing revealed these output artifacts.

A side-effect is that this changes the absolute range of output embedding values by a factor of about 2.5x.

The output on Gaussian blobs is now a "flower," which is what I would expect and is consistent with the FFT implementation (see https://github.com/rapidsai/cuml/issues/2980#issuecomment-715651403). The results are also more consistent between runs.

| Run 1 | Run 2 | Run 3 | Run 4 |
| --- | --- | --- | --- |
| ![new-2](https://user-images.githubusercontent.com/469365/97622084-61928a00-19e9-11eb-9bab-79f05ab87f48.png) | ![new-3](https://user-images.githubusercontent.com/469365/97622101-67886b00-19e9-11eb-9dcd-d8aa6f4b19ce.png) | ![new4](https://user-images.githubusercontent.com/469365/97622333-bafab900-19e9-11eb-8667-d2813f907f13.png) | ![nes5](https://user-images.githubusercontent.com/469365/97622342-bfbf6d00-19e9-11eb-9b58-e8671f6ebf21.png)



