### PR TITLE
[REVIEW] FIX Fix EXITCODE override in test_notebooks script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PR #3162: Removing accidentally checked in debug file
 - PR #3175: Fix gtest pinned cmake version for build from source option
 - PR #3182: Fix a bug in MSE metric calculation
+- PR #3208: Fix EXITCODE override in notebook test script
 
 
 # cuML 0.16.0 (23 Oct 2020)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -241,4 +241,8 @@ else
 
 fi
 
+if [ -n "\${CODECOV_TOKEN}" ]; then
+    codecov -t \$CODECOV_TOKEN
+fi
+
 return ${EXITCODE}

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -110,9 +110,6 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     ################################################################################
     # TEST - Run GoogleTest and py.tests for libcuml and cuML
     ################################################################################
-    set +e -Eo pipefail
-    EXITCODE=0
-    trap "EXITCODE=1" ERR
     
     if hasArg --skip-tests; then
         gpuci_logger "Skipping Tests"
@@ -139,6 +136,9 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     ################################################################################
     # TEST - Run notebook tests
     ################################################################################
+    set +e -Eo pipefail
+    EXITCODE=0
+    trap "EXITCODE=1" ERR
 
     gpuci_logger "Notebook tests"
     ${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log

--- a/ci/gpu/test-notebooks.sh
+++ b/ci/gpu/test-notebooks.sh
@@ -15,7 +15,7 @@ SKIPNBS="cuml_benchmarks.ipynb"
 ## Check env
 env
 
-EXITCODE=0
+NOTEBOOKS_EXITCODE=0
 
 # Always run nbtest in all TOPLEVEL_NB_FOLDERS, set EXITCODE to failure
 # if any run fails
@@ -36,7 +36,7 @@ for nb in $(find . -name "*.ipynb"); do
     else
         nvidia-smi
         ${NBTEST} ${nbBasename}
-        EXITCODE=$((EXITCODE | $?))
+        NOTEBOOKS_EXITCODE=$((NOTEBOOKS_EXITCODE | $?))
         rm -rf ${LIBCUDF_KERNEL_CACHE_PATH}/*
     fi
 done
@@ -44,4 +44,4 @@ done
 
 nvidia-smi
 
-exit ${EXITCODE}
+exit ${NOTEBOOKS_EXITCODE}


### PR DESCRIPTION
This script used to override the `EXITCODE` trap in `gpu/build.sh` causing failures in anything ran before the notebooks to be missed. Renaming the variable will avoid this problem in the future.

Closes: https://github.com/rapidsai/cuml/issues/3207