### PR TITLE
Fix stable logic - `21.08`

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -43,7 +43,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 # Remove rapidsai-nightly channel if it is stable build
-if [ "${IS_STABLE_BUILD}" != "true" ]; then
+if [ "${IS_STABLE_BUILD}" = "true" ]; then
   conda config --system --remove channels rapidsai-nightly
 fi
 


### PR DESCRIPTION
This PR fixes the logic for when the `nightly` channel should be removed.