### PR TITLE
[FIX] Add Treelite_BINARY_DIR include to `cuml++` build interface include paths

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -321,6 +321,7 @@ if(BUILD_CUML_CPP_LIBRARY)
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:$<$<BOOL:${ENABLE_CUMLPRIMS_MG}>:${cumlprims_mg_INCLUDE_DIRS}>>
+      $<BUILD_INTERFACE:$<$<BOOL:Treelite_ADDED>:${Treelite_BINARY_DIR}/include>>
       $<$<BOOL:Treelite_ADDED>:${Treelite_SOURCE_DIR}/include>
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>


### PR DESCRIPTION
This PR fixes an issue causing cuML source builds to fail when CPM adds Treelite.

Treelite's generated include path isn't in their `INTERFACE_INCLUDE_DIRECTORIES`, so this path isn't added to the `cuml++` target's include dirs either. The fix is to add Treelite's generated include path to the `cuml++` target.

```shell
In file included from _deps/cuml-src/cpp/src/decisiontree/decisiontree_impl.cuh:20,
                 from _deps/cuml-src/cpp/src/decisiontree/decisiontree.cu:22:
_deps/treelite-src/include/treelite/tree.h:11:10: fatal error: treelite/version.h: No such file or directory
   11 | #include <treelite/version.h>
```