### PR TITLE
[WIP] Add output_type for all dataset generators

### DIFF
--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -100,13 +100,6 @@ def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
         or 'double'
     output_type: {'cudf', 'cupy', 'numpy'}
         Type of the returned dataset
-
-        .. deprecated:: 0.17
-           `output_type` is deprecated in 0.17 and will be removed in 0.18.
-           Please use the module level output type control,
-           `cuml.global_output_type`.
-           See :ref:`output-data-type-configuration` for more info.
-
     handle: cuml.Handle
         If it is None, a new one is created just for this function call
 
@@ -116,13 +109,8 @@ def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
         Array of the requested type containing the generated dataset
     """
 
-    # Check for deprecated `output_type` and warn. Set manually if specified
+    # Check for deprecated `output_type`. Set manually if specified
     if (output_type is not None):
-        warnings.warn("Using the `output_type` argument is deprecated and "
-                      "will be removed in 0.18. Please specify the output "
-                      "type using `cuml.using_output_type()` instead",
-                      DeprecationWarning)
-
         cuml.internals.set_api_output_type(output_type)
 
     cdef ARIMAOrder cpp_order

--- a/python/cuml/datasets/blobs.py
+++ b/python/cuml/datasets/blobs.py
@@ -68,7 +68,8 @@ def _get_centers(rs, centers, center_box, n_samples, n_features, dtype):
 @cuml.internals.api_return_any()
 def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
                center_box=(-10.0, 10.0), shuffle=True, random_state=None,
-               return_centers=False, order='F', dtype='float32'):
+               return_centers=False, order='F', dtype='float32',
+               output_type='cupy'):
     """Generate isotropic Gaussian blobs for clustering.
 
     Parameters
@@ -102,6 +103,8 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
         The order of the generated samples
     dtype : str, optional (default='float32')
         Dtype of the generated samples
+    output_type: {'cudf', 'cupy', 'numpy'}
+        Type of the returned dataset
 
     Returns
     -------
@@ -133,6 +136,9 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     --------
     make_classification: a more intricate variant
     """
+    # Check for deprecated `output_type`. Set manually if specified
+    if (output_type is not None):
+        cuml.internals.set_api_output_type(output_type)
     generator = _create_rs_generator(random_state=random_state)
 
     centers, n_centers = _get_centers(generator, centers, center_box,

--- a/python/cuml/datasets/blobs.py
+++ b/python/cuml/datasets/blobs.py
@@ -136,7 +136,6 @@ def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
     --------
     make_classification: a more intricate variant
     """
-    # Check for deprecated `output_type`. Set manually if specified
     if (output_type is not None):
         cuml.internals.set_api_output_type(output_type)
     generator = _create_rs_generator(random_state=random_state)

--- a/python/cuml/datasets/classification.py
+++ b/python/cuml/datasets/classification.py
@@ -47,7 +47,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
                         n_clusters_per_class=2, weights=None, flip_y=0.01,
                         class_sep=1.0, hypercube=True, shift=0.0, scale=1.0,
                         shuffle=True, random_state=None, order='F',
-                        dtype='float32', _centroids=None,
+                        dtype='float32', output_type='cupy', _centroids=None,
                         _informative_covariance=None,
                         _redundant_covariance=None,
                         _repeated_indices=None):
@@ -162,6 +162,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         The order of the generated samples
     dtype : str, optional (default='float32')
         Dtype of the generated samples
+    output_type: {'cudf', 'cupy', 'numpy'}
+        Type of the returned dataset
     _centroids: array of centroids of shape (n_clusters, n_informative)
     _informative_covariance: array for covariance between informative features
         of shape (n_clusters, n_informative, n_informative)
@@ -204,6 +206,9 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
            selection benchmark", 2003.
 
     """
+    # Check for deprecated `output_type`. Set manually if specified
+    if (output_type is not None):
+        cuml.internals.set_api_output_type(output_type)
     generator = _create_rs_generator(random_state)
     np_seed = int(generator.randint(n_samples, size=1))
     np.random.seed(np_seed)

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -86,7 +86,8 @@ def make_regression(
     coef=False,
     random_state=None,
     dtype='single',
-    handle=None
+    handle=None,
+    output_type='cupy'
 ) -> typing.Union[typing.Tuple[CumlArray, CumlArray],
                   typing.Tuple[CumlArray, CumlArray, CumlArray]]:
     """Generate a random regression problem.
