### PR TITLE
Deprecate usage of `bootstrap_features` parameter in Random Forests

### DIFF
--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -288,7 +288,7 @@ void DecisionTreeBase<T, L>::plant(
   ML::PUSH_RANGE("DecisionTreeBase::plant::bootstrapping features");
   //Bootstrap features
   unsigned int *h_colids = tempmem->h_colids->data();
-  if (tree_params.bootstrap_features) {
+  if (tree_params.max_features != 1.f) {
     srand(treeid * 1000);
     for (int i = 0; i < dinfo.Ncols; i++) {
       h_colids[i] = rand() % dinfo.Ncols;

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -288,13 +288,13 @@ void DecisionTreeBase<T, L>::plant(
   ML::PUSH_RANGE("DecisionTreeBase::plant::bootstrapping features");
   //Bootstrap features
   unsigned int *h_colids = tempmem->h_colids->data();
-  if (tree_params.max_features != 1.f) {
+  // fill with ascending range of indices
+  std::iota(h_colids, h_colids + dinfo.Ncols, 0);
+  // if feature sampling, shuffle
+  if (tree_params.max_features == 1.f) {
+    // seed with treeid
     srand(treeid * 1000);
-    for (int i = 0; i < dinfo.Ncols; i++) {
-      h_colids[i] = rand() % dinfo.Ncols;
-    }
-  } else {
-    std::iota(h_colids, h_colids + dinfo.Ncols, 0);
+    std::random_shuffle(h_colids, h_colids + dinfo.Ncols, [](int j){ return rand() % j; });
   }
   ML::POP_RANGE();
   prepare_time = prepare_fit_timer.getElapsedSeconds();

--- a/cpp/src/decisiontree/decisiontree_impl.cuh
+++ b/cpp/src/decisiontree/decisiontree_impl.cuh
@@ -294,7 +294,8 @@ void DecisionTreeBase<T, L>::plant(
   if (tree_params.max_features == 1.f) {
     // seed with treeid
     srand(treeid * 1000);
-    std::random_shuffle(h_colids, h_colids + dinfo.Ncols, [](int j){ return rand() % j; });
+    std::random_shuffle(h_colids, h_colids + dinfo.Ncols,
+                        [](int j) { return rand() % j; });
   }
   ML::POP_RANGE();
   prepare_time = prepare_fit_timer.getElapsedSeconds();

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -618,6 +618,16 @@ RF_params set_rf_params(int max_depth, int max_leaves, float max_features,
                         CRITERION split_criterion, bool quantile_per_tree,
                         int cfg_n_streams, bool use_experimental_backend,
                         int max_batch_size) {
+  // give deprecation notice for use of bootstrap_features
+  if(bootstrap_features) {
+    CUML_LOG_WARN("Parameter 'bootstrap_features' is deprecated and will be"
+                  " removed in 0.21 release. Please use 'max_features' instead.");
+    if(max_features == 1.f) {
+      CUML_LOG_WARN("Parameter conflict: 'max_features' is set to 1.0 when "
+                    "'bootstrap_features' is enabled. "
+                    "'max_features' will be used to override 'bootstrap_features'.");
+    }
+  }
   DecisionTree::DecisionTreeParams tree_params;
   DecisionTree::set_tree_params(
     tree_params, max_depth, max_leaves, max_features, n_bins, split_algo,

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -619,13 +619,15 @@ RF_params set_rf_params(int max_depth, int max_leaves, float max_features,
                         int cfg_n_streams, bool use_experimental_backend,
                         int max_batch_size) {
   // give deprecation notice for use of bootstrap_features
-  if(bootstrap_features) {
-    CUML_LOG_WARN("Parameter 'bootstrap_features' is deprecated and will be"
-                  " removed in 0.21 release. Please use 'max_features' instead.");
-    if(max_features == 1.f) {
-      CUML_LOG_WARN("Parameter conflict: 'max_features' is set to 1.0 when "
-                    "'bootstrap_features' is enabled. "
-                    "'max_features' will be used to override 'bootstrap_features'.");
+  if (bootstrap_features) {
+    CUML_LOG_WARN(
+      "Parameter 'bootstrap_features' is deprecated and will be"
+      " removed in 0.21 release. Please use 'max_features' instead.");
+    if (max_features == 1.f) {
+      CUML_LOG_WARN(
+        "Parameter conflict: 'max_features' is set to 1.0 when "
+        "'bootstrap_features' is enabled. "
+        "'max_features' will be used to override 'bootstrap_features'.");
     }
   }
   DecisionTree::DecisionTreeParams tree_params;


### PR DESCRIPTION
  * This PR addresses [this](https://github.com/rapidsai/cuml/issues/3769#3765) issue.
  * Adds a Deprecation warning notifying user, when `bootstrap_features` is set for `RandomForestClassifier` and `RandomForestRegressor`
  * Further, if there is a conflict between `bootstrap_features` parameter and `max_features` parameter, the latter is made to take precedence. 
  * This PR also fixes [this](https://github.com/rapidsai/cuml/issues/3795) bug