### PR TITLE
Fix permutation explainer

### DIFF
--- a/cpp/src/explainer/permutation_shap.cu
+++ b/cpp/src/explainer/permutation_shap.cu
@@ -34,8 +34,8 @@ __global__ void _fused_tile_scatter_pe(DataT* dataset, const DataT* background,
 
     if (row_major) {
       row = tid / ncols;
-      col = tid % ncols;
-      start = (idx[col] + 1) * nrows_background;
+      col = idx[tid % ncols];
+      start = ((tid % ncols) + 1) * nrows_background;
       end = start + sc_size * nrows_background;
 
       if ((start <= row && row < end)) {


### PR DESCRIPTION
Shap permutation explainer has an indexing mistake that causes the wrong permutation cycle to be assigned to each feature. Before this PR all results are incorrect, but the tests still passed because the efficiency property was preserved even with the bug i.e. the shap values added up to the correct amount but were assigned to the wrong features in each permutation. 

I have added a test checking the results without using the efficiency property.

As a side note, the cuda functions here accept a row-major bool parameter, but from the python side everything seems to be hardcoded as always row-major. I haven't fixed this bug for the column major case, maybe we should remove all column major cuda code as it is not tested and there is no way to use it currently.

@dantegd @JohnZed 