### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -125,8 +125,8 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
 
     gpuci_logger "Install the main version of dask and distributed"
     set -x
-    pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
-    pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
+    pip install "git+https://github.com/dask/distributed.git@2022.01.0" --upgrade --no-deps
+    pip install "git+https://github.com/dask/dask.git@2022.01.0" --upgrade --no-deps
     set +x
 
     gpuci_logger "Python pytest for cuml"
@@ -217,8 +217,8 @@ else
     
     gpuci_logger "Install the main version of dask and distributed"
     set -x
-    pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
-    pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
+    pip install "git+https://github.com/dask/distributed.git@2022.01.0" --upgrade --no-deps
+    pip install "git+https://github.com/dask/dask.git@2022.01.0" --upgrade --no-deps
     set +x
     
     gpuci_logger "Python pytest for cuml"

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -31,8 +31,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@main
-    - git+https://github.com/dask/distributed.git@main
+    - git+https://github.com/dask/dask.git@2022.01.0
+    - git+https://github.com/dask/distributed.git@2022.01.0
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -31,8 +31,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@main
-    - git+https://github.com/dask/distributed.git@main
+    - git+https://github.com/dask/dask.git@2022.01.0
+    - git+https://github.com/dask/distributed.git@2022.01.0
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -31,8 +31,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@main
-    - git+https://github.com/dask/distributed.git@main
+    - git+https://github.com/dask/dask.git@2022.01.0
+    - git+https://github.com/dask/distributed.git@2022.01.0
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -31,8 +31,8 @@ dependencies:
 - pip
 - pip:
     - sphinx_markdown_tables
-    - git+https://github.com/dask/dask.git@main
-    - git+https://github.com/dask/distributed.git@main
+    - git+https://github.com/dask/dask.git@2022.01.0
+    - git+https://github.com/dask/distributed.git@2022.01.0
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -49,8 +49,8 @@ requirements:
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - dask>=2021.11.1
-    - distributed>=2021.11.1
+    - dask>=2021.11.1,<=2022.01.0
+    - distributed>=2021.11.1,<=2022.01.0
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - cuda-python >=11.5,<12.0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.