### PR TITLE
[REVIEW] Hide silhouette_score Python binding due to memory issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # cuML 0.17.0 (Date TBD)
 
 ## New Features
-- PR #3164: Expose silhouette score in Python
+- PR #3164: Expose silhouette score in Python (REMOVED in #3258)
 - PR #3160: Least Angle Regression (experimental)
 - PR #2659: Add initial max inner product sparse knn
 - PR #2836: Refactor UMAP to accept sparse inputs
@@ -55,6 +55,7 @@
 - PR #3240: Minor doc updates
 
 ## Bug Fixes
+- PR #3258: Hide silhouette_score Python binding due to memory issue
 - PR #3218: Specify dependency branches in conda dev environment to avoid pip resolver issue
 - PR #3196: Disable ascending=false path for sortColumnsPerRow
 - PR #3051: MNMG KNN Cl&Re fix + multiple improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@
 - PR #3240: Minor doc updates
 
 ## Bug Fixes
-- PR #3258: Hide silhouette_score Python binding due to memory issue
+- PR #3164: Expose silhouette score in Python
+- PR #3258: Revert silhouette_score Python exposure due to memory issue
 - PR #3218: Specify dependency branches in conda dev environment to avoid pip resolver issue
 - PR #3196: Disable ascending=false path for sortColumnsPerRow
 - PR #3051: MNMG KNN Cl&Re fix + multiple improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # cuML 0.17.0 (Date TBD)
 
 ## New Features
-- PR #3164: Expose silhouette score in Python (REMOVED in #3258)
 - PR #3160: Least Angle Regression (experimental)
 - PR #2659: Add initial max inner product sparse knn
 - PR #2836: Refactor UMAP to accept sparse inputs

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -169,9 +169,6 @@ Metrics (clustering and trustworthiness)
 
   .. automodule:: cuml.metrics.cluster.homogeneity_score
     :members:
-
-  .. automodule:: cuml.metrics.cluster.silhouette_score
-    :members:
        
   .. automodule:: cuml.metrics.cluster.completeness_score
     :members:

--- a/python/cuml/metrics/cluster/__init__.py
+++ b/python/cuml/metrics/cluster/__init__.py
@@ -22,7 +22,10 @@ from cuml.metrics.cluster.completeness_score import \
 from cuml.metrics.cluster.mutual_info_score import \
    cython_mutual_info_score as mutual_info_score
 from cuml.metrics.cluster.entropy import cython_entropy as entropy
-from cuml.metrics.cluster.silhouette_score import \
-    cython_silhouette_score as silhouette_score
+
+# Temporarily disabled due to memory issue in C++ implementation. See
+# https://github.com/rapidsai/cuml/issues/3255
+# from cuml.metrics.cluster.silhouette_score import \
+#     cython_silhouette_score as silhouette_score
 # from cuml.metrics.cluster.silhouette_score import \
 #     cython_silhouette_samples as silhouette_samples

--- a/python/cuml/metrics/cluster/__init__.py
+++ b/python/cuml/metrics/cluster/__init__.py
@@ -24,5 +24,5 @@ from cuml.metrics.cluster.mutual_info_score import \
 from cuml.metrics.cluster.entropy import cython_entropy as entropy
 from cuml.metrics.cluster.silhouette_score import \
     cython_silhouette_score as silhouette_score
-from cuml.metrics.cluster.silhouette_score import \
-    cython_silhouette_samples as silhouette_samples
+# from cuml.metrics.cluster.silhouette_score import \
+#     cython_silhouette_samples as silhouette_samples

