### PR TITLE
[REVIEW] Add xfail on fetching 20newsgroup dataset (test_naive_bayes)

### DIFF
--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -28,9 +28,9 @@ def pytest_configure(config):
 def nlp_20news():
     try:
         twenty_train = fetch_20newsgroups(subset='train',
-                                    shuffle=True,
-                                    random_state=42)
-    except:
+                                          shuffle=True,
+                                          random_state=42)
+    except IOError:
         pytest.xfail(reason="Error fetching 20 newsgroup dataset")
 
     count_vect = CountVectorizer()

--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -26,9 +26,12 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="module")
 def nlp_20news():
-    twenty_train = fetch_20newsgroups(subset='train',
-                                      shuffle=True,
-                                      random_state=42)
+    try:
+        twenty_train = fetch_20newsgroups(subset='train',
+                                    shuffle=True,
+                                    random_state=42)
+    except:
+        pytest.xfail(reason="Error fetching 20 newsgroup dataset")
 
     count_vect = CountVectorizer()
     X = count_vect.fit_transform(twenty_train.data)


### PR DESCRIPTION
This PR fixes CI fails that happen on `test_naive_bayes` when the machine can't download the 20 newsgroup dataset.

It closes #3260 