### PR TITLE
Changes to use RAFT standalone in Python

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@ Contents:
 
 - [cuML Python Package](#cuml-python-package)
     - [Build Configuration](#build-configuration)
-    - [RAFT Integration in cuml.raft](#raft-integration-in-cumlraft)
+    - [RAFT Integration in raft](#raft-integration-in-cumlraft)
     - [Build Requirements](#build-requirements)
     - [Python Tests](#python-tests)
 
@@ -34,7 +34,7 @@ example `setup.py --singlegpu`) are:
 | --singlegpu | Option to build cuML without multiGPU algorithms. Removes dependency on nccl, libcumlprims and ucx-py. |
 
 
-### RAFT Integration in cuml.raft
+### RAFT Integration in raft
 
 RAFT's Python and Cython is located in the [RAFT repository](https://github.com/rapidsai/raft/python). It was designed to be included in projects as opposed to be distributed by itself, so at build time, **setup.py creates a symlink from cuML, located in `/python/cuml/raft/` to the Python folder of RAFT**.
 

--- a/python/cuml/__init__.py
+++ b/python/cuml/__init__.py
@@ -88,7 +88,7 @@ from cuml.common.memory_utils import set_global_output_type, using_output_type
 
 # RAFT
 
-from cuml.raft import raft_include_test
+from raft import raft_include_test
 
 # Import verion. Remove at end of file
 from ._version import get_versions

--- a/python/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cluster/agglomerative.pyx
@@ -23,7 +23,7 @@ import numpy as np
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.mixins import ClusterMixin

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -28,7 +28,7 @@ from libc.stdlib cimport calloc, malloc, free
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.common.array_descriptor import CumlArrayDescriptor

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -35,7 +35,7 @@ from cuml.common.mixins import ClusterMixin
 from cuml.common.mixins import CMajorInputTagMixin
 from cuml.common import input_to_cuml_array
 from cuml.cluster.kmeans_utils cimport *
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans":
 

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -29,7 +29,7 @@ from libc.stdlib cimport calloc, malloc, free
 
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 
 from cuml.cluster import KMeans

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -24,7 +24,7 @@ import cuml.common
 import cuml.common.cuda
 import cuml.common.logger as logger
 import cuml.internals
-import cuml.raft.common.handle
+import raft.common.handle
 import cuml.common.input_utils
 
 from cuml.common.doc_utils import generate_docstring
@@ -165,7 +165,7 @@ class Base(TagsMixin,
         Constructor. All children must call init method of this base class.
 
         """
-        self.handle = cuml.raft.common.handle.Handle() if handle is None \
+        self.handle = raft.common.handle.Handle() if handle is None \
             else handle
 
         # Internally, self.verbose follows the spdlog/c++ standard of

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -16,6 +16,6 @@
 
 # distutils: language = c++
 
-from cuml.raft.common.handle import Handle as raftHandle
+from raft.common.handle import Handle as raftHandle
 
 Handle = raftHandle

--- a/python/cuml/dask/cluster/dbscan.py
+++ b/python/cuml/dask/cluster/dbscan.py
@@ -20,8 +20,8 @@ from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import DelayedTransformMixin
 from cuml.dask.common.base import mnmg_import
 
-from cuml.raft.dask.common.comms import Comms
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import Comms
+from raft.dask.common.comms import get_raft_comm_state
 
 from cuml.dask.common.utils import wait_and_raise_from_futures
 

--- a/python/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/dask/cluster/kmeans.py
@@ -23,8 +23,8 @@ from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.input_utils import concatenate
 from cuml.dask.common.input_utils import DistributedDataHandler
 
-from cuml.raft.dask.common.comms import Comms
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import Comms
+from raft.dask.common.comms import get_raft_comm_state
 
 from cuml.dask.common.utils import wait_and_raise_from_futures
 

--- a/python/cuml/dask/common/base.py
+++ b/python/cuml/dask/common/base.py
@@ -25,7 +25,7 @@ from cuml.dask.common.utils import get_client
 from cuml import Base
 from cuml.common.array import CumlArray
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from cuml.raft.dask.common.comms import Comms
+from raft.dask.common.comms import Comms
 from cuml.dask.common.input_utils import DistributedDataHandler
 from cuml.dask.common import parts_to_ranks
 from cuml.internals import BaseMetaClass

--- a/python/cuml/dask/decomposition/base.py
+++ b/python/cuml/dask/decomposition/base.py
@@ -14,8 +14,8 @@
 #
 
 from cuml.dask.common import raise_exception_from_futures
-from cuml.raft.dask.common.comms import get_raft_comm_state
-from cuml.raft.dask.common.comms import Comms
+from raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import Comms
 
 from cuml.dask.common.input_utils import to_output
 from cuml.dask.common import parts_to_ranks

--- a/python/cuml/dask/linear_model/linear_regression.py
+++ b/python/cuml/dask/linear_model/linear_regression.py
@@ -17,7 +17,7 @@ from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.base import SyncFitMixinLinearModel
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import get_raft_comm_state
 
 
 class LinearRegression(BaseEstimator,

--- a/python/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/dask/linear_model/ridge.py
@@ -17,7 +17,7 @@ from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.base import SyncFitMixinLinearModel
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import get_raft_comm_state
 
 
 class Ridge(BaseEstimator,

--- a/python/cuml/dask/neighbors/kneighbors_classifier.py
+++ b/python/cuml/dask/neighbors/kneighbors_classifier.py
@@ -20,7 +20,7 @@ from cuml.dask.common import parts_to_ranks
 from cuml.dask.common import flatten_grouped_results
 from cuml.dask.common.utils import raise_mg_import_exception
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import get_raft_comm_state
 from cuml.dask.neighbors import NearestNeighbors
 from dask.dataframe import Series as DaskSeries
 import dask.array as da

--- a/python/cuml/dask/neighbors/kneighbors_regressor.py
+++ b/python/cuml/dask/neighbors/kneighbors_regressor.py
@@ -20,7 +20,7 @@ from cuml.dask.common import parts_to_ranks
 from cuml.dask.common import flatten_grouped_results
 from cuml.dask.common.utils import raise_mg_import_exception
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import get_raft_comm_state
 from cuml.dask.neighbors import NearestNeighbors
 import dask.array as da
 from uuid import uuid1

--- a/python/cuml/dask/neighbors/nearest_neighbors.py
+++ b/python/cuml/dask/neighbors/nearest_neighbors.py
@@ -19,8 +19,8 @@ from cuml.dask.common import flatten_grouped_results
 from cuml.dask.common import raise_mg_import_exception
 from cuml.dask.common.base import BaseEstimator
 
-from cuml.raft.dask.common.comms import get_raft_comm_state
-from cuml.raft.dask.common.comms import Comms
+from raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import Comms
 from cuml.dask.common.input_utils import to_output
 from cuml.dask.common.input_utils import DistributedDataHandler
 

--- a/python/cuml/dask/solvers/cd.py
+++ b/python/cuml/dask/solvers/cd.py
@@ -17,7 +17,7 @@ from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.base import SyncFitMixinLinearModel
-from cuml.raft.dask.common.comms import get_raft_comm_state
+from raft.dask.common.comms import get_raft_comm_state
 
 
 class CD(BaseEstimator,

--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -22,8 +22,8 @@ import numpy as np
 
 from cuml.common.array import CumlArray as cumlArray
 import cuml.internals
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 from cuml.tsa.arima cimport ARIMAOrder
 
 from libc.stdint cimport uint64_t, uintptr_t

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -23,8 +23,8 @@ import numpy as np
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 
 from libcpp cimport bool
 from libc.stdint cimport uint64_t, uintptr_t

--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -33,7 +33,7 @@ import cuml.common.opg_data_utils_mg as opg
 
 import cuml.internals
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 from cuml.common import input_to_cuml_array
 from cuml.common.opg_data_utils_mg cimport *

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -36,8 +36,8 @@ import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 import cuml.common.logger as logger
 from cuml.decomposition.utils cimport *
 from cuml.common.input_utils import input_to_cuml_array

--- a/python/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/decomposition/pca_mg.pyx
@@ -34,7 +34,7 @@ import cuml.common.opg_data_utils_mg as opg
 
 import cuml.internals
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport paramsSolver
 from cuml.common.opg_data_utils_mg cimport *
 

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -30,7 +30,7 @@ from libc.stdint cimport uintptr_t
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor

--- a/python/cuml/decomposition/tsvd_mg.pyx
+++ b/python/cuml/decomposition/tsvd_mg.pyx
@@ -29,7 +29,7 @@ from cython.operator cimport dereference as deref
 
 import cuml.internals
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 import cuml.common.opg_data_utils_mg as opg
 from cuml.common.opg_data_utils_mg cimport *

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -24,7 +24,7 @@ from inspect import signature
 import numpy as np
 from cuml import ForestInference
 from cuml.fil.fil import TreeliteModel
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
 import cuml.internals

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -25,10 +25,10 @@ from libc.stdlib cimport calloc, malloc, free
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 from cuml import ForestInference
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 cdef extern from "treelite/c_api.h":

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -29,7 +29,7 @@ from cuml.common.mixins import ClassifierMixin
 import cuml.internals
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.doc_utils import insert_into_docstring
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 
 from cuml.ensemble.randomforest_common import BaseRandomForestModel
@@ -48,7 +48,7 @@ from libc.stdlib cimport calloc, malloc, free
 from numba import cuda
 
 from cuml.common.cuda import nvtx_range_wrap, nvtx_range_push, nvtx_range_pop
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 cimport cython

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -29,7 +29,7 @@ import cuml.internals
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.doc_utils import insert_into_docstring
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 
 from cuml.ensemble.randomforest_common import BaseRandomForestModel
@@ -48,7 +48,7 @@ from libc.stdlib cimport calloc, malloc, free
 from numba import cuda
 
 from cuml.common.cuda import nvtx_range_wrap, nvtx_range_push, nvtx_range_pop
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 cimport cython

--- a/python/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/experimental/linear_model/lars.pyx
@@ -39,7 +39,7 @@ from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.exceptions import NotFittedError
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 cdef extern from "cuml/solvers/lars.hpp" namespace "ML::Solver::Lars":
 

--- a/python/cuml/explainer/base.pyx
+++ b/python/cuml/explainer/base.pyx
@@ -33,7 +33,7 @@ from cuml.explainer.common import get_tag_from_model_func
 from cuml.explainer.common import model_func_call
 from cuml.explainer.common import output_list_shap_values
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 
@@ -89,7 +89,7 @@ class SHAPBase():
         (as CuPy arrays), otherwise it will use NumPy arrays to call `model`.
         Set to True to force the explainer to use GPU data,  set to False to
         force the Explainer to use NumPy data.
-    handle : cuml.raft.common.handle
+    handle : raft.common.handle
         Specifies the handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
         stream that will be used for the model's computations, so users can

--- a/python/cuml/explainer/common.py
+++ b/python/cuml/explainer/common.py
@@ -69,7 +69,7 @@ def get_handle_from_cuml_model_func(func, create_new=False):
         handle = owner.handle
 
     else:
-        handle = cuml.raft.common.handle.Handle() if create_new else None
+        handle = raft.common.handle.Handle() if create_new else None
 
     return handle
 

--- a/python/cuml/explainer/kernel_shap.pyx
+++ b/python/cuml/explainer/kernel_shap.pyx
@@ -27,13 +27,13 @@ from cuml.explainer.common import model_func_call
 from cuml.explainer.common import output_list_shap_values
 from cuml.linear_model import Lasso
 from cuml.linear_model import LinearRegression
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 from functools import lru_cache
 from itertools import combinations
 from numbers import Number
 from random import randint
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from libc.stdint cimport uint64_t
 
@@ -134,7 +134,7 @@ class KernelExplainer(SHAPBase):
         (as CuPy arrays), otherwise it will use NumPy arrays to call `model`.
         Set to True to force the explainer to use GPU data,  set to False to
         force the Explainer to use NumPy data.
-    handle : cuml.raft.common.handle (default = None)
+    handle : raft.common.handle (default = None)
         Specifies the handle that holds internal CUDA state for
         computations in this model, a new one is created if it is None.
         Most importantly, this specifies the CUDA stream that will be used for

--- a/python/cuml/explainer/permutation_shap.pyx
+++ b/python/cuml/explainer/permutation_shap.pyx
@@ -30,7 +30,7 @@ from cuml.explainer.common import model_func_call
 from numba import cuda
 from pandas import DataFrame as pd_df
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 
@@ -139,7 +139,7 @@ class PermutationExplainer(SHAPBase):
         (as CuPy arrays), otherwise it will use NumPy arrays to call `model`.
         Set to True to force the explainer to use GPU data,  set to False to
         force the Explainer to use NumPy data.
-    handle : cuml.raft.common.handle (default = None)
+    handle : raft.common.handle (default = None)
         Specifies the handle that holds internal CUDA state for
         computations in this model, a new one is created if it is None.
         Most importantly, this specifies the CUDA stream that will be used for

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -33,7 +33,7 @@ from libc.stdlib cimport calloc, malloc, free
 import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array, logger
 from cuml.common.mixins import CMajorInputTagMixin
 

--- a/python/cuml/linear_model/base.pyx
+++ b/python/cuml/linear_model/base.pyx
@@ -34,7 +34,7 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -28,7 +28,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -34,7 +34,7 @@ from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.linear_model.base import LinearPredictMixin
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/linear_model/linear_regression_mg.pyx
+++ b/python/cuml/linear_model/linear_regression_mg.pyx
@@ -30,7 +30,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -33,7 +33,7 @@ from cuml.common.mixins import RegressorMixin
 from cuml.common.array import CumlArray
 from cuml.common.doc_utils import generate_docstring
 from cuml.linear_model.base import LinearPredictMixin
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/linear_model/ridge_mg.pyx
+++ b/python/cuml/linear_model/ridge_mg.pyx
@@ -30,7 +30,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -29,7 +29,7 @@ import cupy
 import cuml.internals
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 import cuml.common.logger as logger
 
 from cuml.common.array import CumlArray

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -37,7 +37,7 @@ from cupyx.scipy.sparse import csr_matrix as cp_csr_matrix,\
 import cuml.internals
 from cuml.common import using_output_type
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.doc_utils import generate_docstring
 from cuml.common import logger
 from cuml.common.input_utils import input_to_cuml_array

--- a/python/cuml/metrics/accuracy.pyx
+++ b/python/cuml/metrics/accuracy.pyx
@@ -25,8 +25,8 @@ import cudf
 import cuml.internals
 
 from cuml.common.input_utils import input_to_cuml_array
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 cimport cuml.common.cuda
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -22,9 +22,9 @@ import warnings
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 cimport cuml.common.cuda
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/completeness_score.pyx
+++ b/python/cuml/metrics/cluster/completeness_score.pyx
@@ -17,10 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/entropy.pyx
+++ b/python/cuml/metrics/cluster/entropy.pyx
@@ -24,10 +24,10 @@ import cupy as cp
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import CumlArray
 from cuml.common.input_utils import input_to_cupy_array
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 cimport cuml.common.cuda
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/homogeneity_score.pyx
+++ b/python/cuml/metrics/cluster/homogeneity_score.pyx
@@ -17,10 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/mutual_info_score.pyx
+++ b/python/cuml/metrics/cluster/mutual_info_score.pyx
@@ -17,11 +17,11 @@
 # distutils: language = c++
 
 import cuml.internals
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from cuml.raft.common.handle import Handle
+from raft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/metrics/cluster/silhouette_score.pyx
@@ -21,8 +21,8 @@ from libc.stdint cimport uintptr_t
 
 from cuml.common import input_to_cuml_array
 from cuml.metrics.pairwise_distances import _determine_metric
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 from cuml.metrics.distance_type cimport DistanceType
 from cuml.prims.label.classlabels import make_monotonic, check_labels
 

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -20,8 +20,8 @@ import warnings
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 import cupy as cp
 import numpy as np
 import scipy

--- a/python/cuml/metrics/regression.pxd
+++ b/python/cuml/metrics/regression.pxd
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
 

--- a/python/cuml/metrics/regression.pyx
+++ b/python/cuml/metrics/regression.pyx
@@ -23,8 +23,8 @@ from libc.stdint cimport uintptr_t
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle import Handle
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle import Handle
+from raft.common.handle cimport handle_t
 from cuml.metrics cimport regression
 from cuml.common.input_utils import input_to_cuml_array
 

--- a/python/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/metrics/trustworthiness.pyx
@@ -25,8 +25,8 @@ from numba import cuda
 from libc.stdint cimport uintptr_t
 import cuml.internals
 from cuml.common.input_utils import input_to_cuml_array
-from cuml.raft.common.handle import Handle
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle import Handle
+from raft.common.handle cimport handle_t
 
 cdef extern from "raft/linalg/distance_type.h" namespace "raft::distance":
 
@@ -88,7 +88,7 @@ def trustworthiness(X, X_embedded, handle=None, n_neighbors=5,
         warnings.warn("Parameter should_downcast is deprecated, use "
                       "convert_dtype instead. ")
 
-    handle = cuml.raft.common.handle.Handle() if handle is None else handle
+    handle = raft.common.handle.Handle() if handle is None else handle
 
     cdef uintptr_t d_X_ptr
     cdef uintptr_t d_X_embedded_ptr

--- a/python/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier.pyx
@@ -35,7 +35,7 @@ import cudf
 
 from cython.operator cimport dereference as deref
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from libcpp.vector cimport vector
 
 from libcpp cimport bool

--- a/python/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -23,7 +23,7 @@ from cuml.internals import api_base_return_generic_skipall
 
 from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common import input_to_cuml_array
 

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -34,7 +34,7 @@ from cython.operator cimport dereference as deref
 
 from libcpp.vector cimport vector
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr

--- a/python/cuml/neighbors/kneighbors_regressor_mg.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor_mg.pyx
@@ -23,7 +23,7 @@ from cuml.internals import api_base_return_generic_skipall
 
 from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 
 from libcpp cimport bool

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -41,7 +41,7 @@ from cuml.common.sparse_utils import is_dense
 from cuml.metrics.distance_type cimport DistanceType
 
 from cuml.neighbors.ann cimport *
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 from cython.operator cimport dereference as deref
 

--- a/python/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -25,7 +25,7 @@ from cudf.core import DataFrame as cudfDataFrame
 
 from cuml.neighbors import NearestNeighbors
 
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common.opg_data_utils_mg import _build_part_inputs
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -25,7 +25,7 @@ from libcpp cimport bool
 import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport *
+from raft.common.handle cimport *
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -29,7 +29,7 @@ from cuml.common import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/solvers/cd_mg.pyx
+++ b/python/cuml/solvers/cd_mg.pyx
@@ -27,7 +27,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -27,7 +27,7 @@ from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 from cuml.metrics import accuracy_score

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -33,7 +33,7 @@ from cuml.common.base import Base
 from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -34,7 +34,7 @@ from cuml.common.mixins import ClassifierMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.logger import warn
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array, input_to_host_array, with_cupy_rmm
 from cuml.common.input_utils import input_to_cupy_array
 from cuml.preprocessing import LabelEncoder

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -30,7 +30,7 @@ from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
 from cuml.common.exceptions import NotFittedError
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.common.mixins import FMajorInputTagMixin

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -30,7 +30,7 @@ from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.metrics import r2_score
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from libcpp cimport bool, nullptr
 from cuml.svm.svm_base import SVMBase

--- a/python/cuml/test/explainer/test_explainer_base.py
+++ b/python/cuml/test/explainer/test_explainer_base.py
@@ -37,7 +37,7 @@ def test_init_explainer_base_init_cuml_model(handle,
     model = cuLR().fit(bg, y)
 
     if handle:
-        handle = cuml.raft.common.handle.Handle()
+        handle = raft.common.handle.Handle()
     else:
         handle = None
 
@@ -85,7 +85,7 @@ def test_init_explainer_base_init_abritrary_model(handle,
     bg = np.arange(10).reshape(5, 2).astype(np.float32)
 
     if handle:
-        handle = cuml.raft.common.handle.Handle()
+        handle = raft.common.handle.Handle()
     else:
         handle = None
 
@@ -125,7 +125,7 @@ def test_init_explainer_base_init_abritrary_model(handle,
     if handle is not None:
         assert explainer.handle == handle
     else:
-        isinstance(explainer.handle, cuml.raft.common.handle.Handle)
+        isinstance(explainer.handle, raft.common.handle.Handle)
 
 
 def test_init_explainer_base_wrong_dtype():

--- a/python/cuml/test/explainer/test_explainer_common.py
+++ b/python/cuml/test/explainer/test_explainer_common.py
@@ -149,7 +149,7 @@ def test_get_handle_from_cuml_model_func(model):
 
     # Naive Bayes does not use a handle currently
     if model != cuml.naive_bayes.naive_bayes.MultinomialNB:
-        assert isinstance(handle, cuml.raft.common.handle.Handle)
+        assert isinstance(handle, raft.common.handle.Handle)
 
 
 @pytest.mark.parametrize("create_new", [True, False])
@@ -157,7 +157,7 @@ def test_get_handle_from_dummy_func(create_new):
     handle = get_handle_from_cuml_model_func(dummy_func,
                                              create_new=create_new)
 
-    res = isinstance(handle, cuml.raft.common.handle.Handle)
+    res = isinstance(handle, raft.common.handle.Handle)
 
     assert res == create_new
 

--- a/python/cuml/test/test_raft.py
+++ b/python/cuml/test/test_raft.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-import cuml.raft
+import raft
 
 
 def test_raft():
-    assert cuml.raft.raft_include_test()
+    assert raft.raft_include_test()

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -30,7 +30,7 @@ import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 import cuml.common.logger as logger
 from cuml.common import has_scipy

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -33,8 +33,8 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.internals import _deprecate_pos_args
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.tsa.arima import ARIMA

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -27,7 +27,7 @@ from cuml.common import using_output_type
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 
 cdef extern from "cuml/tsa/holtwinters_params.h" namespace "ML":
     enum SeasonalType:

--- a/python/cuml/tsa/seasonality.pyx
+++ b/python/cuml/tsa/seasonality.pyx
@@ -22,7 +22,7 @@ from libcpp cimport bool
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
+from raft.common.handle cimport handle_t
 from cuml.common.input_utils import input_to_host_array, input_to_cuml_array
 
 # TODO: #2234 and #2235

--- a/python/cuml/tsa/stationarity.pyx
+++ b/python/cuml/tsa/stationarity.pyx
@@ -22,8 +22,8 @@ from libcpp cimport bool
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from cuml.raft.common.handle cimport handle_t
-from cuml.raft.common.handle import Handle
+from raft.common.handle cimport handle_t
+from raft.common.handle import Handle
 from cuml.common.input_utils import input_to_cuml_array
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -103,7 +103,7 @@ if clean_artifacts:
 ##############################################################################
 # - Cloning RAFT and dependencies if needed ----------------------------------
 
-# Use RAFT repository in cuml.raft
+# Use RAFT repository in raft
 
 raft_include_dir = use_raft_package(raft_path, libcuml_path)
 


### PR DESCRIPTION
PR to show prototype of changes needed to use RAFT Python as its own package as opposed to part of cuml.raft