### PR TITLE
Split FIL infer_k into phases to speed up compilation (when a patch is applied)

### DIFF
--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -788,6 +788,33 @@ __device__ __forceinline__ void tree_aggregator_t<NITEMS, CATEGORICAL_LEAF>::fin
   }
 }
 
+__device__ __noinline__ void load_data(float* sdata,
+                                       const float* block_input,
+                                       predict_params params,
+                                       int rows_per_block,
+                                       int block_num_rows)
+{
+  int num_cols     = params.num_cols;
+  int sdata_stride = params.sdata_stride();
+  // cache the row for all threads to reuse
+  // 2021: latest SMs still do not have >256KiB of shared memory/block required to
+  // exceed the uint16_t
+#pragma unroll
+  for (uint16_t input_idx = threadIdx.x; input_idx < block_num_rows * num_cols;
+       input_idx += blockDim.x) {
+    // for even num_cols, we need to pad sdata_stride to reduce bank conflicts
+    // assuming here that sdata_stride == num_cols + 1
+    // then, idx / num_cols * sdata_stride + idx % num_cols == idx + idx / num_cols
+    uint16_t sdata_idx =
+      sdata_stride == num_cols ? input_idx : input_idx + input_idx / (uint16_t)num_cols;
+    sdata[sdata_idx] = block_input[input_idx];
+  }
+#pragma unroll
+  for (int idx = block_num_rows * sdata_stride; idx < rows_per_block * sdata_stride;
+       idx += blockDim.x)
+    sdata[idx] = 0.0f;
+}
+
 template <int NITEMS, leaf_algo_t leaf_algo, bool cols_in_shmem, class storage_type>
 __global__ void infer_k(storage_type forest, predict_params params)
 {
@@ -802,25 +829,8 @@ __global__ void infer_k(storage_type forest, predict_params params)
     int block_num_rows =
       max(0, (int)min((int64_t)rows_per_block, (int64_t)params.num_rows - block_row0));
     const float* block_input = params.data + block_row0 * num_cols;
-    if (cols_in_shmem) {
-      // cache the row for all threads to reuse
-      // 2021: latest SMs still do not have >256KiB of shared memory/block required to
-      // exceed the uint16_t
-#pragma unroll
-      for (uint16_t input_idx = threadIdx.x; input_idx < block_num_rows * num_cols;
-           input_idx += blockDim.x) {
-        // for even num_cols, we need to pad sdata_stride to reduce bank conflicts
-        // assuming here that sdata_stride == num_cols + 1
-        // then, idx / num_cols * sdata_stride + idx % num_cols == idx + idx / num_cols
-        uint16_t sdata_idx =
-          sdata_stride == num_cols ? input_idx : input_idx + input_idx / (uint16_t)num_cols;
-        sdata[sdata_idx] = block_input[input_idx];
-      }
-#pragma unroll
-      for (int idx = block_num_rows * sdata_stride; idx < rows_per_block * sdata_stride;
-           idx += blockDim.x)
-        sdata[idx] = 0.0f;
-    }
+    if constexpr (cols_in_shmem)
+      load_data(sdata, block_input, params, rows_per_block, block_num_rows);
 
     tree_aggregator_t<NITEMS, leaf_algo> acc(
       params, (char*)sdata + params.cols_shmem_size(), sdata, forest.vector_leaf_);

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -23,14 +23,7 @@
 #include <fil/internal.cuh>
 #include "common.cuh"
 
-#ifndef FIL_FAST_COMPILE
-// reduces what goes into hundreds of `infer_k` instantiations to speed up compilation.
-// for now, used sparingly. When we determine if current use has a perf impact,
-// we can roll it out to all functions, and use an appropriate name.
-#define INLINE_UNLESS_DEBUG __forceinline__
-#else
-#define INLINE_UNLESS_DEBUG __noinline__
-#endif
+#define NOINLINE_FAST_COMPILE __noinline__
 
 namespace ML {
 namespace fil {
@@ -287,50 +280,41 @@ struct tree_aggregator_t {
     acc += single_tree_prediction;
   }
 
-  __device__ INLINE_UNLESS_DEBUG void finalize(float* block_out,
-                                               int block_num_rows,
-                                               int output_stride,
-                                               output_t transform,
-                                               int num_trees,
-                                               int log2_threads_per_tree);
-};
-
-template <int NITEMS,
-          leaf_algo_t leaf_algo>  // = FLOAT_UNARY_BINARY
-__device__ INLINE_UNLESS_DEBUG void tree_aggregator_t<NITEMS, leaf_algo>::finalize(
-  float* block_out,
-  int block_num_rows,
-  int output_stride,
-  output_t transform,
-  int num_trees,
-  int log2_threads_per_tree)
-{
-  if (FIL_TPB != 1 << log2_threads_per_tree) {  // anything to reduce?
-    // ensure input columns can be overwritten (no threads traversing trees)
-    __syncthreads();
-    if (log2_threads_per_tree == 0) {
-      acc = block_reduce(acc, vectorized(cub::Sum()), tmp_storage);
-    } else {
-      auto per_thread         = (vec<NITEMS, float>*)tmp_storage;
-      per_thread[threadIdx.x] = acc;
+  __device__ NOINLINE_FAST_COMPILE void finalize(float* block_out,
+                                                 int block_num_rows,
+                                                 int output_stride,
+                                                 output_t transform,
+                                                 int num_trees,
+                                                 int log2_threads_per_tree)
+  {
+    if (FIL_TPB != 1 << log2_threads_per_tree) {  // anything to reduce?
+      // ensure input columns can be overwritten (no threads traversing trees)
       __syncthreads();
-      // We have two pertinent cases for splitting FIL_TPB == 256 values:
-      // 1. 2000 columns, which fit few threads/tree in shared memory,
-      // so ~256 groups. These are the models that will run the slowest.
-      // multi_sum performance is not sensitive to the radix here.
-      // 2. 50 columns, so ~32 threads/tree, so ~8 groups. These are the most
-      // popular.
-      acc = multi_sum<5>(per_thread, 1 << log2_threads_per_tree, FIL_TPB >> log2_threads_per_tree);
+      if (log2_threads_per_tree == 0) {
+        acc = block_reduce(acc, vectorized(cub::Sum()), tmp_storage);
+      } else {
+        auto per_thread         = (vec<NITEMS, float>*)tmp_storage;
+        per_thread[threadIdx.x] = acc;
+        __syncthreads();
+        // We have two pertinent cases for splitting FIL_TPB == 256 values:
+        // 1. 2000 columns, which fit few threads/tree in shared memory,
+        // so ~256 groups. These are the models that will run the slowest.
+        // multi_sum performance is not sensitive to the radix here.
+        // 2. 50 columns, so ~32 threads/tree, so ~8 groups. These are the most
+        // popular.
+        acc =
+          multi_sum<5>(per_thread, 1 << log2_threads_per_tree, FIL_TPB >> log2_threads_per_tree);
+      }
+    }
+
+    if (threadIdx.x * NITEMS >= block_num_rows) return;
+#pragma unroll
+    for (int row = 0; row < NITEMS; ++row) {
+      int out_preds_i = threadIdx.x * NITEMS + row;
+      if (out_preds_i < block_num_rows) block_out[out_preds_i * output_stride] = acc[row];
     }
   }
-
-  if (threadIdx.x * NITEMS >= block_num_rows) return;
-#pragma unroll
-  for (int row = 0; row < NITEMS; ++row) {
-    int out_preds_i = threadIdx.x * NITEMS + row;
-    if (out_preds_i < block_num_rows) block_out[out_preds_i * output_stride] = acc[row];
-  }
-}
+};
 
 // tmp_storage may overlap shared memory addressed by [begin, end)
 // allreduce_shmem ensures no race conditions
@@ -478,40 +462,31 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES> {
     acc += single_tree_prediction;
   }
 
-  __device__ INLINE_UNLESS_DEBUG void finalize(float* out,
-                                               int num_rows,
-                                               int num_outputs,
-                                               output_t transform,
-                                               int num_trees,
-                                               int log2_threads_per_tree);
+  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+                                                 int num_rows,
+                                                 int num_outputs,
+                                                 output_t transform,
+                                                 int num_trees,
+                                                 int log2_threads_per_tree)
+  {
+    __syncthreads();  // free up input row in case it was in shared memory
+    // load margin into shared memory
+    per_thread[threadIdx.x] = acc;
+    __syncthreads();
+    acc = multi_sum<6>(per_thread, num_classes, blockDim.x / num_classes);
+    if (threadIdx.x < num_classes) per_thread[threadIdx.x] = acc;
+    __syncthreads();  // per_thread needs to be fully populated
+
+    class_margins_to_global_memory(per_thread,
+                                   per_thread + num_classes,
+                                   transform,
+                                   num_trees / num_classes,
+                                   tmp_storage,
+                                   out,
+                                   num_rows,
+                                   num_outputs);
+  }
 };
-
-template <int NITEMS>
-__device__ INLINE_UNLESS_DEBUG void
-tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES>::finalize(float* out,
-                                                                 int num_rows,
-                                                                 int num_outputs,
-                                                                 output_t transform,
-                                                                 int num_trees,
-                                                                 int log2_threads_per_tree)
-{
-  __syncthreads();  // free up input row in case it was in shared memory
-  // load margin into shared memory
-  per_thread[threadIdx.x] = acc;
-  __syncthreads();
-  acc = multi_sum<6>(per_thread, num_classes, blockDim.x / num_classes);
-  if (threadIdx.x < num_classes) per_thread[threadIdx.x] = acc;
-  __syncthreads();  // per_thread needs to be fully populated
-
-  class_margins_to_global_memory(per_thread,
-                                 per_thread + num_classes,
-                                 transform,
-                                 num_trees / num_classes,
-                                 tmp_storage,
-                                 out,
-                                 num_rows,
-                                 num_outputs);
-}
 
 template <int NITEMS>
 struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES> {
@@ -559,32 +534,23 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES> {
     __syncthreads();
   }
 
-  __device__ INLINE_UNLESS_DEBUG void finalize(float* out,
-                                               int num_rows,
-                                               int num_outputs,
-                                               output_t transform,
-                                               int num_trees,
-                                               int log2_threads_per_tree);
+  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+                                                 int num_rows,
+                                                 int num_outputs,
+                                                 output_t transform,
+                                                 int num_trees,
+                                                 int log2_threads_per_tree)
+  {
+    class_margins_to_global_memory(per_class_margin,
+                                   per_class_margin + num_classes,
+                                   transform,
+                                   num_trees / num_classes,
+                                   tmp_storage,
+                                   out,
+                                   num_rows,
+                                   num_outputs);
+  }
 };
