### PR TITLE
Change the error type to match sklearn.

### DIFF
--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -326,7 +326,7 @@ class SVMBase(Base,
     @cuml.internals.api_base_return_array_skipall
     def coef_(self):
         if self._c_kernel != LINEAR:
-            raise RuntimeError("coef_ is only available for linear kernels")
+            raise AttributeError("coef_ is only available for linear kernels")
         if self._model is None:
             raise RuntimeError("Call fit before prediction")
         if self._internal_coef_ is None:

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -328,7 +328,7 @@ class SVMBase(Base,
         if self._c_kernel != LINEAR:
             raise AttributeError("coef_ is only available for linear kernels")
         if self._model is None:
-            raise RuntimeError("Call fit before prediction")
+            raise AttributeError("Call fit before prediction")
         if self._internal_coef_ is None:
             self._internal_coef_ = self._calc_coef()
         # Call the base class to perform the output conversion


### PR DESCRIPTION
Change the error type when trying to predict before fitting SVM to match sklearn.

Fixes #4192