### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cmake>=3.14
     - treelite=1.0.0
     - cudf {{ minor_version }}
-    - libcuml={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ minor_version }}
@@ -39,7 +39,7 @@ requirements:
     - python x.x
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
-    - libcuml={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cupy>=7.8.0,<9.0.0a0
     - treelite=1.0.0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.