### PR TITLE
Combine and expose SVC's support vectors in the multiclass case

### DIFF
--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -283,6 +283,20 @@ class SVC(SVMBase,
 
     @property
     @cuml.internals.api_base_return_array_skipall
+    def support_(self):
+        if self.n_classes_ > 2:
+            estimators = self.multiclass_svc.multiclass_estimator.estimators_
+            return cp.concatenate(
+                [cp.asarray(cls._support_) for cls in estimators])
+        else:
+            return self._support_ #super().support_
+
+    @support_.setter
+    def support_(self, value):
+        self._support_ = value
+        
+    @property
+    @cuml.internals.api_base_return_array_skipall
     def intercept_(self):
         if self.n_classes_ > 2:
             estimators = self.multiclass_svc.multiclass_estimator.estimators_


### PR DESCRIPTION
The purpose of this (draft) PR is to resolve issue #4206, allowing for the filling of SVC's `support_` attribute by combining the support_ attribute from each of the estimators used in a multi-class one-versus-one SVC fit.  

This is a new PR, now updated to branch-21.12, replacing [this PR I have now closed](https://github.com/rapidsai/cuml/pull/4218).

This change will allow libraries that rely on sklearn's SVC attribute `support_`, [like imbalanced-learn](https://github.com/scikit-learn-contrib/imbalanced-learn/blob/56eefdf3d92afca77bc16fc13d315db5287df2fa/imblearn/over_sampling/_smote/filter.py#L366), to utilize cuML's SVC in place of sklearn's SVC.

In order to properly fill the `support_` indices, we must first extract the `support_` indices from each estimator in the multi-class wrapper. Then, these indices must be aligned with the full multi-class dataset, as each estimator only receives a binary (ovo) dataset that has certain classes removed by the multi-class wrapper.

Here is a gist that displays and compares the (current) behavior of sklearn and cuml when performing a multi-class fit(). Prior to the changes in this PR, clf_cuml.support_ simply returned None.