### PR TITLE
Reduce the size of the cuml libraries

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -325,6 +325,9 @@ set(FAISS_GPU_ARCHS "${FAISS_GPU_ARCHS} ${ptx}")
 set(CMAKE_CUDA_FLAGS
   "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=unrecognized_gcc_pragma")
 
+# make sure we produce smallest binary size
+string(APPEND CMAKE_CUDA_FLAGS -Xfatbin=-compress-all)
+
 ##############################################################################
 # - dependencies -------------------------------------------------------------
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -326,7 +326,7 @@ set(CMAKE_CUDA_FLAGS
   "${CMAKE_CUDA_FLAGS} -Xcudafe --diag_suppress=unrecognized_gcc_pragma")
 
 # make sure we produce smallest binary size
-string(APPEND CMAKE_CUDA_FLAGS -Xfatbin=-compress-all)
+string(APPEND CMAKE_CUDA_FLAGS " -Xfatbin=-compress-all")
 
 ##############################################################################
 # - dependencies -------------------------------------------------------------


### PR DESCRIPTION
By explicitly telling nvcc's fatbin pass to always compress device code we can ensure that our binaries are the smallest possible size.

See https://github.com/rapidsai/cudf/pull/7583 for additional context.