### PR TITLE
Pin max version of `cuda-python` to `11.7.0`

### DIFF
--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.0
-- cuda-python >=11.5,<12.0
+- cuda-python >=11.5,<11.7.1
 - rapids-build-env=22.06.*
 - rapids-notebook-env=22.06.*
 - rapids-doc-env=22.06.*

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.2
-- cuda-python >=11.5,<12.0
+- cuda-python >=11.5,<11.7.1
 - rapids-build-env=22.06.*
 - rapids-notebook-env=22.06.*
 - rapids-doc-env=22.06.*

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.4
-- cuda-python >=11.5,<12.0
+- cuda-python >=11.5,<11.7.1
 - rapids-build-env=22.06.*
 - rapids-notebook-env=22.06.*
 - rapids-doc-env=22.06.*

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.5
-- cuda-python >=11.5,<12.0
+- cuda-python >=11.5,<11.7.1
 - rapids-build-env=22.06.*
 - rapids-notebook-env=22.06.*
 - rapids-doc-env=22.06.*

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - cuda-python >=11.5,<12.0
+    - cuda-python >=11.5,<11.7.1
   run:
     - python x.x
     - cudf {{ minor_version }}
@@ -60,7 +60,7 @@ requirements:
     - distributed==2022.05.2
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-    - cuda-python >=11.5,<12.0
+    - cuda-python >=11.5,<11.7.1
 
 tests:                                 # [linux64]
   requirements:                        # [linux64]


### PR DESCRIPTION
Pin max version of `cuda-python` to `11.7.0`

This is a back port of #4793.