### PR TITLE
Use ninja as default CMake generator

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -60,6 +60,11 @@ $ ./build.sh cuml --singlegpu          # build the cuML python package without M
 $ ./build.sh --ccache                  # use ccache to cache compilations, speeding up subsequent builds
 ```
 
+By default, Ninja is used as the cmake generator. To override this and use (e.g.) `make`, define the `CMAKE_GENERATOR` environment variable accodingly:
+```bash
+CMAKE_GENERATOR='Unix Makefiles' ./build.sh
+```
+
 Note. If you are using GCC 7.5, make sure to read [RDN 0002: updates to from-source builds with conda for gcc '7.5.0'](https://docs.rapids.ai/notices/rdn0002/).
 
 To run the C++ unit tests (optional), from the repo root:

--- a/build.sh
+++ b/build.sh
@@ -83,6 +83,10 @@ BUILD_STATIC_FAISS=OFF
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX}}}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:=""}
 
+
+# Default to Ninja if generator is not specified
+export CMAKE_GENERATOR="${CMAKE_GENERATOR:=Ninja}"
+
 # Allow setting arbitrary cmake args via the $CUML_ADDL_CMAKE_ARGS variable. Any
 # values listed here will override existing arguments. For example:
 # CUML_EXTRA_CMAKE_ARGS="-DBUILD_CUML_C_LIBRARY=OFF" ./build.sh


### PR DESCRIPTION
Also update documentation with instructions on using alternate generators

Since ccache instructions have already been added to BUILD.md, making this the default should avoid the necessity of any special build tips as discussed in #3544

Close #3544