### PR TITLE
[REVIEW] Removed FIL node types with `_t` suffix

### DIFF
--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -43,31 +43,6 @@ __host__ __device__ __forceinline__ int forest_num_nodes(int num_trees,
 // FIL_TPB is the number of threads per block to use with FIL kernels
 const int FIL_TPB = 256;
 
-/** base_node contains common implementation details for dense and sparse nodes */
-struct base_node : dense_node_t {
-  static const int FID_MASK = (1 << 30) - 1;
-  static const int DEF_LEFT_MASK = 1 << 30;
-  static const int IS_LEAF_MASK = 1 << 31;
-  template <class o_t>
-  __host__ __device__ o_t output() const {
-    return val;
-  }
-  __host__ __device__ float thresh() const { return val.f; }
-  __host__ __device__ int fid() const { return bits & FID_MASK; }
-  __host__ __device__ bool def_left() const { return bits & DEF_LEFT_MASK; }
-  __host__ __device__ bool is_leaf() const { return bits & IS_LEAF_MASK; }
-  base_node() = default;
-  base_node(dense_node_t node) : dense_node_t(node) {}
-  base_node(val_t output, float thresh, int fid, bool def_left, bool is_leaf) {
-    bits = (fid & FID_MASK) | (def_left ? DEF_LEFT_MASK : 0) |
-           (is_leaf ? IS_LEAF_MASK : 0);
-    if (is_leaf)
-      val = output;
-    else
-      val.f = thresh;
-  }
-};
-
 template <>
 __host__ __device__ __forceinline__ float base_node::output<float>() const {
   return val.f;
@@ -76,16 +51,6 @@ template <>
 __host__ __device__ __forceinline__ int base_node::output<int>() const {
   return val.idx;
 }
-
-/** dense_node is a single node of a dense forest */
-struct alignas(8) dense_node : base_node {
-  dense_node() = default;
-  dense_node(dense_node_t node) : base_node(node) {}
-  dense_node(val_t output, float thresh, int fid, bool def_left, bool is_leaf)
-    : base_node(output, thresh, fid, def_left, is_leaf) {}
-  /** index of the left child, where curr is the index of the current node */
-  __host__ __device__ int left(int curr) const { return 2 * curr + 1; }
-};
 
 /** dense_tree represents a dense tree */
 struct dense_tree {
@@ -114,51 +79,6 @@ struct dense_storage {
   int num_trees_ = 0;
   int tree_stride_ = 0;
   int node_pitch_ = 0;
-};
-
-/** sparse_node16 is a 16-byte node in a sparse forest */
-struct alignas(16) sparse_node16 : base_node, sparse_node16_extra_data {
-  sparse_node16(sparse_node16_t node)
-    : base_node(node), sparse_node16_extra_data(node) {}
-  sparse_node16(val_t output, float thresh, int fid, bool def_left,
-                bool is_leaf, int left_index)
-    : base_node(output, thresh, fid, def_left, is_leaf),
-      sparse_node16_extra_data({.left_idx = left_index, .dummy = 0}) {}
-  __host__ __device__ int left_index() const { return left_idx; }
-  /** index of the left child, where curr is the index of the current node */
-  __host__ __device__ int left(int curr) const { return left_idx; }
-};
-
-/** sparse_node8 is a node of reduced size (8 bytes) in a sparse forest */
-struct alignas(8) sparse_node8 : base_node {
-  static const int FID_NUM_BITS = 14;
-  static const int FID_MASK = (1 << FID_NUM_BITS) - 1;
-  static const int LEFT_OFFSET = FID_NUM_BITS;
-  static const int LEFT_NUM_BITS = 16;
-  static const int LEFT_MASK = ((1 << LEFT_NUM_BITS) - 1) << LEFT_OFFSET;
-  static const int DEF_LEFT_OFFSET = LEFT_OFFSET + LEFT_NUM_BITS;
-  static const int DEF_LEFT_MASK = 1 << DEF_LEFT_OFFSET;
-  static const int IS_LEAF_OFFSET = 31;
-  static const int IS_LEAF_MASK = 1 << IS_LEAF_OFFSET;
-  __host__ __device__ int fid() const { return bits & FID_MASK; }
-  __host__ __device__ bool def_left() const { return bits & DEF_LEFT_MASK; }
-  __host__ __device__ bool is_leaf() const { return bits & IS_LEAF_MASK; }
-  __host__ __device__ int left_index() const {
-    return (bits & LEFT_MASK) >> LEFT_OFFSET;
-  }
-  sparse_node8(sparse_node8_t node) : base_node(node) {}
-  sparse_node8(val_t output, float thresh, int fid, bool def_left, bool is_leaf,
-               int left_index) {
-    if (is_leaf)
-      val = output;
-    else
-      val.f = thresh;
-    bits = fid | left_index << LEFT_OFFSET |
-           (def_left ? 1 : 0) << DEF_LEFT_OFFSET |
-           (is_leaf ? 1 : 0) << IS_LEAF_OFFSET;
-  }
-  /** index of the left child, where curr is the index of the current node */
-  __host__ __device__ int left(int curr) const { return left_index(); }
 };
 
 /** sparse_tree is a sparse tree */

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -208,8 +208,8 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
         default:
           ASSERT(false, "internal error: invalid ps.leaf_algo");
       }
-      fil::node_init(&nodes[i], w, thresholds_h[i], fids_h[i], def_lefts_h[i],
-                     is_leafs_h[i]);
+      nodes[i] = fil::dense_node(w, thresholds_h[i], fids_h[i], def_lefts_h[i],
+                                 is_leafs_h[i]);
     }
 
     // clean up
@@ -365,18 +365,14 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
                                   stream));
   }
 
