### PR TITLE
Allow linear regression for  with CUDA >=10.2

### DIFF
--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -38,8 +38,8 @@ else(DEFINED ENV{RAFT_PATH})
   set(RAFT_DIR ${CMAKE_CURRENT_BINARY_DIR}/raft CACHE STRING "Path to RAFT repo")
 
   ExternalProject_Add(raft
-    GIT_REPOSITORY    https://github.com/rapidsai/raft.git
-    GIT_TAG           9dbf2c8a9134ce8135f7fe947ec523d874fcab6a 
+    GIT_REPOSITORY    https://github.com/wphicks/raft.git
+    GIT_TAG           80a4a39de60da75936634f48d5d0c27028d64fa6
     PREFIX            ${RAFT_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""


### PR DESCRIPTION
DO NOT MERGE UNTIL RAFT REFERENCE HAS BEEN UPDATED
Update RAFT to allow linear regression with over 46340 rows and one column for CUDA versions >= 10.2
Provide test to ensure linear regression can be performed in this case