### PR TITLE
Fixed a typo in SVC's predict_proba AttributeError when the model is not fit with probability=True [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #3062: Bumping xgboost version to match cuml version
 - PR #3084: Fix artifacts in t-SNE results
 - PR #3086: Reverting FIL Notebook Testing
+- PR #3114: Fixed a typo in SVC's predict_proba AttributeError
 
 # cuML 0.16.0 (Date TBD)
 

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -461,7 +461,7 @@ class SVC(SVMBase, ClassifierMixin):
             return _to_output(preds, out_type)
         else:
             raise AttributeError("This classifier is not fitted to predict "
-                                 "probabilities. Fit a new classifier with"
+                                 "probabilities. Fit a new classifier with "
                                  "probability=True to enable predict_proba.")
 
     @generate_docstring(return_values={'name': 'preds',


### PR DESCRIPTION
"with" at the end of the second line, and "probability" at the beginning of the third line did not have a space between them.

Current Error:
`AttributeError: This classifier is not fitted to predict probabilities. Fit a new classifier withprobability=True to enable predict_proba.`

New Error:
`AttributeError: This classifier is not fitted to predict probabilities. Fit a new classifier with probability=True to enable predict_proba.`