### PR TITLE
Update `treelite` version in `get_treelite.cmake`

### DIFF
--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -45,4 +45,4 @@ function(find_and_configure_treelite)
 endfunction()
 
 find_and_configure_treelite(VERSION     1.3.0
-                        PINNED_TAG  342be01cde4fd99f81e529c1a0c85c496b2a3226)
+                        PINNED_TAG  ae5436c45563a5c2ed7aa8f0f41f88fff48f49e4)

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-function(find_and_configure_nccl)
+function(find_and_configure_treelite)
 
     if(TARGET treelite::treelite)
         return()
@@ -44,5 +44,5 @@ function(find_and_configure_nccl)
 
 endfunction()
 
-find_and_configure_nccl(VERSION     1.1.0
+find_and_configure_treelite(VERSION     1.3.0
                         PINNED_TAG  342be01cde4fd99f81e529c1a0c85c496b2a3226)


### PR DESCRIPTION
This PR updates `get_treelite.cmake` to use `treelite` version `1.3.0`, similarly to #3855.