### PR TITLE
[WIP] Reduce redundant compilation through explicit specialization of extern templates [skip-ci]

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -390,6 +390,7 @@ if(BUILD_CUML_CPP_LIBRARY)
   # single GPU components
   add_library(${CUML_CPP_TARGET} SHARED
     src/specializations/prims/selection/knn.cu
+    src/specializations/raft/mr/device/buffer.cpp
     src/arima/batched_arima.cu
     src/arima/batched_kalman.cu
     src/common/logger.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -390,6 +390,7 @@ if(BUILD_CUML_CPP_LIBRARY)
   # single GPU components
   add_library(${CUML_CPP_TARGET} SHARED
     src/specializations/prims/selection/knn.cu
+    src/specializations/raft/cudart_utils.cpp
     src/specializations/raft/mr/device/buffer.cpp
     src/arima/batched_arima.cu
     src/arima/batched_kalman.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -389,6 +389,7 @@ if(BUILD_CUML_CPP_LIBRARY)
 
   # single GPU components
   add_library(${CUML_CPP_TARGET} SHARED
+    src/specializations/prims/selection/knn.cu
     src/arima/batched_arima.cu
     src/arima/batched_kalman.cu
     src/common/logger.cpp

--- a/cpp/bench/common/ml_benchmark.hpp
+++ b/cpp/bench/common/ml_benchmark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/common/ml_benchmark.hpp
+++ b/cpp/bench/common/ml_benchmark.hpp
@@ -18,7 +18,7 @@
 
 #include <benchmark/benchmark.h>
 #include <cuda_runtime.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/logger.hpp>
 #include <cuml/common/utils.hpp>

--- a/cpp/bench/prims/distance_common.cuh
+++ b/cpp/bench/prims/distance_common.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/prims/distance_common.cuh
+++ b/cpp/bench/prims/distance_common.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/distance.cuh>
 #include "../common/ml_benchmark.hpp"
 

--- a/cpp/bench/prims/fused_l2_nn.cu
+++ b/cpp/bench/prims/fused_l2_nn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/prims/fused_l2_nn.cu
+++ b/cpp/bench/prims/fused_l2_nn.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/fused_l2_nn.cuh>
 #include <limits>
 #include <raft/linalg/norm.cuh>

--- a/cpp/bench/prims/permute.cu
+++ b/cpp/bench/prims/permute.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/prims/permute.cu
+++ b/cpp/bench/prims/permute.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/random/rng.cuh>
 #include <random/permute.cuh>
 #include "../common/ml_benchmark.hpp"

--- a/cpp/bench/prims/rng.cu
+++ b/cpp/bench/prims/rng.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/prims/rng.cu
+++ b/cpp/bench/prims/rng.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/random/rng.cuh>
 #include "../common/ml_benchmark.hpp"
 

--- a/cpp/bench/sg/arima_loglikelihood.cu
+++ b/cpp/bench/sg/arima_loglikelihood.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/sg/arima_loglikelihood.cu
+++ b/cpp/bench/sg/arima_loglikelihood.cu
@@ -24,7 +24,7 @@
 #include <cuml/tsa/batched_arima.hpp>
 #include <raft/random/rng.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "benchmark.cuh"
 
 namespace ML {

--- a/cpp/bench/sg/benchmark.cuh
+++ b/cpp/bench/sg/benchmark.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/bench/sg/benchmark.cuh
+++ b/cpp/bench/sg/benchmark.cuh
@@ -18,7 +18,7 @@
 
 #include <benchmark/benchmark.h>
 #include <cuda_runtime.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/logger.hpp>
 #include <cuml/cuml.hpp>
 #include "../common/ml_benchmark.hpp"

--- a/cpp/bench/sg/dataset.cuh
+++ b/cpp/bench/sg/dataset.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <cuml/cuml.hpp>
 #include <cuml/datasets/make_blobs.hpp>

--- a/cpp/bench/sg/dataset.cuh
+++ b/cpp/bench/sg/dataset.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/cuml.hpp>
 #include <cuml/datasets/make_blobs.hpp>
 #include <fstream>

--- a/cpp/bench/sg/dataset_ts.cuh
+++ b/cpp/bench/sg/dataset_ts.cuh
@@ -19,7 +19,7 @@
 #include <cuml/cuml.hpp>
 #include <raft/cuda_utils.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/random/rng.cuh>
 
 namespace ML {

--- a/cpp/include/cuml/common/device_buffer.hpp
+++ b/cpp/include/cuml/common/device_buffer.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 namespace MLCommon {
 

--- a/cpp/include/cuml/common/utils.hpp
+++ b/cpp/include/cuml/common/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cuml/common/utils.hpp
+++ b/cpp/include/cuml/common/utils.hpp
@@ -18,7 +18,7 @@
 
 #include <cuda_runtime.h>
 #include <execinfo.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cstdio>
 #include <raft/error.hpp>
 #include <sstream>

--- a/cpp/include/cuml/tsa/arima_common.h
+++ b/cpp/include/cuml/tsa/arima_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cuml/tsa/arima_common.h
+++ b/cpp/include/cuml/tsa/arima_common.h
@@ -20,7 +20,7 @@
 
 #include <algorithm>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/include/specializations/prims/selection/knn.cuh
+++ b/cpp/include/specializations/prims/selection/knn.cuh
@@ -1,0 +1,13 @@
+#pragma once
+#include <selection/knn.cuh>
+
+namespace MLCommon {
+namespace Selection {
+
+extern template class MetricProcessor<float>;
+extern template class CosineMetricProcessor<float>;
+extern template class CorrelationMetricProcessor<float>;
+extern template class DefaultMetricProcessor<float>;
+
+}
+}

--- a/cpp/include/specializations/prims/selection/knn.cuh
+++ b/cpp/include/specializations/prims/selection/knn.cuh
@@ -9,5 +9,5 @@ extern template class CosineMetricProcessor<float>;
 extern template class CorrelationMetricProcessor<float>;
 extern template class DefaultMetricProcessor<float>;
 
-}
-}
+}  // namespace Selection
+}  // namespace MLCommon

--- a/cpp/include/specializations/prims/selection/knn.cuh
+++ b/cpp/include/specializations/prims/selection/knn.cuh
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.;
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 #include <selection/knn.cuh>
 

--- a/cpp/include/specializations/raft/cudart_utils.h
+++ b/cpp/include/specializations/raft/cudart_utils.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.; 
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef WHTEST
+#define WHTEST
+#include <raft/cudart_utils.h>
+
+namespace raft {
+extern template void copy<float>(float*, const float*, size_t, cudaStream_t);
+extern template void copy<double>(double*, const double*, size_t, cudaStream_t);
+extern template void copy<int>(int*, const int*, size_t, cudaStream_t);
+extern template void copy<char>(char*, const char*, size_t, cudaStream_t);
+extern template void copy<long>(long*, const long*, size_t, cudaStream_t);
+extern template void copy<bool>(bool*, const bool*, size_t, cudaStream_t);
+extern template void copy<unsigned long>(unsigned long*, const unsigned long*,
+                                         size_t, cudaStream_t);
+extern template void copy<unsigned int>(unsigned int*, const unsigned int*,
+                                        size_t, cudaStream_t);
+extern template void copy<unsigned long long>(unsigned long long*,
+                                              const unsigned long long*, size_t,
+                                              cudaStream_t);
+}  // namespace raft
+#endif

--- a/cpp/include/specializations/raft/cudart_utils.h
+++ b/cpp/include/specializations/raft/cudart_utils.h
@@ -15,8 +15,6 @@
  */
 
 #pragma once
-#ifndef WHTEST
-#define WHTEST
 #include <raft/cudart_utils.h>
 
 namespace raft {
@@ -34,4 +32,3 @@ extern template void copy<unsigned long long>(unsigned long long*,
                                               const unsigned long long*, size_t,
                                               cudaStream_t);
 }  // namespace raft
-#endif

--- a/cpp/include/specializations/raft/mr/device/buffer.hpp
+++ b/cpp/include/specializations/raft/mr/device/buffer.hpp
@@ -3,25 +3,26 @@
 
 namespace raft {
 namespace mr {
-  extern template class buffer_base<int, raft::mr::device::allocator>;
-  extern template class buffer_base<int*, raft::mr::device::allocator>;
-  extern template class buffer_base<unsigned int, raft::mr::device::allocator>;
-  extern template class buffer_base<float, raft::mr::device::allocator>;
-  extern template class buffer_base<float*, raft::mr::device::allocator>;
-  extern template class buffer_base<double, raft::mr::device::allocator>;
-  extern template class buffer_base<double*, raft::mr::device::allocator>;
-  extern template class buffer_base<char, raft::mr::device::allocator>;
-  extern template class buffer_base<long, raft::mr::device::allocator>;
-  extern template class buffer_base<unsigned long, raft::mr::device::allocator>;
-  extern template class buffer_base<unsigned long long, raft::mr::device::allocator>;
-  extern template class buffer_base<bool, raft::mr::device::allocator>;
+extern template class buffer_base<int, raft::mr::device::allocator>;
+extern template class buffer_base<int*, raft::mr::device::allocator>;
+extern template class buffer_base<unsigned int, raft::mr::device::allocator>;
+extern template class buffer_base<float, raft::mr::device::allocator>;
+extern template class buffer_base<float*, raft::mr::device::allocator>;
+extern template class buffer_base<double, raft::mr::device::allocator>;
+extern template class buffer_base<double*, raft::mr::device::allocator>;
+extern template class buffer_base<char, raft::mr::device::allocator>;
+extern template class buffer_base<long, raft::mr::device::allocator>;
+extern template class buffer_base<unsigned long, raft::mr::device::allocator>;
+extern template class buffer_base<unsigned long long,
+                                  raft::mr::device::allocator>;
+extern template class buffer_base<bool, raft::mr::device::allocator>;
 namespace device {
-  extern template class buffer<float>;
-  extern template class buffer<int>;
-  extern template class buffer<unsigned int>;
-  extern template class buffer<double>;
-  extern template class buffer<char>;
-  extern template class buffer<long>;
-}
-}
-}
+extern template class buffer<float>;
+extern template class buffer<int>;
+extern template class buffer<unsigned int>;
+extern template class buffer<double>;
+extern template class buffer<char>;
+extern template class buffer<long>;
+}  // namespace device
+}  // namespace mr
+}  // namespace raft

--- a/cpp/include/specializations/raft/mr/device/buffer.hpp
+++ b/cpp/include/specializations/raft/mr/device/buffer.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <raft/mr/device/buffer.hpp>
+
+namespace raft {
+namespace mr {
+namespace device {
+  extern template class buffer<float>;
+  extern template class buffer<int>;
+  extern template class buffer<unsigned int>;
+  extern template class buffer<double>;
+  extern template class buffer<char>;
+  extern template class buffer<long>;
+}
+}
+}

