### PR TITLE
Refactor `ForestInference_impl` keyword arguments for easier import parameter threading

### DIFF
--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -224,7 +224,8 @@ cdef class ForestInference_impl():
                             ' to the documentation')
         return algo_dict[algo_str]
 
-    def get_storage_type(self, storage_type_str):
+    def get_storage_type(self, storage_type):
+        storage_type_str = str(storage_type)
         storage_type_dict={'auto': storage_type_t.AUTO,
                            'False': storage_type_t.DENSE,
                            'dense': storage_type_t.DENSE,
@@ -314,25 +315,20 @@ cdef class ForestInference_impl():
         return preds
 
     def load_from_treelite_model_handle(self,
-                                        uintptr_t model_handle,
-                                        bool output_class,
-                                        str algo,
-                                        float threshold,
-                                        str storage_type,
-                                        int blocks_per_sm):
+                                        **kwargs):
         cdef treelite_params_t treelite_params
 
-        self.output_class = output_class
+        self.output_class = kwargs['output_class']
         treelite_params.output_class = self.output_class
-        treelite_params.threshold = threshold
-        treelite_params.algo = self.get_algo(algo)
-        treelite_params.storage_type = self.get_storage_type(storage_type)
-        treelite_params.blocks_per_sm = blocks_per_sm
+        treelite_params.threshold = kwargs['threshold']
+        treelite_params.algo = self.get_algo(kwargs['algo'])
+        treelite_params.storage_type = self.get_storage_type(kwargs['storage_type'])
+        treelite_params.blocks_per_sm = kwargs['blocks_per_sm']
 
         self.forest_data = NULL
         cdef handle_t* handle_ =\
             <handle_t*><size_t>self.handle.getHandle()
-        cdef uintptr_t model_ptr = <uintptr_t>model_handle
+        cdef uintptr_t model_ptr = <uintptr_t>kwargs['model_handle']
 
         from_treelite(handle_[0],
                       &self.forest_data,
@@ -343,39 +339,27 @@ cdef class ForestInference_impl():
         return self
 
     def load_from_treelite_model(self,
-                                 TreeliteModel model,
-                                 bool output_class,
-                                 str algo,
-                                 float threshold,
-                                 str storage_type,
-                                 int blocks_per_sm):
-        TreeliteQueryNumClass(<ModelHandle> model.handle,
-                              & self.num_class)
-        return self.load_from_treelite_model_handle(<uintptr_t>model.handle,
-                                                    output_class, algo,
-                                                    threshold, storage_type,
-                                                    blocks_per_sm)
+                                 **kwargs):
+        cdef TreeliteModel model = kwargs['model']
+        return self.load_from_treelite_model_handle(
+            model_handle=<uintptr_t>model.handle, **kwargs)
+
 
     def load_using_treelite_handle(self,
-                                   model_handle,
-                                   bool output_class,
-                                   str algo,
-                                   float threshold,
-                                   str storage_type,
-                                   int blocks_per_sm):
+                                   **kwargs):
 
         cdef treelite_params_t treelite_params
 
-        self.output_class = output_class
+        self.output_class = kwargs['output_class']
         treelite_params.output_class = self.output_class
-        treelite_params.threshold = threshold
-        treelite_params.algo = self.get_algo(algo)
-        treelite_params.storage_type = self.get_storage_type(storage_type)
-        treelite_params.blocks_per_sm = blocks_per_sm
+        treelite_params.threshold = kwargs['threshold']
+        treelite_params.algo = self.get_algo(kwargs['algo'])
+        treelite_params.storage_type = self.get_storage_type(kwargs['storage_type'])
+        treelite_params.blocks_per_sm = kwargs['blocks_per_sm']
 
         cdef handle_t* handle_ =\
             <handle_t*><size_t>self.handle.getHandle()
