### PR TITLE
[REVIEW] Use stable 1.0.0 version of Treelite

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2020, NVIDIA CORPORATION.
 ##############################################
 # cuML GPU build and test script for CI      #
 ##############################################
@@ -57,8 +57,6 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*"
-
-gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia treelite=1.0.0
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -58,6 +58,8 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*"
 
+gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia treelite=1.0.0
+
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_conda_retry install -y "your-pkg=1.0.0"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 ##############################################
 # cuML GPU build and test script for CI      #
 ##############################################

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1
+- treelite=1.0.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1|1.0.0
+- treelite=1.0.0rc1
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1
+- treelite=1.0.0rc1|1.0.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1
+- treelite=1.0.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1|1.0.0
+- treelite=1.0.0rc1
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1
+- treelite=1.0.0rc1|1.0.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1
+- treelite=1.0.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1|1.0.0
+- treelite=1.0.0rc1
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -21,7 +21,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0rc1
+- treelite=1.0.0rc1|1.0.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.14
-    - treelite=1.0.0rc1
+    - treelite=1.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -40,7 +40,7 @@ requirements:
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - treelite=1.0.0rc1
+    - treelite=1.0.0
     - cupy>7.1.0,<9.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.14
-    - treelite=1.0.0rc1
+    - treelite=1.0.0rc1|1.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -40,7 +40,7 @@ requirements:
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - treelite=1.0.0rc1
+    - treelite=1.0.0rc1|1.0.0
     - cupy>7.1.0,<9.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build . -c defaults -c conda-forge -c numba -c rapidsai -c pytorch

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.14
-    - treelite=1.0.0rc1|1.0.0
+    - treelite=1.0.0rc1
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -40,7 +40,7 @@ requirements:
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - treelite=1.0.0rc1|1.0.0
+    - treelite=1.0.0rc1
     - cupy>7.1.0,<9.0.0a0
     - nccl>=2.5
     - ucx-py {{ minor_version }}

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - ucx-py {{ minor_version }}
     - libcumlprims {{ minor_version }}
     - lapack
-    - treelite=1.0.0rc1|1.0.0
+    - treelite=1.0.0rc1
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - libfaiss=1.6.3
@@ -47,7 +47,7 @@ requirements:
     - nccl>=2.5
     - ucx-py {{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - treelite=1.0.0rc1|1.0.0
+    - treelite=1.0.0rc1
     - faiss-proc=*=cuda
     - libfaiss=1.6.3
 

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - ucx-py {{ minor_version }}
     - libcumlprims {{ minor_version }}
     - lapack
-    - treelite=1.0.0rc1
+    - treelite=1.0.0
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - libfaiss=1.6.3
@@ -47,7 +47,7 @@ requirements:
     - nccl>=2.5
     - ucx-py {{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - treelite=1.0.0rc1
+    - treelite=1.0.0
     - faiss-proc=*=cuda
     - libfaiss=1.6.3
 

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build . -c defaults -c conda-forge -c nvidia -c rapidsai -c pytorch

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - ucx-py {{ minor_version }}
     - libcumlprims {{ minor_version }}
     - lapack
-    - treelite=1.0.0rc1
+    - treelite=1.0.0rc1|1.0.0
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - libfaiss=1.6.3
@@ -47,7 +47,7 @@ requirements:
     - nccl>=2.5
     - ucx-py {{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - treelite=1.0.0rc1
+    - treelite=1.0.0rc1|1.0.0
     - faiss-proc=*=cuda
     - libfaiss=1.6.3
 


### PR DESCRIPTION
The stable 1.0.0 version of Treelite is [virtually identical to the 1.0.0 RC1 version](https://github.com/dmlc/treelite/pull/246). Using `1.0.0rc1|1.0.0` so that the CI doesn't break until https://github.com/rapidsai/integration/pull/210 is merged.