-  fil::val_t infer_one_tree(fil::dense_node_t* root, float* data) {
+  fil::val_t infer_one_tree(fil::dense_node* root, float* data) {
     int curr = 0;
-    float threshold = 0.0f;
     fil::val_t output{.f = 0.0f};
-    int fid = 0;
-    bool def_left = false, is_leaf = false;
     for (;;) {
-      fil::node_decode(&root[curr], &output, &threshold, &fid, &def_left,
-                       &is_leaf);
-      if (is_leaf) break;
-      float val = data[fid];
-      bool cond = isnan(val) ? !def_left : val >= threshold;
+      const fil::dense_node& node = root[curr];
+      if (node.is_leaf()) return node.base_node::output<val_t>();
+      float val = data[node.fid()];
+      bool cond = isnan(val) ? !node.def_left() : val >= node.thresh();
       curr = (curr << 1) + 1 + (cond ? 1 : 0);
     }
     return output;
@@ -397,7 +393,7 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
   std::vector<float> data_h;
 
   // forest data
-  std::vector<fil::dense_node_t> nodes;
+  std::vector<fil::dense_node> nodes;
 
   // parameters
   cudaStream_t stream;
@@ -428,18 +424,14 @@ class PredictDenseFilTest : public BaseFilTest {
 template <typename fil_node_t>
 class BasePredictSparseFilTest : public BaseFilTest {
  protected:
-  void dense2sparse_node(const fil::dense_node_t* dense_root, int i_dense,
+  void dense2sparse_node(const fil::dense_node* dense_root, int i_dense,
                          int i_sparse_root, int i_sparse) {
-    float threshold;
-    fil::val_t output;
-    int feature;
-    bool def_left, is_leaf;
-    fil::node_decode(&dense_root[i_dense], &output, &threshold, &feature,
-                     &def_left, &is_leaf);
-    if (is_leaf) {
+    const fil::dense_node& node = dense_root[i_dense];
+    if (node.is_leaf()) {
       // leaf sparse node
-      node_init(&sparse_nodes[i_sparse], output, threshold, feature, def_left,
-                is_leaf, 0);
+      sparse_nodes[i_sparse] =
+        fil_node_t(node.base_node::output<val_t>(), node.thresh(), node.fid(),
+                   node.def_left(), node.is_leaf(), 0);
       return;
     }
     // inner sparse node
@@ -447,14 +439,15 @@ class BasePredictSparseFilTest : public BaseFilTest {
     int left_index = sparse_nodes.size();
     sparse_nodes.push_back(fil_node_t());
     sparse_nodes.push_back(fil_node_t());
-    node_init(&sparse_nodes[i_sparse], output, threshold, feature, def_left,
-              is_leaf, left_index - i_sparse_root);
+    sparse_nodes[i_sparse] =
+      fil_node_t(node.base_node::output<val_t>(), node.thresh(), node.fid(),
+                 node.def_left(), node.is_leaf(), left_index - i_sparse_root);
     dense2sparse_node(dense_root, 2 * i_dense + 1, i_sparse_root, left_index);
     dense2sparse_node(dense_root, 2 * i_dense + 2, i_sparse_root,
                       left_index + 1);
   }
 
-  void dense2sparse_tree(const fil::dense_node_t* dense_root) {
+  void dense2sparse_tree(const fil::dense_node* dense_root) {
     int i_sparse_root = sparse_nodes.size();
     sparse_nodes.push_back(fil_node_t());
     dense2sparse_node(dense_root, 0, i_sparse_root, i_sparse_root);
@@ -489,8 +482,8 @@ class BasePredictSparseFilTest : public BaseFilTest {
   std::vector<int> trees;
 };
 
-typedef BasePredictSparseFilTest<fil::sparse_node16_t> PredictSparse16FilTest;
-typedef BasePredictSparseFilTest<fil::sparse_node8_t> PredictSparse8FilTest;
+typedef BasePredictSparseFilTest<fil::sparse_node16> PredictSparse16FilTest;
+typedef BasePredictSparseFilTest<fil::sparse_node8> PredictSparse8FilTest;
 
 class TreeliteFilTest : public BaseFilTest {
  protected:
@@ -501,28 +494,27 @@ class TreeliteFilTest : public BaseFilTest {
                        int node) {
     int key = (*pkey)++;
     builder->CreateNode(key);
-    int feature;
-    float threshold;
-    fil::val_t output;
-    bool is_leaf, default_left;
-    fil::node_decode(&nodes[node], &output, &threshold, &feature, &default_left,
-                     &is_leaf);
-    if (is_leaf) {
+    const fil::dense_node& dense_node = nodes[node];
+    if (dense_node.is_leaf()) {
       switch (ps.leaf_algo) {
         case fil::leaf_algo_t::FLOAT_UNARY_BINARY:
         case fil::leaf_algo_t::GROVE_PER_CLASS:
           // default is fil::FLOAT_UNARY_BINARY
-          builder->SetLeafNode(key, output.f);
+          builder->SetLeafNode(key, dense_node.base_node::output<val_t>().f);
           break;
         case fil::leaf_algo_t::CATEGORICAL_LEAF:
           std::vector<tl::tl_float> vec(ps.num_classes);
-          for (int i = 0; i < ps.num_classes; ++i)
-            vec[i] = i == output.idx ? 1.0f : 0.0f;
+          for (int i = 0; i < ps.num_classes; ++i) {
+            vec[i] =
+              i == dense_node.base_node::output<val_t>().idx ? 1.0f : 0.0f;
+          }
           builder->SetLeafVectorNode(key, vec);
       }
     } else {
       int left = root + 2 * (node - root) + 1;
       int right = root + 2 * (node - root) + 2;
+      float threshold = dense_node.thresh();
+      bool default_left = dense_node.def_left();
       switch (ps.op) {
         case tl::Operator::kLT:
           break;
@@ -545,7 +537,7 @@ class TreeliteFilTest : public BaseFilTest {
       }
       int left_key = node_to_treelite(builder, pkey, root, left);
       int right_key = node_to_treelite(builder, pkey, root, right);
-      builder->SetNumericalTestNode(key, feature, ps.op, threshold,
+      builder->SetNumericalTestNode(key, dense_node.fid(), ps.op, threshold,
                                     default_left, left_key, right_key);
     }
     return key;


### PR DESCRIPTION
Removed FIL node types with `_t` suffix.

- only the node types without the `_t` suffix are now used
- removed the functions necessary to handle node types with the `_t` suffix