### PR TITLE
cmake: add support to ALL GPUs.

### DIFF
--- a/cpp/cmake/EvalGpuArchs.cmake
+++ b/cpp/cmake/EvalGpuArchs.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/cmake/EvalGpuArchs.cmake
+++ b/cpp/cmake/EvalGpuArchs.cmake
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   set(__gpu_archs_filtered "${__gpu_archs}")
   foreach(arch ${__gpu_archs})
-    if (arch VERSION_LESS 60)
+    if (arch VERSION_LESS 60 AND NOT arch STREQUAL ALL)
       list(REMOVE_ITEM __gpu_archs_filtered ${arch})
     endif()
   endforeach()


### PR DESCRIPTION
Docker container works well if you decide do compile cuML without specifying or
passing a GPU device. If you pass a GPU, you are restricted to that compute
capability higher or equal than 6.0.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>