### PR TITLE
Update conda developer environments [skip-ci]

### DIFF
--- a/conda/environments/cuml_dev_cuda10.1.yml
+++ b/conda/environments/cuml_dev_cuda10.1.yml
@@ -6,15 +6,15 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=10.1
-- rapids-build-env=0.20
-- rapids-notebook-env=0.20
-- rapids-doc-env=0.20
-- cudf=0.20.*
-- rmm=0.20.*
-- libcumlprims=0.20.*
-- dask-cudf=0.20.*
-- dask-cuda=0.20.*
-- ucx-py=0.20.*
+- rapids-build-env=21.06
+- rapids-notebook-env=21.06
+- rapids-doc-env=21.06
+- cudf=21.06.*
+- rmm=21.06.*
+- libcumlprims=21.06.*
+- dask-cudf=21.06.*
+- dask-cuda=21.06.*
+- ucx-py=21.06.*
 - ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20

--- a/conda/environments/cuml_dev_cuda10.2.yml
+++ b/conda/environments/cuml_dev_cuda10.2.yml
@@ -6,15 +6,15 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=10.2
-- rapids-build-env=0.20
-- rapids-notebook-env=0.20
-- rapids-doc-env=0.20
-- cudf=0.20.*
-- rmm=0.20.*
-- libcumlprims=0.20.*
-- dask-cudf=0.20.*
-- dask-cuda=0.20.*
-- ucx-py=0.20.*
+- rapids-build-env=21.06
+- rapids-notebook-env=21.06
+- rapids-doc-env=21.06
+- cudf=21.06.*
+- rmm=21.06.*
+- libcumlprims=21.06.*
+- dask-cudf=21.06.*
+- dask-cuda=21.06.*
+- ucx-py=21.06.*
 - ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -6,15 +6,15 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.0
-- rapids-build-env=0.20
-- rapids-notebook-env=0.20
-- rapids-doc-env=0.20
-- cudf=0.20.*
-- rmm=0.20.*
-- libcumlprims=0.20.*
-- dask-cudf=0.20.*
-- dask-cuda=0.20.*
-- ucx-py=0.20.*
+- rapids-build-env=21.06
+- rapids-notebook-env=21.06
+- rapids-doc-env=21.06
+- cudf=21.06.*
+- rmm=21.06.*
+- libcumlprims=21.06.*
+- dask-cudf=21.06.*
+- dask-cuda=21.06.*
+- ucx-py=21.06.*
 - ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -6,15 +6,15 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.2
-- rapids-build-env=0.20
-- rapids-notebook-env=0.20
-- rapids-doc-env=0.20
-- cudf=0.20.*
-- rmm=0.20.*
-- libcumlprims=0.20.*
-- dask-cudf=0.20.*
-- dask-cuda=0.20.*
-- ucx-py=0.20.*
+- rapids-build-env=21.06
+- rapids-notebook-env=21.06
+- rapids-doc-env=21.06
+- cudf=21.06.*
+- rmm=21.06.*
+- libcumlprims=21.06.*
+- dask-cudf=21.06.*
+- dask-cuda=21.06.*
+- ucx-py=21.06.*
 - ucx-proc=*=gpu
 - dask-ml
 - doxygen>=1.8.20


### PR DESCRIPTION
Updates conda dependencies from `0.20` to `21.06`.