### PR TITLE
Resolve KRR hypothesis test failure

### DIFF
--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -178,6 +178,13 @@ def array_strategy(draw):
 def test_pairwise_kernels(kernel_arg, XY):
     X, Y = XY
     kernel, args = kernel_arg
+
+    if kernel == 'cosine':
+        # this kernel is very unstable for both sklearn/cuml
+        assume(as_type('numpy', X).min() > 0.1)
+        if Y is not None:
+            assume(as_type('numpy', Y).min() > 0.1)
+
     K = pairwise_kernels(X, Y, metric=kernel, **args)
     skl_kernel = kernel.py_func if hasattr(kernel, "py_func") else kernel
     K_sklearn = skl_pairwise_kernels(

--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -210,7 +210,7 @@ def estimator_array_strategy(draw):
 
     alpha = draw(
         arrays(dtype=dtype, shape=(n_targets),
-               elements=st.floats(0, 5, width=32))
+               elements=st.floats(0.0010000000474974513, 5, width=32))
     )
 
     sample_weight = draw(


### PR DESCRIPTION
On updating the hypothesis version, examples were generated with very small values. Both sklearn and cuml experience numerical instability for the cosine kernel in these cases.

I have verified that after this PR, the test passes with up to 10000 examples.