### PR TITLE
[REVIEW] Fix gtest pinned cmake version for build from source option [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - PR #3152: Fix access to attributes of individual NB objects in dask NB
 - PR #3156: Force local conda artifact install
 - PR #3162: Removing accidentally checked in debug file
+- PR #3175: Fix gtest pinned cmake version for build from source option
 
 
 # cuML 0.16.0 (Date TBD)

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -199,7 +199,7 @@ if(BUILD_GTEST)
 	include(ExternalProject)
 	ExternalProject_Add(googletest
 	  GIT_REPOSITORY    https://github.com/google/googletest.git
-	  GIT_TAG           6ce9b98f541b8bcd84c5c5b3483f29a933c4aefb
+	  GIT_TAG           release-1.10.0
 	  PREFIX            ${GTEST_DIR}
 	  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 	                    -DBUILD_SHARED_LIBS=OFF


### PR DESCRIPTION
Note: CI does not build from source, so skip ci seems appropriate