-        cdef uintptr_t model_ptr = <uintptr_t>model_handle
+        cdef uintptr_t model_ptr = <uintptr_t>kwargs['model_handle']
 
         from_treelite(handle_[0],
                       &self.forest_data,
@@ -601,14 +585,11 @@ class ForestInference(Base,
         """
         if isinstance(model, TreeliteModel):
             # TreeliteModel defined in this file
-            return self._impl.load_from_treelite_model(
-                model, output_class, algo, threshold, str(storage_type),
-                blocks_per_sm)
+            return self._impl.load_from_treelite_model(**locals())
         else:
             # assume it is treelite.Model
             return self._impl.load_from_treelite_model_handle(
-                model.handle.value, output_class, algo, threshold,
-                str(storage_type), blocks_per_sm)
+                model_handle=model.handle.value, **locals())
 
     @staticmethod
     def load_from_sklearn(skl_model,
@@ -672,15 +653,14 @@ class ForestInference(Base,
             model passed.
 
         """
+        kwargs = locals()
+        [kwargs.pop(key) for key in ['skl_model', 'handle']]
         cuml_fm = ForestInference(handle=handle)
         logger.warn("Treelite currently does not support float64 model"
                     " parameters. Accuracy may degrade slightly relative to"
                     " native sklearn invocation.")
         tl_model = tl_skl.import_model(skl_model)
-        cuml_fm.load_from_treelite_model(
-            tl_model, algo=algo, output_class=output_class,
-            storage_type=str(storage_type), threshold=threshold,
-            blocks_per_sm=blocks_per_sm)
+        cuml_fm.load_from_treelite_model(model=tl_model, **kwargs)
         return cuml_fm
 
     @staticmethod
@@ -737,14 +717,11 @@ class ForestInference(Base,
             inferencing on the model read from the file.
 
         """
+        kwargs = locals()
+        [kwargs.pop(key) for key in ['filename', 'handle', 'model_type']]
         cuml_fm = ForestInference(handle=handle)
         tl_model = TreeliteModel.from_filename(filename, model_type=model_type)
-        cuml_fm.load_from_treelite_model(tl_model,
-                                         algo=algo,
-                                         output_class=output_class,
-                                         storage_type=str(storage_type),
-                                         threshold=threshold,
-                                         blocks_per_sm=blocks_per_sm)
+        cuml_fm.load_from_treelite_model(model=tl_model, **kwargs)
         return cuml_fm
 
     def load_using_treelite_handle(self,
@@ -793,10 +770,6 @@ class ForestInference(Base,
             A Forest Inference model which can be used to perform
             inferencing on the random forest model.
         """
-        self._impl.load_using_treelite_handle(model_handle,
-                                              output_class,
-                                              algo, threshold,
-                                              str(storage_type),
-                                              blocks_per_sm)
+        self._impl.load_using_treelite_handle(**locals())
         # DO NOT RETURN self._impl here!!
         return self

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -321,7 +321,7 @@ cdef class ForestInference_impl():
         treelite_params.output_class = self.output_class
         treelite_params.threshold = kwargs['threshold']
         treelite_params.algo = self.get_algo(kwargs['algo'])
-        treelite_params.storage_type =
+        treelite_params.storage_type =\
             self.get_storage_type(kwargs['storage_type'])
         treelite_params.blocks_per_sm = kwargs['blocks_per_sm']
 
@@ -344,7 +344,6 @@ cdef class ForestInference_impl():
         return self.load_from_treelite_model_handle(
             model_handle=<uintptr_t>model.handle, **kwargs)
 
-
     def load_using_treelite_handle(self, **kwargs):
         cdef treelite_params_t treelite_params
 
@@ -352,7 +351,7 @@ cdef class ForestInference_impl():
         treelite_params.output_class = self.output_class
         treelite_params.threshold = kwargs['threshold']
         treelite_params.algo = self.get_algo(kwargs['algo'])
-        treelite_params.storage_type =
+        treelite_params.storage_type =\
             self.get_storage_type(kwargs['storage_type'])
         treelite_params.blocks_per_sm = kwargs['blocks_per_sm']
 

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -314,15 +314,15 @@ cdef class ForestInference_impl():
 
         return preds
 
-    def load_from_treelite_model_handle(self,
-                                        **kwargs):
+    def load_from_treelite_model_handle(self, **kwargs):
         cdef treelite_params_t treelite_params
 
         self.output_class = kwargs['output_class']
         treelite_params.output_class = self.output_class
         treelite_params.threshold = kwargs['threshold']
         treelite_params.algo = self.get_algo(kwargs['algo'])
-        treelite_params.storage_type = self.get_storage_type(kwargs['storage_type'])
+        treelite_params.storage_type =
+            self.get_storage_type(kwargs['storage_type'])
         treelite_params.blocks_per_sm = kwargs['blocks_per_sm']
 
         self.forest_data = NULL
@@ -345,16 +345,15 @@ cdef class ForestInference_impl():
             model_handle=<uintptr_t>model.handle, **kwargs)
 
 
-    def load_using_treelite_handle(self,
-                                   **kwargs):
-
+    def load_using_treelite_handle(self, **kwargs):
         cdef treelite_params_t treelite_params
 
         self.output_class = kwargs['output_class']
         treelite_params.output_class = self.output_class
         treelite_params.threshold = kwargs['threshold']
         treelite_params.algo = self.get_algo(kwargs['algo'])
-        treelite_params.storage_type = self.get_storage_type(kwargs['storage_type'])
+        treelite_params.storage_type =
+            self.get_storage_type(kwargs['storage_type'])
         treelite_params.blocks_per_sm = kwargs['blocks_per_sm']
 
         cdef handle_t* handle_ =\


### PR DESCRIPTION
As we keep adding new API arguments, there are necessary changes to the public function signatures, but also unnecessary changes to every `load*` call to propagate the new option through all code paths.
This change will simplify all future changes.