### PR TITLE
[bug-fix] avoid paramsSolver::{n_rows,n_cols} shadowing their base class counterparts

### DIFF
--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -38,8 +38,6 @@ class params {
 
 class paramsSolver : public params {
  public:
-  int n_rows;
-  int n_cols;
   // math_t tol = 0.0;
   float tol        = 0.0;
   int n_iterations = 15;


### PR DESCRIPTION
This looks to me like a typo, and may be problematic and confusing if the `n_rows` and `n_cols` members from the base class instead of the ones from the derived class are accessed.

Signed-off-by: Yitao Li <yitao@rstudio.com>