### PR TITLE
Allow CuPy 10

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - cupy>=7.8.0,<10.0.0a0
+    - cupy>=7.8.0,<11.0.0a0
     - treelite=2.1.0
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}


### PR DESCRIPTION
Relaxes version constraints to allow CuPy 10.

xref: https://github.com/rapidsai/integration/pull/413