### PR TITLE
[REVIEW] Improving Copyright Check When Not Running in CI

### DIFF
--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -20,8 +20,7 @@ import io
 import os
 import sys
 
-SCRIPT_DIR = os.path.dirname(
-    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
+SCRIPT_DIR = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
 
 # Add the scripts dir for gitutils
 sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR,
@@ -41,9 +40,11 @@ FilesToCheck = [
 ]
 
 # this will break starting at year 10000, which is probably OK :)
-CheckSimple = re.compile(r"Copyright \(c\) (\d{4}), NVIDIA CORPORATION")
+CheckSimple = re.compile(
+    r"Copyright *(?:\(c\))? *(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)")
 CheckDouble = re.compile(
-    r"Copyright \(c\) (\d{4})-(\d{4}), NVIDIA CORPORATION")
+    r"Copyright *(?:\(c\))? *(\d{4})-(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)"  # noqa: E501
+)
 
 
 def checkThisFile(f):

--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -18,7 +18,18 @@ import re
 import argparse
 import io
 import os
-import gitutils
+import sys
+
+SCRIPT_DIR = os.path.dirname(
+    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
+
+# Add the scripts dir for gitutils
+sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR,
+                                              "../../cpp/scripts")))
+
+# Now import gitutils. Ignore flake8 error here since there is no other way to
+# set up imports
+import gitutils  # noqa: E402
 
 FilesToCheck = [
     re.compile(r"[.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx)$"),
@@ -37,7 +48,7 @@ CheckDouble = re.compile(
 
 def checkThisFile(f):
     # This check covers things like symlinks which point to files that DNE
-    if not(os.path.exists(f)):
+    if not (os.path.exists(f)):
         return False
     if gitutils and gitutils.isFileEmpty(f):
         return False
@@ -84,12 +95,22 @@ def checkCopyright(f, update_current_year):
             continue
         crFound = True
         if start > end:
-            e = [f, lineNum, "First year after second year in the copyright "
-                 "header (manual fix required)", None]
+            e = [
+                f,
+                lineNum,
+                "First year after second year in the copyright "
+                "header (manual fix required)",
+                None
+            ]
             errs.append(e)
         if thisYear < start or thisYear > end:
-            e = [f, lineNum, "Current year not included in the "
-                 "copyright header", None]
+            e = [
+                f,
+                lineNum,
+                "Current year not included in the "
+                "copyright header",
+                None
+            ]
             if thisYear < start:
                 e[-1] = replaceCurrentYear(line, thisYear, end)
             if thisYear > end:
@@ -100,8 +121,13 @@ def checkCopyright(f, update_current_year):
     fp.close()
     # copyright header itself not found
     if not crFound:
-        e = [f, 0, "Copyright header missing or formatted incorrectly "
-             "(manual fix required)", None]
+        e = [
+            f,
+            0,
+            "Copyright header missing or formatted incorrectly "
+            "(manual fix required)",
+            None
+        ]
         errs.append(e)
     # even if the year matches a copyright header, make the check pass
     if yearMatched:
@@ -142,12 +168,18 @@ def checkCopyright_main():
 
     argparser = argparse.ArgumentParser(
         "Checks for a consistent copyright header in git's modified files")
-    argparser.add_argument("--update-current-year", dest='update_current_year',
-                           action="store_true", required=False, help="If set, "
+    argparser.add_argument("--update-current-year",
+                           dest='update_current_year',
+                           action="store_true",
+                           required=False,
+                           help="If set, "
                            "update the current year if a header is already "
                            "present and well formatted.")
-    argparser.add_argument("--git-modified-only", dest='git_modified_only',
-                           action="store_true", required=False, help="If set, "
+    argparser.add_argument("--git-modified-only",
+                           dest='git_modified_only',
+                           action="store_true",
+                           required=False,
+                           help="If set, "
                            "only files seen as modified by git will be "
                            "processed.")
 
@@ -157,7 +189,7 @@ def checkCopyright_main():
     else:
         files = []
         for d in [os.path.abspath(d) for d in dirs]:
-            if not(os.path.isdir(d)):
+            if not (os.path.isdir(d)):
                 raise ValueError(f"{d} is not a directory.")
             files += getAllFilesUnderDir(d, pathFilter=checkThisFile)
 
@@ -174,8 +206,9 @@ def checkCopyright_main():
         path_parts = os.path.abspath(__file__).split(os.sep)
         file_from_repo = os.sep.join(path_parts[path_parts.index("ci"):])
         if n_fixable > 0:
-            print("You can run {} --update-current-year to fix {} of these "
-                  "errors.\n".format(file_from_repo, n_fixable))
+            print(("You can run `python {} --git-modified-only "
+                   "--update-current-year` to fix {} of these "
+                   "errors.\n").format(file_from_repo, n_fixable))
         retVal = 1
     else:
         print("Copyright check passed")

--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -43,7 +43,7 @@ FilesToCheck = [
 CheckSimple = re.compile(
     r"Copyright *(?:\(c\))? *(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)")
 CheckDouble = re.compile(
-    r"Copyright *(?:\(c\))? *(\d{4})-(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)"  # noqa: E501
+    r"Copyright *(?:\(c\))? *(\d{4})-(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)"
 )
 
 

--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -43,7 +43,7 @@ FilesToCheck = [
 CheckSimple = re.compile(
     r"Copyright *(?:\(c\))? *(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)")
 CheckDouble = re.compile(
-    r"Copyright *(?:\(c\))? *(\d{4})-(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)"
+    r"Copyright *(?:\(c\))? *(\d{4})-(\d{4}),? *NVIDIA C(?:ORPORATION|orporation)"  # noqa: E501
 )
 
 

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # Check for copyright headers in the files modified currently
-COPYRIGHT=`env PYTHONPATH=cpp/scripts python ci/checks/copyright.py --git-modified-only 2>&1`
+COPYRIGHT=`python ci/checks/copyright.py --git-modified-only 2>&1`
 CR_RETVAL=$?
 if [ "$RETVAL" = "0" ]; then
   RETVAL=$CR_RETVAL

--- a/cpp/scripts/gitutils.py
+++ b/cpp/scripts/gitutils.py
@@ -26,7 +26,7 @@ def __git(*opts):
     """Runs a git command and returns its output"""
     cmd = "git " + " ".join(list(opts))
     ret = subprocess.check_output(cmd, shell=True)
-    return ret.decode("UTF-8")
+    return ret.decode("UTF-8").rstrip("\n")
 
 
 def __gitdiff(*opts):
@@ -39,6 +39,111 @@ def branch():
     name = __git("rev-parse", "--abbrev-ref", "HEAD")
     name = name.rstrip()
     return name
+
+
+def repo_version():
+    """
+    Determines the version of the repo by using `git describe`
+
+    Returns
+    -------
+    str
+        The full version of the repo in the format 'v#.#.#{a|b|rc}'
+    """
+    return __git("describe", "--tags", "--abbrev=0")
+
+
+def repo_version_major_minor():
+    """
+    Determines the version of the repo using `git describe` and returns only
+    the major and minor portion
+
+    Returns
+    -------
+    str
+        The partial version of the repo in the format '{major}.{minor}'
+    """
+
+    full_repo_version = repo_version()
+
+    match = re.match(r"^v?(?P<major>[0-9]+)(?:\.(?P<minor>[0-9]+))?",
+                     full_repo_version)
+
+    if (match is None):
+        print("   [DEBUG] Could not determine repo major minor version. "
+              f"Full repo version: {full_repo_version}.")
+        return None
+
+    out_version = match.group("major")
+
+    if (match.group("minor")):
+        out_version += "." + match.group("minor")
+
+    return out_version
+
+
+def determine_merge_commit(current_branch="HEAD"):
+    """
+    When running outside of CI, this will estimate the target merge commit hash
+    of `current_branch` by finding a common ancester with the remote branch
+    'branch-{major}.{minor}' where {major} and {minor} are determined from the
+    repo version.
+
+    Parameters
+    ----------
+    current_branch : str, optional
+        Which branch to consider as the current branch, by default "HEAD"
+
+    Returns
+    -------
+    str
+        The common commit hash ID
+    """
+
+    try:
+        # Try to determine the target branch from the most recent tag
+        head_branch = __git("describe",
+                            "--all",
+                            "--tags",
+                            "--match='branch-*'",
+                            "--abbrev=0")
+    except subprocess.CalledProcessError:
+        print("   [DEBUG] Could not determine target branch from most recent "
+              "tag. Falling back to 'branch-{major}.{minor}.")
+        head_branch = None
+
+    if (head_branch is not None):
+        # Convert from head to branch name
+        head_branch = __git("name-rev", "--name-only", head_branch)
+    else:
+        # Try and guess the target branch as "branch-<major>.<minor>"
+        version = repo_version_major_minor()
+
+        if (version is None):
+            return None
+
+        head_branch = "branch-{}".format(version)
+
+    try:
+        # Now get the remote tracking branch
+        remote_branch = __git("rev-parse",
+                              "--abbrev-ref",
+                              "--symbolic-full-name",
+                              head_branch + "@{upstream}")
+    except subprocess.CalledProcessError:
+        print("   [DEBUG] Could not remote tracking reference for "
+              f"branch {head_branch}.")
+        remote_branch = None
+
+    if (remote_branch is None):
+        return None
+
+    print(f"   [DEBUG] Determined TARGET_BRANCH as: '{remote_branch}'. "
+          "Finding common ancestor.")
+
+    common_commit = __git("merge-base", remote_branch, current_branch)
+
+    return common_commit
 
 
 def uncommittedFiles():
@@ -72,7 +177,8 @@ def changedFilesBetween(baseName, branchName, commitHash):
     # checkout latest commit from branch
     __git("checkout", "-fq", commitHash)
 
-    files = __gitdiff("--name-only", "--ignore-submodules",
+    files = __gitdiff("--name-only",
+                      "--ignore-submodules",
                       f"{baseName}..{branchName}")
 
     # restore the original branch
@@ -85,8 +191,13 @@ def changesInFileBetween(file, b1, b2, filter=None):
     current = branch()
     __git("checkout", "--quiet", b1)
     __git("checkout", "--quiet", b2)
-    diffs = __gitdiff("--ignore-submodules", "-w", "--minimal", "-U0",
-                      "%s...%s" % (b1, b2), "--", file)
+    diffs = __gitdiff("--ignore-submodules",
+                      "-w",
+                      "--minimal",
+                      "-U0",
+                      "%s...%s" % (b1, b2),
+                      "--",
+                      file)
     __git("checkout", "--quiet", current)
     lines = []
     for line in diffs.splitlines():
@@ -99,8 +210,10 @@ def modifiedFiles(pathFilter=None):
     """
     If inside a CI-env (ie. TARGET_BRANCH and COMMIT_HASH are defined, and
     current branch is "current-pr-branch"), then lists out all files modified
-    between these 2 branches. Else, lists out all the uncommitted files in the
-    current branch.
+    between these 2 branches. Locally, TARGET_BRANCH will try to be determined
+    from the current repo version and finding a coresponding branch named
+    'branch-{major}.{minor}'. If this fails, this functino will list out all
+    the uncommitted files in the current branch.
 
     Such utility function is helpful while putting checker scripts as part of
     cmake, as well as CI process. This way, during development, only the files
@@ -111,15 +224,30 @@ def modifiedFiles(pathFilter=None):
     targetBranch = os.environ.get("TARGET_BRANCH")
     commitHash = os.environ.get("COMMIT_HASH")
     currentBranch = branch()
-    print(f"   [DEBUG] TARGET_BRANCH={targetBranch}, COMMIT_HASH={commitHash}, "
-          f"currentBranch={currentBranch}")
+    print(
+        f"   [DEBUG] TARGET_BRANCH={targetBranch}, COMMIT_HASH={commitHash}, "
+        f"currentBranch={currentBranch}")
 
     if targetBranch and commitHash and (currentBranch == "current-pr-branch"):
         print("   [DEBUG] Assuming a CI environment.")
         allFiles = changedFilesBetween(targetBranch, currentBranch, commitHash)
     else:
-        print("   [DEBUG] Did not detect CI environment.")
-        allFiles = uncommittedFiles()
+        print("   [DEBUG] Did not detect CI environment. "
+              "Determining TARGET_BRANCH locally.")
+
+        common_commit = determine_merge_commit(currentBranch)
+
+        if (common_commit is not None):
+
+            # Now get the diff. Use --staged to get both diff between
+            # common_commit..HEAD and any locally staged files
+            allFiles = __gitdiff("--name-only",
+                                 "--ignore-submodules",
+                                 "--staged",
+                                 f"{common_commit}").splitlines()
+        else:
+            # Fallback to just uncommitted files
+            allFiles = uncommittedFiles()
 
     files = []
     for f in allFiles:


### PR DESCRIPTION
This PR fixes some a few issues that were encountered recently with the new copyright check. Currently, if you get a copyright error in the style check, you get an error message that states: 
```
You can run ci/checks/copyright.py --update-current-year to fix 1 of these errors.
```
This unfortunately wouldn't work if you tried to run it locally for a few reasons:

1. If you run `ci/checks/copyright.py --update-current-year`, it wont work since you are missing `python`
2. The script `copyright.py` imports `gitutils` which is not on the `PYTHONPATH`
3. The script would determine which files to fix by looking for uncommited changes in your repo and fixing these files. If you have already gotten the error message in CI, all of your files have been committed already so it will report nothing to fix.

This PR fixes the above issues by printing the correct code to run to fix the error, appending `sys.path` with the location of `gitutils` and modifying the copyright.py script to more intelligently determine the PR target branch, even when running locally.