### PR TITLE
In FIL, clip blocks_per_sm to one wave instead of asserting

### DIFF
--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -147,10 +147,7 @@ struct forest {
     int max_threads_per_sm, sm_count;
     CUDA_CHECK(
       cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device));
-    int max_blocks_per_sm = max_threads_per_sm / FIL_TPB;
-    ASSERT(blocks_per_sm <= max_blocks_per_sm,
-           "on this GPU, FIL blocks_per_sm cannot exceed %d",
-           max_blocks_per_sm);
+    blocks_per_sm = std::min(blocks_per_sm, max_threads_per_sm / FIL_TPB);
     CUDA_CHECK(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
     fixed_block_count_ = blocks_per_sm * sm_count;
   }


### PR DESCRIPTION
After using the feature for a while, we found it easier to sometimes set a high number and expect FIL to scale down when the GPU requires, instead of checking externally every time.