### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip gpuci]

### DIFF
--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -298,8 +298,14 @@ class UMAPParametrizableTest : public ::testing::Test {
 
     assertions(handle, X_d.data(), e1, test_params, umap_params);
 
+    // v21.08: Reproducibility looks to be busted for CTK 11.4. Need to figure out
+    // why this is happening and re-enable this.
+#if CUDART_VERSION == 11040
+    return;
+#else
     // Disable reproducibility tests after transformation
     if (!test_params.fit_transform) { return; }
+#endif
 
     device_buffer<float> embeddings2(alloc, stream, n_samples * umap_params.n_components);
     float* e2 = embeddings2.data();


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.