### PR TITLE
Upgrade Treelite to 2.0.0

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,11 +61,6 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
 
-gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      --force rapids-build-env rapids-notebook-env
-gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      treelite=2.0.0
-
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_conda_retry install -y "your-pkg=1.0.0"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,6 +61,11 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
 
+gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      --force rapids-build-env rapids-notebook-env
+gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      treelite=2.0.0
+
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_conda_retry install -y "your-pkg=1.0.0"

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.3.0
+- treelite=2.0.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=1.3.0
+- treelite=2.0.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.20.1
-    - treelite=1.3.0
+    - treelite=2.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -42,7 +42,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cupy>=7.8.0,<10.0.0a0
-    - treelite=1.3.0
+    - treelite=2.0.0
     - nccl>=2.9.9
     - ucx-py 0.21
     - ucx-proc=*=gpu

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - ucx-proc=*=gpu
     - libcumlprims {{ minor_version }}
     - lapack
-    - treelite=1.3.0
+    - treelite=2.0.0
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - gmock
@@ -57,7 +57,7 @@ requirements:
     - ucx-py 0.21
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - treelite=1.3.0
+    - treelite=2.0.0
     - faiss-proc=*=cuda
     - conda-forge::libfaiss=1.7.0
 

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -58,5 +58,5 @@ function(find_and_configure_treelite)
 
 endfunction()
 
-find_and_configure_treelite(VERSION     1.3.0
-                        PINNED_TAG  ae5436c45563a5c2ed7aa8f0f41f88fff48f49e4)
+find_and_configure_treelite(VERSION     2.0.0
+                        PINNED_TAG  b117da58d7d9a5cc54aa3711e5ad9a8407734c6e)

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -302,8 +302,7 @@ void build_treelite_forest(ModelHandle* model_handle,
     model->task_type = tl::TaskType::kBinaryClfRegr;
   }
 
-  model->task_param =
-    tl::TaskParam{tl::TaskParam::OutputType::kFloat, false, num_class, num_class};
+  model->task_param = tl::TaskParam{tl::TaskParam::OutputType::kFloat, false, num_class, num_class};
   model->num_feature         = num_features;
   model->average_tree_output = true;
   model->SetTreeLimit(forest->rf_params.n_trees);

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -303,7 +303,7 @@ void build_treelite_forest(ModelHandle* model_handle,
   }
 
   model->task_param =
-    tl::TaskParameter{tl::TaskParameter::OutputType::kFloat, false, num_class, num_class};
+    tl::TaskParam{tl::TaskParam::OutputType::kFloat, false, num_class, num_class};
   model->num_feature         = num_features;
   model->average_tree_output = true;
   model->SetTreeLimit(forest->rf_params.n_trees);

--- a/cpp/test/sg/rf_treelite_test.cu
+++ b/cpp/test/sg/rf_treelite_test.cu
@@ -89,14 +89,13 @@ class RfTreeliteTestCommon : public ::testing::TestWithParam<RfInputs<T>> {
 
     CompilerHandle compiler;
     // "ast_navive" is the default compiler treelite used in their Python code.
-    TREELITE_CHECK(TreeliteCompilerCreate("ast_native", &compiler));
+    TREELITE_CHECK(TreeliteCompilerCreateV2("ast_native", "{}", &compiler));
 
-    int verbose = 0;
     // Generate C code in the directory specified below.
     // The parallel comilplation is disabled. To enable it, one needs to specify parallel_comp of
     // CompilerHandle. Treelite will create a directory if it doesn't exist.
     TREELITE_CHECK(
-      TreeliteCompilerGenerateCode(compiler, treelite_indiv_handles[0], verbose, dir_name.c_str()));
+      TreeliteCompilerGenerateCodeV2(compiler, treelite_indiv_handles[0], dir_name.c_str()));
     TREELITE_CHECK(TreeliteCompilerFree(compiler));
 
     // Options copied from
@@ -135,6 +134,7 @@ class RfTreeliteTestCommon : public ::testing::TestWithParam<RfInputs<T>> {
     // avoid seg faults. Altough later we only use first params.n_inference_rows elements.
     size_t treelite_predicted_labels_size;
 
+    int verbose = 0;
     TREELITE_CHECK(TreelitePredictorPredictBatch(predictor,
                                                  dmat,
                                                  verbose,


### PR DESCRIPTION
Closes #4037.

The 2.0.0 version of Treelite incorporates the following major improvements:

* **Remove dmlc-core dependency** (dmlc/treelite#284).
* Rename CHECK and LOG macros to avoid name collisions (dmlc/treelite#295)
* Suppress warning about build time when parallel_comp is specified (dmlc/treelite#297)
* Handle LightGBM models with '=' in feature names (dmlc/treelite#298)
* Remove OpenMP dependency (dmlc/treelite#300)

Depends on rapidsai/integration#315