### PR TITLE
[REVIEW] Parallelize Treelite to FIL conversion over trees

### DIFF
--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -544,7 +544,8 @@ void tree2fil_dense(std::vector<dense_node>* pnodes, int root,
 }
 
 template <typename fil_node_t, typename T, typename L>
-int tree2fil_sparse(fil_node_t* const pnodes, const int root, const tl::Tree<T, L>& tree,
+int tree2fil_sparse(fil_node_t* const pnodes, const int root,
+                    const tl::Tree<T, L>& tree,
                     const forest_params_t& forest_params) {
   typedef std::pair<int, int> pair_t;
   std::stack<pair_t> stack;
@@ -754,8 +755,8 @@ void tl2fil_sparse(std::vector<int>* ptrees, std::vector<fil_node_t>* pnodes,
 
   ptrees->reserve(num_trees);
   ptrees->push_back(0);
-  for (size_t i=0; i < num_trees - 1; ++i) {
-      ptrees->push_back(model.trees[i].num_nodes + (*ptrees)[i]);
+  for (size_t i = 0; i < num_trees - 1; ++i) {
+    ptrees->push_back(model.trees[i].num_nodes + (*ptrees)[i]);
   }
   size_t total_nodes = ptrees->back() + model.trees.back().num_nodes;
 
@@ -768,8 +769,9 @@ void tl2fil_sparse(std::vector<int>* ptrees, std::vector<fil_node_t>* pnodes,
   // convert the nodes
   fil_node_t* front = pnodes->data();
 #pragma omp parallel for num_threads(16)
-  for (int i=0; i < num_trees; ++i) {
-    tree2fil_sparse(front + (*ptrees)[i], (*ptrees)[i], model.trees[i], *params);
+  for (int i = 0; i < num_trees; ++i) {
+    tree2fil_sparse(front + (*ptrees)[i], (*ptrees)[i], model.trees[i],
+                    *params);
   }
 
   params->num_nodes = pnodes->size();

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -764,11 +764,7 @@ void tl2fil_sparse(std::vector<int>* ptrees, std::vector<fil_node_t>* pnodes,
   }
   size_t total_nodes = ptrees->back() + model.trees.back().num_nodes;
 
-  pnodes->reserve(total_nodes);
-  for (size_t i = 0; i < total_nodes; ++i) {
-    // TODO
-    pnodes->emplace_back();
-  }
+  pnodes->resize(total_nodes);
 
   // convert the nodes
   fil_node_t* front = pnodes->data();

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -759,7 +759,7 @@ void tl2fil_sparse(std::vector<int>* ptrees, std::vector<fil_node_t>* pnodes,
   ptrees->reserve(num_trees);
   ptrees->push_back(0);
   for (size_t i = 0; i < num_trees - 1; ++i) {
-    ptrees->push_back(model.trees[i].num_nodes + (*ptrees)[i]);
+    ptrees->push_back(model.trees[i].num_nodes + ptrees->back());
   }
   size_t total_nodes = ptrees->back() + model.trees.back().num_nodes;
 

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -547,7 +547,7 @@ void tree2fil_dense(std::vector<dense_node>* pnodes, int root,
 }
 
 template <typename fil_node_t, typename T, typename L>
-int tree2fil_sparse(std::vector<fil_node_t>& nodes, const int root,
+int tree2fil_sparse(std::vector<fil_node_t>& nodes, int root,
                     const tl::Tree<T, L>& tree,
                     const forest_params_t& forest_params) {
   typedef std::pair<int, int> pair_t;
@@ -766,7 +766,6 @@ void tl2fil_sparse(std::vector<int>* ptrees, std::vector<fil_node_t>* pnodes,
   pnodes->resize(total_nodes);
 
   // convert the nodes
-  // fil_node_t* front = pnodes->data();
 #pragma omp parallel for
   for (int i = 0; i < num_trees; ++i) {
     tree2fil_sparse(*pnodes, (*ptrees)[i], model.trees[i], *params);

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -749,36 +749,32 @@ struct tl2fil_sparse_check_t<sparse_node8> {
 // uses treelite model with additional tl_params to initialize FIL params,
 // trees (stored in *ptrees) and sparse nodes (stored in *pnodes)
 template <typename fil_node_t, typename T, typename L>
-void tl2fil_sparse(std::vector<int>* ptrees, std::vector<fil_node_t>* pnodes,
-                   forest_params_t* params, const tl::ModelImpl<T, L>& model,
-                   const treelite_params_t* tl_params) {
+std::unique_ptr<fil_node_t[]> tl2fil_sparse(std::vector<int>& trees,
+                                          forest_params_t* params,
+                                          const tl::ModelImpl<T, L>& model,
+                                          const treelite_params_t* tl_params) {
   tl2fil_common(params, model, tl_params);
   tl2fil_sparse_check_t<fil_node_t>::check(model);
 
   size_t num_trees = model.trees.size();
+  trees.reserve(num_trees);
 
-  ptrees->reserve(num_trees);
-  ptrees->push_back(0);
+  trees.push_back(0);
   for (size_t i = 0; i < num_trees - 1; ++i) {
-    ptrees->push_back(model.trees[i].num_nodes + (*ptrees)[i]);
+    trees.push_back(model.trees[i].num_nodes + trees[i]);
   }
-  size_t total_nodes = ptrees->back() + model.trees.back().num_nodes;
+  params->num_nodes = trees.back() + model.trees.back().num_nodes;
 
-  pnodes->reserve(total_nodes);
-  for (size_t i = 0; i < total_nodes; ++i) {
-    // TODO
-    pnodes->emplace_back();
-  }
+  auto nodes = std::make_unique<fil_node_t[]>(params->num_nodes);
 
   // convert the nodes
-  fil_node_t* front = pnodes->data();
+  fil_node_t* front = nodes.get();
 #pragma omp parallel for
   for (int i = 0; i < num_trees; ++i) {
-    tree2fil_sparse(front + (*ptrees)[i], (*ptrees)[i], model.trees[i],
-                    *params);
+    tree2fil_sparse(front + trees[i], trees[i], model.trees[i], *params);
   }
 
-  params->num_nodes = pnodes->size();
+  return nodes;
 }
 
 void init_dense(const raft::handle_t& h, forest_t* pf, const dense_node* nodes,
@@ -847,6 +843,7 @@ void from_treelite(const raft::handle_t& handle, forest_t* pforest,
   }
 
   forest_params_t params;
+
   switch (storage_type) {
     case storage_type_t::DENSE: {
       std::vector<dense_node> nodes;
@@ -859,23 +856,26 @@ void from_treelite(const raft::handle_t& handle, forest_t* pforest,
     }
     case storage_type_t::SPARSE: {
       std::vector<int> trees;
-      std::vector<sparse_node16> nodes;
-      tl2fil_sparse(&trees, &nodes, &params, model, tl_params);
-      init_sparse(handle, pforest, trees.data(), nodes.data(), &params);
+      auto nodes = tl2fil_sparse<sparse_node16, T, L>(
+        trees, &params, model, tl_params);
+      init_sparse(handle, pforest, trees.data(), nodes.get(), &params);
       CUDA_CHECK(cudaStreamSynchronize(handle.get_stream()));
       break;
     }
     case storage_type_t::SPARSE8: {
       std::vector<int> trees;
-      std::vector<sparse_node8> nodes;
-      tl2fil_sparse(&trees, &nodes, &params, model, tl_params);
-      init_sparse(handle, pforest, trees.data(), nodes.data(), &params);
+      auto nodes = tl2fil_sparse<sparse_node8, T, L>(
+        trees, &params, model, tl_params);
+      init_sparse(handle, pforest, trees.data(), nodes.get(), &params);
       CUDA_CHECK(cudaStreamSynchronize(handle.get_stream()));
       break;
     }
     default:
       ASSERT(false, "tl_params->sparse must be one of AUTO, DENSE or SPARSE");
   }
+
+
+
 }
 
 void from_treelite(const raft::handle_t& handle, forest_t* pforest,

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <numeric>
 #include <stack>
 #include <utility>
 


### PR DESCRIPTION
Convert Treelite trees to FIL in parallel
Improve speed of initial prediction for a model with 300 trees of approximately 4M nodes by an average of 5.9% on a system with 12 Intel Xeon Gold 6128 CPUs available