### PR TITLE
Add sparse docstring comments

### DIFF
--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -369,6 +369,7 @@ class TSNE(Base,
         self.sparse_fit = False
 
     @generate_docstring(skip_parameters_heading=True,
+                        X='dense_sparse',
                         convert_dtype_cast='np.float32')
     def fit(self, X, convert_dtype=True, knn_graph=None) -> "TSNE":
         """

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -553,6 +553,7 @@ class UMAP(Base,
         return (None, None), (None, None)
 
     @generate_docstring(convert_dtype_cast='np.float32',
+                        X='dense_sparse',
                         skip_parameters_heading=True)
     def fit(self, X, y=None, convert_dtype=True,
             knn_graph=None) -> "UMAP":

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -148,9 +148,10 @@ def pairwise_distances(X, Y=None, metric="euclidean", handle=None,
 
     Parameters
     ----------
-    X : array-like (device or host) of shape (n_samples_x, n_features)
+    X : Dense or sparse matrix (device or host) of shape (n_samples_x, n_features)
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
-        ndarray, cuda array interface compliant array like CuPy
+        ndarray, cuda array interface compliant array like CuPy, or
+        cupyx.scipy.sparse for sparse input
 
     Y : array-like (device or host) of shape (n_samples_y, n_features),\
         optional

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -148,7 +148,8 @@ def pairwise_distances(X, Y=None, metric="euclidean", handle=None,
 
     Parameters
     ----------
-    X : Dense or sparse matrix (device or host) of shape (n_samples_x, n_features)
+    X : Dense or sparse matrix (device or host) of shape
+        (n_samples_x, n_features)
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
         ndarray, cuda array interface compliant array like CuPy, or
         cupyx.scipy.sparse for sparse input

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -319,7 +319,7 @@ class NearestNeighbors(Base,
         self.algo_params = algo_params
         self.knn_index = <uintptr_t> 0
 
-    @generate_docstring()
+    @generate_docstring(X='dense_sparse')
     def fit(self, X, convert_dtype=True) -> "NearestNeighbors":
         """
         Fit GPU index for performing nearest neighbor queries.


### PR DESCRIPTION
Closes #3607

Uses the docstring generator to flag a few more algorithms that can consume sparse inputs.
Grepped for all uses of is_sparse in algorithms to find candidates.﻿
