### PR TITLE
Update cub 1.13.1 calls

### DIFF
--- a/cpp/src/hdbscan/detail/membership.cuh
+++ b/cpp/src/hdbscan/detail/membership.cuh
@@ -80,7 +80,7 @@ void get_probabilities(const raft::handle_t& handle,
     n_clusters,
     sorted_parents_offsets.data(),
     stream,
-    cub::DeviceSegmentedReduce::Max<const value_t*, value_t*, const value_idx*>);
+    cub::DeviceSegmentedReduce::Max<const value_t*, value_t*, const value_idx*, const value_idx*>);
 
   // Calculate probability per point
   thrust::fill(exec_policy, probabilities, probabilities + n_leaves, 0.0f);

--- a/cpp/src/hdbscan/detail/stabilities.cuh
+++ b/cpp/src/hdbscan/detail/stabilities.cuh
@@ -102,7 +102,7 @@ void compute_stabilities(const raft::handle_t& handle,
     n_clusters - 1,
     sorted_parents_offsets.data() + 1,
     stream,
-    cub::DeviceSegmentedReduce::Min<const value_t*, value_t*, const value_idx*>);
+    cub::DeviceSegmentedReduce::Min<const value_t*, value_t*, const value_idx*, const value_idx*>);
   // finally, we find minimum between initialized births where parent=child
   // and births of parents for their childrens
   auto births_zip =


### PR DESCRIPTION
Updates calls to account for API changes in CUB 1.13.1 allowing upgrade to thrust 1.13+