### PR TITLE
Use the new RAPIDS.cmake to fetch rapids-cmake

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,13 +15,9 @@
 #=============================================================================
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
-include(FetchContent)
-FetchContent_Declare(
-  rapids-cmake
-  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG        origin/branch-21.08
-  )
-FetchContent_MakeAvailable(rapids-cmake)
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.10/RAPIDS.cmake
+    ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)


### PR DESCRIPTION
The original approach of using FetchContent naively has a subtle
bug when multiple projects that use rapids-cmake are combined together inside as sibling projects. This bug causes any
`include(rapids-*)` commands to fail, causing CMake errors.

Bug using `RAPIDS.cmake` we can resolve this issue and remove
the new complex logic from each consumer.