### PR TITLE
Add CMake `install` rules for tests

### DIFF
--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -107,7 +107,8 @@ if(BUILD_CUML_PRIMS_BENCH)
 
   set_target_properties(
     ${PRIMS_BENCH_TARGET}
-    PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+    PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
+  )
 
   install(
     TARGETS ${PRIMS_BENCH_TARGET}

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -105,5 +105,7 @@ if(BUILD_CUML_PRIMS_BENCH)
   install(
     TARGETS ${PRIMS_BENCH_TARGET}
     COMPONENT testing
-    EXCLUDE_FROM_ALL)
+    DESTINATION bin/benchmarks/libcuml_prims
+    EXCLUDE_FROM_ALL
+  )
 endif()

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -55,6 +55,11 @@ if(BUILD_CUML_BENCH)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src_prims>
   )
 
+  set_target_properties(
+    ${CUML_CPP_BENCH_TARGET}
+    PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
+  )
+
   install(
     TARGETS ${CUML_CPP_BENCH_TARGET}
     COMPONENT testing

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -54,6 +54,13 @@ if(BUILD_CUML_BENCH)
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src_prims>
   )
+
+  install(
+    TARGETS ${CUML_CPP_BENCH_TARGET}
+    COMPONENT testing
+    DESTINATION bin/benchmarks/libcuml
+    EXCLUDE_FROM_ALL
+  )
 endif()
 
 ##############################################################################

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -97,4 +97,13 @@ if(BUILD_CUML_PRIMS_BENCH)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src_prims>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   )
+
+  set_target_properties(
+    ${PRIMS_BENCH_TARGET}
+    PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+
+  install(
+    TARGETS ${PRIMS_BENCH_TARGET}
+    COMPONENT testing
+    EXCLUDE_FROM_ALL)
 endif()

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -222,6 +222,14 @@ if(BUILD_PRIMS_TESTS)
       ${COMMON_TEST_LINK_LIBRARIES}
   )
 
+  set_target_properties(
+    ${PRIMS_TEST_TARGET}
+    PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+
+  install(
+    TARGETS ${PRIMS_TEST_TARGET}
+    COMPONENT testing
+    EXCLUDE_FROM_ALL)
 endif()
 
 ##############################################################################

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -237,7 +237,8 @@ if(BUILD_PRIMS_TESTS)
 
   set_target_properties(
     ${PRIMS_TEST_TARGET}
-    PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+    PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
+  )
 
   install(
     TARGETS ${PRIMS_TEST_TARGET}

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -229,7 +229,9 @@ if(BUILD_PRIMS_TESTS)
   install(
     TARGETS ${PRIMS_TEST_TARGET}
     COMPONENT testing
-    EXCLUDE_FROM_ALL)
+    DESTINATION bin/gtests/libcuml_prims
+    EXCLUDE_FROM_ALL
+  )
 endif()
 
 ##############################################################################

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -96,6 +96,12 @@ if(BUILD_CUML_TESTS)
         ${COMMON_TEST_LINK_LIBRARIES}
     )
 
+    install(
+      TARGETS ${CUML_CPP_TARGET}
+      COMPONENT testing
+      DESTINATION bin/gtests/libcuml
+      EXCLUDE_FROM_ALL
+    )
 endif()
 
 #############################################################################
@@ -131,6 +137,13 @@ if(BUILD_CUML_MG_TESTS)
       NCCL::NCCL
       ${MPI_CXX_LIBRARIES}
       cumlprims_mg::cumlprims_mg
+    )
+
+    install(
+      TARGETS ${CUML_MG_TEST_TARGET}
+      COMPONENT testing
+      DESTINATION bin/gtests/libcuml_mg
+      EXCLUDE_FROM_ALL
     )
 
   else(MPI_CXX_FOUND)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -96,6 +96,11 @@ if(BUILD_CUML_TESTS)
         ${COMMON_TEST_LINK_LIBRARIES}
     )
 
+    set_target_properties(
+      ${CUML_CPP_TARGET}
+      PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
+    )
+
     install(
       TARGETS ${CUML_CPP_TARGET}
       COMPONENT testing
@@ -137,6 +142,11 @@ if(BUILD_CUML_MG_TESTS)
       NCCL::NCCL
       ${MPI_CXX_LIBRARIES}
       cumlprims_mg::cumlprims_mg
+    )
+
+    set_target_properties(
+      ${CUML_MG_TEST_TARGET}
+      PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
     )
 
     install(


### PR DESCRIPTION
This PR adds a CMake `install` rule for test and benchmark targets. This step is a prerequisite to being able to package tests/benchmarks in their own `conda` package, which will enable use to deprecate _Project Flash_.