### PR TITLE
Correct install path for include folder to avoid double nesting

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -71,12 +71,6 @@ if [ "$py_ver" == "3.6" ];then
     conda install contextvars
 fi
 
-gpuci_logger "Install the main version of dask and distributed"
-set -x
-pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
-set +x
-
 gpuci_logger "Check compiler versions"
 python --version
 $CC --version
@@ -125,6 +119,12 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
 
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
     export LD_LIBRARY_PATH_CACHED=""
+
+    gpuci_logger "Install the main version of dask and distributed"
+    set -x
+    pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+    pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
+    set +x
 
     gpuci_logger "Python pytest for cuml"
     cd $WORKSPACE/python
@@ -192,6 +192,12 @@ else
     CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
     gpuci_logger "Installing $CONDA_FILE"
     conda install -c ${CONDA_ARTIFACT_PATH} "$CONDA_FILE"
+
+    gpuci_logger "Install the main version of dask and distributed"
+    set -x
+    pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+    pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
+    set +x
 
     gpuci_logger "Building cuml"
     "$WORKSPACE/build.sh" -v cuml --codecov

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -414,7 +414,7 @@ install(TARGETS
           cuml-exports)
 
 install(DIRECTORY include/
-        DESTINATION include/cuml)
+        DESTINATION include)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/cuml/version_config.hpp
         DESTINATION include/cuml)


### PR DESCRIPTION
Small oversight with the CMake changes, there already is a `cuml` folder in our `cpp/include`, so we were double nesting it. After the fix we're back to the old (expected) behavior, and consistent with RMM and cuDF. 

cc @hcho3 @wphicks 