### PR TITLE
doc: removing deprecated use of libcumlcomms for containerized build [skip-ci]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,6 @@ RUN source activate ${CONDA_ENV} && \
     make -j && \
     make install
 
-# libcumlcomms build/install
-RUN source activate ${CONDA_ENV} && \
-    cd cpp/comms/std && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
-    make -j && \
-    make install
-
 # cuML build/install
 RUN source activate ${CONDA_ENV} && \
     cd python && \

--- a/python/README.md
+++ b/python/README.md
@@ -31,7 +31,7 @@ example `setup.py --singlegpu`) are:
 | Argument | Behavior |
 | --- | --- |
 | clean --all | Cleans all Python and Cython artifacts, including pycache folders, .cpp files resulting of cythonization and compiled extensions. |
-| --singlegpu | Option to build cuML without multiGPU algorithms. Removes dependency on nccl, libcumlcomms and ucx-py. |
+| --singlegpu | Option to build cuML without multiGPU algorithms. Removes dependency on nccl, libcumlprims and ucx-py. |
 
 
 ### RAFT Integration in cuml.raft


### PR DESCRIPTION
This commit fixes the Dockerfile reference to libcumlcomms and other
references inside the Python README.md document.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>