### PR TITLE
Compiling cuML with per thread default stream

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -22,7 +22,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif()
 
-list(APPEND CUML_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
+list(APPEND CUML_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr --default-stream per-thread)
 
 # set warnings as errors
 # list(APPEND CUML_CUDA_FLAGS -Werror=cross-execution-space-call)

--- a/cpp/src/svm/workingset.cuh
+++ b/cpp/src/svm/workingset.cuh
@@ -427,7 +427,8 @@ class WorkingSet {
                                available_sorted.data(),
                                idx_tmp.data(),
                                d_num_selected,
-                               n_train);
+                               n_train,
+                               stream);
     int n_selected;
     raft::update_host(&n_selected, d_num_selected, 1, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -475,7 +476,8 @@ class WorkingSet {
                           ws_idx_selected.data(),
                           d_num_selected,
                           n_ws,
-                          op);
+                          op,
+                          stream);
     int n_selected;
     raft::update_host(&n_selected, d_num_selected, 1, stream);
     CUDA_CHECK(cudaStreamSynchronize(stream));

--- a/cpp/test/sg/lars_test.cu
+++ b/cpp/test/sg/lars_test.cu
@@ -80,10 +80,12 @@ class LarsTest : public ::testing::Test {
                                    stream);
     EXPECT_EQ(n_active, 3);
 
-    EXPECT_TRUE(raft::devArrMatchHost(cor_exp, cor.data(), n_cols, raft::Compare<math_t>()));
-    EXPECT_TRUE(raft::devArrMatchHost(G_exp, G.data(), n_cols * n_cols, raft::Compare<math_t>()));
     EXPECT_TRUE(
-      raft::devArrMatch((math_t)1.0, sign.data() + n_active - 1, 1, raft::Compare<math_t>()));
+      raft::devArrMatchHost(cor_exp, cor.data(), n_cols, raft::Compare<math_t>(), stream));
+    EXPECT_TRUE(
+      raft::devArrMatchHost(G_exp, G.data(), n_cols * n_cols, raft::Compare<math_t>(), stream));
+    EXPECT_TRUE(raft::devArrMatch(
+      (math_t)1.0, sign.data() + n_active - 1, 1, raft::Compare<math_t>(), stream));
 
     // Do it again with G == nullptr to test if X is properly changed
     n_active = 2;
@@ -100,7 +102,8 @@ class LarsTest : public ::testing::Test {
                                    n_cols,
                                    sign.data(),
                                    stream);
-    EXPECT_TRUE(raft::devArrMatchHost(X_exp, X.data(), n_rows * n_cols, raft::Compare<math_t>()));
+    EXPECT_TRUE(
+      raft::devArrMatchHost(X_exp, X.data(), n_rows * n_cols, raft::Compare<math_t>(), stream));
   }
 
   void calcUExp(math_t* G, int n_cols, math_t* U_dev_exp)
@@ -173,7 +176,7 @@ class LarsTest : public ::testing::Test {
                                      eps,
                                      stream);
     EXPECT_TRUE(raft::devArrMatch(
-      U_dev_exp.data(), U.data(), n_cols * n_cols, raft::CompareApprox<math_t>(1e-5)));
+      U_dev_exp.data(), U.data(), n_cols * n_cols, raft::CompareApprox<math_t>(1e-5), stream));
 
     // Next test where G and U are separate arrays
     initGU(U.data(), G.data(), U_dev_exp.data(), n_active, false);
@@ -191,7 +194,7 @@ class LarsTest : public ::testing::Test {
                                      eps,
                                      stream);
     EXPECT_TRUE(raft::devArrMatch(
-      U_dev_exp.data(), U.data(), n_cols * n_cols, raft::CompareApprox<math_t>(1e-5)));
+      U_dev_exp.data(), U.data(), n_cols * n_cols, raft::CompareApprox<math_t>(1e-5), stream));
 
     // Third test without Gram matrix.
     initGU(U.data(), G.data(), U_dev_exp.data(), n_active, false);
