### PR TITLE
[REVIEW] Fix Attribute error on ICPA #3183 and PCA input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - PR #3162: Removing accidentally checked in debug file
 - PR #3175: Fix gtest pinned cmake version for build from source option
 - PR #3182: Fix a bug in MSE metric calculation
+- PR #3190: Fix Attribute error on ICPA #3183 and PCA input type
 
 
 # cuML 0.16.0 (23 Oct 2020)

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -433,7 +433,7 @@ class PCA(Base):
         if cupyx.scipy.sparse.issparse(X):
             return self._sparse_fit(X)
         elif scipy.sparse.issparse(X):
-            X = sparse_scipy_to_cp(X)
+            X = sparse_scipy_to_cp(X, dtype=None)
             return self._sparse_fit(X)
 
         X_m, self.n_rows, self.n_cols, self.dtype = \
@@ -521,13 +521,14 @@ class PCA(Base):
             cp.multiply(self.components_,
                         (1 / cp.sqrt(self.n_rows - 1)), out=self.components_)
             cp.multiply(self.components_,
-                        self.singular_values_, out=self.components_)
+                        self.singular_values_.reshape((-1,1)),
+                        out=self.components_)
 
         X_inv = cp.dot(X, self.components_)
         cp.add(X_inv, self.mean_, out=X_inv)
 
         if self.whiten:
-            self.components_ /= self.singular_values_
+            self.components_ /= self.singular_values_.reshape((-1,1))
             self.components_ *= cp.sqrt(self.n_rows - 1)
 
         if return_sparse:
@@ -558,7 +559,7 @@ class PCA(Base):
                                                   return_sparse=return_sparse,
                                                   sparse_tol=sparse_tol)
         elif scipy.sparse.issparse(X):
-            X = sparse_scipy_to_cp(X)
+            X = sparse_scipy_to_cp(X, dtype=None)
             return self._sparse_inverse_transform(X,
                                                   return_sparse=return_sparse,
                                                   sparse_tol=sparse_tol)
@@ -627,13 +628,13 @@ class PCA(Base):
 
             if self.whiten:
                 self.components_ *= cp.sqrt(self.n_rows - 1)
-                self.components_ /= self.singular_values_
+                self.components_ /= self.singular_values_.reshape((-1, 1))
 
             X = X - self.mean_
             X_transformed = X.dot(self.components_.T)
 
             if self.whiten:
-                self.components_ *= self.singular_values_
+                self.components_ *= self.singular_values_.reshape((-1,1))
                 self.components_ *= (1 / cp.sqrt(self.n_rows - 1))
 
         return X_transformed
@@ -655,7 +656,7 @@ class PCA(Base):
         if cupyx.scipy.sparse.issparse(X):
             return self._sparse_transform(X)
         elif scipy.sparse.issparse(X):
-            X = sparse_scipy_to_cp(X)
+            X = sparse_scipy_to_cp(X, dtype=None)
             return self._sparse_transform(X)
         elif self._sparse_model:
             X, _, _, _ = \

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -521,14 +521,14 @@ class PCA(Base):
             cp.multiply(self.components_,
                         (1 / cp.sqrt(self.n_rows - 1)), out=self.components_)
             cp.multiply(self.components_,
-                        self.singular_values_.reshape((-1,1)),
+                        self.singular_values_.reshape((-1, 1)),
                         out=self.components_)
 
         X_inv = cp.dot(X, self.components_)
         cp.add(X_inv, self.mean_, out=X_inv)
 
         if self.whiten:
-            self.components_ /= self.singular_values_.reshape((-1,1))
+            self.components_ /= self.singular_values_.reshape((-1, 1))
             self.components_ *= cp.sqrt(self.n_rows - 1)
 
         if return_sparse:
@@ -634,7 +634,7 @@ class PCA(Base):
             X_transformed = X.dot(self.components_.T)
 
             if self.whiten:
-                self.components_ *= self.singular_values_.reshape((-1,1))
+                self.components_ *= self.singular_values_.reshape((-1, 1))
                 self.components_ *= (1 / cp.sqrt(self.n_rows - 1))
 
         return X_transformed

--- a/python/cuml/experimental/decomposition/incremental_pca.py
+++ b/python/cuml/experimental/decomposition/incremental_pca.py
@@ -348,6 +348,7 @@ class IncrementalPCA(PCA):
         explained_variance = S ** 2 / (n_total_samples - 1)
         explained_variance_ratio = S ** 2 / cp.sum(col_var * n_total_samples)
 
+        self.n_rows = n_total_samples
         self.n_samples_seen_ = n_total_samples
         self.components_ = V[:self.n_components_]
         self.singular_values_ = S[:self.n_components_]

