### PR TITLE
[REVIEW] Improve runtime performance of RF to Treelite conversion

### DIFF
--- a/cpp/include/cuml/tree/flatnode.h
+++ b/cpp/include/cuml/tree/flatnode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cuml/tree/flatnode.h
+++ b/cpp/include/cuml/tree/flatnode.h
@@ -32,3 +32,13 @@ struct SparseTreeNode {
   DataT best_metric_val;
   IdxT left_child_id = IdxT(-1);
 };
+
+template <typename T, typename L>
+struct Node_ID_info {
+  const SparseTreeNode<T, L>* node;
+  int unique_node_id;
+
+  Node_ID_info() : node(nullptr), unique_node_id(-1) {}
+  Node_ID_info(const SparseTreeNode<T, L>& cfg_node, int cfg_unique_node_id)
+    : node(&cfg_node), unique_node_id(cfg_unique_node_id) {}
+};

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
+#include <cuml/tree/flatnode.h>
 #include <decisiontree/quantile/quantile.h>
 #include <raft/cudart_utils.h>
+#include <treelite/tree.h>
 #include <common/iota.cuh>
 #include <cuml/common/logger.hpp>
-#include <cuml/tree/flatnode.h>
 #include <iomanip>
 #include <locale>
 #include <random>
 #include <type_traits>
-#include <treelite/tree.h>
 #include "batched-levelalgo/builder.cuh"
 #include "decisiontree_impl.h"
 #include "levelalgo/levelfunc_classifier.cuh"
