### PR TITLE
[TYPO] Change "principal" to "principles"

### DIFF
--- a/docs/source/cuml_intro.rst
+++ b/docs/source/cuml_intro.rst
@@ -2,7 +2,7 @@ Intro and key concepts for cuML
 =================================
 
 cuML accelerates machine learning on GPUs. The library follows a
-couple of key principals, and understanding these will help you take
+couple of key principles, and understanding these will help you take
 full advantage cuML.
 
 


### PR DESCRIPTION
This PR fixes a minor typo in the cuML intro documentation.