### PR TITLE
Remove classmethod of SimpleImputer

### DIFF
--- a/python/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
+++ b/python/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
@@ -41,7 +41,6 @@ class BaseEstimator(Base):
 
         cls.__init__ = init
 
-    @classmethod
     def _check_n_features(self, X, reset):
         """Set the `n_features_in_` attribute, or check against it.
 


### PR DESCRIPTION
Closes #4341.
The `classmethod` decorator seems to not be useful here and is blocking the serialization of SimpleImputer.