### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -46,9 +46,8 @@ conda list --show-channel-urls
 
 # Build Doxygen docs
 gpuci_logger "Build Doxygen docs"
-cd $PROJECT_WORKSPACE/cpp/build
-make doc
-	
+$PROJECT_WORKSPACE/build.sh cppdocs -v
+
 # Build Python docs
 gpuci_logger "Build Sphinx docs"
 cd $PROJECT_WORKSPACE/docs


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.