### PR TITLE
[Doc] Expose train_test_split in API doc

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -63,7 +63,7 @@ Preprocessing, Metrics, and Utilities
 Model Selection and Data Splitting
 ----------------------------------
 
- .. autofunction:: cuml.preprocessing.model_selection.train_test_split
+ .. autofunction:: cuml.model_selection.train_test_split
 
 Feature and Label Encoding (Single-GPU)
 ---------------------------------------


### PR DESCRIPTION
Currently `train_test_split` isn't showing up in the cuML API doc.