### PR TITLE
Fix unnecessary f32/f64 conversions in t-SNE KL calc

### DIFF
--- a/cpp/src/tsne/utils.cuh
+++ b/cpp/src/tsne/utils.cuh
@@ -221,7 +221,7 @@ value_t compute_kl_div(value_t* restrict Ps,
 template <typename value_t>
 __device__ value_t compute_q(value_t dist, value_t dof)
 {
-  const value_t exponent = (dof + 1.0) / 2.0;
+  const value_t exponent = (dof + 1.0f) / 2.0f;
   const value_t Q        = __powf(dof / (dof + dist), exponent);
   return Q;
 }


### PR DESCRIPTION
The old code compiles to
```asm
cvt.f64.f32     %fd1, %f1;
add.f64         %fd2, %fd1, 0d3FF0000000000000;
mul.f64         %fd3, %fd2, 0d3FE0000000000000;
cvt.rn.f32.f64  %f2, %fd3;
```
instead of just
```asm
add.f32         %f2, %f1, 0f3F800000;
mul.f32         %f3, %f2, 0f3F000000;
```