### PR TITLE
XFail Holt Winters test where statsmodels has known issues with gcc 9.3.0

### DIFF
--- a/python/cuml/test/test_holtwinters.py
+++ b/python/cuml/test/test_holtwinters.py
@@ -72,6 +72,9 @@ def test_singlets_holtwinters(seasonal, h, datatype):
     train = airpassengers[:-h]
     test = airpassengers[-h:]
 
+    if seasonal == "multiplicative":
+        pytest.xfail("Statsmodels nan errors with gcc 9.3 (Issue #3384)")
+
     sm_hw = sm_ES(train, seasonal=seasonal,
                   seasonal_periods=12)
     sm_hw = sm_hw.fit()
@@ -97,6 +100,9 @@ def test_multits_holtwinters(seasonal, h, datatype):
     global airpassengers, co2
     airpassengers = np.asarray(airpassengers, dtype=datatype)
     co2 = np.asarray(co2, dtype=datatype)
+
+    if seasonal == "multiplicative":
+        pytest.xfail("Statsmodels nan errors with gcc 9.3 (Issue #3384)")
 
     air_train = airpassengers[:-h]
     air_test = airpassengers[-h:]


### PR DESCRIPTION
In PR #3379, we observed this error in statsmodels (obtaining nans) that is unrelated to cuml but occurs with gcc 9.3.0. (See issue #3384.) For now, we will xfail.﻿
