### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -304,6 +304,13 @@ class UMAPParametrizableTest : public ::testing::Test {
 
     float* e1 = embeddings1.data();
 
+#if CUDART_VERSION >= 11020
+    // Always use random init w/ CUDA 11.2. For some reason the
+    // spectral solver doesn't always converge w/ this CUDA version.
+    umap_params.init         = 0;
+    umap_params.random_state = 43;
+    umap_params.n_epochs     = 500;
+#endif
     get_embedding(handle, X_d.data(), (float*)y_d.data(), e1, test_params, umap_params);
 
     assertions(handle, X_d.data(), e1, test_params, umap_params);

--- a/python/cuml/test/test_nearest_neighbors.py
+++ b/python/cuml/test/test_nearest_neighbors.py
@@ -598,7 +598,14 @@ def test_nearest_neighbors_sparse(metric,
 
     skD, skI = sknn.kneighbors(b.get())
 
-    cp.testing.assert_allclose(cuD, skD, atol=1e-3, rtol=1e-3)
+    # For some reason, this will occasionally fail w/ a single
+    # mismatched element in CI. Try again if this happens.
+    try:
+        cp.testing.assert_allclose(cuD, skD, atol=1e-3, rtol=1e-3)
+    except AssertionError:
+        sknn.fit(sk_X)
+        skD, skI = sknn.kneighbors(b.get())
+        cp.testing.assert_allclose(cuD, skD, atol=1e-3, rtol=1e-3)
 
     # Jaccard & Chebyshev have a high potential for mismatched indices
     # due to duplicate distances. We can ignore the indices in this case.


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.