### PR TITLE
Fix sg benchmark build.

### DIFF
--- a/cpp/bench/sg/benchmark.cuh
+++ b/cpp/bench/sg/benchmark.cuh
@@ -36,7 +36,7 @@ class Fixture : public MLCommon::Bench::Fixture {
 
   void SetUp(const ::benchmark::State& state) override
   {
-    auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(NumStreams);
+    auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(numStreams());
     handle.reset(new raft::handle_t{rmm::cuda_stream_per_thread, stream_pool});
     MLCommon::Bench::Fixture::SetUp(state);
   }
@@ -88,7 +88,7 @@ class Fixture : public MLCommon::Bench::Fixture {
   ///@todo: ideally, this should be determined at runtime based on the inputs
   ///       passed to the fixture. That will require a whole lot of plumbing of
   ///       interfaces. Thus, as a quick workaround, defining this static var.
-  static const int NumStreams = 16;
+  constexpr static std::int32_t numStreams() { return 16; }
 };  // end class Fixture
 
 /**


### PR DESCRIPTION
Fix static storage error:

```
/usr/bin/ld: bench/CMakeFiles/sg_benchmark.dir/sg/arima_loglikelihood.cu.o: in function `ML::Bench::Fixture::SetUp(benchmark::State const&)':
tmpxft_0000bc8b_00000000-6_arima_loglikelihood.cudafe1.cpp:(.text._ZN2ML5Bench7Fixture5SetUpERKN9benchmark5StateE[_ZN2ML5Bench7Fixture5SetUpERKN9benchmark5StateE]+0x2d): undefined reference to `ML::Bench::Fixture::NumStreams'
```