### PR TITLE
[REVIEW] Fix Codecov.io Coverage Upload for Branch Builds

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -260,11 +260,17 @@ if [ -n "${CODECOV_TOKEN}" ]; then
     # CodeCov uses a local merge commit created by Jenkins. Since this commit
     # never gets pushed, it causes issues in Codecov
     if [ -n "${REPORT_HASH}" ]; then
-        EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -C ${REPORT_HASH}"
+        EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS}"
     fi
 
     # Append the PR ID. This is needed when running the build inside docker
-    EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -P ${PR_ID} -c"
+    EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -c"
+
+    # TEMP: Override Jenkins auto config with manual settings
+    export CODECOV_SLUG="${PR_AUTHOR}/${SOURCE_BRANCH}"
+    export ghprbSourceBranch="${SOURCE_BRANCH}"
+    export ghprbActualCommit="${REPORT_HASH}"
+    export ghprbPullId="${PR_ID}"
 
     # Upload the two reports with separate flags. Delete the report on success
     # to prevent further CI steps from re-uploading

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -242,16 +242,19 @@ fi
 
 if [ -n "${CODECOV_TOKEN}" ]; then
 
+    # NOTE: The code coverage upload needs to work for both PR builds and normal
+    # branch builds (aka `branch-0.XX`). Ensure the following settings to the
+    # codecov CLI will work with and without a PR
     gpuci_logger "Uploading Code Coverage to codecov.io"
 
     # Directory containing reports
     REPORT_DIR="${WORKSPACE}/python/cuml"
 
     # Base name to use in Codecov UI
-    CODECOV_NAME="${OS},py${PYTHON},cuda${CUDA}"
+    CODECOV_NAME=${JOB_BASE_NAME:-"${OS},py${PYTHON},cuda${CUDA}"}
 
     # Codecov args needed by both calls
-    EXTRA_CODECOV_ARGS=""
+    EXTRA_CODECOV_ARGS="-c"
 
     # Save the OS PYTHON and CUDA flags
     EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -e OS,PYTHON,CUDA"
@@ -260,17 +263,17 @@ if [ -n "${CODECOV_TOKEN}" ]; then
     # CodeCov uses a local merge commit created by Jenkins. Since this commit
     # never gets pushed, it causes issues in Codecov
     if [ -n "${REPORT_HASH}" ]; then
-        EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS}"
+        EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -C ${REPORT_HASH}"
     fi
 
-    # Append the PR ID. This is needed when running the build inside docker
-    EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -c"
+    # Append the PR ID. This is needed when running the build inside docker for
+    # PR builds
+    if [ -n "${PR_ID}" ]; then
+        EXTRA_CODECOV_ARGS="${EXTRA_CODECOV_ARGS} -P ${PR_ID}"
+    fi
 
-    # TEMP: Override Jenkins auto config with manual settings
-    export CODECOV_SLUG="${PR_AUTHOR}/${SOURCE_BRANCH}"
-    export ghprbSourceBranch="${SOURCE_BRANCH}"
-    export ghprbActualCommit="${REPORT_HASH}"
-    export ghprbPullId="${PR_ID}"
+    # Set the slug since this does not work in jenkins.
+    export CODECOV_SLUG="${PR_AUTHOR:-"rapidsai"}/cuml"
 
     # Upload the two reports with separate flags. Delete the report on success
     # to prevent further CI steps from re-uploading

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,8 +6,9 @@ coverage:
 comment:
   behavior: new
 
-# Fixes "missing base report" issue when using Squash and Merge Strategy in
-# GitHub. See this comment from CodeCov support about this undocumented option:
-# https://community.codecov.io/t/unable-to-determine-a-parent-commit-to-compare-against-in-base-branch-after-squash-and-merge/2480/15?u=mdemoret-nv
+# Suggested workaround to fix "missing base report" issue when using Squash and
+# Merge Strategy in GitHub. See this comment from CodeCov support about this
+# undocumented option:
+# https://community.codecov.io/t/unable-to-determine-a-parent-commit-to-compare-against-in-base-branch-after-squash-and-merge/2480/15
 codecov:
   allow_coverage_offsets: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,8 @@ coverage:
 comment:
   behavior: new
 
+# Fixes "missing base report" issue when using Squash and Merge Strategy in
+# GitHub. See this comment from CodeCov support about this undocumented option:
+# https://community.codecov.io/t/unable-to-determine-a-parent-commit-to-compare-against-in-base-branch-after-squash-and-merge/2480/15?u=mdemoret-nv
+codecov:
+  allow_coverage_offsets: true


### PR DESCRIPTION
Testing the following undocumented option:
```yml
codecov:
  allow_coverage_offsets: true
```

Suggested by Codecov.io support [here](https://community.codecov.io/t/unable-to-determine-a-parent-commit-to-compare-against-in-base-branch-after-squash-and-merge/2480/15?u=mdemoret-nv) to fix the linked issue with missing base reports.