### PR TITLE
[Review] Improve warning message when QN solver reaches max_iter

### DIFF
--- a/cpp/src/glm/qn/qn_solvers.cuh
+++ b/cpp/src/glm/qn/qn_solvers.cuh
@@ -374,6 +374,12 @@ inline int qn_minimize(const raft::handle_t &handle, SimpleVec<T> &x, T *fx,
 
     CUML_LOG_DEBUG("OWL-QN Done");
   }
+  if (ret == OPT_MAX_ITERS_REACHED) {
+    CUML_LOG_WARN(
+      "Maximum iterations reached before solver is converged. To increase "
+      "model accuracy you can increase the number of iterations (max_iter) or "
+      "improve the scaling of the input data.");
+  }
   return ret;
 }
 


### PR DESCRIPTION
closes #2546

This PR improves the warning message printed when max iterations are reached during fitting a linear model.

Example:
```python
import numpy as np
from cuml.linear_model import LogisticRegression
from sklearn.datasets import load_breast_cancer
X, y = load_breast_cancer(return_X_y=True)
y = y.astype(np.float64)
cls = LogisticRegression(penalty='none', C=1)
cls.fit(X, y)
```
This produces the following output, where the last line is added by this PR:
```
[W] [15:31:04.467478] L-BFGS: max iterations reached
[W] [15:31:04.467804] Maximum iterations reached before solver is converged. To increase model accuracy you can increase the number of iterations (max_iter) or improve the scaling of the input data.
```