### PR TITLE
Directly invoke make for non-CMake docs target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -257,6 +257,6 @@ if completeBuild || hasArg cuml || hasArg pydocs; then
 
     if hasArg pydocs; then
         cd ${REPODIR}/docs
-        cmake --build ${LIBCUML_BUILD_DIR} --target html
+        make html
     fi
 fi


### PR DESCRIPTION
For pydocs target, which invokes a handcrafted Makefile rather than a CMake target, revert to invoking make directly