### PR TITLE
ENH Remove conda defaults channel in builddocs environment

### DIFF
--- a/conda/environments/builddocs_py36.yml
+++ b/conda/environments/builddocs_py36.yml
@@ -4,7 +4,6 @@ channels:
 - pytorch
 - conda-forge
 - numba
-- defaults
 dependencies:
 - python=3.6*
 - cuml=0.5*


### PR DESCRIPTION
Remove conda defaults channel in builddocs environment