### PR TITLE
[WIP] Updating PyTests to Stay Below 4 Gb Limit

### DIFF
--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -23,6 +23,14 @@ from sklearn.feature_extraction.text import CountVectorizer
 def pytest_configure(config):
     cp.cuda.set_allocator(None)
 
+    import rmm
+
+    # TEMP: Set the max memory pool that is used to 4.95 GiB for 1/7 A100
+    rmm.mr.set_current_device_resource(
+        rmm.mr.PoolMemoryResource(rmm.mr.get_current_device_resource(),
+                                  None,
+                                  int(4.95 * (1 << 30))))
+
 
 @pytest.fixture(scope="module")
 def nlp_20news():

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -201,7 +201,7 @@ def test_pca_inverse_transform(datatype, input_type,
 
 
 @pytest.mark.parametrize('nrows', [4000, 8000])
-@pytest.mark.parametrize('ncols', [5000, 10000])
+@pytest.mark.parametrize('ncols', [5000, stress_param(20000)])
 @pytest.mark.parametrize('whiten', [True, False])
 @pytest.mark.parametrize('return_sparse', [True, False])
 @pytest.mark.parametrize('cupy_input', [True, False])


### PR DESCRIPTION
Closes #3120 

Current WIP. Changed the lone test >4Gb in testing to be a stress param. Added a rmm.mr.PoolMemoryResource to limit the max memory that can be allocated. Only using the MR for testing in CI. Would be removed once PR is complete.