### PR TITLE
Use IS_STABLE_BUILD env variable to detect nightly builds

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -27,7 +27,7 @@ export CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
 cd $WORKSPACE
 
 # If nightly build, append current YYMMDD to version
-if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = branch-* ]] ; then
+if [ "${IS_STABLE_BUILD}" != "true" ] ; then
   export VERSION_SUFFIX=`date +%y%m%d`
 fi
 
@@ -42,8 +42,8 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-# Remove rapidsai-nightly channel if we are building main branch
-if [ "$SOURCE_BRANCH" = "main" ]; then
+# Remove rapidsai-nightly channel if it is stable build
+if [ "${IS_STABLE_BUILD}" != "true" ]; then
   conda config --system --remove channels rapidsai-nightly
 fi
 


### PR DESCRIPTION
As we are doing release from branches, we need to use `IS_STABLE_BUILD` to detect stable builds