### PR TITLE
Add gain to RF JSON dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - PR #3164: Expose silhouette score in Python
 - PR #2659: Add initial max inner product sparse knn
 - PR #2836: Refactor UMAP to accept sparse inputs
+- PR #3186: Add gain to RF JSON dump
 
 ## Improvements
 - PR #3077: Improve runtime for test_kmeans

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -105,6 +105,7 @@ std::string dump_node_as_json(
     oss << prefix << "{\"nodeid\": " << idx
         << ", \"split_feature\": " << node.colid
         << ", \"split_threshold\": " << to_string_high_precision(node.quesval)
+        << ", \"gain\": " << to_string_high_precision(node.best_metric_val)
         << ", \"yes\": " << node.left_child_id
         << ", \"no\": " << (node.left_child_id + 1) << ", \"children\": [\n";
     // enter the next tree level - left and right branch


### PR DESCRIPTION
I found it helpful when debugging the MSE metric calculation in random forest.

Gain = Change in the metric (MSE / MAE / Gini / Entropy) that's attributed directly to each internal node (split).