### PR TITLE
Fixing -1 key access in 1nn reduce op in HDBSCAN

### DIFF
--- a/cpp/src/hdbscan/runner.h
+++ b/cpp/src/hdbscan/runner.h
@@ -58,7 +58,13 @@ struct FixConnectivitiesRedOp {
         colors[rit] != colors[other.key]) {
       value_t core_dist_rit   = core_dists[rit];
       value_t core_dist_other = max(core_dist_rit, max(core_dists[other.key], other.value));
-      value_t core_dist_out   = max(core_dist_rit, max(core_dists[out->key], out->value));
+
+      value_t core_dist_out;
+      if (out->key > -1) {
+        core_dist_out = max(core_dist_rit, max(core_dists[out->key], out->value));
+      } else {
+        core_dist_out = out->value;
+      }
 
       bool smaller = core_dist_other < core_dist_out;
       out->key     = smaller ? other.key : out->key;


### PR DESCRIPTION
closes #4025 again. This is happening because the underlying assumptions in the fused-1nn have likely changed, and that trickles down to HDBSCAN and the functors we use for accessing that API - as discussed with @cjnolet 