### PR TITLE
Fix Nearest Neighbor Stress Test

### DIFF
--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -484,7 +484,7 @@ def test_nearest_neighbors_sparse(nrows, ncols,
 
     sknn = skKNN(metric=metric, n_neighbors=n_neighbors,
                  algorithm="brute", n_jobs=-1)
-    sk_X = a
+    sk_X = a.get()
     sknn.fit(sk_X)
 
     skD, skI = sknn.kneighbors(sk_X)

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -327,7 +327,7 @@ def test_knn_separate_index_search(input_type, nrows, n_feats, k, metric):
 @pytest.mark.parametrize('input_type', ['dataframe', 'ndarray'])
 @pytest.mark.parametrize('nrows', [unit_param(500), quality_param(5000),
                          stress_param(70000)])
-@pytest.mark.parametrize('n_feats', [unit_param(3), qu0ality_param(100),
+@pytest.mark.parametrize('n_feats', [unit_param(3), quality_param(100),
                          stress_param(1000)])
 @pytest.mark.parametrize('k', [unit_param(3), quality_param(30),
                          stress_param(50)])

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -21,7 +21,7 @@ from cuml.test.utils import array_equal, unit_param, quality_param, \
 from cuml.neighbors import NearestNeighbors as cuKNN
 
 from sklearn.neighbors import NearestNeighbors as skKNN
-from sklearn.datasets import make_blobs
+from cuml.datasets import make_blobs
 
 from cuml.common import logger
 
@@ -43,6 +43,10 @@ def predict(neigh_ind, _y, n_neighbors):
     import scipy.stats as stats
 
     neigh_ind = neigh_ind.astype(np.int32)
+    if isinstance(_y, cp.core.core.ndarray):
+        _y = _y.get()
+    if isinstance(neigh_ind, cp.core.core.ndarray):
+        neigh_ind = neigh_ind.get()
 
     ypred, count = stats.mode(_y[neigh_ind], axis=1)
     return ypred.ravel(), count.ravel() * 1.0 / n_neighbors
@@ -147,7 +151,7 @@ def test_neighborhood_predictions(nrows, ncols, n_neighbors, n_clusters,
         assert isinstance(neigh_ind, cudf.DataFrame)
         neigh_ind = neigh_ind.as_gpu_matrix().copy_to_host()
     else:
-        assert isinstance(neigh_ind, np.ndarray)
+        assert isinstance(neigh_ind, cp.core.core.ndarray)
 
     labels, probs = predict(neigh_ind, y, n_neighbors)
 
@@ -277,8 +281,8 @@ def test_knn_separate_index_search(input_type, nrows, n_feats, k, metric):
 
     p = 5  # Testing 5-norm of the minkowski metric only
     knn_sk = skKNN(metric=metric, p=p)  # Testing
-    knn_sk.fit(X_index)
-    D_sk, I_sk = knn_sk.kneighbors(X_search, k)
+    knn_sk.fit(X_index.get())
+    D_sk, I_sk = knn_sk.kneighbors(X_search.get(), k)
 
     X_orig = X_index
 
@@ -296,14 +300,14 @@ def test_knn_separate_index_search(input_type, nrows, n_feats, k, metric):
         D_cuml_arr = D_cuml.as_gpu_matrix().copy_to_host()
         I_cuml_arr = I_cuml.as_gpu_matrix().copy_to_host()
     else:
-        assert isinstance(D_cuml, np.ndarray)
-        assert isinstance(I_cuml, np.ndarray)
-        D_cuml_arr = D_cuml
-        I_cuml_arr = I_cuml
+        assert isinstance(D_cuml, cp.core.core.ndarray)
+        assert isinstance(I_cuml, cp.core.core.ndarray)
+        D_cuml_arr = D_cuml.get()
+        I_cuml_arr = I_cuml.get()
 
     with cuml.using_output_type("numpy"):
         # Assert the cuml model was properly reverted
-        np.testing.assert_allclose(knn_cu.X_m, X_orig,
+        np.testing.assert_allclose(knn_cu.X_m, X_orig.get(),
                                    atol=1e-3, rtol=1e-3)
 
     if metric == 'braycurtis':
@@ -332,7 +336,7 @@ def test_knn_x_none(input_type, nrows, n_feats, k, metric):
 
     p = 5  # Testing 5-norm of the minkowski metric only
     knn_sk = skKNN(metric=metric, p=p)  # Testing
-    knn_sk.fit(X)
+    knn_sk.fit(X.get())
     D_sk, I_sk = knn_sk.kneighbors(X=None, n_neighbors=k)
 
     X_orig = X
@@ -384,7 +388,9 @@ def test_knn_fit_twice():
 @pytest.mark.parametrize('n_feats', [unit_param(20), quality_param(100),
                          stress_param(1000)])
 def test_nn_downcast_fails(input_type, nrows, n_feats):
-    X, y = make_blobs(n_samples=nrows,
+    from sklearn.datasets import make_blobs as skmb
+
+    X, y = skmb(n_samples=nrows,
                       n_features=n_feats, random_state=0)
 
     knn_cu = cuKNN()
@@ -421,13 +427,13 @@ def test_knn_graph(input_type, nrows, n_feats, p, k, metric, mode,
                       n_features=n_feats, random_state=0)
 
     if as_instance:
-        sparse_sk = sklearn.neighbors.kneighbors_graph(X, k, mode,
+        sparse_sk = sklearn.neighbors.kneighbors_graph(X.get(), k, mode,
                                                        metric=metric, p=p,
                                                        include_self='auto')
     else:
         knn_sk = skKNN(metric=metric, p=p)
-        knn_sk.fit(X)
-        sparse_sk = knn_sk.kneighbors_graph(X, k, mode)
+        knn_sk.fit(X.get())
+        sparse_sk = knn_sk.kneighbors_graph(X.get(), k, mode)
 
     if input_type == "dataframe":
         X = cudf.DataFrame(X)

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -106,7 +106,9 @@ def test_self_neighboring(datatype, metric_p, nrows):
         neigh_ind = neigh_ind.as_gpu_matrix().copy_to_host()
         neigh_dist = neigh_dist.as_gpu_matrix().copy_to_host()
     else:
-        assert isinstance(neigh_ind, np.ndarray)
+        assert isinstance(neigh_ind, cp.core.core.ndarray)
+        neigh_ind = neigh_ind.get()
+        neigh_dist = neigh_dist.get()
 
     neigh_ind = neigh_ind[:, 0]
     neigh_dist = neigh_dist[:, 0]

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -391,7 +391,7 @@ def test_nn_downcast_fails(input_type, nrows, n_feats):
     from sklearn.datasets import make_blobs as skmb
 
     X, y = skmb(n_samples=nrows,
-                      n_features=n_feats, random_state=0)
+                n_features=n_feats, random_state=0)
 
     knn_cu = cuKNN()
     if input_type == 'dataframe':

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -326,8 +326,8 @@ def test_knn_separate_index_search(input_type, nrows, n_feats, k, metric):
 
 @pytest.mark.parametrize('input_type', ['dataframe', 'ndarray'])
 @pytest.mark.parametrize('nrows', [unit_param(500), quality_param(5000),
-                         stress_param(5000)])
-@pytest.mark.parametrize('n_feats', [unit_param(3), quality_param(100),
+                         stress_param(70000)])
+@pytest.mark.parametrize('n_feats', [unit_param(3), qu0ality_param(100),
                          stress_param(1000)])
 @pytest.mark.parametrize('k', [unit_param(3), quality_param(30),
                          stress_param(50)])
@@ -386,7 +386,7 @@ def test_knn_fit_twice():
 
 @pytest.mark.parametrize('input_type', ['ndarray'])
 @pytest.mark.parametrize('nrows', [unit_param(500), quality_param(5000),
-                         stress_param(5000)])
+                         stress_param(70000)])
 @pytest.mark.parametrize('n_feats', [unit_param(20), quality_param(100),
                          stress_param(1000)])
 def test_nn_downcast_fails(input_type, nrows, n_feats):


### PR DESCRIPTION
Closes #3300.

This PR is changing the number of rows from 500k to 5k for the stress tests, and changing the dataset generator to cuml `make_blobs`. The stress tests are now running in just under 30 minutes.