### PR TITLE
Upgrade to Treelite 1.1.0

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,9 +59,8 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*" \
-      "shap>=0.37,<=0.39"
-
-gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia treelite=1.1.0
+      "shap>=0.37,<=0.39" \
+      "treelite=1.1.0"
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,6 +61,8 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
 
+gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia treelite=1.1.0
+
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_conda_retry install -y "your-pkg=1.0.0"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,7 +59,11 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*" \
-      "shap>=0.37,<=0.39" \
+      "shap>=0.37,<=0.39"
+      
+gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      --force rapids-build-env rapids-notebook-env
+gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "treelite=1.1.0"
 
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -60,11 +60,6 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
-      
-gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      --force rapids-build-env rapids-notebook-env
-gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      "treelite=1.1.0"
 
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env

--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0
+- treelite=1.1.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0
+- treelite=1.1.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0
+- treelite=1.1.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.0.0
+- treelite=1.1.0
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.14
-    - treelite=1.0.0
+    - treelite=1.1.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -42,7 +42,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cupy>=7.8.0,<9.0.0a0
-    - treelite=1.0.0
+    - treelite=1.1.0
     - nccl>=2.8.4
     - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - ucx-proc=*=gpu
     - libcumlprims {{ minor_version }}
     - lapack
-    - treelite=1.0.0
+    - treelite=1.1.0
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - conda-forge::libfaiss=1.7.0
@@ -56,7 +56,7 @@ requirements:
     - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - treelite=1.0.0
+    - treelite=1.1.0
     - faiss-proc=*=cuda
     - conda-forge::libfaiss=1.7.0
 


### PR DESCRIPTION
This unblocks #3699, as the current version of Treelite (1.0.0) cannot handle model JSON files generated by XGBoost 1.4.0. The new Treelite release has the following improvements:

* Support JSON model files from XGBoost 1.4.0 
* Support DART models

I'll also file a pull request to `integration`.