### PR TITLE
Fixing intermittent HBDSCAN pytest failure in CI

### DIFF
--- a/cpp/src/hdbscan/runner.h
+++ b/cpp/src/hdbscan/runner.h
@@ -71,7 +71,14 @@ struct FixConnectivitiesRedOp {
     if (rit < m && a.key > -1 && colors[rit] != colors[a.key]) {
       value_t core_dist_rit = core_dists[rit];
       value_t core_dist_a = max(core_dist_rit, max(core_dists[a.key], a.value));
-      value_t core_dist_b = max(core_dist_rit, max(core_dists[b.key], b.value));
+      
+      value_t core_dist_b;
+      if (b.key > -1) {
+        core_dist_b = max(core_dist_rit, max(core_dists[b.key], b.value));
+      }
+      else {
+        core_dist_b = b.value;
+      }
 
       return core_dist_a < core_dist_b ? KVP(a.key, core_dist_a)
                                        : KVP(b.key, core_dist_b);

--- a/cpp/src/hdbscan/runner.h
+++ b/cpp/src/hdbscan/runner.h
@@ -71,12 +71,11 @@ struct FixConnectivitiesRedOp {
     if (rit < m && a.key > -1 && colors[rit] != colors[a.key]) {
       value_t core_dist_rit = core_dists[rit];
       value_t core_dist_a = max(core_dist_rit, max(core_dists[a.key], a.value));
-      
+
       value_t core_dist_b;
       if (b.key > -1) {
         core_dist_b = max(core_dist_rit, max(core_dists[b.key], b.value));
-      }
-      else {
+      } else {
         core_dist_b = b.value;
       }
 


### PR DESCRIPTION
There was an OOB access occurring here https://github.com/rapidsai/cuml/blob/f7fb363b6c2e175e8b2a32f4233c520e2ec1510d/cpp/src/hdbscan/runner.h#L74 when `b.key == 1`. This error was getting swallowed up and we were seeing those `thrust::transform` errors in CI.

Tagging @cjnolet to confirm if this is the intended way to use this functor and the fix is correct.