### PR TITLE
Temporarily xfail KBinsDiscretizer uniform tests

### DIFF
--- a/python/cuml/test/test_preprocessing.py
+++ b/python/cuml/test/test_preprocessing.py
@@ -556,7 +556,11 @@ def test_robust_scale_sparse(sparse_clf_dataset,  # noqa: F811
 @pytest.mark.parametrize("n_bins", [5, 20])
 @pytest.mark.parametrize("encode", ['ordinal', 'onehot-dense', 'onehot'])
 @pytest.mark.parametrize("strategy", [
-    'uniform',
+    pytest.param('uniform', marks=pytest.mark.xfail(
+        strict=False,
+        reason='Intermittent mismatch with sklearn'
+        ' (https://github.com/rapidsai/cuml/issues/3481)'
+    )),
     pytest.param('quantile', marks=pytest.mark.xfail(
         strict=False,
         reason='Bug in cupy.percentile'


### PR DESCRIPTION
Temporarily mark KBinsDiscretizer tests with "uniform" strategy as xfail due to #3481