### PR TITLE
Ensure GPU is used for input transposing of host arrays

### DIFF
--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -320,8 +320,7 @@ def input_to_cuml_array(X,
     elif hasattr(X, "__array_interface__") or \
             hasattr(X, "__cuda_array_interface__"):
 
-        if hasattr(X, "__array_interface__"):
-            host_array = True
+        host_array = hasattr(X, "__array_interface__")
 
         # Since we create the array with the correct order here, do the order
         # check now if necessary

--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -320,6 +320,9 @@ def input_to_cuml_array(X,
     elif hasattr(X, "__array_interface__") or \
             hasattr(X, "__cuda_array_interface__"):
 
+        if hasattr(X, "__array_interface__"):
+            host_array = True
+
         # Since we create the array with the correct order here, do the order
         # check now if necessary
         interface = getattr(X, "__array_interface__", None) or getattr(
@@ -337,6 +340,11 @@ def input_to_cuml_array(X,
                       "contiguous copy of the data will be done.")
                 # X = cp.array(X, order=order, copy=True)
                 make_copy = True
+
+        # If we have a host array, we copy it first before changing order
+        # to transpose using the GPU
+        if host_array:
+            X = cp.array(X)
 
         cp_arr = cp.array(X, copy=make_copy, order=order)
 

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -373,6 +373,7 @@ def test_stratify_retain_index(test_size, train_size):
         assert X_test.shape[0] == (int)(X.shape[0] * test_size)
 
 
+@pytest.mark.skip("See issue https://github.com/rapidsai/cuml/issues/3839")
 def test_stratified_binary_classification():
     X = cp.array([[0.37487513, -2.3031888, 1.662633, 0.7671007],
                   [-0.49796826, -1.0621182, -0.32518214, -0.20583323],


### PR DESCRIPTION
Closes issue #3832 

Related to #3767 

cc @teju85 and @venkywonka and @vinaydes who are working on RF

Will be profiling the solution before flipping the PR to ready to review

Quick profiling, on a 2070S laptop,average of 10 runs of a simple LinearRegression.fit (that expects data in `F` format), with a `X` matrix of 500 columns with 100000 rows shows:

- Before the fix:
```
common.input_utils.input_to_cuml_array                     :   0.1795 s
```

- After the fix:
```
common.input_utils.input_to_cuml_array                     :   0.0632 s
```