### PR TITLE
Add Raft and RMM as dependency for kmeans example

### DIFF
--- a/cpp/examples/kmeans/CMakeLists_standalone.txt
+++ b/cpp/examples/kmeans/CMakeLists_standalone.txt
@@ -26,15 +26,45 @@ if(IS_DIRECTORY ${CUML_INCLUDE_DIR})
 else()
     message(FATAL_ERROR "CUML_INCLUDE_DIR not specified.")
 endif(IS_DIRECTORY ${CUML_INCLUDE_DIR})
+
+if(DEFINED ENV{RAFT_PATH})
+  message(STATUS "RAFT_PATH environment variable detected.")
+  message(STATUS "RAFT_DIR set to $ENV{RAFT_PATH}")
+  set(RAFT_DIR ENV{RAFT_PATH})
+else(DEFINED ENV{RAFT_PATH})
+  message(STATUS "RAFT_PATH environment variable NOT detected, cloning RAFT")
+  set(RAFT_GIT_DIR ${CMAKE_CURRENT_BINARY_DIR}/raft CACHE STRING "Path to RAFT repo")
+  include(ExternalProject)
+  ExternalProject_Add(raft
+    GIT_REPOSITORY    https://github.com/rapidsai/raft.git
+    GIT_TAG           branch-21.10
+    PREFIX            ${RAFT_GIT_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   "")
+
+  set(RAFT_INCLUDE_DIR ${RAFT_GIT_DIR}/src/raft/cpp/include CACHE STRING "RAFT include variable")
+  message(STATUS "RAFT_INCLUDE_DIR set to ${RAFT_INCLUDE_DIR}")
+endif(DEFINED ENV{RAFT_PATH})
+
+
+find_package(rmm 0.19.00)
+include_directories(${RAFT_INCLUDE_DIR})
+
 if(IS_DIRECTORY ${CUML_LIBRARY_DIR})
-    # CUML_LIBRARY_DIR point to the director where libcuml++.so lives
+    # CUML_LIBRARY_DIR point to the directory where libcuml++.so lives
     link_directories(${CUML_LIBRARY_DIR})
 else()
     message(FATAL_ERROR "CUML_LIBRARY_DIR not specified.")
 endif(IS_DIRECTORY ${CUML_LIBRARY_DIR})
 
 add_executable(kmeans_example kmeans_example.cpp)
+add_dependencies(kmeans_example raft)
 # Need to set linker language to CUDA to link the CUDA Runtime
 set_target_properties(kmeans_example PROPERTIES LINKER_LANGUAGE "CUDA")
 # Link cuml
-target_link_libraries(kmeans_example cuml++)
+target_link_libraries(kmeans_example
+    cuml++
+    rmm::rmm
+    CUDA::cublas
+    CUDA::cusolver)


### PR DESCRIPTION
While investigating #3283 I found that the CMake for the examples were not including RMM and Raft.