### PR TITLE
Fix `is_stable_build` logic for CI scripts

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -43,7 +43,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 # Remove rapidsai-nightly channel if it is stable build
-if [ "${IS_STABLE_BUILD}" != "true" ]; then
+if [ "${IS_STABLE_BUILD}" = "true" ]; then
   conda config --system --remove channels rapidsai-nightly
 fi
 


### PR DESCRIPTION
This PR fixes the logic for when the `nightly` channel should be removed.

The change is also incorporated in the forward-merger PR below, but it may take a while to resolve the conflicts there.

https://github.com/rapidsai/cuml/pull/4349