### PR TITLE
Allow CuPy 11

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - pyraft {{ minor_version }}
-    - cupy>=7.8.0,<11.0.0a0
+    - cupy>=7.8.0,<12.0.0a0
     - treelite=2.4.0
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}


### PR DESCRIPTION
Allows cuML to be installed with CuPy 11.

xref: https://github.com/rapidsai/integration/pull/508