### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - pyraft {{ minor_version }}
-    - cupy>=7.8.0,<12.0.0a0
+    - cupy>=7.8.0,<11.0.0a0
     - treelite=2.4.0
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.