### PR TITLE
[REVIEW] Fix experimental RF backend crashes and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #3084: Fix artifacts in t-SNE results
 - PR #3086: Reverting FIL Notebook Testing
 - PR #3114: Fixed a typo in SVC's predict_proba AttributeError
+- PR #3117: Fix two crashes in experimental RF backend
 - PR #3119: Fix memset args for benchmark 
 
 # cuML 0.16.0 (Date TBD)

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -451,7 +451,8 @@ struct RegTraits {
   static void computeSplit(Builder<RegTraits<DataT, IdxT>>& b, IdxT col,
                            IdxT batchSize, CRITERION splitType,
                            cudaStream_t s) {
-    auto n_col_blks = b.n_blks_for_cols;
+    auto n_col_blks = std::min(b.n_blks_for_cols, b.input.nSampledCols - col);
+
     dim3 grid(b.n_blks_for_rows, n_col_blks, batchSize);
     auto nbins = b.params.n_bins;
     size_t smemSize = 7 * nbins * sizeof(DataT) + nbins * sizeof(int);

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -464,7 +464,7 @@ struct RegTraits {
 
     // Room for alignment in worst case (see alignPointer in
     // computeSplitRegressionKernel)
-    smemSize += 5 * sizeof(DataT*) + 2 * sizeof(int);
+    smemSize += 5 * sizeof(DataT) + 2 * sizeof(int);
 
     CUDA_CHECK(
       cudaMemsetAsync(b.pred, 0, sizeof(DataT) * b.nPredCounts * 2, s));

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -394,6 +394,7 @@ struct ClsTraits {
     dim3 grid(b.n_blks_for_rows, colBlks, batchSize);
     size_t smemSize = sizeof(int) * binSize + sizeof(DataT) * nbins;
     smemSize += sizeof(int);
+    smemSize += 3 * sizeof(DataT*);  // Room for alignment in worst case
     CUDA_CHECK(cudaMemsetAsync(b.hist, 0, sizeof(int) * b.nHistBins, s));
     computeSplitClassificationKernel<DataT, LabelT, IdxT, TPB_DEFAULT>
       <<<grid, TPB_DEFAULT, smemSize, s>>>(
@@ -457,6 +458,7 @@ struct RegTraits {
     auto nbins = b.params.n_bins;
     size_t smemSize = 7 * nbins * sizeof(DataT) + nbins * sizeof(int);
     smemSize += sizeof(int);
+    smemSize += 7 * sizeof(DataT*);  // Room for alignment in worst case
     CUDA_CHECK(
       cudaMemsetAsync(b.pred, 0, sizeof(DataT) * b.nPredCounts * 2, s));
     if (splitType == CRITERION::MAE) {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -354,12 +354,6 @@ __global__ void computeSplitRegressionKernel(
   }
   for (IdxT i = threadIdx.x; i < nbins; i += blockDim.x) {
     scount[i] = 0;
-    if (col < 0) {
-      printf(
-        "indexing q with %d, col: %d, nbins: %d, i: %d, from colStart: %d + "
-        "blockIdx.y: %d\n",
-        col * nbins + i, col, nbins, i, colStart, blockIdx.y);
-    }
     sbins[i] = input.quantiles[col * nbins + i];
   }
   __syncthreads();

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -250,6 +250,12 @@ __global__ void nodeSplitKernel(IdxT max_depth, IdxT min_rows_per_node,
                                              total_nodes, (char*)smem);
 }
 
+/* Returns 'input' rounded up to a correctly-aligned pointer of type OutT */
+template <typename OutT, typename InT>
+__device__ OutT alignPointer(InT input) {
+  return reinterpret_cast<OutT>(raft::alignTo((size_t)input, sizeof(OutT)));
+}
+
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 __global__ void computeSplitClassificationKernel(
   int* hist, IdxT nbins, IdxT max_depth, IdxT min_rows_per_node,
@@ -269,9 +275,9 @@ __global__ void computeSplitClassificationKernel(
   auto end = range_start + range_len;
   auto nclasses = input.nclasses;
   auto len = nbins * 2 * nclasses;
-  auto* shist = reinterpret_cast<int*>(smem);
-  auto* sbins = reinterpret_cast<DataT*>(shist + len);
-  auto* sDone = reinterpret_cast<int*>(sbins + nbins);
+  auto* shist = alignPointer<int*>(smem);
+  auto* sbins = alignPointer<DataT*>(shist + len);
+  auto* sDone = alignPointer<int*>(sbins + nbins);
   IdxT stride = blockDim.x * gridDim.x;
   IdxT tid = threadIdx.x + blockIdx.x * blockDim.x;
   auto col = input.colids[colStart + blockIdx.y];
@@ -338,14 +344,15 @@ __global__ void computeSplitRegressionKernel(
   }
   auto end = range_start + range_len;
   auto len = nbins * 2;
-  auto* spred = reinterpret_cast<DataT*>(smem);
-  auto* scount = reinterpret_cast<int*>(spred + len);
-  auto* sbins = reinterpret_cast<DataT*>(scount + nbins);
+  auto* spred = alignPointer<DataT*>(smem);
+  auto* scount = alignPointer<int*>(spred + len);
+  auto* sbins = alignPointer<DataT*>(scount + nbins);
+
   // used only for MAE criterion
-  auto* spred2 = reinterpret_cast<DataT*>(sbins + nbins);
-  auto* spred2P = reinterpret_cast<DataT*>(spred2 + len);
-  auto* spredP = reinterpret_cast<DataT*>(spred2P + nbins);
-  auto* sDone = reinterpret_cast<int*>(spredP + nbins);
+  auto* spred2 = alignPointer<DataT*>(sbins + nbins);
+  auto* spred2P = alignPointer<DataT*>(spred2 + len);
+  auto* spredP = alignPointer<DataT*>(spred2P + nbins);
+  auto* sDone = alignPointer<int*>(spredP + nbins);
   IdxT stride = blockDim.x * gridDim.x;
   IdxT tid = threadIdx.x + blockIdx.x * blockDim.x;
   auto col = input.colids[colStart + blockIdx.y];
@@ -354,12 +361,8 @@ __global__ void computeSplitRegressionKernel(
   }
   for (IdxT i = threadIdx.x; i < nbins; i += blockDim.x) {
     scount[i] = 0;
-    if (col < 0 || col > 100) {
-      printf(
-        "indexing q with %d, col: %d, nbins: %d, i: %d, from colStart: %d + "
-        "blockIdx.y: %d\n",
-        col * nbins + i, col, nbins, i, colStart, blockIdx.y);
-    }
+    // printf("indexing from sbins: %p  to %p, sizeof: %d (spred: %p)\n", sbins,
+    //        &sbins[i], (int)sizeof(DataT*), spred);
     sbins[i] = input.quantiles[col * nbins + i];
   }
   __syncthreads();

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -354,6 +354,12 @@ __global__ void computeSplitRegressionKernel(
   }
   for (IdxT i = threadIdx.x; i < nbins; i += blockDim.x) {
     scount[i] = 0;
+    if (col < 0 || col > 100) {
+      printf(
+        "indexing q with %d, col: %d, nbins: %d, i: %d, from colStart: %d + "
+        "blockIdx.y: %d\n",
+        col * nbins + i, col, nbins, i, colStart, blockIdx.y);
+    }
     sbins[i] = input.quantiles[col * nbins + i];
   }
   __syncthreads();

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -354,10 +354,17 @@ __global__ void computeSplitRegressionKernel(
   }
   for (IdxT i = threadIdx.x; i < nbins; i += blockDim.x) {
     scount[i] = 0;
+    if (col < 0) {
+      printf(
+        "indexing q with %d, col: %d, nbins: %d, i: %d, from colStart: %d + "
+        "blockIdx.y: %d\n",
+        col * nbins + i, col, nbins, i, colStart, blockIdx.y);
+    }
     sbins[i] = input.quantiles[col * nbins + i];
   }
   __syncthreads();
   auto coloffset = col * input.M;
+
   // compute prediction averages for all bins in shared mem
   for (auto i = range_start + tid; i < end; i += stride) {
     auto row = input.rowids[i];
@@ -440,6 +447,7 @@ __global__ void computeSplitRegressionKernel(
     last = MLCommon::signalDone(done_count + nid * gridDim.y + blockIdx.y,
                                 gridDim.x, blockIdx.x == 0, sDone);
   }
+
   if (!last) return;
   // last block computes the final gain
   Split<DataT, IdxT> sp;

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -77,6 +77,7 @@ if(BUILD_CUML_TESTS)
   add_dependencies(ml cutlass)
 
   target_include_directories(ml PRIVATE ${CUML_TEST_INCLUDE_DIRS})
+  target_compile_options(ml PRIVATE $<$<COMPILE_LANGUAGE:CUDA>: --generate-line-info>)
 
   target_link_libraries(ml ${CUML_TEST_LINK_LIBRARIES})
 

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -77,7 +77,6 @@ if(BUILD_CUML_TESTS)
   add_dependencies(ml cutlass)
 
   target_include_directories(ml PRIVATE ${CUML_TEST_INCLUDE_DIRS})
-  target_compile_options(ml PRIVATE $<$<COMPILE_LANGUAGE:CUDA>: --generate-line-info>)
 
   target_link_libraries(ml ${CUML_TEST_LINK_LIBRARIES})
 

--- a/cpp/test/sg/rf_batched_classification_test.cu
+++ b/cpp/test/sg/rf_batched_classification_test.cu
@@ -42,6 +42,7 @@ struct RfInputs {
   float min_impurity_decrease;
   int n_streams;
   CRITERION split_criterion;
+  float min_expected_acc;
 };
 
 template <typename T>
@@ -143,6 +144,14 @@ class RFBatchedClsTest : public ::testing::TestWithParam<RfInputs> {
 
 //-------------------------------------------------------------------------------------------------------------------------------------
 const std::vector<RfInputs> inputsf2_clf = {
+  // Simple non-crash tests with small datasets
+  {100, 59, 1, 1.0f, 0.4f, 16, -1, true, false, 10, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::GINI, 0.0f},
+  {101, 59, 2, 1.0f, 0.4f, 10, -1, true, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::GINI, 0.0f},
+  {100, 1, 2, 1.0f, 0.4f, 10, -1, true, false, 15, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::GINI, 0.0f},
+  // Simple accuracy tests
   {20000, 10, 25, 1.0f, 0.4f, 16, -1, true, false, 10,
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::GINI},
   {20000, 10, 5, 1.0f, 0.4f, 14, -1, true, false, 10,
@@ -150,11 +159,7 @@ const std::vector<RfInputs> inputsf2_clf = {
 
 typedef RFBatchedClsTest<float> RFBatchedClsTestF;
 TEST_P(RFBatchedClsTestF, Fit) {
-  if (!params.bootstrap && (params.max_features == 1.0f)) {
-    ASSERT_TRUE(accuracy == 1.0f);
-  } else {
-    ASSERT_TRUE(accuracy >= 0.75f);  // Empirically derived accuracy range
-  }
+  ASSERT_TRUE(accuracy >= params.min_expected_acc);
 }
 
 INSTANTIATE_TEST_CASE_P(RFBatchedClsTests, RFBatchedClsTestF,
@@ -162,11 +167,7 @@ INSTANTIATE_TEST_CASE_P(RFBatchedClsTests, RFBatchedClsTestF,
 
 typedef RFBatchedClsTest<double> RFBatchedClsTestD;
 TEST_P(RFBatchedClsTestD, Fit) {
-  if (!params.bootstrap && (params.max_features == 1.0f)) {
-    ASSERT_TRUE(accuracy == 1.0f);
-  } else {
-    ASSERT_TRUE(accuracy >= 0.75f);  // Empirically derived accuracy range
-  }
+  ASSERT_TRUE(accuracy >= params.min_expected_acc);
 }
 
 INSTANTIATE_TEST_CASE_P(RFBatchedClsTests, RFBatchedClsTestD,

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -44,6 +44,7 @@ struct RfInputs {
   float min_impurity_decrease;
   int n_streams;
   CRITERION split_criterion;
+  float min_expected_acc;
 };
 
 template <typename T>
@@ -120,24 +121,33 @@ class RFBatchedRegTest : public ::testing::TestWithParam<RfInputs> {
 
 //-------------------------------------------------------------------------------------------------------------------------------------
 const std::vector<RfInputs> inputs = {
-  // First two will FAIL (small data, small ensemble) but in old code will crash as well
+  // Small datasets to repro corner cases as in #3107 (test no crash)
   {100, 29, 1, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE},
-  {100, 57, 1, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE},
+   2, 0.0, 2, CRITERION::MAE, 0.0},
+  {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::MAE, 0.0},
+  {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::MSE, 0.0},
+  {100, 1, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::MAE, 0.0},
+  // Larger datasets for accuracy
   {1000, 10, 10, 1.0f, 1.0f, 12, -1, true, false, 10,
-   SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MAE},
+   SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MAE, 0.7f},
   {2000, 20, 20, 1.0f, 0.6f, 13, -1, true, false, 10,
-   SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MSE}};
+   SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MSE, 0.7f}};
 
 typedef RFBatchedRegTest<float> RFBatchedRegTestF;
-TEST_P(RFBatchedRegTestF, Fit) { ASSERT_TRUE(accuracy >= 0.7f); }
+TEST_P(RFBatchedRegTestF, Fit) {
+  ASSERT_TRUE(accuracy >= params.min_expected_acc);
+}
 
 INSTANTIATE_TEST_CASE_P(RFBatchedRegTests, RFBatchedRegTestF,
                         ::testing::ValuesIn(inputs));
 
 typedef RFBatchedRegTest<double> RFBatchedRegTestD;
-TEST_P(RFBatchedRegTestD, Fit) { ASSERT_TRUE(accuracy >= 0.7f); }
+TEST_P(RFBatchedRegTestD, Fit) {
+  ASSERT_TRUE(accuracy >= params.min_expected_acc);
+}
 
 INSTANTIATE_TEST_CASE_P(RFBatchedRegTests, RFBatchedRegTestD,
                         ::testing::ValuesIn(inputs));

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -120,6 +120,11 @@ class RFBatchedRegTest : public ::testing::TestWithParam<RfInputs> {
 
 //-------------------------------------------------------------------------------------------------------------------------------------
 const std::vector<RfInputs> inputs = {
+  // First two will FAIL (small data, small ensemble) but in old code will crash as well
+  {100, 29, 1, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::MAE},
+  {100, 57, 1, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
+   2, 0.0, 2, CRITERION::MAE},
   {1000, 10, 10, 1.0f, 1.0f, 12, -1, true, false, 10,
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MAE},
   {2000, 20, 20, 1.0f, 0.6f, 13, -1, true, false, 10,

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -121,15 +121,16 @@ class RFBatchedRegTest : public ::testing::TestWithParam<RfInputs> {
 
 //-------------------------------------------------------------------------------------------------------------------------------------
 const std::vector<RfInputs> inputs = {
-  // Small datasets to repro corner cases as in #3107 (test no crash)
+  // Small datasets to repro corner cases as in #3107 (test for crash)
   {100, 29, 1, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE, -1.0},
+   2, 0.0, 2, CRITERION::MAE, -10.0},
   {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE, -1.0},
+   2, 0.0, 2, CRITERION::MAE, -10.0},
   {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MSE, -1.0},
+   2, 0.0, 2, CRITERION::MSE, -10.0},
   {100, 1, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE, -1.0},
+   2, 0.0, 2, CRITERION::MAE, -10.0},
+
   // Larger datasets for accuracy
   {1000, 10, 10, 1.0f, 1.0f, 12, -1, true, false, 10,
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MAE, 0.7f},
@@ -137,17 +138,13 @@ const std::vector<RfInputs> inputs = {
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MSE, 0.7f}};
 
 typedef RFBatchedRegTest<float> RFBatchedRegTestF;
-TEST_P(RFBatchedRegTestF, Fit) {
-  ASSERT_TRUE(accuracy >= params.min_expected_acc);
-}
+TEST_P(RFBatchedRegTestF, Fit) { ASSERT_GT(accuracy, params.min_expected_acc); }
 
 INSTANTIATE_TEST_CASE_P(RFBatchedRegTests, RFBatchedRegTestF,
                         ::testing::ValuesIn(inputs));
 
 typedef RFBatchedRegTest<double> RFBatchedRegTestD;
-TEST_P(RFBatchedRegTestD, Fit) {
-  ASSERT_TRUE(accuracy >= params.min_expected_acc);
-}
+TEST_P(RFBatchedRegTestD, Fit) { ASSERT_GT(accuracy, params.min_expected_acc); }
 
 INSTANTIATE_TEST_CASE_P(RFBatchedRegTests, RFBatchedRegTestD,
                         ::testing::ValuesIn(inputs));

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -123,13 +123,13 @@ class RFBatchedRegTest : public ::testing::TestWithParam<RfInputs> {
 const std::vector<RfInputs> inputs = {
   // Small datasets to repro corner cases as in #3107 (test no crash)
   {100, 29, 1, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE, 0.0},
+   2, 0.0, 2, CRITERION::MAE, -1.0},
   {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE, 0.0},
+   2, 0.0, 2, CRITERION::MAE, -1.0},
   {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MSE, 0.0},
+   2, 0.0, 2, CRITERION::MSE, -1.0},
   {100, 1, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
-   2, 0.0, 2, CRITERION::MAE, 0.0},
+   2, 0.0, 2, CRITERION::MAE, -1.0},
   // Larger datasets for accuracy
   {1000, 10, 10, 1.0f, 1.0f, 12, -1, true, false, 10,
    SPLIT_ALGO::GLOBAL_QUANTILE, 2, 0.0, 2, CRITERION::MAE, 0.7f},

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -126,7 +126,7 @@ const std::vector<RfInputs> inputs = {
    2, 0.0, 2, CRITERION::MAE, -10.0},
   {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 16, SPLIT_ALGO::GLOBAL_QUANTILE,
    2, 0.0, 2, CRITERION::MAE, -10.0},
-  {100, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
+  {101, 57, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
    2, 0.0, 2, CRITERION::MSE, -10.0},
   {100, 1, 2, 1.0f, 1.0f, 2, -1, false, false, 13, SPLIT_ALGO::GLOBAL_QUANTILE,
    2, 0.0, 2, CRITERION::MAE, -10.0},

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -212,16 +212,18 @@ def test_rf_classification(small_clf, datatype, split_algo,
 @pytest.mark.parametrize('rows_sample', [unit_param(1.0), quality_param(0.90),
                          stress_param(0.95)])
 @pytest.mark.parametrize('datatype', [np.float32])
-@pytest.mark.parametrize('split_algo,max_features,use_experimental_backend',
-                         [(0,1.0,False),
-                          (1,1.0,False),
-                          (0,'auto',False),
-                          (1,'log2',False),
-                          (1,'sqrt',False),
-                          (1,1.0,True),
-                         ])
+@pytest.mark.parametrize(
+    'split_algo,max_features,use_experimental_backend,n_bins',
+    [(0,1.0,False,16),
+     (1,1.0,False,11),
+     (0,'auto',False,128),
+     (1,'log2',False,100),
+     (1,'sqrt',False,100),
+     (1,1.0,True,17),
+     (1,1.0,True,32),
+     ])
 def test_rf_regression(special_reg, datatype, split_algo, max_features,
-                       rows_sample, use_experimental_backend):
+                       rows_sample, use_experimental_backend, n_bins):
 
     use_handle = True
 
@@ -238,7 +240,7 @@ def test_rf_regression(special_reg, datatype, split_algo, max_features,
     if use_experimental_backend:
         print("EXPERIMENTAL")
     cuml_model = curfr(max_features=max_features, rows_sample=rows_sample,
-                       n_bins=16, split_algo=split_algo, split_criterion=2,
+                       n_bins=n_bins, split_algo=split_algo, split_criterion=2,
                        min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=50, handle=handle, max_leaves=-1,
                        max_depth=16, accuracy_metric='mse',

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -237,8 +237,6 @@ def test_rf_regression(special_reg, datatype, split_algo, max_features,
     handle, stream = get_handle(use_handle, n_streams=1)
 
     # Initialize and fit using cuML's random forest regression model
-    if use_experimental_backend:
-        print("EXPERIMENTAL")
     cuml_model = curfr(max_features=max_features, rows_sample=rows_sample,
                        n_bins=n_bins, split_algo=split_algo, split_criterion=2,
                        min_rows_per_node=2, random_state=123, n_streams=1,

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -212,10 +212,16 @@ def test_rf_classification(small_clf, datatype, split_algo,
 @pytest.mark.parametrize('rows_sample', [unit_param(1.0), quality_param(0.90),
                          stress_param(0.95)])
 @pytest.mark.parametrize('datatype', [np.float32])
-@pytest.mark.parametrize('split_algo', [0, 1])
-@pytest.mark.parametrize('max_features', [1.0, 'auto', 'log2', 'sqrt'])
+@pytest.mark.parametrize('split_algo,max_features,use_experimental_backend',
+                         [(0,1.0,False),
+                          (1,1.0,False),
+                          (0,'auto',False),
+                          (1,'log2',False),
+                          (1,'sqrt',False),
+                          (1,1.0,True),
+                         ])
 def test_rf_regression(special_reg, datatype, split_algo, max_features,
-                       rows_sample):
+                       rows_sample, use_experimental_backend):
 
     use_handle = True
 
@@ -229,11 +235,14 @@ def test_rf_regression(special_reg, datatype, split_algo, max_features,
     handle, stream = get_handle(use_handle, n_streams=1)
 
     # Initialize and fit using cuML's random forest regression model
+    if use_experimental_backend:
+        print("EXPERIMENTAL")
     cuml_model = curfr(max_features=max_features, rows_sample=rows_sample,
                        n_bins=16, split_algo=split_algo, split_criterion=2,
                        min_rows_per_node=2, random_state=123, n_streams=1,
                        n_estimators=50, handle=handle, max_leaves=-1,
-                       max_depth=16, accuracy_metric='mse')
+                       max_depth=16, accuracy_metric='mse',
+                       use_experimental_backend=use_experimental_backend)
     cuml_model.fit(X_train, y_train)
     # predict using FIL
     fil_preds = cuml_model.predict(X_test, predict_model="GPU")

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -214,13 +214,13 @@ def test_rf_classification(small_clf, datatype, split_algo,
 @pytest.mark.parametrize('datatype', [np.float32])
 @pytest.mark.parametrize(
     'split_algo,max_features,use_experimental_backend,n_bins',
-    [(0,1.0,False,16),
-     (1,1.0,False,11),
-     (0,'auto',False,128),
-     (1,'log2',False,100),
-     (1,'sqrt',False,100),
-     (1,1.0,True,17),
-     (1,1.0,True,32),
+    [(0, 1.0, False, 16),
+     (1, 1.0, False, 11),
+     (0, 'auto', False, 128),
+     (1, 'log2', False, 100),
+     (1, 'sqrt', False, 100),
+     (1, 1.0, True, 17),
+     (1, 1.0, True, 32),
      ])
 def test_rf_regression(special_reg, datatype, split_algo, max_features,
                        rows_sample, use_experimental_backend, n_bins):


### PR DESCRIPTION
Relates to #3107. We're exceeding the array bounds of the column ids array and getting gibberish,
which eventually leads to memory errors. With this patch, the two test cases no longer crash (though
they still fail due to accuracy as expected). Other tests at the Python layer work smoothly too.﻿

Closes #3107 