### PR TITLE
BUG fix BatchedLevelAlgo DtClsTest & DtRegTest failing tests

### DIFF
--- a/cpp/test/sg/decisiontree_batchedlevel_algo.cu
+++ b/cpp/test/sg/decisiontree_batchedlevel_algo.cu
@@ -72,7 +72,8 @@ class DtBaseTest : public ::testing::TestWithParam<DtTestParams> {
       (T*)allocator->allocate(sizeof(T) * inparams.nbins * inparams.N, stream);
 
     // computing the quantiles
-    computeQuantiles(quantiles, inparams.nbins, data, inparams.M, inparams.N, allocator, stream);
+    computeQuantiles(quantiles, inparams.nbins, data, inparams.M, inparams.N,
+                     allocator, stream);
   }
 
   void TearDown() {

--- a/cpp/test/sg/decisiontree_batchedlevel_algo.cu
+++ b/cpp/test/sg/decisiontree_batchedlevel_algo.cu
@@ -71,12 +71,8 @@ class DtBaseTest : public ::testing::TestWithParam<DtTestParams> {
     quantiles =
       (T*)allocator->allocate(sizeof(T) * inparams.nbins * inparams.N, stream);
 
-    std::shared_ptr<TemporaryMemory<T, int>> tempmem;
-    tempmem = std::make_shared<TemporaryMemory<T, int>>(
-      *handle, handle->get_stream(), inparams.M, inparams.N, 1, params);
-
-    preprocess_quantile((const T*)data, (const unsigned*)rowids, inparams.M,
-                        inparams.N, inparams.M, inparams.nbins, tempmem);
+    // computing the quantiles
+    computeQuantiles(quantiles, inparams.nbins, data, inparams.M, inparams.N, allocator, stream);
   }
 
   void TearDown() {


### PR DESCRIPTION
* This PR fixes the regressions shown by `BatchedLevelAlgo/DtClsTestF` and `BatchedLevelAlgo/DtRegTestF` wherein the quantiles parameter passed to `grow_tree` function was uninitialized garbage memory as opposed to what should have been quantiles computed for each column. 
* It also replaces the old method of computing quantiles (`preprocess_quantiles`) with new, more accurate one (`computeQuantiles`)
* removes an unnecessary memory allocation to `tempmem` in the setup phase of the test fixture.
* This fixes failing `BatchedLevelAlgo/DtRegTestF` tests as reported in issue #3406 
* It also fixes failing `BatchedLevelAlgo/DtClsTestF` tests in PR #3616

cc @teju85 @vinaydes @JohnZed @hcho3 