### PR TITLE
Add CUML_USING_RANGE macro for easier NVTX profiling

### DIFF
--- a/cpp/src/common/nvtx.hpp
+++ b/cpp/src/common/nvtx.hpp
@@ -75,6 +75,7 @@ class AUTO_RANGE {
    *
    * @param stream stream to synchronize
    * @param name range name (accepts printf-style arguments)
+   * @param args the arguments for the printf-style formatting
    */
   template <typename... Args>
   AUTO_RANGE(rmm::cuda_stream_view stream, const char* name, Args... args)
@@ -88,6 +89,7 @@ class AUTO_RANGE {
    * At the end of the object lifetime, pop the range back.
    *
    * @param name range name (accepts printf-style arguments)
+   * @param args the arguments for the printf-style formatting
    */
   template <typename... Args>
   AUTO_RANGE(const char* name, Args... args) : stream(std::nullopt)
@@ -106,9 +108,10 @@ class AUTO_RANGE {
 
 /*!
   \def CUML_USING_RANGE(...)
-  When NVTX is enabled, push a named nvtx range now and pop it at the end of the code block.
+  When NVTX is enabled, push a named nvtx range and pop it at the end of the enclosing code block.
 
   This macro initializes a dummy AUTO_RANGE variable on the stack,
+  which pushes the range in its constructor and pops it in the destructor.
 */
 #ifdef NVTX_ENABLED
 #define CUML_USING_RANGE(...) ML::AUTO_RANGE _AUTO_RANGE_##__LINE__(__VA_ARGS__)

--- a/cpp/src/glm/ols.cuh
+++ b/cpp/src/glm/ols.cuh
@@ -94,17 +94,18 @@ void olsFit(const raft::handle_t& handle,
   int selectedAlgo = algo;
   if (n_cols > n_rows || n_cols == 1) selectedAlgo = 0;
 
-  ML::PUSH_RANGE("Trace::MLCommon::LinAlg::ols-lstsq*", stream);
-  switch (selectedAlgo) {
-    case 0: LinAlg::lstsqSvdJacobi(handle, input, n_rows, n_cols, labels, coef, stream); break;
-    case 1: LinAlg::lstsqEig(handle, input, n_rows, n_cols, labels, coef, stream); break;
-    case 2: LinAlg::lstsqQR(handle, input, n_rows, n_cols, labels, coef, stream); break;
-    case 3: LinAlg::lstsqSvdQR(handle, input, n_rows, n_cols, labels, coef, stream); break;
-    default:
-      ASSERT(false, "olsFit: no algorithm with this id (%d) has been implemented", algo);
-      break;
+  {
+    CUML_USING_RANGE(stream, "ML::GLM::olsFit::impl-%d", selectedAlgo);
+    switch (selectedAlgo) {
+      case 0: LinAlg::lstsqSvdJacobi(handle, input, n_rows, n_cols, labels, coef, stream); break;
+      case 1: LinAlg::lstsqEig(handle, input, n_rows, n_cols, labels, coef, stream); break;
+      case 2: LinAlg::lstsqQR(handle, input, n_rows, n_cols, labels, coef, stream); break;
+      case 3: LinAlg::lstsqSvdQR(handle, input, n_rows, n_cols, labels, coef, stream); break;
+      default:
+        ASSERT(false, "olsFit: no algorithm with this id (%d) has been implemented", algo);
+        break;
+    }
   }
-  ML::POP_RANGE(stream);
 
   if (fit_intercept) {
     postProcessData(handle,

--- a/cpp/src/svm/linear.cu
+++ b/cpp/src/svm/linear.cu
@@ -362,6 +362,8 @@ LinearSVMModel<T> LinearSVMModel<T>::fit(const raft::handle_t& handle,
                                          const T* y,
                                          const T* sampleWeight)
 {
+  CUML_USING_RANGE("ML::SVM::LinearSVMModel-%d-%d", nRows, nCols);
+
   cudaStream_t stream = handle.get_stream();
   rmm::device_uvector<T> classesBuf(0, stream);
   const std::size_t nClasses =
@@ -375,8 +377,6 @@ LinearSVMModel<T> LinearSVMModel<T>::fit(const raft::handle_t& handle,
 
   const int coefCols         = narrowDown(model.coefCols());
   const std::size_t coefRows = model.coefRows;
-
-  ML::PUSH_RANGE("Trace::LinearSVMModel::fit");
 
   auto nCols1 = nCols + int(params.fit_intercept && params.penalized_intercept);
   T iC        = params.C > 0 ? (1.0 / params.C) : 1.0;
@@ -504,7 +504,6 @@ LinearSVMModel<T> LinearSVMModel<T>::fit(const raft::handle_t& handle,
       raft::linalg::transpose(handle, ps1, model.probScale, 2, coefCols, stream);
   }
 
-  ML::POP_RANGE();
   return model;
 }
 

--- a/cpp/src_prims/linalg/lstsq.cuh
+++ b/cpp/src_prims/linalg/lstsq.cuh
@@ -301,9 +301,10 @@ void lstsqEig(const raft::handle_t& handle,
   multAbDone.record(multAbStream);
 
   // Q S Q* <- covA
-  ML::PUSH_RANGE("Trace::MLCommon::LinAlg::lstsq::eigDC", mainStream);
-  raft::linalg::eigDC(handle, covA, n_cols, n_cols, Q, S, mainStream);
-  ML::POP_RANGE(mainStream);
+  {
+    CUML_USING_RANGE("raft::linalg::eigDC", mainStream);
+    raft::linalg::eigDC(handle, covA, n_cols, n_cols, Q, S, mainStream);
+  }
 
   // QS  <- Q invS
   raft::linalg::matrixVectorOp(


### PR DESCRIPTION
Add an `AUTO_RANGE` type and a `CUML_USING_RANGE` macro for easier profiling with NVTX.

  1.  `CUML_USING_RANGE` creates a variable `AUTO_RANGE` on the stack, so it's destructed at the end of the enclosing code block (and triggers `POP_RANGE`). The benefit is to (a) never forget to pop the range and (b) do not mess up the NVTX profile in the presence of exceptions.
  2. The macro and the constructor support printf-style varargs to label things in a more meaningful way (e.g. add an epoch number to the label).