### PR TITLE
Update `CHANGELOG.md` [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# cuML 0.20.0 (Date TBD)
+# cuML 21.06.00 (Date TBD)
 
-Please see https://github.com/rapidsai/cuml/releases/tag/v0.20.0a for the latest changes to this development branch.
+Please see https://github.com/rapidsai/cuml/releases/tag/v21.06.00a for the latest changes to this development branch.
 
 # cuML 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
This PR updates the changelog for `branch-0.19`. I think the automated changelog script that we use was overlooked for a few repos during the `0.19` release.
