### PR TITLE
[REVIEW] Improving the Deprecation Message Formatting in Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #3112: Speed test_array
 - PR #3111: Adding Cython to Code Coverage
 - PR #3129:  Update notebooks README
+- PR #3134: Improving the Deprecation Message Formatting in Documentation
 
 ## Bug Fixes
 - PR #3065: Refactoring prims metrics function names from camelcase to underscore format

--- a/docs/source/_static/infoboxes.css
+++ b/docs/source/_static/infoboxes.css
@@ -1,0 +1,87 @@
+/* This contains code with copyright by the scikit-learn project, subject to
+the license in /thirdparty/LICENSES/LICENSE.scikit_learn */
+
+/* info boxes */
+
+div.topic {
+  padding: 0.5rem;
+  background-color: #eee;
+  margin-bottom: 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid #CCC;
+}
+
+div.topic p {
+  margin-bottom: 0.25rem;
+}
+
+div.topic dd {
+  margin-bottom: 0.25rem;
+}
+
+p.topic-title {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+div.topic > ul.simple {
+  margin-bottom: 0.25rem;
+}
+
+p.admonition-title {
+  margin-right: 0.5rem;
+  font-weight: bold;
+  display: inline;
+}
+
+p.admonition-title:after {
+  content: ":";
+}
+
+div.admonition p.admonition-title + p, div.deprecated p {
+  display: inline;
+}
+
+div.admonition, div.deprecated {
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #ddd;
+  margin-bottom: 1rem;
+}
+
+div.admonition {
+  background-color: #eee;
+}
+
+div.admonition p, div.admonition dl, div.admonition dd {
+  margin-bottom: 0
+}
+
+div.deprecated {
+  color: #b94a48;
+  background-color: #F3E5E5;
+  border: 1px solid #eed3d7;
+}
+
+div.seealso {
+  background-color: #FFFBE8;
+  border: 1px solid #fbeed5;
+  color: #AF8A4B;
+}
+
+div.versionchanged {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background-color: #FFFBE8;
+  border: 1px solid #fbeed5;
+  border-radius: 0.5rem;
+}
+
+div.versionchanged p {
+  margin-bottom: 0;
+}
+
+dt.label {
+  float: left;
+  padding-right: 0.5rem;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -191,6 +191,7 @@ numpydoc_class_members_toctree = False
 
 def setup(app):
     app.add_css_file('copybutton.css')
+    app.add_css_file('infoboxes.css')
     app.add_css_file('params.css')
     app.add_css_file('references.css')
 

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -115,9 +115,13 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
     random_state : int (default = None)
         Seed for the random number generator. Unseeded by default.
     seed : int (default = None)
-        Deprecated in favor of `random_state`.
         Base seed for the random number generator. Unseeded by default. Does
         not currently fully guarantee the exact same results.
+
+        .. deprecated:: 0.15
+           Parameter `seed` is deprecated and will be removed in 0.17. Please
+           use `random_state` instead
+
     ignore_empty_partitions: Boolean (default = False)
         Specify behavior when a worker does not hold any data
         while splitting. When True, it returns the results from workers

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -121,9 +121,13 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
     random_state : int (default = None)
         Seed for the random number generator. Unseeded by default.
     seed : int (default = None)
-        Deprecated in favor of `random_state`.
         Base seed for the random number generator. Unseeded by default. Does
         not currently fully guarantee the exact same results.
+
+        .. deprecated:: 0.15
+           Parameter `seed` is deprecated and will be removed in 0.17. Please
+           use `random_state` instead
+
     ignore_empty_partitions: Boolean (default = False)
         Specify behavior when a worker does not hold any data
         while splitting. When True, it returns the results from workers

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -229,8 +229,12 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     random_state : int (default = None)
         Seed for the random number generator. Unseeded by default.
     seed : int (default = None)
-        Deprecated in favor of `random_state`.
         Seed for the random number generator. Unseeded by default.
+
+        .. deprecated:: 0.16
+           Parameter `seed` is deprecated and will be removed in 0.17. Please
+           use `random_state` instead
+
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
@@ -588,9 +592,13 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             while performing the predict operation on the GPU.
             It is applied if output_class == True, else it is ignored
         num_classes : int (default = None)
-            number of different classes present in the dataset. This variable
-            will be deprecated in 0.16. The number of classes passed
-            must match the number of classes the model was trained on
+            number of different classes present in the dataset.
+
+            .. deprecated:: 0.16
+                Parameter 'num_classes' is deprecated and will be removed in
+                an upcoming version. The number of classes passed must match
+                the number of classes the model was trained on.
+
         convert_dtype : bool, optional (default = True)
             When set to True, the predict method will, when necessary, convert
             the input to the data type which was used to train the model. This
@@ -734,9 +742,13 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             while performing the predict operation on the GPU.
             It is applied if output_class == True, else it is ignored
         num_classes : int (default = None)
-            number of different classes present in the dataset. This variable
-            will be deprecated in 0.16. The number of classes passed
-            must match the number of classes the model was trained on
+            number of different classes present in the dataset.
+
+            .. deprecated:: 0.16
+                Parameter 'num_classes' is deprecated and will be removed in
+                an upcoming version. The number of classes passed must match
+                the number of classes the model was trained on.
+
         convert_dtype : bool, optional (default = True)
             When set to True, the predict method will, when necessary, convert
             the input to the data type which was used to train the model. This
@@ -810,9 +822,13 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             This is optional and required only while performing the
             predict operation on the GPU.
         num_classes : int (default = None)
-            number of different classes present in the dataset. This variable
-            will be deprecated in 0.16. The number of classes passed
-            must match the number of classes the model was trained on
+            number of different classes present in the dataset.
+
+            .. deprecated:: 0.16
+                Parameter 'num_classes' is deprecated and will be removed in
+                an upcoming version. The number of classes passed must match
+                the number of classes the model was trained on.
+
         convert_dtype : boolean, default=True
             whether to convert input data to correct dtype automatically
         predict_model : String (default = 'GPU')

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -221,9 +221,13 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         Seed for the random number generator. Unseeded by default. Does not
         currently fully guarantee the exact same results.
     seed : int (default = None)
-        Deprecated in favor of `random_state`.
         Seed for the random number generator. Unseeded by default. Does not
         currently fully guarantee the exact same results.
+
+        .. deprecated:: 0.16
+           Parameter `seed` is deprecated and will be removed in 0.17. Please
+           use `random_state` instead
+
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA

--- a/python/cuml/preprocessing/model_selection.py
+++ b/python/cuml/preprocessing/model_selection.py
@@ -246,8 +246,12 @@ def train_test_split(X,
     random_state : int, CuPy RandomState or NumPy RandomState optional
         If shuffle is true, seeds the generator. Unseeded by default
     seed: random_state : int, CuPy RandomState or NumPy RandomState optional
-        Deprecated in favor of `random_state`.
         If shuffle is true, seeds the generator. Unseeded by default
+
+        .. deprecated:: 0.11
+           Parameter `seed` is deprecated and will be removed in 0.17. Please
+           use `random_state` instead
+
     stratify: bool, optional
         Whether to stratify the input data based on class labels.
         None by default


### PR DESCRIPTION
Following more of sklearn's documentation, we should be using the `deprecated` reST directive:

```
.. deprecated:: 0.16
   Parameter `seed` is deprecated and will be removed in 0.17. Please
   use `random_state` instead
```

This will generate a nice message like the following:
![image](https://user-images.githubusercontent.com/42954918/98997023-12704d00-24f1-11eb-951c-58b25063786d.png)

This PR adds the necessary CSS files to the doc build and updates the documentation where "deprecated" was mentioned.