### PR TITLE
Update clang-format version in docs; allow unanchored version string

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -18,7 +18,7 @@ The `test` directory has subdirectories that reflect this distinction between th
 1. cmake (>= 3.20.1)
 2. CUDA (>= 11.0)
 3. gcc (>=9.3.0)
-4. clang-format (= 8.0.1) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=8` and `clang-tools=8` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
+4. clang-format (= 11.0.0) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=11` and `clang-tools=11` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
 5. UCX with CUDA support [optional](>=1.7) - enables point-to-point messaging in the cuML communicator.
 
 ### Building cuML:

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -65,7 +65,7 @@ def parse_args():
         args.dstdir = tempfile.mkdtemp()
     ret = subprocess.check_output("%s --version" % args.exe, shell=True)
     ret = ret.decode("utf-8")
-    version = VERSION_REGEX.match(ret)
+    version = VERSION_REGEX.search(ret)
     if version is None:
         raise Exception("Failed to figure out clang-format version!")
     version = version.group(1)


### PR DESCRIPTION
`clang-format -version` installed with apt on Ubuntu reports `Ubuntu clang-format version 11.0.0-2~ubuntu20.04.1`, so we need an unanchored search here.

The script also requires 11.0.0 and not 8.0.1 now.