### PR TITLE
[HOTFIX] Remove `-g` from cython compile commands

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -210,11 +210,20 @@ class cuml_build_ext(cython_build_ext, object):
     boolean_options = ["singlegpu"] + cython_build_ext.boolean_options
 
     def build_extensions(self):
-        try:
-            # Silence the '-Wstrict-prototypes' warning
-            self.compiler.compiler_so.remove("-Wstrict-prototypes")
-        except Exception:
-            pass
+        def remove_flags(compiler, *flags):
+            for flag in flags:
+                try:
+                    compiler.compiler_so = list(
+                        filter((flag).__ne__, compiler.compiler_so)
+                    )
+                except Exception:
+                    pass
+        # Full optimization
+        self.compiler.compiler_so.append("-O3")
+        # No debug symbols, full optimization, no '-Wstrict-prototypes' warning
+        remove_flags(
+            self.compiler, "-g", "-G", "-O1", "-O2", "-Wstrict-prototypes"
+        )
         cython_build_ext.build_extensions(self)
 
     def initialize_options(self):


### PR DESCRIPTION
Removes `-g` from the compile commands generated by distutils to compile Cython files.

This will make our container images, conda packages, and python wheels smaller.