### PR TITLE
Restore the functionality of RF score()

### DIFF
--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -859,7 +859,7 @@ class RandomForestClassifier(BaseRandomForestModel,
                                 convert_to_dtype=(np.int32 if convert_dtype
                                                   else False))
         y_ptr = y_m.ptr
-        preds = self.predict(X, output_class=True,
+        preds = self.predict(X,
                              threshold=threshold, algo=algo,
                              convert_dtype=convert_dtype,
                              predict_model=predict_model,

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -518,7 +518,8 @@ def test_rf_classification_sparse(small_clf, datatype,
                                        algo=algo)
         fil_preds = np.reshape(fil_preds, np.shape(y_test))
         fil_acc = accuracy_score(y_test, fil_preds)
-        np.testing.assert_almost_equal(fil_acc, cuml_model.score(X_test, y_test))
+        np.testing.assert_almost_equal(fil_acc,
+                                       cuml_model.score(X_test, y_test))
 
         fil_model = cuml_model.convert_to_fil_model()
 

--- a/python/cuml/test/test_random_forest.py
+++ b/python/cuml/test/test_random_forest.py
@@ -518,6 +518,7 @@ def test_rf_classification_sparse(small_clf, datatype,
                                        algo=algo)
         fil_preds = np.reshape(fil_preds, np.shape(y_test))
         fil_acc = accuracy_score(y_test, fil_preds)
+        np.testing.assert_almost_equal(fil_acc, cuml_model.score(X_test, y_test))
 
         fil_model = cuml_model.convert_to_fil_model()
 


### PR DESCRIPTION
Closes #3682

In #3609, I unintentionally broke the function `score()` in the random forest. This PR restores the functionality. In addition, I added `score()` to one of the unit tests to ensure that `score()` does not break again.