### PR TITLE
ENH Update conda recipes pinning of repo dependencies

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cmake>=3.14
     - treelite=1.0.0
     - cudf {{ minor_version }}
-    - libcuml={{ version }}
+    - libcuml={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - libcumlprims {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
@@ -39,7 +39,7 @@ requirements:
     - python x.x
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
-    - libcuml={{ version }}
+    - libcuml={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - libcumlprims {{ minor_version }}
     - cupy>=7.8.0,<9.0.0a0
     - treelite=1.0.0


### PR DESCRIPTION
Ensure all conda packages created in this repo that depend on other packages are all version pinned to the same build number. This way it prevents a conda solve from picking mismatched versions of `cuml` and `libcuml` that can break this repo during builds and testing.