### PR TITLE
Fixing compatibility issue with CUDA array interface

### DIFF
--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -310,6 +310,11 @@ def _check_array_contiguity(ary):
         else:
             raise TypeError("No array_interface attribute detected in input. ")
 
+        # __cuda_array_interface__ v2 requires the strides to be omitted
+        # (either not set or set to None) for C-contiguous arrays.
+        if 'strides' not in ary_interface or ary_interface['strides'] is None:
+            return True
+
         shape = ary_interface['shape']
         strides = ary_interface['strides']
         dtype = cp.dtype(ary_interface['typestr'])

--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -310,8 +310,7 @@ def _check_array_contiguity(ary):
         else:
             raise TypeError("No array_interface attribute detected in input. ")
 
-        # __cuda_array_interface__ v2 requires the strides to be omitted
-        # (either not set or set to None) for C-contiguous arrays.
+        # if the strides are not set or none, then the array is C-contiguous
         if 'strides' not in ary_interface or ary_interface['strides'] is None:
             return True
 


### PR DESCRIPTION
Closes #3576.

This PR is a fix for CUDA arrays that don't have the `strides` property or that set this property to `None`.
Since it seems to be compliant with CUDA array interface v2 we should be able to support it.