### PR TITLE
Fix check on RandomState type to use isinstance

### DIFF
--- a/python/cuml/datasets/utils.py
+++ b/python/cuml/datasets/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/datasets/utils.py
+++ b/python/cuml/datasets/utils.py
@@ -25,16 +25,9 @@ def _create_rs_generator(random_state):
         The random_state from which the CuPy random state is generated
     """
 
-    if hasattr(random_state, '__module__'):
-        rs_type = random_state.__module__ + '.' + type(random_state).__name__
-    else:
-        rs_type = type(random_state).__name__
-
-    rs = None
-    if rs_type == "NoneType" or rs_type == "int":
-        rs = cp.random.RandomState(seed=random_state)
-    elif rs_type == "cupy.random.generator.RandomState":
-        rs = rs_type
+    if random_state is None or isinstance(random_state, int):
+        return cp.random.RandomState(seed=random_state)
+    elif isinstance(random_state, cp.random.RandomState):
+        return random_state
     else:
         raise ValueError('random_state type must be int or CuPy RandomState')
-    return rs


### PR DESCRIPTION
Currently if we try and pass in a RandomState to e.g. make_classification(...) like so:

```
from cuml.datasets import make_classification
from cupy.random import RandomState
rng = RandomState(42)
x, y = make_classification(40, 10, random_state=rng)
```

then we get:

```
  File "/opt/conda/lib/python3.8/site-packages/cuml/internals/api_decorators.py", line 473, in inner
    ret_val = func(*args, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/cuml/datasets/classification.py", line 210, in make_classification
    generator = _create_rs_generator(random_state)
  File "/opt/conda/lib/python3.8/site-packages/cuml/datasets/utils.py", line 39, in _create_rs_generator
    raise ValueError('random_state type must be int or CuPy RandomState')
ValueError: random_state type must be int or CuPy RandomState
```

This PR replaces the current type detection approach with a more conventional `isinstance(...)` check, fixing the problem.