### PR TITLE
Fix typo in umap `target_weight` parameter

### DIFF
--- a/cpp/include/cuml/manifold/umapparams.h
+++ b/cpp/include/cuml/manifold/umapparams.h
@@ -146,7 +146,7 @@ class UMAPParams {
 
   MetricType target_metric = CATEGORICAL;
 
-  float target_weights = 0.5;
+  float target_weight = 0.5;
 
   uint64_t random_state = 0;
 

--- a/cpp/src/umap/supervised.cuh
+++ b/cpp/src/umap/supervised.cuh
@@ -221,8 +221,8 @@ void perform_categorical_intersection(
   UMAPParams *params, std::shared_ptr<raft::mr::device::allocator> d_alloc,
   cudaStream_t stream) {
   float far_dist = 1.0e12;  // target weight
-  if (params->target_weights < 1.0)
-    far_dist = 2.5 * (1.0 / (1.0 - params->target_weights));
+  if (params->target_weight < 1.0)
+    far_dist = 2.5 * (1.0 / (1.0 - params->target_weight));
 
   categorical_simplicial_set_intersection<T, TPB_X>(rgraph_coo, y, stream,
                                                     far_dist);
@@ -314,7 +314,7 @@ void perform_general_intersection(const raft::handle_t &handle, value_t *y,
   raft::sparse::COO<value_t> result_coo(d_alloc, stream);
   general_simplicial_set_intersection<value_t, TPB_X>(
     xrow_ind.data(), rgraph_coo, yrow_ind.data(), &cygraph_coo, &result_coo,
-    params->target_weights, d_alloc, stream);
+    params->target_weight, d_alloc, stream);
 
   /**
    * Remove zeros

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -97,7 +97,7 @@ cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
         int init,
         int target_n_neighbors,
         MetricType target_metric,
-        float target_weights,
+        float target_weight,
         uint64_t random_state,
         bool deterministic,
         int optim_batch_size,
@@ -350,13 +350,14 @@ class UMAP(Base,
                  a=None,
                  b=None,
                  target_n_neighbors=-1,
-                 target_weights=0.5,
+                 target_weight=0.5,
                  target_metric="categorical",
                  handle=None,
                  hash_input=False,
                  random_state=None,
                  callback=None,
-                 output_type=None):
+                 output_type=None,
+                 target_weights=None):
 
         super().__init__(handle=handle,
                          verbose=verbose,
@@ -388,7 +389,16 @@ class UMAP(Base,
         self.negative_sample_rate = negative_sample_rate
         self.transform_queue_size = transform_queue_size
         self.target_n_neighbors = target_n_neighbors
-        self.target_weights = target_weights
+        if target_weights is not None:
+            import warnings
+            warnings.warn("Parameter 'target_weights' is deprecated and"
+                          " will be removed in 21.08. Please use"
+                          " 'target_weight' instead. Setting 'target_weight'"
+                          " as the curent 'target_weights' value",
+                          DeprecationWarning)
+            self.target_weight = target_weights
+        else:
+            self.target_weight = target_weight
 
         self.deterministic = random_state is not None
 
@@ -453,7 +463,7 @@ class UMAP(Base,
             umap_params.target_metric = MetricType.EUCLIDEAN
         else:  # self.target_metric == "categorical"
             umap_params.target_metric = MetricType.CATEGORICAL
-        umap_params.target_weights = <float> cls.target_weights
+        umap_params.target_weight = <float> cls.target_weight
         umap_params.random_state = <uint64_t> cls.random_state
         umap_params.deterministic = <bool> cls.deterministic
 
@@ -871,7 +881,7 @@ class UMAP(Base,
             "a",
             "b",
             "target_n_neighbors",
-            "target_weights",
+            "target_weight",
             "target_metric",
             "hash_input",
             "random_state",

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -172,7 +172,7 @@ def test_base_children_get_param_names(child_class: str):
         # Now ensure the base parameters are included in get_param_names
         for name, param in sig.parameters.items():
             if child_class == 'UMAP' and name == 'target_weights':
-                continue # Temporary fix to be removed in 21.08. See #3914
+                continue  # Temporary fix to be removed in 21.08. See #3914
 
             if (param.kind == inspect.Parameter.VAR_KEYWORD
                     or param.kind == inspect.Parameter.VAR_POSITIONAL):

--- a/python/cuml/test/test_base.py
+++ b/python/cuml/test/test_base.py
@@ -171,6 +171,8 @@ def test_base_children_get_param_names(child_class: str):
 
         # Now ensure the base parameters are included in get_param_names
         for name, param in sig.parameters.items():
+            if child_class == 'UMAP' and name == 'target_weights':
+                continue # Temporary fix to be removed in 21.08. See #3914
 
             if (param.kind == inspect.Parameter.VAR_KEYWORD
                     or param.kind == inspect.Parameter.VAR_POSITIONAL):


### PR DESCRIPTION
Closes #3748.
This will fix the UMAP argument in the Python and C++ side to stay consistent.