### PR TITLE
[Review] Parallelize RF to Treelite conversion over trees

### DIFF
--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -335,6 +335,9 @@ void build_treelite_forest(ModelHandle* model,
       model_builder, "pred_transform", "max_index"));
   }
 
+  int n_streams = forest->rf_params.n_streams;
+
+#pragma omp parallel for num_threads(n_streams)
   for (int i = 0; i < forest->rf_params.n_trees; i++) {
     DecisionTree::TreeMetaDataNode<T, L>* tree_ptr = &forest->trees[i];
     TreeBuilderHandle tree_builder;

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -335,7 +335,7 @@ void build_treelite_forest(ModelHandle* model,
       model_builder, "pred_transform", "max_index"));
   }
 
-#pragma omp parallel for num_threads(forest->rf_params.n_streams)
+#pragma omp parallel for
   for (int i = 0; i < forest->rf_params.n_trees; i++) {
     DecisionTree::TreeMetaDataNode<T, L>* tree_ptr = &forest->trees[i];
     TreeBuilderHandle tree_builder;

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -349,6 +349,7 @@ void build_treelite_forest(ModelHandle* model,
                                               num_class);
 
       // The third argument -1 means append to the end of the tree list.
+#pragma omp critical
       TREELITE_CHECK(
         TreeliteModelBuilderInsertTree(model_builder, tree_builder, -1));
     }

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -335,9 +335,7 @@ void build_treelite_forest(ModelHandle* model,
       model_builder, "pred_transform", "max_index"));
   }
 
-  int n_streams = forest->rf_params.n_streams;
-
-#pragma omp parallel for num_threads(n_streams)
+#pragma omp parallel for num_threads(forest->rf_params.n_streams)
   for (int i = 0; i < forest->rf_params.n_trees; i++) {
     DecisionTree::TreeMetaDataNode<T, L>* tree_ptr = &forest->trees[i];
     TreeBuilderHandle tree_builder;


### PR DESCRIPTION
Perform construction of Treelite trees in parallel when converting from a cuML RF model
Improve speed of initial prediction for a model with 300 trees of approximately 4M nodes by an average of 2.04x on a system with 12 Intel Xeon Gold 6128 CPUs available