### PR TITLE
[REVIEW] Fix SVR unit test parameter

### DIFF
--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -1295,7 +1295,7 @@ class SvrTest : public ::testing::Test {
          {2, 3}         //y
        },
        smoOutput2<math_t>{
-         2, {-0.8, 0.8}, 1.3, {0.8}, {1, 2, 5, 5}, {0, 1}, {2.1, 2.9}}},
+         2, {-0.8, 0.8}, 1.3, {0.8, 0.0}, {1, 2, 5, 5}, {0, 1}, {2.1, 2.9}}},
 
       {SvrInput<math_t>{
          svmParameter{1, 0, 100, 10, 1e-6, CUML_LEVEL_INFO, 0.1, EPSILON_SVR},


### PR DESCRIPTION
Linear SVR has the coef_ attribute in the python layer. In the C++ unit test the same vector is denoted by _w_, and it is defined as a linear combination of the support vectors

![image](https://user-images.githubusercontent.com/3671106/101908077-ce3d9e80-3bbb-11eb-98ff-e7be90828dde.png)

The number of elements in _w_ is n_cols. One of the SVR tests only defined 1 expected value for _w_, instead of the expected n_cols=2 values, which lead to accessing an uninitialized value. This would fail the test unless the value is accidentally zero initialized. Surprisingly this happened extremely rarely.

This PR fixes the expected value _w_exp_.