-
-template <int NITEMS>
-__device__ INLINE_UNLESS_DEBUG void
-tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES>::finalize(float* out,
-                                                                  int num_rows,
-                                                                  int num_outputs,
-                                                                  output_t transform,
-                                                                  int num_trees,
-                                                                  int log2_threads_per_tree)
-{
-  class_margins_to_global_memory(per_class_margin,
-                                 per_class_margin + num_classes,
-                                 transform,
-                                 num_trees / num_classes,
-                                 tmp_storage,
-                                 out,
-                                 num_rows,
-                                 num_outputs);
-}
 
 template <int NITEMS>
 struct tree_aggregator_t<NITEMS, VECTOR_LEAF> {
@@ -667,39 +633,30 @@ struct tree_aggregator_t<NITEMS, VECTOR_LEAF> {
       }
     }
   }
-  __device__ INLINE_UNLESS_DEBUG void finalize(float* out,
-                                               int num_rows,
-                                               int num_outputs,
-                                               output_t transform,
-                                               int num_trees,
-                                               int log2_threads_per_tree);
-};
-
-template <int NITEMS>
-__device__ INLINE_UNLESS_DEBUG void tree_aggregator_t<NITEMS, VECTOR_LEAF>::finalize(
-  float* out,
-  int num_rows,
-  int num_outputs,
-  output_t transform,
-  int num_trees,
-  int log2_threads_per_tree)
-{
-  if (num_classes < blockDim.x) {
-    __syncthreads();
-    // Efficient implementation for small number of classes
-    auto acc = multi_sum<6>(per_class_margin, num_classes, max(1, blockDim.x / num_classes));
-    if (threadIdx.x < num_classes) per_class_margin[threadIdx.x] = acc;
-    __syncthreads();
+  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+                                                 int num_rows,
+                                                 int num_outputs,
+                                                 output_t transform,
+                                                 int num_trees,
+                                                 int log2_threads_per_tree)
+  {
+    if (num_classes < blockDim.x) {
+      __syncthreads();
+      // Efficient implementation for small number of classes
+      auto acc = multi_sum<6>(per_class_margin, num_classes, max(1, blockDim.x / num_classes));
+      if (threadIdx.x < num_classes) per_class_margin[threadIdx.x] = acc;
+      __syncthreads();
+    }
+    class_margins_to_global_memory(per_class_margin,
+                                   per_class_margin + num_classes,
+                                   transform,
+                                   num_trees,
+                                   tmp_storage,
+                                   out,
+                                   num_rows,
+                                   num_outputs);
   }
-  class_margins_to_global_memory(per_class_margin,
-                                 per_class_margin + num_classes,
-                                 transform,
-                                 num_trees,
-                                 tmp_storage,
-                                 out,
-                                 num_rows,
-                                 num_outputs);
-}
+};
 
 template <int NITEMS>
 struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
