### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -57,6 +57,7 @@ requirements:
     - treelite=2.1.0
     - faiss-proc=*=cuda
     - libfaiss 1.7.0 *_cuda
+    - libcusolver>=11.2.1
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.