### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/cpp/bench/prims/fused_l2_nn.cu
+++ b/cpp/bench/prims/fused_l2_nn.cu
@@ -21,6 +21,7 @@
 #include <raft/handle.hpp>
 #include <raft/linalg/norm.cuh>
 #include <raft/random/rng.hpp>
+#include <raft/spatial/knn/specializations.hpp>
 
 namespace MLCommon {
 namespace Bench {


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.