### PR TITLE
[REVIEW] Added a missing __syncthreads()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - PR #3162: Removing accidentally checked in debug file
 - PR #3175: Fix gtest pinned cmake version for build from source option
 - PR #3182: Fix a bug in MSE metric calculation
+- PR #3215: Add a missing `__syncthreads()`
 
 
 # cuML 0.16.0 (23 Oct 2020)

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -247,6 +247,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES> : finalize_block {
     per_thread[threadIdx.x] = acc;
     __syncthreads();
     acc = multi_sum<6>(per_thread, num_classes, blockDim.x / num_classes);
+    __syncthreads();
     write_best_class_in_block(to_vec(threadIdx.x, acc), num_classes, out,
                               num_rows);
   }

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -752,8 +752,8 @@ std::vector<FilTestParams> predict_sparse_inputs = {
 TEST_P(PredictSparse16FilTest, Predict) { compare(); }
 
 // Temporarily disabled, see https://github.com/rapidsai/cuml/issues/3205
-// INSTANTIATE_TEST_CASE_P(FilTests, PredictSparse16FilTest,
-//                        testing::ValuesIn(predict_sparse_inputs));
+INSTANTIATE_TEST_CASE_P(FilTests, PredictSparse16FilTest,
+                        testing::ValuesIn(predict_sparse_inputs));
 
 TEST_P(PredictSparse8FilTest, Predict) { compare(); }
 


### PR DESCRIPTION
Added a missing `__syncthreads()`.

- also re-enabled Sparse16 FIL tests
- this should fix #3205 and #3206