### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/cpp/src/decisiontree/batched-levelalgo/node.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/node.cuh
@@ -111,7 +111,7 @@ struct Node {
     nodes[pos].depth = depth + 1;
     nodes[pos].start = start + split.nLeft;
     nodes[pos].count = count - split.nLeft;
-    nodes[pos].info.unique_id = 2 * info.unique_id + 1;
+    nodes[pos].info.unique_id = 2 * info.unique_id + 2;
     // update depth
     auto val = atomicMax(n_depth, depth + 1);
     __threadfence();

--- a/cpp/src/decisiontree/batched-levelalgo/split.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/split.cuh
@@ -74,7 +74,11 @@ struct Split {
    * @brief updates the current split if the input gain is better
    */
   DI void update(const SplitT& other) {
-    if (other.best_metric_val > best_metric_val) *this = other;
+    if (other.best_metric_val == best_metric_val) {
+      if (other.colid < colid) *this = other;
+    } else if (other.best_metric_val > best_metric_val) {
+      *this = other;
+    }
   }
 
   /**


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.