@@ -209,7 +212,7 @@ class LarsTest : public ::testing::Test {
                                      eps,
                                      stream);
     EXPECT_TRUE(raft::devArrMatch(
-      U_dev_exp.data(), U.data(), n_cols * n_cols, raft::CompareApprox<math_t>(1e-4)));
+      U_dev_exp.data(), U.data(), n_cols * n_cols, raft::CompareApprox<math_t>(1e-4), stream));
   }
 
   void testCalcW0()
@@ -223,8 +226,8 @@ class LarsTest : public ::testing::Test {
 
     ML::Solver::Lars::calcW0(
       handle, n_active, n_cols, sign.data(), U.data(), ld_U, ws.data(), stream);
-    EXPECT_TRUE(
-      raft::devArrMatchHost(ws0_exp, ws.data(), n_active, raft::CompareApprox<math_t>(1e-3)));
+    EXPECT_TRUE(raft::devArrMatchHost(
+      ws0_exp, ws.data(), n_active, raft::CompareApprox<math_t>(1e-3), stream));
   }
 
   void testCalcA()
@@ -235,7 +238,7 @@ class LarsTest : public ::testing::Test {
 
     ML::Solver::Lars::calcA(handle, A.data(), n_active, sign.data(), ws.data(), stream);
     EXPECT_TRUE(raft::devArrMatch(
-      (math_t)0.20070615686577709, A.data(), 1, raft::CompareApprox<math_t>(1e-6)));
+      (math_t)0.20070615686577709, A.data(), 1, raft::CompareApprox<math_t>(1e-6), stream));
   }
 
   void testEquiangular()
@@ -268,8 +271,8 @@ class LarsTest : public ::testing::Test {
                                          (math_t)-1,
                                          stream);
 
-    EXPECT_TRUE(
-      raft::devArrMatchHost(ws_exp, ws.data(), n_active, raft::CompareApprox<math_t>(1e-3)));
+    EXPECT_TRUE(raft::devArrMatchHost(
+      ws_exp, ws.data(), n_active, raft::CompareApprox<math_t>(1e-3), stream));
 
     EXPECT_TRUE(raft::devArrMatch(
       (math_t)0.20070615686577709, A.data(), 1, raft::CompareApprox<math_t>(1e-4)));
@@ -294,7 +297,8 @@ class LarsTest : public ::testing::Test {
                                          (math_t)-1,
                                          stream);
 
-    EXPECT_TRUE(raft::devArrMatchHost(u_eq_exp, u_eq.data(), 1, raft::CompareApprox<math_t>(1e-3)));
+    EXPECT_TRUE(
+      raft::devArrMatchHost(u_eq_exp, u_eq.data(), 1, raft::CompareApprox<math_t>(1e-3), stream));
   }
 
   void testCalcMaxStep()
@@ -336,10 +340,11 @@ class LarsTest : public ::testing::Test {
                                   a_vec.data(),
                                   stream);
     math_t gamma_exp = 0.20095407186830386;
-    EXPECT_TRUE(raft::devArrMatch(gamma_exp, gamma.data(), 1, raft::CompareApprox<math_t>(1e-6)));
+    EXPECT_TRUE(
+      raft::devArrMatch(gamma_exp, gamma.data(), 1, raft::CompareApprox<math_t>(1e-6), stream));
     math_t a_vec_exp[2] = {24.69447886, -139.66289908};
     EXPECT_TRUE(raft::devArrMatchHost(
-      a_vec_exp, a_vec.data(), a_vec.size(), raft::CompareApprox<math_t>(1e-4)));
+      a_vec_exp, a_vec.data(), a_vec.size(), raft::CompareApprox<math_t>(1e-4), stream));
 
     // test without G matrix, we use U as input in this case
     CUDA_CHECK(cudaMemsetAsync(gamma.data(), 0, sizeof(math_t), stream));
@@ -361,9 +366,10 @@ class LarsTest : public ::testing::Test {
                                   gamma.data(),
                                   a_vec.data(),
                                   stream);
-    EXPECT_TRUE(raft::devArrMatch(gamma_exp, gamma.data(), 1, raft::CompareApprox<math_t>(1e-6)));
+    EXPECT_TRUE(
+      raft::devArrMatch(gamma_exp, gamma.data(), 1, raft::CompareApprox<math_t>(1e-6), stream));
     EXPECT_TRUE(raft::devArrMatchHost(
-      a_vec_exp, a_vec.data(), a_vec.size(), raft::CompareApprox<math_t>(1e-4)));
+      a_vec_exp, a_vec.data(), a_vec.size(), raft::CompareApprox<math_t>(1e-4), stream));
 
     // Last iteration
     n_active = max_iter;
