### PR TITLE
[REVIEW] Fix cuDF to cuPy conversion (missing value)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PR #3008: Check number of columns in check_array validator
 - PR #3012: Increasing learning rate for SGD log loss and invscaling pytests
 - PR #2950: Fix includes in UMAP
+- PR #3194: Fix cuDF to cuPy conversion (missing value)
 - PR #3021: Fix a hang in cuML RF experimental backend
 - PR #3039: Update RF and decision tree parameter initializations in benchmark codes
 - PR #3060: Speed up test suite `test_fil`

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -398,32 +398,34 @@ def input_to_cupy_array(X,
                         check_cols=False,
                         check_rows=False,
                         fail_on_order=False,
-                        force_contiguous=True) -> cuml_array:
+                        force_contiguous=True,
+                        fail_on_nan=True) -> cuml_array:
     """
     Identical to input_to_cuml_array but it returns a cupy array instead of
     CumlArray
     """
-    if isinstance(X, cudf.DataFrame):
-        # Columns containing missing values
-        colWithMissing = X.isnull().any().to_array()
-        if colWithMissing.any():
-            # Columns types
-            colTypes = X.dtypes.values
-            # Types of columns containing missing values
-            colTypesWithMissing = colTypes[colWithMissing]
-            checkIfFloatType = np.vectorize(
-                lambda x: not np.issubclass_(x, float))
-            # Columns that require conversion
-            colToConvert = checkIfFloatType(colTypesWithMissing)
-            if colToConvert.any():
-                X = X.astype('float64', copy=False)
+    if not fail_on_nan:
+        if isinstance(X, cudf.DataFrame):
+            # Columns containing missing values
+            colWithMissing = X.isnull().any().to_array()
+            if colWithMissing.any():
+                # Columns types
+                colTypes = X.dtypes.values
+                # Types of columns containing missing values
+                colTypesWithMissing = colTypes[colWithMissing]
+                checkIfFloatType = np.vectorize(
+                    lambda x: not np.issubclass_(x, float))
+                # Columns that require conversion
+                colToConvert = checkIfFloatType(colTypesWithMissing)
+                if colToConvert.any():
+                    X = X.astype('float64', copy=False)
+                X.fillna(cp.nan, inplace=True)
+        elif isinstance(X, cudf.Series):
+            hasMissing = X.isnull().any()
+            if hasMissing:
+                if not np.issubclass_(X.dtype, float):
+                    X = X.astype('float64', copy=False)
             X.fillna(cp.nan, inplace=True)
