### PR TITLE
Prepare upload scripts for Python 3.7 removal

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) 2022, NVIDIA CORPORATION.
 
 export UPLOAD_CUML=1
 

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -2,7 +2,7 @@
 
 export UPLOAD_CUML=1
 
-if [[ "$PYTHON" == "3.7" ]]; then
+if [[ "$PYTHON" == "3.8" ]]; then
     export UPLOAD_LIBCUML=1
 else
     export UPLOAD_LIBCUML=0


### PR DESCRIPTION
As we will remove Python 3.7, we need to update the Python version in the upload scripts