### PR TITLE
FIL and Dask demo

### DIFF
--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -16,19 +16,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
+    "import cupy\n",
     "import os\n",
     "\n",
     "from cuml.test.utils import array_equal\n",
     "from cuml.common.import_utils import has_xgboost\n",
     "\n",
-    "from sklearn.datasets import make_classification\n",
-    "from sklearn.metrics import accuracy_score\n",
-    "from sklearn.model_selection import train_test_split\n",
+    "from cuml.datasets import make_classification\n",
+    "from cuml.metrics import accuracy_score\n",
+    "from cuml.model_selection import train_test_split\n",
     "    \n",
     "from cuml import ForestInference"
    ]
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,8 +51,69 @@
     "    import xgboost as xgb\n",
     "else:\n",
     "    raise ImportError(\"Please install xgboost using the conda package,\"\n",
-    "                      \" Use conda install -c conda-forge xgboost \"\n",
-    "                      \"command to install xgboost\")"
+    "                      \"e.g.: conda install -c conda-forge xgboost\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# synthetic data size\n",
+    "n_rows = 10000\n",
+    "n_columns = 100\n",
+    "n_categories = 2\n",
+    "random_state = cupy.random.RandomState(43210)\n",
+    "\n",
+    "# fraction of data used for model training\n",
+    "train_size = 0.8\n",
+    "\n",
+    "# trained model output filename\n",
+    "model_path = 'xgb.model'\n",
+    "\n",
+    "# num of iterations for which xgboost is trained\n",
+    "num_rounds = 100\n",
+    "\n",
+    "# maximum tree depth in each training round\n",
+    "max_depth = 20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create the dataset\n",
+    "X, y = make_classification(\n",
+    "    n_samples=n_rows,\n",
+    "    n_features=n_columns,\n",
+    "    n_informative=int(n_columns/5),\n",
+    "    n_classes=n_categories,\n",
+    "    random_state=42\n",
+    ")\n",
+    "\n",
+    "# convert the dataset to float32\n",
+    "X = X.astype('float32')\n",
+    "y = y.astype('float32')\n",
+    "\n",
+    "# split the dataset into training and validation splits\n",
+    "X_train, X_validation, y_train, y_validation = train_test_split(X, y, train_size=0.8)"
    ]
   },
   {
@@ -68,24 +129,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def train_xgboost_model(X_train, y_train,\n",
-    "                        num_rounds, model_path):\n",
+    "def train_xgboost_model(\n",
+    "    X_train, \n",
+    "    y_train,\n",
+    "    model_path='xgb.model',\n",
+    "    num_rounds=150, \n",
+    "    max_depth=20\n",
+    "):\n",
+    "    \n",
     "    # set the xgboost model parameters\n",
-    "    params = {'silent': 1, 'eval_metric':'error',\n",
-    "              'objective':'binary:logistic',\n",
-    "              'max_depth': 25}\n",
+    "    params = {\n",
+    "        'silent': 0, \n",
+    "        'eval_metric':'error',\n",
+    "        'objective':'binary:logistic',\n",
+    "        'max_depth': max_depth,\n",
+    "        'tree_method': 'gpu_hist'\n",
+    "    }\n",
+    "    \n",
+    "    # convert training data into DMatrix\n",
     "    dtrain = xgb.DMatrix(X_train, label=y_train)\n",
+    "    \n",
     "    # train the xgboost model\n",
-    "    bst = xgb.train(params, dtrain, num_rounds)\n",
+    "    trained_model = xgb.train(params, dtrain, num_rounds)\n",
     "\n",
     "    # save the trained xgboost model\n",
-    "    bst.save_model(model_path)\n",
+    "    trained_model.save_model(model_path)\n",
     "\n",
-    "    return bst"
+    "    return trained_model"
    ]
   },
   {
@@ -98,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,66 +180,12 @@
     "\n",
     "    # predict using the xgboost model\n",
     "    dvalidation = xgb.DMatrix(X_validation, label=y_validation)\n",
-    "    xgb_preds = xgb_model.predict(dvalidation)\n",
+    "    predictions = xgb_model.predict(dvalidation)\n",
     "\n",
     "    # convert the predicted values from xgboost into class labels\n",
-    "    xgb_preds = np.around(xgb_preds)\n",
-    "    return xgb_preds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Define parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n_rows = 10000\n",
-    "n_columns = 100\n",
-    "n_categories = 2\n",
-    "random_state = np.random.RandomState(43210)\n",
-    "\n",
-    "# enter path to the directory where the trained model will be saved\n",
-    "model_path = 'xgb.model'\n",
-    "\n",
-    "# num of iterations for which the model is trained\n",
-    "num_rounds = 15"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Generate data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create the dataset\n",
-    "X, y = make_classification(n_samples=n_rows,\n",
-    "                           n_features=n_columns,\n",
-    "                           n_informative=int(n_columns/5),\n",
-    "                           n_classes=n_categories,\n",
-    "                           random_state=random_state)\n",
-    "train_size = 0.8\n",
-    "\n",
-    "# convert the dataset to np.float32\n",
-    "X = X.astype(np.float32)\n",
-    "y = y.astype(np.float32)\n",
-    "\n",
-    "# split the dataset into training and validation splits\n",
-    "X_train, X_validation, y_train, y_validation = train_test_split(\n",
-    "    X, y, train_size=train_size)"
+    "    predictions = cupy.around(predictions)\n",
+    "    \n",
+    "    return predictions"
    ]
   },
   {
@@ -178,26 +198,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[17:05:27] WARNING: /opt/conda/envs/rapids/conda-bld/xgboost_1612969655237/work/src/learner.cc:541: \n",
+      "Parameters: { silent } might not be used.\n",
+      "\n",
+      "  This may not be accurate due to some parameters are only used in language bindings but\n",
+      "  passed down to XGBoost core.  Or some parameters are not used but slip through this\n",
+      "  verification. Please open an issue if you find above cases.\n",
+      "\n",
+      "\n",
+      "CPU times: user 1.28 s, sys: 63.6 ms, total: 1.34 s\n",
+      "Wall time: 1.36 s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "# train the xgboost model\n",
-    "xgboost_model = train_xgboost_model(X_train, y_train,\n",
-    "                                    num_rounds, model_path)"
+    "xgboost_model = train_xgboost_model(\n",
+    "    X_train, \n",
+    "    y_train, \n",
+    "    model_path,\n",
+    "    num_rounds,\n",
+    "    max_depth\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.84 ms, sys: 4.83 ms, total: 6.66 ms\n",
+      "Wall time: 5.22 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# test the xgboost model\n",
-    "trained_model_preds = predict_xgboost_model(X_validation,\n",
-    "                                            y_validation,\n",
-    "                                            xgboost_model)"
+    "trained_model_preds = predict_xgboost_model(\n",
+    "    X_validation,\n",
+    "    y_validation,\n",
+    "    xgboost_model\n",
+    ")"
    ]
   },
   {
@@ -238,15 +292,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fm = ForestInference.load(filename=model_path,\n",
-    "                          algo='BATCH_TREE_REORG',\n",
-    "                          output_class=True,\n",
-    "                          threshold=0.50,\n",
-    "                          model_type='xgboost')"
+    "fil_model = ForestInference.load(\n",
+    "    filename=model_path,\n",
+    "    algo='BATCH_TREE_REORG',\n",
+    "    output_class=True,\n",
+    "    threshold=0.50,\n",
+    "    model_type='xgboost'\n",
+    ")"
    ]
   },
   {
@@ -258,13 +314,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 452 µs, sys: 2.53 ms, total: 2.98 ms\n",
+      "Wall time: 2.36 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# perform prediction on the model loaded from path\n",
-    "fil_preds = fm.predict(X_validation)"
+    "fil_preds = fil_model.predict(X_validation)"
    ]
   },
   {
@@ -278,13 +343,325 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The shape of predictions obtained from xgboost :  (2000,)\n",
+      "The shape of predictions obtained from FIL :  (2000,)\n",
+      "Are the predictions for xgboost and FIL the same :  True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"The shape of predictions obtained from xgboost : \", (trained_model_preds).shape)\n",
+    "print(\"The shape of predictions obtained from FIL : \", (fil_preds).shape)\n",
+    "print(\"Are the predictions for xgboost and FIL the same : \",  array_equal(trained_model_preds, fil_preds))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Distributed FIL with Dask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets demonstrate how we can use FIL and Dask together to run parallel inference on multiple-GPUs while leveraging our trained model. \n",
+    "\n",
+    "Below we will:\n",
+    "1. **create a Dask cluster** with n_GPU workers,\n",
+    "\n",
+    "2. **generate synthetic data** and partition it evenly among the workers,\n",
+    "    \n",
+    "3. **load FIL model** on each worker,\n",
+    "\n",
+    "4. and **run parallel FIL .predict()** on each worker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Optional Kernel Restart*"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "import IPython\n",
+    "IPython.Application.instance().kernel.do_shutdown(restart=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dask Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"The shape of predictions obtained from xgboost : \",(trained_model_preds).shape)\n",
-    "print(\"The shape of predictions obtained from FIL : \",(fil_preds).shape)\n",
-    "print(\"Are the predictions for xgboost and FIL the same : \" ,   array_equal(trained_model_preds, fil_preds))"
+    "from dask_cuda import LocalCUDACluster\n",
+    "from distributed import Client, wait, get_worker\n",
+    "\n",
+    "import dask.dataframe\n",
+    "import dask.array\n",
+    "import dask_cudf\n",
+    "\n",
+    "from cuml import ForestInference\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a LocalCUDACluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we'll be partitioning the data equally among the workers. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster = LocalCUDACluster()\n",
+    "client = Client(cluster)\n",
+    "\n",
+    "workers = client.has_what().keys()\n",
+    "n_workers = len(workers)\n",
+    "n_partitions = n_workers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define size of synthetic data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = 1_000_000\n",
+    "cols = 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate synthetic query/inference data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we will generate data on the CPU as a dask array, then move it into GPU memory as a dask.dataframe and ultimately conver it into a dask_cudf.dataframe so that it can be used in the upstream FIL predict."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = dask.array.random.random(\n",
+    "    size=(rows, cols), \n",
+    "    chunks=(rows//n_partitions, cols)\n",
+    ").astype('float32')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dask_cudf.from_dask_dataframe(\n",
+    "    dask.dataframe.from_array(x)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Persist data in GPU memory\n",
+    "We can optionally persist our generated data (see [Persist documentation](https://docs.dask.org/en/latest/dataframe-best-practices.html?highlight=persist#persist-intelligently)), so that our lazy dataframe starts to be executed and saved in memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.persist(); wait(df);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pre-load FIL model on each worker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we run inference on our distributed dataset let's first load the FIL model (trained by XGBoost above), onto each worker.\n",
+    "\n",
+    "Here we'll leverage the worker's local storage which will persist after the function/task completes.\n",
+    "\n",
+    "For more see the [Dask worker documentation on storage](https://distributed.dask.org/en/latest/worker.html#storing-data)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def worker_init(model_file='xgb.model'):   \n",
+    "   worker = get_worker()\n",
+    "\n",
+    "   worker.data[\"fil_model\"] = ForestInference.load(\n",
+    "       filename=model_file,\n",
+    "       algo='BATCH_TREE_REORG',\n",
+    "       output_class=True,\n",
+    "       threshold=0.50,\n",
+    "       model_type='xgboost'\n",
+    "   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 263 ms, sys: 91 ms, total: 354 ms\n",
+      "Wall time: 7.96 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'tcp://127.0.0.1:35345': None,\n",
+       " 'tcp://127.0.0.1:37763': None,\n",
+       " 'tcp://127.0.0.1:37847': None,\n",
+       " 'tcp://127.0.0.1:46517': None}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "client.run(worker_init)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Distributed FIL Predict on persisted data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict(input_df):\n",
+    "   worker = get_worker()\n",
+    "   return worker.data[\"fil_model\"].predict(input_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets map the predict call to each of our partitions (i.e., the dask_cudf.dataframe chunks that we distributed among the workers )."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "distributed_predictions = df.map_partitions(predict, meta=\"float\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tic = time.perf_counter()\n",
+    "distributed_predictions.compute()\n",
+    "toc = time.perf_counter()\n",
+    "\n",
+    "fil_inference_time = toc-tic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summarize the performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1,000,000 inferences in 0.20101 seconds -- 4,974,774 inferences per second \n"
+     ]
+    }
+   ],
+   "source": [
+    "total_samples = len(df)\n",
+    "print(f' {total_samples:,} inferences in {fil_inference_time:.5f} seconds'\n",
+    "      f' -- {int(total_samples/fil_inference_time):,} inferences per second ')"
    ]
   }
  ],
