### PR TITLE
[REVIEW] Rename rows_sample -> max_samples in RF to be consistent with sklearn's RF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 - PR #3214: Correct flaky silhouette score test by setting atol
 - PR #3216: Ignore splits that do not satisfy constraints
 - PR #3239: Fix intermittent dask random forest failure
+- PR #3245: Rename `rows_sample` -> `max_samples` to be consistent with sklearn's RF
 
 # cuML 0.16.0 (23 Oct 2020)
 

--- a/cpp/bench/sg/fil.cu
+++ b/cpp/bench/sg/fil.cu
@@ -146,7 +146,7 @@ std::vector<Params> getInputs() {
   set_rf_params(p.rf,  // Output RF parameters
                 1,  // n_trees, just a placeholder value, anyway changed below
                 true,  // bootstrap
-                1.f,   // rows_sample
+                1.f,   // max_samples
                 1234,  // seed
                 8);    // n_streams
 

--- a/cpp/bench/sg/rf_classifier.cu
+++ b/cpp/bench/sg/rf_classifier.cu
@@ -86,7 +86,7 @@ std::vector<Params> getInputs() {
   set_rf_params(p.rf,  // Output RF parameters
                 500,   // n_trees
                 true,  // bootstrap
-                1.f,   // rows_sample
+                1.f,   // max_samples
                 1234,  // seed
                 8);    // n_streams
 

--- a/cpp/bench/sg/rf_regressor.cu
+++ b/cpp/bench/sg/rf_regressor.cu
@@ -88,7 +88,7 @@ std::vector<RegParams> getInputs() {
   set_rf_params(p.rf,  // Output RF parameters
                 500,   // n_trees
                 true,  // bootstrap
-                1.f,   // rows_sample
+                1.f,   // max_samples
                 1234,  // seed
                 8);    // n_streams
 

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -60,7 +60,7 @@ struct RF_params {
    * Control bootstrapping.
    * If bootstrapping is set to true, bootstrapped samples are used for building
    * each tree. Bootstrapped sampling is done by randomly drawing
-   * round(rows_sample * n_samples) number of samples with replacement. More on
+   * round(max_samples * n_samples) number of samples with replacement. More on
    * bootstrapping:
    *     https://en.wikipedia.org/wiki/Bootstrap_aggregating
    * If boostrapping is set to false, whole dataset is used to build each
@@ -70,7 +70,7 @@ struct RF_params {
   /**
    * Ratio of dataset rows used while fitting each tree.
    */
-  float rows_sample;
+  float max_samples;
   /**
    * Decision tree training hyper parameter struct.
    */
@@ -88,10 +88,10 @@ struct RF_params {
 };
 
 void set_rf_params(RF_params& params, int cfg_n_trees = 1,
-                   bool cfg_bootstrap = true, float cfg_rows_sample = 1.0f,
+                   bool cfg_bootstrap = true, float cfg_max_samples = 1.0f,
                    int cfg_seed = -1, int cfg_n_streams = 8);
 void set_all_rf_params(RF_params& params, int cfg_n_trees, bool cfg_bootstrap,
-                       float cfg_rows_sample, int cfg_seed, int cfg_n_streams,
+                       float cfg_max_samples, int cfg_seed, int cfg_n_streams,
                        DecisionTree::DecisionTreeParams cfg_tree_params);
 void validity_check(const RF_params rf_params);
 void print(const RF_params rf_params);
@@ -190,7 +190,7 @@ RF_params set_rf_class_obj(int max_depth, int max_leaves, float max_features,
                            int n_bins, int split_algo, int min_samples_leaf,
                            int min_samples_split, float min_impurity_decrease,
                            bool bootstrap_features, bool bootstrap, int n_trees,
-                           float rows_sample, int seed,
+                           float max_samples, int seed,
                            CRITERION split_criterion, bool quantile_per_tree,
                            int cfg_n_streams, bool use_experimental_backend,
                            int max_batch_size);

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -155,14 +155,14 @@ void postprocess_labels(int n_rows, std::vector<int>& labels,
  * @param[in,out] params: update with random forest parameters
  * @param[in] cfg_n_trees: number of trees; default 1
  * @param[in] cfg_bootstrap: bootstrapping; default true
- * @param[in] cfg_rows_sample: rows sample; default 1.0f
+ * @param[in] cfg_max_samples: rows sample; default 1.0f
  * @param[in] cfg_n_streams: No of parallel CUDA for training forest
  */
 void set_rf_params(RF_params& params, int cfg_n_trees, bool cfg_bootstrap,
-                   float cfg_rows_sample, int cfg_seed, int cfg_n_streams) {
+                   float cfg_max_samples, int cfg_seed, int cfg_n_streams) {
   params.n_trees = cfg_n_trees;
   params.bootstrap = cfg_bootstrap;
-  params.rows_sample = cfg_rows_sample;
+  params.max_samples = cfg_max_samples;
   params.seed = cfg_seed;
   params.n_streams = min(cfg_n_streams, omp_get_max_threads());
   if (params.n_streams == cfg_n_streams) {
@@ -178,16 +178,16 @@ void set_rf_params(RF_params& params, int cfg_n_trees, bool cfg_bootstrap,
  * @param[in,out] params: update with random forest parameters
  * @param[in] cfg_n_trees: number of trees
  * @param[in] cfg_bootstrap: bootstrapping
- * @param[in] cfg_rows_sample: rows sample
+ * @param[in] cfg_max_samples: rows sample
  * @param[in] cfg_n_streams: No of parallel CUDA for training forest
  * @param[in] cfg_tree_params: tree parameters
  */
 void set_all_rf_params(RF_params& params, int cfg_n_trees, bool cfg_bootstrap,
-                       float cfg_rows_sample, int cfg_seed, int cfg_n_streams,
+                       float cfg_max_samples, int cfg_seed, int cfg_n_streams,
                        DecisionTree::DecisionTreeParams cfg_tree_params) {
   params.n_trees = cfg_n_trees;
   params.bootstrap = cfg_bootstrap;
-  params.rows_sample = cfg_rows_sample;
+  params.max_samples = cfg_max_samples;
   params.seed = cfg_seed;
   params.n_streams = min(cfg_n_streams, omp_get_max_threads());
   if (cfg_n_trees < params.n_streams) params.n_streams = cfg_n_trees;
@@ -201,9 +201,9 @@ void set_all_rf_params(RF_params& params, int cfg_n_trees, bool cfg_bootstrap,
  */
 void validity_check(const RF_params rf_params) {
   ASSERT((rf_params.n_trees > 0), "Invalid n_trees %d", rf_params.n_trees);
-  ASSERT((rf_params.rows_sample > 0) && (rf_params.rows_sample <= 1.0),
-         "rows_sample value %f outside permitted (0, 1] range",
-         rf_params.rows_sample);
+  ASSERT((rf_params.max_samples > 0) && (rf_params.max_samples <= 1.0),
+         "max_samples value %f outside permitted (0, 1] range",
+         rf_params.max_samples);
   DecisionTree::validity_check(rf_params.tree_params);
 }
 
@@ -215,7 +215,7 @@ void print(const RF_params rf_params) {
   ML::PatternSetter _("%v");
   CUML_LOG_DEBUG("n_trees: %d", rf_params.n_trees);
   CUML_LOG_DEBUG("bootstrap: %d", rf_params.bootstrap);
-  CUML_LOG_DEBUG("rows_sample: %f", rf_params.rows_sample);
+  CUML_LOG_DEBUG("max_samples: %f", rf_params.max_samples);
   CUML_LOG_DEBUG("n_streams: %d", rf_params.n_streams);
   DecisionTree::print(rf_params.tree_params);
 }
@@ -615,7 +615,7 @@ RF_params set_rf_class_obj(int max_depth, int max_leaves, float max_features,
                            int n_bins, int split_algo, int min_samples_leaf,
                            int min_samples_split, float min_impurity_decrease,
                            bool bootstrap_features, bool bootstrap, int n_trees,
-                           float rows_sample, int seed,
+                           float max_samples, int seed,
                            CRITERION split_criterion, bool quantile_per_tree,
                            int cfg_n_streams, bool use_experimental_backend,
                            int max_batch_size) {
@@ -626,7 +626,7 @@ RF_params set_rf_class_obj(int max_depth, int max_leaves, float max_features,
     bootstrap_features, split_criterion, quantile_per_tree,
     use_experimental_backend, max_batch_size);
   RF_params rf_params;
-  set_all_rf_params(rf_params, n_trees, bootstrap, rows_sample, seed,
+  set_all_rf_params(rf_params, n_trees, bootstrap, max_samples, seed,
                     cfg_n_streams, tree_params);
   return rf_params;
 }

--- a/cpp/src/randomforest/randomforest_impl.cuh
+++ b/cpp/src/randomforest/randomforest_impl.cuh
@@ -157,13 +157,13 @@ void rfClassifier<T>::fit(const raft::handle_t& user_handle, const T* input,
   const raft::handle_t& handle = user_handle;
   int n_sampled_rows = 0;
   if (this->rf_params.bootstrap) {
-    n_sampled_rows = std::round(this->rf_params.rows_sample * n_rows);
+    n_sampled_rows = std::round(this->rf_params.max_samples * n_rows);
   } else {
-    if (this->rf_params.rows_sample != 1.0) {
+    if (this->rf_params.max_samples != 1.0) {
       CUML_LOG_WARN(
-        "If bootstrap sampling is disabled, rows_sample value is ignored and "
+        "If bootstrap sampling is disabled, max_samples value is ignored and "
         "whole dataset is used for building each tree");
-      this->rf_params.rows_sample = 1.0;
+      this->rf_params.max_samples = 1.0;
     }
     n_sampled_rows = n_rows;
   }
@@ -436,11 +436,11 @@ void rfRegressor<T>::fit(const raft::handle_t& user_handle, const T* input,
   const raft::handle_t& handle = user_handle;
   int n_sampled_rows = 0;
   if (this->rf_params.bootstrap) {
-    n_sampled_rows = this->rf_params.rows_sample * n_rows;
+    n_sampled_rows = this->rf_params.max_samples * n_rows;
   } else {
-    if (this->rf_params.rows_sample != 1.0) {
+    if (this->rf_params.max_samples != 1.0) {
       CUML_LOG_WARN(
-        "If bootstrap sampling is disabled, rows_sample value is ignored and "
+        "If bootstrap sampling is disabled, max_samples value is ignored and "
         "whole dataset is used for building each tree");
     }
     n_sampled_rows = n_rows;

--- a/cpp/test/sg/rf_accuracy_test.cu
+++ b/cpp/test/sg/rf_accuracy_test.cu
@@ -98,7 +98,7 @@ class RFClassifierAccuracyTest : public ::testing::TestWithParam<RFInputs> {
     );
     set_all_rf_params(rfp, 1, /* n_trees */
                       true,   /* bootstrap */
-                      1.0,    /* rows_sample */
+                      1.0,    /* max_samples */
                       -1,     /* seed */
                       1,      /* n_streams */
                       tree_params);

--- a/cpp/test/sg/rf_batched_classification_test.cu
+++ b/cpp/test/sg/rf_batched_classification_test.cu
@@ -31,7 +31,7 @@ struct RfInputs {
   int n_cols;
   int n_trees;
   float max_features;
-  float rows_sample;
+  float max_samples;
   int max_depth;
   int max_leaves;
   bool bootstrap;
@@ -60,7 +60,7 @@ class RFBatchedClsTest : public ::testing::TestWithParam<RfInputs> {
                     params.split_criterion, false, true);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
 
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.reset(new raft::handle_t(rf_params.n_streams));

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -33,7 +33,7 @@ struct RfInputs {
   int n_cols;
   int n_trees;
   float max_features;
-  float rows_sample;
+  float max_samples;
   int max_depth;
   int max_leaves;
   bool bootstrap;
@@ -62,7 +62,7 @@ class RFBatchedRegTest : public ::testing::TestWithParam<RfInputs> {
                     params.split_criterion, false, true);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
 
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.reset(new raft::handle_t(rf_params.n_streams));

--- a/cpp/test/sg/rf_depth_test.cu
+++ b/cpp/test/sg/rf_depth_test.cu
@@ -31,7 +31,7 @@ struct RfInputs {
   int n_cols;
   int n_trees;
   float max_features;
-  float rows_sample;
+  float max_samples;
   int max_depth;
   int max_leaves;
   bool bootstrap;
@@ -75,7 +75,7 @@ class RfClassifierDepthTest : public ::testing::TestWithParam<int> {
                     params.split_criterion, false);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
 
     int data_len = params.n_rows * params.n_cols;
     raft::allocate(data, data_len);
@@ -169,7 +169,7 @@ class RfRegressorDepthTest : public ::testing::TestWithParam<int> {
                     params.split_criterion, false);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
 
     int data_len = params.n_rows * params.n_cols;
     raft::allocate(data, data_len);

--- a/cpp/test/sg/rf_test.cu
+++ b/cpp/test/sg/rf_test.cu
@@ -30,7 +30,7 @@ struct RfInputs {
   int n_cols;
   int n_trees;
   float max_features;
-  float rows_sample;
+  float max_samples;
   int n_inference_rows;
   int max_depth;
   int max_leaves;
@@ -64,7 +64,7 @@ class RfClassifierTest : public ::testing::TestWithParam<RfInputs<T>> {
                     params.split_criterion, false);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
     //print(rf_params);
 
     //--------------------------------------------------------
@@ -167,7 +167,7 @@ class RfRegressorTest : public ::testing::TestWithParam<RfInputs<T>> {
                     params.split_criterion, false);
     RF_params rf_params;
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
     //print(rf_params);
 
     //--------------------------------------------------------

--- a/cpp/test/sg/rf_treelite_test.cu
+++ b/cpp/test/sg/rf_treelite_test.cu
@@ -42,7 +42,7 @@ struct RfInputs {
   int n_cols;
   int n_trees;
   float max_features;
-  float rows_sample;
+  float max_samples;
   int n_inference_rows;
   int max_depth;
   int max_leaves;
@@ -190,7 +190,7 @@ class RfTreeliteTestCommon : public ::testing::TestWithParam<RfInputs<T>> {
                     params.min_impurity_decrease, params.bootstrap_features,
                     params.split_criterion, false);
     set_all_rf_params(rf_params, params.n_trees, params.bootstrap,
-                      params.rows_sample, -1, params.n_streams, tree_params);
+                      params.max_samples, -1, params.n_streams, tree_params);
     handle.reset(new raft::handle_t(rf_params.n_streams));
 
     data_len = params.n_rows * params.n_cols;

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -91,7 +91,7 @@ class RandomForestClassifier(BaseRandomForestModel, DelayedPredictionMixin,
     bootstrap_features : boolean (default = False)
         Control bootstrapping for features.
         If features are drawn with or without replacement
-    rows_sample : float (default = 1.0)
+    max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
     max_depth : int (default = -1)
         Maximum tree depth. Unlimited (i.e, until leaves are pure), if -1.

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -84,7 +84,7 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
     bootstrap_features : boolean (default = False)
         Control bootstrapping for features.
         If features are drawn with or without replacement
-    rows_sample : float (default = 1.0)
+    max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
     max_depth : int (default = -1)
         Maximum tree depth. Unlimited (i.e, until leaves are pure), if -1.

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -62,7 +62,7 @@ class BaseRandomForestModel(Base):
                  bootstrap_features=False,
                  verbose=False, min_rows_per_node=None,
                  min_samples_leaf=1, min_samples_split=2,
-                 max_samples=1.0, max_leaves=-1,
+                 rows_sample=None, max_samples=1.0, max_leaves=-1,
                  accuracy_metric=None, dtype=None,
                  output_type=None,
                  min_weight_fraction_leaf=None, n_jobs=None,
@@ -115,6 +115,11 @@ class BaseRandomForestModel(Base):
                           "and will be removed in 0.18. Please use "
                           "'min_samples_leaf' parameter instead.")
             min_samples_leaf = min_rows_per_node
+        if rows_sample is not None:
+            warnings.warn("The 'rows_sample' parameter is deprecated and will "
+                          "be removed in 0.18. Please use 'max_samples' "
+                          "parameter instead.")
+            max_samples = rows_sample
         if handle is None:
             handle = Handle(n_streams)
 

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -45,7 +45,7 @@ class BaseRandomForestModel(Base):
                     'min_samples_split',
                     'min_impurity_decrease',
                     'bootstrap', 'bootstrap_features',
-                    'verbose', 'rows_sample',
+                    'verbose', 'max_samples',
                     'max_leaves', 'quantile_per_tree',
                     'accuracy_metric', 'use_experimental_backend',
                     'max_batch_size']
@@ -62,7 +62,7 @@ class BaseRandomForestModel(Base):
                  bootstrap_features=False,
                  verbose=False, min_rows_per_node=None,
                  min_samples_leaf=1, min_samples_split=2,
-                 rows_sample=1.0, max_leaves=-1,
+                 max_samples=1.0, max_leaves=-1,
                  accuracy_metric=None, dtype=None,
                  output_type=None,
                  min_weight_fraction_leaf=None, n_jobs=None,
@@ -141,7 +141,7 @@ class BaseRandomForestModel(Base):
         self.min_samples_split = min_samples_split
         self.min_impurity_decrease = min_impurity_decrease
         self.bootstrap_features = bootstrap_features
-        self.rows_sample = rows_sample
+        self.max_samples = max_samples
         self.max_leaves = max_leaves
         self.n_estimators = n_estimators
         self.max_depth = max_depth

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -77,7 +77,7 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
     cdef struct RF_params:
         int n_trees
         bool bootstrap
-        float rows_sample
+        float max_samples
         int seed
         pass
 

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -189,7 +189,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     bootstrap_features : boolean (default = False)
         Control bootstrapping for features.
         If features are drawn with or without replacement
-    rows_sample : float (default = 1.0)
+    max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
     max_depth : int (default = 16)
         Maximum tree depth. Unlimited (i.e, until leaves are pure),
@@ -472,7 +472,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
                                      <bool> self.bootstrap_features,
                                      <bool> self.bootstrap,
                                      <int> self.n_estimators,
-                                     <float> self.rows_sample,
+                                     <float> self.max_samples,
                                      <int> seed_val,
                                      <CRITERION> self.split_criterion,
                                      <bool> self.quantile_per_tree,

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -173,7 +173,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
     bootstrap_features : boolean (default = False)
         Control bootstrapping for features.
         If features are drawn with or without replacement
-    rows_sample : float (default = 1.0)
+    max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
     max_depth : int (default = 16)
         Maximum tree depth. Unlimited (i.e, until leaves are pure),
@@ -452,7 +452,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
                                      <bool> self.bootstrap_features,
                                      <bool> self.bootstrap,
                                      <int> self.n_estimators,
-                                     <float> self.rows_sample,
+                                     <float> self.max_samples,
                                      <int> seed_val,
                                      <CRITERION> self.split_criterion,
                                      <bool> self.quantile_per_tree,

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -140,14 +140,14 @@ def special_reg(request):
     return X, y
 
 
-@pytest.mark.parametrize('rows_sample', [unit_param(1.0), quality_param(0.90),
+@pytest.mark.parametrize('max_samples', [unit_param(1.0), quality_param(0.90),
                          stress_param(0.95)])
 @pytest.mark.parametrize('datatype', [np.float32])
 @pytest.mark.parametrize('split_algo', [0, 1])
 @pytest.mark.parametrize('max_features', [1.0, 'auto', 'log2', 'sqrt'])
 @pytest.mark.parametrize('use_experimental_backend', [True, False])
 def test_rf_classification(small_clf, datatype, split_algo,
-                           rows_sample, max_features,
+                           max_samples, max_features,
                            use_experimental_backend):
     use_handle = True
 
@@ -161,7 +161,7 @@ def test_rf_classification(small_clf, datatype, split_algo,
 
     # Initialize, fit and predict using cuML's
     # random forest classification model
-    cuml_model = curfc(max_features=max_features, rows_sample=rows_sample,
+    cuml_model = curfc(max_features=max_features, max_samples=max_samples,
                        n_bins=16, split_algo=split_algo, split_criterion=0,
                        min_samples_leaf=2, random_state=123, n_streams=1,
                        n_estimators=40, handle=handle, max_leaves=-1,
@@ -210,7 +210,7 @@ def test_rf_classification(small_clf, datatype, split_algo,
     assert fil_acc >= (cuml_acc - 0.02)
 
 
-@pytest.mark.parametrize('rows_sample', [unit_param(1.0), quality_param(0.90),
+@pytest.mark.parametrize('max_samples', [unit_param(1.0), quality_param(0.90),
                          stress_param(0.95)])
 @pytest.mark.parametrize('datatype', [np.float32])
 @pytest.mark.parametrize(
@@ -224,7 +224,7 @@ def test_rf_classification(small_clf, datatype, split_algo,
      (1, 1.0, True, 32),
      ])
 def test_rf_regression(special_reg, datatype, split_algo, max_features,
-                       rows_sample, use_experimental_backend, n_bins):
+                       max_samples, use_experimental_backend, n_bins):
 
     use_handle = True
 
@@ -238,7 +238,7 @@ def test_rf_regression(special_reg, datatype, split_algo, max_features,
     handle, stream = get_handle(use_handle, n_streams=1)
 
     # Initialize and fit using cuML's random forest regression model
-    cuml_model = curfr(max_features=max_features, rows_sample=rows_sample,
+    cuml_model = curfr(max_features=max_features, max_samples=max_samples,
                        n_bins=n_bins, split_algo=split_algo, split_criterion=2,
                        min_samples_leaf=2, random_state=123, n_streams=1,
                        n_estimators=50, handle=handle, max_leaves=-1,
@@ -406,7 +406,7 @@ def check_predict_proba(test_proba, baseline_proba, y_test, rel_err):
     assert test_mse <= baseline_mse * (1.0 + rel_err)
 
 
-def rf_classification(datatype, array_type, max_features, rows_sample,
+def rf_classification(datatype, array_type, max_features, max_samples,
                       fixture):
     X, y = fixture
     X = X.astype(datatype[0])
@@ -418,7 +418,7 @@ def rf_classification(datatype, array_type, max_features, rows_sample,
     handle, stream = get_handle(True, n_streams=1)
     # Initialize, fit and predict using cuML's
     # random forest classification model
-    cuml_model = curfc(max_features=max_features, rows_sample=rows_sample,
+    cuml_model = curfc(max_features=max_features, max_samples=max_samples,
                        n_bins=16, split_criterion=0,
                        min_samples_leaf=2, random_state=123,
                        n_estimators=40, handle=handle, max_leaves=-1,
@@ -470,12 +470,12 @@ def test_rf_classification_multi_class(mclass_clf, datatype, array_type):
 
 
 @pytest.mark.parametrize('datatype', [(np.float32, np.float32)])
-@pytest.mark.parametrize('rows_sample', [unit_param(1.0),
+@pytest.mark.parametrize('max_samples', [unit_param(1.0),
                          stress_param(0.95)])
 @pytest.mark.parametrize('max_features', [1.0, 'auto', 'log2', 'sqrt'])
 def test_rf_classification_proba(small_clf, datatype,
-                                 rows_sample, max_features):
-    rf_classification(datatype, 'numpy', max_features, rows_sample,
+                                 max_samples, max_features):
+    rf_classification(datatype, 'numpy', max_features, max_samples,
                       small_clf)
 
 
@@ -749,7 +749,7 @@ def test_rf_printing(capfd, n_estimators, detailed_printing):
     handle, stream = get_handle(True, n_streams=1)
 
     # Initialize cuML Random Forest classification model
-    cuml_model = curfc(handle=handle, max_features=1.0, rows_sample=1.0,
+    cuml_model = curfc(handle=handle, max_features=1.0, max_samples=1.0,
                        n_bins=16, split_algo=0, split_criterion=0,
                        min_samples_leaf=2, random_state=23707, n_streams=1,
                        n_estimators=n_estimators, max_leaves=-1,
@@ -788,14 +788,14 @@ def test_dump_json(estimator_type, max_depth, n_estimators):
                                random_state=123, n_classes=2)
     X = X.astype(np.float32)
     if estimator_type == 'classification':
-        cuml_model = curfc(max_features=1.0, rows_sample=1.0,
+        cuml_model = curfc(max_features=1.0, max_samples=1.0,
                            n_bins=16, split_algo=0, split_criterion=0,
                            min_samples_leaf=2, seed=23707, n_streams=1,
                            n_estimators=n_estimators, max_leaves=-1,
                            max_depth=max_depth)
         y = y.astype(np.int32)
     elif estimator_type == 'regression':
-        cuml_model = curfr(max_features=1.0, rows_sample=1.0,
+        cuml_model = curfr(max_features=1.0, max_samples=1.0,
                            n_bins=16, split_algo=0,
                            min_samples_leaf=2, seed=23707, n_streams=1,
                            n_estimators=n_estimators, max_leaves=-1,


### PR DESCRIPTION
Rename rows_sample -> max_samples to be consistent with sklearn's RF.

From https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html:

> **max_samples**: int or float, default=None
> If bootstrap is True, the number of samples to draw from X to train each base estimator.
> If None (default), then draw X.shape[0] samples.
> If int, then draw max_samples samples.
> If float, then draw max_samples * X.shape[0] samples. Thus, max_samples should be in the interval (0, 1).
> New in version 0.22.