### PR TITLE
Document model_type='xgboost_json' in FIL

### DIFF
--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -120,7 +120,7 @@ cdef class TreeliteModel():
             Path to treelite model file to load
 
         model_type : string
-            Type of model: 'xgboost', or 'lightgbm'
+            Type of model: 'xgboost', 'xgboost_json', or 'lightgbm'
         """
         filename_bytes = filename.encode("UTF-8")
         cdef ModelHandle handle
@@ -727,7 +727,7 @@ class ForestInference(Base,
 
         model_type : string (default="xgboost")
             Format of the saved treelite model to be load.
-            It can be 'xgboost', 'lightgbm'.
+            It can be 'xgboost', 'xgboost_json', 'lightgbm'.
 
         Returns
         ----------

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -338,19 +338,21 @@ def test_fil_skl_regression(n_rows, n_columns, n_classes, model_class,
     assert np.allclose(fil_preds, skl_preds, 1.2e-3)
 
 
-@pytest.fixture(scope="session")
-def small_classifier_and_preds(tmpdir_factory):
+@pytest.fixture(scope="session", params=['binary', 'json'])
+def small_classifier_and_preds(tmpdir_factory, request):
     X, y = simulate_data(500, 10,
                          random_state=43210,
                          classification=True)
 
-    model_path = str(tmpdir_factory.mktemp("models").join("small_class.model"))
+    ext = 'json' if request.param == 'json' else 'model'
+    model_type = 'xgboost_json' if request.param == 'json' else 'xgboost'
+    model_path = str(tmpdir_factory.mktemp("models").join(f"small_class.{ext}"))
     bst = _build_and_save_xgboost(model_path, X, y)
     # just do within-sample since it's not an accuracy test
     dtrain = xgb.DMatrix(X, label=y)
     xgb_preds = bst.predict(dtrain)
 
-    return (model_path, X, xgb_preds)
+    return (model_path, model_type, X, xgb_preds)
 
 
 @pytest.mark.skipif(has_xgboost() is False, reason="need to install xgboost")
@@ -359,8 +361,9 @@ def small_classifier_and_preds(tmpdir_factory):
                                   'auto', 'naive', 'tree_reorg',
                                   'batch_tree_reorg'])
 def test_output_algos(algo, small_classifier_and_preds):
-    model_path, X, xgb_preds = small_classifier_and_preds
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
     fm = ForestInference.load(model_path,
+                              model_type=model_type,
                               algo=algo,
                               output_class=True,
                               threshold=0.50)
@@ -376,8 +379,9 @@ def test_output_algos(algo, small_classifier_and_preds):
 @pytest.mark.parametrize('storage_type',
                          [False, True, 'auto', 'dense', 'sparse', 'sparse8'])
 def test_output_storage_type(storage_type, small_classifier_and_preds):
-    model_path, X, xgb_preds = small_classifier_and_preds
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
     fm = ForestInference.load(model_path,
+                              model_type=model_type,
                               output_class=True,
                               storage_type=storage_type,
                               threshold=0.50)
@@ -394,8 +398,9 @@ def test_output_storage_type(storage_type, small_classifier_and_preds):
 @pytest.mark.parametrize('blocks_per_sm', [1, 2, 3, 4])
 def test_output_blocks_per_sm(storage_type, blocks_per_sm,
                               small_classifier_and_preds):
-    model_path, X, xgb_preds = small_classifier_and_preds
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
     fm = ForestInference.load(model_path,
+                              model_type=model_type,
                               output_class=True,
                               storage_type=storage_type,
                               threshold=0.50,
@@ -411,8 +416,9 @@ def test_output_blocks_per_sm(storage_type, blocks_per_sm,
 @pytest.mark.parametrize('output_class', [True, False])
 @pytest.mark.skipif(has_xgboost() is False, reason="need to install xgboost")
 def test_thresholding(output_class, small_classifier_and_preds):
-    model_path, X, xgb_preds = small_classifier_and_preds
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
     fm = ForestInference.load(model_path,
+                              model_type=model_type,
                               algo='TREE_REORG',
                               output_class=output_class,
                               threshold=0.50)
@@ -425,8 +431,9 @@ def test_thresholding(output_class, small_classifier_and_preds):
 
 @pytest.mark.skipif(has_xgboost() is False, reason="need to install xgboost")
 def test_output_args(small_classifier_and_preds):
-    model_path, X, xgb_preds = small_classifier_and_preds
+    model_path, model_type, X, xgb_preds = small_classifier_and_preds
     fm = ForestInference.load(model_path,
+                              model_type=model_type,
                               algo='TREE_REORG',
                               output_class=False,
                               threshold=0.50)

--- a/python/cuml/test/test_fil.py
+++ b/python/cuml/test/test_fil.py
@@ -346,7 +346,8 @@ def small_classifier_and_preds(tmpdir_factory, request):
 
     ext = 'json' if request.param == 'json' else 'model'
     model_type = 'xgboost_json' if request.param == 'json' else 'xgboost'
-    model_path = str(tmpdir_factory.mktemp("models").join(f"small_class.{ext}"))
+    model_path = str(tmpdir_factory.mktemp("models").join(
+                 f"small_class.{ext}"))
     bst = _build_and_save_xgboost(model_path, X, y)
     # just do within-sample since it's not an accuracy test
     dtrain = xgb.DMatrix(X, label=y)


### PR DESCRIPTION
Closes #3625. Treelite already supports the XGBoost JSON format, so we just need to expose the capability to the FIL loading function too.

Also add `model_type='xgboost_json'` to the FIL testing matrix.