### PR TITLE
Replacing sklearn functions with cuml in RF MNMG notebook

### DIFF
--- a/notebooks/random_forest_mnmg_demo.ipynb
+++ b/notebooks/random_forest_mnmg_demo.ipynb
@@ -31,8 +31,9 @@
     "import cuml\n",
     "\n",
     "from sklearn.metrics import accuracy_score\n",
-    "from sklearn import model_selection, datasets\n",
+    "from sklearn import model_selection\n",
     "\n",
+    "from cuml import datasets\n",
     "from cuml.dask.common import utils as dask_utils\n",
     "from dask.distributed import Client, wait\n",
     "from dask_cuda import LocalCUDACluster\n",
@@ -132,7 +133,7 @@
     "\n",
     "def distribute(X, y):\n",
     "    # First convert to cudf (with real data, you would likely load in cuDF format to start)\n",
-    "    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X))\n",
+    "    X_cudf = cudf.DataFrame(X)\n",
     "    y_cudf = cudf.Series(y)\n",
     "\n",
     "    # Partition with Dask\n",
@@ -169,7 +170,7 @@
     "\n",
     "# Use all avilable CPU cores\n",
     "skl_model = sklRF(max_depth=max_depth, n_estimators=n_trees, n_jobs=-1)\n",
-    "skl_model.fit(X_train, y_train)"
+    "skl_model.fit(X_train.get(), y_train.get())"
    ]
   },
   {
@@ -206,12 +207,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "skl_y_pred = skl_model.predict(X_test)\n",
+    "skl_y_pred = skl_model.predict(X_test.get())\n",
     "cuml_y_pred = cuml_model.predict(X_test_dask).compute().to_array()\n",
     "\n",
     "# Due to randomness in the algorithm, you may see slight variation in accuracies\n",
-    "print(\"SKLearn accuracy:  \", accuracy_score(y_test, skl_y_pred))\n",
-    "print(\"CuML accuracy:     \", accuracy_score(y_test, cuml_y_pred))"
+    "print(\"SKLearn accuracy:  \", accuracy_score(y_test.get(), skl_y_pred))\n",
+    "print(\"CuML accuracy:     \", accuracy_score(y_test.get(), cuml_y_pred))"
    ]
   }
  ],

--- a/notebooks/random_forest_mnmg_demo.ipynb
+++ b/notebooks/random_forest_mnmg_demo.ipynb
@@ -30,10 +30,10 @@
     "import cudf\n",
     "import cuml\n",
     "\n",
-    "from sklearn.metrics import accuracy_score\n",
     "from sklearn import model_selection\n",
     "\n",
     "from cuml import datasets\n",
+    "from cuml.metrics import accuracy_score\n",
     "from cuml.dask.common import utils as dask_utils\n",
     "from dask.distributed import Client, wait\n",
     "from dask_cuda import LocalCUDACluster\n",
@@ -211,8 +211,8 @@
     "cuml_y_pred = cuml_model.predict(X_test_dask).compute().to_array()\n",
     "\n",
     "# Due to randomness in the algorithm, you may see slight variation in accuracies\n",
-    "print(\"SKLearn accuracy:  \", accuracy_score(y_test.get(), skl_y_pred))\n",
-    "print(\"CuML accuracy:     \", accuracy_score(y_test.get(), cuml_y_pred))"
+    "print(\"SKLearn accuracy:  \", accuracy_score(y_test, skl_y_pred))\n",
+    "print(\"CuML accuracy:     \", accuracy_score(y_test, cuml_y_pred))"
    ]
   }
  ],


### PR DESCRIPTION
Closes #2864.

This PR will replace `datasets.make_blobs` and `metrics.accuracy_score` from sklearn to cuml.