### PR TITLE
[REVIEW] Remove Base.enable_rmm_pool method as it is no longer needed

### DIFF
--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -210,9 +210,6 @@ class Base(TagsMixin,
         string = string.rstrip(', ')
         return string + ')'
 
-    def enable_rmm_pool(self):
-        self.handle.enable_rmm_pool()
-
     def get_param_names(self):
         """
         Returns a list of hyperparameter names owned by this class. It is


### PR DESCRIPTION
This should resolve the confusion caused in the issue https://github.com/rapidsai/raft/issues/228. Tagging @dantegd for review.