### PR TITLE
[REVIEW] Fix for multi GPU PCA compute failing bug after transform and added error handling when n_components is not passed

### DIFF
--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -30,7 +30,6 @@ from cython.operator cimport dereference as deref
 
 from cuml.common.array import CumlArray
 import cuml.common.opg_data_utils_mg as opg
-import cuml.common.logger as logger
 import cuml.internals
 from cuml.common.base import Base
 from cuml.raft.common.handle cimport handle_t
@@ -60,15 +59,7 @@ class BaseDecompositionMG(object):
         self._set_n_features_in(n_cols)
 
         if self.n_components is None:
-            # logger.warn(
-            #    'Warning(`fit`): As of v0.16, PCA invoked without an'
-            #    ' n_components argument defauts to using'
-            #    ' min(n_samples, n_features) rather than 1'
-            # )
-            # n_rows = total_rows
-            # n_cols = n_cols
-            # self._n_components = min(n_rows, n_cols)
-            self._n_components = 1
+            self._n_components = min(total_rows, n_cols)
         else:
             self._n_components = self.n_components
 

--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ class BaseDecompositionMG(object):
             self._n_components = 1
         else:
             self._n_components = self.n_components
-        
+
         X_arys = []
         for i in range(len(X)):
             if i == 0:

--- a/python/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/decomposition/pca_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/decomposition/pca_mg.pyx
@@ -116,7 +116,7 @@ class PCAMG(BaseDecompositionMG, PCA):
 
     def _build_params(self, n_rows, n_cols):
         cpdef paramsPCAMG *params = new paramsPCAMG()
-        params.n_components = self.n_components
+        params.n_components = self._n_components
         params.n_rows = n_rows
         params.n_cols = n_cols
         params.whiten = self.whiten

--- a/python/cuml/test/dask/test_pca.py
+++ b/python/cuml/test/dask/test_pca.py
@@ -87,7 +87,10 @@ def test_pca_fit_transform_fp32(nrows, ncols, n_parts, client):
                            random_state=10, dtype=np.float32)
 
     cupca = daskPCA(n_components=20, whiten=True)
-    cupca.fit_transform(X_cudf)
+    res = cupca.fit_transform(X_cudf)
+    res = res.compute()
+    assert res.shape[0] == nrows and res.shape[1]==20
+
 
 
 @pytest.mark.mg
@@ -107,4 +110,29 @@ def test_pca_fit_transform_fp64(nrows, ncols, n_parts, client):
                            random_state=10, dtype=np.float64)
 
     cupca = daskPCA(n_components=30, whiten=False)
-    cupca.fit_transform(X_cudf)
+    res = cupca.fit_transform(X_cudf)
+    res = res.compute()
+    assert res.shape[0] == nrows and res.shape[1]==30
+
+
+@pytest.mark.mg
+@pytest.mark.parametrize("nrows", [1000])
+@pytest.mark.parametrize("ncols", [20])
+@pytest.mark.parametrize("n_parts", [28])
+def test_pca_fit_transform_fp32_noncomponents(nrows, ncols, n_parts, client):
+    # Tests the case when n_components is not passed for MG scenarios
+    from cuml.dask.decomposition import PCA as daskPCA
+    from cuml.dask.datasets import make_blobs
+
+    X_cudf, _ = make_blobs(n_samples=nrows,
+                           n_features=ncols,
+                           centers=1,
+                           n_parts=n_parts,
+                           cluster_std=1.5,
+                           random_state=10, dtype=np.float32)
+
+    cupca = daskPCA(whiten=False)
+    res = cupca.fit_transform(X_cudf)
+    res = res.compute()
+    assert res.shape[0] == nrows and res.shape[1]==1 #20
+

--- a/python/cuml/test/dask/test_pca.py
+++ b/python/cuml/test/dask/test_pca.py
@@ -133,4 +133,4 @@ def test_pca_fit_transform_fp32_noncomponents(nrows, ncols, n_parts, client):
     cupca = daskPCA(whiten=False)
     res = cupca.fit_transform(X_cudf)
     res = res.compute()
-    assert res.shape[0] == nrows and res.shape[1] == 1  # 20
+    assert res.shape[0] == nrows and res.shape[1] == 20

--- a/python/cuml/test/dask/test_pca.py
+++ b/python/cuml/test/dask/test_pca.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,8 +89,7 @@ def test_pca_fit_transform_fp32(nrows, ncols, n_parts, client):
     cupca = daskPCA(n_components=20, whiten=True)
     res = cupca.fit_transform(X_cudf)
     res = res.compute()
-    assert res.shape[0] == nrows and res.shape[1]==20
-
+    assert res.shape[0] == nrows and res.shape[1] == 20
 
 
 @pytest.mark.mg
@@ -112,7 +111,7 @@ def test_pca_fit_transform_fp64(nrows, ncols, n_parts, client):
     cupca = daskPCA(n_components=30, whiten=False)
     res = cupca.fit_transform(X_cudf)
     res = res.compute()
-    assert res.shape[0] == nrows and res.shape[1]==30
+    assert res.shape[0] == nrows and res.shape[1] == 30
 
 
 @pytest.mark.mg
@@ -134,5 +133,4 @@ def test_pca_fit_transform_fp32_noncomponents(nrows, ncols, n_parts, client):
     cupca = daskPCA(whiten=False)
     res = cupca.fit_transform(X_cudf)
     res = res.compute()
-    assert res.shape[0] == nrows and res.shape[1]==1 #20
-
+    assert res.shape[0] == nrows and res.shape[1] == 1  # 20


### PR DESCRIPTION
 This PR fixes #3913 where Multi GPU PCA is failing on calling compute() after transform. 

This fix is similar to what has been done in a previous PR #3320 . The current PR :

1. Fixes the problem of `AttributeError` when calling `compute()` after `transform()` while using `cuml.dask.decomposition.PCA`
2. Added setting of `n_components=1` when n_components is not set in the multi GPU case.  (The tests were failing if I don't set n_components, however, I did not find a place where n_component is set to 1. I may be wrong.  PR #3320 seems to fix `n_component=min(n_cols, n_rows` as of 0.16 for single GPU. Not entirely sure if that should also be the case for MG as well. )
3. Added test cases for the above two changes. 