### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -56,11 +56,9 @@ set(CUML_BRANCH_VERSION_raft "${CUML_VERSION_MAJOR}.${CUML_VERSION_MINOR}")
 # Change pinned tag here to test a commit in CI
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
-find_and_configure_raft(VERSION    ${CUML_MIN_VERSION_raft}
-                        # FORK       rapidsai
-                        # PINNED_TAG branch-${CUML_BRANCH_VERSION_raft}
-                        FORK             robertmaynard
-                        PINNED_TAG       refactor_cmake_raft_target_logic
+find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
+                        FORK             rapidsai
+                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
                         USE_RAFT_NN      ${CUML_USE_RAFT_NN}
                         USE_FAISS_STATIC ${CUML_USE_FAISS_STATIC}
                         )


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.