### PR TITLE
[REVIEW] Use cmake --build in build.sh to facilitate switching build tools

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -230,12 +230,22 @@ if completeBuild || hasArg libcuml || hasArg prims || hasArg bench || hasArg cpp
     # If there are no targets specified when calling build.sh, it will
     # just call `make -j`. This avoids a lot of extra printing
     cd ${LIBCUML_BUILD_DIR}
-    make -j${PARALLEL_LEVEL} ${MAKE_TARGETS} VERBOSE=${VERBOSE} ${INSTALL_TARGET}
+    build_args="--target ${MAKE_TARGETS} ${INSTALL_TARGET}"
+    if [ ! -z ${VERBOSE} ]
+    then
+      build_args="-v ${build_args}"
+    fi
+    if [ ! -z ${PARALLEL_LEVEL} ]
+    then
+      build_args="-j${PARALLEL_LEVEL} ${build_args}"
+    fi
+    echo "cmake --build ${LIBCUML_BUILD_DIR} ${build_args}"
+    cmake --build ${LIBCUML_BUILD_DIR} ${build_args}
 fi
 
 if hasArg cppdocs; then
     cd ${LIBCUML_BUILD_DIR}
-    make doc
+    cmake --build ${LIBCUML_BUILD_DIR} --target doc
 fi
 
 
@@ -250,6 +260,6 @@ if completeBuild || hasArg cuml || hasArg pydocs; then
 
     if hasArg pydocs; then
         cd ${REPODIR}/docs
-        make html
+        cmake --build ${LIBCUML_BUILD_DIR} --target html
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -227,8 +227,6 @@ fi
 
 # If `./build.sh cuml` is called, don't build C/C++ components
 if completeBuild || hasArg libcuml || hasArg prims || hasArg bench || hasArg cpp-mgtests; then
-    # If there are no targets specified when calling build.sh, it will
-    # just call `make -j`. This avoids a lot of extra printing
     cd ${LIBCUML_BUILD_DIR}
     build_args="--target ${MAKE_TARGETS} ${INSTALL_TARGET}"
     if [ ! -z ${VERBOSE} ]
@@ -239,7 +237,6 @@ if completeBuild || hasArg libcuml || hasArg prims || hasArg bench || hasArg cpp
     then
       build_args="-j${PARALLEL_LEVEL} ${build_args}"
     fi
-    echo "cmake --build ${LIBCUML_BUILD_DIR} ${build_args}"
     cmake --build ${LIBCUML_BUILD_DIR} ${build_args}
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 
 # cuml build script
 


### PR DESCRIPTION
Use `cmake --build` in build.sh rather than invoking `make` directly. This should not affect existing usage at all but will allow developers to build with e.g. Ninja simply by setting `CUML_EXTRA_CMAKE_ARGS='-GNinja'` when building.