### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - gmock
-    - conda-forge::libfaiss=1.7.0
+    - libfaiss 1.7.0 *_cuda
   run:
     - libcumlprims {{ minor_version }}
     - cudf {{ minor_version }}
@@ -59,7 +59,7 @@ requirements:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - treelite=2.0.0
     - faiss-proc=*=cuda
-    - conda-forge::libfaiss=1.7.0
+    - libfaiss 1.7.0 *_cuda
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.