### PR TITLE
Use clang-tools on x86 only

### DIFF
--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -35,8 +35,8 @@ build:
 requirements:
   build:
     - cmake>=3.20.1
-    - clang=8.0.1
-    - clang-tools=8.0.1
+    - clang=8.0.1        # [x86_64]
+    - clang-tools=8.0.1  # [x86_64]
   host:
     - nccl>=2.9.9
     - cudf {{ minor_version }}

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 import argparse
 import tempfile
+import shutil
 
 
 EXPECTED_VERSION = "8.0.1"
@@ -129,6 +130,12 @@ def main():
         sys.exit(-1)
     all_files = list_all_src_files(args.regex_compiled, args.ignore_compiled,
                                    args.dirs, args.dstdir, args.inplace)
+
+    # Check whether clang-format exists
+    if shutil.which("clang-format") is None:
+        print("clang-format not found. Exiting...")
+        return
+
     # actual format checker
     status = True
     for src, dst in all_files:

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -20,6 +20,7 @@ import subprocess
 import argparse
 import json
 import multiprocessing as mp
+import shutil
 
 
 EXPECTED_VERSION = "8.0.1"
@@ -237,6 +238,10 @@ def main():
     # Attempt to making sure that we run this script from root of repo always
     if not os.path.exists(".git"):
         raise Exception("This needs to always be run from the root of repo")
+    # Check whether clang-tidy exists
+    if shutil.which("clang-tidy") is not None:
+        print("clang-tidy not found. Exiting...")
+        return
     all_files = get_all_commands(args.cdb)
     status = run_tidy_for_all_files(args, all_files)
     if not status:


### PR DESCRIPTION
Since there is a specific version of `clang-tools` we need and it may be difficult to migrate that to other architectures, restrict installing `clang-tools` to x86. After all this is only needed for checking code style, which can be done just on x86 without loss of generality.