### PR TITLE
[REVIEW] Disable ascending=false path for sortColumnsPerRow and sporadically-failing FIL test [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PR #3180: FIL: `blocks_per_sm` support in Python
 
 ## Bug Fixes
+- PR #3196: Disable ascending=false path for sortColumnsPerRow
 - PR #3179: Remove unused metrics.cu file
 - PR #3069: Prevent conversion of DataFrames to Series in preprocessing
 - PR #3065: Refactoring prims metrics function names from camelcase to underscore format

--- a/cpp/src_prims/selection/columnWiseSort.cuh
+++ b/cpp/src_prims/selection/columnWiseSort.cuh
@@ -160,7 +160,7 @@ cudaError_t layoutSortOffset(T *in, T value, int n_times, cudaStream_t stream) {
 
 /**
  * @brief sort columns within each row of row-major input matrix and return sorted indexes
- * modelled as key-value sort with key being input matrix and value being index of values 
+ * modelled as key-value sort with key being input matrix and value being index of values
  * @param in: input matrix
  * @param out: output value(index) matrix
  * @param n_rows: number rows of input matrix
@@ -176,6 +176,7 @@ void sortColumnsPerRow(const InType *in, OutType *out, int n_rows,
                        int n_columns, bool &bAllocWorkspace, void *workspacePtr,
                        size_t &workspaceSize, cudaStream_t stream,
                        InType *sortedKeys = nullptr, bool ascending = true) {
+  ASSERT(ascending, "Descending sort not implemented yet");
   // assume non-square row-major matrices
   // current use-case: KNN, trustworthiness scores
   // output : either sorted indices or sorted indices and input values

--- a/cpp/test/prims/columnSort.cu
+++ b/cpp/test/prims/columnSort.cu
@@ -46,7 +46,7 @@ struct columnSort {
   int n_row;
   int n_col;
   bool testKeys;
-  bool asending;
+  bool ascending;
 };
 
 template <typename T>
@@ -81,7 +81,7 @@ class ColumnSort : public ::testing::TestWithParam<columnSort<T>> {
     for (int i = 0; i < params.n_row; i++) {
       std::vector<T> tmp(vals.begin() + i * params.n_col,
                          vals.begin() + (i + 1) * params.n_col);
-      auto cpuOut = sort_indexes(tmp, params.asending);
+      auto cpuOut = sort_indexes(tmp, params.ascending);
       std::copy((*cpuOut).begin(), (*cpuOut).end(),
                 cValGolden.begin() + i * params.n_col);
       delete cpuOut;
@@ -101,8 +101,17 @@ class ColumnSort : public ::testing::TestWithParam<columnSort<T>> {
 
     bool needWorkspace = false;
     size_t workspaceSize = 0;
-    sortColumnsPerRow(keyIn, valueOut, params.n_row, params.n_col,
-                      needWorkspace, NULL, workspaceSize, stream, keySorted);
+    if (!params.ascending) {
+      // Remove this branch once the implementation of descending sort is fixed.
+      EXPECT_THROW(sortColumnsPerRow(
+                     keyIn, valueOut, params.n_row, params.n_col, needWorkspace,
+                     NULL, workspaceSize, stream, keySorted, params.ascending),
+                   raft::exception);
+    } else {
+      sortColumnsPerRow(keyIn, valueOut, params.n_row, params.n_col,
+                        needWorkspace, NULL, workspaceSize, stream, keySorted,
+                        params.ascending);
+    }
     if (needWorkspace) {
       raft::allocate(workspacePtr, workspaceSize);
       sortColumnsPerRow(keyIn, valueOut, params.n_row, params.n_col,
@@ -140,12 +149,16 @@ const std::vector<columnSort<float>> inputsf1 = {
 
 typedef ColumnSort<float> ColumnSortF;
 TEST_P(ColumnSortF, Result) {
-  ASSERT_TRUE(devArrMatch(valueOut, goldenValOut, params.n_row * params.n_col,
-                          raft::CompareApprox<float>(params.tolerance)));
-  if (params.testKeys) {
-    ASSERT_TRUE(devArrMatch(keySorted, keySortGolden,
-                            params.n_row * params.n_col,
+  // Remove this condition once the implementation of of descending sort is
+  // fixed.
+  if (params.ascending) {
+    ASSERT_TRUE(devArrMatch(valueOut, goldenValOut, params.n_row * params.n_col,
                             raft::CompareApprox<float>(params.tolerance)));
+    if (params.testKeys) {
+      ASSERT_TRUE(devArrMatch(keySorted, keySortGolden,
+                              params.n_row * params.n_col,
+                              raft::CompareApprox<float>(params.tolerance)));
+    }
   }
 }
 

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -751,8 +751,9 @@ std::vector<FilTestParams> predict_sparse_inputs = {
 
 TEST_P(PredictSparse16FilTest, Predict) { compare(); }
 
-INSTANTIATE_TEST_CASE_P(FilTests, PredictSparse16FilTest,
-                        testing::ValuesIn(predict_sparse_inputs));
+// Temporarily disabled, see https://github.com/rapidsai/cuml/issues/3205
+// INSTANTIATE_TEST_CASE_P(FilTests, PredictSparse16FilTest,
+//                        testing::ValuesIn(predict_sparse_inputs));
 
 TEST_P(PredictSparse8FilTest, Predict) { compare(); }
 


### PR DESCRIPTION
Temporarily disable ascending=false option for sortColumnsPerRow.