### PR TITLE
[REVIEW] Fix irreproducibility issue in RF classification

### DIFF
--- a/cpp/src/decisiontree/batched-levelalgo/node.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/node.cuh
@@ -111,7 +111,7 @@ struct Node {
     nodes[pos].depth = depth + 1;
     nodes[pos].start = start + split.nLeft;
     nodes[pos].count = count - split.nLeft;
-    nodes[pos].info.unique_id = 2 * info.unique_id + 1;
+    nodes[pos].info.unique_id = 2 * info.unique_id + 2;
     // update depth
     auto val = atomicMax(n_depth, depth + 1);
     __threadfence();

--- a/cpp/src/decisiontree/batched-levelalgo/split.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/split.cuh
@@ -74,7 +74,11 @@ struct Split {
    * @brief updates the current split if the input gain is better
    */
   DI void update(const SplitT& other) {
-    if (other.best_metric_val > best_metric_val) *this = other;
+    if (other.best_metric_val == best_metric_val) {
+      if(other.colid < colid) *this = other;
+    } else if (other.best_metric_val > best_metric_val) {
+      *this = other;
+    }
   }
 
   /**

--- a/cpp/src/decisiontree/batched-levelalgo/split.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/split.cuh
@@ -75,7 +75,7 @@ struct Split {
    */
   DI void update(const SplitT& other) {
     if (other.best_metric_val == best_metric_val) {
-      if(other.colid < colid) *this = other;
+      if (other.colid < colid) *this = other;
     } else if (other.best_metric_val > best_metric_val) {
       *this = other;
     }


### PR DESCRIPTION
Plugging one of the sources of irreproducibility in Random Forest experimental (batched) backend classification. The irreproducibility in classification comes from the fact that two or more splits at a node can have exactly same partitioning of samples. Therefore these splits have exact same information gain. Which one of the tied splits gets picked is decided by a race condition in the code. This typically happens at deeper nodes since there are fewer samples in these nodes.
To fix this, this PR implements a tie-break logic. If the metric values of two splits are same, then one with a lower feature id (column) is picked. We do not have to worry about floating point errors while comparing since, the arithmetic to evaluate `best_metric_val` is executed sequentially by a single thread in exact same order every time.
The PR also fixes a bug in `unique_id` assignment.