### PR TITLE
Upgrade xgboost to 1.4.2

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -55,7 +55,7 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
       "ucx-proc=*=gpu" \
-      "xgboost=1.4.0dev.rapidsai${MINOR_VERSION}" \
+      "xgboost=1.4.2dev.rapidsai${MINOR_VERSION}" \
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*" \


### PR DESCRIPTION
Nightly versions of xgboost-1.4.2dev.rapidsai21.06 have been available for a little bit, this PR updates that to run tests in CI. 