### PR TITLE
FIX Accept small floats in RandomForest

### DIFF
--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -116,7 +116,7 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
          * If type ``int``, then ``min_samples_split`` represents the minimum
            number.
          * If type ``float``, then ``min_samples_split`` represents a fraction
-           and ``max(2, ceil(min_samples_split * n_rows))`` is the minimum number of
+           and ``ceil(min_samples_split * n_rows)`` is the minimum number of
            samples for each split.
     accuracy_metric : string (default = 'r2')
         Decides the metric used to evaluate the performance of the model.

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -116,7 +116,7 @@ class RandomForestRegressor(BaseRandomForestModel, DelayedPredictionMixin,
          * If type ``int``, then ``min_samples_split`` represents the minimum
            number.
          * If type ``float``, then ``min_samples_split`` represents a fraction
-           and ``ceil(min_samples_split * n_rows)`` is the minimum number of
+           and ``max(2, ceil(min_samples_split * n_rows))`` is the minimum number of
            samples for each split.
     accuracy_metric : string (default = 'r2')
         Decides the metric used to evaluate the performance of the model.

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -307,7 +307,7 @@ class BaseRandomForestModel(Base):
                 math.ceil(self.min_samples_leaf * self.n_rows)
         if type(self.min_samples_split) == float:
             self.min_samples_split = \
-                math.ceil(self.min_samples_split * self.n_rows)
+                max(2, math.ceil(self.min_samples_split * self.n_rows))
         return X_m, y_m, max_feature_val
 
     def _tl_handle_from_bytes(self, treelite_serialized_model):

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -201,7 +201,7 @@ class RandomForestClassifier(BaseRandomForestModel,
          * If type ``int``, then min_samples_split represents the minimum
            number.
          * If type ``float``, then ``min_samples_split`` represents a fraction
-           and ``ceil(min_samples_split * n_rows)`` is the minimum number of
+           and ``max(2, ceil(min_samples_split * n_rows))`` is the minimum number of
            samples for each split.
     min_impurity_decrease : float (default = 0.0)
         Minimum decrease in impurity requried for

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -201,8 +201,8 @@ class RandomForestClassifier(BaseRandomForestModel,
          * If type ``int``, then min_samples_split represents the minimum
            number.
          * If type ``float``, then ``min_samples_split`` represents a fraction
-           and ``max(2, ceil(min_samples_split * n_rows))`` is the minimum number of
-           samples for each split.
+           and ``max(2, ceil(min_samples_split * n_rows))`` is the minimum
+           number of samples for each split.
     min_impurity_decrease : float (default = 0.0)
         Minimum decrease in impurity requried for
         node to be spilt.

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -200,8 +200,8 @@ class RandomForestRegressor(BaseRandomForestModel,
          * If type ``int``, then min_samples_split represents the minimum
            number.
          * If type ``float``, then ``min_samples_split`` represents a fraction
-           and ``ceil(min_samples_split * n_rows)`` is the minimum number of
-           samples for each split.
+           and ``max(2, ceil(min_samples_split * n_rows))`` is the minimum
+           number of samples for each split.
     min_impurity_decrease : float (default = 0.0)
         The minimum decrease in impurity required for node to be split
     accuracy_metric : string (default = 'r2')

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -1302,3 +1302,17 @@ def test_rf_multiclass_classifier_gtil_integration(tmpdir):
     tl_model = treelite.Model.deserialize(checkpoint_path)
     out_prob = treelite.gtil.predict(tl_model, X, pred_margin=True)
     np.testing.assert_almost_equal(out_prob, expected_prob, decimal=5)
+
+
+@pytest.mark.parametrize("estimator, make_data", [
+    (curfc, make_classification),
+    (curfr, make_regression),
+])
+def test_rf_min_samples_split_with_small_float(estimator, make_data):
+    # Check that min_samples leaf is works with a small float
+    # Non-regression test for gh-4613
+    X, y = make_data(random_state=0)
+    clf = estimator(min_samples_split=0.0001, random_state=0, n_estimators=2)
+
+    # Does not error
+    clf.fit(X, y)


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cuml/issues/4613

This is basically the same as what scikit-learn does: https://github.com/scikit-learn/scikit-learn/blob/3578a9f9825514d3bfd2f2448bf4e0f95326b938/sklearn/tree/_classes.py#L281-L282