### PR TITLE
[REVIEW] Upgrade `clang` to `11.1.0`

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -18,7 +18,7 @@ The `test` directory has subdirectories that reflect this distinction between th
 1. cmake (>= 3.20.1)
 2. CUDA (>= 11.0)
 3. gcc (>=9.3.0)
-4. clang-format (= 11.0.0) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=11` and `clang-tools=11` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
+4. clang-format (= 11.1.0) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=11` and `clang-tools=11` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
 5. UCX with CUDA support [optional](>=1.7) - enables point-to-point messaging in the cuML communicator.
 
 ### Building cuML:

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -23,7 +23,7 @@ import tempfile
 import shutil
 
 
-EXPECTED_VERSION = "11.0.0"
+EXPECTED_VERSION = "11.1.0"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to
 #       to the cuml repo


### PR DESCRIPTION
This upgrade is required to be in-line with: rapidsai/cudf#9716

Depends on: rapidsai/integration#390