### PR TITLE
[FIX] Always add `faiss` library alias if it's missing

### DIFF
--- a/cpp/cmake/thirdparty/get_faiss.cmake
+++ b/cpp/cmake/thirdparty/get_faiss.cmake
@@ -40,7 +40,10 @@ function(find_and_configure_faiss)
 
     if(FAISS_ADDED)
       target_include_directories(faiss INTERFACE $<BUILD_INTERFACE:${FAISS_SOURCE_DIR}>)
-      add_library(FAISS::FAISS ALIAS faiss)
+    endif()
+
+    if(TARGET faiss AND NOT TARGET FAISS::FAISS)
+        add_library(FAISS::FAISS ALIAS faiss)
     endif()
 
 endfunction()


### PR DESCRIPTION
Always add the `FAISS::FAISS` library target alias if it doesn't exist. This can happen if cuGraph is built and installs FAISS before cuML.

https://github.com/rapidsai/cugraph/pull/1694