### PR TITLE
Enable crosslink to rmm

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -46,6 +46,7 @@ conda list --show-channel-urls
 # Build Doxygen docs
 gpuci_logger "Build Doxygen docs"
 "$PROJECT_WORKSPACE/build.sh" cppdocs -v
+wget "https://raw.githubusercontent.com/rapidsai/docs/gh-pages/api/librmm/${BRANCH_VERSION}/rmm.tag" || echo "Failed to download rmm Doxygen tag"
 
 # Build Python docs
 gpuci_logger "Build Sphinx docs"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,3 +47,6 @@ for FILE in conda/environments/*.yml; do
    sed_runner "s/rapids-notebook-env=${CURRENT_SHORT_TAG}/rapids-notebook-env=${NEXT_SHORT_TAG}/g" ${FILE};
    sed_runner "s/rapids-doc-env=${CURRENT_SHORT_TAG}/rapids-doc-env=${NEXT_SHORT_TAG}/g" ${FILE};
 done
+
+# Doxyfile update
+sed_runner "s|\(TAGFILES.*librmm/\).*|\1${NEXT_SHORT_TAG}|" cpp/doxygen/Doxyfile

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -49,4 +49,4 @@ for FILE in conda/environments/*.yml; do
 done
 
 # Doxyfile update
-sed_runner "s|\(TAGFILES.*librmm/\).*|\1${NEXT_SHORT_TAG}|" cpp/doxygen/Doxyfile
+sed_runner "s|\(TAGFILES.*librmm/\).*|\1${NEXT_SHORT_TAG}|" cpp/Doxyfile

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -49,4 +49,4 @@ for FILE in conda/environments/*.yml; do
 done
 
 # Doxyfile update
-sed_runner "s|\(TAGFILES.*librmm/\).*|\1${NEXT_SHORT_TAG}|" cpp/Doxyfile
+sed_runner "s|\(TAGFILES.*librmm/\).*|\1${NEXT_SHORT_TAG}|" cpp/Doxyfile.in

--- a/cpp/Doxyfile.in
+++ b/cpp/Doxyfile.in
@@ -2062,7 +2062,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = rmm.tag=https://docs.rapids.ai/api/librmm/0.18
+TAGFILES               = rmm.tag=https://docs.rapids.ai/api/librmm/21.12
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/cpp/Doxyfile.in
+++ b/cpp/Doxyfile.in
@@ -2062,7 +2062,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = rmm.tag=https://docs.rapids.ai/api/librmm/0.18
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to


### PR DESCRIPTION
This PR updates cpp/Doxyfile.in to consume the generated Doxygen tags from rmm (see rapidsai/rmm#672). This will enable linking between the cuml docs and rmm docs.