### PR TITLE
Fix docs builds

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -51,7 +51,6 @@ gpuci_logger "Build Doxygen docs"
 gpuci_logger "Build Sphinx docs"
 cd "$PROJECT_WORKSPACE/docs"
 make html
-RETVAL=$?
 
 #Commit to Website
 cd "$DOCS_WORKSPACE"
@@ -66,5 +65,3 @@ done
 
 mv "$PROJECT_WORKSPACE/cpp/build/html/"* "$DOCS_WORKSPACE/api/libcuml/$BRANCH_VERSION"
 mv "$PROJECT_WORKSPACE/docs/build/html/"* "$DOCS_WORKSPACE/api/cuml/$BRANCH_VERSION"
-
-exit $RETVAL

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -28,10 +28,6 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-# TODO: Move installs to docs-build-env meta package
-conda install -c anaconda beautifulsoup4 jq
-pip install sphinx-markdown-tables
-
 
 gpuci_logger "Check versions"
 python --version


### PR DESCRIPTION
This PR fixes our nightly docs build by removing the `exit` statement at the bottom of this script. In our nightly docs builds, this script is invoked via `source`, so any `exit` statements cause the parent script to exit which prevents completion of the rest of the build.

It also removes some unnecessary `pip`/`conda` install commands since these packages exist already in the container.