@@ -304,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,13 +137,13 @@
     "    X_train, \n",
     "    y_train,\n",
     "    model_path='xgb.model',\n",
-    "    num_rounds=150, \n",
+    "    num_rounds=100, \n",
     "    max_depth=20\n",
     "):\n",
     "    \n",
     "    # set the xgboost model parameters\n",
     "    params = {\n",
-    "        'silent': 0, \n",
+    "        'verbosity': 0, \n",
     "        'eval_metric':'error',\n",
     "        'objective':'binary:logistic',\n",
     "        'max_depth': max_depth,\n",
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,26 +198,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[17:05:27] WARNING: /opt/conda/envs/rapids/conda-bld/xgboost_1612969655237/work/src/learner.cc:541: \n",
-      "Parameters: { silent } might not be used.\n",
-      "\n",
-      "  This may not be accurate due to some parameters are only used in language bindings but\n",
-      "  passed down to XGBoost core.  Or some parameters are not used but slip through this\n",
-      "  verification. Please open an issue if you find above cases.\n",
-      "\n",
-      "\n",
-      "CPU times: user 1.28 s, sys: 63.6 ms, total: 1.34 s\n",
-      "Wall time: 1.36 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# train the xgboost model\n",
@@ -232,18 +215,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 1.84 ms, sys: 4.83 ms, total: 6.66 ms\n",
-      "Wall time: 5.22 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# test the xgboost model\n",
@@ -292,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,18 +288,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 452 µs, sys: 2.53 ms, total: 2.98 ms\n",
-      "Wall time: 2.36 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# perform prediction on the model loaded from path\n",
@@ -343,19 +308,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The shape of predictions obtained from xgboost :  (2000,)\n",
-      "The shape of predictions obtained from FIL :  (2000,)\n",
-      "Are the predictions for xgboost and FIL the same :  True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"The shape of predictions obtained from xgboost : \", (trained_model_preds).shape)\n",
     "print(\"The shape of predictions obtained from FIL : \", (fil_preds).shape)\n",
