### PR TITLE
[REVIEW] Fix for crash in RF when `max_leaves` parameter is specified

### DIFF
--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -185,9 +185,8 @@ __global__ void nodeSplitKernel(IdxT max_depth,
   volatile auto* node = curr_nodes + nid;
   auto range_start = node->start, n_samples = node->count;
   __shared__ bool isLeaf;
-  if (threadIdx.x == 0)
-  {
-     isLeaf = leafBasedOnParams<DataT, IdxT>(
+  if (threadIdx.x == 0) {
+    isLeaf = leafBasedOnParams<DataT, IdxT>(
       node->depth, max_depth, min_samples_split, max_leaves, n_leaves, n_samples);
   }
   __syncthreads();

--- a/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels.cuh
@@ -184,8 +184,14 @@ __global__ void nodeSplitKernel(IdxT max_depth,
   IdxT nid            = blockIdx.x;
   volatile auto* node = curr_nodes + nid;
   auto range_start = node->start, n_samples = node->count;
-  auto isLeaf = leafBasedOnParams<DataT, IdxT>(
-    node->depth, max_depth, min_samples_split, max_leaves, n_leaves, n_samples);
+  __shared__ bool isLeaf;
+  if (threadIdx.x == 0)
+  {
+     isLeaf = leafBasedOnParams<DataT, IdxT>(
+      node->depth, max_depth, min_samples_split, max_leaves, n_leaves, n_samples);
+  }
+  __syncthreads();
+
   auto split = splits[nid];
   if (isLeaf || split.best_metric_val <= min_impurity_decrease || split.nLeft < min_samples_leaf ||
       (n_samples - split.nLeft) < min_samples_leaf) {


### PR DESCRIPTION
Fixes issue #4046. 
In the `nodeSplitKernel` each thread calls `leafBasedOnParams()` which reads global variable `n_leaves`. Different threads from same threadblock read `n_leaves` at different times. Between two threads reading `n_leaves`, value of it could be changed by some other threadblock. Thus one or few threads might concluded that `max_leaves` is reached, and rest of the threads might conclude otherwise. This caused crash in partitioning the samples.

In the solution provided here, instead of every thread reading `n_leaves`, only one thread from a threadblock reads the value and broadcasts it to every other thread via shared memory. This ensures complete agreement on `max_leaves` criterion among threads from threadblock.

Performance results to be posted shortly.