### PR TITLE
Fix for `mean_squared_error`

### DIFF
--- a/python/cuml/metrics/regression.pyx
+++ b/python/cuml/metrics/regression.pyx
@@ -105,11 +105,12 @@ def _prepare_input_reg(y_true, y_pred, sample_weight, multioutput):
     Converts inputs to CumlArray and check multioutput parameter validity.
     """
     y_true, n_rows, n_cols, ytype = \
-        input_to_cuml_array(y_true, check_dtype=[np.float32, np.float64,
-                                                 np.int32, np.int64])
+        input_to_cuml_array(y_true.squeeze(),
+                            check_dtype=[np.float32, np.float64,
+                                         np.int32, np.int64])
 
     y_pred, _, _, _ = \
-        input_to_cuml_array(y_pred, check_dtype=ytype,
+        input_to_cuml_array(y_pred.squeeze(), check_dtype=ytype,
                             check_rows=n_rows, check_cols=n_cols)
 
     if sample_weight is not None:

--- a/python/cuml/metrics/regression.pyx
+++ b/python/cuml/metrics/regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,14 +104,15 @@ def _prepare_input_reg(y_true, y_pred, sample_weight, multioutput):
     Helper function to avoid code duplication for regression metrics.
     Converts inputs to CumlArray and check multioutput parameter validity.
     """
+    y_true = y_true.squeeze() if len(y_true) > 1 else y_true
     y_true, n_rows, n_cols, ytype = \
-        input_to_cuml_array(y_true.squeeze(),
-                            check_dtype=[np.float32, np.float64,
-                                         np.int32, np.int64])
+        input_to_cuml_array(y_true, check_dtype=[np.float32, np.float64,
+                                                 np.int32, np.int64])
 
+    y_pred = y_pred.squeeze() if len(y_pred) > 1 else y_pred
     y_pred, _, _, _ = \
-        input_to_cuml_array(y_pred.squeeze(), check_dtype=ytype,
-                            check_rows=n_rows, check_cols=n_cols)
+        input_to_cuml_array(y_pred, check_dtype=ytype, check_rows=n_rows,
+                            check_cols=n_cols)
 
     if sample_weight is not None:
         sample_weight, _, _, _ = \

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -1446,3 +1446,11 @@ def test_kl_divergence(nfeatures, input_type, dtypeP, dtypeQ):
         cu_res = cu_kl_divergence(P, Q, convert_dtype=False)
 
     cp.testing.assert_array_almost_equal(cu_res, sk_res)
+
+
+def test_mean_squared_error():
+    y1 = np.array([[1], [2], [3]])
+    y2 = y1.squeeze()
+
+    assert mean_squared_error(y1, y2) == 0
+    assert mean_squared_error(y2, y1) == 0


### PR DESCRIPTION
Closes #4281

The bug happens when providing a vector and a 1D array as inputs to the `mean_squared_error` function (see #4281).