@@ -386,7 +392,8 @@ class LarsTest : public ::testing::Test {
                                   a_vec.data(),
                                   stream);
     gamma_exp = 11.496044516528272;
-    EXPECT_TRUE(raft::devArrMatch(gamma_exp, gamma.data(), 1, raft::CompareApprox<math_t>(1e-6)));
+    EXPECT_TRUE(
+      raft::devArrMatch(gamma_exp, gamma.data(), 1, raft::CompareApprox<math_t>(1e-6), stream));
   }
 
   raft::handle_t handle;
@@ -490,12 +497,12 @@ class LarsTestFitPredict : public ::testing::Test {
                               n_cols,
                               (math_t)-1);
     EXPECT_EQ(n_cols, n_active);
-    EXPECT_TRUE(
-      raft::devArrMatchHost(beta_exp, beta.data(), n_cols, raft::CompareApprox<math_t>(1e-5)));
     EXPECT_TRUE(raft::devArrMatchHost(
-      alphas_exp, alphas.data(), n_cols + 1, raft::CompareApprox<math_t>(1e-4)));
+      beta_exp, beta.data(), n_cols, raft::CompareApprox<math_t>(1e-5), stream));
+    EXPECT_TRUE(raft::devArrMatchHost(
+      alphas_exp, alphas.data(), n_cols + 1, raft::CompareApprox<math_t>(1e-4), stream));
     EXPECT_TRUE(
-      raft::devArrMatchHost(indices_exp, active_idx.data(), n_cols, raft::Compare<int>()));
+      raft::devArrMatchHost(indices_exp, active_idx.data(), n_cols, raft::Compare<int>(), stream));
   }
 
   void testFitX()
@@ -520,12 +527,12 @@ class LarsTestFitPredict : public ::testing::Test {
                               n_cols,
                               (math_t)-1);
     EXPECT_EQ(n_cols, n_active);
-    EXPECT_TRUE(
-      raft::devArrMatchHost(beta_exp, beta.data(), n_cols, raft::CompareApprox<math_t>(2e-4)));
     EXPECT_TRUE(raft::devArrMatchHost(
-      alphas_exp, alphas.data(), n_cols + 1, raft::CompareApprox<math_t>(1e-4)));
+      beta_exp, beta.data(), n_cols, raft::CompareApprox<math_t>(2e-4), stream));
+    EXPECT_TRUE(raft::devArrMatchHost(
+      alphas_exp, alphas.data(), n_cols + 1, raft::CompareApprox<math_t>(1e-4), stream));
     EXPECT_TRUE(
-      raft::devArrMatchHost(indices_exp, active_idx.data(), n_cols, raft::Compare<int>()));
+      raft::devArrMatchHost(indices_exp, active_idx.data(), n_cols, raft::Compare<int>(), stream));
   }
 
   void testPredictV1()
@@ -547,7 +554,7 @@ class LarsTestFitPredict : public ::testing::Test {
                                   intercept,
                                   y.data());
     EXPECT_TRUE(
-      raft::devArrMatchHost(pred_exp, y.data(), n_rows, raft::CompareApprox<math_t>(1e-5)));
+      raft::devArrMatchHost(pred_exp, y.data(), n_rows, raft::CompareApprox<math_t>(1e-5), stream));
   }
 
   void testPredictV2()
@@ -573,7 +580,7 @@ class LarsTestFitPredict : public ::testing::Test {
                                   intercept,
                                   y.data());
     EXPECT_TRUE(
-      raft::devArrMatchHost(pred_exp, y.data(), n_rows, raft::CompareApprox<math_t>(1e-5)));
+      raft::devArrMatchHost(pred_exp, y.data(), n_rows, raft::CompareApprox<math_t>(1e-5), stream));
   }
 
   void testFitLarge()


### PR DESCRIPTION
This is essential to have a non-blocking default stream, so that other streams can share work with the default stream if needed.