--- a/cpp/include/specializations/raft/mr/device/buffer.hpp
+++ b/cpp/include/specializations/raft/mr/device/buffer.hpp
@@ -3,6 +3,18 @@
 
 namespace raft {
 namespace mr {
+  extern template class buffer_base<int, raft::mr::device::allocator>;
+  extern template class buffer_base<int*, raft::mr::device::allocator>;
+  extern template class buffer_base<unsigned int, raft::mr::device::allocator>;
+  extern template class buffer_base<float, raft::mr::device::allocator>;
+  extern template class buffer_base<float*, raft::mr::device::allocator>;
+  extern template class buffer_base<double, raft::mr::device::allocator>;
+  extern template class buffer_base<double*, raft::mr::device::allocator>;
+  extern template class buffer_base<char, raft::mr::device::allocator>;
+  extern template class buffer_base<long, raft::mr::device::allocator>;
+  extern template class buffer_base<unsigned long, raft::mr::device::allocator>;
+  extern template class buffer_base<unsigned long long, raft::mr::device::allocator>;
+  extern template class buffer_base<bool, raft::mr::device::allocator>;
 namespace device {
   extern template class buffer<float>;
   extern template class buffer<int>;

--- a/cpp/include/specializations/raft/mr/host/buffer.hpp
+++ b/cpp/include/specializations/raft/mr/host/buffer.hpp
@@ -3,17 +3,17 @@
 
 namespace raft {
 namespace mr {
-  extern template class buffer_base<int, raft::mr::host::allocator>;
-  extern template class buffer_base<unsigned int, raft::mr::host::allocator>;
-  extern template class buffer_base<float, raft::mr::host::allocator>;
-  extern template class buffer_base<double, raft::mr::host::allocator>;
-  extern template class buffer_base<char, raft::mr::host::allocator>;
-  extern template class buffer_base<bool, raft::mr::host::allocator>;
-  extern template class buffer_base<long, raft::mr::host::allocator>;
+extern template class buffer_base<int, raft::mr::host::allocator>;
+extern template class buffer_base<unsigned int, raft::mr::host::allocator>;
+extern template class buffer_base<float, raft::mr::host::allocator>;
+extern template class buffer_base<double, raft::mr::host::allocator>;
+extern template class buffer_base<char, raft::mr::host::allocator>;
+extern template class buffer_base<bool, raft::mr::host::allocator>;
+extern template class buffer_base<long, raft::mr::host::allocator>;
 namespace host {
-  extern template class buffer<float>;
-  extern template class buffer<int>;
-  extern template class buffer<unsigned int>;
-}
-}
-}
+extern template class buffer<float>;
+extern template class buffer<int>;
+extern template class buffer<unsigned int>;
+}  // namespace host
+}  // namespace mr
+}  // namespace raft