@@ -409,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,12 +435,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we will generate data on the CPU as a dask array, then move it into GPU memory as a dask.dataframe and ultimately conver it into a dask_cudf.dataframe so that it can be used in the upstream FIL predict."
+    "Next we will generate data on the CPU as a dask array, then move it into GPU memory as a dask.dataframe and ultimately convert it into a dask_cudf.dataframe so that it can be used in the upstream FIL predict."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,11 +471,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df.persist(); wait(df);"
+    "df = df.persist(); \n",
+    "wait(df);"
    ]
   },
   {
@@ -543,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,31 +517,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 263 ms, sys: 91 ms, total: 354 ms\n",
-      "Wall time: 7.96 s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'tcp://127.0.0.1:35345': None,\n",
-       " 'tcp://127.0.0.1:37763': None,\n",
-       " 'tcp://127.0.0.1:37847': None,\n",
-       " 'tcp://127.0.0.1:46517': None}"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "client.run(worker_init)"
@@ -600,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,17 +581,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 1,000,000 inferences in 0.20101 seconds -- 4,974,774 inferences per second \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "total_samples = len(df)\n",
     "print(f' {total_samples:,} inferences in {fil_inference_time:.5f} seconds'\n",

--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,9 +198,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.28 s, sys: 78.4 ms, total: 1.36 s\n",
+      "Wall time: 1.38 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# train the xgboost model\n",
@@ -215,9 +224,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.49 ms, sys: 3.31 ms, total: 5.79 ms\n",
+      "Wall time: 4.47 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# test the xgboost model\n",
@@ -266,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,9 +306,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.92 ms, sys: 0 ns, total: 2.92 ms\n",
+      "Wall time: 1.92 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# perform prediction on the model loaded from path\n",
@@ -308,9 +335,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The shape of predictions obtained from xgboost :  (2000,)\n",
+      "The shape of predictions obtained from FIL :  (2000,)\n",
+      "Are the predictions for xgboost and FIL the same :  True\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"The shape of predictions obtained from xgboost : \", (trained_model_preds).shape)\n",
     "print(\"The shape of predictions obtained from FIL : \", (fil_preds).shape)\n",
@@ -364,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,12 +508,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DoneAndNotDoneFutures(done={<Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 1)>, <Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 0)>, <Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 3)>, <Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 2)>}, not_done=set())"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "df = df.persist(); \n",
-    "wait(df);"
+    "df = df.persist()\n",
+    "wait(df)"
    ]
   },
   {

--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,18 +198,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 1.28 s, sys: 78.4 ms, total: 1.36 s\n",
-      "Wall time: 1.38 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# train the xgboost model\n",
@@ -224,18 +215,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 2.49 ms, sys: 3.31 ms, total: 5.79 ms\n",
-      "Wall time: 4.47 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# test the xgboost model\n",
@@ -284,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,18 +288,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 2.92 ms, sys: 0 ns, total: 2.92 ms\n",
-      "Wall time: 1.92 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# perform prediction on the model loaded from path\n",
@@ -335,19 +308,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The shape of predictions obtained from xgboost :  (2000,)\n",
-      "The shape of predictions obtained from FIL :  (2000,)\n",
-      "Are the predictions for xgboost and FIL the same :  True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"The shape of predictions obtained from xgboost : \", (trained_model_preds).shape)\n",
     "print(\"The shape of predictions obtained from FIL : \", (fil_preds).shape)\n",
@@ -401,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,20 +471,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DoneAndNotDoneFutures(done={<Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 1)>, <Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 0)>, <Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 3)>, <Future: finished, type: cudf.DataFrame, key: ('from_pandas-bc688bffb544dd22b0084a9c038babe7', 2)>}, not_done=set())"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = df.persist()\n",
     "wait(df)"


### PR DESCRIPTION
- Replaced numpy with cupy, and sklearn with cuml (e.g., data generation and splitting)
- Resized XGBoost model params from 15 trees at 25 max_depth, to 100 trees at 20 max_depth
- Added Dask distributed data generation, FIL model loading on worker init, and distributed FIL prediction