### PR TITLE
Remove xfail for KBinsDiscretizer quantile tests

### DIFF
--- a/python/cuml/test/test_preprocessing.py
+++ b/python/cuml/test/test_preprocessing.py
@@ -659,11 +659,7 @@ def test_robust_scale_sparse(failure_logger, sparse_clf_dataset,  # noqa: F811
         reason='Intermittent mismatch with sklearn'
         ' (https://github.com/rapidsai/cuml/issues/3481)'
     )),
-    pytest.param('quantile', marks=pytest.mark.xfail(
-        strict=False,
-        reason='Bug in cupy.percentile'
-        ' (https://github.com/cupy/cupy/issues/4607)'
-    )),
+    'quantile',
     'kmeans'
 ])
 def test_kbinsdiscretizer(failure_logger, blobs_dataset, n_bins,  # noqa: F811


### PR DESCRIPTION
Following the update to cupy 8.5.0, the bad read in the `cupy.percentile` kernel should no longer be an issue, allowing us to remove the xfail on this test.

Close #2933