### PR TITLE
Upgrade Treelite to 2.1.0

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,11 +61,6 @@ gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
 
-gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      --force rapids-build-env rapids-notebook-env
-gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      treelite=2.1.0
-
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_mamba_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_mamba_retry install -y "your-pkg=1.0.0"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,7 +61,7 @@ gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
 
-gpuci_mamba_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       --force rapids-build-env rapids-notebook-env
 gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       treelite=2.1.0

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,6 +61,11 @@ gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rapids-doc-env=${MINOR_VERSION}.*" \
       "shap>=0.37,<=0.39"
 
+gpuci_mamba_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      --force rapids-build-env rapids-notebook-env
+gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      treelite=2.1.0
+
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_mamba_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_mamba_retry install -y "your-pkg=1.0.0"

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=2.0.0
+- treelite=2.1.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=2.0.0
+- treelite=2.1.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -22,7 +22,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.23.1
-- treelite=2.0.0
+- treelite=2.1.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - cython>=0.29,<0.30
     - cmake>=3.20.1
-    - treelite=2.0.0
+    - treelite=2.1.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -42,7 +42,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - cupy>=7.8.0,<10.0.0a0
-    - treelite=2.0.0
+    - treelite=2.1.0
     - nccl>=2.9.9
     - ucx-py 0.22
     - ucx-proc=*=gpu

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - ucx-proc=*=gpu
     - libcumlprims {{ minor_version }}
     - lapack
-    - treelite=2.0.0
+    - treelite=2.1.0
     - faiss-proc=*=cuda
     - gtest=1.10.0
     - gmock
@@ -55,7 +55,7 @@ requirements:
     - ucx-py 0.22
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - treelite=2.0.0
+    - treelite=2.1.0
     - faiss-proc=*=cuda
     - libfaiss 1.7.0 *_cuda
 

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -54,5 +54,5 @@ function(find_and_configure_treelite)
 
 endfunction()
 
-find_and_configure_treelite(VERSION     2.0.0
-                        PINNED_TAG  b117da58d7d9a5cc54aa3711e5ad9a8407734c6e)
+find_and_configure_treelite(VERSION     2.1.0
+                        PINNED_TAG  e5248931c62e3807248e0b150e27b2530a510634)


### PR DESCRIPTION
The 2.1.0 version of Treelite incorporates the following major improvements:

* dmlc/treelite#311
* dmlc/treelite#302
* dmlc/treelite#303
* dmlc/treelite#296

In particular, dmlc/treelite#311 is a critical follow-up to #4191 and addresses a performance regression.

Requires https://github.com/rapidsai/integration/pull/353