### PR TITLE
[REVIEW] Fix array_equal in tests

### DIFF
--- a/python/cuml/test/utils.py
+++ b/python/cuml/test/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ def array_equal(a, b, unit_tol=1e-4, total_tol=1e-4, with_sign=True):
 
     if not with_sign:
         a, b = np.abs(a), np.abs(b)
-    res = (np.sum(np.abs(a - b) > unit_tol)) / len(a) < total_tol
+    res = (np.sum(np.abs(a - b) > unit_tol)) / a.size < total_tol
     return res
 
 


### PR DESCRIPTION
Answers #1970
This PR fixes the `array_equal` function. More specifically, the calculation of the percentage of correct element in the array. This had as an effect a release in testing (necessary changes harder to detect). After verification, it appeared that the `total_tol` parameter was (explicitly or implicitly) set at default value everywhere. No change in pytests was necessary.