### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@ CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
 
-ci:
+gpuCI:
   - 'ci/**'
 
 conda:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,20 +6,19 @@ Cython / Python:
   - 'python/**'
   - 'notebooks/**'
   
-libcuml:
+cpp:
   - 'cpp/**'
 
 CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
-  
-cuml (Java):
-  - 'java/**'
+
+ci:
+  - 'ci/**'
+
+conda:
+  - 'conda/**'
   
 Ops:
   - '.github/**'
-  - 'ci/**'
-  - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,3 @@ ci:
 conda:
   - 'conda/**'
   
-Ops:
-  - '.github/**'
-

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ Cython / Python:
   - 'python/**'
   - 'notebooks/**'
   
-cpp:
+CUDA/C++:
   - 'cpp/**'
 
 CMake:


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).