--- a/python/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/metrics/cluster/silhouette_score.pyx
@@ -43,6 +43,14 @@ def _silhouette_coeff(
     """Function wrapped by silhouette_score and silhouette_samples to compute
     silhouette coefficients
 
+    Warning
+    -------
+    The underlying silhouette_score implementation's memory usage is quadratic
+    in the number of samples, so this call will fail on anything more than a
+    modest-size input (relative to available GPU memory). This issue is being
+    tracked at https://github.com/rapidsai/cuml/issues/3255 and will be fixed
+    in an upcoming release.
+
     Parameters
     ----------
     X : array-like, shape = (n_samples, n_features)
@@ -117,6 +125,14 @@ def cython_silhouette_score(
     distance (b) for each sample. The silhouette coefficient for a sample is
     then (b - a) / max(a, b).
 
+    Warning
+    -------
+    The underlying silhouette_score implementation's memory usage is quadratic
+    in the number of samples, so this call will fail on anything more than a
+    modest-size input (relative to available GPU memory). This issue is being
+    tracked at https://github.com/rapidsai/cuml/issues/3255 and will be fixed
+    in an upcoming release.
+
     Parameters
     ----------
     X : array-like, shape = (n_samples, n_features)
@@ -152,6 +168,14 @@ def cython_silhouette_samples(
     compute the mean intra-cluster distance (a) and the mean nearest-cluster
     distance (b) for each sample. The silhouette coefficient for a sample is
     then (b - a) / max(a, b).
+
+    Warning
+    -------
+    The underlying silhouette_score implementation's memory usage is quadratic
+    in the number of samples, so this call will fail on anything more than a
+    modest-size input (relative to available GPU memory). This issue is being
+    tracked at https://github.com/rapidsai/cuml/issues/3255 and will be fixed
+    in an upcoming release.
 
     Parameters
     ----------

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -27,8 +27,6 @@ import cudf
 from cuml.ensemble import RandomForestClassifier as curfc
 from cuml.metrics.cluster import adjusted_rand_score as cu_ars
 from cuml.metrics import accuracy_score as cu_acc_score
-from cuml.metrics.cluster import silhouette_score as cu_silhouette_score
-from cuml.metrics.cluster import silhouette_samples as cu_silhouette_samples
 from cuml.test.utils import get_handle, get_pattern, array_equal, \
     unit_param, quality_param, stress_param, generate_random_labels, \
     score_labeling_with_handle
@@ -44,8 +42,6 @@ from sklearn.metrics.cluster import adjusted_rand_score as sk_ars
 from sklearn.metrics.cluster import homogeneity_score as sk_homogeneity_score
 from sklearn.metrics.cluster import completeness_score as sk_completeness_score
 from sklearn.metrics.cluster import mutual_info_score as sk_mutual_info_score
-from sklearn.metrics.cluster import silhouette_score as sk_silhouette_score
-from sklearn.metrics.cluster import silhouette_samples as sk_silhouette_samples
 from sklearn.preprocessing import StandardScaler
 
 from cuml.metrics.cluster import entropy
@@ -225,26 +221,6 @@ def test_rand_index_score(name, nrows):
     cu_score_using_sk = sk_ars(y, cp.asnumpy(cu_y_pred))
 
     assert array_equal(cu_score, cu_score_using_sk)
-
-
-@pytest.mark.parametrize('metric', (
-    'cityblock', 'cosine', 'euclidean', 'l1', 'sqeuclidean'
-))
-def test_silhouette_score(metric, labeled_clusters):
-    X, labels = labeled_clusters
-    cuml_score = cu_silhouette_score(X, labels, metric=metric)
-    sk_score = sk_silhouette_score(X, labels, metric=metric)
-    assert_almost_equal(cuml_score, sk_score)
-
-
-@pytest.mark.parametrize('metric', (
-    'cityblock', 'cosine', 'euclidean', 'l1', 'sqeuclidean'
-))
-def test_silhouette_samples(metric, labeled_clusters):
-    X, labels = labeled_clusters
-    cuml_scores = cu_silhouette_samples(X, labels, metric=metric)
-    sk_scores = sk_silhouette_samples(X, labels, metric=metric)
-    assert_allclose(cuml_scores, sk_scores, rtol=1e-2, atol=1e-5)
 
 
 def score_homogeneity(ground_truth, predictions, use_handle):

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -30,7 +30,6 @@ from cuml.metrics import accuracy_score as cu_acc_score
 from cuml.test.utils import get_handle, get_pattern, array_equal, \
     unit_param, quality_param, stress_param, generate_random_labels, \
     score_labeling_with_handle
-from cupy.testing import assert_allclose
 
 from numba import cuda
 from numpy.testing import assert_almost_equal


### PR DESCRIPTION
Remove silhouette_score Python binding due to memory issues when handling more than a modest number of samples