### PR TITLE
Including log loss metric to the documentation website

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -154,6 +154,8 @@ Metrics (regression, classification, and distance)
 
   .. autofunction:: cuml.metrics.confusion_matrix
 
+  .. autofunction:: cuml.metrics.log_loss
+
   .. autofunction:: cuml.metrics.roc_auc_score
 
   .. autofunction:: cuml.metrics.precision_recall_curve


### PR DESCRIPTION
Closes #1596.

The documentation already existed, it was just not listed in the api.rst for Sphinx.