### PR TITLE
[REVIEW] Fix brute force KNN distance metric issue

### DIFF
--- a/cpp/src/knn/knn_opg_common.cuh
+++ b/cpp/src/knn/knn_opg_common.cuh
@@ -426,7 +426,8 @@ void perform_local_knn(opg_knn_param<in_t, ind_t, dist_t, out_t> &params,
   raft::spatial::knn::brute_force_knn(
     handle, ptrs, sizes, params.idx_desc->N, query, query_size,
     work.res_I.data(), work.res_D.data(), params.k, params.rowMajorIndex,
-    params.rowMajorQuery, &start_indices_long);
+    params.rowMajorQuery, &start_indices_long,
+    raft::distance::DistanceType::L2SqrtExpanded);
   CUDA_CHECK(cudaStreamSynchronize(handle.get_stream()));
   CUDA_CHECK(cudaPeekAtLastError());
 }

--- a/cpp/src_prims/metrics/scores.cuh
+++ b/cpp/src_prims/metrics/scores.cuh
@@ -82,7 +82,8 @@ __global__ void compute_rank(math_t *ind_X, knn_index_t *ind_X_embedded, int n,
  */
 template <typename math_t>
 long *get_knn_indices(const raft::handle_t &h, math_t *input, int n, int d,
-                      int n_neighbors) {
+                      int n_neighbors,
+                      raft::distance::DistanceType distance_type) {
   cudaStream_t stream = h.get_stream();
   auto d_alloc = h.get_device_allocator();
 
@@ -97,7 +98,8 @@ long *get_knn_indices(const raft::handle_t &h, math_t *input, int n, int d,
   sizes[0] = n;
 
   raft::spatial::knn::brute_force_knn(h, ptrs, sizes, d, input, n, d_pred_I,
-                                      d_pred_D, n_neighbors);
+                                      d_pred_D, n_neighbors, true, true,
+                                      nullptr, distance_type);
 
   d_alloc->deallocate(d_pred_D, n * n_neighbors * sizeof(math_t), stream);
   return d_pred_I;
@@ -133,7 +135,7 @@ double trustworthiness_score(const raft::handle_t &h, math_t *X,
   int *d_ind_X_tmp = (int *)d_alloc->allocate(TMP_SIZE * sizeof(int), stream);
 
   int64_t *ind_X_embedded =
-    get_knn_indices(h, X_embedded, n, d, n_neighbors + 1);
+    get_knn_indices(h, X_embedded, n, d, n_neighbors + 1, distance_type);
 
   double t_tmp = 0.0;
   double t = 0.0;


### PR DESCRIPTION
The brute force KNN default distance metric switched from `L2SqrtExpanded` (or equivalent with FAISS metrics) to `L2Unexpanded` recently. I believe that it was a voluntary move to speedup calculations. However some calls to the `raft::spatial::knn::brute_force_knn` function in the cuML codebase required specifying a non-default metric. This is the case of distances that are not kept internally by an estimator but are instead provided to the end-user as results. This is also the case of features that specify a specific distance metric for their calculations. Please tell if you notice some other places where a non-default distance metric should have been specified.

cc @MatthiasKohl 