### PR TITLE
HOTFIX Add ucx-proc package back that got lost during an auto merge conflict [skip-ci] 

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -13,7 +13,7 @@ source activate gdf
 cd $WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
-conda install "ucx-py=${MINOR_VERSION}"
+conda install "ucx-py=${MINOR_VERSION}" "ucx-proc=*=gpu"
 
 # Run flake8 and get results/return code
 FLAKE=`flake8 --config=python/setup.cfg`

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,6 +53,7 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
+      "ucx-proc=*=gpu" \
       "xgboost=1.3.0dev.rapidsai${MINOR_VERSION}" \
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -15,6 +15,7 @@ dependencies:
 - dask-cudf=0.18.*
 - dask-cuda=0.18.*
 - ucx-py=0.18.*
+- ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20
 - libfaiss>=1.6.3

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -15,6 +15,7 @@ dependencies:
 - dask-cudf=0.18.*
 - dask-cuda=0.18.*
 - ucx-py=0.18.*
+- ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20
 - libfaiss>=1.6.3

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -15,6 +15,7 @@ dependencies:
 - dask-cudf=0.18.*
 - dask-cuda=0.18.*
 - ucx-py=0.18.*
+- ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20
 - libfaiss>=1.6.3

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - libcumlprims {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
   run:
     - python x.x
     - cudf {{ minor_version }}
@@ -44,6 +45,7 @@ requirements:
     - treelite=1.0.0
     - nccl>=2.5
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
     - dask>=2.12.0
     - distributed>=2.12.0
     - joblib >=0.11

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - cudf {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
     - libcumlprims {{ minor_version }}
     - lapack
     - treelite=1.0.0
@@ -46,6 +47,7 @@ requirements:
     - cudf {{ minor_version }}
     - nccl>=2.5
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - treelite=1.0.0
     - faiss-proc=*=cuda


### PR DESCRIPTION
Similar to #3550 but targetting branch-0.18, can remove [skip-ci] if/when we decide to merge it to 0.18 as opposed to 0.19 