### PR TITLE
Change dask and distributed branch to main [skip-ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -69,10 +69,10 @@ if [ "$py_ver" == "3.6" ];then
     conda install contextvars
 fi
 
-gpuci_logger "Install the master version of dask and distributed"
+gpuci_logger "Install the main version of dask and distributed"
 set -x
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
 set +x
 
 gpuci_logger "Check compiler versions"

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -26,8 +26,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@master
-    - git+https://github.com/dask/distributed.git@master
+    - git+https://github.com/dask/dask.git@main
+    - git+https://github.com/dask/distributed.git@main
 
 # rapids-build-env, notebook-env and doc-env meta packages are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -26,8 +26,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@master
-    - git+https://github.com/dask/distributed.git@master
+    - git+https://github.com/dask/dask.git@main
+    - git+https://github.com/dask/distributed.git@main
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -26,8 +26,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@master
-    - git+https://github.com/dask/distributed.git@master
+    - git+https://github.com/dask/dask.git@main
+    - git+https://github.com/dask/distributed.git@main
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/


### PR DESCRIPTION
`dask` and `distributed` are changing their default branches name from `master` to `main`, this will break our dev environments and CI, this PR updates the required files. 

`distributed` already merged the PR that does the change, `dask` will probably do the same very soon so a PR that updates both seems to be the best approach. 