### PR TITLE
Make sure we keep the rapids-cmake and cuml cal version in sync

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -31,6 +31,8 @@ function sed_runner() {
 }
 
 sed_runner 's/'"CUML VERSION .* LANGUAGES"'/'"CUML VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' cpp/CMakeLists.txt
+
 # RTD update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
 sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py


### PR DESCRIPTION
when we make a new cuml version, we need to also bump the rapids-cmake version at the
same time. Otherwise we will get the previous releases dependencies by mistake.