### PR TITLE
Update conda environment files to UCX 1.13.0

### DIFF
--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -19,7 +19,7 @@ dependencies:
 - pyraft=22.08.*
 - dask-cudf=22.08.*
 - dask-cuda=22.08.*
-- ucx>=1.12.1
+- ucx>=1.13.0
 - ucx-py=0.27.*
 - ucx-proc=*=gpu
 - dask-ml

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -19,7 +19,7 @@ dependencies:
 - pyraft=22.08.*
 - dask-cudf=22.08.*
 - dask-cuda=22.08.*
-- ucx>=1.12.1
+- ucx>=1.13.0
 - ucx-py=0.27.*
 - ucx-proc=*=gpu
 - dask-ml

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -19,7 +19,7 @@ dependencies:
 - pyraft=22.08.*
 - dask-cudf=22.08.*
 - dask-cuda=22.08.*
-- ucx>=1.12.1
+- ucx>=1.13.0
 - ucx-py=0.27.*
 - ucx-proc=*=gpu
 - dask-ml

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -19,7 +19,7 @@ dependencies:
 - pyraft=22.08.*
 - dask-cudf=22.08.*
 - dask-cuda=22.08.*
-- ucx>=1.12.1
+- ucx>=1.13.0
 - ucx-py=0.27.*
 - ucx-proc=*=gpu
 - dask-ml


### PR DESCRIPTION
The conda recipe was updated to UCX 1.13.0 in #4809 , but updating conda environment files was missing there.