### PR TITLE
[REVIEW] updated clang version to 11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #3115: Speeding up MNMG UMAP testing
 - PR #3112: Speed test_array
 - PR #3111: Adding Cython to Code Coverage
+- PR #3121: clang version updated to 11.0.0
 
 ## Bug Fixes
 - PR #3065: Refactoring prims metrics function names from camelcase to underscore format

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -19,8 +19,9 @@ The `test` directory has subdirectories that reflect this distinction between th
 2. CUDA (>= 10.0)
 3. gcc (>=5.4.0)
 4. BLAS - Any BLAS compatible with cmake's [FindBLAS](https://cmake.org/cmake/help/v3.14/module/FindBLAS.html). Note that the blas has to be installed to the same folder system as cmake, for example if using conda installed cmake, the blas implementation should also be installed in the conda environment.
-5. clang-format (= 8.0.1) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=8` and `clang-tools=8` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
-6. UCX with CUDA support [optional] (>=1.7) - enables point-to-point messaging in the cuML communicator.
+5. clang-format (= 11.0.0) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=11.0.0` and `clang-tools=11.0.0` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
+6. clang-tidy(= 11.0.0) - enforces uniform C++ coding standard; required to build cuML from source. Installation instructions are the same as above.
+7. UCX with CUDA support [optional] (>=1.7) - enables point-to-point messaging in the cuML communicator.
 
 ### Building cuML:
 

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -22,7 +22,7 @@ import argparse
 import tempfile
 
 
-EXPECTED_VERSION = "8.0.1"
+EXPECTED_VERSION = "11.0.0"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to
 #       to the cuml repo

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -22,7 +22,7 @@ import json
 import multiprocessing as mp
 
 
-EXPECTED_VERSION = "8.0.1"
+EXPECTED_VERSION = "11.0.0"
 VERSION_REGEX = re.compile(r"  LLVM version ([0-9.]+)")
 GPU_ARCH_REGEX = re.compile(r"sm_(\d+)")
 SPACES = re.compile(r"\s+")

--- a/cpp/src_prims/distance/fused_l2_nn.cuh
+++ b/cpp/src_prims/distance/fused_l2_nn.cuh
@@ -303,7 +303,7 @@ struct FusedL2NN : public BaseClass {
 
   DI void stsXY() { pipe.wait_prior<0>(); }
 #endif  // ENABLE_MEMCPY_ASYNC
-};      // struct FusedL2NN
+};  // struct FusedL2NN
 
 template <typename DataT, typename OutT, typename IdxT, bool Sqrt,
           typename Policy, typename ReduceOpT>

--- a/cpp/test/sg/nvtx_test.cpp
+++ b/cpp/test/sg/nvtx_test.cpp
@@ -26,7 +26,7 @@ uint32_t generateNextColor(const std::string &tag);
 
 class nvtxNextColorTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() override {  // NOLINT
     const std::string temp1 = "foo";
     const std::string temp2 = "bar";
 
@@ -35,7 +35,7 @@ class nvtxNextColorTest : public ::testing::Test {
     if (ML::generateNextColor(temp1) == ML::generateNextColor(temp1))
       same_string_same_color = true;
   }
-  void TearDown() {}
+
   bool diff_string_diff_color = false;
   bool same_string_same_color = false;
 };


### PR DESCRIPTION
This PR will upgrade the clang version required to 11.0.0 in order to enable us with running clang-tidy on .cu files, while running on cuda v11. See https://github.com/rapidsai/raft/issues/88 for more details.

CI will not pass as the underlying conda-env still uses 8.0.1. Once we have the rapids-build-env meta package updated, this should pass.