### PR TITLE
[REVIEW] Reverting FIL Notebook Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #3039: Update RF and decision tree parameter initializations in benchmark codes
 - PR #3073: Update mathjax CDN URL for documentation
 - PR #3062: Bumping xgboost version to match cuml version
+- PR #3086: Reverting FIL Notebook Testing
 
 # cuML 0.16.0 (Date TBD)
 

--- a/ci/gpu/test-notebooks.sh
+++ b/ci/gpu/test-notebooks.sh
@@ -10,9 +10,7 @@ TOPLEVEL_NB_FOLDERS=$(find . -name *.ipynb |cut -d'/' -f2|sort -u)
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
 
-# TODO: (MDD) Temporarily adding forest_inference_demo.ipynb since xgboost is broken in 0.17
-#       Remove once xgboost is working again.
-SKIPNBS="cuml_benchmarks.ipynb forest_inference_demo.ipynb"
+SKIPNBS="cuml_benchmarks.ipynb"
 
 ## Check env
 env


### PR DESCRIPTION
Closes #3082 

Now that CentOS7 CI is able to import XGBoost, revert the notebook testing to enable `forest_inference_demo.ipynb`