### PR TITLE
Make KNN cython object use __dealloc__ instead of __del__

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -78,8 +78,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-                        FORK             rapidsai
-                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
+                        FORK             achirkin
+                        PINNED_TAG       196b83fed03fbc99bfcb218b1645a05f4f049236
 
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -79,7 +79,7 @@ endfunction()
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
                         FORK             achirkin
-                        PINNED_TAG       196b83fed03fbc99bfcb218b1645a05f4f049236
+                        PINNED_TAG       e6a815bdaa10a520da94088dbeb4b4d4b6da4e07
 
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -895,7 +895,7 @@ class NearestNeighbors(Base,
 
         return sparse_csr
 
-    def __del__(self):
+    def __dealloc__(self):
         cdef knnIndex* knn_index = <knnIndex*>0
         cdef BallCoverIndex* rbc_index = <BallCoverIndex*>0
 


### PR DESCRIPTION
The new code in https://github.com/rapidsai/raft/pull/652 makes cython `NearestNeighbors` wrapper segfault during deallocation / garbage collection when trying to destruct mdarray members of `ivf_flat::index`.
The reason for this may be way cython handles `__del__` vs `__dealloc__`, thus we replace here the former with the latter.