### PR TITLE
Upgrade Treelite to 2.4.0

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -73,6 +73,11 @@ if [ "$(arch)" = "x86_64" ]; then
         "rapids-doc-env=${MINOR_VERSION}.*"
 fi
 
+gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      --force rapids-build-env rapids-notebook-env
+gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+      treelite=2.4.0
+
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_mamba_retry install -y "your-pkg=1.0.0"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -73,11 +73,6 @@ if [ "$(arch)" = "x86_64" ]; then
         "rapids-doc-env=${MINOR_VERSION}.*"
 fi
 
-gpuci_conda_retry remove -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      --force rapids-build-env rapids-notebook-env
-gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
-      treelite=2.4.0
-
 # https://docs.rapids.ai/maintainers/depmgmt/
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_mamba_retry install -y "your-pkg=1.0.0"

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -28,7 +28,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.24
-- treelite=2.3.0
+- treelite=2.4.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -28,7 +28,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.24
-- treelite=2.3.0
+- treelite=2.4.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -28,7 +28,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.24
-- treelite=2.3.0
+- treelite=2.4.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -28,7 +28,7 @@ dependencies:
 - faiss-proc=*=cuda
 - umap-learn
 - scikit-learn=0.24
-- treelite=2.3.0
+- treelite=2.4.0
 - statsmodels
 - seaborn
 - hdbscan

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - python x.x
     - setuptools
     - cython>=0.29,<0.30
-    - treelite=2.3.0
+    - treelite=2.4.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -52,7 +52,7 @@ requirements:
     - libcumlprims {{ minor_version }}
     - pyraft {{ minor_version }}
     - cupy>=7.8.0,<11.0.0a0
-    - treelite=2.3.0
+    - treelite=2.4.0
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -20,7 +20,7 @@ ucx_version:
   - "1.12.1"
 
 treelite_version:
-  - "2.3.0"
+  - "2.4.0"
 
 gtest_version:
   - "1.10.0"

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -88,6 +88,6 @@ function(find_and_configure_treelite)
     rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
 endfunction()
 
-find_and_configure_treelite(VERSION     2.3.0
-                        PINNED_TAG  b65bedceef9893c1ad92977dd466f582540ba7ab
+find_and_configure_treelite(VERSION     2.4.0
+                        PINNED_TAG  dcd54779ce9324c69452db9b906f2d258374d5b9
                         BUILD_STATIC_LIBS ${CUML_USE_TREELITE_STATIC})


### PR DESCRIPTION
The 2.4.0 version of Treelite incorporates the following improvements:

* https://github.com/dmlc/treelite/pull/370
* https://github.com/dmlc/treelite/pull/381
* https://github.com/dmlc/treelite/pull/380
* https://github.com/dmlc/treelite/pull/383

Requires https://github.com/rapidsai/integration/pull/474

This PR targets the 22.06 release.

Closes #4715