### PR TITLE
MNT Removes unused optim_batch_size from UMAP's docstring

### DIFF
--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -100,7 +100,6 @@ cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
         float target_weight,
         uint64_t random_state,
         bool deterministic,
-        int optim_batch_size,
         GraphBasedDimRedCallback * callback
 
 
@@ -270,11 +269,6 @@ class UMAP(Base,
         consistency of trained embeddings, allowing for reproducible results
         to 3 digits of precision, but will do so at the expense of potentially
         slower training and increased memory usage.
-    optim_batch_size: int (optional, default 100000 / n_components)
-        Used to maintain the consistency of embeddings for large datasets.
-        The optimization step will be processed with at most optim_batch_size
-        edges at once preventing inconsistencies. A lower batch size will yield
-        more consistently repeatable embeddings at the cost of speed.
     callback: An instance of GraphBasedDimRedCallback class
         Used to intercept the internal state of embeddings while they are being
         trained. Example of callback usage:


### PR DESCRIPTION
Closes https://github.com/rapidsai/cuml/issues/4725

https://github.com/rapidsai/cuml/pull/3848 removes the usage of `optim_batch_size` in code. This PR removes the parameter from the docstring and in `UMAPParams`.