### PR TITLE
[REVIEW] Set absolute tolerance to improve silhouette_score test consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 - PR #3164: Expose silhouette score in Python
-- PR #3213: Correct flaky silhouette score test by setting atol
+- PR #3214: Correct flaky silhouette score test by setting atol
 - PR #2659: Add initial max inner product sparse knn
 - PR #2836: Refactor UMAP to accept sparse inputs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 - PR #3164: Expose silhouette score in Python
+- PR #3213: Correct flaky silhouette score test by setting atol
 - PR #2659: Add initial max inner product sparse knn
 - PR #2836: Refactor UMAP to accept sparse inputs
 

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -244,7 +244,7 @@ def test_silhouette_samples(metric, labeled_clusters):
     X, labels = labeled_clusters
     cuml_scores = cu_silhouette_samples(X, labels, metric=metric)
     sk_scores = sk_silhouette_samples(X, labels, metric=metric)
-    assert_allclose(cuml_scores, sk_scores, rtol=1e-2)
+    assert_allclose(cuml_scores, sk_scores, rtol=1e-2, atol=1e-5)
 
 
 def score_homogeneity(ground_truth, predictions, use_handle):


### PR DESCRIPTION
Add atol parameter to silhouette_score test to ensure consistent test behavior