### PR TITLE
Ignore splits that do not satisfy constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - PR #3182: Fix a bug in MSE metric calculation
 - PR #3190: Fix Attribute error on ICPA #3183 and PCA input type
 - PR #3208: Fix EXITCODE override in notebook test script
+- PR #3216: Ignore splits that do not satisfy constraints
 
 
 # cuML 0.16.0 (23 Oct 2020)

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -402,6 +402,7 @@ struct ClsTraits {
     computeSplitClassificationKernel<DataT, LabelT, IdxT, TPB_DEFAULT>
       <<<grid, TPB_DEFAULT, smemSize, s>>>(
         b.hist, b.params.n_bins, b.params.max_depth, b.params.min_samples_split,
+        b.params.min_samples_leaf, b.params.min_impurity_decrease,
         b.params.max_leaves, b.input, b.curr_nodes, col, b.done_count, b.mutex,
         b.n_leaves, b.splits, splitType);
   }

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -479,9 +479,10 @@ struct RegTraits {
     computeSplitRegressionKernel<DataT, DataT, IdxT, TPB_DEFAULT>
       <<<grid, TPB_DEFAULT, smemSize, s>>>(
         b.pred, b.pred2, b.pred2P, b.pred_count, b.params.n_bins,
-        b.params.max_depth, b.params.min_samples_split, b.params.max_leaves,
-        b.input, b.curr_nodes, col, b.done_count, b.mutex, b.n_leaves, b.splits,
-        b.block_sync, splitType);
+        b.params.max_depth, b.params.min_samples_split,
+        b.params.min_samples_leaf, b.params.min_impurity_decrease,
+        b.params.max_leaves, b.input, b.curr_nodes, col, b.done_count, b.mutex,
+        b.n_leaves, b.splits, b.block_sync, splitType);
   }
 
   /**

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -267,10 +267,10 @@ __device__ OutT* alignPointer(InT input) {
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 __global__ void computeSplitClassificationKernel(
   int* hist, IdxT nbins, IdxT max_depth, IdxT min_samples_split,
-  IdxT max_leaves, Input<DataT, LabelT, IdxT> input,
-  const Node<DataT, LabelT, IdxT>* nodes, IdxT colStart, int* done_count,
-  int* mutex, const IdxT* n_leaves, Split<DataT, IdxT>* splits,
-  CRITERION splitType) {
+  IdxT min_samples_leaf, DataT min_impurity_decrease, IdxT max_leaves,
+  Input<DataT, LabelT, IdxT> input, const Node<DataT, LabelT, IdxT>* nodes,
+  IdxT colStart, int* done_count, int* mutex, const IdxT* n_leaves,
+  Split<DataT, IdxT>* splits, CRITERION splitType) {
   extern __shared__ char smem[];
   IdxT nid = blockIdx.z;
   auto node = nodes[nid];
@@ -326,7 +326,8 @@ __global__ void computeSplitClassificationKernel(
   sp.init();
   __syncthreads();
   if (splitType == CRITERION::GINI) {
-    giniGain<DataT, IdxT>(shist, sbins, sp, col, range_len, nbins, nclasses);
+    giniGain<DataT, IdxT>(shist, sbins, sp, col, range_len, nbins, nclasses,
+                          min_samples_leaf, min_impurity_decrease);
   } else {
     entropyGain<DataT, IdxT>(shist, sbins, sp, col, range_len, nbins, nclasses);
   }

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -337,7 +337,8 @@ __global__ void computeSplitClassificationKernel(
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 __global__ void computeSplitRegressionKernel(
   DataT* pred, DataT* pred2, DataT* pred2P, IdxT* count, IdxT nbins,
-  IdxT max_depth, IdxT min_samples_split, IdxT max_leaves,
+  IdxT max_depth, IdxT min_samples_split, IdxT min_samples_leaf,
+  DataT min_impurity_decrease, IdxT max_leaves,
   Input<DataT, LabelT, IdxT> input, const Node<DataT, LabelT, IdxT>* nodes,
   IdxT colStart, int* done_count, int* mutex, const IdxT* n_leaves,
   Split<DataT, IdxT>* splits, void* workspace, CRITERION splitType) {
@@ -471,7 +472,8 @@ __global__ void computeSplitRegressionKernel(
       scount[i] = count[gcOffset + i];
     }
     __syncthreads();
-    mseGain(spred, scount, sbins, sp, col, range_len, nbins);
+    mseGain(spred, scount, sbins, sp, col, range_len, nbins, min_samples_leaf,
+            min_impurity_decrease);
   } else {
     for (IdxT i = threadIdx.x; i < len; i += blockDim.x) {
       spred2[i] = pred2[gOffset + i];

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -329,7 +329,8 @@ __global__ void computeSplitClassificationKernel(
     giniGain<DataT, IdxT>(shist, sbins, sp, col, range_len, nbins, nclasses,
                           min_samples_leaf, min_impurity_decrease);
   } else {
-    entropyGain<DataT, IdxT>(shist, sbins, sp, col, range_len, nbins, nclasses);
+    entropyGain<DataT, IdxT>(shist, sbins, sp, col, range_len, nbins, nclasses,
+                             min_samples_leaf, min_impurity_decrease);
   }
   __syncthreads();
   sp.evalBestSplit(smem, splits + nid, mutex + nid);
@@ -483,7 +484,8 @@ __global__ void computeSplitRegressionKernel(
       spred2P[i] = pred2P[gcOffset + i];
     }
     __syncthreads();
-    maeGain(spred2, spred2P, scount, sbins, sp, col, range_len, nbins);
+    maeGain(spred2, spred2P, scount, sbins, sp, col, range_len, nbins,
+            min_samples_leaf, min_impurity_decrease);
   }
   __syncthreads();
   sp.evalBestSplit(smem, splits + nid, mutex + nid);

--- a/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
@@ -157,20 +157,20 @@ DI void entropyGain(int* shist, DataT* sbins, Split<DataT, IdxT>& sp, IdxT col,
         auto lval_i = shist[i * 2 * nclasses + j];
         if (lval_i != 0) {
           auto lval = DataT(lval_i);
-          gain += raft::myLog(lval * invLeft) * lval * invlen;
+          gain += raft::myLog(lval * invLeft) / raft::myLog(DataT(2)) * lval * invlen;
         }
 
         val_i += lval_i;
         auto rval_i = shist[i * 2 * nclasses + nclasses + j];
         if (rval_i != 0) {
           auto rval = DataT(rval_i);
-          gain += raft::myLog(rval * invRight) * rval * invlen;
+          gain += raft::myLog(rval * invRight) / raft::myLog(DataT(2)) * rval * invlen;
         }
 
         val_i += rval_i;
         if (val_i != 0) {
           auto val = DataT(val_i) * invlen;
-          gain -= val * raft::myLog(val);
+          gain -= val * raft::myLog(val) / raft::myLog(DataT(2));
         }
       }
     }

--- a/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
@@ -157,14 +157,16 @@ DI void entropyGain(int* shist, DataT* sbins, Split<DataT, IdxT>& sp, IdxT col,
         auto lval_i = shist[i * 2 * nclasses + j];
         if (lval_i != 0) {
           auto lval = DataT(lval_i);
-          gain += raft::myLog(lval * invLeft) / raft::myLog(DataT(2)) * lval * invlen;
+          gain +=
+            raft::myLog(lval * invLeft) / raft::myLog(DataT(2)) * lval * invlen;
         }
 
         val_i += lval_i;
         auto rval_i = shist[i * 2 * nclasses + nclasses + j];
         if (rval_i != 0) {
           auto rval = DataT(rval_i);
-          gain += raft::myLog(rval * invRight) / raft::myLog(DataT(2)) * rval * invlen;
+          gain += raft::myLog(rval * invRight) / raft::myLog(DataT(2)) * rval *
+                  invlen;
         }
 
         val_i += rval_i;

--- a/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
@@ -102,27 +102,41 @@ DI void giniGain(int* shist, DataT* sbins, Split<DataT, IdxT>& sp, IdxT col,
         gain -= val * val;
       }
     }
+    // if the gain is not "enough", don't bother!
     if (gain <= min_impurity_decrease) {
-      sp.update({sbins[i], col, gain, nLeft});
+      gain = -NumericLimits<DataT>::kMax;
     }
+    sp.update({sbins[i], col, gain, nLeft});
   }
 }
 
 /**
  * @brief Compute gain based on entropy
  *
- * @param[in]    shist    left/right class histograms for all bins
- *                        [dim = nbins x 2 x nclasses]
- * @param[in]    sbins    quantiles for the current column [len = nbins]
- * @param[inout] sp       will contain the per-thread best split so far
- * @param[in]    col      current column
- * @param[in]    len      total number of samples for the current node to be split
- * @param[in]    nbins    number of bins
- * @param[in]    nclasses number of classes
+ * @param[in]    shist                 left/right class histograms for all bins
+ *                                     [dim = nbins x 2 x nclasses]
+ * @param[in]    sbins                 quantiles for the current column
+ *                                     [len = nbins]
+ * @param[inout] sp                    will contain the per-thread best split
+ *                                     so far
+ * @param[in]    col                   current column
+ * @param[in]    len                   total number of samples for the current
+ *                                     node to be split
+ * @param[in]    nbins                 number of bins
+ * @param[in]    nclasses              number of classes
+ * @param[in]    min_samples_leaf      minimum number of samples per each leaf.
+ *                                     Any splits that lead to a leaf node with
+ *                                     samples fewer than min_samples_leaf will
+ *                                     be ignored.
+ * @param[in]    min_impurity_decrease minimum improvement in MSE metric. Any
+ *                                     splits that do not improve (decrease)
+ *                                     the MSE metric at least by this amount
+ *                                     will be ignored.
  */
 template <typename DataT, typename IdxT>
 DI void entropyGain(int* shist, DataT* sbins, Split<DataT, IdxT>& sp, IdxT col,
-                    IdxT len, IdxT nbins, IdxT nclasses) {
+                    IdxT len, IdxT nbins, IdxT nclasses, IdxT min_samples_leaf,
+                    DataT min_impurity_decrease) {
   constexpr DataT One = DataT(1.0);
   DataT invlen = One / len;
   for (IdxT i = threadIdx.x; i < nbins; i += blockDim.x) {
@@ -131,31 +145,38 @@ DI void entropyGain(int* shist, DataT* sbins, Split<DataT, IdxT>& sp, IdxT col,
       nLeft += shist[i * 2 * nclasses + j];
     }
     auto nRight = len - nLeft;
-    auto invLeft = One / nLeft;
-    auto invRight = One / nRight;
     auto gain = DataT(0.0);
-    for (IdxT j = 0; j < nclasses; ++j) {
-      int val_i = 0;
-      if (nLeft != 0) {
+    // if there aren't enough samples in this split, don't bother!
+    if (nLeft < min_samples_leaf || nRight < min_samples_leaf) {
+      gain = -NumericLimits<DataT>::kMax;
+    } else {
+      auto invLeft = One / nLeft;
+      auto invRight = One / nRight;
+      for (IdxT j = 0; j < nclasses; ++j) {
+        int val_i = 0;
         auto lval_i = shist[i * 2 * nclasses + j];
         if (lval_i != 0) {
           auto lval = DataT(lval_i);
           gain += raft::myLog(lval * invLeft) * lval * invlen;
         }
+
         val_i += lval_i;
-      }
-      if (nRight != 0) {
         auto rval_i = shist[i * 2 * nclasses + nclasses + j];
         if (rval_i != 0) {
           auto rval = DataT(rval_i);
           gain += raft::myLog(rval * invRight) * rval * invlen;
         }
+
         val_i += rval_i;
+        if (val_i != 0) {
+          auto val = DataT(val_i) * invlen;
+          gain -= val * raft::myLog(val);
+        }
       }
-      if (val_i != 0) {
-        auto val = DataT(val_i) * invlen;
-        gain -= val * raft::myLog(val);
-      }
+    }
+    // if the gain is not "enough", don't bother!
+    if (gain <= min_impurity_decrease) {
+      gain = -NumericLimits<DataT>::kMax;
     }
     sp.update({sbins[i], col, gain, nLeft});
   }
@@ -219,32 +240,51 @@ DI void mseGain(DataT* spred, IdxT* scount, DataT* sbins,
 /**
  * @brief Compute gain based on MAE
  *
- * @param[in]    spred   left/right child sum of abs diff of prediction for all
- *                       bins [dim = 2 x bins]
- * @param[in]    spredP  parent's sum of abs diff of prediction for all bins
- *                       [dim = 2 x bins]
- * @param[in]    scount  left child count for all bins [len = nbins]
- * @param[in]    sbins   quantiles for the current column [len = nbins]
- * @param[inout] sp      will contain the per-thread best split so far
- * @param[in]    col     current column
- * @param[in]    len     total number of samples for current node to be split
- * @param[in]    nbins   number of bins
+ * @param[in]    spred                 left/right child sum of abs diff of
+ *                                     prediction for all bins [dim = 2 x bins]
+ * @param[in]    spredP                parent's sum of abs diff of prediction
+ *                                     for all bins [dim = 2 x bins]
+ * @param[in]    scount                left child count for all bins
+ *                                     [len = nbins]
+ * @param[in]    sbins                 quantiles for the current column
+ *                                     [len = nbins]
+ * @param[inout] sp                    will contain the per-thread best split
+ *                                     so far
+ * @param[in]    col                   current column
+ * @param[in]    len                   total number of samples for current node
+ *                                     to be split
+ * @param[in]    nbins                 number of bins
+ * @param[in]    min_samples_leaf      minimum number of samples per each leaf.
+ *                                     Any splits that lead to a leaf node with
+ *                                     samples fewer than min_samples_leaf will
+ *                                     be ignored.
+ * @param[in]    min_impurity_decrease minimum improvement in MSE metric. Any
+ *                                     splits that do not improve (decrease)
+ *                                     the MSE metric at least by this amount
+ *                                     will be ignored.
  */
 template <typename DataT, typename IdxT>
 DI void maeGain(DataT* spred, DataT* spredP, IdxT* scount, DataT* sbins,
-                Split<DataT, IdxT>& sp, IdxT col, IdxT len, IdxT nbins) {
+                Split<DataT, IdxT>& sp, IdxT col, IdxT len, IdxT nbins,
+                IdxT min_samples_leaf, DataT min_impurity_decrease) {
   auto invlen = DataT(1.0) / len;
   for (IdxT i = threadIdx.x; i < nbins; i += blockDim.x) {
     auto nLeft = scount[i];
     auto nRight = len - nLeft;
-    DataT gain = spredP[i];
-    if (nLeft != 0) {
+    DataT gain;
+    // if there aren't enough samples in this split, don't bother!
+    if (nLeft < min_samples_leaf || nRight < min_samples_leaf) {
+      gain = -NumericLimits<DataT>::kMax;
+    } else {
+      gain = spredP[i];
       gain -= spred[i];
-    }
-    if (nRight != 0) {
       gain -= spred[i + nbins];
+      gain *= invlen;
     }
-    gain *= invlen;
+    // if the gain is not "enough", don't bother!
+    if (gain <= min_impurity_decrease) {
+      gain = -NumericLimits<DataT>::kMax;
+    }
     sp.update({sbins[i], col, gain, nLeft});
   }
 }

--- a/cpp/test/sg/decisiontree_batchedlevel_unittest.cu
+++ b/cpp/test/sg/decisiontree_batchedlevel_unittest.cu
@@ -301,7 +301,8 @@ TEST_P(TestMetric, MSEGain) {
   computeSplitRegressionKernel<DataT, DataT, IdxT, 32>
     <<<grid, 32, smemSize, 0>>>(
       pred, nullptr, nullptr, pred_count, n_bins, params.max_depth,
-      params.min_samples_split, params.max_leaves, input, curr_nodes, 0,
+      params.min_samples_split, params.min_samples_leaf,
+      params.min_impurity_decrease, params.max_leaves, input, curr_nodes, 0,
       done_count, mutex, n_new_leaves, splits, nullptr, params.split_criterion);
   raft::update_host(h_splits.data(), splits, 1, 0);
   CUDA_CHECK(cudaGetLastError());


### PR DESCRIPTION
Per suggestion of @teju85. We should ignore all split candidates that do not satisfy the constraints `min_samples_leaf` and `min_impurity_decrease`.

TODO: Apply the same fix to the following functions:
- [x] `maeGain`
- [x] `entropyGain`
- [x] `giniGain`