### PR TITLE
Fix number of permutations in pytest and getting handle for cuml models 

### DIFF
--- a/python/cuml/explainer/common.py
+++ b/python/cuml/explainer/common.py
@@ -66,11 +66,10 @@ def get_handle_from_cuml_model_func(func, create_new=False):
     owner = getattr(func, '__self__', None)
 
     if owner is not None and isinstance(owner, cuml.common.base.Base):
-        handle = owner.handle
+        if owner.handle is not None:
+            return owner.handle
 
-    else:
-        handle = cuml.raft.common.handle.Handle() if create_new else None
-
+    handle = cuml.raft.common.handle.Handle() if create_new else None
     return handle
 
 

--- a/python/cuml/test/explainer/test_explainer_common.py
+++ b/python/cuml/test/explainer/test_explainer_common.py
@@ -145,11 +145,9 @@ def test_get_handle_from_cuml_model_func(model):
     mod = create_dummy_model(model)
 
     handle = get_handle_from_cuml_model_func(mod.get_param_names,
-                                             create_new=False)
+                                             create_new=True)
 
-    # Naive Bayes does not use a handle currently
-    if model != cuml.naive_bayes.naive_bayes.MultinomialNB:
-        assert isinstance(handle, cuml.raft.common.handle.Handle)
+    assert isinstance(handle, cuml.raft.common.handle.Handle)
 
 
 @pytest.mark.parametrize("create_new", [True, False])

--- a/python/cuml/test/explainer/test_explainer_permutation_shap.py
+++ b/python/cuml/test/explainer/test_explainer_permutation_shap.py
@@ -92,9 +92,10 @@ def test_exact_classification_datasets(exact_shap_classification_dataset):
 @pytest.mark.parametrize("n_background", [10, 50])
 @pytest.mark.parametrize("model", [cuml.LinearRegression,
                                    cuml.SVR])
-@pytest.mark.parametrize("npermutations", [5, 50])
+@pytest.mark.parametrize("npermutations", [20])
+@pytest.mark.parametrize("reps", np.arange(1000))
 def test_different_parameters(dtype, n_features, n_background, model,
-                              npermutations):
+                              npermutations, reps):
     cp.random.seed(42)
     X_train, X_test, y_train, y_test = create_synthetic_dataset(
         n_samples=n_background + 5,

--- a/python/cuml/test/explainer/test_explainer_permutation_shap.py
+++ b/python/cuml/test/explainer/test_explainer_permutation_shap.py
@@ -93,9 +93,8 @@ def test_exact_classification_datasets(exact_shap_classification_dataset):
 @pytest.mark.parametrize("model", [cuml.LinearRegression,
                                    cuml.SVR])
 @pytest.mark.parametrize("npermutations", [20])
-@pytest.mark.parametrize("reps", np.arange(1000))
 def test_different_parameters(dtype, n_features, n_background, model,
-                              npermutations, reps):
+                              npermutations):
     cp.random.seed(42)
     X_train, X_test, y_train, y_test = create_synthetic_dataset(
         n_samples=n_background + 5,


### PR DESCRIPTION
Closes #3819 
Bug fixes:

- Increase npermutations in pytest (and reduce number of tests a bit), to avoid sporadic failure
- Simplified code in common avoids a problem for cuML models that have handle as `none` (Naive Bayes)