--- a/cpp/include/specializations/raft/mr/host/buffer.hpp
+++ b/cpp/include/specializations/raft/mr/host/buffer.hpp
@@ -3,6 +3,13 @@
 
 namespace raft {
 namespace mr {
+  extern template class buffer_base<int, raft::mr::host::allocator>;
+  extern template class buffer_base<unsigned int, raft::mr::host::allocator>;
+  extern template class buffer_base<float, raft::mr::host::allocator>;
+  extern template class buffer_base<double, raft::mr::host::allocator>;
+  extern template class buffer_base<char, raft::mr::host::allocator>;
+  extern template class buffer_base<bool, raft::mr::host::allocator>;
+  extern template class buffer_base<long, raft::mr::host::allocator>;
 namespace host {
   extern template class buffer<float>;
   extern template class buffer<int>;

--- a/cpp/include/specializations/raft/mr/host/buffer.hpp
+++ b/cpp/include/specializations/raft/mr/host/buffer.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <raft/mr/host/buffer.hpp>
+
+namespace raft {
+namespace mr {
+namespace host {
+  extern template class buffer<float>;
+  extern template class buffer<int>;
+  extern template class buffer<unsigned int>;
+}
+}
+}

--- a/cpp/src/arima/batched_arima.cu
+++ b/cpp/src/arima/batched_arima.cu
@@ -28,7 +28,7 @@
 #include <cuml/tsa/batched_arima.hpp>
 #include <cuml/tsa/batched_kalman.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/nvtx.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <linalg/batched/matrix.cuh>

--- a/cpp/src/arima/batched_kalman.cu
+++ b/cpp/src/arima/batched_kalman.cu
@@ -25,8 +25,8 @@
 #include <cuml/cuml.hpp>
 #include <cuml/tsa/batched_kalman.hpp>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/nvtx.hpp>
 #include <linalg/batched/matrix.cuh>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src/arima/batched_kalman.cu
+++ b/cpp/src/arima/batched_kalman.cu
@@ -25,7 +25,7 @@
 #include <cuml/cuml.hpp>
 #include <cuml/tsa/batched_kalman.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <common/nvtx.hpp>
 #include <linalg/batched/matrix.cuh>

--- a/cpp/src/common/allocatorAdapter.hpp
+++ b/cpp/src/common/allocatorAdapter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/common/allocatorAdapter.hpp
+++ b/cpp/src/common/allocatorAdapter.hpp
@@ -22,7 +22,7 @@
 
 #include <cuml/cuml.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 
 namespace ML {

--- a/cpp/src/common/cumlHandle.cpp
+++ b/cpp/src/common/cumlHandle.cpp
@@ -16,10 +16,10 @@
 
 #include "cumlHandle.hpp"
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/logger.hpp>
 

--- a/cpp/src/common/cumlHandle.cpp
+++ b/cpp/src/common/cumlHandle.cpp
@@ -16,7 +16,7 @@
 
 #include "cumlHandle.hpp"
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <raft/sparse/cusparse_wrappers.h>

--- a/cpp/src/common/cuml_api.cpp
+++ b/cpp/src/common/cuml_api.cpp
@@ -16,7 +16,7 @@
 
 #include <cuml/cuml_api.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/utils.hpp>
 #include <functional>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src/common/tensor.hpp
+++ b/cpp/src/common/tensor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/common/tensor.hpp
+++ b/cpp/src/common/tensor.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <vector>
 

--- a/cpp/src/dbscan/adjgraph/naive.cuh
+++ b/cpp/src/dbscan/adjgraph/naive.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/host_buffer.hpp>
 #include <raft/cuda_utils.cuh>
 #include "../common.cuh"

--- a/cpp/src/dbscan/dbscan.cu
+++ b/cpp/src/dbscan/dbscan.cu
@@ -16,7 +16,7 @@
 
 #include <cuml/cluster/dbscan.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "dbscan.cuh"
 
 namespace ML {

--- a/cpp/src/dbscan/runner.cuh
+++ b/cpp/src/dbscan/runner.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/nvtx.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <label/classlabels.cuh>

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -15,7 +15,7 @@
  */
 
 #include <cuml/tree/flatnode.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <treelite/tree.h>
 #include <common/iota.cuh>
 #include <cuml/common/logger.hpp>

--- a/cpp/src/decisiontree/levelalgo/common_helper.cuh
+++ b/cpp/src/decisiontree/levelalgo/common_helper.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/levelalgo/common_helper.cuh
+++ b/cpp/src/decisiontree/levelalgo/common_helper.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuml/tree/flatnode.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/logger.hpp>
 #include <raft/random/rng.cuh>
 #include <stats/minmax.cuh>

--- a/cpp/src/decisiontree/levelalgo/levelfunc_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelfunc_classifier.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/levelalgo/levelfunc_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelfunc_classifier.cuh
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <cuml/tree/flatnode.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/logger.hpp>
 #include <cuml/tree/decisiontree.hpp>
 #include <iostream>

--- a/cpp/src/decisiontree/levelalgo/levelfunc_regressor.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelfunc_regressor.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/levelalgo/levelfunc_regressor.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelfunc_regressor.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 #include <cuml/tree/flatnode.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/tree/decisiontree.hpp>
 #include <iostream>
 #include <numeric>

--- a/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_classifier.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "levelkernel_classifier.cuh"
 
 namespace ML {

--- a/cpp/src/decisiontree/levelalgo/levelhelper_regressor.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_regressor.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/levelalgo/levelhelper_regressor.cuh
+++ b/cpp/src/decisiontree/levelalgo/levelhelper_regressor.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "levelkernel_regressor.cuh"
 
 namespace ML {

--- a/cpp/src/decisiontree/levelalgo/metric_def.cuh
+++ b/cpp/src/decisiontree/levelalgo/metric_def.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/levelalgo/metric_def.cuh
+++ b/cpp/src/decisiontree/levelalgo/metric_def.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <vector>
 #include "../memory.h"

--- a/cpp/src/decisiontree/memory.h
+++ b/cpp/src/decisiontree/memory.h
@@ -16,7 +16,7 @@
 
 #pragma once
 #include <cuml/tree/flatnode.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/host_buffer.hpp>

--- a/cpp/src/decisiontree/quantile/quantile.cuh
+++ b/cpp/src/decisiontree/quantile/quantile.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/decisiontree/quantile/quantile.cuh
+++ b/cpp/src/decisiontree/quantile/quantile.cuh
@@ -15,7 +15,7 @@
  */
 
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include "quantile.h"
 

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -29,7 +29,7 @@
 #include <utility>
 
 #include <cuml/fil/fil.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include "common.cuh"
 

--- a/cpp/src/glm/preprocess.cuh
+++ b/cpp/src/glm/preprocess.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/norm.cuh>
 #include <raft/matrix/math.cuh>

--- a/cpp/src/glm/preprocess_mg.cu
+++ b/cpp/src/glm/preprocess_mg.cu
@@ -16,7 +16,7 @@
 
 #include <cuml/linear_model/preprocess_mg.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <opg/linalg/norm.hpp>
 #include <opg/matrix/math.hpp>
 #include <opg/stats/mean.hpp>

--- a/cpp/src/glm/qn/glm_base.cuh
+++ b/cpp/src/glm/qn/glm_base.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/qn/glm_base.cuh
+++ b/cpp/src/glm/qn/glm_base.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/add.cuh>

--- a/cpp/src/glm/qn/glm_base.cuh
+++ b/cpp/src/glm/qn/glm_base.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/binary_op.cuh>

--- a/cpp/src/glm/qn/glm_regularizer.cuh
+++ b/cpp/src/glm/qn/glm_regularizer.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/glm/qn/glm_regularizer.cuh
+++ b/cpp/src/glm/qn/glm_regularizer.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/binary_op.cuh>
 #include <raft/linalg/map_then_reduce.cuh>

--- a/cpp/src/glm/qn/simple_mat.cuh
+++ b/cpp/src/glm/qn/simple_mat.cuh
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <vector>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <linalg/ternary_op.cuh>

--- a/cpp/src/glm/qn/simple_mat.cuh
+++ b/cpp/src/glm/qn/simple_mat.cuh
@@ -18,8 +18,8 @@
 #include <iostream>
 #include <vector>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <linalg/ternary_op.cuh>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/norm.cuh>

--- a/cpp/src/glm/ridge_mg.cu
+++ b/cpp/src/glm/ridge_mg.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/linear_model/preprocess_mg.hpp>
 #include <cuml/linear_model/ridge_mg.hpp>
 #include <opg/linalg/mv_aTb.hpp>

--- a/cpp/src/holtwinters/internal/hw_decompose.cuh
+++ b/cpp/src/holtwinters/internal/hw_decompose.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/holtwinters/internal/hw_decompose.cuh
+++ b/cpp/src/holtwinters/internal/hw_decompose.cuh
@@ -15,7 +15,7 @@
  */
 
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "hw_utils.cuh"
 
 // optimize, maybe im2col ?

--- a/cpp/src/holtwinters/internal/hw_eval.cuh
+++ b/cpp/src/holtwinters/internal/hw_eval.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/holtwinters/internal/hw_eval.cuh
+++ b/cpp/src/holtwinters/internal/hw_eval.cuh
@@ -15,7 +15,7 @@
  */
 
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "hw_utils.cuh"
 
 template <typename Dtype>

--- a/cpp/src/holtwinters/internal/hw_optim.cuh
+++ b/cpp/src/holtwinters/internal/hw_optim.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/holtwinters/internal/hw_optim.cuh
+++ b/cpp/src/holtwinters/internal/hw_optim.cuh
@@ -15,7 +15,7 @@
  */
 
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "hw_eval.cuh"
 #include "hw_utils.cuh"
 

--- a/cpp/src/holtwinters/internal/hw_utils.cuh
+++ b/cpp/src/holtwinters/internal/hw_utils.cuh
@@ -17,7 +17,7 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuml/tsa/holtwinters_params.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <cuml/common/cuml_allocator.hpp>

--- a/cpp/src/holtwinters/internal/hw_utils.cuh
+++ b/cpp/src/holtwinters/internal/hw_utils.cuh
@@ -17,9 +17,9 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cuml/tsa/holtwinters_params.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>
 #include <raft/linalg/eltwise.cuh>

--- a/cpp/src/holtwinters/runner.cuh
+++ b/cpp/src/holtwinters/runner.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuml/tsa/holtwinters_params.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <cuml/common/device_buffer.hpp>
 #include "internal/hw_decompose.cuh"

--- a/cpp/src/holtwinters/runner.cuh
+++ b/cpp/src/holtwinters/runner.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cuml/tsa/holtwinters_params.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include "internal/hw_decompose.cuh"
 #include "internal/hw_eval.cuh"

--- a/cpp/src/kmeans/common.cuh
+++ b/cpp/src/kmeans/common.cuh
@@ -47,7 +47,7 @@
 
 #include <cuml/cluster/kmeans_mg.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <fstream>
 
 namespace ML {

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "common.cuh"
 #include "sg_impl.cuh"
 

--- a/cpp/src/kmeans/sg_impl.cuh
+++ b/cpp/src/kmeans/sg_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/kmeans/sg_impl.cuh
+++ b/cpp/src/kmeans/sg_impl.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "common.cuh"
 
 namespace ML {

--- a/cpp/src/knn/knn.cu
+++ b/cpp/src/knn/knn.cu
@@ -20,7 +20,7 @@
 #include <ml_mg_utils.cuh>
 
 #include <label/classlabels.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <cuda_runtime.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src/knn/knn_opg_common.cuh
+++ b/cpp/src/knn/knn_opg_common.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 #include <cuml/neighbors/knn_mg.hpp>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src/knn/knn_opg_common.cuh
+++ b/cpp/src/knn/knn_opg_common.cuh
@@ -26,7 +26,7 @@
 #include <memory>
 #include <set>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include "knn_opg_common.cuh"

--- a/cpp/src/ml_cuda_utils.h
+++ b/cpp/src/ml_cuda_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/ml_cuda_utils.h
+++ b/cpp/src/ml_cuda_utils.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 namespace ML {
 

--- a/cpp/src/ml_mg_utils.cuh
+++ b/cpp/src/ml_mg_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/ml_mg_utils.cuh
+++ b/cpp/src/ml_mg_utils.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <cuda_runtime.h>

--- a/cpp/src/pca/pca_mg.cu
+++ b/cpp/src/pca/pca_mg.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/decomposition/pca.hpp>

--- a/cpp/src/pca/pca_mg.cu
+++ b/cpp/src/pca/pca_mg.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src/random_projection/rproj.cuh
+++ b/cpp/src/random_projection/rproj.cuh
@@ -21,9 +21,9 @@
 #include <vector>
 
 #include <cuml/random_projection/rproj_c.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include "rproj_utils.cuh"
 

--- a/cpp/src/random_projection/rproj.cuh
+++ b/cpp/src/random_projection/rproj.cuh
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include <cuml/random_projection/rproj_c.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src/random_projection/rproj_utils.cuh
+++ b/cpp/src/random_projection/rproj_utils.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuml/random_projection/rproj_c.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <sys/time.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/src/randomforest/randomforest_impl.cuh
+++ b/cpp/src/randomforest/randomforest_impl.cuh
@@ -20,7 +20,7 @@
 #include <decisiontree/memory.h>
 #include <decisiontree/quantile/quantile.h>
 #include <decisiontree/treelite_util.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/logger.hpp>
 #include <metrics/scores.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/solvers/params.hpp>
 #include <functions/linearReg.cuh>

--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/solvers/params.hpp>

--- a/cpp/src/solver/cd_mg.cu
+++ b/cpp/src/solver/cd_mg.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/linear_model/preprocess_mg.hpp>

--- a/cpp/src/solver/lars_impl.cuh
+++ b/cpp/src/solver/lars_impl.cuh
@@ -20,7 +20,7 @@
 #include <limits>
 #include <numeric>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/gemv.h>
 #include <thrust/copy.h>

--- a/cpp/src/solver/lars_impl.cuh
+++ b/cpp/src/solver/lars_impl.cuh
@@ -20,9 +20,9 @@
 #include <limits>
 #include <numeric>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/gemv.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/solver/sgd.cuh
+++ b/cpp/src/solver/sgd.cuh
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/gemv.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/solvers/params.hpp>
 #include <functions/hinge.cuh>

--- a/cpp/src/solver/sgd.cuh
+++ b/cpp/src/solver/sgd.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/gemv.h>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src/specializations/prims/selection/knn.cu
+++ b/cpp/src/specializations/prims/selection/knn.cu
@@ -1,0 +1,10 @@
+#include <specializations/prims/selection/knn.cuh>
+
+namespace MLCommon {
+namespace Selection {
+    template class MetricProcessor<float>;
+    template class CosineMetricProcessor<float>;
+    template class CorrelationMetricProcessor<float>;
+    template class DefaultMetricProcessor<float>;
+}
+}

--- a/cpp/src/specializations/prims/selection/knn.cu
+++ b/cpp/src/specializations/prims/selection/knn.cu
@@ -2,9 +2,9 @@
 
 namespace MLCommon {
 namespace Selection {
-    template class MetricProcessor<float>;
-    template class CosineMetricProcessor<float>;
-    template class CorrelationMetricProcessor<float>;
-    template class DefaultMetricProcessor<float>;
-}
-}
+template class MetricProcessor<float>;
+template class CosineMetricProcessor<float>;
+template class CorrelationMetricProcessor<float>;
+template class DefaultMetricProcessor<float>;
+}  // namespace Selection
+}  // namespace MLCommon

--- a/cpp/src/specializations/raft/cudart_utils.cpp
+++ b/cpp/src/specializations/raft/cudart_utils.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.; 
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,;
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <specializations/raft/cudart_utils.h>
+
+namespace raft {
+template void copy<float>(float*, const float*, size_t, cudaStream_t);
+template void copy<double>(double*, const double*, size_t, cudaStream_t);
+template void copy<int>(int*, const int*, size_t, cudaStream_t);
+template void copy<char>(char*, const char*, size_t, cudaStream_t);
+template void copy<long>(long*, const long*, size_t, cudaStream_t);
+template void copy<bool>(bool*, const bool*, size_t, cudaStream_t);
+template void copy<unsigned long>(unsigned long*, const unsigned long*, size_t,
+                                  cudaStream_t);
+template void copy<unsigned int>(unsigned int*, const unsigned int*, size_t,
+                                 cudaStream_t);
+template void copy<unsigned long long>(unsigned long long*,
+                                       const unsigned long long*, size_t,
+                                       cudaStream_t);
+}  // namespace raft

--- a/cpp/src/specializations/raft/mr/device/buffer.cpp
+++ b/cpp/src/specializations/raft/mr/device/buffer.cpp
@@ -2,6 +2,20 @@
 
 namespace raft {
 namespace mr {
+
+template class buffer_base<int, raft::mr::device::allocator>;
+template class buffer_base<int*, raft::mr::device::allocator>;
+template class buffer_base<unsigned int, raft::mr::device::allocator>;
+template class buffer_base<float, raft::mr::device::allocator>;
+template class buffer_base<float*, raft::mr::device::allocator>;
+template class buffer_base<double, raft::mr::device::allocator>;
+template class buffer_base<double*, raft::mr::device::allocator>;
+template class buffer_base<char, raft::mr::device::allocator>;
+template class buffer_base<long, raft::mr::device::allocator>;
+template class buffer_base<unsigned long, raft::mr::device::allocator>;
+template class buffer_base<unsigned long long, raft::mr::device::allocator>;
+template class buffer_base<bool, raft::mr::device::allocator>;
+
 namespace device {
 
 template class buffer<float>;

--- a/cpp/src/specializations/raft/mr/device/buffer.cpp
+++ b/cpp/src/specializations/raft/mr/device/buffer.cpp
@@ -1,0 +1,16 @@
+#include <specializations/raft/mr/device/buffer.hpp>
+
+namespace raft {
+namespace mr {
+namespace device {
+
+template class buffer<float>;
+template class buffer<int>;
+template class buffer<unsigned int>;
+template class buffer<double>;
+template class buffer<char>;
+template class buffer<long>;
+
+}  // namespace device
+}  // namespace mr
+}  // namespace raft

--- a/cpp/src/specializations/raft/mr/host/buffer.cpp
+++ b/cpp/src/specializations/raft/mr/host/buffer.cpp
@@ -1,0 +1,13 @@
+#include <specializations/raft/mr/host/buffer.hpp>
+
+namespace raft {
+namespace mr {
+namespace host {
+
+template class buffer<float>;
+template class buffer<int>;
+template class buffer<unsigned int>;
+
+}  // namespace host
+}  // namespace mr
+}  // namespace raft

--- a/cpp/src/specializations/raft/mr/host/buffer.cpp
+++ b/cpp/src/specializations/raft/mr/host/buffer.cpp
@@ -2,6 +2,15 @@
 
 namespace raft {
 namespace mr {
+
+template class buffer_base<int, raft::mr::host::allocator>;
+template class buffer_base<unsigned int, raft::mr::host::allocator>;
+template class buffer_base<float, raft::mr::host::allocator>;
+template class buffer_base<double, raft::mr::host::allocator>;
+template class buffer_base<char, raft::mr::host::allocator>;
+template class buffer_base<bool, raft::mr::host::allocator>;
+template class buffer_base<long, raft::mr::host::allocator>;
+
 namespace host {
 
 template class buffer<float>;

--- a/cpp/src/svm/kernelcache.cuh
+++ b/cpp/src/svm/kernelcache.cuh
@@ -18,7 +18,7 @@
 
 #include <cuml/svm/svm_parameter.h>
 #include <linalg/init.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cache/cache.cuh>
 #include <cache/cache_util.cuh>
 #include <cub/cub.cuh>

--- a/cpp/src/svm/results.cuh
+++ b/cpp/src/svm/results.cuh
@@ -23,7 +23,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <linalg/init.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/device/device_select.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src/svm/smosolver.cuh
+++ b/cpp/src/svm/smosolver.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/device_ptr.h>
 #include <thrust/fill.h>
 #include <iostream>

--- a/cpp/src/svm/workingset.cuh
+++ b/cpp/src/svm/workingset.cuh
@@ -19,7 +19,7 @@
 #include <cuml/svm/svm_parameter.h>
 #include <limits.h>
 #include <linalg/init.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/device_ptr.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <cub/cub.cuh>

--- a/cpp/src/tsa/auto_arima.cuh
+++ b/cpp/src/tsa/auto_arima.cuh
@@ -27,7 +27,7 @@
 #include <thrust/transform.h>
 #include <cub/device/device_scan.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/fast_int_div.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src/tsne/barnes_hut.cuh
+++ b/cpp/src/tsne/barnes_hut.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/logger.hpp>
 #include "bh_kernels.cuh"

--- a/cpp/src/tsne/bh_kernels.cuh
+++ b/cpp/src/tsne/bh_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/tsne/bh_kernels.cuh
+++ b/cpp/src/tsne/bh_kernels.cuh
@@ -34,7 +34,7 @@
 #define FACTOR7 1
 
 #include <float.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/device_atomics.cuh>
 
 namespace ML {

--- a/cpp/src/tsne/distances.cuh
+++ b/cpp/src/tsne/distances.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/tsne/distances.cuh
+++ b/cpp/src/tsne/distances.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/neighbors/knn_sparse.hpp>
 #include <raft/linalg/eltwise.cuh>
 #include <specializations/prims/selection/knn.cuh>

--- a/cpp/src/tsne/distances.cuh
+++ b/cpp/src/tsne/distances.cuh
@@ -19,7 +19,7 @@
 #include <raft/cudart_utils.h>
 #include <cuml/neighbors/knn_sparse.hpp>
 #include <raft/linalg/eltwise.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include <sparse/coo.cuh>
 #include <sparse/linalg/symmetrize.cuh>
 #include <sparse/selection/knn.cuh>

--- a/cpp/src/tsne/distances.cuh
+++ b/cpp/src/tsne/distances.cuh
@@ -19,10 +19,10 @@
 #include <specializations/raft/cudart_utils.h>
 #include <cuml/neighbors/knn_sparse.hpp>
 #include <raft/linalg/eltwise.cuh>
-#include <specializations/prims/selection/knn.cuh>
 #include <sparse/coo.cuh>
 #include <sparse/linalg/symmetrize.cuh>
 #include <sparse/selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <cuml/manifold/common.hpp>
 

--- a/cpp/src/tsne/exact_kernels.cuh
+++ b/cpp/src/tsne/exact_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/tsne/exact_kernels.cuh
+++ b/cpp/src/tsne/exact_kernels.cuh
@@ -18,7 +18,7 @@
 
 #include <float.h>
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/eltwise.cuh>
 
 #define restrict __restrict__

--- a/cpp/src/tsne/exact_tsne.cuh
+++ b/cpp/src/tsne/exact_tsne.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/logger.hpp>
 #include "exact_kernels.cuh"

--- a/cpp/src/tsne/tsne_runner.cuh
+++ b/cpp/src/tsne/tsne_runner.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/logger.hpp>
 #include <cuml/manifold/common.hpp>
 #include <rmm/device_uvector.hpp>

--- a/cpp/src/tsvd/tsvd.cuh
+++ b/cpp/src/tsvd/tsvd.cuh
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <common/allocatorAdapter.hpp>

--- a/cpp/src/tsvd/tsvd.cuh
+++ b/cpp/src/tsvd/tsvd.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/transpose.h>
 #include <thrust/device_vector.h>

--- a/cpp/src/tsvd/tsvd_mg.cu
+++ b/cpp/src/tsvd/tsvd_mg.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/decomposition/sign_flip_mg.hpp>

--- a/cpp/src/umap/fuzzy_simpl_set/naive.cuh
+++ b/cpp/src/umap/fuzzy_simpl_set/naive.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/umap/fuzzy_simpl_set/naive.cuh
+++ b/cpp/src/umap/fuzzy_simpl_set/naive.cuh
@@ -20,7 +20,7 @@
 #include <cuml/common/logger.hpp>
 #include <cuml/neighbors/knn.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <sparse/op/sort.h>

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -21,7 +21,7 @@
 #include <cuml/neighbors/knn_sparse.hpp>
 #include <iostream>
 #include <raft/linalg/unary_op.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include <sparse/selection/knn.cuh>
 
 #include <raft/cudart_utils.h>

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -24,7 +24,7 @@
 #include <specializations/prims/selection/knn.cuh>
 #include <sparse/selection/knn.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/error.hpp>

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -21,8 +21,8 @@
 #include <cuml/neighbors/knn_sparse.hpp>
 #include <iostream>
 #include <raft/linalg/unary_op.cuh>
-#include <specializations/prims/selection/knn.cuh>
 #include <sparse/selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <specializations/raft/cudart_utils.h>
 

--- a/cpp/src/umap/optimize.cuh
+++ b/cpp/src/umap/optimize.cuh
@@ -21,7 +21,7 @@
 
 #include <cuml/common/device_buffer.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/power.cuh>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/binary_op.cuh>

--- a/cpp/src/umap/simpl_set_embed/algo.cuh
+++ b/cpp/src/umap/simpl_set_embed/algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/umap/simpl_set_embed/algo.cuh
+++ b/cpp/src/umap/simpl_set_embed/algo.cuh
@@ -19,7 +19,7 @@
 #include <cuml/manifold/umapparams.h>
 #include <curand.h>
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/device_ptr.h>
 #include <thrust/extrema.h>
 #include <thrust/system/cuda/execution_policy.h>

--- a/cpp/src/umap/simpl_set_embed/optimize_batch_kernel.cuh
+++ b/cpp/src/umap/simpl_set_embed/optimize_batch_kernel.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuml/manifold/umapparams.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/fast_int_div.cuh>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src/umap/supervised.cuh
+++ b/cpp/src/umap/supervised.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/umap/supervised.cuh
+++ b/cpp/src/umap/supervised.cuh
@@ -21,7 +21,7 @@
 #include <cuml/neighbors/knn.hpp>
 #include "optimize.cuh"
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "fuzzy_simpl_set/runner.cuh"
 #include "init_embed/runner.cuh"
 #include "knn_graph/runner.cuh"

--- a/cpp/src_prims/cache/cache.cuh
+++ b/cpp/src_prims/cache/cache.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/functions/hinge.cuh
+++ b/cpp/src_prims/functions/hinge.cuh
@@ -27,10 +27,10 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <rmm/device_uvector.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include "penalty.cuh"
 
 namespace MLCommon {

--- a/cpp/src_prims/functions/hinge.cuh
+++ b/cpp/src_prims/functions/hinge.cuh
@@ -27,7 +27,7 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <rmm/device_uvector.hpp>

--- a/cpp/src_prims/functions/linearReg.cuh
+++ b/cpp/src_prims/functions/linearReg.cuh
@@ -25,10 +25,10 @@
 #include <raft/linalg/subtract.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <rmm/device_uvector.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include "penalty.cuh"
 
 namespace MLCommon {

--- a/cpp/src_prims/functions/linearReg.cuh
+++ b/cpp/src_prims/functions/linearReg.cuh
@@ -25,7 +25,7 @@
 #include <raft/linalg/subtract.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <rmm/device_uvector.hpp>

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eltwise.cuh>

--- a/cpp/src_prims/label/classlabels.cuh
+++ b/cpp/src_prims/label/classlabels.cuh
@@ -18,7 +18,7 @@
 
 #include <cub/cub.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/label/merge_labels.cuh
+++ b/cpp/src_prims/label/merge_labels.cuh
@@ -20,7 +20,7 @@
 #include <limits>
 
 #include <linalg/init.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 namespace MLCommon {

--- a/cpp/src_prims/linalg/batched/matrix.cuh
+++ b/cpp/src_prims/linalg/batched/matrix.cuh
@@ -28,7 +28,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/fast_int_div.cuh>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/utils.hpp>

--- a/cpp/src_prims/linalg/cutlass_wrappers.cuh
+++ b/cpp/src_prims/linalg/cutlass_wrappers.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/linalg/cutlass_wrappers.cuh
+++ b/cpp/src_prims/linalg/cutlass_wrappers.cuh
@@ -26,8 +26,8 @@
 #include <cutlass/gemm/linear_scaling.h>
 #include <cutlass/gemm/thread_multiply_add.h>
 #include <cutlass/util/platform.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 namespace MLCommon {

--- a/cpp/src_prims/linalg/cutlass_wrappers.cuh
+++ b/cpp/src_prims/linalg/cutlass_wrappers.cuh
@@ -26,7 +26,7 @@
 #include <cutlass/gemm/linear_scaling.h>
 #include <cutlass/gemm/thread_multiply_add.h>
 #include <cutlass/util/platform.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/linalg/lstsq.cuh
+++ b/cpp/src_prims/linalg/lstsq.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <raft/linalg/gemv.h>

--- a/cpp/src_prims/linalg/lstsq.cuh
+++ b/cpp/src_prims/linalg/lstsq.cuh
@@ -30,7 +30,7 @@
 #include <raft/linalg/svd.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src_prims/linalg/lstsq.cuh
+++ b/cpp/src_prims/linalg/lstsq.cuh
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <raft/linalg/gemv.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <raft/cuda_utils.cuh>
@@ -30,9 +30,9 @@
 #include <raft/linalg/svd.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
 #include <rmm/device_uvector.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 namespace MLCommon {
 namespace LinAlg {

--- a/cpp/src_prims/linalg/rsvd.cuh
+++ b/cpp/src_prims/linalg/rsvd.cuh
@@ -28,7 +28,7 @@
 #include <raft/linalg/svd.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
 
 namespace MLCommon {

--- a/cpp/src_prims/linalg/rsvd.cuh
+++ b/cpp/src_prims/linalg/rsvd.cuh
@@ -28,8 +28,8 @@
 #include <raft/linalg/svd.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 namespace MLCommon {
 namespace LinAlg {

--- a/cpp/src_prims/matrix/kernelfactory.cuh
+++ b/cpp/src_prims/matrix/kernelfactory.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/matrix/kernelfactory.cuh
+++ b/cpp/src_prims/matrix/kernelfactory.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuml/matrix/kernelparams.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include "grammatrix.cuh"
 #include "kernelmatrices.cuh"
 

--- a/cpp/src_prims/metrics/adjusted_rand_index.cuh
+++ b/cpp/src_prims/metrics/adjusted_rand_index.cuh
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/metrics/contingencyMatrix.cuh
+++ b/cpp/src_prims/metrics/contingencyMatrix.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/metrics/contingencyMatrix.cuh
+++ b/cpp/src_prims/metrics/contingencyMatrix.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/device_ptr.h>
 #include <thrust/reduce.h>
 #include <cub/cub.cuh>

--- a/cpp/src_prims/metrics/dispersion.cuh
+++ b/cpp/src_prims/metrics/dispersion.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/metrics/entropy.cuh
+++ b/cpp/src_prims/metrics/entropy.cuh
@@ -19,7 +19,7 @@
 */
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/metrics/kl_divergence.cuh
+++ b/cpp/src_prims/metrics/kl_divergence.cuh
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/metrics/mutual_info_score.cuh
+++ b/cpp/src_prims/metrics/mutual_info_score.cuh
@@ -25,7 +25,7 @@
 */
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/metrics/pairwise_distance.cuh
+++ b/cpp/src_prims/metrics/pairwise_distance.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <distance/distance.cuh>

--- a/cpp/src_prims/metrics/rand_index.cuh
+++ b/cpp/src_prims/metrics/rand_index.cuh
@@ -43,7 +43,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/metrics/scores.cuh
+++ b/cpp/src_prims/metrics/scores.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/metrics/scores.cuh
+++ b/cpp/src_prims/metrics/scores.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/power.cuh>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/linalg/subtract.cuh>

--- a/cpp/src_prims/metrics/scores.cuh
+++ b/cpp/src_prims/metrics/scores.cuh
@@ -28,7 +28,7 @@
 
 #include <distance/distance.cuh>
 #include <selection/columnWiseSort.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <thrust/device_ptr.h>
 #include <thrust/reduce.h>

--- a/cpp/src_prims/metrics/silhouette_score.cuh
+++ b/cpp/src_prims/metrics/silhouette_score.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <algorithm>
 #include <cub/cub.cuh>

--- a/cpp/src_prims/metrics/silhouette_score.cuh
+++ b/cpp/src_prims/metrics/silhouette_score.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <math.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cub/cub.cuh>
 #include <cuml/common/cuml_allocator.hpp>

--- a/cpp/src_prims/random/make_blobs.cuh
+++ b/cpp/src_prims/random/make_blobs.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/random/make_regression.cuh
+++ b/cpp/src_prims/random/make_regression.cuh
@@ -24,7 +24,7 @@
 #include <cuml/common/cuml_allocator.hpp>
 
 #include <linalg/init.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/transpose.h>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/random/make_regression.cuh
+++ b/cpp/src_prims/random/make_regression.cuh
@@ -24,16 +24,16 @@
 #include <cuml/common/cuml_allocator.hpp>
 
 #include <linalg/init.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <raft/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/qr.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include "permute.cuh"
 
 namespace MLCommon {

--- a/cpp/src_prims/random/make_regression.cuh
+++ b/cpp/src_prims/random/make_regression.cuh
@@ -32,7 +32,7 @@
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/qr.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
 #include "permute.cuh"
 

--- a/cpp/src_prims/random/mvg.cuh
+++ b/cpp/src_prims/random/mvg.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/random/mvg.cuh
+++ b/cpp/src_prims/random/mvg.cuh
@@ -15,7 +15,7 @@
  */
 
 #pragma once
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <stdio.h>

--- a/cpp/src_prims/random/mvg.cuh
+++ b/cpp/src_prims/random/mvg.cuh
@@ -15,9 +15,9 @@
  */
 
 #pragma once
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <stdio.h>
 #include <cmath>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/random/permute.cuh
+++ b/cpp/src_prims/random/permute.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/random/permute.cuh
+++ b/cpp/src_prims/random/permute.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cooperative_groups.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <memory>
 #include <raft/cuda_utils.cuh>
 #include <raft/vectorized.cuh>

--- a/cpp/src_prims/selection/knn.cuh
+++ b/cpp/src_prims/selection/knn.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <distance/distance.cuh>

--- a/cpp/src_prims/selection/processing.cuh
+++ b/cpp/src_prims/selection/processing.cuh
@@ -183,11 +183,5 @@ inline std::unique_ptr<MetricProcessor<math_t>> create_processor(
   return std::unique_ptr<MetricProcessor<math_t>>(mp);
 }
 
-// Currently only being used by floats
-template class MetricProcessor<float>;
-template class CosineMetricProcessor<float>;
-template class CorrelationMetricProcessor<float>;
-template class DefaultMetricProcessor<float>;
-
 };  // namespace Selection
 };  // namespace MLCommon

--- a/cpp/src_prims/sparse/batched/csr.cuh
+++ b/cpp/src_prims/sparse/batched/csr.cuh
@@ -37,7 +37,7 @@
 #include <cuml/common/utils.hpp>
 #include <cuml/cuml.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <cuml/common/device_buffer.hpp>
 #include <linalg/batched/matrix.cuh>

--- a/cpp/src_prims/sparse/batched/csr.cuh
+++ b/cpp/src_prims/sparse/batched/csr.cuh
@@ -37,8 +37,8 @@
 #include <cuml/common/utils.hpp>
 #include <cuml/cuml.hpp>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <linalg/batched/matrix.cuh>
 #include <raft/matrix/matrix.cuh>

--- a/cpp/src_prims/sparse/convert/coo.cuh
+++ b/cpp/src_prims/sparse/convert/coo.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/sparse/convert/coo.cuh
+++ b/cpp/src_prims/sparse/convert/coo.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <thrust/device_ptr.h>

--- a/cpp/src_prims/sparse/convert/csr.cuh
+++ b/cpp/src_prims/sparse/convert/csr.cuh
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/convert/csr.cuh
+++ b/cpp/src_prims/sparse/convert/csr.cuh
@@ -23,7 +23,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>

--- a/cpp/src_prims/sparse/convert/csr.cuh
+++ b/cpp/src_prims/sparse/convert/csr.cuh
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>

--- a/cpp/src_prims/sparse/convert/dense.cuh
+++ b/cpp/src_prims/sparse/convert/dense.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/sparse/convert/dense.cuh
+++ b/cpp/src_prims/sparse/convert/dense.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <thrust/device_ptr.h>

--- a/cpp/src_prims/sparse/coo.cuh
+++ b/cpp/src_prims/sparse/coo.cuh
@@ -20,7 +20,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <cusparse_v2.h>
 

--- a/cpp/src_prims/sparse/coo.cuh
+++ b/cpp/src_prims/sparse/coo.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/coo.cuh
+++ b/cpp/src_prims/sparse/coo.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/csr.cuh
+++ b/cpp/src_prims/sparse/csr.cuh
@@ -19,8 +19,8 @@
 #include <cuml/common/logger.hpp>
 
 #include <cusparse_v2.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 

--- a/cpp/src_prims/sparse/csr.cuh
+++ b/cpp/src_prims/sparse/csr.cuh
@@ -19,7 +19,7 @@
 #include <cuml/common/logger.hpp>
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/bin_distance.cuh
+++ b/cpp/src_prims/sparse/distance/bin_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../utils.h"
 #include "common.h"

--- a/cpp/src_prims/sparse/distance/bin_distance.cuh
+++ b/cpp/src_prims/sparse/distance/bin_distance.cuh
@@ -18,9 +18,9 @@
 
 #include <limits.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/bin_distance.cuh
+++ b/cpp/src_prims/sparse/distance/bin_distance.cuh
@@ -18,7 +18,7 @@
 
 #include <limits.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/sparse/distance/coo_spmv.cuh
+++ b/cpp/src_prims/sparse/distance/coo_spmv.cuh
@@ -20,7 +20,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../csr.cuh"
 #include "../utils.h"

--- a/cpp/src_prims/sparse/distance/coo_spmv.cuh
+++ b/cpp/src_prims/sparse/distance/coo_spmv.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/distance/coo_spmv.cuh
+++ b/cpp/src_prims/sparse/distance/coo_spmv.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/csr_spmv.cuh
+++ b/cpp/src_prims/sparse/distance/csr_spmv.cuh
@@ -20,7 +20,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../csr.cuh"
 #include "../utils.h"

--- a/cpp/src_prims/sparse/distance/csr_spmv.cuh
+++ b/cpp/src_prims/sparse/distance/csr_spmv.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/distance/csr_spmv.cuh
+++ b/cpp/src_prims/sparse/distance/csr_spmv.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/distance.cuh
+++ b/cpp/src_prims/sparse/distance/distance.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>

--- a/cpp/src_prims/sparse/distance/distance.cuh
+++ b/cpp/src_prims/sparse/distance/distance.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../convert/coo.cuh"
 #include "../convert/csr.cuh"

--- a/cpp/src_prims/sparse/distance/ip_distance.cuh
+++ b/cpp/src_prims/sparse/distance/ip_distance.cuh
@@ -23,7 +23,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../convert/csr.cuh"
 #include "../convert/dense.cuh"

--- a/cpp/src_prims/sparse/distance/ip_distance.cuh
+++ b/cpp/src_prims/sparse/distance/ip_distance.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <limits.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/sparse/distance/ip_distance.cuh
+++ b/cpp/src_prims/sparse/distance/ip_distance.cuh
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <limits.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/l2_distance.cuh
+++ b/cpp/src_prims/sparse/distance/l2_distance.cuh
@@ -18,9 +18,9 @@
 
 #include <cuml/neighbors/knn.hpp>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/l2_distance.cuh
+++ b/cpp/src_prims/sparse/distance/l2_distance.cuh
@@ -18,7 +18,7 @@
 
 #include <cuml/neighbors/knn.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/sparse/distance/l2_distance.cuh
+++ b/cpp/src_prims/sparse/distance/l2_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../csr.cuh"
 #include "../utils.h"

--- a/cpp/src_prims/sparse/distance/lp_distance.cuh
+++ b/cpp/src_prims/sparse/distance/lp_distance.cuh
@@ -18,9 +18,9 @@
 
 #include <limits.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/distance/lp_distance.cuh
+++ b/cpp/src_prims/sparse/distance/lp_distance.cuh
@@ -18,7 +18,7 @@
 
 #include <limits.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/sparse/distance/lp_distance.cuh
+++ b/cpp/src_prims/sparse/distance/lp_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include "../csr.cuh"
 #include "../utils.h"

--- a/cpp/src_prims/sparse/linalg/add.cuh
+++ b/cpp/src_prims/sparse/linalg/add.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>

--- a/cpp/src_prims/sparse/linalg/add.cuh
+++ b/cpp/src_prims/sparse/linalg/add.cuh
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/linalg/add.cuh
+++ b/cpp/src_prims/sparse/linalg/add.cuh
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/linalg/degree.cuh
+++ b/cpp/src_prims/sparse/linalg/degree.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/sparse/linalg/degree.cuh
+++ b/cpp/src_prims/sparse/linalg/degree.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <thrust/device_ptr.h>

--- a/cpp/src_prims/sparse/linalg/norm.cuh
+++ b/cpp/src_prims/sparse/linalg/norm.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/sparse/linalg/norm.cuh
+++ b/cpp/src_prims/sparse/linalg/norm.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <thrust/device_ptr.h>

--- a/cpp/src_prims/sparse/linalg/spectral.cuh
+++ b/cpp/src_prims/sparse/linalg/spectral.cuh
@@ -22,7 +22,7 @@
 #include <raft/mr/device/buffer.hpp>
 #include <raft/spectral/partition.hpp>
 
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include "../convert/csr.cuh"
 #include "../coo.cuh"
 

--- a/cpp/src_prims/sparse/linalg/spectral.cuh
+++ b/cpp/src_prims/sparse/linalg/spectral.cuh
@@ -19,8 +19,8 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/spectral/partition.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <specializations/prims/selection/knn.cuh>
 #include "../convert/csr.cuh"

--- a/cpp/src_prims/sparse/linalg/spectral.cuh
+++ b/cpp/src_prims/sparse/linalg/spectral.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/sparse/linalg/spectral.cuh
+++ b/cpp/src_prims/sparse/linalg/spectral.cuh
@@ -19,7 +19,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 #include <raft/spectral/partition.hpp>
 
 #include <specializations/prims/selection/knn.cuh>

--- a/cpp/src_prims/sparse/linalg/symmetrize.cuh
+++ b/cpp/src_prims/sparse/linalg/symmetrize.cuh
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/linalg/symmetrize.cuh
+++ b/cpp/src_prims/sparse/linalg/symmetrize.cuh
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/linalg/symmetrize.cuh
+++ b/cpp/src_prims/sparse/linalg/symmetrize.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <raft/device_atomics.cuh>
 

--- a/cpp/src_prims/sparse/linalg/transpose.h
+++ b/cpp/src_prims/sparse/linalg/transpose.h
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>

--- a/cpp/src_prims/sparse/linalg/transpose.h
+++ b/cpp/src_prims/sparse/linalg/transpose.h
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/linalg/transpose.h
+++ b/cpp/src_prims/sparse/linalg/transpose.h
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/op/filter.cuh
+++ b/cpp/src_prims/sparse/op/filter.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>

--- a/cpp/src_prims/sparse/op/filter.cuh
+++ b/cpp/src_prims/sparse/op/filter.cuh
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/op/filter.cuh
+++ b/cpp/src_prims/sparse/op/filter.cuh
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/op/row_op.cuh
+++ b/cpp/src_prims/sparse/op/row_op.cuh
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/sparse/op/row_op.cuh
+++ b/cpp/src_prims/sparse/op/row_op.cuh
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <thrust/device_ptr.h>

--- a/cpp/src_prims/sparse/op/slice.h
+++ b/cpp/src_prims/sparse/op/slice.h
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>

--- a/cpp/src_prims/sparse/op/slice.h
+++ b/cpp/src_prims/sparse/op/slice.h
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
 

--- a/cpp/src_prims/sparse/op/sort.h
+++ b/cpp/src_prims/sparse/op/sort.h
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>

--- a/cpp/src_prims/sparse/op/sort.h
+++ b/cpp/src_prims/sparse/op/sort.h
@@ -18,8 +18,8 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/src_prims/sparse/op/sort.h
+++ b/cpp/src_prims/sparse/op/sort.h
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/src_prims/sparse/selection/knn.cuh
+++ b/cpp/src_prims/sparse/selection/knn.cuh
@@ -28,7 +28,7 @@
 #include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include "../coo.cuh"
 #include "../csr.cuh"
 #include "../distance/distance.cuh"

--- a/cpp/src_prims/sparse/selection/knn.cuh
+++ b/cpp/src_prims/sparse/selection/knn.cuh
@@ -19,9 +19,9 @@
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/matrix/matrix.cuh>

--- a/cpp/src_prims/sparse/selection/knn.cuh
+++ b/cpp/src_prims/sparse/selection/knn.cuh
@@ -19,7 +19,7 @@
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/sparse/selection/knn.cuh
+++ b/cpp/src_prims/sparse/selection/knn.cuh
@@ -26,7 +26,7 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/matrix/matrix.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <specializations/prims/selection/knn.cuh>
 #include "../coo.cuh"

--- a/cpp/src_prims/sparse/selection/selection.cuh
+++ b/cpp/src_prims/sparse/selection/selection.cuh
@@ -18,7 +18,7 @@
 
 #include <specializations/prims/selection/knn.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/matrix/matrix.cuh>

--- a/cpp/src_prims/sparse/selection/selection.cuh
+++ b/cpp/src_prims/sparse/selection/selection.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>

--- a/cpp/src_prims/sparse/selection/selection.cuh
+++ b/cpp/src_prims/sparse/selection/selection.cuh
@@ -18,8 +18,8 @@
 
 #include <specializations/prims/selection/knn.cuh>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/matrix/matrix.cuh>
 

--- a/cpp/src_prims/stats/histogram.cuh
+++ b/cpp/src_prims/stats/histogram.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/stats/histogram.cuh
+++ b/cpp/src_prims/stats/histogram.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <stdint.h>
 #include <common/seive.cuh>
 #include <raft/cuda_utils.cuh>

--- a/cpp/src_prims/stats/minmax.cuh
+++ b/cpp/src_prims/stats/minmax.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/stats/minmax.cuh
+++ b/cpp/src_prims/stats/minmax.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <limits>
 #include <raft/cuda_utils.cuh>
 

--- a/cpp/src_prims/stats/weighted_mean.cuh
+++ b/cpp/src_prims/stats/weighted_mean.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/stats/weighted_mean.cuh
+++ b/cpp/src_prims/stats/weighted_mean.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/coalesced_reduction.cuh>
 #include <raft/linalg/strided_reduction.cuh>
 

--- a/cpp/src_prims/timeSeries/arima_helpers.cuh
+++ b/cpp/src_prims/timeSeries/arima_helpers.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src_prims/timeSeries/arima_helpers.cuh
+++ b/cpp/src_prims/timeSeries/arima_helpers.cuh
@@ -19,7 +19,7 @@
 #include <cuda_runtime.h>
 
 #include <cuml/tsa/arima_common.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/batched/matrix.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/matrix_vector_op.cuh>

--- a/cpp/src_prims/timeSeries/jones_transform.cuh
+++ b/cpp/src_prims/timeSeries/jones_transform.cuh
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <math.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>

--- a/cpp/src_prims/timeSeries/stationarity.cuh
+++ b/cpp/src_prims/timeSeries/stationarity.cuh
@@ -33,7 +33,7 @@
 #include <thrust/scan.h>
 #include <vector>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/src_prims/timeSeries/stationarity.cuh
+++ b/cpp/src_prims/timeSeries/stationarity.cuh
@@ -33,8 +33,8 @@
 #include <thrust/scan.h>
 #include <vector>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <raft/linalg/matrix_vector_op.cuh>

--- a/cpp/test/mg/knn_test_helper.cuh
+++ b/cpp/test/mg/knn_test_helper.cuh
@@ -24,7 +24,7 @@
 #include <raft/comms/mpi_comms.hpp>
 
 #include <linalg/reduce_rows_by_key.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 
 #include <cuml/common/cuml_allocator.hpp>
 

--- a/cpp/test/mg/pca.cu
+++ b/cpp/test/mg/pca.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/logger.hpp>

--- a/cpp/test/mg/pca.cu
+++ b/cpp/test/mg/pca.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <test_utils.h>
 #include <cuml/common/device_buffer.hpp>

--- a/cpp/test/prims/add_sub_dev_scalar.cu
+++ b/cpp/test/prims/add_sub_dev_scalar.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/add_sub_dev_scalar.cu
+++ b/cpp/test/prims/add_sub_dev_scalar.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/subtract.cuh>
 #include <raft/linalg/unary_op.cuh>

--- a/cpp/test/prims/adjusted_rand_index.cu
+++ b/cpp/test/prims/adjusted_rand_index.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/adjusted_rand_index.cu
+++ b/cpp/test/prims/adjusted_rand_index.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/batched/csr.cu
+++ b/cpp/test/prims/batched/csr.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/batched/csr.cu
+++ b/cpp/test/prims/batched/csr.cu
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include <linalg_naive.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <linalg/batched/matrix.cuh>
 #include <sparse/batched/csr.cuh>

--- a/cpp/test/prims/batched/gemv.cu
+++ b/cpp/test/prims/batched/gemv.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/batched/gemv.cu
+++ b/cpp/test/prims/batched/gemv.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <linalg/batched/gemv.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/batched/information_criterion.cu
+++ b/cpp/test/prims/batched/information_criterion.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/batched/information_criterion.cu
+++ b/cpp/test/prims/batched/information_criterion.cu
@@ -21,7 +21,7 @@
 #include <random>
 #include <vector>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <metrics/batched/information_criterion.cuh>
 #include "../test_utils.h"

--- a/cpp/test/prims/batched/make_symm.cu
+++ b/cpp/test/prims/batched/make_symm.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/batched/make_symm.cu
+++ b/cpp/test/prims/batched/make_symm.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <linalg/batched/make_symm.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/batched/matrix.cu
+++ b/cpp/test/prims/batched/matrix.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/batched/matrix.cu
+++ b/cpp/test/prims/batched/matrix.cu
@@ -23,7 +23,7 @@
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/cuml.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <linalg/batched/matrix.cuh>
 #include <raft/linalg/add.cuh>

--- a/cpp/test/prims/cache.cu
+++ b/cpp/test/prims/cache.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/cache.cu
+++ b/cpp/test/prims/cache.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cache/cache.cuh>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/columnSort.cu
+++ b/cpp/test/prims/columnSort.cu
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019-2020, NVIDIA CORPORATION.
+* Copyright (c) 2019-2021, NVIDIA CORPORATION.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/columnSort.cu
+++ b/cpp/test/prims/columnSort.cu
@@ -15,7 +15,7 @@
 */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <numeric>
 #include <selection/columnWiseSort.cuh>

--- a/cpp/test/prims/completeness_score.cu
+++ b/cpp/test/prims/completeness_score.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/completeness_score.cu
+++ b/cpp/test/prims/completeness_score.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/contingencyMatrix.cu
+++ b/cpp/test/prims/contingencyMatrix.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/contingencyMatrix.cu
+++ b/cpp/test/prims/contingencyMatrix.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <iostream>
 #include <metrics/contingencyMatrix.cuh>

--- a/cpp/test/prims/cov.cu
+++ b/cpp/test/prims/cov.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/cov.cu
+++ b/cpp/test/prims/cov.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/random/rng.cuh>
 #include <raft/stats/mean.cuh>
 #include <stats/cov.cuh>

--- a/cpp/test/prims/csr.cu
+++ b/cpp/test/prims/csr.cu
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <sparse/csr.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"
 

--- a/cpp/test/prims/cutlass_gemm.cu
+++ b/cpp/test/prims/cutlass_gemm.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/cutlass_gemm.cu
+++ b/cpp/test/prims/cutlass_gemm.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/cutlass_gemm.cuh>
 
 namespace MLCommon {

--- a/cpp/test/prims/decoupled_lookback.cu
+++ b/cpp/test/prims/decoupled_lookback.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/decoupled_lookback.cu
+++ b/cpp/test/prims/decoupled_lookback.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <decoupled_lookback.cuh>
 #include <raft/cuda_utils.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/device_utils.cu
+++ b/cpp/test/prims/device_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/device_utils.cu
+++ b/cpp/test/prims/device_utils.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/device_utils.cuh>
 #include "test_utils.h"
 

--- a/cpp/test/prims/dispersion.cu
+++ b/cpp/test/prims/dispersion.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/dispersion.cu
+++ b/cpp/test/prims/dispersion.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <metrics/dispersion.cuh>

--- a/cpp/test/prims/dist_adj.cu
+++ b/cpp/test/prims/dist_adj.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/dist_adj.cu
+++ b/cpp/test/prims/dist_adj.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/distance.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/distance_base.cuh
+++ b/cpp/test/prims/distance_base.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/distance_base.cuh
+++ b/cpp/test/prims/distance_base.cuh
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/distance.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/eltwise2d.cu
+++ b/cpp/test/prims/eltwise2d.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/eltwise2d.cu
+++ b/cpp/test/prims/eltwise2d.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/eltwise2d.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/entropy.cu
+++ b/cpp/test/prims/entropy.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/entropy.cu
+++ b/cpp/test/prims/entropy.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/epsilon_neighborhood.cu
+++ b/cpp/test/prims/epsilon_neighborhood.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/epsilon_neighborhood.cuh>
 #include <random/make_blobs.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/fast_int_div.cu
+++ b/cpp/test/prims/fast_int_div.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/fast_int_div.cu
+++ b/cpp/test/prims/fast_int_div.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/fast_int_div.cuh>
 #include "test_utils.h"
 

--- a/cpp/test/prims/fused_l2_nn.cu
+++ b/cpp/test/prims/fused_l2_nn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/fused_l2_nn.cu
+++ b/cpp/test/prims/fused_l2_nn.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/fused_l2_nn.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/norm.cuh>

--- a/cpp/test/prims/gather.cu
+++ b/cpp/test/prims/gather.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/gather.cu
+++ b/cpp/test/prims/gather.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <matrix/gather.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/gram.cu
+++ b/cpp/test/prims/gram.cu
@@ -16,7 +16,7 @@
 
 #include <cuml/matrix/kernelparams.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/host_buffer.hpp>
 #include <iostream>

--- a/cpp/test/prims/grid_sync.cu
+++ b/cpp/test/prims/grid_sync.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/grid_sync.cu
+++ b/cpp/test/prims/grid_sync.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <common/grid_sync.cuh>
 #include <raft/cuda_utils.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/hinge.cu
+++ b/cpp/test/prims/hinge.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <functions/hinge.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/histogram.cu
+++ b/cpp/test/prims/histogram.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/histogram.cu
+++ b/cpp/test/prims/histogram.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>
 #include <stats/histogram.cuh>

--- a/cpp/test/prims/homogeneity_score.cu
+++ b/cpp/test/prims/homogeneity_score.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/homogeneity_score.cu
+++ b/cpp/test/prims/homogeneity_score.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/jones_transform.cu
+++ b/cpp/test/prims/jones_transform.cu
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/jones_transform.cu
+++ b/cpp/test/prims/jones_transform.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION. *
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION. *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/cpp/test/prims/kl_divergence.cu
+++ b/cpp/test/prims/kl_divergence.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/kl_divergence.cu
+++ b/cpp/test/prims/kl_divergence.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/knn.cu
+++ b/cpp/test/prims/knn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/knn.cu
+++ b/cpp/test/prims/knn.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <iostream>
 #include <raft/cuda_utils.cuh>
 #include <specializations/prims/selection/knn.cuh>

--- a/cpp/test/prims/knn.cu
+++ b/cpp/test/prims/knn.cu
@@ -18,7 +18,7 @@
 #include <raft/cudart_utils.h>
 #include <iostream>
 #include <raft/cuda_utils.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include <vector>
 #include "test_utils.h"
 

--- a/cpp/test/prims/knn_classify.cu
+++ b/cpp/test/prims/knn_classify.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/knn_classify.cu
+++ b/cpp/test/prims/knn_classify.cu
@@ -20,7 +20,7 @@
 #include <label/classlabels.cuh>
 #include <raft/cuda_utils.cuh>
 #include <random/make_blobs.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include <vector>
 #include "test_utils.h"
 

--- a/cpp/test/prims/knn_classify.cu
+++ b/cpp/test/prims/knn_classify.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <iostream>
 #include <label/classlabels.cuh>
 #include <raft/cuda_utils.cuh>

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <iostream>
 #include <label/classlabels.cuh>

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <iostream>
 #include <label/classlabels.cuh>
 #include <raft/cuda_utils.cuh>

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -22,7 +22,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/reduce.cuh>
 #include <raft/random/rng.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include <vector>
 #include "test_utils.h"
 

--- a/cpp/test/prims/kselection.cu
+++ b/cpp/test/prims/kselection.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/kselection.cu
+++ b/cpp/test/prims/kselection.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <stdlib.h>
 #include <algorithm>
 #include <limits>

--- a/cpp/test/prims/label.cu
+++ b/cpp/test/prims/label.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/label.cu
+++ b/cpp/test/prims/label.cu
@@ -18,7 +18,7 @@
 
 #include <label/classlabels.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <raft/cuda_utils.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/linearReg.cu
+++ b/cpp/test/prims/linearReg.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <functions/linearReg.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/log.cu
+++ b/cpp/test/prims/log.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/log.cu
+++ b/cpp/test/prims/log.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <functions/log.cuh>
 #include <raft/cuda_utils.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/logisticReg.cu
+++ b/cpp/test/prims/logisticReg.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <functions/logisticReg.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/make_arima.cu
+++ b/cpp/test/prims/make_arima.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/make_arima.cu
+++ b/cpp/test/prims/make_arima.cu
@@ -18,7 +18,7 @@
 #include <thrust/count.h>
 #include <thrust/device_vector.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <random/make_arima.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/make_blobs.cu
+++ b/cpp/test/prims/make_blobs.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/make_blobs.cu
+++ b/cpp/test/prims/make_blobs.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cub/cub.cuh>
 #include <raft/cuda_utils.cuh>
 #include <random/make_blobs.cuh>

--- a/cpp/test/prims/make_regression.cu
+++ b/cpp/test/prims/make_regression.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/make_regression.cu
+++ b/cpp/test/prims/make_regression.cu
@@ -18,7 +18,7 @@
 #include <thrust/count.h>
 #include <thrust/device_vector.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/transpose.h>
 #include <raft/cuda_utils.cuh>

--- a/cpp/test/prims/make_regression.cu
+++ b/cpp/test/prims/make_regression.cu
@@ -18,9 +18,9 @@
 #include <thrust/count.h>
 #include <thrust/device_vector.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/subtract.cuh>
 #include <random/make_regression.cuh>

--- a/cpp/test/prims/merge_labels.cu
+++ b/cpp/test/prims/merge_labels.cu
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <label/merge_labels.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <thrust/device_ptr.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <raft/handle.hpp>

--- a/cpp/test/prims/minmax.cu
+++ b/cpp/test/prims/minmax.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/minmax.cu
+++ b/cpp/test/prims/minmax.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits>

--- a/cpp/test/prims/mutual_info_score.cu
+++ b/cpp/test/prims/mutual_info_score.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/mutual_info_score.cu
+++ b/cpp/test/prims/mutual_info_score.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/mvg.cu
+++ b/cpp/test/prims/mvg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/mvg.cu
+++ b/cpp/test/prims/mvg.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cmath>
 #include <iostream>
 #include <random/mvg.cuh>

--- a/cpp/test/prims/penalty.cu
+++ b/cpp/test/prims/penalty.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/penalty.cu
+++ b/cpp/test/prims/penalty.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <functions/penalty.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/permute.cu
+++ b/cpp/test/prims/permute.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/permute.cu
+++ b/cpp/test/prims/permute.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/power.cu
+++ b/cpp/test/prims/power.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/power.cu
+++ b/cpp/test/prims/power.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/power.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/rand_index.cu
+++ b/cpp/test/prims/rand_index.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/rand_index.cu
+++ b/cpp/test/prims/rand_index.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/reduce_cols_by_key.cu
+++ b/cpp/test/prims/reduce_cols_by_key.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/reduce_cols_by_key.cu
+++ b/cpp/test/prims/reduce_cols_by_key.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/reduce_cols_by_key.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/reduce_rows_by_key.cu
+++ b/cpp/test/prims/reduce_rows_by_key.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/reduce_rows_by_key.cu
+++ b/cpp/test/prims/reduce_rows_by_key.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <iostream>
 #include <linalg/reduce_rows_by_key.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/reverse.cu
+++ b/cpp/test/prims/reverse.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/reverse.cu
+++ b/cpp/test/prims/reverse.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <matrix/reverse.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/rsvd.cu
+++ b/cpp/test/prims/rsvd.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/rsvd.cu
+++ b/cpp/test/prims/rsvd.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/rsvd.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>

--- a/cpp/test/prims/score.cu
+++ b/cpp/test/prims/score.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/score.cu
+++ b/cpp/test/prims/score.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <iostream>
 #include <metrics/scores.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/prims/sigmoid.cu
+++ b/cpp/test/prims/sigmoid.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sigmoid.cu
+++ b/cpp/test/prims/sigmoid.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <functions/sigmoid.cuh>
 #include <raft/cuda_utils.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/silhouette_score.cu
+++ b/cpp/test/prims/silhouette_score.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>

--- a/cpp/test/prims/silhouette_score.cu
+++ b/cpp/test/prims/silhouette_score.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/prims/sparse/add.cu
+++ b/cpp/test/prims/sparse/add.cu
@@ -19,7 +19,7 @@
 #include <sparse/csr.cuh>
 #include <sparse/linalg/add.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sparse/convert_coo.cu
+++ b/cpp/test/prims/sparse/convert_coo.cu
@@ -19,7 +19,7 @@
 #include <sparse/convert/coo.cuh>
 #include <sparse/csr.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/random/rng.cuh>
 
 #include <test_utils.h>

--- a/cpp/test/prims/sparse/convert_csr.cu
+++ b/cpp/test/prims/sparse/convert_csr.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sparse/csr_row_slice.cu
+++ b/cpp/test/prims/sparse/csr_row_slice.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/csr_row_slice.cu
+++ b/cpp/test/prims/sparse/csr_row_slice.cu
@@ -15,7 +15,7 @@
  */
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 #include <gtest/gtest.h>
 #include <raft/sparse/cusparse_wrappers.h>

--- a/cpp/test/prims/sparse/csr_row_slice.cu
+++ b/cpp/test/prims/sparse/csr_row_slice.cu
@@ -20,7 +20,7 @@
 #include <gtest/gtest.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <sparse/op/slice.h>
 

--- a/cpp/test/prims/sparse/csr_to_dense.cu
+++ b/cpp/test/prims/sparse/csr_to_dense.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/csr_to_dense.cu
+++ b/cpp/test/prims/sparse/csr_to_dense.cu
@@ -15,7 +15,7 @@
  */
 
 #include <cusparse_v2.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>
 

--- a/cpp/test/prims/sparse/csr_to_dense.cu
+++ b/cpp/test/prims/sparse/csr_to_dense.cu
@@ -17,7 +17,7 @@
 #include <cusparse_v2.h>
 #include <raft/cudart_utils.h>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <gtest/gtest.h>
 #include <raft/sparse/cusparse_wrappers.h>

--- a/cpp/test/prims/sparse/csr_transpose.cu
+++ b/cpp/test/prims/sparse/csr_transpose.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/csr_transpose.cu
+++ b/cpp/test/prims/sparse/csr_transpose.cu
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/test/prims/sparse/csr_transpose.cu
+++ b/cpp/test/prims/sparse/csr_transpose.cu
@@ -21,7 +21,7 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 #include <sparse/linalg/transpose.h>
 

--- a/cpp/test/prims/sparse/csr_transpose.cu
+++ b/cpp/test/prims/sparse/csr_transpose.cu
@@ -18,8 +18,8 @@
 
 #include <gtest/gtest.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>
 

--- a/cpp/test/prims/sparse/degree.cu
+++ b/cpp/test/prims/sparse/degree.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/degree.cu
+++ b/cpp/test/prims/sparse/degree.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sparse/dist_coo_spmv.cu
+++ b/cpp/test/prims/sparse/dist_coo_spmv.cu
@@ -18,9 +18,9 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
 

--- a/cpp/test/prims/sparse/dist_coo_spmv.cu
+++ b/cpp/test/prims/sparse/dist_coo_spmv.cu
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/linalg/unary_op.cuh>

--- a/cpp/test/prims/sparse/dist_csr_spmv.cu
+++ b/cpp/test/prims/sparse/dist_csr_spmv.cu
@@ -18,9 +18,9 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
 

--- a/cpp/test/prims/sparse/dist_csr_spmv.cu
+++ b/cpp/test/prims/sparse/dist_csr_spmv.cu
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/linalg/unary_op.cuh>

--- a/cpp/test/prims/sparse/distance.cu
+++ b/cpp/test/prims/sparse/distance.cu
@@ -18,7 +18,7 @@
 
 #include <cusparse_v2.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/mr/device/allocator.hpp>

--- a/cpp/test/prims/sparse/distance.cu
+++ b/cpp/test/prims/sparse/distance.cu
@@ -18,9 +18,9 @@
 
 #include <cusparse_v2.h>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/mr/device/allocator.hpp>
 
 #include <sparse/distance/distance.cuh>

--- a/cpp/test/prims/sparse/filter.cu
+++ b/cpp/test/prims/sparse/filter.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/filter.cu
+++ b/cpp/test/prims/sparse/filter.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sparse/knn.cu
+++ b/cpp/test/prims/sparse/knn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/knn.cu
+++ b/cpp/test/prims/sparse/knn.cu
@@ -23,7 +23,7 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <specializations/raft/mr/device/buffer.hpp>
 
 namespace raft {
 namespace sparse {

--- a/cpp/test/prims/sparse/knn.cu
+++ b/cpp/test/prims/sparse/knn.cu
@@ -20,8 +20,8 @@
 #include <test_utils.h>
 #include <sparse/selection/knn.cuh>
 
-#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>
 

--- a/cpp/test/prims/sparse/knn.cu
+++ b/cpp/test/prims/sparse/knn.cu
@@ -20,7 +20,7 @@
 #include <test_utils.h>
 #include <sparse/selection/knn.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/mr/device/allocator.hpp>
 #include <specializations/raft/mr/device/buffer.hpp>

--- a/cpp/test/prims/sparse/norm.cu
+++ b/cpp/test/prims/sparse/norm.cu
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 #include <sparse/csr.cuh>

--- a/cpp/test/prims/sparse/row_op.cu
+++ b/cpp/test/prims/sparse/row_op.cu
@@ -19,7 +19,7 @@
 #include <sparse/csr.cuh>
 #include <sparse/op/row_op.cuh>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sparse/selection.cu
+++ b/cpp/test/prims/sparse/selection.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/selection.cu
+++ b/cpp/test/prims/sparse/selection.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 #include <test_utils.h>
 #include <cuml/common/logger.hpp>

--- a/cpp/test/prims/sparse/sort.cu
+++ b/cpp/test/prims/sparse/sort.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/sort.cu
+++ b/cpp/test/prims/sparse/sort.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sparse/symmetrize.cu
+++ b/cpp/test/prims/sparse/symmetrize.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sparse/symmetrize.cu
+++ b/cpp/test/prims/sparse/symmetrize.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/random/rng.cuh>
 

--- a/cpp/test/prims/sqrt.cu
+++ b/cpp/test/prims/sqrt.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/sqrt.cu
+++ b/cpp/test/prims/sqrt.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/sqrt.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/ternary_op.cu
+++ b/cpp/test/prims/ternary_op.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/ternary_op.cu
+++ b/cpp/test/prims/ternary_op.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <linalg/ternary_op.cuh>
 #include <raft/random/rng.cuh>
 #include "test_utils.h"

--- a/cpp/test/prims/test_utils.h
+++ b/cpp/test/prims/test_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/test_utils.h
+++ b/cpp/test/prims/test_utils.h
@@ -16,7 +16,7 @@
 
 #pragma once
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <iostream>
 #include <memory>
 #include <raft/cuda_utils.cuh>

--- a/cpp/test/prims/trustworthiness.cu
+++ b/cpp/test/prims/trustworthiness.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/trustworthiness.cu
+++ b/cpp/test/prims/trustworthiness.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <distance/distance.cuh>
 #include <iostream>
 #include <metrics/scores.cuh>

--- a/cpp/test/prims/v_measure.cu
+++ b/cpp/test/prims/v_measure.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/prims/v_measure.cu
+++ b/cpp/test/prims/v_measure.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <algorithm>
 #include <cuml/common/cuml_allocator.hpp>
 #include <iostream>

--- a/cpp/test/sg/cd_test.cu
+++ b/cpp/test/sg/cd_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/cd_test.cu
+++ b/cpp/test/sg/cd_test.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/matrix/matrix.cuh>
 #include <solver/cd.cuh>

--- a/cpp/test/sg/cd_test.cu
+++ b/cpp/test/sg/cd_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <test_utils.h>
 #include <raft/matrix/matrix.cuh>

--- a/cpp/test/sg/dbscan_test.cu
+++ b/cpp/test/sg/dbscan_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <vector>
 

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -16,7 +16,7 @@
 
 #include <cuml/fil/fil.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <treelite/c_api.h>
 #include <treelite/frontend.h>

--- a/cpp/test/sg/genetic/node_test.cpp
+++ b/cpp/test/sg/genetic/node_test.cpp
@@ -16,7 +16,7 @@
 
 #include <cuml/genetic/node.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/test/sg/holtwinters_test.cu
+++ b/cpp/test/sg/holtwinters_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/holtwinters_test.cu
+++ b/cpp/test/sg/holtwinters_test.cu
@@ -16,7 +16,7 @@
 
 #include <cuml/tsa/holtwinters.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <algorithm>
 #include <cuml/common/logger.hpp>

--- a/cpp/test/sg/kmeans_test.cu
+++ b/cpp/test/sg/kmeans_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <vector>

--- a/cpp/test/sg/knn_test.cu
+++ b/cpp/test/sg/knn_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/neighbors/knn.hpp>
 #include <iostream>

--- a/cpp/test/sg/lars_test.cu
+++ b/cpp/test/sg/lars_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/lars_test.cu
+++ b/cpp/test/sg/lars_test.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <iomanip>
 #include <raft/handle.hpp>

--- a/cpp/test/sg/lars_test.cu
+++ b/cpp/test/sg/lars_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <test_utils.h>
 #include <iomanip>

--- a/cpp/test/sg/multi_sum_test.cu
+++ b/cpp/test/sg/multi_sum_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/multi_sum_test.cu
+++ b/cpp/test/sg/multi_sum_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>

--- a/cpp/test/sg/ols.cu
+++ b/cpp/test/sg/ols.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/ols.cu
+++ b/cpp/test/sg/ols.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <glm/ols.cuh>

--- a/cpp/test/sg/pca_test.cu
+++ b/cpp/test/sg/pca_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/pca_test.cu
+++ b/cpp/test/sg/pca_test.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/decomposition/params.hpp>
 #include <pca/pca.cuh>

--- a/cpp/test/sg/pca_test.cu
+++ b/cpp/test/sg/pca_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cublas_wrappers.h>
 #include <test_utils.h>
 #include <cuml/decomposition/params.hpp>

--- a/cpp/test/sg/quasi_newton.cu
+++ b/cpp/test/sg/quasi_newton.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <test_utils.h>
 #include <cuml/linear_model/glm.hpp>

--- a/cpp/test/sg/quasi_newton.cu
+++ b/cpp/test/sg/quasi_newton.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/linear_model/glm.hpp>
 #include <glm/qn/glm_linear.cuh>

--- a/cpp/test/sg/rf_accuracy_test.cu
+++ b/cpp/test/sg/rf_accuracy_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/ensemble/randomforest.hpp>
 #include <raft/cuda_utils.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/test/sg/rf_batched_classification_test.cu
+++ b/cpp/test/sg/rf_batched_classification_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <test_utils.h>
 #include <cuml/datasets/make_blobs.hpp>

--- a/cpp/test/sg/rf_batched_classification_test.cu
+++ b/cpp/test/sg/rf_batched_classification_test.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/ensemble/randomforest.hpp>

--- a/cpp/test/sg/rf_batched_regression_test.cu
+++ b/cpp/test/sg/rf_batched_regression_test.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 
 #include <gtest/gtest.h>
 #include <raft/linalg/transpose.h>

--- a/cpp/test/sg/rf_depth_test.cu
+++ b/cpp/test/sg/rf_depth_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/ensemble/randomforest.hpp>
 #include <queue>
 #include <raft/cuda_utils.cuh>

--- a/cpp/test/sg/rf_test.cu
+++ b/cpp/test/sg/rf_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/ensemble/randomforest.hpp>
 #include <raft/cuda_utils.cuh>

--- a/cpp/test/sg/rf_treelite_test.cu
+++ b/cpp/test/sg/rf_treelite_test.cu
@@ -17,9 +17,9 @@
 #include <decisiontree/decisiontree_impl.h>
 #include <decisiontree/treelite_util.h>
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/gemv.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <sys/stat.h>
 #include <test_utils.h>
 #include <treelite/c_api.h>

--- a/cpp/test/sg/rf_treelite_test.cu
+++ b/cpp/test/sg/rf_treelite_test.cu
@@ -17,7 +17,7 @@
 #include <decisiontree/decisiontree_impl.h>
 #include <decisiontree/treelite_util.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/gemv.h>
 #include <raft/linalg/transpose.h>
 #include <sys/stat.h>

--- a/cpp/test/sg/ridge.cu
+++ b/cpp/test/sg/ridge.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/ridge.cu
+++ b/cpp/test/sg/ridge.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <glm/ols.cuh>
 #include <glm/ridge.cuh>

--- a/cpp/test/sg/rproj_test.cu
+++ b/cpp/test/sg/rproj_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/rproj_test.cu
+++ b/cpp/test/sg/rproj_test.cu
@@ -16,8 +16,8 @@
 
 #include <cuml/random_projection/rproj_c.h>
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <distance/distance.cuh>
 #include <iostream>

--- a/cpp/test/sg/rproj_test.cu
+++ b/cpp/test/sg/rproj_test.cu
@@ -16,7 +16,7 @@
 
 #include <cuml/random_projection/rproj_c.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <test_utils.h>
 #include <distance/distance.cuh>

--- a/cpp/test/sg/sgd.cu
+++ b/cpp/test/sg/sgd.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/sgd.cu
+++ b/cpp/test/sg/sgd.cu
@@ -15,8 +15,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <raft/matrix/matrix.cuh>
 #include <solver/sgd.cuh>

--- a/cpp/test/sg/sgd.cu
+++ b/cpp/test/sg/sgd.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/cusolver_wrappers.h>
 #include <test_utils.h>
 #include <raft/matrix/matrix.cuh>

--- a/cpp/test/sg/shap_kernel.cu
+++ b/cpp/test/sg/shap_kernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/shap_kernel.cu
+++ b/cpp/test/sg/shap_kernel.cu
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <cuml/explainer/kernel_shap.hpp>
 
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
 #include <thrust/device_ptr.h>

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -17,8 +17,8 @@
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
 #include <gtest/gtest.h>
-#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <thrust/device_ptr.h>
 #include <thrust/fill.h>

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -17,7 +17,7 @@
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <raft/linalg/transpose.h>
 #include <test_utils.h>
 #include <thrust/device_ptr.h>

--- a/cpp/test/sg/trustworthiness_test.cu
+++ b/cpp/test/sg/trustworthiness_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/trustworthiness_test.cu
+++ b/cpp/test/sg/trustworthiness_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <metrics/trustworthiness.cuh>
 #include <raft/cuda_utils.cuh>
 #include <vector>

--- a/cpp/test/sg/tsne_test.cu
+++ b/cpp/test/sg/tsne_test.cu
@@ -17,7 +17,7 @@
 #include <cuml/manifold/tsne.h>
 #include <datasets/digits.h>
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <cuml/common/cuml_allocator.hpp>

--- a/cpp/test/sg/tsvd_test.cu
+++ b/cpp/test/sg/tsvd_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/sg/tsvd_test.cu
+++ b/cpp/test/sg/tsvd_test.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <test_utils.h>
 #include <cuml/decomposition/params.hpp>
 #include <raft/random/rng.cuh>

--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -31,7 +31,7 @@
 #include <linalg/reduce_rows_by_key.cuh>
 #include <metrics/trustworthiness.cuh>
 #include <raft/cuda_utils.cuh>
-#include <selection/knn.cuh>
+#include <specializations/prims/selection/knn.cuh>
 #include <umap/runner.cuh>
 
 using namespace ML;

--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -20,7 +20,7 @@
 
 #include <cuml/manifold/umapparams.h>
 #include <datasets/digits.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/cuml.hpp>

--- a/cpp/test/sg/umap_test.cu
+++ b/cpp/test/sg/umap_test.cu
@@ -20,7 +20,7 @@
 
 #include <cuml/manifold/umapparams.h>
 #include <datasets/digits.h>
-#include <raft/cudart_utils.h>
+#include <specializations/raft/cudart_utils.h>
 #include <cuml/common/cuml_allocator.hpp>
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/common/logger.hpp>


### PR DESCRIPTION
DO NOT MERGE YET: Posting this to facilitate discussion

Declare some of the most redundantly-compiled templates as extern and provide explicit specializations in order to reduce unnecessary compilation time