### PR TITLE
Updating cmake files to enable NVTX markers for cuML build

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -523,6 +523,11 @@ if(BUILD_CUML_CPP_LIBRARY)
       $<$<BOOL:${ENABLE_CUMLPRIMS_MG}>:cumlprims_mg::cumlprims_mg>
   )
 
+  if(NVTX)
+    target_link_libraries(${CUML_CPP_TARGET} PRIVATE nvToolsExt)
+    target_compile_options(${CUML_CPP_TARGET} PRIVATE "-DNVTX_ENABLED")
+  endif()
+
   # If we export the libdmlc symbols, they can lead to weird crashes with other
   # libraries that use libdmlc. This just hides the symbols internally.
   target_link_options(${CUML_CPP_TARGET} PRIVATE "-Wl,--exclude-libs,libdmlc.a")

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -104,6 +104,11 @@ if(BUILD_CUML_PRIMS_BENCH)
       raft::distance
   )
 
+  if(NVTX)
+    target_compile_options(${PRIMS_BENCH_TARGET} PRIVATE "-DNVTX_ENABLED")
+    target_link_libraries(${PRIMS_BENCH_TARGET} PRIVATE nvToolsExt)
+  endif()
+
   target_include_directories(${PRIMS_BENCH_TARGET}
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src_prims>

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -57,6 +57,11 @@ function(ConfigureTest)
     $<TARGET_NAME_IF_EXISTS:conda_env>
   )
 
+  if(NVTX)
+    target_compile_options(${TEST_NAME} PRIVATE "-DNVTX_ENABLED")
+    target_link_libraries(${TEST_NAME} PRIVATE nvToolsExt)
+  endif()
+
   target_compile_options(${TEST_NAME}
         PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUML_CXX_FLAGS}>"
                 "$<$<COMPILE_LANGUAGE:CUDA>:${CUML_CUDA_FLAGS}>"


### PR DESCRIPTION
Currently cuML is not built with NVTX markers even when compiled with `NVTX=ON`. This PR enables NVTX markers for cuML (`libcuml++so`, tests and benchmark binary) build when RAFT is picked from conda environment (which is default behavior right now). It should work even when RAFT is picked from user specified path, but I haven't tested it.
As discussed previously elsewhere, we might decide to enable NVTX by default in future, this is a patch for time being.
@venkywonka @teju85 @achirkin @cjnolet @dantegd 