### PR TITLE
[REVIEW] Get rid of warnings in random projection test and related deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #3040: Improved Array Conversion with CumlArrayDescriptor and Decorators
 - PR #3134: Improving the Deprecation Message Formatting in Documentation
 - PR #3137: Reorganize Pytest Config and Add Quick Run Option
+- PR #3155: Eliminate unnecessary warnings from random projection test
 
 ## Bug Fixes
 - PR #3069: Prevent conversion of DataFrames to Series in preprocessing

--- a/cpp/examples/dbscan/gen_dataset.py
+++ b/cpp/examples/dbscan/gen_dataset.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 import argparse
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 
 parser = argparse.ArgumentParser('gen_dataset.py ')
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -343,7 +343,7 @@ class GaussianRandomProjection(Base, BaseRandomProjection):
     .. code-block:: python
 
         from cuml.random_projection import GaussianRandomProjection
-        from sklearn.datasets.samples_generator import make_blobs
+        from sklearn.datasets import make_blobs
         from sklearn.svm import SVC
 
         # dataset generation
@@ -475,7 +475,7 @@ class SparseRandomProjection(Base, BaseRandomProjection):
     .. code-block:: python
 
         from cuml.random_projection import SparseRandomProjection
-        from sklearn.datasets.samples_generator import make_blobs
+        from sklearn.datasets import make_blobs
         from sklearn.svm import SVC
 
         # dataset generation

--- a/python/cuml/test/test_dbscan.py
+++ b/python/cuml/test/test_dbscan.py
@@ -22,7 +22,7 @@ from cuml.test.utils import get_pattern, unit_param, \
     quality_param, stress_param, array_equal
 
 from sklearn.cluster import DBSCAN as skDBSCAN
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import adjusted_rand_score
 

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -44,12 +44,12 @@ from sklearn.preprocessing import StandardScaler
 from cuml.metrics.cluster import entropy
 from cuml.metrics.regression import mean_squared_error, \
     mean_squared_log_error, mean_absolute_error
-from sklearn.metrics.regression import mean_squared_error as sklearn_mse
+from sklearn.metrics import mean_squared_error as sklearn_mse
 from sklearn.metrics import confusion_matrix as sk_confusion_matrix
 
 from cuml.metrics import confusion_matrix
-from sklearn.metrics.regression import mean_absolute_error as sklearn_mae
-from sklearn.metrics.regression import mean_squared_log_error as sklearn_msle
+from sklearn.metrics import mean_absolute_error as sklearn_mae
+from sklearn.metrics import mean_squared_log_error as sklearn_msle
 
 from cuml.common import has_scipy
 

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -21,7 +21,7 @@ from cuml.test.utils import array_equal, unit_param, quality_param, \
 from cuml.neighbors import NearestNeighbors as cuKNN
 
 from sklearn.neighbors import NearestNeighbors as skKNN
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 
 import cupy as cp
 import cupyx

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -25,7 +25,7 @@ from cuml.test.utils import get_handle, array_equal, unit_param, \
 from sklearn import datasets
 from sklearn.datasets import make_multilabel_classification
 from sklearn.decomposition import PCA as skPCA
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 
 
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])

--- a/python/cuml/test/test_random_projection.py
+++ b/python/cuml/test/test_random_projection.py
@@ -23,7 +23,7 @@ from cuml.random_projection import johnson_lindenstrauss_min_dim \
 
 from sklearn.random_projection import johnson_lindenstrauss_min_dim \
                             as sklearn_johnson_lindenstrauss_min_dim
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 
 from cuml.common import has_scipy
 
@@ -94,8 +94,8 @@ def test_johnson_lindenstrauss_min_dim():
     tests = zip(n_samples, eps_values)
 
     for n_samples, eps in tests:
-        cuml_value = cuml_johnson_lindenstrauss_min_dim(n_samples, eps)
-        sklearn_value = sklearn_johnson_lindenstrauss_min_dim(n_samples, eps)
+        cuml_value = cuml_johnson_lindenstrauss_min_dim(n_samples, eps=eps)
+        sklearn_value = sklearn_johnson_lindenstrauss_min_dim(n_samples, eps=eps)
         assert cuml_value == sklearn_value
 
 

--- a/python/cuml/test/test_random_projection.py
+++ b/python/cuml/test/test_random_projection.py
@@ -95,7 +95,8 @@ def test_johnson_lindenstrauss_min_dim():
 
     for n_samples, eps in tests:
         cuml_value = cuml_johnson_lindenstrauss_min_dim(n_samples, eps=eps)
-        sklearn_value = sklearn_johnson_lindenstrauss_min_dim(n_samples, eps=eps)
+        sklearn_value = sklearn_johnson_lindenstrauss_min_dim(n_samples,
+                                                              eps=eps)
         assert cuml_value == sklearn_value
 
 

--- a/python/cuml/test/test_sgd.py
+++ b/python/cuml/test/test_sgd.py
@@ -20,7 +20,7 @@ import cudf
 
 from cuml.solvers import SGD as cumlSGD
 
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 from sklearn.model_selection import train_test_split
 
 

--- a/python/cuml/test/test_tsne.py
+++ b/python/cuml/test/test_tsne.py
@@ -19,7 +19,7 @@ import pytest
 from cuml.manifold import TSNE
 from cuml.test.utils import stress_param
 
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 from sklearn.manifold.t_sne import trustworthiness
 from sklearn import datasets
 

--- a/python/cuml/test/test_tsvd.py
+++ b/python/cuml/test/test_tsvd.py
@@ -20,7 +20,7 @@ from cuml.test.utils import get_handle
 from cuml.test.utils import array_equal, unit_param, \
     quality_param, stress_param
 
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 from sklearn.decomposition import TruncatedSVD as skTSVD
 from sklearn.utils import check_random_state
 

--- a/python/cuml/test/test_umap.py
+++ b/python/cuml/test/test_umap.py
@@ -30,7 +30,7 @@ import joblib
 
 from sklearn import datasets
 from sklearn.cluster import KMeans
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 from sklearn.manifold.t_sne import trustworthiness
 from sklearn.metrics import adjusted_rand_score
 


### PR DESCRIPTION
This eliminates a very large number of sklearn warnings and means we will work reliably with newer sklearn versions post-0.25.