### PR TITLE
[REVIEW] Return confusion matrix as int unless float weights are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PR #3177: Make Multinomial Naive Bayes inherit from `ClassifierMixin` and use it for score
 - PR #3241: Updating RAFT to latest
 - PR #3240: Minor doc updates
+- PR #3275: Return confusion matrix as int unless float weights are used
 
 ## Bug Fixes
 - PR #3164: Expose silhouette score in Python

--- a/python/cuml/metrics/confusion_matrix.py
+++ b/python/cuml/metrics/confusion_matrix.py
@@ -99,6 +99,11 @@ def confusion_matrix(y_true, y_pred,
                                        shape=(n_labels, n_labels),
                                        dtype=np.float64).toarray()
 
+    # Choose the accumulator dtype to always have high precision
+    if sample_weight.dtype.kind in {'i', 'u', 'b'}:
+         cm = cm.astype(np.int64)
+
+
     with np.errstate(all='ignore'):
         if normalize == 'true':
             cm = cp.divide(cm, cm.sum(axis=1, keepdims=True))

--- a/python/cuml/metrics/confusion_matrix.py
+++ b/python/cuml/metrics/confusion_matrix.py
@@ -101,7 +101,7 @@ def confusion_matrix(y_true, y_pred,
 
     # Choose the accumulator dtype to always have high precision
     if sample_weight.dtype.kind in {'i', 'u', 'b'}:
-         cm = cm.astype(np.int64)
+        cm = cm.astype(np.int64)
 
     with np.errstate(all='ignore'):
         if normalize == 'true':

--- a/python/cuml/metrics/confusion_matrix.py
+++ b/python/cuml/metrics/confusion_matrix.py
@@ -103,7 +103,6 @@ def confusion_matrix(y_true, y_pred,
     if sample_weight.dtype.kind in {'i', 'u', 'b'}:
          cm = cm.astype(np.int64)
 
-
     with np.errstate(all='ignore'):
         if normalize == 'true':
             cm = cp.divide(cm, cm.sum(axis=1, keepdims=True))


### PR DESCRIPTION
This PR aims at converting the confusion matrix to int when possible, to avoid the scientific notation when possible.

See this example:

![image](https://user-images.githubusercontent.com/9810050/101400035-9808d200-38d0-11eb-9f81-4d217a5ff202.png)