@@ -150,6 +151,8 @@ def make_regression(
         or 'double'.
     handle: cuml.Handle
         If it is None, a new one is created just for this function call
+    output_type: {'cudf', 'cupy', 'numpy'}
+        Type of the returned dataset
 
     Returns
     -------
@@ -167,7 +170,10 @@ def make_regression(
     # Set the default output type to "cupy". This will be ignored if the user
     # has set `cuml.global_output_type`. Only necessary for array generation
     # methods that do not take an array as input
-    cuml.internals.set_api_output_type("cupy")
+    if (output_type is not None):
+        cuml.internals.set_api_output_type(output_type)
+    else:
+        cuml.internals.set_api_output_type("cupy")
 
     if dtype not in ['single', 'float', 'double', np.float32, np.float64]:
         raise TypeError("dtype must be either 'float' or 'double'")

--- a/python/cuml/test/test_make_arima.py
+++ b/python/cuml/test/test_make_arima.py
@@ -15,6 +15,9 @@
 
 import cuml
 import pytest
+import cudf
+import cupy as cp
+import numpy as np
 
 
 # Note: this test is not really strict, it only checks that the function
@@ -30,6 +33,12 @@ random_state = [None, 1234]
 order = [(3, 0, 0, 0, 0, 0, 0, 1),
          (0, 1, 2, 0, 0, 0, 0, 1),
          (1, 1, 1, 2, 1, 0, 12, 0)]
+output_type = ['cudf', 'cupy', 'numpy']
+output_array = {
+    'cudf': cudf.core.dataframe.DataFrame,
+    'cupy': cp.core.core.ndarray,
+    'numpy': np.ndarray
+}
 
 
 @pytest.mark.parametrize('dtype', dtype)
@@ -37,12 +46,15 @@ order = [(3, 0, 0, 0, 0, 0, 0, 1),
 @pytest.mark.parametrize('n_obs', n_obs)
 @pytest.mark.parametrize('random_state', random_state)
 @pytest.mark.parametrize('order', order)
-def test_make_arima(dtype, batch_size, n_obs, random_state, order):
+@pytest.mark.parametrize('output_type', output_type)
+def test_make_arima(dtype, batch_size, n_obs, random_state, order, output_type):
     p, d, q, P, D, Q, s, k = order
 
     out = cuml.make_arima(batch_size, n_obs,
                           (p, d, q), (P, D, Q, s), k,
                           random_state=random_state,
-                          dtype=dtype)
+                          dtype=dtype,
+                          output_type=output_type)
 
     assert out.shape == (n_obs, batch_size), "out shape mismatch"
+    assert type(out) == output_array[output_type]

--- a/python/cuml/test/test_make_blobs.py
+++ b/python/cuml/test/test_make_blobs.py
@@ -16,7 +16,8 @@
 import cuml
 import pytest
 import cupy as cp
-
+import cudf
+import numpy as np
 
 # Testing parameters for scalar parameter tests
 
@@ -60,6 +61,13 @@ random_state = [
     9
 ]
 
+output_type = ['cudf', 'cupy', 'numpy']
+
+output_array = {
+    'cudf': cudf.core.dataframe.DataFrame,
+    'cupy': cp.core.core.ndarray,
+    'numpy': np.ndarray
+}
 
 @pytest.mark.parametrize('dtype', dtype)
 @pytest.mark.parametrize('n_samples', n_samples)
@@ -70,18 +78,20 @@ random_state = [
 @pytest.mark.parametrize('shuffle', shuffle)
 @pytest.mark.parametrize('random_state', random_state)
 @pytest.mark.parametrize('order', ['F', 'C'])
+@pytest.mark.parametrize('output_type', output_type)
 def test_make_blobs_scalar_parameters(dtype, n_samples, n_features, centers,
                                       cluster_std, center_box, shuffle,
-                                      random_state, order):
+                                      random_state, order, output_type):
 
     out, labels = cuml.make_blobs(dtype=dtype, n_samples=n_samples,
                                   n_features=n_features, centers=centers,
                                   cluster_std=0.001,
                                   center_box=center_box, shuffle=shuffle,
-                                  random_state=random_state, order=order)
+                                  random_state=random_state, order=order, output_type=output_type)
 
     assert out.shape == (n_samples, n_features), "out shape mismatch"
     assert labels.shape == (n_samples,), "labels shape mismatch"
+    assert type(out) == output_array[output_type], "output type mismatch"
 
     if order == 'F':
         assert out.flags['F_CONTIGUOUS']

--- a/python/cuml/test/test_make_classification.py
+++ b/python/cuml/test/test_make_classification.py
@@ -18,10 +18,16 @@ import pytest
 from functools import partial
 import numpy as np
 import cupy as cp
+import cudf
 
 from cuml.datasets.classification import make_classification
 from cuml.test.utils import array_equal
 
+output_array = {
+    'cudf': cudf.core.dataframe.DataFrame,
+    'cupy': cp.core.core.ndarray,
+    'numpy': np.ndarray
+}
 
 @pytest.mark.parametrize('n_samples', [500, 1000])
 @pytest.mark.parametrize('n_features', [50, 100])
@@ -31,20 +37,23 @@ from cuml.test.utils import array_equal
 @pytest.mark.parametrize('n_informative', [7, 20])
 @pytest.mark.parametrize('random_state', [None, 1234])
 @pytest.mark.parametrize('order', ['C', 'F'])
+@pytest.mark.parametrize('output_type', ['cudf', 'cupy', 'numpy'])
 def test_make_classification(n_samples, n_features, hypercube, n_classes,
                              n_clusters_per_class, n_informative,
-                             random_state, order):
+                             random_state, order, output_type):
 
     X, y = make_classification(n_samples=n_samples, n_features=n_features,
                                n_classes=n_classes, hypercube=hypercube,
                                n_clusters_per_class=n_clusters_per_class,
                                n_informative=n_informative,
-                               random_state=random_state, order=order)
+                               random_state=random_state, order=order,
+                               output_type=output_type)
 
     assert X.shape == (n_samples, n_features)
     import cupy as cp
     assert len(cp.unique(y)) == n_classes
     assert y.shape == (n_samples, )
+    assert type(out) == output_array[output_type]
     if order == 'F':
         assert X.flags['F_CONTIGUOUS']
     elif order == 'C':


### PR DESCRIPTION
Closes #3266.
Adding `output_type` for all dataset generators.
Deleted warnings of deprecations since we're keeping this feature in `make_arima`.