@@ -773,35 +730,27 @@ struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
       out[row] = best_class;
     }
   }
-  __device__ INLINE_UNLESS_DEBUG void finalize(float* out,
-                                               int num_rows,
-                                               int num_outputs,
-                                               output_t transform,
-                                               int num_trees,
-                                               int log2_threads_per_tree);
-};
-template <int NITEMS>
-__device__ INLINE_UNLESS_DEBUG void tree_aggregator_t<NITEMS, CATEGORICAL_LEAF>::finalize(
-  float* out,
-  int num_rows,
-  int num_outputs,
-  output_t transform,
-  int num_trees,
-  int log2_threads_per_tree)
-{
-  if (num_outputs > 1) {
-    // only supporting num_outputs == num_classes
-    finalize_multiple_outputs(out, num_rows);
-  } else {
-    finalize_class_label(out, num_rows);
+  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+                                                 int num_rows,
+                                                 int num_outputs,
+                                                 output_t transform,
+                                                 int num_trees,
+                                                 int log2_threads_per_tree)
+  {
+    if (num_outputs > 1) {
+      // only supporting num_outputs == num_classes
+      finalize_multiple_outputs(out, num_rows);
+    } else {
+      finalize_class_label(out, num_rows);
+    }
   }
-}
+};
 
