### PR TITLE
[REVIEW] Remove xfail from test_hinge_loss

### DIFF
--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -1381,8 +1381,6 @@ def test_sparse_pairwise_distances_output_types(input_type, output_type):
             assert isinstance(S, cp.ndarray)
 
 
-@pytest.mark.xfail(reason='Temporarily disabling this test. '
-                          'See rapidsai/cuml#3569')
 @pytest.mark.parametrize("nrows, ncols, n_info",
                          [
                              unit_param(30, 10, 7),

--- a/python/cuml/test/test_metrics.py
+++ b/python/cuml/test/test_metrics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #3569 
The test passes and does not need the xfail decorator. 