### PR TITLE
[REVIEW] Fixing Python Documentation Errors and Warnings

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,8 +10,8 @@ Module Configuration
 Output Data Type Configuration
 ------------------------------
 
- .. automethod:: cuml.common.memory_utils.set_global_output_type
- .. automethod:: cuml.common.memory_utils.using_output_type
+ .. autofunction:: cuml.common.memory_utils.set_global_output_type
+ .. autofunction:: cuml.common.memory_utils.using_output_type
 
 .. _verbosity-levels:
 
@@ -58,7 +58,7 @@ Preprocessing, Metrics, and Utilities
 Model Selection and Data Splitting
 ----------------------------------
 
- .. automethod:: cuml.preprocessing.model_selection.train_test_split
+ .. autofunction:: cuml.preprocessing.model_selection.train_test_split
 
 Feature and Label Encoding (Single-GPU)
 ---------------------------------------
@@ -69,7 +69,7 @@ Feature and Label Encoding (Single-GPU)
  .. autoclass:: cuml.preprocessing.LabelBinarizer
     :members:
 
- .. automethod:: cuml.preprocessing.label_binarize
+ .. autofunction:: cuml.preprocessing.label_binarize
 
  .. autoclass:: cuml.preprocessing.OneHotEncoder
     :members:
@@ -115,10 +115,10 @@ Dataset Generation (Single-GPU)
     random_state
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
-  .. automethod:: cuml.datasets.make_blobs
-  .. automethod:: cuml.datasets.make_classification
-  .. automethod:: cuml.datasets.make_regression
-  .. automethod:: cuml.datasets.make_arima
+  .. autofunction:: cuml.datasets.make_blobs
+  .. autofunction:: cuml.datasets.make_classification
+  .. autofunction:: cuml.datasets.make_regression
+  .. autofunction:: cuml.datasets.make_arima
 
 
 Dataset Generation (Dask-based Multi-GPU)
@@ -147,11 +147,11 @@ Metrics (regression, classification, and distance)
   .. automodule:: cuml.metrics.accuracy
     :members:
 
-  .. automethod:: cuml.metrics.confusion_matrix
+  .. autofunction:: cuml.metrics.confusion_matrix
 
-  .. automethod:: cuml.metrics.roc_auc_score
+  .. autofunction:: cuml.metrics.roc_auc_score
 
-  .. automethod:: cuml.metrics.precision_recall_curve
+  .. autofunction:: cuml.metrics.precision_recall_curve
 
   .. automodule:: cuml.metrics.pairwise_distances
     :members:
@@ -333,7 +333,7 @@ Principal Component Analysis
     :members:
 
 Incremental PCA
--------------
+---------------
 .. autoclass:: cuml.IncrementalPCA
    :members:
 
@@ -358,7 +358,7 @@ Random Projections
 .. autoclass:: cuml.random_projection.SparseRandomProjection
     :members:
 
-.. automethod:: cuml.random_projection.johnson_lindenstrauss_min_dim
+.. autofunction:: cuml.random_projection.johnson_lindenstrauss_min_dim
 
 
 TSNE

--- a/python/cuml/datasets/classification.py
+++ b/python/cuml/datasets/classification.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/datasets/classification.py
+++ b/python/cuml/datasets/classification.py
@@ -51,7 +51,8 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
                         _informative_covariance=None,
                         _redundant_covariance=None,
                         _repeated_indices=None):
-    """Generate a random n-class classification problem.
+    """
+    Generate a random n-class classification problem.
     This initially creates clusters of points normally distributed (std=1)
     about vertices of an ``n_informative``-dimensional hypercube with sides of
     length ``2*class_sep`` and assigns an equal number of clusters to each
@@ -179,7 +180,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
     Notes
     -----
-    The algorithm is adapted from Guyon [1] and was designed to generate
+    The algorithm is adapted from Guyon [1]_ and was designed to generate
     the "Madelon" dataset. How we optimized for GPUs:
 
         1. Firstly, we generate X from a standard univariate instead of zeros.

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -366,20 +366,16 @@ class TSNE(Base):
 
         self.sparse_fit = False
 
