### PR TITLE
Disable three flaky tests

### DIFF
--- a/cpp/test/prims/adjusted_rand_index.cu
+++ b/cpp/test/prims/adjusted_rand_index.cu
@@ -152,7 +152,9 @@ const std::vector<adjustedRandIndexParam> inputs = {
   {100, 1, 20, false, 0.000001, false},  {10, 1, 10, false, 0.000001, false},
   {198, 1, 100, false, 0.000001, false}, {300, 3, 99, false, 0.000001, false},
   {199, 1, 10, true, 0.000001, false},   {200, 15, 100, true, 0.000001, false},
-  {100, 1, 20, true, 0.000001, false},   {10, 1, 10, true, 0.000001, false},
+  {100, 1, 20, true, 0.000001, false},
+  // FIXME: disabled temporarily due to flaky test
+  // {10, 1, 10, true, 0.000001, false},
   {198, 1, 100, true, 0.000001, false},  {300, 3, 99, true, 0.000001, false},
 
   {199, 0, 0, false, 0.000001, true},    {200, 0, 0, false, 0.000001, true},

--- a/cpp/test/prims/adjusted_rand_index.cu
+++ b/cpp/test/prims/adjusted_rand_index.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,21 +148,32 @@ class adjustedRandIndexTest
 };
 
 const std::vector<adjustedRandIndexParam> inputs = {
-  {199, 1, 10, false, 0.000001, false},  {200, 15, 100, false, 0.000001, false},
-  {100, 1, 20, false, 0.000001, false},  {10, 1, 10, false, 0.000001, false},
-  {198, 1, 100, false, 0.000001, false}, {300, 3, 99, false, 0.000001, false},
-  {199, 1, 10, true, 0.000001, false},   {200, 15, 100, true, 0.000001, false},
+  {199, 1, 10, false, 0.000001, false},
+  {200, 15, 100, false, 0.000001, false},
+  {100, 1, 20, false, 0.000001, false},
+  {10, 1, 10, false, 0.000001, false},
+  {198, 1, 100, false, 0.000001, false},
+  {300, 3, 99, false, 0.000001, false},
+  {199, 1, 10, true, 0.000001, false},
+  {200, 15, 100, true, 0.000001, false},
   {100, 1, 20, true, 0.000001, false},
   // FIXME: disabled temporarily due to flaky test
   // {10, 1, 10, true, 0.000001, false},
-  {198, 1, 100, true, 0.000001, false},  {300, 3, 99, true, 0.000001, false},
+  {198, 1, 100, true, 0.000001, false},
+  {300, 3, 99, true, 0.000001, false},
 
-  {199, 0, 0, false, 0.000001, true},    {200, 0, 0, false, 0.000001, true},
-  {100, 0, 0, false, 0.000001, true},    {10, 0, 0, false, 0.000001, true},
-  {198, 0, 0, false, 0.000001, true},    {300, 0, 0, false, 0.000001, true},
-  {199, 0, 0, true, 0.000001, true},     {200, 0, 0, true, 0.000001, true},
-  {100, 0, 0, true, 0.000001, true},     {10, 0, 0, true, 0.000001, true},
-  {198, 0, 0, true, 0.000001, true},     {300, 0, 0, true, 0.000001, true},
+  {199, 0, 0, false, 0.000001, true},
+  {200, 0, 0, false, 0.000001, true},
+  {100, 0, 0, false, 0.000001, true},
+  {10, 0, 0, false, 0.000001, true},
+  {198, 0, 0, false, 0.000001, true},
+  {300, 0, 0, false, 0.000001, true},
+  {199, 0, 0, true, 0.000001, true},
+  {200, 0, 0, true, 0.000001, true},
+  {100, 0, 0, true, 0.000001, true},
+  {10, 0, 0, true, 0.000001, true},
+  {198, 0, 0, true, 0.000001, true},
+  {300, 0, 0, true, 0.000001, true},
 };
 
 const std::vector<adjustedRandIndexParam> large_inputs = {

--- a/cpp/test/prims/silhouette_score.cu
+++ b/cpp/test/prims/silhouette_score.cu
@@ -207,7 +207,8 @@ class silhouetteScoreTest
 //setting test parameter values
 const std::vector<silhouetteScoreParam> inputs = {
   {4, 2, 3, raft::distance::DistanceType::L2Expanded, 4, 0.00001},
-  {4, 2, 2, raft::distance::DistanceType::L2SqrtUnexpanded, 2, 0.00001},
+  // FIXME: temporarily disabled due to flaky test
+  // {4, 2, 2, raft::distance::DistanceType::L2SqrtUnexpanded, 2, 0.00001},
   {8, 8, 3, raft::distance::DistanceType::L2Unexpanded, 4, 0.00001},
   {11, 2, 5, raft::distance::DistanceType::L2Expanded, 3, 0.00001},
   {40, 2, 8, raft::distance::DistanceType::L2Expanded, 10, 0.00001},

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -75,6 +75,10 @@ def test_pca_fit(datatype, input_type, name, use_handle):
 @pytest.mark.parametrize('n_features', [100, 300])
 @pytest.mark.parametrize('sparse', [True, False])
 def test_pca_defaults(n_samples, n_features, sparse):
+    # FIXME: Disable the case True-300-200 due to flaky test
+    if sparse and n_features == 30 and n_samples == 200:
+        pytest.xfail('Skipping the case True-300-200 due to flaky test')
+
     if sparse:
         X = cupyx.scipy.sparse.random(n_samples, n_features,
                                       density=0.03, dtype=cp.float32,

--- a/python/cuml/test/test_pca.py
+++ b/python/cuml/test/test_pca.py
@@ -76,7 +76,7 @@ def test_pca_fit(datatype, input_type, name, use_handle):
 @pytest.mark.parametrize('sparse', [True, False])
 def test_pca_defaults(n_samples, n_features, sparse):
     # FIXME: Disable the case True-300-200 due to flaky test
-    if sparse and n_features == 30 and n_samples == 200:
+    if sparse and n_features == 300 and n_samples == 200:
         pytest.xfail('Skipping the case True-300-200 due to flaky test')
 
     if sparse:


### PR DESCRIPTION
* `adjusted_rand_index/ARI_ii.Result/9`: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cuml/job/prb/job/cuml-gpu-test/CUDA=10.2,GPU_LABEL=gpu,OS=centos7,PYTHON=3.8/861/console
* `silhouetteScore/silhouetteScoreTestClass.Result/1`: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cuml/job/prb/job/cuml-gpu-test/CUDA=10.1,GPU_LABEL=gpu,OS=ubuntu16.04,PYTHON=3.7/854/console
* `cuml.test.test_pca.test_pca_defaults[True-300-200]`: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cuml/job/prb/job/cuml-gpu-test/CUDA=10.1,GPU_LABEL=gpu,OS=ubuntu16.04,PYTHON=3.7/856/testReport/junit/cuml.test/test_pca/test_pca_defaults_True_300_200_/