-    elif isinstance(X, cudf.Series):
-        hasMissing = X.isnull().any()
-        if hasMissing:
-            if not np.issubclass_(X.dtype, float):
-                X = X.astype('float64', copy=False)
-        X.fillna(cp.nan, inplace=True)
 
     out_data = input_to_cuml_array(X,
                                    order=order,

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -403,6 +403,28 @@ def input_to_cupy_array(X,
     Identical to input_to_cuml_array but it returns a cupy array instead of
     CumlArray
     """
+    if isinstance(X, cudf.DataFrame):
+        # Columns containing missing values
+        colWithMissing = X.isnull().any().to_array()
+        if colWithMissing.any():
+            # Columns types
+            colTypes = X.dtypes.values
+            # Types of columns containing missing values
+            colTypesWithMissing = colTypes[colWithMissing]
+            checkIfFloatType = np.vectorize(
+                lambda x: not np.issubclass_(x, float))
+            # Columns that require conversion
+            colToConvert = checkIfFloatType(colTypesWithMissing)
+            if colToConvert.any():
+                X = X.astype('float64', copy=False)
+            X.fillna(cp.nan, inplace=True)
+    elif isinstance(X, cudf.Series):
+        hasMissing = X.isnull().any()
+        if hasMissing:
+            if not np.issubclass_(X.dtype, float):
+                X = X.astype('float64', copy=False)
+        X.fillna(cp.nan, inplace=True)
+
     out_data = input_to_cuml_array(X,
                                    order=order,
                                    deepcopy=deepcopy,

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -399,12 +399,12 @@ def input_to_cupy_array(X,
                         check_rows=False,
                         fail_on_order=False,
                         force_contiguous=True,
-                        fail_on_nan=True) -> cuml_array:
+                        fail_on_null=True) -> cuml_array:
     """
     Identical to input_to_cuml_array but it returns a cupy array instead of
     CumlArray
     """
-    if not fail_on_nan:
+    if not fail_on_null:
         if isinstance(X, (cudf.DataFrame, cudf.Series)):
             try:
                 X = X.values

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -363,3 +363,8 @@ def test_tocupy_missing_values_handling():
     array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
     assert str(array.dtype) == 'float64'
     assert cp.isnan(array[1])
+
+    with pytest.raises(ValueError):
+        df = cudf.Series(data=[7, None, 3])
+        array, n_rows, n_cols, dtype = input_to_cupy_array(df,
+                                                           fail_on_nan=True)

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -349,17 +349,17 @@ def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
 
 def test_tocupy_missing_values_handling():
     df = cudf.DataFrame(data=[[7, 2, 3], [4, 5, 6], [10, 5, 9]])
-    array, n_rows, n_cols, dtype = input_to_cupy_array(df)
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
     assert isinstance(array, cp.ndarray)
     assert str(array.dtype) == 'int64'
 
     df = cudf.DataFrame(data=[[7, 2, 3], [4, None, 6], [10, 5, 9]])
-    array, n_rows, n_cols, dtype = input_to_cupy_array(df)
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
     assert isinstance(array, cp.ndarray)
     assert str(array.dtype) == 'float64'
     assert cp.isnan(array[1, 1])
 
     df = cudf.Series(data=[7, None, 3])
-    array, n_rows, n_cols, dtype = input_to_cupy_array(df)
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
     assert str(array.dtype) == 'float64'
     assert cp.isnan(array[1])

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -349,22 +349,22 @@ def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
 
 def test_tocupy_missing_values_handling():
     df = cudf.DataFrame(data=[[7, 2, 3], [4, 5, 6], [10, 5, 9]])
-    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_null=False)
     assert isinstance(array, cp.ndarray)
     assert str(array.dtype) == 'int64'
 
     df = cudf.DataFrame(data=[[7, 2, 3], [4, None, 6], [10, 5, 9]])
-    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_null=False)
     assert isinstance(array, cp.ndarray)
     assert str(array.dtype) == 'float64'
     assert cp.isnan(array[1, 1])
 
     df = cudf.Series(data=[7, None, 3])
-    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_nan=False)
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df, fail_on_null=False)
     assert str(array.dtype) == 'float64'
     assert cp.isnan(array[1])
 
     with pytest.raises(ValueError):
         df = cudf.Series(data=[7, None, 3])
         array, n_rows, n_cols, dtype = input_to_cupy_array(df,
-                                                           fail_on_nan=True)
+                                                           fail_on_null=True)

--- a/python/cuml/test/test_input_utils.py
+++ b/python/cuml/test/test_input_utils.py
@@ -23,6 +23,7 @@ from pandas import DataFrame as pdDF
 
 from cuml.common import input_to_cuml_array, CumlArray
 from cuml.common import input_to_host_array
+from cuml.common.input_utils import input_to_cupy_array
 from cuml.common import has_cupy
 from cuml.common.input_utils import convert_dtype
 from cuml.common.memory_utils import _check_array_contiguity
@@ -344,3 +345,21 @@ def get_input(type, nrows, ncols, dtype, order='C', out_dtype=False):
                                 order=order)
     else:
         return result, np.array(cp.asnumpy(rand_mat), order=order)
+
+
+def test_tocupy_missing_values_handling():
+    df = cudf.DataFrame(data=[[7, 2, 3], [4, 5, 6], [10, 5, 9]])
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df)
+    assert isinstance(array, cp.ndarray)
+    assert str(array.dtype) == 'int64'
+
+    df = cudf.DataFrame(data=[[7, 2, 3], [4, None, 6], [10, 5, 9]])
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df)
+    assert isinstance(array, cp.ndarray)
+    assert str(array.dtype) == 'float64'
+    assert cp.isnan(array[1, 1])
+
+    df = cudf.Series(data=[7, None, 3])
+    array, n_rows, n_cols, dtype = input_to_cupy_array(df)
+    assert str(array.dtype) == 'float64'
+    assert cp.isnan(array[1])

--- a/python/cuml/thirdparty_adapters/adapters.py
+++ b/python/cuml/thirdparty_adapters/adapters.py
@@ -277,7 +277,8 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     else:
         X, n_rows, n_cols, dtype = input_to_cupy_array(array,
                                                        order=order,
-                                                       deepcopy=copy)
+                                                       deepcopy=copy,
+                                                       fail_on_nan=False)
         if correct_dtype != dtype:
             X = X.astype(correct_dtype)
         check_finite(X, force_all_finite)

--- a/python/cuml/thirdparty_adapters/adapters.py
+++ b/python/cuml/thirdparty_adapters/adapters.py
@@ -278,7 +278,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
         X, n_rows, n_cols, dtype = input_to_cupy_array(array,
                                                        order=order,
                                                        deepcopy=copy,
-                                                       fail_on_nan=False)
+                                                       fail_on_null=False)
         if correct_dtype != dtype:
             X = X.astype(correct_dtype)
         check_finite(X, force_all_finite)


### PR DESCRIPTION
Answers #2966 .
This change should probably be implemented in cuDF. In the meantime, I modified the `input_to_cupy_array` function to produce a proper conversion of cuDF Dataframe and Series to cuPy array even when they contain missing values. The data is upcasted to float64 when necessary.