-    @generate_docstring(convert_dtype_cast='np.float32')
+    @generate_docstring(skip_parameters_heading=True,
+                        convert_dtype_cast='np.float32')
     def fit(self, X, convert_dtype=True, knn_graph=None) -> "TSNE":
         """
         Fit X into an embedded space.
 
         Parameters
         -----------
-        X : array-like (device or host) shape = (n_samples, n_features)
-            X contains a sample per row.
-        convert_dtype : bool, optional (default = True)
-            When set to True, the fit method will automatically
-            convert the inputs to np.float32.
-        knn_graph : sparse array-like (device or host)
-            shape=(n_samples, n_samples)
+        knn_graph : sparse array-like (device or host), \
+                shape=(n_samples, n_samples)
             A sparse array containing the k-nearest neighbors of X,
             where the columns are the nearest neighbor indices
             for each row and the values are their distances.

--- a/python/cuml/multiclass/multiclass.py
+++ b/python/cuml/multiclass/multiclass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/multiclass/multiclass.py
+++ b/python/cuml/multiclass/multiclass.py
@@ -75,10 +75,11 @@ class MulticlassClassifier(Base, ClassifierMixin):
 
     Attributes
     ----------
-    classes_ : float, shape (n_classes_)
+    classes_ : float, shape (`n_classes_`)
         Array of class labels.
     n_classes_ : int
         Number of classes.
+
     """
     def __init__(self,
                  estimator,

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -162,19 +162,21 @@ class NearestNeighbors(Base):
         handles in several streams.
         If it is None, a new one is created.
     algorithm : string (default='brute')
-        The query algorithm to use. Valid options are :
-        - 'brute' for brute-force, slow but produces exact results
-        - 'ivfflat' for inverted file, divide the dataset in partitions
-            and perform search on relevant partitions only
-        - 'ivfpq' for inverted file and product quantization,
-            same as inverted list, in addition the vectors are broken
-            in n_features/M sub-vectors that will be encoded thanks
-            to intermediary k-means clusterings. This encoding provide
-            partial information allowing faster distances calculations
-        - 'ivfsq' for inverted file and scalar quantization,
-            same as inverted list, in addition vectors components
-            are quantized into reduced binary representation allowing
-            faster distances calculations
+        The query algorithm to use. Valid options are:
+
+        - ``'brute'``: for brute-force, slow but produces exact results
+        - ``'ivfflat'``: for inverted file, divide the dataset in partitions
+          and perform search on relevant partitions only
+        - ``'ivfpq'``: for inverted file and product quantization,
+          same as inverted list, in addition the vectors are broken
+          in n_features/M sub-vectors that will be encoded thanks
+          to intermediary k-means clusterings. This encoding provide
+          partial information allowing faster distances calculations
+        - ``'ivfsq'``: for inverted file and scalar quantization,
+          same as inverted list, in addition vectors components
+          are quantized into reduced binary representation allowing
+          faster distances calculations
+
     metric : string (default='euclidean').
         Distance metric to use. Supported distances are ['l1, 'cityblock',
         'taxicab', 'manhattan', 'euclidean', 'l2', 'braycurtis', 'canberra',
@@ -187,33 +189,42 @@ class NearestNeighbors(Base):
         neighbors algorithms.
 
         When algorithm='brute' and inputs are sparse:
-            - batch_size_index : (int) number of rows in each batch of
+
+            - batch_size_index : (int) number of rows in each batch of \
                                  index array
-            - batch_size_query : (int) number of rows in each batch of
+            - batch_size_query : (int) number of rows in each batch of \
                                  query array
+
     metric_expanded : bool
         Can increase performance in Minkowski-based (Lp) metrics (for p > 1)
         by using the expanded form and not computing the n-th roots.
     algo_params : dict, optional (default = None) Used to configure the
         nearest neighbor algorithm to be used.
         If set to None, parameters will be generated automatically.
-        Parameters for algorithm 'ivfflat':
-            - nlist : (int) number of cells to partition dataset into
-            - nprobe : (int) at query time, number of cells used for search
-        Parameters for algorithm 'ivfpq':
-            - nlist : (int) number of cells to partition dataset into
-            - nprobe : (int) at query time, number of cells used for search
-            - M : (int) number of subquantizers
-            - n_bits : (int) bits allocated per subquantizer
+        Parameters for algorithm ``'ivfflat'``:
+
+            - nlist: (int) number of cells to partition dataset into
+            - nprobe: (int) at query time, number of cells used for search
+
+        Parameters for algorithm ``'ivfpq'``:
+
+            - nlist: (int) number of cells to partition dataset into
+            - nprobe: (int) at query time, number of cells used for search
+            - M: (int) number of subquantizers
+            - n_bits: (int) bits allocated per subquantizer
             - usePrecomputedTables : (bool) wether to use precomputed tables
-        Parameters for algorithm 'ivfsq':
-            - nlist : (int) number of cells to partition dataset into
-            - nprobe : (int) at query time, number of cells used for search
-            - qtype : (string) quantizer type (among QT_8bit, QT_4bit,
-                QT_8bit_uniform, QT_4bit_uniform, QT_fp16, QT_8bit_direct,
-                QT_6bit)
-            - encodeResidual : (bool) wether to encode residuals
-    metric_params : dict, optional (default = None) This is currently ignored.
+
+        Parameters for algorithm ``'ivfsq'``:
+
+            - nlist: (int) number of cells to partition dataset into
+            - nprobe: (int) at query time, number of cells used for search
+            - qtype: (string) quantizer type (among QT_8bit, QT_4bit,
+              QT_8bit_uniform, QT_4bit_uniform, QT_fp16, QT_8bit_direct,
+              QT_6bit)
+            - encodeResidual: (bool) wether to encode residuals
+
+    metric_params : dict, optional (default = None)
+        This is currently ignored.
 
     output_type : {'input', 'cudf', 'cupy', 'numpy', 'numba'}, default=None
         Variable to control output type of the results and attributes of
@@ -225,26 +236,26 @@ class NearestNeighbors(Base):
     --------
     .. code-block:: python
 
-      import cudf
-      from cuml.neighbors import NearestNeighbors
-      from cuml.datasets import make_blobs
+        import cudf
+        from cuml.neighbors import NearestNeighbors
+        from cuml.datasets import make_blobs
 
-      X, _ = make_blobs(n_samples=25, centers=5,
-                        n_features=10, random_state=42)
+        X, _ = make_blobs(n_samples=25, centers=5,
+                            n_features=10, random_state=42)
 
-      # build a cudf Dataframe
-      X_cudf = cudf.DataFrame(X)
+        # build a cudf Dataframe
+        X_cudf = cudf.DataFrame(X)
 
-      # fit model
-      model = NearestNeighbors(n_neighbors=3)
-      model.fit(X)
+        # fit model
+        model = NearestNeighbors(n_neighbors=3)
+        model.fit(X)
 
-      # get 3 nearest neighbors
-      distances, indices = model.kneighbors(X_cudf)
+        # get 3 nearest neighbors
+        distances, indices = model.kneighbors(X_cudf)
 
-      # print results
-      print(indices)
-      print(distances)
+        # print results
+        print(indices)
+        print(distances)
 
 
     Output:
@@ -286,6 +297,7 @@ class NearestNeighbors(Base):
 
     For additional docs, see `scikit-learn's NearestNeighbors
     <https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.NearestNeighbors.html#sklearn.neighbors.NearestNeighbors>`_.
+
     """
 
     X_m = CumlArrayDescriptor()

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -116,20 +116,20 @@ class SVC(SVMBase, ClassifierMixin):
     --------
     .. code-block:: python
 
-            import numpy as np
-            from cuml.svm import SVC
-            X = np.array([[1,1], [2,1], [1,2], [2,2], [1,3], [2,3]],
-                         dtype=np.float32);
-            y = np.array([-1, -1, 1, -1, 1, 1], dtype=np.float32)
-            clf = SVC(kernel='poly', degree=2, gamma='auto', C=1)
-            clf.fit(X, y)
-            print("Predicted labels:", clf.predict(X))
+        import numpy as np
+        from cuml.svm import SVC
+        X = np.array([[1,1], [2,1], [1,2], [2,2], [1,3], [2,3]],
+                        dtype=np.float32);
+        y = np.array([-1, -1, 1, -1, 1, 1], dtype=np.float32)
+        clf = SVC(kernel='poly', degree=2, gamma='auto', C=1)
+        clf.fit(X, y)
+        print("Predicted labels:", clf.predict(X))
 
     Output:
 
     .. code-block:: none
 
-            Predicted labels: [-1. -1.  1. -1.  1.  1.]
+        Predicted labels: [-1. -1.  1. -1.  1.  1.]
 
     Parameters
     ----------
@@ -150,8 +150,10 @@ class SVC(SVMBase, ClassifierMixin):
     gamma : float or string (default = 'scale')
         Coefficient for rbf, poly, and sigmoid kernels. You can specify the
         numeric value, or use one of the following options:
-        - 'auto': gamma will be set to 1 / n_features
-        - 'scale': gamma will be se to 1 / (n_features * X.var())
+
+        - 'auto': gamma will be set to ``1 / n_features``
+        - 'scale': gamma will be se to ``1 / (n_features * X.var())``
+
     coef0 : float (default = 0.0)
         Independent term in kernel function, only signifficant for poly and
         sigmoid
@@ -167,8 +169,8 @@ class SVC(SVMBase, ClassifierMixin):
         buffer as well.
     class_weight : dict or string (default=None)
         Weights to modify the parameter C for class i to class_weight[i]*C. The
-        string 'balanced' is also accepted, in which case class_weight[i] =
-        n_samples / (n_classes * n_samples_of_class[i])
+        string 'balanced' is also accepted, in which case ``class_weight[i] =
+        n_samples / (n_classes * n_samples_of_class[i])``
     max_iter : int (default = 100*n_samples)
         Limit the number of outer iterations in the solver
     multiclass_strategy : str ('ovo' or 'ovr', default 'ovo')
@@ -214,7 +216,7 @@ class SVC(SVMBase, ClassifierMixin):
     coef_ : float, shape (1, n_cols)
         Only available for linear kernels. It is the normal of the
         hyperplane.
-        coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]
+        ``coef_ = sum_k=1..n_support dual_coef_[k] * support_vectors[k,:]``
     classes_: shape (n_classes_,)
         Array of class labels
     n_classes_ : int


### PR DESCRIPTION
Closes #3268 

General cleanup of sphinx documentation to eliminate all warnings and fix issue #3268. Main change was using `autofunction::` instead of `automethod::` (which is designed for class methods)