--- a/python/cuml/test/test_incremental_pca.py
+++ b/python/cuml/test/test_incremental_pca.py
@@ -28,17 +28,19 @@ from cuml.test.utils import array_equal
 
 @pytest.mark.parametrize(
     'nrows, ncols, n_components, sparse_input, density, sparse_format,'
-    ' batch_size_divider', [
-        (500, 15, 2, True, 0.4, 'csr', 5),
-        (5000, 25, 12, False, 0.07, 'csc', 10),
-        (5000, 15, None, True, 0.4, 'csc', 5),
-        (500, 25, 2, False, 0.07, 'csr', 10),
-        (5000, 25, 12, False, 0.07, 'csr', 10)
+    ' batch_size_divider, whiten',  [
+        (500, 15, 2, True, 0.4, 'csr', 5, True),
+        (5000, 25, 12, False, 0.07, 'csc', 10, False),
+        (5000, 15, None, True, 0.4, 'csc', 5, False),
+        (500, 25, 2, False, 0.07, 'csr', 10, False),
+        (5000, 25, 12, False, 0.07, 'csr', 10, True),
+        (500, 2500, 9, False, 0.07, 'csr', 50, True),
+        (500, 250, 14, True, 0.07, 'csr', 1, True),
     ]
 )
 @pytest.mark.no_bad_cuml_array_check
 def test_fit(nrows, ncols, n_components, sparse_input, density,
-             sparse_format, batch_size_divider):
+             sparse_format, batch_size_divider, whiten):
 
     if sparse_format == 'csc':
         pytest.skip("cupyx.scipy.sparse.csc.csc_matrix does not support"
@@ -50,13 +52,13 @@ def test_fit(nrows, ncols, n_components, sparse_input, density,
     else:
         X, _ = make_blobs(n_samples=nrows, n_features=ncols, random_state=10)
 
-    cu_ipca = cuIPCA(n_components=n_components,
+    cu_ipca = cuIPCA(n_components=n_components, whiten=whiten,
                      batch_size=int(nrows / batch_size_divider))
     cu_ipca.fit(X)
     cu_t = cu_ipca.transform(X)
     cu_inv = cu_ipca.inverse_transform(cu_t)
 
-    sk_ipca = skIPCA(n_components=n_components,
+    sk_ipca = skIPCA(n_components=n_components, whiten=whiten,
                      batch_size=int(nrows / batch_size_divider))
     if sparse_input:
         X = X.get()
@@ -71,20 +73,22 @@ def test_fit(nrows, ncols, n_components, sparse_input, density,
 
 
 @pytest.mark.parametrize(
-    'nrows, ncols, n_components, density, batch_size_divider', [
-        (500, 15, 2, 0.07, 5),
-        (5000, 25, 12, 0.07, 10),
-        (5000, 15, 2, 0.4, 5),
-        (500, 25, 12, 0.4, 10),
+    'nrows, ncols, n_components, density, batch_size_divider, whiten', [
+        (500, 15, 2, 0.07, 5, False),
+        (500, 15, 2, 0.07, 5, True),
+        (5000, 25, 12, 0.07, 10, False),
+        (5000, 15, 2, 0.4, 5, True),
+        (500, 25, 12, 0.4, 10, False),
+        (5000, 4, 2, 0.1, 100, False)
     ]
 )
 @pytest.mark.no_bad_cuml_array_check
 def test_partial_fit(nrows, ncols, n_components, density,
-                     batch_size_divider):
+                     batch_size_divider, whiten):
 
     X, _ = make_blobs(n_samples=nrows, n_features=ncols, random_state=10)
 
-    cu_ipca = cuIPCA(n_components=n_components)
+    cu_ipca = cuIPCA(n_components=n_components, whiten=whiten)
 
     sample_size = int(nrows / batch_size_divider)
     for i in range(0, nrows, sample_size):
@@ -93,7 +97,7 @@ def test_partial_fit(nrows, ncols, n_components, density,
     cu_t = cu_ipca.transform(X)
     cu_inv = cu_ipca.inverse_transform(cu_t)
 
-    sk_ipca = skIPCA(n_components=n_components)
+    sk_ipca = skIPCA(n_components=n_components, whiten=whiten)
 
     X = cp.asnumpy(X)
 

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -204,13 +204,16 @@ def test_pca_inverse_transform(datatype, input_type,
 @pytest.mark.parametrize('ncols', [5000, 10000])
 @pytest.mark.parametrize('whiten', [True, False])
 @pytest.mark.parametrize('return_sparse', [True, False])
-def test_sparse_pca_inputs(nrows, ncols, whiten, return_sparse):
+@pytest.mark.parametrize('cupy_input', [True, False])
+def test_sparse_pca_inputs(nrows, ncols, whiten, return_sparse, cupy_input):
 
     if return_sparse:
         pytest.skip("Loss of information in converting to cupy sparse csr")
 
     X = cupyx.scipy.sparse.random(nrows, ncols, density=0.07, dtype=cp.float32,
                                   random_state=10)
+    if not(cupy_input):
+        X = X.get()
 
     p_sparse = cuPCA(n_components=ncols, whiten=whiten)
 
@@ -226,6 +229,7 @@ def test_sparse_pca_inputs(nrows, ncols, whiten, return_sparse):
         assert array_equal(i_sparse.todense(), X.todense(), 1e-1,
                            with_sign=True)
     else:
-        assert isinstance(i_sparse, cp.core.ndarray)
+        if cupy_input:
+            assert isinstance(i_sparse, cp.core.ndarray)
 
         assert array_equal(i_sparse, X.todense(), 1e-1, with_sign=True)


### PR DESCRIPTION
This PR is fixing the attribute error of #3183, and additional bugs on the input type of PCA (`sparse_scipy_to_cp()` function call missed an argument) and on the shape of `self.singular_values_`.

I am also adding additional tests on the bug fixed here.