-__device__ INLINE_UNLESS_DEBUG void load_data(float* sdata,
-                                              const float* block_input,
-                                              predict_params params,
-                                              int rows_per_block,
-                                              int block_num_rows)
+__device__ NOINLINE_FAST_COMPILE void load_data(float* sdata,
+                                                const float* block_input,
+                                                predict_params params,
+                                                int rows_per_block,
+                                                int block_num_rows)
 {
   int num_cols     = params.num_cols;
   int sdata_stride = params.sdata_stride();

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -278,7 +278,7 @@ struct tree_aggregator_t {
     acc += single_tree_prediction;
   }
 
-  __device__ __forceinline__ void finalize(float* block_out,
+  __device__ __noinline__ void finalize(float* block_out,
                                            int block_num_rows,
                                            int output_stride,
                                            output_t transform,
@@ -288,7 +288,7 @@ struct tree_aggregator_t {
 
 template <int NITEMS,
           leaf_algo_t leaf_algo>  // = FLOAT_UNARY_BINARY
-__device__ __forceinline__ void tree_aggregator_t<NITEMS, leaf_algo>::finalize(
+__device__ __noinline__ void tree_aggregator_t<NITEMS, leaf_algo>::finalize(
   float* block_out,
   int block_num_rows,
   int output_stride,
@@ -469,7 +469,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES> {
     acc += single_tree_prediction;
   }
 
-  __device__ __forceinline__ void finalize(float* out,
+  __device__ __noinline__ void finalize(float* out,
                                            int num_rows,
                                            int num_outputs,
                                            output_t transform,
@@ -478,7 +478,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES> {
 };
 
 template <int NITEMS>
-__device__ __forceinline__ void tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES>::finalize(
+__device__ __noinline__ void tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES>::finalize(
   float* out,
   int num_rows,
   int num_outputs,
@@ -550,7 +550,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES> {
     __syncthreads();
   }
 
-  __device__ __forceinline__ void finalize(float* out,
+  __device__ __noinline__ void finalize(float* out,
                                            int num_rows,
                                            int num_outputs,
                                            output_t transform,
@@ -559,7 +559,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES> {
 };
 
 template <int NITEMS>
-__device__ __forceinline__ void tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES>::finalize(
+__device__ __noinline__ void tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES>::finalize(
   float* out,
   int num_rows,
   int num_outputs,
@@ -658,7 +658,7 @@ struct tree_aggregator_t<NITEMS, VECTOR_LEAF> {
       }
     }
   }
-  __device__ __forceinline__ void finalize(float* out,
+  __device__ __noinline__ void finalize(float* out,
                                            int num_rows,
                                            int num_outputs,
                                            output_t transform,
@@ -667,7 +667,7 @@ struct tree_aggregator_t<NITEMS, VECTOR_LEAF> {
 };
 
 template <int NITEMS>
-__device__ __forceinline__ void tree_aggregator_t<NITEMS, VECTOR_LEAF>::finalize(
+__device__ __noinline__ void tree_aggregator_t<NITEMS, VECTOR_LEAF>::finalize(
   float* out,
   int num_rows,
   int num_outputs,
@@ -764,7 +764,7 @@ struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
       out[row] = best_class;
     }
   }
-  __device__ __forceinline__ void finalize(float* out,
+  __device__ __noinline__ void finalize(float* out,
                                            int num_rows,
                                            int num_outputs,
                                            output_t transform,
@@ -772,7 +772,7 @@ struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
                                            int log2_threads_per_tree);
 };
 template <int NITEMS>
-__device__ __forceinline__ void tree_aggregator_t<NITEMS, CATEGORICAL_LEAF>::finalize(
+__device__ __noinline__ void tree_aggregator_t<NITEMS, CATEGORICAL_LEAF>::finalize(
   float* out,
   int num_rows,
   int num_outputs,

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -279,11 +279,11 @@ struct tree_aggregator_t {
   }
 
   __device__ __noinline__ void finalize(float* block_out,
-                                           int block_num_rows,
-                                           int output_stride,
-                                           output_t transform,
-                                           int num_trees,
-                                           int log2_threads_per_tree);
+                                        int block_num_rows,
+                                        int output_stride,
+                                        output_t transform,
+                                        int num_trees,
+                                        int log2_threads_per_tree);
 };
 
 template <int NITEMS,
@@ -470,11 +470,11 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES> {
   }
 
   __device__ __noinline__ void finalize(float* out,
-                                           int num_rows,
-                                           int num_outputs,
-                                           output_t transform,
-                                           int num_trees,
-                                           int log2_threads_per_tree);
+                                        int num_rows,
+                                        int num_outputs,
+                                        output_t transform,
+                                        int num_trees,
+                                        int log2_threads_per_tree);
 };
 
 template <int NITEMS>
@@ -551,11 +551,11 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES> {
   }
 
   __device__ __noinline__ void finalize(float* out,
-                                           int num_rows,
-                                           int num_outputs,
-                                           output_t transform,
-                                           int num_trees,
-                                           int log2_threads_per_tree);
+                                        int num_rows,
+                                        int num_outputs,
+                                        output_t transform,
+                                        int num_trees,
+                                        int log2_threads_per_tree);
 };
 
 template <int NITEMS>
@@ -659,11 +659,11 @@ struct tree_aggregator_t<NITEMS, VECTOR_LEAF> {
     }
   }
   __device__ __noinline__ void finalize(float* out,
-                                           int num_rows,
-                                           int num_outputs,
-                                           output_t transform,
-                                           int num_trees,
-                                           int log2_threads_per_tree);
+                                        int num_rows,
+                                        int num_outputs,
+                                        output_t transform,
+                                        int num_trees,
+                                        int log2_threads_per_tree);
 };
 
 template <int NITEMS>
@@ -765,11 +765,11 @@ struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
     }
   }
   __device__ __noinline__ void finalize(float* out,
-                                           int num_rows,
-                                           int num_outputs,
-                                           output_t transform,
-                                           int num_trees,
-                                           int log2_threads_per_tree);
+                                        int num_rows,
+                                        int num_outputs,
+                                        output_t transform,
+                                        int num_trees,
+                                        int log2_threads_per_tree);
 };
 template <int NITEMS>
 __device__ __noinline__ void tree_aggregator_t<NITEMS, CATEGORICAL_LEAF>::finalize(

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -23,7 +23,7 @@
 #include <fil/internal.cuh>
 #include "common.cuh"
 
-#define NOINLINE_FAST_COMPILE __noinline__
+#define INLINE_CONFIG __forceinline__
 
 namespace ML {
 namespace fil {
@@ -280,7 +280,7 @@ struct tree_aggregator_t {
     acc += single_tree_prediction;
   }
 
-  __device__ NOINLINE_FAST_COMPILE void finalize(float* block_out,
+  __device__ INLINE_CONFIG void finalize(float* block_out,
                                                  int block_num_rows,
                                                  int output_stride,
                                                  output_t transform,
@@ -462,7 +462,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_FEW_CLASSES> {
     acc += single_tree_prediction;
   }
 
-  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+  __device__ INLINE_CONFIG void finalize(float* out,
                                                  int num_rows,
                                                  int num_outputs,
                                                  output_t transform,
@@ -534,7 +534,7 @@ struct tree_aggregator_t<NITEMS, GROVE_PER_CLASS_MANY_CLASSES> {
     __syncthreads();
   }
 
-  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+  __device__ INLINE_CONFIG void finalize(float* out,
                                                  int num_rows,
                                                  int num_outputs,
                                                  output_t transform,
@@ -633,7 +633,7 @@ struct tree_aggregator_t<NITEMS, VECTOR_LEAF> {
       }
     }
   }
-  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+  __device__ INLINE_CONFIG void finalize(float* out,
                                                  int num_rows,
                                                  int num_outputs,
                                                  output_t transform,
@@ -730,7 +730,7 @@ struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
       out[row] = best_class;
     }
   }
-  __device__ NOINLINE_FAST_COMPILE void finalize(float* out,
+  __device__ INLINE_CONFIG void finalize(float* out,
                                                  int num_rows,
                                                  int num_outputs,
                                                  output_t transform,
@@ -746,7 +746,7 @@ struct tree_aggregator_t<NITEMS, CATEGORICAL_LEAF> {
   }
 };
 
-__device__ NOINLINE_FAST_COMPILE void load_data(float* sdata,
+__device__ INLINE_CONFIG void load_data(float* sdata,
                                                 const float* block_input,
                                                 predict_params params,
                                                 int rows_per_block,

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -123,6 +123,7 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
   {
     // setup
     ps = testing::TestWithParam<FilTestParams>::GetParam();
+    std::cout << ps << std::endl;
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
 

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -123,7 +123,6 @@ class BaseFilTest : public testing::TestWithParam<FilTestParams> {
   {
     // setup
     ps = testing::TestWithParam<FilTestParams>::GetParam();
-    std::cout << ps << std::endl;
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
 


### PR DESCRIPTION
FIL takes several minutes to compile every time even on release (up to 15mins on debug). When combined with an occasional larger recompile, it makes iterating on the code much slower. This code reduces the release compile time of `infer.cu` to 18s and probably a similar speedup on debug builds.

Some phases depend on fewer template parameters than the whole `infer_k`. If we merely avoid inlining those pieces, a lot of the code will no longer be duplicated 240 times (3 storage_type x 2 cols_in_shmem x 4 NITEMS x 5 leaf_algo x 2 branch_can_be_categorical).
Since those functions are called once per `rows_per_block` (and once per whole forest within that), the runtime overhead should be low enough. An empirical test confirms this.

We are keeping the default compilation as joint due to the theoretical uncertainty with function call overhead.