### PR TITLE
Fix for ANN memory release bug

### DIFF
--- a/cpp/include/cuml/neighbors/knn.hpp
+++ b/cpp/include/cuml/neighbors/knn.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cuml/neighbors/knn.hpp
+++ b/cpp/include/cuml/neighbors/knn.hpp
@@ -44,8 +44,8 @@ struct knnIndex {
   faiss::gpu::GpuIndex *index;
   int device;
   ~knnIndex() {
-    delete gpu_res;
     delete index;
+    delete gpu_res;
   }
 };
 


### PR DESCRIPTION
Answers #3318
This may fix the error observed in CI.

Before the change, the memory manager handler was released first, then the FAISS index.
After the change, the FAISS index is released first, then the memory manager handler is released.