### PR TITLE
Fix for default arguments of PCA

### DIFF
--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -428,6 +428,8 @@ class PCA(Base):
                 ' n_components argument defauts to using'
                 ' min(n_samples, n_features) rather than 1'
             )
+            n_rows = X.shape[0]
+            n_cols = X.shape[1]
             self.n_components_ = min(n_rows, n_cols)
         else:
             self.n_components_ = self.n_components

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -341,7 +341,7 @@ class PCA(Base):
 
     def _build_params(self, n_rows, n_cols):
         cpdef paramsPCA *params = new paramsPCA()
-        params.n_components = self.n_components_
+        params.n_components = self._n_components
         params.n_rows = n_rows
         params.n_cols = n_cols
         params.whiten = self.whiten
@@ -390,22 +390,22 @@ class PCA(Base):
 
         self.components_ = cp.flip(self.components_, axis=1)
 
-        self.components_ = self.components_.T[:self.n_components_, :]
+        self.components_ = self.components_.T[:self._n_components, :]
 
         self.explained_variance_ratio_ = self.explained_variance_ / cp.sum(
             self.explained_variance_)
 
-        if self.n_components_ < min(self.n_rows, self.n_cols):
+        if self._n_components < min(self.n_rows, self.n_cols):
             self.noise_variance_ = \
-                self.explained_variance_[self.n_components_:].mean()
+                self.explained_variance_[self._n_components:].mean()
         else:
             self.noise_variance_ = cp.array([0.0])
 
         self.explained_variance_ = \
-            self.explained_variance_[:self.n_components_]
+            self.explained_variance_[:self._n_components]
 
         self.explained_variance_ratio_ = \
-            self.explained_variance_ratio_[:self.n_components_]
+            self.explained_variance_ratio_[:self._n_components]
 
         # Truncating negative explained variance values to 0
         self.singular_values_ = \
@@ -430,9 +430,9 @@ class PCA(Base):
             )
             n_rows = X.shape[0]
             n_cols = X.shape[1]
-            self.n_components_ = min(n_rows, n_cols)
+            self._n_components = min(n_rows, n_cols)
         else:
-            self.n_components_ = self.n_components
+            self._n_components = self.n_components
 
         if cupyx.scipy.sparse.issparse(X):
             return self._sparse_fit(X)
@@ -585,7 +585,7 @@ class PCA(Base):
 
         # todo: check n_cols and dtype
         cpdef paramsPCA params
-        params.n_components = self.n_components_
+        params.n_components = self._n_components
         params.n_rows = n_rows
         params.n_cols = self.n_cols
         params.whiten = self.whiten
@@ -678,7 +678,7 @@ class PCA(Base):
 
         # todo: check dtype
         cpdef paramsPCA params
-        params.n_components = self.n_components_
+        params.n_components = self._n_components
         params.n_rows = n_rows
         params.n_cols = n_cols
         params.whiten = self.whiten

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -75,14 +75,15 @@ def test_pca_fit(datatype, input_type, name, use_handle):
 @pytest.mark.parametrize('sparse', [True, False])
 def test_pca_defaults(n_samples, n_features, sparse):
     if sparse:
-        X = cupyx.scipy.sparse.random(n_samples, n_features, density=0.03, dtype=cp.float32,
+        X = cupyx.scipy.sparse.random(n_samples, n_features,
+                                      density=0.03, dtype=cp.float32,
                                       random_state=10)
     else:
         X, Y = make_multilabel_classification(n_samples=n_samples,
-                                            n_features=n_features,
-                                            n_classes=2,
-                                            n_labels=1,
-                                            random_state=1)
+                                              n_features=n_features,
+                                              n_classes=2,
+                                              n_labels=1,
+                                              random_state=1)
     cupca = cuPCA()
     cupca.fit(X)
     curesult = cupca.transform(X)

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -72,21 +72,30 @@ def test_pca_fit(datatype, input_type, name, use_handle):
 
 @pytest.mark.parametrize('n_samples', [200])
 @pytest.mark.parametrize('n_features', [100, 300])
-def test_pca_defaults(n_samples, n_features):
-    X, Y = make_multilabel_classification(n_samples=n_samples,
-                                          n_features=n_features,
-                                          n_classes=2,
-                                          n_labels=1,
-                                          random_state=1)
+@pytest.mark.parametrize('sparse', [True, False])
+def test_pca_defaults(n_samples, n_features, sparse):
+    if sparse:
+        X = cupyx.scipy.sparse.random(nrows, ncols, density=0.03, dtype=cp.float32,
+                                      random_state=10)
+    else:
+        X, Y = make_multilabel_classification(n_samples=n_samples,
+                                            n_features=n_features,
+                                            n_classes=2,
+                                            n_labels=1,
+                                            random_state=1)
     skpca = skPCA()
     skpca.fit(X)
+    skresult = skpca.transform(X)
 
     cupca = cuPCA()
     cupca.fit(X)
+    curesult = cupca.transform(X)
     cupca.handle.sync()
 
     assert skpca.svd_solver == cupca.svd_solver
     assert cupca.components_.shape[0] == skpca.components_.shape[0]
+    assert cupca.shape == skpca.shape
+    assert cupca == skpca
 
 
 @pytest.mark.parametrize('datatype', [np.float32, np.float64])


### PR DESCRIPTION
When using default arguments on PCA I faced an error on the following line `PCA().fit(X).transform(X)`.

`transform` was failing because n_components was `None` so I introduced `n_components_` to store the number of components used by the fit function without overwriting the user' `n_components`.

I added some tests on this feature too.