### PR TITLE
Forward-merge `branch-21.08` into `branch-21.10`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -210,11 +210,20 @@ class cuml_build_ext(cython_build_ext, object):
     boolean_options = ["singlegpu"] + cython_build_ext.boolean_options
 
     def build_extensions(self):
-        try:
-            # Silence the '-Wstrict-prototypes' warning
-            self.compiler.compiler_so.remove("-Wstrict-prototypes")
-        except Exception:
-            pass
+        def remove_flags(compiler, *flags):
+            for flag in flags:
+                try:
+                    compiler.compiler_so = list(
+                        filter((flag).__ne__, compiler.compiler_so)
+                    )
+                except Exception:
+                    pass
+        # Full optimization
+        self.compiler.compiler_so.append("-O3")
+        # No debug symbols, full optimization, no '-Wstrict-prototypes' warning
+        remove_flags(
+            self.compiler, "-g", "-G", "-O1", "-O2", "-Wstrict-prototypes"
+        )
         cython_build_ext.build_extensions(self)
 
     def initialize_options(self):


### PR DESCRIPTION
This PR merges the latest changes from `branch-21.08` into `branch-21.10`. Typically this process happens automatically, but the forward-merger automation has been updated to forward-merge `branch-21.10` into `branch-21.12` at this time so there were some changes from `branch-21.08` that didn't make it into `branch-21.10`.

We'll also want to confirm that these changes are automatically forward-merged into `branch-21.12` after this PR merges.