### PR TITLE
Small auto arima fixes

### DIFF
--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -371,8 +371,11 @@ class AutoARIMA(Base):
                 if p_ + q_ + P_ + Q_ + k_ == 0:
                     continue
                 s_ = s if (P_ + D_ + Q_) else 0
-                model = ARIMA(data_temp.to_output("cupy"), (p_, d_, q_),
-                              (P_, D_, Q_, s_), k_, handle=self.handle,
+                model = ARIMA(endog=data_temp.to_output("cupy"),
+                              order=(p_, d_, q_),
+                              seasonal_order=(P_, D_, Q_, s_),
+                              fit_intercept=k_,
+                              handle=self.handle,
                               simple_differencing=self.simple_differencing,
                               output_type="cupy")
                 logger.debug("Fitting {} ({})".format(model, method))
@@ -385,7 +388,7 @@ class AutoARIMA(Base):
             # Organize the results into a matrix
             n_models = len(all_orders)
             ic_matrix, *_ = input_to_cuml_array(
-                cp.concatenate([ic_arr.reshape(batch_size, 1)
+                cp.concatenate([ic_arr.to_output('cupy').reshape(batch_size, 1)
                                 for ic_arr in all_ic], 1))
 
             # Divide the batch, choosing the best model for each series


### PR DESCRIPTION
Before this, running a call to autoarima.forecast would run into the following issue:

```bash
Traceback (most recent call last):
  File "bla2.py", line 17, in <module>
    model.search(s=12, d=1)
  File "/home/galahad/miniconda3/envs/cumlbench-019/lib/python3.8/site-packages/cuml/internals/api_decorators.py", line 360, in inner
    return func(*args, **kwargs)
  File "cuml/tsa/auto_arima.pyx", line 388, in cuml.tsa.auto_arima.AutoARIMA.search
AttributeError: 'CumlArray' object has no attribute 'reshape'
```

which was not caught since there is no forecast pytest for autoarima, only for arima