### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,58 @@
 # cuML 22.02.00 (2 Feb 2022)
 
-## 🚨 Beaking Changes
+## 🚨 Breaking Changes
 
-- Move NVTX ange helpes to aft ([#4445](https://github.com/rapidsai/cuml/pull/4445)) [@achikin](https://github.com/achikin)
+- Move NVTX range helpers to raft ([#4445](https://github.com/rapidsai/cuml/pull/4445)) [@achirkin](https://github.com/achirkin)
 
 ## 🐛 Bug Fixes
 
-- Always upload libcuml ([#4530](https://github.com/rapidsai/cuml/pull/4530)) [@aydouglass](https://github.com/aydouglass)
-- Fix RAFT pin to main banch ([#4508](https://github.com/rapidsai/cuml/pull/4508)) [@dantegd](https://github.com/dantegd)
-- Pin `dask` &amp; `distibuted` ([#4505](https://github.com/rapidsai/cuml/pull/4505)) [@galipemsaga](https://github.com/galipemsaga)
-- Replace use of RMM povided CUDA bindings with CUDA Python ([#4499](https://github.com/rapidsai/cuml/pull/4499)) [@shwina](https://github.com/shwina)
-- Datafame Index as columns in ColumnTansfome ([#4481](https://github.com/rapidsai/cuml/pull/4481)) [@viclafague](https://github.com/viclafague)
-- Suppot compilation with Thust 1.15 ([#4469](https://github.com/rapidsai/cuml/pull/4469)) [@obetmaynad](https://github.com/obetmaynad)
-- fix mino ASAN issues in UMAPAlgo::Optimize::find_paams_ab() ([#4405](https://github.com/rapidsai/cuml/pull/4405)) [@yitao-li](https://github.com/yitao-li)
+- Always upload libcuml ([#4530](https://github.com/rapidsai/cuml/pull/4530)) [@raydouglass](https://github.com/raydouglass)
+- Fix RAFT pin to main branch ([#4508](https://github.com/rapidsai/cuml/pull/4508)) [@dantegd](https://github.com/dantegd)
+- Pin `dask` &amp; `distributed` ([#4505](https://github.com/rapidsai/cuml/pull/4505)) [@galipremsagar](https://github.com/galipremsagar)
+- Replace use of RMM provided CUDA bindings with CUDA Python ([#4499](https://github.com/rapidsai/cuml/pull/4499)) [@shwina](https://github.com/shwina)
+- Dataframe Index as columns in ColumnTransformer ([#4481](https://github.com/rapidsai/cuml/pull/4481)) [@viclafargue](https://github.com/viclafargue)
+- Support compilation with Thrust 1.15 ([#4469](https://github.com/rapidsai/cuml/pull/4469)) [@robertmaynard](https://github.com/robertmaynard)
+- fix minor ASAN issues in UMAPAlgo::Optimize::find_params_ab() ([#4405](https://github.com/rapidsai/cuml/pull/4405)) [@yitao-li](https://github.com/yitao-li)
 
 ## 📖 Documentation
 
-- Remove comment numeical waning ([#4408](https://github.com/rapidsai/cuml/pull/4408)) [@viclafague](https://github.com/viclafague)
-- Fix docsting fo npemutations in PemutationExplaine ([#4402](https://github.com/rapidsai/cuml/pull/4402)) [@hcho3](https://github.com/hcho3)
+- Remove comment numerical warning ([#4408](https://github.com/rapidsai/cuml/pull/4408)) [@viclafargue](https://github.com/viclafargue)
+- Fix docstring for npermutations in PermutationExplainer ([#4402](https://github.com/rapidsai/cuml/pull/4402)) [@hcho3](https://github.com/hcho3)
 
-## 🚀 New Featues
+## 🚀 New Features
 
-- Combine and expose SVC&#39;s suppot vectos when fitting multi-class data ([#4454](https://github.com/rapidsai/cuml/pull/4454)) [@NV-jpt](https://github.com/NV-jpt)
-- Accept fold index fo TagetEncode ([#4453](https://github.com/rapidsai/cuml/pull/4453)) [@daxiongshu](https://github.com/daxiongshu)
-- Move NVTX ange helpes to aft ([#4445](https://github.com/rapidsai/cuml/pull/4445)) [@achikin](https://github.com/achikin)
+- Combine and expose SVC&#39;s support vectors when fitting multi-class data ([#4454](https://github.com/rapidsai/cuml/pull/4454)) [@NV-jpt](https://github.com/NV-jpt)
+- Accept fold index for TargetEncoder ([#4453](https://github.com/rapidsai/cuml/pull/4453)) [@daxiongshu](https://github.com/daxiongshu)
+- Move NVTX range helpers to raft ([#4445](https://github.com/rapidsai/cuml/pull/4445)) [@achirkin](https://github.com/achirkin)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
 - Fix packages upload ([#4517](https://github.com/rapidsai/cuml/pull/4517)) [@Ethyling](https://github.com/Ethyling)
 - Testing split fused l2 knn compilation units ([#4514](https://github.com/rapidsai/cuml/pull/4514)) [@cjnolet](https://github.com/cjnolet)
-- Pepae upload scipts fo Python 3.7 emoval ([#4500](https://github.com/rapidsai/cuml/pull/4500)) [@Ethyling](https://github.com/Ethyling)
-- Renaming macos with thei RAFT countepats ([#4496](https://github.com/rapidsai/cuml/pull/4496)) [@divyegala](https://github.com/divyegala)
-- Allow CuPy 10 ([#4487](https://github.com/rapidsai/cuml/pull/4487)) [@jakikham](https://github.com/jakikham)
-- Upgade Teelite to 2.2.1 ([#4484](https://github.com/rapidsai/cuml/pull/4484)) [@hcho3](https://github.com/hcho3)
-- Unpin `dask` and `distibuted` ([#4482](https://github.com/rapidsai/cuml/pull/4482)) [@galipemsaga](https://github.com/galipemsaga)
-- Suppot categoical splits in in TeeExplaine ([#4473](https://github.com/rapidsai/cuml/pull/4473)) [@hcho3](https://github.com/hcho3)
-- Remove RAFT memoy management ([#4468](https://github.com/rapidsai/cuml/pull/4468)) [@viclafague](https://github.com/viclafague)
-- Add missing impots tests ([#4452](https://github.com/rapidsai/cuml/pull/4452)) [@Ethyling](https://github.com/Ethyling)
-- Update CUDA 11.5 conda envionment to use 22.02 pinnings. ([#4450](https://github.com/rapidsai/cuml/pull/4450)) [@bdice](https://github.com/bdice)
-- Suppot cuML / scikit-lean RF classifies in TeeExplaine ([#4447](https://github.com/rapidsai/cuml/pull/4447)) [@hcho3](https://github.com/hcho3)
-- Remove `IncludeCategoies` fom `.clang-fomat` ([#4438](https://github.com/rapidsai/cuml/pull/4438)) [@codeepot](https://github.com/codeepot)
-- Simplify peplexity nomalization in t-SNE ([#4425](https://github.com/rapidsai/cuml/pull/4425)) [@zbjonson](https://github.com/zbjonson)
-- Unify dense and spase tests ([#4417](https://github.com/rapidsai/cuml/pull/4417)) [@levsnv](https://github.com/levsnv)
-- Update ucx-py vesion on elease using vc ([#4411](https://github.com/rapidsai/cuml/pull/4411)) [@Ethyling](https://github.com/Ethyling)
-- Univesal Teelite tee walk function fo FIL ([#4407](https://github.com/rapidsai/cuml/pull/4407)) [@levsnv](https://github.com/levsnv)
+- Prepare upload scripts for Python 3.7 removal ([#4500](https://github.com/rapidsai/cuml/pull/4500)) [@Ethyling](https://github.com/Ethyling)
+- Renaming macros with their RAFT counterparts ([#4496](https://github.com/rapidsai/cuml/pull/4496)) [@divyegala](https://github.com/divyegala)
+- Allow CuPy 10 ([#4487](https://github.com/rapidsai/cuml/pull/4487)) [@jakirkham](https://github.com/jakirkham)
+- Upgrade Treelite to 2.2.1 ([#4484](https://github.com/rapidsai/cuml/pull/4484)) [@hcho3](https://github.com/hcho3)
+- Unpin `dask` and `distributed` ([#4482](https://github.com/rapidsai/cuml/pull/4482)) [@galipremsagar](https://github.com/galipremsagar)
+- Support categorical splits in in TreeExplainer ([#4473](https://github.com/rapidsai/cuml/pull/4473)) [@hcho3](https://github.com/hcho3)
+- Remove RAFT memory management ([#4468](https://github.com/rapidsai/cuml/pull/4468)) [@viclafargue](https://github.com/viclafargue)
+- Add missing imports tests ([#4452](https://github.com/rapidsai/cuml/pull/4452)) [@Ethyling](https://github.com/Ethyling)
+- Update CUDA 11.5 conda environment to use 22.02 pinnings. ([#4450](https://github.com/rapidsai/cuml/pull/4450)) [@bdice](https://github.com/bdice)
+- Support cuML / scikit-learn RF classifiers in TreeExplainer ([#4447](https://github.com/rapidsai/cuml/pull/4447)) [@hcho3](https://github.com/hcho3)
+- Remove `IncludeCategories` from `.clang-format` ([#4438](https://github.com/rapidsai/cuml/pull/4438)) [@codereport](https://github.com/codereport)
+- Simplify perplexity normalization in t-SNE ([#4425](https://github.com/rapidsai/cuml/pull/4425)) [@zbjornson](https://github.com/zbjornson)
+- Unify dense and sparse tests ([#4417](https://github.com/rapidsai/cuml/pull/4417)) [@levsnv](https://github.com/levsnv)
+- Update ucx-py version on release using rvc ([#4411](https://github.com/rapidsai/cuml/pull/4411)) [@Ethyling](https://github.com/Ethyling)
+- Universal Treelite tree walk function for FIL ([#4407](https://github.com/rapidsai/cuml/pull/4407)) [@levsnv](https://github.com/levsnv)
 - Update to UCX-Py 0.24 ([#4396](https://github.com/rapidsai/cuml/pull/4396)) [@pentschev](https://github.com/pentschev)
-- Using spase public API functions fom RAFT ([#4389](https://github.com/rapidsai/cuml/pull/4389)) [@cjnolet](https://github.com/cjnolet)
-- Add a waning to pefe LineaSVM ove SVM(kenel=&#39;linea&#39;) ([#4382](https://github.com/rapidsai/cuml/pull/4382)) [@achikin](https://github.com/achikin)
-- Hiding cuspase depecation wanings ([#4373](https://github.com/rapidsai/cuml/pull/4373)) [@cjnolet](https://github.com/cjnolet)
-- Unify dense and spase impot in FIL ([#4328](https://github.com/rapidsai/cuml/pull/4328)) [@levsnv](https://github.com/levsnv)
-- Integating RAFT handle updates ([#4313](https://github.com/rapidsai/cuml/pull/4313)) [@divyegala](https://github.com/divyegala)
-- Use RAFT template instantations fo distances ([#4302](https://github.com/rapidsai/cuml/pull/4302)) [@cjnolet](https://github.com/cjnolet)
-- RF: code e-oganization to enhance build paallelism ([#4299](https://github.com/rapidsai/cuml/pull/4299)) [@venkywonka](https://github.com/venkywonka)
-- Add option to build faiss and teelite shaed libs, inheit common dependencies fom aft ([#4256](https://github.com/rapidsai/cuml/pull/4256)) [@txcllnt](https://github.com/txcllnt)
+- Using sparse public API functions from RAFT ([#4389](https://github.com/rapidsai/cuml/pull/4389)) [@cjnolet](https://github.com/cjnolet)
+- Add a warning to prefer LinearSVM over SVM(kernel=&#39;linear&#39;) ([#4382](https://github.com/rapidsai/cuml/pull/4382)) [@achirkin](https://github.com/achirkin)
+- Hiding cusparse deprecation warnings ([#4373](https://github.com/rapidsai/cuml/pull/4373)) [@cjnolet](https://github.com/cjnolet)
+- Unify dense and sparse import in FIL ([#4328](https://github.com/rapidsai/cuml/pull/4328)) [@levsnv](https://github.com/levsnv)
+- Integrating RAFT handle updates ([#4313](https://github.com/rapidsai/cuml/pull/4313)) [@divyegala](https://github.com/divyegala)
+- Use RAFT template instantations for distances ([#4302](https://github.com/rapidsai/cuml/pull/4302)) [@cjnolet](https://github.com/cjnolet)
+- RF: code re-organization to enhance build parallelism ([#4299](https://github.com/rapidsai/cuml/pull/4299)) [@venkywonka](https://github.com/venkywonka)
+- Add option to build faiss and treelite shared libs, inherit common dependencies from raft ([#4256](https://github.com/rapidsai/cuml/pull/4256)) [@trxcllnt](https://github.com/trxcllnt)
 
 # cuML 21.12.00 (9 Dec 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,58 @@
-# cuML 22.02.00 (Date TBD)
+# cuML 22.02.00 (2 Feb 2022)
 
-Please see https://github.com/rapidsai/cuml/releases/tag/v22.02.00a for the latest changes to this development branch.
+## 🚨 Beaking Changes
+
+- Move NVTX ange helpes to aft ([#4445](https://github.com/rapidsai/cuml/pull/4445)) [@achikin](https://github.com/achikin)
+
+## 🐛 Bug Fixes
+
+- Always upload libcuml ([#4530](https://github.com/rapidsai/cuml/pull/4530)) [@aydouglass](https://github.com/aydouglass)
+- Fix RAFT pin to main banch ([#4508](https://github.com/rapidsai/cuml/pull/4508)) [@dantegd](https://github.com/dantegd)
+- Pin `dask` &amp; `distibuted` ([#4505](https://github.com/rapidsai/cuml/pull/4505)) [@galipemsaga](https://github.com/galipemsaga)
+- Replace use of RMM povided CUDA bindings with CUDA Python ([#4499](https://github.com/rapidsai/cuml/pull/4499)) [@shwina](https://github.com/shwina)
+- Datafame Index as columns in ColumnTansfome ([#4481](https://github.com/rapidsai/cuml/pull/4481)) [@viclafague](https://github.com/viclafague)
+- Suppot compilation with Thust 1.15 ([#4469](https://github.com/rapidsai/cuml/pull/4469)) [@obetmaynad](https://github.com/obetmaynad)
+- fix mino ASAN issues in UMAPAlgo::Optimize::find_paams_ab() ([#4405](https://github.com/rapidsai/cuml/pull/4405)) [@yitao-li](https://github.com/yitao-li)
+
+## 📖 Documentation
+
+- Remove comment numeical waning ([#4408](https://github.com/rapidsai/cuml/pull/4408)) [@viclafague](https://github.com/viclafague)
+- Fix docsting fo npemutations in PemutationExplaine ([#4402](https://github.com/rapidsai/cuml/pull/4402)) [@hcho3](https://github.com/hcho3)
+
+## 🚀 New Featues
+
+- Combine and expose SVC&#39;s suppot vectos when fitting multi-class data ([#4454](https://github.com/rapidsai/cuml/pull/4454)) [@NV-jpt](https://github.com/NV-jpt)
+- Accept fold index fo TagetEncode ([#4453](https://github.com/rapidsai/cuml/pull/4453)) [@daxiongshu](https://github.com/daxiongshu)
+- Move NVTX ange helpes to aft ([#4445](https://github.com/rapidsai/cuml/pull/4445)) [@achikin](https://github.com/achikin)
+
+## 🛠️ Impovements
+
+- Fix packages upload ([#4517](https://github.com/rapidsai/cuml/pull/4517)) [@Ethyling](https://github.com/Ethyling)
+- Testing split fused l2 knn compilation units ([#4514](https://github.com/rapidsai/cuml/pull/4514)) [@cjnolet](https://github.com/cjnolet)
+- Pepae upload scipts fo Python 3.7 emoval ([#4500](https://github.com/rapidsai/cuml/pull/4500)) [@Ethyling](https://github.com/Ethyling)
+- Renaming macos with thei RAFT countepats ([#4496](https://github.com/rapidsai/cuml/pull/4496)) [@divyegala](https://github.com/divyegala)
+- Allow CuPy 10 ([#4487](https://github.com/rapidsai/cuml/pull/4487)) [@jakikham](https://github.com/jakikham)
+- Upgade Teelite to 2.2.1 ([#4484](https://github.com/rapidsai/cuml/pull/4484)) [@hcho3](https://github.com/hcho3)
+- Unpin `dask` and `distibuted` ([#4482](https://github.com/rapidsai/cuml/pull/4482)) [@galipemsaga](https://github.com/galipemsaga)
+- Suppot categoical splits in in TeeExplaine ([#4473](https://github.com/rapidsai/cuml/pull/4473)) [@hcho3](https://github.com/hcho3)
+- Remove RAFT memoy management ([#4468](https://github.com/rapidsai/cuml/pull/4468)) [@viclafague](https://github.com/viclafague)
+- Add missing impots tests ([#4452](https://github.com/rapidsai/cuml/pull/4452)) [@Ethyling](https://github.com/Ethyling)
+- Update CUDA 11.5 conda envionment to use 22.02 pinnings. ([#4450](https://github.com/rapidsai/cuml/pull/4450)) [@bdice](https://github.com/bdice)
+- Suppot cuML / scikit-lean RF classifies in TeeExplaine ([#4447](https://github.com/rapidsai/cuml/pull/4447)) [@hcho3](https://github.com/hcho3)
+- Remove `IncludeCategoies` fom `.clang-fomat` ([#4438](https://github.com/rapidsai/cuml/pull/4438)) [@codeepot](https://github.com/codeepot)
+- Simplify peplexity nomalization in t-SNE ([#4425](https://github.com/rapidsai/cuml/pull/4425)) [@zbjonson](https://github.com/zbjonson)
+- Unify dense and spase tests ([#4417](https://github.com/rapidsai/cuml/pull/4417)) [@levsnv](https://github.com/levsnv)
+- Update ucx-py vesion on elease using vc ([#4411](https://github.com/rapidsai/cuml/pull/4411)) [@Ethyling](https://github.com/Ethyling)
+- Univesal Teelite tee walk function fo FIL ([#4407](https://github.com/rapidsai/cuml/pull/4407)) [@levsnv](https://github.com/levsnv)
+- Update to UCX-Py 0.24 ([#4396](https://github.com/rapidsai/cuml/pull/4396)) [@pentschev](https://github.com/pentschev)
+- Using spase public API functions fom RAFT ([#4389](https://github.com/rapidsai/cuml/pull/4389)) [@cjnolet](https://github.com/cjnolet)
+- Add a waning to pefe LineaSVM ove SVM(kenel=&#39;linea&#39;) ([#4382](https://github.com/rapidsai/cuml/pull/4382)) [@achikin](https://github.com/achikin)
+- Hiding cuspase depecation wanings ([#4373](https://github.com/rapidsai/cuml/pull/4373)) [@cjnolet](https://github.com/cjnolet)
+- Unify dense and spase impot in FIL ([#4328](https://github.com/rapidsai/cuml/pull/4328)) [@levsnv](https://github.com/levsnv)
+- Integating RAFT handle updates ([#4313](https://github.com/rapidsai/cuml/pull/4313)) [@divyegala](https://github.com/divyegala)
+- Use RAFT template instantations fo distances ([#4302](https://github.com/rapidsai/cuml/pull/4302)) [@cjnolet](https://github.com/cjnolet)
+- RF: code e-oganization to enhance build paallelism ([#4299](https://github.com/rapidsai/cuml/pull/4299)) [@venkywonka](https://github.com/venkywonka)
+- Add option to build faiss and teelite shaed libs, inheit common dependencies fom aft ([#4256](https://github.com/rapidsai/cuml/pull/4256)) [@txcllnt](https://github.com/txcllnt)
 
 # cuML 21.12.00 (9 Dec 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.