### PR TITLE
Add CUB include directory to CMake for CUDA 11.5

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -190,6 +190,14 @@ endif()
 rapids_cpm_init()
 
 include(cmake/thirdparty/get_thrust.cmake)
+# need to find cub's include directory after change to rapids-cmake 21.12
+  find_path(
+  CUB_INCLUDE "cub" HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
+                          "${CUDF_CPP_BUILD_DIR}/_deps/thrust-src" "$ENV{CONDA_PREFIX}/include"
+)
+
+message(STATUS "CUB: CUB_INCLUDE set to ${CUB_INCLUDE}")
+
 include(cmake/thirdparty/get_rmm.cmake)
 
 if(LINK_FAISS)
@@ -363,6 +371,7 @@ if(BUILD_CUML_CPP_LIBRARY)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:$<$<BOOL:${ENABLE_CUMLPRIMS_MG}>:${cumlprims_mg_INCLUDE_DIRS}>>
     PRIVATE
+      "${CUB_INCLUDE}"
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/metrics>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src_prims>
@@ -378,6 +387,7 @@ if(BUILD_CUML_CPP_LIBRARY)
       cuml::Thrust
       raft::raft
     PRIVATE
+      CUB::CUB
       CUDA::cublas
       CUDA::cufft
       CUDA::curand

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -195,6 +195,7 @@ include(cmake/thirdparty/get_thrust.cmake)
 find_path(
 CUB_INCLUDE "cub" HINTS "$ENV{CUML_ROOT}/_deps/thrust-src"
                         "${CMAKE_CURRENT_BINARY_DIR}/_deps/thrust-src"
+                        "$ENV{CONDA_PREFIX}/include"
 )
 
 message(STATUS "CUML: Setting CUB_INCLUDE to ${CUB_INCLUDE}")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -190,13 +190,14 @@ endif()
 rapids_cpm_init()
 
 include(cmake/thirdparty/get_thrust.cmake)
+
 # need to find cub's include directory after change to rapids-cmake 21.12
-  find_path(
-  CUB_INCLUDE "cub" HINTS "$ENV{CUML_ROOT}/_deps/thrust-src"
-                          "${CUML_CPP_BUILD_DIR}/_deps/thrust-src" "$ENV{CONDA_PREFIX}/include"
+find_path(
+CUB_INCLUDE "cub" HINTS "$ENV{CUML_ROOT}/_deps/thrust-src"
+                        "${CMAKE_CURRENT_BINARY_DIR}/_deps/thrust-src"
 )
 
-message(STATUS "CUB: CUB_INCLUDE set to ${CUB_INCLUDE}")
+message(STATUS "CUML: Setting CUB_INCLUDE to ${CUB_INCLUDE}")
 
 include(cmake/thirdparty/get_rmm.cmake)
 
@@ -387,7 +388,6 @@ if(BUILD_CUML_CPP_LIBRARY)
       cuml::Thrust
       raft::raft
     PRIVATE
-      CUB::CUB
       CUDA::cublas
       CUDA::cufft
       CUDA::curand

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -192,8 +192,8 @@ rapids_cpm_init()
 include(cmake/thirdparty/get_thrust.cmake)
 # need to find cub's include directory after change to rapids-cmake 21.12
   find_path(
-  CUB_INCLUDE "cub" HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
-                          "${CUDF_CPP_BUILD_DIR}/_deps/thrust-src" "$ENV{CONDA_PREFIX}/include"
+  CUB_INCLUDE "cub" HINTS "$ENV{CUML_ROOT}/_deps/thrust-src"
+                          "${CUML_CPP_BUILD_DIR}/_deps/thrust-src" "$ENV{CONDA_PREFIX}/include"
 )
 
 message(STATUS "CUB: CUB_INCLUDE set to ${CUB_INCLUDE}")

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -90,6 +90,7 @@ if(BUILD_CUML_TESTS)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src_prims>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/prims>
+      "${CUB_INCLUDE}"
   )
 
   target_link_libraries(${CUML_CPP_TEST_TARGET}


### PR DESCRIPTION
Not sure why, but changng RAPIDS-CMake from 21.10 to 21.12  made this change necessary for CUDA 11.5, taken from cuDF. Will open an issue in RAPIDS-CMake later today 