### PR TITLE
Non project-flash CI ml test 18.04 issue debugging and bugfixing

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -102,15 +102,12 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
 
     gpuci_logger "Resetting LD_LIBRARY_PATH"
 
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
-    export LD_LIBRARY_PATH_CACHED=""
-
     cd $WORKSPACE
 
     ################################################################################
     # TEST - Run GoogleTest and py.tests for libcuml and cuML
     ################################################################################
-    
+
     if hasArg --skip-tests; then
         gpuci_logger "Skipping Tests"
         exit 0
@@ -124,7 +121,9 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     cd $WORKSPACE/cpp/build
     GTEST_OUTPUT="xml:${WORKSPACE}/test-results/libcuml_cpp/" ./test/ml
 
-    
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
+    export LD_LIBRARY_PATH_CACHED=""
+
     gpuci_logger "Python pytest for cuml"
     cd $WORKSPACE/python
 
@@ -165,7 +164,7 @@ else
     #Project Flash
     export LIBCUML_BUILD_DIR="$WORKSPACE/ci/artifacts/cuml/cpu/conda_work/cpp/build"
     export LD_LIBRARY_PATH="$LIBCUML_BUILD_DIR:$LD_LIBRARY_PATH"
-    
+
     if hasArg --skip-tests; then
         gpuci_logger "Skipping Tests"
         exit 0
@@ -191,7 +190,7 @@ else
     CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
     gpuci_logger "Installing $CONDA_FILE"
     conda install -c $WORKSPACE/ci/artifacts/cuml/cpu/conda-bld/ "$CONDA_FILE"
-        
+
     gpuci_logger "Building cuml"
     "$WORKSPACE/build.sh" -v cuml --codecov
 
@@ -205,7 +204,7 @@ else
     ################################################################################
     # TEST - Run notebook tests
     ################################################################################
-    
+
     gpuci_logger "Notebook tests"
     set +e -Eo pipefail
     EXITCODE=0

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 ##############################################
 # cuML GPU build and test script for CI      #
 ##############################################


### PR DESCRIPTION
PR does a small change for non project FLASH path of the ci/gpu/build.sh script. We were observing a linking bug in the `test/ml` executable _only_ when it was being executed in the Ubuntu 18.04 containers (see https://gpuci.gpuopenanalytics.com/view/RAPIDS%20-%20GPU%20Matrix/job/rapidsai/job/gpuci/job/cuml/job/branches/job/cuml-gpu-matrix-branch-0.18/)

This PR works around the bug for that particular situation by letting LD_LIBRARY_PATH contain the conda lib folder up to the point of execution of `test/ml`, and does not affect regular project FLASH PR CI. 