### PR TITLE
Remove static specifier in DecisionTree unit test for C++14 compliance

### DIFF
--- a/cpp/test/sg/decisiontree_batchedlevel_unittest.cu
+++ b/cpp/test/sg/decisiontree_batchedlevel_unittest.cu
@@ -43,10 +43,10 @@ class BatchedLevelAlgoUnitTestFixture {
   using NodeT = Node<DataT, LabelT, IdxT>;
   using Traits = RegTraits<DataT, IdxT>;
 
-  constexpr static int n_bins = 5;
-  constexpr static IdxT n_row = 5;
-  constexpr static IdxT n_col = 2;
-  constexpr static IdxT max_batch = 8;
+  const int n_bins = 5;
+  const IdxT n_row = 5;
+  const IdxT n_col = 2;
+  const IdxT max_batch = 8;
 
   void SetUp() {
     params.max_depth = 2;


### PR DESCRIPTION
Replace "constexpr static" member variables in DecisionTree unit test fixture with "const" member variables for compliance with C++14, which otherwise requires that const static data members be separately defined in a namespace scope if it is ODR-used (See sections 3.2 and 9.4.2 of the C++11 standard, which remain relevant until C++17).