### PR TITLE
Gracefully accept 'n_jobs', a common sklearn parameter, in NearestNeighbors Estimator

### DIFF
--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -316,10 +316,7 @@ class NearestNeighbors(Base,
         self.algorithm = algorithm
         self.algo_params = algo_params
         self.knn_index = <uintptr_t> 0
-
-        if n_jobs is not None:
-            warnings.warn("\nWarning: 'n_jobs' parameter is unsupported and only available for compatibility")
-
+        self.n_jobs = n_jobs
 
     @generate_docstring(X='dense_sparse')
     def fit(self, X, convert_dtype=True) -> "NearestNeighbors":
@@ -327,6 +324,9 @@ class NearestNeighbors(Base,
         Fit GPU index for performing nearest neighbor queries.
 
         """
+        if self.n_jobs is not None:
+            warnings.warn("\nWarning: 'n_jobs' parameter is unsupported and only available for compatibility")
+
         if len(X.shape) != 2:
             raise ValueError("data should be two dimensional")
 

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -281,7 +281,7 @@ class NearestNeighbors(Base,
     the FAISS release that this cuML version is linked to.
     (see cuML issue #4020)
 
-    Warning: Nearest Neighbor can accept any number of named parameters (**kwargs) 
+    Warning: 'n_jobs' is accepted but with no effect in behavior for compatibility reasons 
 
     For an additional example see `the NearestNeighbors notebook
     <https://github.com/rapidsai/cuml/blob/branch-0.15/notebooks/nearest_neighbors_demo.ipynb>`_.

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -281,6 +281,8 @@ class NearestNeighbors(Base,
     the FAISS release that this cuML version is linked to.
     (see cuML issue #4020)
 
+    Warning: Nearest Neighbor can accept any number of named parameters (**kwargs) 
+
     For an additional example see `the NearestNeighbors notebook
     <https://github.com/rapidsai/cuml/blob/branch-0.15/notebooks/nearest_neighbors_demo.ipynb>`_.
 
@@ -316,7 +318,6 @@ class NearestNeighbors(Base,
         self.algorithm = algorithm
         self.algo_params = algo_params
         self.knn_index = <uintptr_t> 0
-        self.n_jobs = n_jobs
 
     @generate_docstring(X='dense_sparse')
     def fit(self, X, convert_dtype=True) -> "NearestNeighbors":
@@ -324,7 +325,6 @@ class NearestNeighbors(Base,
         Fit GPU index for performing nearest neighbor queries.
 
         """
-
         if len(X.shape) != 2:
             raise ValueError("data should be two dimensional")
 

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -300,7 +300,8 @@ class NearestNeighbors(Base,
                  p=2,
                  algo_params=None,
                  metric_params=None,
-                 output_type=None):
+                 output_type=None,
+                 n_jobs=None):
 
         super().__init__(handle=handle,
                          verbose=verbose,
@@ -315,6 +316,10 @@ class NearestNeighbors(Base,
         self.algorithm = algorithm
         self.algo_params = algo_params
         self.knn_index = <uintptr_t> 0
+
+        if n_jobs is not None:
+            warnings.warn("\nWarning: 'n_jobs' parameter is unsupported and only available for compatibility")
+
 
     @generate_docstring(X='dense_sparse')
     def fit(self, X, convert_dtype=True) -> "NearestNeighbors":
@@ -389,7 +394,7 @@ class NearestNeighbors(Base,
     def get_param_names(self):
         return super().get_param_names() + \
             ["n_neighbors", "algorithm", "metric",
-                "p", "metric_params", "algo_params"]
+                "p", "metric_params", "algo_params", "n_jobs"]
 
     @staticmethod
     def _build_metric_type(metric):

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -301,7 +301,7 @@ class NearestNeighbors(Base,
                  algo_params=None,
                  metric_params=None,
                  output_type=None,
-                 n_jobs=None):
+                 **kwargs):
 
         super().__init__(handle=handle,
                          verbose=verbose,
@@ -324,8 +324,6 @@ class NearestNeighbors(Base,
         Fit GPU index for performing nearest neighbor queries.
 
         """
-        if self.n_jobs is not None:
-            warnings.warn("\nWarning: 'n_jobs' parameter is unsupported and only available for compatibility")
 
         if len(X.shape) != 2:
             raise ValueError("data should be two dimensional")
@@ -394,7 +392,7 @@ class NearestNeighbors(Base,
     def get_param_names(self):
         return super().get_param_names() + \
             ["n_neighbors", "algorithm", "metric",
-                "p", "metric_params", "algo_params", "n_jobs"]
+                "p", "metric_params", "algo_params"]
 
     @staticmethod
     def _build_metric_type(metric):

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -281,7 +281,9 @@ class NearestNeighbors(Base,
     the FAISS release that this cuML version is linked to.
     (see cuML issue #4020)
 
-    Warning: 'n_jobs' is accepted but with no effect in behavior for compatibility reasons 
+    Warning: For compatibility with libraries that rely on scikit-learn, 
+    kwargs allows for passing of arguments that are not explicit in the 
+    class constructor, such as 'n_jobs', but they have no effect on behavior.  
 
     For an additional example see `the NearestNeighbors notebook
     <https://github.com/rapidsai/cuml/blob/branch-0.15/notebooks/nearest_neighbors_demo.ipynb>`_.

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -281,9 +281,9 @@ class NearestNeighbors(Base,
     the FAISS release that this cuML version is linked to.
     (see cuML issue #4020)
 
-    Warning: For compatibility with libraries that rely on scikit-learn, 
-    kwargs allows for passing of arguments that are not explicit in the 
-    class constructor, such as 'n_jobs', but they have no effect on behavior.  
+    Warning: For compatibility with libraries that rely on scikit-learn,
+    kwargs allows for passing of arguments that are not explicit in the
+    class constructor, such as 'n_jobs', but they have no effect on behavior.
 
     For an additional example see `the NearestNeighbors notebook
     <https://github.com/rapidsai/cuml/blob/branch-0.15/notebooks/nearest_neighbors_demo.ipynb>`_.


### PR DESCRIPTION
This pull request partially solves [[FEA] #3461](https://github.com/rapidsai/cuml/issues/3461).

This quick-fix has been created to enable cuML's NearestNeighbor estimator to gracefully accept sklearns 'n_jobs' parameter as a pass-through.  

The purpose of making this quick fix is to allow Imbalanced-Learn samplers to rely on cuML's NearestNeighbor estimator, without producing an error when setting the estimators n_jobs parameter `.set_params(**{"n_jobs": self.n_jobs})` [1](https://github.com/scikit-learn-contrib/imbalanced-learn/blob/edf6eae2c00f7fa6d76ee381f5b625155061a725/imblearn/over_sampling/_adasyn.py#L112)
