### PR TITLE
[REVIEW] Fix intermittent dask random forest failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PR #3208: Fix EXITCODE override in notebook test script
 - PR #3216: Ignore splits that do not satisfy constraints
 - PR #3239: Fix intermittent dask random forest failure
+
 # cuML 0.16.0 (23 Oct 2020)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 - PR #3190: Fix Attribute error on ICPA #3183 and PCA input type
 - PR #3208: Fix EXITCODE override in notebook test script
 - PR #3216: Ignore splits that do not satisfy constraints
-
+- PR #3239: Fix intermittent dask random forest failure
 # cuML 0.16.0 (23 Oct 2020)
 
 ## New Features

--- a/python/cuml/test/dask/test_random_forest.py
+++ b/python/cuml/test/dask/test_random_forest.py
@@ -320,7 +320,7 @@ def test_rf_concatenation_dask(client, model_type):
 @pytest.mark.parametrize('model_type', ['classification', 'regression'])
 @pytest.mark.parametrize('ignore_empty_partitions', [True, False])
 def test_single_input(client, model_type, ignore_empty_partitions):
-    X, y = make_classification(n_samples=1)
+    X, y = make_classification(n_samples=1, n_classes=1)
     X = X.astype(np.float32)
     if model_type == 'classification':
         y = y.astype(np.int32)


### PR DESCRIPTION
Adding `n_classes=1` when `n_samples=1` to ensure that class is always labelled 0.

Closes https://github.com/rapidsai/cuml/issues/3202

