### PR TITLE
Maintain uppercase cmake project name [skip-ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -30,7 +30,7 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-sed_runner 's/'"CUML VERSION .* LANGUAGES"'/'"cuML VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"CUML VERSION .* LANGUAGES"'/'"CUML VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
 # RTD update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
 sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py


### PR DESCRIPTION
Fixes `update-version.sh` so that the `CUML` is maintained in CMakeLists.txt.

Note: this should be merged into `branch-21.06` in case we need to hotfix `v21.06`.