### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -35,8 +35,6 @@ build:
 requirements:
   build:
     - cmake>=3.20.1
-    - clang=8.0.1        # [x86_64]
-    - clang-tools=8.0.1  # [x86_64]
   host:
     - nccl>=2.9.9
     - cudf {{ minor_version }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.