### PR TITLE
NVTX benchmark

### DIFF
--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -138,6 +138,16 @@ uint32_t generateNextColor(const std::string &tag) {
 
 nvtxDomainHandle_t domain = nvtxDomainCreateA("cuml_cpp");
 
+void PUSH_RANGE(const char *name, cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  PUSH_RANGE(name);
+}
+
+void POP_RANGE(cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  POP_RANGE();
+}
+
 void PUSH_RANGE(const char *name) {
   nvtxEventAttributes_t eventAttrib = {0};
   eventAttrib.version = NVTX_VERSION;
@@ -152,6 +162,10 @@ void PUSH_RANGE(const char *name) {
 void POP_RANGE() { nvtxDomainRangePop(domain); }
 
 #else  // NVTX_ENABLED
+
+void PUSH_RANGE(const char *name, cudaStream_t stream) {}
+
+void POP_RANGE(cudaStream_t stream) {}
 
 void PUSH_RANGE(const char *name) {}
 

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -149,9 +149,7 @@ void PUSH_RANGE(const char *name) {
   nvtxDomainRangePushEx(domain, &eventAttrib);
 }
 
-void POP_RANGE() {
-  nvtxDomainRangePop(domain);
-}
+void POP_RANGE() { nvtxDomainRangePop(domain); }
 
 #else  // NVTX_ENABLED
 

--- a/cpp/src/common/nvtx.cu
+++ b/cpp/src/common/nvtx.cu
@@ -136,6 +136,8 @@ uint32_t generateNextColor(const std::string &tag) {
 
 #include <nvToolsExt.h>
 
+nvtxDomainHandle_t domain = nvtxDomainCreateA("cuml_cpp");
+
 void PUSH_RANGE(const char *name) {
   nvtxEventAttributes_t eventAttrib = {0};
   eventAttrib.version = NVTX_VERSION;
@@ -144,10 +146,12 @@ void PUSH_RANGE(const char *name) {
   eventAttrib.color = generateNextColor(name);
   eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
   eventAttrib.message.ascii = name;
-  nvtxRangePushEx(&eventAttrib);
+  nvtxDomainRangePushEx(domain, &eventAttrib);
 }
 
-void POP_RANGE() { nvtxRangePop(); }
+void POP_RANGE() {
+  nvtxDomainRangePop(domain);
+}
 
 #else  // NVTX_ENABLED
 

--- a/cpp/src/common/nvtx.hpp
+++ b/cpp/src/common/nvtx.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/common/nvtx.hpp
+++ b/cpp/src/common/nvtx.hpp
@@ -16,7 +16,22 @@
 
 #pragma once
 
+#include <raft/cudart_utils.h>
+
 namespace ML {
+
+/**
+ * @brief Synchronize CUDA stream and push a named nvtx range
+ * @param name range name
+ * @param stream stream to synchronize
+ */
+void PUSH_RANGE(const char *name, cudaStream_t stream);
+
+/** 
+ * @brief Synchronize CUDA stream and pop the latest nvtx range
+ * @param stream stream to synchronize
+ */
+void POP_RANGE(cudaStream_t stream);
 
 /**
  * @brief Push a named nvtx range

--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+from subprocess import run
+import json
+
+
+class Profiler:
+    def __init__(self, tmp_path='/tmp/nsys_report'):
+        self.qdrep_file = tmp_path + '/report.qdrep'
+        self.json_file = tmp_path + '/report.json'
+        self._execute('mkdir -p ' + tmp_path)
+
+    @staticmethod
+    def _execute(command):
+        res = run(command, shell=True, capture_output=True)
+        if res.returncode != 0:
+            raise Exception(res.stderr)
+
+    def _nsys_profile(self, command):
+        profile_command = ('nsys profile '
+                           '--trace=nvtx '
+                           '--force-overwrite=true '
+                           '--output={qdrep_file} {command}')
+        profile_command = profile_command.format(
+            qdrep_file=self.qdrep_file,
+            command=command)
+        self._execute(profile_command)
+
+    def _nsys_export2json(self):
+        export_command = ('nsys export '
+                          '--type=json '
+                          '--separate-strings=true '
+                          '--force-overwrite=true '
+                          '--output={json_file} {qdrep_file}')
+        export_command = export_command.format(
+            json_file=self.json_file,
+            qdrep_file=self.qdrep_file)
+        self._execute(export_command)
+
+    def _parse_json(self):
+        with open(self.json_file, 'r') as json_file:
+            json_content = json_file.read().replace('\n', ',')[:-1]
+            json_content = '{"dict": [\n' + json_content + '\n]}'
+            profile = json.loads(json_content)['dict']
+            nvtx_filtered_profile = [p['NvtxEvent'] for p in profile
+                                     if 'NvtxEvent' in p]
+            nvtx_filtered_profile = [p for p in nvtx_filtered_profile
+                                     if 'Text' in p]
+
+            def _process_nvtx_record(record):
+                new_record = {'measurement': record['Text']}
+                if 'EndTimestamp' in record:
+                    runtime = int(record['EndTimestamp']) -\
+                              int(record['Timestamp'])
+                    new_record['runtime'] = runtime
+                return new_record
+
+            return list(map(_process_nvtx_record, nvtx_filtered_profile))
+
+    @staticmethod
+    def _display_results(results):
+        filtered_results = [r for r in results if 'runtime' in r]
+        max_length = max([len(r['measurement']) for r in filtered_results])
+        for r in filtered_results:
+            measurement = r['measurement'].ljust(max_length + 4)
+            runtime = round(int(r['runtime']) / 10**9, 4)
+            msg = '{measurement} : {runtime:8.4f} s'
+            msg = msg.format(measurement=measurement,
+                             runtime=runtime)
+            print(msg)
+
+    def profile(self, command):
+        self._nsys_profile(command)
+        self._nsys_export2json()
+        results = self._parse_json()
+        self._display_results(results)
+
+
+profiler = Profiler()
+profiler.profile(sys.argv[1])

--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -129,11 +129,24 @@ class Profiler:
                 msg = '\n' + msg
             print(msg)
 
+        def aggregate(calls):
+            agg = {}
+            for c in calls:
+                measurement = c['measurement']
+                runtime = int(c['runtime'])
+                if measurement in agg:
+                    agg[measurement]['runtime'] += runtime
+                else:
+                    agg[measurement] = {'measurement': measurement,
+                                        'runtime': runtime,
+                                        'category': c['category']}
+            return agg.values()
+
         for record, end in zip(py_calls, py_calls_timestamps):
             display(record)
             utils_calls_to_print = [r for r in utils_calls
                                     if r['timestamp'] < end]
-            for u in utils_calls_to_print:
+            for u in aggregate(utils_calls_to_print):
                 display(u)
             utils_calls = [r for r in utils_calls if r['timestamp'] >= end]
 

--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -74,13 +74,19 @@ class Profiler:
     @staticmethod
     def _display_results(results):
         filtered_results = [r for r in results if 'runtime' in r]
-        max_length = max([len(r['measurement']) for r in filtered_results])
+        max_length = max([len(r['measurement']) for r in filtered_results]) + 4
         for r in filtered_results:
-            measurement = r['measurement'].ljust(max_length + 4)
+            measurement = r['measurement']
+            isutil = measurement.startswith('--')
+            if isutil:
+                measurement = '    ' + measurement
+            measurement = measurement.ljust(max_length + 4)
             runtime = round(int(r['runtime']) / 10**9, 4)
             msg = '{measurement} : {runtime:8.4f} s'
             msg = msg.format(measurement=measurement,
                              runtime=runtime)
+            if not isutil:
+                msg = '\n' + msg
             print(msg)
 
     def profile(self, command):

--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -66,6 +66,7 @@ class Profiler:
                 if 'EndTimestamp' in record:
                     runtime = int(record['EndTimestamp']) -\
                               int(record['Timestamp'])
+                    new_record['timestamp'] = int(record['Timestamp'])
                     new_record['runtime'] = runtime
                 return new_record
 
@@ -74,6 +75,7 @@ class Profiler:
     @staticmethod
     def _display_results(results):
         filtered_results = [r for r in results if 'runtime' in r]
+        filtered_results.sort(key=lambda r: r['timestamp'])
         max_length = max([len(r['measurement']) for r in filtered_results]) + 4
         for r in filtered_results:
             measurement = r['measurement']

--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -24,6 +24,7 @@ class Profiler:
     def __init__(self, tmp_path='/tmp/nsys_report'):
         self.qdrep_file = tmp_path + '/report.qdrep'
         self.json_file = tmp_path + '/report.json'
+        self._execute(['rm', '-rf', tmp_path])
         self._execute(['mkdir', '-p', tmp_path])
 
     @staticmethod
@@ -39,8 +40,8 @@ class Profiler:
                            '--trace=nvtx',
                            '--force-overwrite=true',
                            '--output={qdrep_file}'.format(
-                               qdrep_file=self.qdrep_file),
-                           command]
+                               qdrep_file=self.qdrep_file)]
+        profile_command.extend(command.split(' '))
         self._execute(profile_command)
 
     def _nsys_export2json(self):
@@ -180,7 +181,6 @@ class Profiler:
                 print('\n')
 
     def profile(self, command):
-        os.environ['NVTX_BENCHMARK'] = 'TRUE'
         self._nsys_profile(command)
         self._nsys_export2json()
         results = self._parse_json()

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -92,7 +92,8 @@ class CumlArray(Buffer):
 
     """
 
-    @nvtx.annotate(message="-- cuml.common.CumlArray.__init__")
+    @nvtx.annotate(message="common.CumlArray.__init__", category="utils",
+                   domain="cuml_python")
     def __init__(self, data=None, owner=None, dtype=None, shape=None,
                  order=None):
 
@@ -207,7 +208,8 @@ class CumlArray(Buffer):
     def item(self):
         return cp.asarray(self).item()
 
-    @nvtx.annotate(message="-- cuml.common.CumlArray.to_output")
+    @nvtx.annotate(message="common.CumlArray.to_output", category="utils",
+                   domain="cuml_python")
     def to_output(self, output_type='cupy', output_dtype=None):
         """
         Convert array to output format
@@ -286,7 +288,8 @@ class CumlArray(Buffer):
 
         return self
 
-    @nvtx.annotate(message="-- cuml.common.CumlArray.serialize")
+    @nvtx.annotate(message="common.CumlArray.serialize", category="utils",
+                   domain="cuml_python")
     def serialize(self):
         header, frames = super().serialize()
         header["constructor-kwargs"] = {
@@ -298,7 +301,8 @@ class CumlArray(Buffer):
         return header, frames
 
     @classmethod
-    @nvtx.annotate(message="-- cuml.common.CumlArray.empty")
+    @nvtx.annotate(message="common.CumlArray.empty", category="utils",
+                   domain="cuml_python")
     def empty(cls, shape, dtype, order='F'):
         """
         Create an empty Array with an allocated but uninitialized DeviceBuffer
@@ -316,7 +320,8 @@ class CumlArray(Buffer):
         return CumlArray(cp.empty(shape, dtype, order))
 
     @classmethod
-    @nvtx.annotate(message="-- cuml.common.CumlArray.full")
+    @nvtx.annotate(message="common.CumlArray.full", category="utils",
+                   domain="cuml_python")
     def full(cls, shape, value, dtype, order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to value.
@@ -334,7 +339,8 @@ class CumlArray(Buffer):
         return CumlArray(cp.full(shape, value, dtype, order))
 
     @classmethod
-    @nvtx.annotate(message="-- cuml.common.CumlArray.zeros")
+    @nvtx.annotate(message="common.CumlArray.zeros", category="utils",
+                   domain="cuml_python")
     def zeros(cls, shape, dtype='float32', order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to zeros.
@@ -351,7 +357,8 @@ class CumlArray(Buffer):
         return CumlArray.full(value=0, shape=shape, dtype=dtype, order=order)
 
     @classmethod
-    @nvtx.annotate(message="-- cuml.common.CumlArray.ones")
+    @nvtx.annotate(message="common.CumlArray.ones", category="utils",
+                   domain="cuml_python")
     def ones(cls, shape, dtype='float32', order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to zeros.

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -92,7 +92,7 @@ class CumlArray(Buffer):
 
     """
 
-    @nvtx.annotate(message="cuml.common.CumlArray.__init__")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.__init__")
     def __init__(self, data=None, owner=None, dtype=None, shape=None,
                  order=None):
 
@@ -207,7 +207,7 @@ class CumlArray(Buffer):
     def item(self):
         return cp.asarray(self).item()
 
-    @nvtx.annotate(message="cuml.common.CumlArray.to_output")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.to_output")
     def to_output(self, output_type='cupy', output_dtype=None):
         """
         Convert array to output format
@@ -286,7 +286,7 @@ class CumlArray(Buffer):
 
         return self
 
-    @nvtx.annotate(message="cuml.common.CumlArray.serialize")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.serialize")
     def serialize(self):
         header, frames = super().serialize()
         header["constructor-kwargs"] = {
@@ -298,7 +298,7 @@ class CumlArray(Buffer):
         return header, frames
 
     @classmethod
-    @nvtx.annotate(message="cuml.common.CumlArray.empty")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.empty")
     def empty(cls, shape, dtype, order='F'):
         """
         Create an empty Array with an allocated but uninitialized DeviceBuffer
@@ -316,7 +316,7 @@ class CumlArray(Buffer):
         return CumlArray(cp.empty(shape, dtype, order))
 
     @classmethod
-    @nvtx.annotate(message="cuml.common.CumlArray.full")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.full")
     def full(cls, shape, value, dtype, order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to value.
@@ -334,7 +334,7 @@ class CumlArray(Buffer):
         return CumlArray(cp.full(shape, value, dtype, order))
 
     @classmethod
-    @nvtx.annotate(message="cuml.common.CumlArray.zeros")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.zeros")
     def zeros(cls, shape, dtype='float32', order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to zeros.
@@ -351,7 +351,7 @@ class CumlArray(Buffer):
         return CumlArray.full(value=0, shape=shape, dtype=dtype, order=order)
 
     @classmethod
-    @nvtx.annotate(message="cuml.common.CumlArray.ones")
+    @nvtx.annotate(message="-- cuml.common.CumlArray.ones")
     def ones(cls, shape, dtype='float32', order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to zeros.

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -17,6 +17,7 @@
 import cupy as cp
 import numpy as np
 import operator
+import nvtx
 
 from rmm import DeviceBuffer
 from cudf.core import Buffer, Series, DataFrame
@@ -91,6 +92,7 @@ class CumlArray(Buffer):
 
     """
 
+    @nvtx.annotate(message="cuml.common.CumlArray.__init__")
     def __init__(self, data=None, owner=None, dtype=None, shape=None,
                  order=None):
 
@@ -205,6 +207,7 @@ class CumlArray(Buffer):
     def item(self):
         return cp.asarray(self).item()
 
+    @nvtx.annotate(message="cuml.common.CumlArray.to_output")
     def to_output(self, output_type='cupy', output_dtype=None):
         """
         Convert array to output format
@@ -283,6 +286,7 @@ class CumlArray(Buffer):
 
         return self
 
+    @nvtx.annotate(message="cuml.common.CumlArray.serialize")
     def serialize(self):
         header, frames = super().serialize()
         header["constructor-kwargs"] = {
@@ -294,6 +298,7 @@ class CumlArray(Buffer):
         return header, frames
 
     @classmethod
+    @nvtx.annotate(message="cuml.common.CumlArray.empty")
     def empty(cls, shape, dtype, order='F'):
         """
         Create an empty Array with an allocated but uninitialized DeviceBuffer
@@ -311,6 +316,7 @@ class CumlArray(Buffer):
         return CumlArray(cp.empty(shape, dtype, order))
 
     @classmethod
+    @nvtx.annotate(message="cuml.common.CumlArray.full")
     def full(cls, shape, value, dtype, order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to value.
@@ -328,6 +334,7 @@ class CumlArray(Buffer):
         return CumlArray(cp.full(shape, value, dtype, order))
 
     @classmethod
+    @nvtx.annotate(message="cuml.common.CumlArray.zeros")
     def zeros(cls, shape, dtype='float32', order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to zeros.
@@ -344,6 +351,7 @@ class CumlArray(Buffer):
         return CumlArray.full(value=0, shape=shape, dtype=dtype, order=order)
 
     @classmethod
+    @nvtx.annotate(message="cuml.common.CumlArray.ones")
     def ones(cls, shape, dtype='float32', order='F'):
         """
         Create an Array with an allocated DeviceBuffer initialized to zeros.

--- a/python/cuml/common/array_sparse.py
+++ b/python/cuml/common/array_sparse.py
@@ -15,6 +15,7 @@
 #
 import cupyx as cpx
 import numpy as np
+import nvtx
 from cuml.common.import_utils import has_scipy
 from cuml.common.memory_utils import class_with_cupy_rmm
 from cuml.common.logger import debug
@@ -69,6 +70,7 @@ class SparseCumlArray():
         Number of nonzeros in underlying arrays
     """
 
+    @nvtx.annotate(message="cuml.common.SparseCumlArray.__init__")
     def __init__(self, data=None,
                  convert_to_dtype=False,
                  convert_index=np.int32,
@@ -120,6 +122,7 @@ class SparseCumlArray():
         self.dtype = self.data.dtype
         self.nnz = data.nnz
 
+    @nvtx.annotate(message="cuml.common.SparseCumlArray.to_output")
     def to_output(self, output_type='cupy',
                   output_format=None,
                   output_dtype=None):

--- a/python/cuml/common/array_sparse.py
+++ b/python/cuml/common/array_sparse.py
@@ -70,7 +70,7 @@ class SparseCumlArray():
         Number of nonzeros in underlying arrays
     """
 
-    @nvtx.annotate(message="cuml.common.SparseCumlArray.__init__")
+    @nvtx.annotate(message="-- cuml.common.SparseCumlArray.__init__")
     def __init__(self, data=None,
                  convert_to_dtype=False,
                  convert_index=np.int32,
@@ -122,7 +122,7 @@ class SparseCumlArray():
         self.dtype = self.data.dtype
         self.nnz = data.nnz
 
-    @nvtx.annotate(message="cuml.common.SparseCumlArray.to_output")
+    @nvtx.annotate(message="-- cuml.common.SparseCumlArray.to_output")
     def to_output(self, output_type='cupy',
                   output_format=None,
                   output_dtype=None):

--- a/python/cuml/common/array_sparse.py
+++ b/python/cuml/common/array_sparse.py
@@ -70,7 +70,8 @@ class SparseCumlArray():
         Number of nonzeros in underlying arrays
     """
 
-    @nvtx.annotate(message="-- cuml.common.SparseCumlArray.__init__")
+    @nvtx.annotate(message="common.SparseCumlArray.__init__", category="utils",
+                   domain="cuml_python")
     def __init__(self, data=None,
                  convert_to_dtype=False,
                  convert_index=np.int32,
@@ -122,7 +123,8 @@ class SparseCumlArray():
         self.dtype = self.data.dtype
         self.nnz = data.nnz
 
-    @nvtx.annotate(message="-- cuml.common.SparseCumlArray.to_output")
+    @nvtx.annotate(message="common.SparseCumlArray.to_output",
+                   category="utils", domain="cuml_python")
     def to_output(self, output_type='cupy',
                   output_format=None,
                   output_dtype=None):

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -365,7 +365,7 @@ class Base(TagsMixin,
             return {'preserves_dtype': [self.dtype]}
         return {}
 
-    def _set_nvtx_annotations(self):
+    def set_nvtx_annotations(self):
         for function in ['fit', 'transform', 'predict', 'fit_predict',
                          'fit_transform']:
             if hasattr(self, function):

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -184,8 +184,6 @@ class Base(TagsMixin,
         self.target_dtype = None
         self.n_features_in_ = None
 
-        self._set_nvtx_annotations()
-
     def __repr__(self):
         """
         Pretty prints the arguments of a class using Scikit-learn standard :)

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 
 import inspect
+import nvtx
 
 import cuml.common
 import cuml.common.cuda
@@ -182,6 +183,8 @@ class Base(TagsMixin,
         self._input_type = None
         self.target_dtype = None
         self.n_features_in_ = None
+
+        self._set_nvtx_annotations()
 
     def __repr__(self):
         """
@@ -363,6 +366,14 @@ class Base(TagsMixin,
         if hasattr(self, 'transform') and hasattr(self, 'dtype'):
             return {'preserves_dtype': [self.dtype]}
         return {}
+
+    def _set_nvtx_annotations(self):
+        for function in ['fit', 'transform', 'predict']:
+            if hasattr(self, function):
+                message = self.__class__.__module__ + '.' + function
+                func = getattr(self, function)
+                func = nvtx.annotate(message=message)(func)
+                setattr(self, function, func)
 
 
 # Internal, non class owned helper functions

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -368,7 +368,8 @@ class Base(TagsMixin,
         return {}
 
     def _set_nvtx_annotations(self):
-        for function in ['fit', 'transform', 'predict']:
+        for function in ['fit', 'transform', 'predict', 'fit_predict',
+                         'fit_transform']:
             if hasattr(self, function):
                 message = self.__class__.__module__ + '.' + function
                 func = getattr(self, function)

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -382,8 +382,9 @@ class Base(TagsMixin,
                 msg = msg.format(class_name=self.__class__.__module__,
                                  func_name=func_name,
                                  addr=hex(id(self)))
+                msg = msg[5:]  # remove cuml.
                 func = getattr(self, func_name)
-                func = nvtx.annotate(message=msg)(func)
+                func = nvtx.annotate(message=msg, domain="cuml_python")(func)
                 setattr(self, func_name, func)
 
 

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -370,17 +370,21 @@ class Base(TagsMixin,
 
     def _set_nvtx_annotations(self):
         nvtx_benchmark = os.getenv('NVTX_BENCHMARK')
-        if nvtx_benchmark.lower() == 'true':
+        if nvtx_benchmark and nvtx_benchmark.lower() == 'true':
             self.set_nvtx_annotations()
 
     def set_nvtx_annotations(self):
-        for function in ['fit', 'transform', 'predict', 'fit_predict',
-                         'fit_transform']:
-            if hasattr(self, function):
-                message = self.__class__.__module__ + '.' + function
-                func = getattr(self, function)
-                func = nvtx.annotate(message=message)(func)
-                setattr(self, function, func)
+        for func_name in ['fit', 'transform', 'predict', 'fit_predict',
+                          'fit_transform']:
+            if hasattr(self, func_name):
+                message = self.__class__.__module__ + '.' + func_name
+                msg = '{class_name}.{func_name} [{addr}]'
+                msg = msg.format(class_name=self.__class__.__module__,
+                                 func_name=func_name,
+                                 addr=hex(id(self)))
+                func = getattr(self, func_name)
+                func = nvtx.annotate(message=msg)(func)
+                setattr(self, func_name, func)
 
 
 # Internal, non class owned helper functions

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -185,7 +185,9 @@ class Base(TagsMixin,
         self.target_dtype = None
         self.n_features_in_ = None
 
-        self._set_nvtx_annotations()
+        nvtx_benchmark = os.getenv('NVTX_BENCHMARK')
+        if nvtx_benchmark and nvtx_benchmark.lower() == 'true':
+            self.set_nvtx_annotations()
 
     def __repr__(self):
         """
@@ -368,14 +370,9 @@ class Base(TagsMixin,
             return {'preserves_dtype': [self.dtype]}
         return {}
 
-    def _set_nvtx_annotations(self):
-        nvtx_benchmark = os.getenv('NVTX_BENCHMARK')
-        if nvtx_benchmark and nvtx_benchmark.lower() == 'true':
-            self.set_nvtx_annotations()
-
     def set_nvtx_annotations(self):
-        for func_name in ['fit', 'transform', 'predict', 'fit_predict',
-                          'fit_transform']:
+        for func_name in ['fit', 'transform', 'predict', 'fit_transform',
+                          'fit_predict']:
             if hasattr(self, func_name):
                 message = self.__class__.__module__ + '.' + func_name
                 msg = '{class_name}.{func_name} [{addr}]'

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -16,6 +16,7 @@
 
 # distutils: language = c++
 
+import os
 import inspect
 import nvtx
 
@@ -183,6 +184,8 @@ class Base(TagsMixin,
         self._input_type = None
         self.target_dtype = None
         self.n_features_in_ = None
+
+        self._set_nvtx_annotations()
 
     def __repr__(self):
         """
@@ -364,6 +367,11 @@ class Base(TagsMixin,
         if hasattr(self, 'transform') and hasattr(self, 'dtype'):
             return {'preserves_dtype': [self.dtype]}
         return {}
+
+    def _set_nvtx_annotations(self):
+        nvtx_benchmark = os.getenv('NVTX_BENCHMARK')
+        if nvtx_benchmark.lower() == 'true':
+            self.set_nvtx_annotations()
 
     def set_nvtx_annotations(self):
         for function in ['fit', 'transform', 'predict', 'fit_predict',

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -201,7 +201,7 @@ def is_array_like(X):
     return determine_array_type(X) is not None
 
 
-@nvtx.annotate(message="cuml.common.input_utils.input_to_cuml_array")
+@nvtx.annotate(message="-- cuml.common.input_utils.input_to_cuml_array")
 @cuml.internals.api_return_any()
 def input_to_cuml_array(X,
                         order='F',
@@ -392,7 +392,7 @@ def input_to_cuml_array(X,
     return cuml_array(array=X_m, n_rows=n_rows, n_cols=n_cols, dtype=X_m.dtype)
 
 
-@nvtx.annotate(message="cuml.common.input_utils.input_to_cupy_array")
+@nvtx.annotate(message="-- cuml.common.input_utils.input_to_cupy_array")
 def input_to_cupy_array(X,
                         order='F',
                         deepcopy=False,
@@ -429,7 +429,7 @@ def input_to_cupy_array(X,
     return out_data._replace(array=out_data.array.to_output("cupy"))
 
 
-@nvtx.annotate(message="cuml.common.input_utils.input_to_host_array")
+@nvtx.annotate(message="-- cuml.common.input_utils.input_to_host_array")
 def input_to_host_array(X,
                         order='F',
                         deepcopy=False,

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -16,6 +16,7 @@
 
 import copy
 from collections import namedtuple
+import nvtx
 
 import cudf
 import cupy as cp
@@ -200,6 +201,7 @@ def is_array_like(X):
     return determine_array_type(X) is not None
 
 
+@nvtx.annotate(message="cuml.common.input_to_cuml_array")
 @cuml.internals.api_return_any()
 def input_to_cuml_array(X,
                         order='F',
@@ -390,6 +392,7 @@ def input_to_cuml_array(X,
     return cuml_array(array=X_m, n_rows=n_rows, n_cols=n_cols, dtype=X_m.dtype)
 
 
+@nvtx.annotate(message="cuml.common.input_to_cupy_array")
 def input_to_cupy_array(X,
                         order='F',
                         deepcopy=False,
@@ -426,6 +429,7 @@ def input_to_cupy_array(X,
     return out_data._replace(array=out_data.array.to_output("cupy"))
 
 
+@nvtx.annotate(message="cuml.common.input_to_host_array")
 def input_to_host_array(X,
                         order='F',
                         deepcopy=False,

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -201,7 +201,8 @@ def is_array_like(X):
     return determine_array_type(X) is not None
 
 
-@nvtx.annotate(message="-- cuml.common.input_utils.input_to_cuml_array")
+@nvtx.annotate(message="common.input_utils.input_to_cuml_array",
+               category="utils", domain="cuml_python")
 @cuml.internals.api_return_any()
 def input_to_cuml_array(X,
                         order='F',
@@ -392,7 +393,8 @@ def input_to_cuml_array(X,
     return cuml_array(array=X_m, n_rows=n_rows, n_cols=n_cols, dtype=X_m.dtype)
 
 
-@nvtx.annotate(message="-- cuml.common.input_utils.input_to_cupy_array")
+@nvtx.annotate(message="common.input_utils.input_to_cupy_array",
+               category="utils", domain="cuml_python")
 def input_to_cupy_array(X,
                         order='F',
                         deepcopy=False,
@@ -429,7 +431,8 @@ def input_to_cupy_array(X,
     return out_data._replace(array=out_data.array.to_output("cupy"))
 
 
-@nvtx.annotate(message="-- cuml.common.input_utils.input_to_host_array")
+@nvtx.annotate(message="common.input_utils.input_to_host_array",
+               category="utils", domain="cuml_python")
 def input_to_host_array(X,
                         order='F',
                         deepcopy=False,

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -201,7 +201,7 @@ def is_array_like(X):
     return determine_array_type(X) is not None
 
 
-@nvtx.annotate(message="cuml.common.input_to_cuml_array")
+@nvtx.annotate(message="cuml.common.input_utils.input_to_cuml_array")
 @cuml.internals.api_return_any()
 def input_to_cuml_array(X,
                         order='F',
@@ -392,7 +392,7 @@ def input_to_cuml_array(X,
     return cuml_array(array=X_m, n_rows=n_rows, n_cols=n_cols, dtype=X_m.dtype)
 
 
-@nvtx.annotate(message="cuml.common.input_to_cupy_array")
+@nvtx.annotate(message="cuml.common.input_utils.input_to_cupy_array")
 def input_to_cupy_array(X,
                         order='F',
                         deepcopy=False,
@@ -429,7 +429,7 @@ def input_to_cupy_array(X,
     return out_data._replace(array=out_data.array.to_output("cupy"))
 
 
-@nvtx.annotate(message="cuml.common.input_to_host_array")
+@nvtx.annotate(message="cuml.common.input_utils.input_to_host_array")
 def input_to_host_array(X,
                         order='F',
                         deepcopy=False,

--- a/python/cuml/datasets/blobs.py
+++ b/python/cuml/datasets/blobs.py
@@ -66,7 +66,7 @@ def _get_centers(rs, centers, center_box, n_samples, n_features, dtype):
     return centers, n_centers
 
 
-@nvtx.annotate(message="cuml.datasets.make_blobs")
+@nvtx.annotate(message="datasets.make_blobs", domain="cuml_python")
 @cuml.internals.api_return_generic()
 def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
                center_box=(-10.0, 10.0), shuffle=True, random_state=None,

--- a/python/cuml/datasets/blobs.py
+++ b/python/cuml/datasets/blobs.py
@@ -15,6 +15,7 @@
 #
 
 
+import nvtx
 import numbers
 from collections.abc import Iterable
 import cupy as cp
@@ -65,6 +66,7 @@ def _get_centers(rs, centers, center_box, n_samples, n_features, dtype):
     return centers, n_centers
 
 
+@nvtx.annotate(message="cuml.datasets.make_blobs")
 @cuml.internals.api_return_generic()
 def make_blobs(n_samples=100, n_features=2, centers=None, cluster_std=1.0,
                center_box=(-10.0, 10.0), shuffle=True, random_state=None,

--- a/python/cuml/datasets/classification.py
+++ b/python/cuml/datasets/classification.py
@@ -19,6 +19,7 @@ from cuml.datasets.utils import _create_rs_generator
 
 import cupy as cp
 import numpy as np
+import nvtx
 
 
 def _generate_hypercube(samples, dimensions, rng):
@@ -41,6 +42,7 @@ def _generate_hypercube(samples, dimensions, rng):
     return out
 
 
+@nvtx.annotate(message="cuml.datasets.make_classification")
 @cuml.internals.api_return_generic()
 def make_classification(n_samples=100, n_features=20, n_informative=2,
                         n_redundant=2, n_repeated=0, n_classes=2,

--- a/python/cuml/datasets/classification.py
+++ b/python/cuml/datasets/classification.py
@@ -42,7 +42,7 @@ def _generate_hypercube(samples, dimensions, rng):
     return out
 
 
-@nvtx.annotate(message="cuml.datasets.make_classification")
+@nvtx.annotate(message="datasets.make_classification", domain="cuml_python")
 @cuml.internals.api_return_generic()
 def make_classification(n_samples=100, n_features=20, n_informative=2,
                         n_redundant=2, n_repeated=0, n_classes=2,

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -73,7 +73,7 @@ inp_to_dtype = {
 }
 
 
-@nvtx.annotate(message="cuml.datasets.make_regression")
+@nvtx.annotate(message="datasets.make_regression", domain="cuml_python")
 @cuml.internals.api_return_generic()
 def make_regression(
     n_samples=100,

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -17,6 +17,7 @@
 # distutils: language = c++
 
 import typing
+import nvtx
 
 import numpy as np
 
@@ -72,6 +73,7 @@ inp_to_dtype = {
 }
 
 
+@nvtx.annotate(message="cuml.datasets.make_regression")
 @cuml.internals.api_return_generic()
 def make_regression(
     n_samples=100,

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -15,6 +15,7 @@
 #
 import math
 import warnings
+import nvtx
 
 import cupy as cp
 import cupy.prof
@@ -244,7 +245,7 @@ class MultinomialNB(Base, ClassifierMixin):
         self.handle = None
 
     @generate_docstring(X='dense_sparse')
-    @cp.prof.TimeRangeDecorator(message="fit()", color_id=0)
+    @nvtx.annotate(message="cuml.naive_bayes.MultinomialNB.fit")
     def fit(self, X, y,
             sample_weight=None, convert_dtype=True) -> "MultinomialNB":
         """
@@ -253,7 +254,7 @@ class MultinomialNB(Base, ClassifierMixin):
         return self.partial_fit(X, y, sample_weight,
                                 convert_dtype=convert_dtype)
 
-    @cp.prof.TimeRangeDecorator(message="fit()", color_id=0)
+    @nvtx.annotate(message="cuml.naive_bayes.MultinomialNB._partial_fit")
     def _partial_fit(self,
                      X,
                      y,
@@ -387,7 +388,7 @@ class MultinomialNB(Base, ClassifierMixin):
                             'description': 'Predicted values',
                             'shape': '(n_rows, 1)'
                         })
-    @cp.prof.TimeRangeDecorator(message="predict()", color_id=1)
+    @nvtx.annotate(message="cuml.naive_bayes.MultinomialNB.predict")
     def predict(self, X) -> CumlArray:
         """
         Perform classification on an array of test vectors X.

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -245,7 +245,6 @@ class MultinomialNB(Base, ClassifierMixin):
         self.handle = None
 
     @generate_docstring(X='dense_sparse')
-    @nvtx.annotate(message="cuml.naive_bayes.MultinomialNB.fit")
     def fit(self, X, y,
             sample_weight=None, convert_dtype=True) -> "MultinomialNB":
         """
@@ -388,7 +387,6 @@ class MultinomialNB(Base, ClassifierMixin):
                             'description': 'Predicted values',
                             'shape': '(n_rows, 1)'
                         })
-    @nvtx.annotate(message="cuml.naive_bayes.MultinomialNB.predict")
     def predict(self, X) -> CumlArray:
         """
         Perform classification on an array of test vectors X.

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -253,7 +253,8 @@ class MultinomialNB(Base, ClassifierMixin):
         return self.partial_fit(X, y, sample_weight,
                                 convert_dtype=convert_dtype)
 
-    @nvtx.annotate(message="cuml.naive_bayes.MultinomialNB._partial_fit")
+    @nvtx.annotate(message="naive_bayes.MultinomialNB._partial_fit",
+                   domain="cuml_python")
     def _partial_fit(self,
                      X,
                      y,

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -372,7 +372,7 @@ class ARIMA(Base):
             return "ARIMA({},{},{}) ({}) - {} series".format(
                 order.p, order.d, order.q, intercept_str, self.batch_size)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA._ic")
+    @nvtx.annotate(message="tsa.arima.ARIMA._ic", domain="cuml_python")
     @cuml.internals.api_base_return_any_skipall
     def _ic(self, ic_type: str):
         """Wrapper around C++ information_criterion
@@ -600,7 +600,7 @@ class ARIMA(Base):
                     d_lower,
                     d_upper)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA.forecast")
+    @nvtx.annotate(message="tsa.arima.ARIMA.forecast", domain="cuml_python")
     @cuml.internals.api_base_return_generic_skipall
     def forecast(
         self,
@@ -663,7 +663,8 @@ class ARIMA(Base):
         if not hasattr(self, "sigma2_"):
             self.sigma2_ = CumlArray.empty(self.batch_size, np.float64)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA._estimate_x0")
+    @nvtx.annotate(message="tsa.arima.ARIMA._estimate_x0",
+                   domain="cuml_python")
     @cuml.internals.api_base_return_any_skipall
     def _estimate_x0(self):
         """Internal method. Estimate initial parameters of the model.
@@ -775,7 +776,7 @@ class ARIMA(Base):
         self.unpack(self._batched_transform(x))
         return self
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA._loglike")
+    @nvtx.annotate(message="tsa.arima.ARIMA._loglike", domain="cuml_python")
     @cuml.internals.api_base_return_any_skipall
     def _loglike(self, x, trans=True, method="ml", truncate=0):
         """Compute the batched log-likelihood for the given parameters.
@@ -829,7 +830,8 @@ class ARIMA(Base):
 
         return np.array(vec_loglike, dtype=np.float64)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA._loglike_grad")
+    @nvtx.annotate(message="tsa.arima.ARIMA._loglike_grad",
+                   domain="cuml_python")
     @cuml.internals.api_base_return_any_skipall
     def _loglike_grad(self, x, h=1e-8, trans=True, method="ml", truncate=0):
         """Compute the gradient (via finite differencing) of the batched
@@ -925,7 +927,7 @@ class ARIMA(Base):
 
         return np.array(vec_loglike, dtype=np.float64)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA.unpack")
+    @nvtx.annotate(message="tsa.arima.ARIMA.unpack", domain="cuml_python")
     def unpack(self, x: Union[list, np.ndarray]):
         """Unpack linearized parameter vector `x` into the separate
         parameter arrays of the model
@@ -950,7 +952,7 @@ class ARIMA(Base):
         cpp_unpack(handle_[0], cpp_params, order, <int> self.batch_size,
                    <double*>d_x_ptr)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA.pack")
+    @nvtx.annotate(message="tsa.arima.ARIMA.pack", domain="cuml_python")
     def pack(self) -> np.ndarray:
         """Pack parameters of the model into a linearized vector `x`
 
@@ -974,7 +976,8 @@ class ARIMA(Base):
 
         return d_x_array.to_output("numpy")
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA._batched_transform")
+    @nvtx.annotate(message="tsa.arima.ARIMA._batched_transform",
+                   domain="cuml_python")
     @cuml.internals.api_base_return_any_skipall
     def _batched_transform(self, x, isInv=False):
         """Applies Jones transform or inverse transform to a parameter vector

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -499,7 +499,6 @@ class ARIMA(Base):
         raise NotImplementedError("ARIMA is unable to be cloned via "
                                   "`get_params` and `set_params`.")
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA.predict")
     @cuml.internals.api_base_return_autoarray(input_arg=None)
     def predict(
         self,
@@ -681,7 +680,6 @@ class ARIMA(Base):
         estimate_x0(handle_[0], cpp_params, <double*> d_y_ptr,
                     <int> self.batch_size, <int> self.n_obs, order)
 
-    @nvtx.annotate(message="cuml.tsa.arima.ARIMA.fit")
     @cuml.internals.api_base_return_any_skipall
     def fit(self,
             start_params: Optional[Mapping[str, object]] = None,

--- a/wiki/python/DEVELOPER_GUIDE.md
+++ b/wiki/python/DEVELOPER_GUIDE.md
@@ -74,4 +74,32 @@ TODO: Add more details.
 
 ## Benchmarking
 
-The cuML code including its Python operations can be benchmarked. The `nvtx_benchmark.py` is a helper script that produces a simple benchmark summary. To use it, run `python nvtx_benchmark.py "python test.py"`.
+The cuML code including its Python operations can be profiled. The `nvtx_benchmark.py` is a helper script that produces a simple benchmark summary. To use it, run `python nvtx_benchmark.py "python test.py"`.
+
+Here is an example with the following script:
+```
+from cuml.datasets import make_blobs
+from cuml.manifold import UMAP
+
+X, y = make_blobs(n_samples=1000, n_features=30)
+
+model = UMAP()
+model.fit(X)
+embeddngs = model.transform(X)
+```
+that once benchmarked can have its profiling summarized:
+```
+datasets.make_blobs                                          :   1.3571 s
+
+manifold.umap.fit [0x7f10eb69d4f0]                           :   0.6629 s
+    |> umap::unsupervised::fit                               :   0.6611 s
+    |==> umap::knnGraph                                      :   0.4693 s
+    |==> umap::simplicial_set                                :   0.0015 s
+    |==> umap::embedding                                     :   0.1902 s
+
+manifold.umap.transform [0x7f10eb69d4f0]                     :   0.0934 s
+    |> umap::transform                                       :   0.0925 s
+    |==> umap::knnGraph                                      :   0.0909 s
+    |==> umap::smooth_knn                                    :   0.0002 s
+    |==> umap::optimization                                  :   0.0011 s
+```

--- a/wiki/python/DEVELOPER_GUIDE.md
+++ b/wiki/python/DEVELOPER_GUIDE.md
@@ -71,3 +71,7 @@ To know more underlying details about stream ordering refer to the corresponding
 ## Multi GPU
 
 TODO: Add more details.
+
+## Benchmarking
+
+The cuML code including its Python operations can be benchmarked. The `nvtx_benchmark.py` is a helper script that produces a simple benchmark summary. To use it, run `python nvtx_benchmark.py "python test.py"`.


### PR DESCRIPTION
This PR enables benchmarking cuML with the help of NVTX ranges. The `nvtx_benchmark.py` script produces a simple display of runtime measurements. To produce the measurements, run `nvtx_benchmark.py <command>`. e.g. : `python nvtx_benchmark.py "python test.py"`, the command should be given as first argument (see quotes).

Currently, the following runtimes will be displayed:
- The `fit`, `transform`, `predict`, `fit_transform`, and `fit_predict` functions of cuML estimators
- Random dataset generator functions such as `make_classification`, `make_regression`, and `make_blobs`
- Utilities such as : the `input_to_cuml_array`, `input_to_cupy_array` and `input_to_host_array` functions and some of the methods in the `CumlArray` and `SparseCumlArray` classes
- NVTX ranges from the C++ layer
- cuDF NVTX ranges

Here is an example with the following script:
```
from cuml.datasets import make_blobs
from cuml.manifold import UMAP

X, y = make_blobs(n_samples=1000, n_features=30)

model = UMAP()
model.fit(X)
embeddngs = model.transform(X)
``` 
that produces this profiling result:
```
datasets.make_blobs                                          :   1.3571 s
    Utils summary:
      common.input_utils.input_to_cuml_array                 :   0.0002 s
      common.CumlArray.__init__                              :   0.0000 s
      common.CumlArray.to_output                             :   0.0000 s


manifold.umap.fit [0x7f10eb69d4f0]                           :   0.6629 s
    |> umap::unsupervised::fit                               :   0.6611 s
    |==> umap::knnGraph                                      :   0.4693 s
    |==> umap::simplicial_set                                :   0.0015 s
    |==> umap::embedding                                     :   0.1902 s

    Utils summary:
      common.input_utils.input_to_cuml_array                 :   0.0015 s
      common.CumlArray.__init__                              :   0.0001 s
      common.CumlArray.zeros                                 :   0.0001 s
      common.CumlArray.full                                  :   0.0001 s


manifold.umap.transform [0x7f10eb69d4f0]                     :   0.0934 s
    |> umap::transform                                       :   0.0925 s
    |==> umap::knnGraph                                      :   0.0909 s
    |==> umap::smooth_knn                                    :   0.0002 s
    |==> umap::optimization                                  :   0.0011 s

    Utils summary:
      common.input_utils.input_to_cuml_array                 :   0.0005 s
      common.CumlArray.__init__                              :   0.0001 s
      common.CumlArray.zeros                                 :   0.0001 s
      common.CumlArray.full                                  :   0.0001 s
      common.CumlArray.to_output                             :   0.0000 s
```