### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -2,12 +2,7 @@
 # Copyright (c) 2022, NVIDIA CORPORATION.
 
 export UPLOAD_CUML=1
-
-if [[ "$PYTHON" == "3.8" ]]; then
-    export UPLOAD_LIBCUML=1
-else
-    export UPLOAD_LIBCUML=0
-fi
+export UPLOAD_LIBCUML=1
 
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     #If project flash is not activate, always build both


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.