### PR TITLE
Optimize dtype conversion for FIL 

### DIFF
--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -209,7 +209,7 @@ def input_to_cuml_array(X,
                         deepcopy=False,
                         check_dtype=False,
                         convert_to_dtype=False,
-                        safe_convert_to_dtype=True,
+                        safe_dtype_conversion=True,
                         check_cols=False,
                         check_rows=False,
                         fail_on_order=False,
@@ -305,7 +305,7 @@ def input_to_cuml_array(X,
     if convert_to_dtype:
         X = convert_dtype(X,
                           to_dtype=convert_to_dtype,
-                          safe_dtype=safe_convert_to_dtype)
+                          safe_dtype=safe_dtype_conversion)
         check_dtype = False
 
     # format conversion

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -569,7 +569,7 @@ class ForestInference(Base,
         safe_dtype_conversion : bool (default = False)
             FIL converts data to np.float32 when needed. Set this parameter to
             True to enable checking for information loss during that
-            conversion, but it can have significant performance penalty.
+            conversion, but note that this check can have a significant performance penalty.
             Parameter will be dropped in a future version.
 
         Returns

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -591,10 +591,9 @@ class ForestInference(Base,
         Parameters
         ----------
     {}
-        preds: gpuarray or cudf.Series, shape = (n_samples,2)
+        preds : gpuarray or cudf.Series, shape = (n_samples,2)
            Binary probability output
            Optional 'out' location to store inference results
-        safe_typecast
 
         safe_dtype_conversion : bool (default = False)
             FIL converts data to np.float32 when needed. Set this parameter to

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -569,8 +569,9 @@ class ForestInference(Base,
         safe_dtype_conversion : bool (default = False)
             FIL converts data to np.float32 when needed. Set this parameter to
             True to enable checking for information loss during that
-            conversion, but note that this check can have a significant performance penalty.
-            Parameter will be dropped in a future version.
+            conversion, but note that this check can have a significant
+            performance penalty. Parameter will be dropped in a future
+            version.
 
         Returns
         ----------
@@ -598,8 +599,9 @@ class ForestInference(Base,
         safe_dtype_conversion : bool (default = False)
             FIL converts data to np.float32 when needed. Set this parameter to
             True to enable checking for information loss during that
-            conversion, but it can have significant performance penalty.
-            Parameter will be dropped in a future version.
+            conversion, but note that this check can have a significant
+            performance penalty. Parameter will be dropped in a future
+            version.
 
         Returns
         ----------

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -312,6 +312,7 @@ cdef class ForestInference_impl():
         X_m, n_rows, n_cols, dtype = \
             input_to_cuml_array(X, order='C',
                                 convert_to_dtype=np.float32,
+                                safe_convert_to_dtype=False,
                                 check_dtype=np.float32)
         X_ptr = X_m.ptr
 


### PR DESCRIPTION
cc @canonizer @levsnv @wphicks 

After doing a little bit of profiling for the slowness we observed for FIL when data had to be converted from int16 to float32 I found out that ~98% of the time was being spent in the check of whether there would be information lost to under/overflows in https://github.com/rapidsai/cuml/blob/3c11ebda9572a651490c555e3f852ace441ea8af/python/cuml/common/input_utils.py#L590

Created this proposal PR to add a parameter to skip that check in methods that are fast enough to benefit from fast dtype conversion like FIL as well as skip the check when upcasting.

 In my first quick benchmarks the dtype conversion was between **4x~14x** faster when disabling the checks in some cases. PR is still in progress, but figured I'd ping you in case you wanted to take a look 

