### PR TITLE
[CI] Add virtual destructor check to clang-tidy

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-modernize-*,-clang-diagnostic-#pragma-messages,-readability-identifier-naming,-clang-diagnostic-switch'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-modernize-*,-clang-diagnostic-#pragma-messages,-readability-identifier-naming,-clang-diagnostic-switch,cppcoreguidelines-virtual-class-destructor'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/cpp/include/cuml/explainer/tree_shap.hpp
+++ b/cpp/include/cuml/explainer/tree_shap.hpp
@@ -31,7 +31,7 @@ class TreePathInfo {
  public:
   enum class ThresholdTypeEnum : std::uint8_t { kFloat, kDouble };
   virtual ThresholdTypeEnum GetThresholdType() const = 0;
-  //virtual ~TreePathInfo() {}
+  // virtual ~TreePathInfo() {}
 };
 
 std::unique_ptr<TreePathInfo> extract_path_info(ModelHandle model);

--- a/cpp/include/cuml/explainer/tree_shap.hpp
+++ b/cpp/include/cuml/explainer/tree_shap.hpp
@@ -31,7 +31,7 @@ class TreePathInfo {
  public:
   enum class ThresholdTypeEnum : std::uint8_t { kFloat, kDouble };
   virtual ThresholdTypeEnum GetThresholdType() const = 0;
-  virtual ~TreePathInfo() {}
+  //virtual ~TreePathInfo() {}
 };
 
 std::unique_ptr<TreePathInfo> extract_path_info(ModelHandle model);


### PR DESCRIPTION
#4671 was delayed for a few days because a base class lacked a virtual destructor. This PR update the clang-tidy check to ensure that all classes with derived classes have a virtual destructor.