### PR TITLE
Also xfail zlib errors when downloading newsgroups data

### DIFF
--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -20,6 +20,7 @@ from sklearn.datasets import fetch_20newsgroups
 from sklearn.feature_extraction.text import CountVectorizer
 import zlib
 
+
 def pytest_configure(config):
     cp.cuda.set_allocator(None)
 

--- a/python/cuml/test/conftest.py
+++ b/python/cuml/test/conftest.py
@@ -18,7 +18,7 @@ import cupy as cp
 import pytest
 from sklearn.datasets import fetch_20newsgroups
 from sklearn.feature_extraction.text import CountVectorizer
-
+import zlib
 
 def pytest_configure(config):
     cp.cuda.set_allocator(None)
@@ -30,7 +30,7 @@ def nlp_20news():
         twenty_train = fetch_20newsgroups(subset='train',
                                           shuffle=True,
                                           random_state=42)
-    except IOError:
+    except (IOError, zlib.error):
         pytest.xfail(reason="Error fetching 20 newsgroup dataset")
 
     count_vect = CountVectorizer()


### PR DESCRIPTION
Download errors can manifest as zlib.error as well as IOException it turns out (just saw this in CI)