### PR TITLE
Prepare for Python 3.7 removal

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -199,10 +199,10 @@ else
     CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
     gpuci_logger "Installing $CONDA_FILE"
     gpuci_mamba_retry install -c ${CONDA_ARTIFACT_PATH} "$CONDA_FILE"
-    
-    # FIXME: Project FLASH only builds for python version 3.7 which is the one used in 
-    # the CUDA 11.0 job, need to change all versions to project flash 
-    if [ "$py_ver" == "3.7" ];then
+
+    # FIXME: Project FLASH only builds for python version 3.8 which is the one used in
+    # the CUDA 11.0 job, need to change all versions to project flash
+    if [ "$py_ver" == "3.8" ];then
         gpuci_logger "Using Project FLASH to install cuml python"
         CONDA_FILE=`find ${CONDA_ARTIFACT_PATH} -name "cuml*.tar.bz2"`
         CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
@@ -212,21 +212,21 @@ else
 
     else
         gpuci_logger "Building cuml python in gpu job"
-        "$WORKSPACE/build.sh" -v cuml --codecov   
+        "$WORKSPACE/build.sh" -v cuml --codecov
     fi
-    
+
     gpuci_logger "Install the main version of dask and distributed"
     set -x
     pip install "git+https://github.com/dask/distributed.git@2022.01.0" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask.git@2022.01.0" --upgrade --no-deps
     set +x
-    
+
     gpuci_logger "Python pytest for cuml"
     cd $WORKSPACE/python
-    
+
     # When installing cuml with project flash, we need to delete all folders except
-    # cuml/test since we are not building cython extensions in place 
-    if [ "$py_ver" == "3.7" ];then
+    # cuml/test since we are not building cython extensions in place
+    if [ "$py_ver" == "3.8" ];then
         find ./cuml -mindepth 1 ! -regex '^./cuml/test\(/.*\)?' -delete
     fi
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/setup.py
+++ b/python/setup.py
@@ -179,10 +179,6 @@ class cuml_build(_build):
         self.distribution.packages = find_packages(include=['cuml', 'cuml.*'],
                                                    exclude=python_exc_list)
 
-        print("--DBG:: libs")
-        print(libs)
-        print("--END")
-
         # Build the extensions list
         extensions = [
             Extension("*",
@@ -198,10 +194,6 @@ class cuml_build(_build):
                       language='c++',
                       extra_compile_args=['-std=c++17'])
         ]
-
-        print("--DBG:: extensions")
-        print(extensions)
-        print("--END")
 
         self.distribution.ext_modules = extensions
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -179,6 +179,10 @@ class cuml_build(_build):
         self.distribution.packages = find_packages(include=['cuml', 'cuml.*'],
                                                    exclude=python_exc_list)
 
+        print("--DBG:: libs")
+        print(libs)
+        print("--END")
+
         # Build the extensions list
         extensions = [
             Extension("*",
@@ -194,6 +198,10 @@ class cuml_build(_build):
                       language='c++',
                       extra_compile_args=['-std=c++17'])
         ]
+
+        print("--DBG:: extensions")
+        print(extensions)
+        print("--END")
 
         self.distribution.ext_modules = extensions
 
@@ -223,6 +231,10 @@ class cuml_build_ext(cython_build_ext, object):
 
         # Ignore deprecation declaraction warnings
         self.compiler.compiler_so.append("-Wno-deprecated-declarations")
+
+        # adding flags to always add symbols/link of libcuml++ and transitive
+        # dependencies to Cython extensions
+        self.compiler.linker_so.append("-Wl,--no-as-needed")
 
         # No debug symbols, full optimization, no '-Wstrict-prototypes' warning
         remove_flags(
@@ -277,8 +289,8 @@ setup(name='cuml',
       classifiers=[
           "Intended Audience :: Developers",
           "Programming Language :: Python",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3.8"
+          "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9"
       ],
       author="NVIDIA Corporation",
       setup_requires=['cython'],


### PR DESCRIPTION
As Python 3.7 is being removed, the new default version is Python 3.8