### PR TITLE
[REVIEW] Correct pure virtual declaration in manifold_inputs_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #3279: Correct pure virtual declaration in manifold_inputs_t
 
 # cuML 0.17.0 (Date TBD)
 

--- a/cpp/include/cuml/manifold/common.hpp
+++ b/cpp/include/cuml/manifold/common.hpp
@@ -60,7 +60,7 @@ struct manifold_inputs_t {
 
   manifold_inputs_t(T *y_, int n_, int d_) : y(y_), n(n_), d(d_) {}
 
-  virtual bool alloc_knn_graph() const;
+  virtual bool alloc_knn_graph() const = 0;
 };
 
 /**


### PR DESCRIPTION
Add missing "=0" to pure virtual declaration of `alloc_knn_graph`