### PR TITLE
Use 2021.01.01 Dask in CI

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 ##############################################
 # cuML GPU build and test script for CI      #
 ##############################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -70,8 +70,9 @@ fi
 
 gpuci_logger "Install the master version of dask and distributed"
 set -x
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+# Temporarily force use of 2021.01.1 due to known crash in 2021.01.2
+pip install "git+https://github.com/dask/distributed.git@2021.01.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@2021.01.1" --upgrade --no-deps
 set +x
 
 gpuci_logger "Check compiler versions"


### PR DESCRIPTION
Temporarily use an older version of Dask due to known issues in 2021.01.2﻿
