### PR TITLE
Restore FIL convention of inlining code

### DIFF
--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -36,7 +36,7 @@
 #endif  // __CUDA_ARCH__
 #endif  // CUDA_PRAGMA_UNROLL
 
-#define INLINE_CONFIG __noinline__
+#define INLINE_CONFIG __forceinline__
 
 namespace ML {
 namespace fil {


### PR DESCRIPTION
A previous PR has accidentally uninlined two methods. We are not aware of a significant perf impact in one or another direction, but the intention was to explore the instruction-level impact more before mainlining the change.