### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 ##############################################
 # cuML CPU conda build script for CI         #
 ##############################################
@@ -63,12 +63,19 @@ conda list --show-channel-urls
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
-# FIXME: for now, force the building of all packages so they are built on a
+# Build python package in CUDA jobs so they are built on a
 # machine with a single CUDA version, then have the gpu/build.sh script simply
 # install. This should eliminate a mismatch between different CUDA versions on
 # cpu vs. gpu builds that is problematic with CUDA 11.5 Enhanced Compat.
-BUILD_LIBCUML=1
-BUILD_CUML=1
+if [ "$BUILD_LIBCUML" == '1' ]; then
+  echo "BUILD_LIBCUML=1: Setting BUILD_CUML to 1..."
+  BUILD_CUML=1
+  # If we are doing CUDA + Python builds, libcuml package is located at ${CONDA_BLD_DIR}
+  CONDA_LOCAL_CHANNEL="${CONDA_BLD_DIR}"
+else
+  # If we are doing Python builds only, libcuml package is placed here by Project Flash
+  CONDA_LOCAL_CHANNEL="ci/artifacts/cuml/cpu/.conda-bld/"
+fi
 
 ################################################################################
 # BUILD - Conda package builds (conda deps: libcuml <- cuml)
@@ -83,9 +90,8 @@ else
   if [ "$BUILD_LIBCUML" == '1' ]; then
     gpuci_logger "PROJECT FLASH: Build conda pkg for libcuml"
     gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcuml --dirty --no-remove-work-dir
-    mkdir -p ${CONDA_BLD_DIR}/libcuml/work
-    cp -r ${CONDA_BLD_DIR}/work/* ${CONDA_BLD_DIR}/libcuml/work
-    rm -rf ${CONDA_BLD_DIR}/work
+    mkdir -p ${CONDA_BLD_DIR}/libcuml
+    mv ${CONDA_BLD_DIR}/work/ ${CONDA_BLD_DIR}/libcuml/work
   fi
 fi
 
@@ -95,10 +101,9 @@ if [ "$BUILD_CUML" == '1' ]; then
     gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/cuml --python=${PYTHON}
   else
     gpuci_logger "PROJECT FLASH: Build conda pkg for cuml"
-    gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cuml -c $CONDA_BLD_DIR --dirty --no-remove-work-dir --python=${PYTHON}
-    mkdir -p ${CONDA_BLD_DIR}/cuml/work
-    cp -r ${CONDA_BLD_DIR}/work/* ${CONDA_BLD_DIR}/cuml/work
-    rm -rf ${CONDA_BLD_DIR}/work
+    gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cuml -c ${CONDA_LOCAL_CHANNEL} --dirty --no-remove-work-dir --python=${PYTHON}
+    mkdir -p ${CONDA_BLD_DIR}/cuml
+    mv ${CONDA_BLD_DIR}/work/ ${CONDA_BLD_DIR}/cuml/work
   fi
 fi
 
@@ -108,4 +113,3 @@ fi
 
 gpuci_logger "Upload conda pkgs"
 source ci/cpu/upload.sh
-


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.