### PR TITLE
[REVIEW] Add type check for y in train_test_split

### DIFF
--- a/python/cuml/model_selection/_split.py
+++ b/python/cuml/model_selection/_split.py
@@ -476,22 +476,22 @@ def train_test_split(X,
     if hasattr(X, "__cuda_array_interface__") or \
             isinstance(X, cupyx.scipy.sparse.csr_matrix):
         X_train = cp.array(X[0:train_size], order=x_order)
-        if y is not None:
-            y_train = cp.array(y[0:train_size], order=y_order)
-    elif isinstance(X, cudf.DataFrame):
-        X_train = X.iloc[0:train_size]
-        if y is not None:
-            y_train = y.iloc[0:train_size]
-
-    if hasattr(X, "__cuda_array_interface__") or \
-            isinstance(X, cupyx.scipy.sparse.csr_matrix):
         X_test = cp.array(X[-1 * test_size:], order=x_order)
         if y is not None:
+            y_train = cp.array(y[0:train_size], order=y_order)
             y_test = cp.array(y[-1 * test_size:], order=y_order)
     elif isinstance(X, cudf.DataFrame):
+        X_train = X.iloc[0:train_size]
         X_test = X.iloc[-1 * test_size:]
         if y is not None:
-            y_test = y.iloc[-1 * test_size:]
+            if isinstance(y, cudf.Series):
+                y_train = y.iloc[0:train_size]
+                y_test = y.iloc[-1 * test_size:]
+            elif hasattr(y, "__cuda_array_interface__") or \
+                    isinstance(y, cupyx.scipy.sparse.csr_matrix):
+                y_train = cp.array(y[0:train_size], order=y_order)
+                y_test = cp.array(y[-1 * test_size:], order=y_order)
+
     if x_numba:
         X_train = cuda.as_cuda_array(X_train)
         X_test = cuda.as_cuda_array(X_test)

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -57,7 +57,6 @@ def test_split_dataframe(train_size, shuffle):
     assert all(out)
 
 
-
 @pytest.mark.parametrize("y_type", ["cudf", "cupy"])
 def test_split_dataframe_array(y_type):
     X = cudf.DataFrame({"x": range(100)})

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -63,7 +63,7 @@ def test_split_dataframe(train_size, shuffle):
 def test_split_dataframe_array(train_size, shuffle, y_type):
     X = cudf.DataFrame({"x": range(100)})
     y = cudf.Series(([0] * (100 // 2)) + ([1] * (100 // 2)))
-    if y_type == "cudf":
+    if y_type == "cupy":
         X_train, X_test, y_train, y_test = train_test_split(
             X, y.values, train_size=train_size, shuffle=shuffle
         )
@@ -79,7 +79,7 @@ def test_split_dataframe_array(train_size, shuffle, y_type):
         assert isinstance(X_test, cudf.DataFrame)
         assert isinstance(y_train, cp.ndarray)
         assert isinstance(y_test, cp.ndarray)
-    elif y_type == "cupy":
+    elif y_type == "cudf":
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, train_size=train_size, shuffle=shuffle
         )

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -57,23 +57,14 @@ def test_split_dataframe(train_size, shuffle):
     assert all(out)
 
 
-@pytest.mark.parametrize("train_size", [0.2, 0.6, 0.8])
-@pytest.mark.parametrize("shuffle", [True, False])
+
 @pytest.mark.parametrize("y_type", ["cudf", "cupy"])
-def test_split_dataframe_array(train_size, shuffle, y_type):
+def test_split_dataframe_array(y_type):
     X = cudf.DataFrame({"x": range(100)})
     y = cudf.Series(([0] * (100 // 2)) + ([1] * (100 // 2)))
     if y_type == "cupy":
         X_train, X_test, y_train, y_test = train_test_split(
-            X, y.values, train_size=train_size, shuffle=shuffle
-        )
-
-        assert (
-            len(X_train) == len(y_train) == pytest.approx(train_size * len(X))
-        )
-        assert (
-            len(X_test) == len(y_test) == pytest.approx(
-                (1 - train_size) * len(X))
+            X, y.values
         )
         assert isinstance(X_train, cudf.DataFrame)
         assert isinstance(X_test, cudf.DataFrame)
@@ -81,15 +72,7 @@ def test_split_dataframe_array(train_size, shuffle, y_type):
         assert isinstance(y_test, cp.ndarray)
     elif y_type == "cudf":
         X_train, X_test, y_train, y_test = train_test_split(
-            X, y, train_size=train_size, shuffle=shuffle
-        )
-
-        assert (
-            len(X_train) == len(y_train) == pytest.approx(train_size * len(X))
-        )
-        assert (
-            len(X_test) == len(y_test) == pytest.approx(
-                (1 - train_size) * len(X))
+            X, y
         )
         assert isinstance(X_train, cudf.DataFrame)
         assert isinstance(X_test, cudf.DataFrame)

--- a/python/cuml/test/test_train_test_split.py
+++ b/python/cuml/test/test_train_test_split.py
@@ -57,6 +57,46 @@ def test_split_dataframe(train_size, shuffle):
     assert all(out)
 
 
+@pytest.mark.parametrize("train_size", [0.2, 0.6, 0.8])
+@pytest.mark.parametrize("shuffle", [True, False])
+@pytest.mark.parametrize("y_type", ["cudf", "cupy"])
+def test_split_dataframe_array(train_size, shuffle, y_type):
+    X = cudf.DataFrame({"x": range(100)})
+    y = cudf.Series(([0] * (100 // 2)) + ([1] * (100 // 2)))
+    if y_type == "cudf":
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y.values, train_size=train_size, shuffle=shuffle
+        )
+
+        assert (
+            len(X_train) == len(y_train) == pytest.approx(train_size * len(X))
+        )
+        assert (
+            len(X_test) == len(y_test) == pytest.approx(
+                (1 - train_size) * len(X))
+        )
+        assert isinstance(X_train, cudf.DataFrame)
+        assert isinstance(X_test, cudf.DataFrame)
+        assert isinstance(y_train, cp.ndarray)
+        assert isinstance(y_test, cp.ndarray)
+    elif y_type == "cupy":
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, train_size=train_size, shuffle=shuffle
+        )
+
+        assert (
+            len(X_train) == len(y_train) == pytest.approx(train_size * len(X))
+        )
+        assert (
+            len(X_test) == len(y_test) == pytest.approx(
+                (1 - train_size) * len(X))
+        )
+        assert isinstance(X_train, cudf.DataFrame)
+        assert isinstance(X_test, cudf.DataFrame)
+        assert isinstance(y_train, cudf.Series)
+        assert isinstance(y_test, cudf.Series)
+
+
 def test_split_column():
     data = cudf.DataFrame(
         {


### PR DESCRIPTION
Closes https://github.com/rapidsai/cuml/issues/3817

Combing the train and test blocks and checking for type of y before applying the split.