### PR TITLE
Temporarily disable new `ops-bot` functionality [skip ci]

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,4 +5,4 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-external_contributors: true
+external_contributors: false


### PR DESCRIPTION
I recently committed a config file to be used by the [rapidsai/ops-bot](https://github.com/rapidsai/ops-bot/) and in hindsight, I should've had the new `external_contributors` functionality set to `false` until we're ready to roll it out everywhere. This PR fixes that.
