### PR TITLE
[WIP] Avoid unnecessary split for degenerate case where all labels are identical, by checking label range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - PR #3190: Fix Attribute error on ICPA #3183 and PCA input type
 - PR #3208: Fix EXITCODE override in notebook test script
 - PR #3216: Ignore splits that do not satisfy constraints
+- PR #3231: Avoid unnecessary split for degenerate case where all labels are identical
 
 # cuML 0.16.0 (23 Oct 2020)
 

--- a/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder_base.cuh
@@ -485,7 +485,7 @@ struct RegTraits {
     }
     CUDA_CHECK(
       cudaMemsetAsync(b.pred_count, 0, sizeof(IdxT) * b.nPredCounts, s));
-    initLabelRange<<<dim3(n_col_blks, batchSize, 1), 1>>>(b.label_range);
+    initLabelRange<<<dim3(n_col_blks, batchSize, 1), 1, 0, s>>>(b.label_range);
     computeSplitRegressionKernel<DataT, DataT, IdxT, TPB_DEFAULT>
       <<<grid, TPB_DEFAULT, smemSize, s>>>(
         b.pred, b.pred2, b.pred2P, b.pred_count, b.label_range, b.params.n_bins,

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -27,21 +27,6 @@
 
 namespace {
 
-template <typename DataT>
-class NumericLimits;
-
-template <>
-class NumericLimits<float> {
- public:
-  static constexpr double kMax = __FLT_MAX__;
-};
-
-template <>
-class NumericLimits<double> {
- public:
-  static constexpr double kMax = __DBL_MAX__;
-};
-
 __device__ void atomicMin(float* const address, const float value) {
   if (*address <= value) {
     return;

--- a/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/metrics.cuh
@@ -22,7 +22,8 @@
 #include "node.cuh"
 #include "split.cuh"
 
-namespace {
+namespace ML {
+namespace DecisionTree {
 
 template <typename DataT>
 class NumericLimits;
@@ -38,11 +39,6 @@ class NumericLimits<double> {
  public:
   static constexpr double kMax = __DBL_MAX__;
 };
-
-}  // anonymous namespace
-
-namespace ML {
-namespace DecisionTree {
 
 /**
  * @brief Compute gain based on gini impurity metric

--- a/cpp/test/sg/decisiontree_batchedlevel_unittest.cu
+++ b/cpp/test/sg/decisiontree_batchedlevel_unittest.cu
@@ -301,6 +301,7 @@ TEST_P(TestMetric, MSEGain) {
   std::vector<Traits::SplitT> h_splits(1);
   std::vector<LabelT> h_label_range(max_batch * 2 * n_col_blks);
 
+  initLabelRange<<<dim3(n_col_blks, batchSize, 1), 1, 0, 0>>>(label_range);
   computeSplitRegressionKernel<DataT, DataT, IdxT, 32>
     <<<grid, 32, smemSize, 0>>>(
       pred, nullptr, nullptr, pred_count, label_range, n_bins, params.max_depth,


### PR DESCRIPTION
Partially addresses #3188 by not adding a new split for the special case where the data in the node have all identical labels. This degenerate case may occur if the data was generated with `make_blobs`.

Closes #3128