### PR TITLE
[WIP] Fixing Indentation for Docstring Generators

### DIFF
--- a/python/cuml/common/doc_utils.py
+++ b/python/cuml/common/doc_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ cuml.dask datatype version of the docstrings will come in a future update.
 """
 
 from inspect import signature
+import inspect
 
 
 _parameters_docstrings = {
@@ -426,7 +427,7 @@ def insert_into_docstring(parameters=False,
                 )
 
         if(len(to_add) > 0):
-            func.__doc__ = str(func.__doc__).format(*to_add)
+            func.__doc__ = str(inspect.getdoc(func)).format(*to_add)
 
         func.__doc__ += '\n\n'
 


### PR DESCRIPTION
When using the decorator `@insert_into_docstring`, the indentation level of the docstring is not taken into consideration. This causes documentation errors. For example, the generated docstring for `RandomForestClassifier.predict()` is:

```
Help on function predict in module cuml.ensemble.randomforestclassifier:

predict(self, X, predict_model='GPU', threshold=0.5, algo='auto', num_classes=None, convert_dtype=True, fil_sparse_format='auto') -> cuml.common.array.CumlArray
    RandomForestClassifier.predict(self, X, predict_model=u'GPU', threshold=0.5, algo=u'auto', num_classes=None, convert_dtype=True, fil_sparse_format=u'auto') -> CumlArray
    
        Predicts the labels for X.
    
        Parameters
        ----------
        X : array-like (device or host) shape = (n_samples, n_features)
    Dense matrix containing floats or doubles.
    Acceptable formats: CUDA array interface compliant objects like
    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas
    DataFrame/Series.
        predict_model : String (default = 'GPU')
            'GPU' to predict using the GPU, 'CPU' otherwise. The 'GPU' can only
            be used if the model was trained on float32 data and `X` is float32
            or convert_dtype is set to True. Also the 'GPU' should only be
            used for binary classification problems.
```
The incorrect indentation for the `X` parameter is shown in the generated documentation:
![image](https://user-images.githubusercontent.com/42954918/112221766-79171d00-8bed-11eb-9dd9-5e6dcbc94952.png)

This PR uses `inspect.getdoc()` to correctly normalize any docstrings indentation. This results in the following docstring:
```
Help on function predict in module cuml.ensemble.randomforestclassifier:

predict(self, X, predict_model='GPU', threshold=0.5, algo='auto', num_classes=None, convert_dtype=True, fil_sparse_format='auto') -> cuml.common.array.CumlArray
    RandomForestClassifier.predict(self, X, predict_model=u'GPU', threshold=0.5, algo=u'auto', num_classes=None, convert_dtype=True, fil_sparse_format=u'auto') -> CumlArray
    
    Predicts the labels for X.
    
    Parameters
    ----------
    X : array-like (device or host) shape = (n_samples, n_features)
        Dense matrix containing floats or doubles.
        Acceptable formats: CUDA array interface compliant objects like
        CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas
        DataFrame/Series.
    predict_model : String (default = 'GPU')
        'GPU' to predict using the GPU, 'CPU' otherwise. The 'GPU' can only
        be used if the model was trained on float32 data and `X` is float32
        or convert_dtype is set to True. Also the 'GPU' should only be
        used for classification problems.
```
And the generated html docs look better as well:
![image](https://user-images.githubusercontent.com/42954918/112236843-0024bf00-8c07-11eb-998b-dd59d553f964.png)