@@ -136,13 +136,11 @@ std::ostream &operator<<(std::ostream &os, const SparseTreeNode<T, L> &node) {
 
 template <class T, class L>
 tl::Tree<T, T> build_treelite_tree(
-    const DecisionTree::TreeMetaDataNode<T, L>& rf_tree,
-    unsigned int num_class,
-    std::vector<Node_ID_info<T, L>>& cur_level_queue,
-    std::vector<Node_ID_info<T, L>>& next_level_queue) {
+  const DecisionTree::TreeMetaDataNode<T, L> &rf_tree, unsigned int num_class,
+  std::vector<Node_ID_info<T, L>> &cur_level_queue,
+  std::vector<Node_ID_info<T, L>> &next_level_queue) {
   tl::Tree<T, T> tl_tree;
   tl_tree.Init();
-
 
   // Track head and tail of bounded "queues" (implemented as vectors for
   // performance)
@@ -157,8 +155,8 @@ tl::Tree<T, T> build_treelite_tree(
 
   while (cur_front != cur_end) {
     size_t cur_level_size = cur_end - cur_front;
-    next_level_queue.resize(std::max(2*cur_level_size,
-                                     next_level_queue.size()));
+    next_level_queue.resize(
+      std::max(2 * cur_level_size, next_level_queue.size()));
 
     for (size_t i = 0; i < cur_level_size; ++i) {
       Node_ID_info<T, L> q_node = cur_level_queue[cur_front];
@@ -171,17 +169,15 @@ tl::Tree<T, T> build_treelite_tree(
         tl_tree.AddChilds(node_id);
 
         // Push left child to next_level queue.
-        next_level_queue[next_end] = Node_ID_info<T, L>(
-          rf_tree.sparsetree[q_node.node->left_child_id],
-          tl_tree.LeftChild(node_id)
-        );
+        next_level_queue[next_end] =
+          Node_ID_info<T, L>(rf_tree.sparsetree[q_node.node->left_child_id],
+                             tl_tree.LeftChild(node_id));
         ++next_end;
 
         // Push right child to next_level queue.
-        next_level_queue[next_end] = Node_ID_info<T, L>(
-          rf_tree.sparsetree[q_node.node->left_child_id + 1],
-          tl_tree.RightChild(node_id)
-        );
+        next_level_queue[next_end] =
+          Node_ID_info<T, L>(rf_tree.sparsetree[q_node.node->left_child_id + 1],
+                             tl_tree.RightChild(node_id));
         ++next_end;
 
         // Set node from current level as numerical node. Children IDs known.
@@ -523,29 +519,25 @@ template class DecisionTreeRegressor<float>;
 template class DecisionTreeRegressor<double>;
 
 template tl::Tree<float, float> build_treelite_tree<float, int>(
-  const DecisionTree::TreeMetaDataNode<float, int>& rf_tree,
+  const DecisionTree::TreeMetaDataNode<float, int> &rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<float, int>>& working_queue_1,
-  std::vector<Node_ID_info<float, int>>& working_queue_2
-);
+  std::vector<Node_ID_info<float, int>> &working_queue_1,
+  std::vector<Node_ID_info<float, int>> &working_queue_2);
 template tl::Tree<double, double> build_treelite_tree<double, int>(
-  const DecisionTree::TreeMetaDataNode<double, int>& rf_tree,
+  const DecisionTree::TreeMetaDataNode<double, int> &rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<double, int>>& working_queue_1,
-  std::vector<Node_ID_info<double, int>>& working_queue_2
-);
+  std::vector<Node_ID_info<double, int>> &working_queue_1,
+  std::vector<Node_ID_info<double, int>> &working_queue_2);
 template tl::Tree<float, float> build_treelite_tree<float, float>(
-  const DecisionTree::TreeMetaDataNode<float, float>& rf_tree,
+  const DecisionTree::TreeMetaDataNode<float, float> &rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<float, float>>& working_queue_1,
-  std::vector<Node_ID_info<float, float>>& working_queue_2
-);
+  std::vector<Node_ID_info<float, float>> &working_queue_1,
+  std::vector<Node_ID_info<float, float>> &working_queue_2);
 template tl::Tree<double, double> build_treelite_tree<double, double>(
-  const DecisionTree::TreeMetaDataNode<double, double>& rf_tree,
+  const DecisionTree::TreeMetaDataNode<double, double> &rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<double, double>>& working_queue_1,
-  std::vector<Node_ID_info<double, double>>& working_queue_2
-);
+  std::vector<Node_ID_info<double, double>> &working_queue_1,
+  std::vector<Node_ID_info<double, double>> &working_queue_2);
 }  //End namespace DecisionTree
 
 }  //End namespace ML

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -144,6 +144,8 @@ tl::Tree<T, T> build_treelite_tree(
   tl_tree.Init();
 
 
+  // Track head and tail of bounded "queues" (implemented as vectors for
+  // performance)
   size_t cur_front = 0;
   size_t cur_end = 0;
   size_t next_front = 0;
@@ -175,7 +177,7 @@ tl::Tree<T, T> build_treelite_tree(
         );
         ++next_end;
 
-        // Push right child to next_level deque.
+        // Push right child to next_level queue.
         next_level_queue[next_end] = Node_ID_info<T, L>(
           rf_tree.sparsetree[q_node.node->left_child_id + 1],
           tl_tree.RightChild(node_id)
@@ -198,7 +200,6 @@ tl::Tree<T, T> build_treelite_tree(
       }
     }
 
-    // The cur_level_queue is empty here, as all the elements are already poped out.
     cur_level_queue.swap(next_level_queue);
     cur_front = next_front;
     cur_end = next_end;

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -167,7 +167,8 @@ tl::Tree<T, T> build_treelite_tree(
   while (cur_front != cur_end) {
     // int cur_level_size = cur_level_queue.size();
     size_t cur_level_size = cur_end - cur_front;
-    next_level_queue.resize(2*cur_level_size);
+    next_level_queue.resize(std::max(2*cur_level_size,
+                                     next_level_queue.size()));
 
     for (size_t i = 0; i < cur_level_size; ++i) {
       Node_ID_info<T, L> q_node = cur_level_queue[cur_front];

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -524,26 +524,26 @@ template class DecisionTreeRegressor<double>;
 template tl::Tree<float, float> build_treelite_tree<float, int>(
   const DecisionTree::TreeMetaDataNode<float, int>& rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<float, int>>& cur_level_queue,
-  std::vector<Node_ID_info<float, int>>& next_level_queue
+  std::vector<Node_ID_info<float, int>>& working_queue_1,
+  std::vector<Node_ID_info<float, int>>& working_queue_2
 );
 template tl::Tree<double, double> build_treelite_tree<double, int>(
   const DecisionTree::TreeMetaDataNode<double, int>& rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<double, int>>& cur_level_queue,
-  std::vector<Node_ID_info<double, int>>& next_level_queue
+  std::vector<Node_ID_info<double, int>>& working_queue_1,
+  std::vector<Node_ID_info<double, int>>& working_queue_2
 );
 template tl::Tree<float, float> build_treelite_tree<float, float>(
   const DecisionTree::TreeMetaDataNode<float, float>& rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<float, float>>& cur_level_queue,
-  std::vector<Node_ID_info<float, float>>& next_level_queue
+  std::vector<Node_ID_info<float, float>>& working_queue_1,
+  std::vector<Node_ID_info<float, float>>& working_queue_2
 );
 template tl::Tree<double, double> build_treelite_tree<double, double>(
   const DecisionTree::TreeMetaDataNode<double, double>& rf_tree,
   unsigned int num_class,
-  std::vector<Node_ID_info<double, double>>& cur_level_queue,
-  std::vector<Node_ID_info<double, double>>& next_level_queue
+  std::vector<Node_ID_info<double, double>>& working_queue_1,
+  std::vector<Node_ID_info<double, double>>& working_queue_2
 );
 }  //End namespace DecisionTree
 

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -144,8 +144,8 @@ struct Node_ID_info {
 };
 
 template <class T, class L>
-tl::Tree<T, T> build_treelite_tree(DecisionTree::TreeMetaDataNode<T, L> *tree_ptr,
-                         int num_class) {
+tl::Tree<T, T> build_treelite_tree(
+    const DecisionTree::TreeMetaDataNode<T, L>& rf_tree, unsigned int num_class) {
   tl::Tree<T, T> tl_tree;
   tl_tree.Init();
 
@@ -153,7 +153,7 @@ tl::Tree<T, T> build_treelite_tree(DecisionTree::TreeMetaDataNode<T, L> *tree_pt
   std::queue<Node_ID_info<T, L>> cur_level_queue;
   std::queue<Node_ID_info<T, L>> next_level_queue;
 
-  cur_level_queue.push(Node_ID_info<T, L>(tree_ptr->sparsetree[0], 0));
+  cur_level_queue.push(Node_ID_info<T, L>(rf_tree.sparsetree[0], 0));
 
   while (!cur_level_queue.empty()) {
     int cur_level_size = cur_level_queue.size();
@@ -170,13 +170,13 @@ tl::Tree<T, T> build_treelite_tree(DecisionTree::TreeMetaDataNode<T, L> *tree_pt
 
         // Push left child to next_level queue.
         next_level_queue.push(Node_ID_info<T, L>(
-          tree_ptr->sparsetree[q_node.node.left_child_id],
+          rf_tree.sparsetree[q_node.node.left_child_id],
           tl_tree.LeftChild(node_id)
         ));
 
         // Push right child to next_level deque.
         next_level_queue.push(Node_ID_info<T, L>(
-          tree_ptr->sparsetree[q_node.node.left_child_id + 1],
+          rf_tree.sparsetree[q_node.node.left_child_id + 1],
           tl_tree.RightChild(node_id)
         ));
 
@@ -516,13 +516,14 @@ template class DecisionTreeRegressor<float>;
 template class DecisionTreeRegressor<double>;
 
 template tl::Tree<float, float> build_treelite_tree<float, int>(
-  DecisionTree::TreeMetaDataNode<float, int> *tree_ptr, int num_class);
+  const DecisionTree::TreeMetaDataNode<float, int>& rf_tree, unsigned int num_class);
 template tl::Tree<double, double> build_treelite_tree<double, int>(
-  DecisionTree::TreeMetaDataNode<double, int> *tree_ptr, int num_class);
+  const DecisionTree::TreeMetaDataNode<double, int>& rf_tree, unsigned int num_class);
 template tl::Tree<float, float> build_treelite_tree<float, float>(
-  DecisionTree::TreeMetaDataNode<float, float> *tree_ptr, int num_class);
+  const DecisionTree::TreeMetaDataNode<float, float>& rf_tree, unsigned int num_class);
 template tl::Tree<double, double> build_treelite_tree<double, double>(
-  DecisionTree::TreeMetaDataNode<double, double> *tree_ptr, int num_class);
+  const DecisionTree::TreeMetaDataNode<double, double>& rf_tree, unsigned int
+  num_class);
 }  //End namespace DecisionTree
 
 }  //End namespace ML

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -59,7 +59,7 @@ std::string get_node_json(const std::string &prefix,
 
 template <class T, class L>
 tl::Tree<T, T> build_treelite_tree(
-  DecisionTree::TreeMetaDataNode<T, L> *tree_ptr, int num_class);
+  const DecisionTree::TreeMetaDataNode<T, L> &rf_tree, unsigned int num_class);
 
 struct DataInfo {
   unsigned int NLocalrows;

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -61,8 +61,8 @@ std::string get_node_json(const std::string &prefix,
 template <class T, class L>
 tl::Tree<T, T> build_treelite_tree(
   const DecisionTree::TreeMetaDataNode<T, L> &rf_tree, unsigned int num_class,
-  std::vector<Node_ID_info<T, L>> &cur_level_queue,
-  std::vector<Node_ID_info<T, L>> &next_level_queue);
+  std::vector<Node_ID_info<T, L>> &working_queue_1,
+  std::vector<Node_ID_info<T, L>> &working_queue_2);
 
 struct DataInfo {
   unsigned int NLocalrows;

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <common/Timer.h>
 #include <cuml/tree/algo_helper.h>
+#include <cuml/tree/flatnode.h>
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
 #include <algorithm>
@@ -59,7 +60,9 @@ std::string get_node_json(const std::string &prefix,
 
 template <class T, class L>
 tl::Tree<T, T> build_treelite_tree(
-  const DecisionTree::TreeMetaDataNode<T, L> &rf_tree, unsigned int num_class);
+  const DecisionTree::TreeMetaDataNode<T, L> &rf_tree, unsigned int num_class,
+  std::vector<Node_ID_info<T, L>> &cur_level_queue,
+  std::vector<Node_ID_info<T, L>> &next_level_queue);
 
 struct DataInfo {
   unsigned int NLocalrows;

--- a/cpp/src/decisiontree/decisiontree_impl.h
+++ b/cpp/src/decisiontree/decisiontree_impl.h
@@ -18,6 +18,7 @@
 #include <common/Timer.h>
 #include <cuml/tree/algo_helper.h>
 #include <treelite/c_api.h>
+#include <treelite/tree.h>
 #include <algorithm>
 #include <climits>
 #include <common/cumlHandle.hpp>
@@ -37,6 +38,8 @@
 
 namespace ML {
 
+namespace tl = treelite;
+
 bool is_dev_ptr(const void *p);
 
 namespace DecisionTree {
@@ -55,9 +58,8 @@ std::string get_node_json(const std::string &prefix,
                           int idx);
 
 template <class T, class L>
-void build_treelite_tree(TreeBuilderHandle tree_builder,
-                         DecisionTree::TreeMetaDataNode<T, L> *tree_ptr,
-                         int num_class);
+tl::Tree<T, T> build_treelite_tree(
+  DecisionTree::TreeMetaDataNode<T, L> *tree_ptr, int num_class);
 
 struct DataInfo {
   unsigned int NLocalrows;

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -324,11 +324,11 @@ void build_treelite_forest(ModelHandle* model_handle,
     // Multi-class classification
     num_class = task_category;
     model->task_type = tl::TaskType::kMultiClfProbDistLeaf;
+    std::strcpy(model->param.pred_transform, "max_index");
   } else {
     // Binary classification or regression
     num_class = 1;
     model->task_type = tl::TaskType::kBinaryClfRegr;
-    std::strcpy(model->param.pred_transform, "max_index");
   }
 
   model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <cuml/common/logger.hpp>
 #include <cuml/ensemble/randomforest.hpp>
+#include <cuml/tree/flatnode.h>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -338,12 +339,15 @@ void build_treelite_forest(ModelHandle* model_handle,
   model->average_tree_output = true;
   model->SetTreeLimit(forest->rf_params.n_trees);
 
+  std::vector<Node_ID_info<T, L>> cur_level_queue;
+  std::vector<Node_ID_info<T, L>> next_level_queue;
+
   for (int i = 0; i < forest->rf_params.n_trees; i++) {
     DecisionTree::TreeMetaDataNode<T, L>& rf_tree = forest->trees[i];
 
     if (rf_tree.sparsetree.size() != 0) {
       model->trees[i] = DecisionTree::build_treelite_tree<T, L>(
-        rf_tree, num_class
+        rf_tree, num_class, cur_level_queue, next_level_queue
       );
     }
   }

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -316,25 +316,21 @@ void build_treelite_forest(ModelHandle* model_handle,
   auto parent_model = tl::Model::Create<T, T>();
   tl::ModelImpl<T, T>* model =
     dynamic_cast<tl::ModelImpl<T, T>*>(parent_model.get());
-  if (model == nullptr) {
-    throw raft::exception("Invalid downcast to Treelite ModelImpl");
-  }
+  ASSERT(model != nullptr, "Invalid downcast to tl::ModelImpl")
 
   unsigned int num_class;
   if (task_category > 2) {
     // Multi-class classification
     num_class = task_category;
     model->task_type = tl::TaskType::kMultiClfProbDistLeaf;
-    model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,
-                                          false, num_class, num_class};
   } else {
     // Binary classification or regression
     num_class = 1;
     model->task_type = tl::TaskType::kBinaryClfRegr;
-    model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,
-                                          false, num_class, 1};
   }
 
+  model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,
+                                        false, num_class, num_class};
   model->num_feature = num_features;
   model->average_tree_output = true;
   model->SetTreeLimit(forest->rf_params.n_trees);

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -339,11 +339,12 @@ void build_treelite_forest(ModelHandle* model_handle,
   model->SetTreeLimit(forest->rf_params.n_trees);
 
   for (int i = 0; i < forest->rf_params.n_trees; i++) {
-    DecisionTree::TreeMetaDataNode<T, L>* tree_ptr = &forest->trees[i];
+    DecisionTree::TreeMetaDataNode<T, L>& rf_tree = forest->trees[i];
 
-    if (tree_ptr->sparsetree.size() != 0) {
-      model->trees[i] = DecisionTree::build_treelite_tree<T, L>(tree_ptr,
-                                                                num_class);
+    if (rf_tree.sparsetree.size() != 0) {
+      model->trees[i] = DecisionTree::build_treelite_tree<T, L>(
+        rf_tree, num_class
+      );
     }
   }
 

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -339,15 +339,15 @@ void build_treelite_forest(ModelHandle* model_handle,
   model->average_tree_output = true;
   model->SetTreeLimit(forest->rf_params.n_trees);
 
-  std::vector<Node_ID_info<T, L>> cur_level_queue;
-  std::vector<Node_ID_info<T, L>> next_level_queue;
+  std::vector<Node_ID_info<T, L>> working_queue_1;
+  std::vector<Node_ID_info<T, L>> working_queue_2;
 
   for (int i = 0; i < forest->rf_params.n_trees; i++) {
     DecisionTree::TreeMetaDataNode<T, L>& rf_tree = forest->trees[i];
 
     if (rf_tree.sparsetree.size() != 0) {
       model->trees[i] = DecisionTree::build_treelite_tree<T, L>(
-        rf_tree, num_class, cur_level_queue, next_level_queue
+        rf_tree, num_class, working_queue_1, working_queue_2
       );
     }
   }

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -316,7 +316,7 @@ void build_treelite_forest(ModelHandle* model_handle,
   auto parent_model = tl::Model::Create<T, T>();
   tl::ModelImpl<T, T>* model =
     dynamic_cast<tl::ModelImpl<T, T>*>(parent_model.get());
-  ASSERT(model != nullptr, "Invalid downcast to tl::ModelImpl")
+  ASSERT(model != nullptr, "Invalid downcast to tl::ModelImpl");
 
   unsigned int num_class;
   if (task_category > 2) {

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -18,15 +18,15 @@
 #else
 #define omp_get_max_threads() 1
 #endif
-#include <raft/error.hpp>
+#include <cuml/tree/flatnode.h>
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
 #include <cstdio>
 #include <cuml/common/logger.hpp>
 #include <cuml/ensemble/randomforest.hpp>
-#include <cuml/tree/flatnode.h>
 #include <fstream>
 #include <iostream>
+#include <raft/error.hpp>
 #include <string>
 #include <vector>
 
@@ -314,8 +314,8 @@ void build_treelite_forest(ModelHandle* model_handle,
                            const RandomForestMetaData<T, L>* forest,
                            int num_features, int task_category) {
   auto parent_model = tl::Model::Create<T, T>();
-  tl::ModelImpl<T, T> * model = dynamic_cast<tl::ModelImpl<T, T>*>(
-    parent_model.get());
+  tl::ModelImpl<T, T>* model =
+    dynamic_cast<tl::ModelImpl<T, T>*>(parent_model.get());
   if (model == nullptr) {
     throw raft::exception("Invalid downcast to Treelite ModelImpl");
   }
@@ -326,13 +326,13 @@ void build_treelite_forest(ModelHandle* model_handle,
     num_class = task_category;
     model->task_type = tl::TaskType::kMultiClfProbDistLeaf;
     model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,
-                                         false, num_class, num_class};
+                                          false, num_class, num_class};
   } else {
     // Binary classification or regression
     num_class = 1;
     model->task_type = tl::TaskType::kBinaryClfRegr;
     model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,
-                                         false, num_class, 1};
+                                          false, num_class, 1};
   }
 
   model->num_feature = num_features;
@@ -347,8 +347,7 @@ void build_treelite_forest(ModelHandle* model_handle,
 
     if (rf_tree.sparsetree.size() != 0) {
       model->trees[i] = DecisionTree::build_treelite_tree<T, L>(
-        rf_tree, num_class, working_queue_1, working_queue_2
-      );
+        rf_tree, num_class, working_queue_1, working_queue_2);
     }
   }
 

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -327,6 +327,7 @@ void build_treelite_forest(ModelHandle* model_handle,
     // Binary classification or regression
     num_class = 1;
     model->task_type = tl::TaskType::kBinaryClfRegr;
+    model->param.pred_transform = "max_index";
   }
 
   model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -22,6 +22,7 @@
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
 #include <cstdio>
+#include <cstring>
 #include <cuml/common/logger.hpp>
 #include <cuml/ensemble/randomforest.hpp>
 #include <fstream>
@@ -327,7 +328,7 @@ void build_treelite_forest(ModelHandle* model_handle,
     // Binary classification or regression
     num_class = 1;
     model->task_type = tl::TaskType::kBinaryClfRegr;
-    model->param.pred_transform = "max_index";
+    std::strcpy(model->param.pred_transform, "max_index");
   }
 
   model->task_param = tl::TaskParameter{tl::TaskParameter::OutputType::kFloat,


### PR DESCRIPTION
Speed up prediction time by an additional factor of 4.82
Build Treelite Trees directly to avoid deletion and `CommitModel` call for TreeBuilder (PoC by @canonizer)
Avoid use of stdlib queues where the growth of those queues is bounded and can be optimized via indexing into a vector of the appropriate size