### PR TITLE
Adding tol to dask test_kmeans

### DIFF
--- a/python/cuml/test/dask/test_kmeans.py
+++ b/python/cuml/test/dask/test_kmeans.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/test/dask/test_kmeans.py
+++ b/python/cuml/test/dask/test_kmeans.py
@@ -193,4 +193,4 @@ def test_score(nrows, ncols, nclusters, n_parts,
     local_model = cumlModel.get_combined_model()
     expected_score = local_model.score(X_train.compute())
 
-    assert actual_score == expected_score
+    assert abs(actual_score - expected_score) < 1e-3


### PR DESCRIPTION
Closes #2969.

This PR add tolerance to dask test_kmeans in order to be flexible with small accumulation mistakes in a distributed context.