### PR TITLE
Update linear models to use RMM memory allocation

### DIFF
--- a/cpp/src/glm/ols.cuh
+++ b/cpp/src/glm/ols.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/ols.cuh
+++ b/cpp/src/glm/ols.cuh
@@ -18,7 +18,6 @@
 
 #include <raft/linalg/gemv.h>
 #include <common/cumlHandle.hpp>
-#include <common/device_buffer.hpp>
 #include <linalg/lstsq.cuh>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/norm.cuh>
@@ -29,6 +28,7 @@
 #include <raft/stats/mean_center.cuh>
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
 #include "preprocess.cuh"
 
 namespace ML {
@@ -56,14 +56,13 @@ void olsFit(const raft::handle_t &handle, math_t *input, int n_rows, int n_cols,
             bool normalize, cudaStream_t stream, int algo = 0) {
   auto cublas_handle = handle.get_cublas_handle();
   auto cusolver_handle = handle.get_cusolver_dn_handle();
-  auto allocator = handle.get_device_allocator();
 
   ASSERT(n_cols > 0, "olsFit: number of columns cannot be less than one");
   ASSERT(n_rows > 1, "olsFit: number of rows cannot be less than two");
 
-  device_buffer<math_t> mu_input(allocator, stream);
-  device_buffer<math_t> norm2_input(allocator, stream);
-  device_buffer<math_t> mu_labels(allocator, stream);
+  rmm::device_uvector<math_t> mu_input(0, stream);
+  rmm::device_uvector<math_t> norm2_input(0, stream);
+  rmm::device_uvector<math_t> mu_labels(0, stream);
 
   if (fit_intercept) {
     mu_input.resize(n_cols, stream);

--- a/cpp/src/glm/ols.cuh
+++ b/cpp/src/glm/ols.cuh
@@ -56,6 +56,7 @@ void olsFit(const raft::handle_t &handle, math_t *input, int n_rows, int n_cols,
             bool normalize, cudaStream_t stream, int algo = 0) {
   auto cublas_handle = handle.get_cublas_handle();
   auto cusolver_handle = handle.get_cusolver_dn_handle();
+  auto allocator = handle.get_device_allocator();
 
   ASSERT(n_cols > 0, "olsFit: number of columns cannot be less than one");
   ASSERT(n_rows > 1, "olsFit: number of rows cannot be less than two");

--- a/cpp/src/glm/ols_mg.cu
+++ b/cpp/src/glm/ols_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/ols_mg.cu
+++ b/cpp/src/glm/ols_mg.cu
@@ -15,7 +15,6 @@
  */
 
 #include <common/cumlHandle.hpp>
-#include <common/device_buffer.hpp>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/linear_model/ols_mg.hpp>
 #include <cuml/linear_model/preprocess_mg.hpp>
@@ -27,6 +26,7 @@
 #include <raft/linalg/gemm.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
+#include <rmm/device_uvector.hpp>
 
 using namespace MLCommon;
 
@@ -44,11 +44,10 @@ void fit_impl(raft::handle_t &handle,
   const auto &comm = handle.get_comms();
   cublasHandle_t cublas_handle = handle.get_cublas_handle();
   cusolverDnHandle_t cusolver_handle = handle.get_cusolver_dn_handle();
-  const auto allocator = handle.get_device_allocator();
 
-  device_buffer<T> mu_input(allocator, streams[0]);
-  device_buffer<T> norm2_input(allocator, streams[0]);
-  device_buffer<T> mu_labels(allocator, streams[0]);
+  rmm::device_uvector<T> mu_input(0, streams[0]);
+  rmm::device_uvector<T> norm2_input(0, streams[0]);
+  rmm::device_uvector<T> mu_labels(0, streams[0]);
 
   if (fit_intercept) {
     mu_input.resize(input_desc.N, streams[0]);

--- a/cpp/src/glm/preprocess.cuh
+++ b/cpp/src/glm/preprocess.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/preprocess.cuh
+++ b/cpp/src/glm/preprocess.cuh
@@ -18,7 +18,6 @@
 
 #include <raft/cudart_utils.h>
 #include <common/cumlHandle.hpp>
-#include <common/device_buffer.hpp>
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/norm.cuh>
 #include <raft/matrix/math.cuh>
@@ -26,6 +25,7 @@
 #include <raft/stats/mean.cuh>
 #include <raft/stats/mean_center.cuh>
 #include <raft/stats/stddev.cuh>
+#include <rmm/device_uvector.hpp>
 
 namespace ML {
 namespace GLM {
@@ -73,8 +73,7 @@ void postProcessData(const raft::handle_t &handle, math_t *input, int n_rows,
          "Parameter n_rows: number of rows cannot be less than two");
 
   cublasHandle_t cublas_handle = handle.get_cublas_handle();
-  auto allocator = handle.get_device_allocator();
-  device_buffer<math_t> d_intercept(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_intercept(1, stream);
 
   if (normalize) {
     raft::matrix::matrixVectorBinaryMult(input, norm2_input, n_rows, n_cols,

--- a/cpp/src/glm/preprocess_mg.cu
+++ b/cpp/src/glm/preprocess_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/preprocess_mg.cu
+++ b/cpp/src/glm/preprocess_mg.cu
@@ -16,8 +16,6 @@
 
 #include <raft/cudart_utils.h>
 #include <common/cumlHandle.hpp>
-#include <common/device_buffer.hpp>
-#include <cuml/common/cuml_allocator.hpp>
 #include <cuml/linear_model/preprocess_mg.hpp>
 #include <opg/linalg/norm.hpp>
 #include <opg/matrix/math.hpp>
@@ -28,6 +26,7 @@
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/subtract.cuh>
 #include <raft/matrix/math.cuh>
+#include <rmm/device_uvector.hpp>
 
 using namespace MLCommon;
 
@@ -46,7 +45,6 @@ void preProcessData_impl(raft::handle_t &handle,
   const auto &comm = handle.get_comms();
   cublasHandle_t cublas_handle = handle.get_cublas_handle();
   cusolverDnHandle_t cusolver_handle = handle.get_cusolver_dn_handle();
-  const auto allocator = handle.get_device_allocator();
 
   if (fit_intercept) {
     Matrix::Data<T> mu_input_data{mu_input, size_t(input_desc.N)};
@@ -87,9 +85,8 @@ void postProcessData_impl(raft::handle_t &handle,
   const auto &comm = handle.get_comms();
   cublasHandle_t cublas_handle = handle.get_cublas_handle();
   cusolverDnHandle_t cusolver_handle = handle.get_cusolver_dn_handle();
-  const auto allocator = handle.get_device_allocator();
 
-  device_buffer<T> d_intercept(allocator, streams[0], 1);
+  rmm::device_uvector<T> d_intercept(1, streams[0]);
 
   if (normalize) {
     Matrix::Data<T> norm2_input_data{norm2_input, input_desc.N};

--- a/cpp/src/glm/qn/qn.cuh
+++ b/cpp/src/glm/qn/qn.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/qn/qn.cuh
+++ b/cpp/src/glm/qn/qn.cuh
@@ -15,8 +15,8 @@
  */
 
 #pragma once
-#include <common/device_buffer.hpp>
 #include <raft/matrix/math.cuh>
+#include <rmm/device_uvector.hpp>
 #include "glm_base.cuh"
 #include "glm_linear.cuh"
 #include "glm_logistic.cuh"
@@ -68,8 +68,7 @@ void qnFit(const raft::handle_t &handle, T *X, T *y, int N, int D, int C,
   STORAGE_ORDER ord = X_col_major ? COL_MAJOR : ROW_MAJOR;
   int C_len = (loss_type == 0) ? (C - 1) : C;
 
-  MLCommon::device_buffer<T> tmp(handle.get_device_allocator(), stream,
-                                 C_len * N);
+  rmm::device_uvector<T> tmp(C_len * N, stream);
   SimpleMat<T> z(tmp.data(), C_len, N);
 
   switch (loss_type) {
@@ -125,8 +124,7 @@ void qnPredict(const raft::handle_t &handle, T *Xptr, int N, int D, int C,
                bool fit_intercept, T *params, bool X_col_major, int loss_type,
                T *preds, cudaStream_t stream) {
   int C_len = (loss_type == 0) ? (C - 1) : C;
-  MLCommon::device_buffer<T> scores(handle.get_device_allocator(), stream,
-                                    C_len * N);
+  rmm::device_uvector<T> scores(C_len * N, stream);
   qnDecisionFunction<T>(handle, Xptr, N, D, C, fit_intercept, params,
                         X_col_major, loss_type, scores.data(), stream);
   SimpleMat<T> Z(scores.data(), C_len, N);

--- a/cpp/src/glm/qn/qn_solvers.cuh
+++ b/cpp/src/glm/qn/qn_solvers.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/qn/qn_solvers.cuh
+++ b/cpp/src/glm/qn/qn_solvers.cuh
@@ -42,6 +42,7 @@
 
 #include <cuml/common/logger.hpp>
 #include <raft/cuda_utils.cuh>
+#include <rmm/device_uvector.hpp>
 #include "qn_linesearch.cuh"
 #include "qn_util.cuh"
 #include "simple_mat.cuh"
@@ -339,8 +340,7 @@ inline int qn_minimize(const raft::handle_t &handle, SimpleVec<T> &x, T *fx,
   // TODO should the worksapce allocation happen outside?
   OPT_RETCODE ret;
   if (l1 == 0.0) {
-    MLCommon::device_buffer<T> tmp(handle.get_device_allocator(), stream,
-                                   lbfgs_workspace_size(opt_param, x.len));
+    rmm::device_uvector<T> tmp(lbfgs_workspace_size(opt_param, x.len), stream);
     SimpleVec<T> workspace(tmp.data(), tmp.size());
 
     ret = min_lbfgs(opt_param,
@@ -360,8 +360,7 @@ inline int qn_minimize(const raft::handle_t &handle, SimpleVec<T> &x, T *fx,
     // handling the term l1norm(x) * l1_pen explicitely, i.e.
     // it needs to evaluate f(x) and its gradient separately
 
-    MLCommon::device_buffer<T> tmp(handle.get_device_allocator(), stream,
-                                   owlqn_workspace_size(opt_param, x.len));
+    rmm::device_uvector<T> tmp(owlqn_workspace_size(opt_param, x.len), stream);
     SimpleVec<T> workspace(tmp.data(), tmp.size());
 
     ret = min_owlqn(opt_param,

--- a/cpp/src/glm/qn/simple_mat.cuh
+++ b/cpp/src/glm/qn/simple_mat.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/qn/simple_mat.cuh
+++ b/cpp/src/glm/qn/simple_mat.cuh
@@ -21,13 +21,13 @@
 #include <raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <common/cumlHandle.hpp>
-#include <common/device_buffer.hpp>
 #include <linalg/ternary_op.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/binary_op.cuh>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/linalg/norm.cuh>
 #include <raft/linalg/unary_op.cuh>
+#include <rmm/device_uvector.hpp>
 
 namespace ML {
 
@@ -299,14 +299,14 @@ std::ostream &operator<<(std::ostream &os, const SimpleMat<T> &mat) {
 template <typename T>
 struct SimpleVecOwning : SimpleVec<T> {
   typedef SimpleVec<T> Super;
-  typedef MLCommon::device_buffer<T> Buffer;
+  typedef rmm::device_uvector<T> Buffer;
   Buffer buf;
 
   SimpleVecOwning() = delete;
 
   SimpleVecOwning(std::shared_ptr<deviceAllocator> allocator, int n,
                   cudaStream_t stream)
-    : Super(), buf(allocator, stream, n) {
+    : Super(), buf(n, stream) {
     Super::reset(buf.data(), n);
   }
 
@@ -316,7 +316,7 @@ struct SimpleVecOwning : SimpleVec<T> {
 template <typename T>
 struct SimpleMatOwning : SimpleMat<T> {
   typedef SimpleMat<T> Super;
-  typedef MLCommon::device_buffer<T> Buffer;
+  typedef rmm::device_uvector<T> Buffer;
   Buffer buf;
   using Super::m;
   using Super::n;
@@ -326,7 +326,7 @@ struct SimpleMatOwning : SimpleMat<T> {
 
   SimpleMatOwning(std::shared_ptr<deviceAllocator> allocator, int m, int n,
                   cudaStream_t stream, STORAGE_ORDER order = COL_MAJOR)
-    : Super(order), buf(allocator, stream, m * n) {
+    : Super(order), buf(m * n, stream) {
     Super::reset(buf.data(), m, n);
   }
 

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -86,10 +86,10 @@ void ridgeSVD(const raft::handle_t &handle, math_t *A, int n_rows, int n_cols,
   rmm::device_uvector<math_t> V(V_len, stream);
   rmm::device_uvector<math_t> U(U_len, stream);
 
-  raft::linalg::svdQR(handle, A, n_rows, n_cols, S.data(), U.data(),
-                      V.data(), true, true, true, stream);
-  ridgeSolve(handle, S.data(), V.data(), U.data(), n_rows, n_cols, b,
-             alpha, n_alpha, w, stream);
+  raft::linalg::svdQR(handle, A, n_rows, n_cols, S.data(), U.data(), V.data(),
+                      true, true, true, stream);
+  ridgeSolve(handle, S.data(), V.data(), U.data(), n_rows, n_cols, b, alpha,
+             n_alpha, w, stream);
 }
 
 template <typename math_t>

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -110,11 +110,11 @@ void ridgeEig(const raft::handle_t &handle, math_t *A, int n_rows, int n_cols,
   rmm::device_uvector<math_t> V(V_len, stream);
   rmm::device_uvector<math_t> U(U_len, stream);
 
-  raft::linalg::svdEig(handle, A, n_rows, n_cols, S.data(), U.data(),
-                       V.data(), true, stream);
+  raft::linalg::svdEig(handle, A, n_rows, n_cols, S.data(), U.data(), V.data(),
+                       true, stream);
 
-  ridgeSolve(handle, S.data(), V.data(), U.data(), n_rows, n_cols,
-             b, alpha, n_alpha, w, stream);
+  ridgeSolve(handle, S.data(), V.data(), U.data(), n_rows, n_cols, b, alpha,
+             n_alpha, w, stream);
 }
 
 /**
@@ -155,8 +155,9 @@ void ridgeFit(const raft::handle_t &handle, math_t *input, int n_rows,
     if (normalize) {
       norm2_input = rmm::device_uvector<math_t>(n_cols, stream);
     }
-    preProcessData(handle, input, n_rows, n_cols, labels, intercept, mu_input.data(),
-                   mu_labels.data(), norm2_input.data(), fit_intercept, normalize, stream);
+    preProcessData(handle, input, n_rows, n_cols, labels, intercept,
+                   mu_input.data(), mu_labels.data(), norm2_input.data(),
+                   fit_intercept, normalize, stream);
   }
 
   if (algo == 0 || n_cols == 1) {

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -85,9 +85,9 @@ void ridgeSVD(const raft::handle_t &handle, math_t *A, int n_rows, int n_cols,
   int U_len = n_rows * n_cols;
   int V_len = n_cols * n_cols;
 
-  rmm::device_uvector<math_t> S_vector(U_len, stream);
+  rmm::device_uvector<math_t> S_vector(n_cols, stream);
   rmm::device_uvector<math_t> V_vector(V_len, stream);
-  rmm::device_uvector<math_t> U_vector(n_cols, stream);
+  rmm::device_uvector<math_t> U_vector(U_len, stream);
   S = S_vector.data();
   V = V_vector.data();
   U = U_vector.data();
@@ -114,9 +114,9 @@ void ridgeEig(const raft::handle_t &handle, math_t *A, int n_rows, int n_cols,
   int U_len = n_rows * n_cols;
   int V_len = n_cols * n_cols;
 
-  rmm::device_uvector<math_t> S_vector(U_len, stream);
+  rmm::device_uvector<math_t> S_vector(n_cols, stream);
   rmm::device_uvector<math_t> V_vector(V_len, stream);
-  rmm::device_uvector<math_t> U_vector(n_cols, stream);
+  rmm::device_uvector<math_t> U_vector(U_len, stream);
   S = S_vector.data();
   V = V_vector.data();
   U = U_vector.data();

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -29,6 +29,7 @@
 #include <raft/stats/mean_center.cuh>
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
 #include "preprocess.cuh"
 
 namespace ML {
@@ -45,7 +46,7 @@ void ridgeSolve(const raft::handle_t &handle, math_t *S, math_t *V, math_t *U,
 
   // Implements this: w = V * inv(S^2 + λ*I) * S * U^T * b
   rmm::device_uvector<math_t> S_nnz_vector(n_cols, stream);
-  math_t *S_nnz = S_nnz_vector.data()
+  math_t *S_nnz = S_nnz_vector.data();
   math_t alp = math_t(1);
   math_t beta = math_t(0);
   math_t thres = math_t(1e-10);
@@ -155,17 +156,17 @@ void ridgeFit(const raft::handle_t &handle, math_t *input, int n_rows,
   ASSERT(n_rows > 1, "ridgeFit: number of rows cannot be less than two");
 
   math_t *mu_input, *norm2_input, *mu_labels;
-  rmm::device_uvector<math_t> mu_input_vector((0, stream);
+  rmm::device_uvector<math_t> mu_input_vector(0, stream);
   rmm::device_uvector<math_t> norm2_input_vector(0, stream);
   rmm::device_uvector<math_t> mu_labels_vector(0, stream);
 
   if (fit_intercept) {
-    mu_input_vector = rmm::device_uvector<math_t>(n_cols, stream)
-    mu_labels_vector = rmm::device_uvector<math_t>(1, stream)
+    mu_input_vector = rmm::device_uvector<math_t>(n_cols, stream);
+    mu_labels_vector = rmm::device_uvector<math_t>(1, stream);
     mu_input = mu_input_vector.data();
     mu_labels = mu_labels_vector.data();
     if (normalize) {
-      norm2_input_vector = rmm::device_uvector<math_t>(n_cols, stream)
+      norm2_input_vector = rmm::device_uvector<math_t>(n_cols, stream);
       norm2_input = norm2_input_vector.data();
     }
     preProcessData(handle, input, n_rows, n_cols, labels, intercept, mu_input,

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -66,7 +66,6 @@ void ridgeSolve(const raft::handle_t &handle, math_t *S, math_t *V, math_t *U,
 
   raft::linalg::gemm(handle, V, n_cols, n_cols, S_nnz, w, n_cols, 1,
                      CUBLAS_OP_N, CUBLAS_OP_N, alp, beta, stream);
-
 }
 
 template <typename math_t>
@@ -95,7 +94,6 @@ void ridgeSVD(const raft::handle_t &handle, math_t *A, int n_rows, int n_cols,
   raft::linalg::svdQR(handle, A, n_rows, n_cols, S, U, V, true, true, true,
                       stream);
   ridgeSolve(handle, S, V, U, n_rows, n_cols, b, alpha, n_alpha, w, stream);
-
 }
 
 template <typename math_t>
@@ -124,7 +122,6 @@ void ridgeEig(const raft::handle_t &handle, math_t *A, int n_rows, int n_cols,
   raft::linalg::svdEig(handle, A, n_rows, n_cols, S, U, V, true, stream);
 
   ridgeSolve(handle, S, V, U, n_rows, n_cols, b, alpha, n_alpha, w, stream);
-
 }
 
 /**

--- a/cpp/src/glm/ridge_mg.cu
+++ b/cpp/src/glm/ridge_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/ridge_mg.cu
+++ b/cpp/src/glm/ridge_mg.cu
@@ -16,7 +16,6 @@
 
 #include <raft/cudart_utils.h>
 #include <common/cumlHandle.hpp>
-#include <common/device_buffer.hpp>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/linear_model/preprocess_mg.hpp>
 #include <cuml/linear_model/ridge_mg.hpp>
@@ -57,8 +56,6 @@ void ridgeSolve(const raft::handle_t &handle, T *S, T *V,
 
   raft::matrix::setSmallValuesZero(S, UDesc.N, streams[0], thres);
 
-  // TO-DO: Update to use `device_buffer` here
-  // Tracking issue: https://github.com/rapidsai/cuml/issues/2524
   rmm::device_uvector<T> S_nnz_vector(UDesc.N, stream);
   S_nnz = S_nnz_vector.data();
   raft::copy(S_nnz, S, UDesc.N, streams[0]);
@@ -92,8 +89,8 @@ void ridgeEig(raft::handle_t &handle, const std::vector<Matrix::Data<T> *> &A,
 
   int rank = comm.get_rank();
 
-  device_buffer<T> S(allocator, streams[0], ADesc.N);
-  device_buffer<T> V(allocator, streams[0], ADesc.N * ADesc.N);
+  rmm::device_uvector<T> S(ADesc.N, streams[0]);
+  rmm::device_uvector<T> V(ADesc.N * ADesc.N, streams[0]);
   std::vector<Matrix::Data<T> *> U;
   std::vector<Matrix::Data<T>> U_temp;
 
@@ -105,7 +102,7 @@ void ridgeEig(raft::handle_t &handle, const std::vector<Matrix::Data<T> *> &A,
   }
   total_size = total_size * ADesc.N;
 
-  device_buffer<T> U_parts(allocator, streams[0], total_size);
+  rmm::device_uvector<T> U_parts(total_size, streams[0]);
   T *curr_ptr = U_parts.data();
 
   for (int i = 0; i < partsToRanks.size(); i++) {
@@ -136,9 +133,9 @@ void fit_impl(raft::handle_t &handle,
               int algo, cudaStream_t *streams, int n_streams, bool verbose) {
   const auto allocator = handle.get_device_allocator();
 
-  device_buffer<T> mu_input(allocator, streams[0]);
-  device_buffer<T> norm2_input(allocator, streams[0]);
-  device_buffer<T> mu_labels(allocator, streams[0]);
+  rmm::device_uvector<T> mu_input(0, streams[0]);
+  rmm::device_uvector<T> norm2_input(0, streams[0]);
+  rmm::device_uvector<T> mu_labels(0, streams[0]);
 
   if (fit_intercept) {
     mu_input.resize(input_desc.N, streams[0]);

--- a/cpp/src_prims/functions/hinge.cuh
+++ b/cpp/src_prims/functions/hinge.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/functions/hinge.cuh
+++ b/cpp/src_prims/functions/hinge.cuh
@@ -31,6 +31,7 @@
 #include <raft/mr/device/buffer.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
 #include "penalty.cuh"
 
 namespace MLCommon {
@@ -82,10 +83,7 @@ void hingeLossGrads(const raft::handle_t &handle, math_t *input, int n_rows,
                     int n_cols, const math_t *labels, const math_t *coef,
                     math_t *grads, penalty pen, math_t alpha, math_t l1_ratio,
                     cudaStream_t stream) {
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
-
-  raft::mr::device::buffer<math_t> labels_pred(allocator, stream, n_rows);
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
 
   raft::linalg::gemm(handle, input, n_rows, n_cols, coef, labels_pred.data(),
                      n_rows, 1, CUBLAS_OP_N, CUBLAS_OP_N, stream);
@@ -95,7 +93,7 @@ void hingeLossGrads(const raft::handle_t &handle, math_t *input, int n_rows,
   hingeLossGradMult(input, labels, labels_pred.data(), n_rows, n_cols, stream);
   raft::stats::mean(grads, input, n_cols, n_rows, false, false, stream);
 
-  raft::mr::device::buffer<math_t> pen_grads(allocator, stream, 0);
+  rmm::device_uvector<math_t> pen_grads(0, stream);
 
   if (pen != penalty::NONE) pen_grads.resize(n_cols, stream);
 
@@ -117,10 +115,7 @@ void hingeLoss(const raft::handle_t &handle, math_t *input, int n_rows,
                int n_cols, const math_t *labels, const math_t *coef,
                math_t *loss, penalty pen, math_t alpha, math_t l1_ratio,
                cudaStream_t stream) {
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
-
-  raft::mr::device::buffer<math_t> labels_pred(allocator, stream, n_rows);
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
 
   raft::linalg::gemm(handle, input, n_rows, n_cols, coef, labels_pred.data(),
                      n_rows, 1, CUBLAS_OP_N, CUBLAS_OP_N, stream);
@@ -133,7 +128,7 @@ void hingeLoss(const raft::handle_t &handle, math_t *input, int n_rows,
 
   raft::stats::sum(loss, labels_pred.data(), 1, n_rows, false, stream);
 
-  raft::mr::device::buffer<math_t> pen_val(allocator, stream, 0);
+  rmm::device_uvector<math_t> pen_val(0, stream);
 
   if (pen != penalty::NONE) pen_val.resize(1, stream);
 

--- a/cpp/src_prims/functions/linearReg.cuh
+++ b/cpp/src_prims/functions/linearReg.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/functions/linearReg.cuh
+++ b/cpp/src_prims/functions/linearReg.cuh
@@ -29,6 +29,7 @@
 #include <raft/mr/device/buffer.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
 #include "penalty.cuh"
 
 namespace MLCommon {
@@ -50,10 +51,7 @@ void linearRegLossGrads(const raft::handle_t &handle, math_t *input, int n_rows,
                         int n_cols, const math_t *labels, const math_t *coef,
                         math_t *grads, penalty pen, math_t alpha,
                         math_t l1_ratio, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
-  auto cublas_handle = handle.get_cublas_handle();
-
-  raft::mr::device::buffer<math_t> labels_pred(allocator, stream, n_rows);
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
 
   linearRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(), math_t(0),
              stream);
@@ -65,7 +63,7 @@ void linearRegLossGrads(const raft::handle_t &handle, math_t *input, int n_rows,
   raft::stats::mean(grads, input, n_cols, n_rows, false, false, stream);
   raft::linalg::scalarMultiply(grads, grads, math_t(2), n_cols, stream);
 
-  raft::mr::device::buffer<math_t> pen_grads(allocator, stream, 0);
+  rmm::device_uvector<math_t> pen_grads(0, stream);
 
   if (pen != penalty::NONE) pen_grads.resize(n_cols, stream);
 
@@ -87,10 +85,7 @@ void linearRegLoss(const raft::handle_t &handle, math_t *input, int n_rows,
                    int n_cols, const math_t *labels, const math_t *coef,
                    math_t *loss, penalty pen, math_t alpha, math_t l1_ratio,
                    cudaStream_t stream) {
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
-
-  raft::mr::device::buffer<math_t> labels_pred(allocator, stream, n_rows);
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
 
   linearRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(), math_t(0),
              stream);
@@ -100,7 +95,7 @@ void linearRegLoss(const raft::handle_t &handle, math_t *input, int n_rows,
   raft::matrix::power(labels_pred.data(), n_rows, stream);
   raft::stats::mean(loss, labels_pred.data(), 1, n_rows, false, false, stream);
 
-  raft::mr::device::buffer<math_t> pen_val(allocator, stream, 0);
+  rmm::device_uvector<math_t> pen_val(0, stream);
 
   if (pen != penalty::NONE) pen_val.resize(1, stream);
 

--- a/cpp/src_prims/functions/logisticReg.cuh
+++ b/cpp/src_prims/functions/logisticReg.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/functions/logisticReg.cuh
+++ b/cpp/src_prims/functions/logisticReg.cuh
@@ -29,6 +29,7 @@
 #include <raft/matrix/matrix.cuh>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
 #include "penalty.cuh"
 #include "sigmoid.cuh"
 
@@ -53,10 +54,7 @@ void logisticRegLossGrads(const raft::handle_t &handle, math_t *input,
                           int n_rows, int n_cols, const math_t *labels,
                           const math_t *coef, math_t *grads, penalty pen,
                           math_t alpha, math_t l1_ratio, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
-  auto cublas_handle = handle.get_cublas_handle();
-
-  raft::mr::device::buffer<math_t> labels_pred(allocator, stream, n_rows);
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
 
   logisticRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(),
                math_t(0), stream);
@@ -67,7 +65,7 @@ void logisticRegLossGrads(const raft::handle_t &handle, math_t *input,
 
   raft::stats::mean(grads, input, n_cols, n_rows, false, false, stream);
 
-  raft::mr::device::buffer<math_t> pen_grads(allocator, stream, 0);
+  rmm::device_uvector<math_t> pen_grads(0, stream);
 
   if (pen != penalty::NONE) pen_grads.resize(n_cols, stream);
 
@@ -114,18 +112,14 @@ void logisticRegLoss(const raft::handle_t &handle, math_t *input, int n_rows,
                      int n_cols, math_t *labels, const math_t *coef,
                      math_t *loss, penalty pen, math_t alpha, math_t l1_ratio,
                      cudaStream_t stream) {
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
-
-  raft::mr::device::buffer<math_t> labels_pred(allocator, stream, n_rows);
-
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
   logisticRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(),
                math_t(0), stream);
   logLoss(labels_pred.data(), labels, labels_pred.data(), n_rows, stream);
 
   raft::stats::mean(loss, labels_pred.data(), 1, n_rows, false, false, stream);
 
-  raft::mr::device::buffer<math_t> pen_val(allocator, stream, 0);
+  rmm::device_uvector<math_t> pen_val(0, stream);
 
   if (pen != penalty::NONE) pen_val.resize(1, stream);
 

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -68,26 +68,24 @@ template <typename math_t>
 void elasticnet(math_t *out, const math_t *coef, const int len,
                 const math_t alpha, const math_t l1_ratio,
                 cudaStream_t stream) {
-  rmm::device_uvector<math_t> out_lasso_vector(1, stream);
-  math_t *out_lasso = out_lasso_vector.data();
+  rmm::device_uvector<math_t> out_lasso(1, stream);
 
   ridge(out, coef, len, alpha * (math_t(1) - l1_ratio), stream);
-  lasso(out_lasso, coef, len, alpha * l1_ratio, stream);
+  lasso(out_lasso.data(), coef, len, alpha * l1_ratio, stream);
 
-  raft::linalg::add(out, out, out_lasso, 1, stream);
+  raft::linalg::add(out, out, out_lasso.data(), 1, stream);
 }
 
 template <typename math_t>
 void elasticnetGrad(math_t *grad, const math_t *coef, const int len,
                     const math_t alpha, const math_t l1_ratio,
                     cudaStream_t stream) {
-  rmm::device_uvector<math_t> out_lasso_vector(len, stream);
-  math_t *grad_lasso = out_lasso_vector.data();
+  rmm::device_uvector<math_t> grad_lasso(len, stream);
 
   ridgeGrad(grad, coef, len, alpha * (math_t(1) - l1_ratio), stream);
-  lassoGrad(grad_lasso, coef, len, alpha * l1_ratio, stream);
+  lassoGrad(grad_lasso.data(), coef, len, alpha * l1_ratio, stream);
 
-  raft::linalg::add(grad, grad, grad_lasso, len, stream);
+  raft::linalg::add(grad, grad, grad_lasso.data(), len, stream);
 }
 
 };  // namespace Functions

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -81,7 +81,7 @@ template <typename math_t>
 void elasticnetGrad(math_t *grad, const math_t *coef, const int len,
                     const math_t alpha, const math_t l1_ratio,
                     cudaStream_t stream) {
-  rmm::device_uvector<math_t> grad_lasso_vector(len, stream);
+  rmm::device_uvector<math_t> out_lasso_vector(len, stream);
   math_t *grad_lasso = out_lasso_vector.data();
 
   ridgeGrad(grad, coef, len, alpha * (math_t(1) - l1_ratio), stream);


### PR DESCRIPTION
Closes #3344.
This PR aims to convert the memory allocation strategy, to use RMM instead of Raft.

Linear model done:
- [X] Ridge
- [X] GLM
- [X] Primitives

