### PR TITLE
Enable training single GPU cuML models using Dask DataFrames and Series

### DIFF
--- a/python/cuml/common/input_utils.py
+++ b/python/cuml/common/input_utils.py
@@ -321,7 +321,8 @@ def input_to_cuml_array(X,
         # pandas doesn't support custom order in to_numpy
         X = cp.asarray(X.to_numpy(copy=False), order=order)
 
-    if isinstance(X, dask_cudf.core.DataFrame):
+    if isinstance(X, dask_cudf.core.DataFrame) or \
+        isinstance(X, dask_cudf.core.Series):
         X = X.compute()
 
     if isinstance(X, cudf.DataFrame):


### PR DESCRIPTION
This PR makes it possible to train single GPU cuML models using Dask DataFrames and Series by converting the Dask data-structures to their cudf counterparts before training.