### PR TITLE
Update CUDA 11.5 conda environment to use 22.02 pinnings.

### DIFF
--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -6,14 +6,14 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.5
-- rapids-build-env=21.12.*
-- rapids-notebook-env=21.12.*
-- rapids-doc-env=21.12.*
-- cudf=21.12.*
-- rmm=21.12.*
-- libcumlprims=21.12.*
-- dask-cudf=21.12.*
-- dask-cuda=21.12.*
+- rapids-build-env=22.02.*
+- rapids-notebook-env=22.02.*
+- rapids-doc-env=22.02.*
+- cudf=22.02.*
+- rmm=22.02.*
+- libcumlprims=22.02.*
+- dask-cudf=22.02.*
+- dask-cuda=22.02.*
 - ucx-py=0.24
 - ucx-proc=*=gpu
 - dask-ml


### PR DESCRIPTION
This PR updates the pinnings of the conda environment for CUDA 11.5 to use 22.02 packages. This resolves conflicts between a5e7cfb5c32f6e7eb7e8d64628f686c3b973789e and #4364.
