### PR TITLE
[REVIEW] Use common code in python docs and defer `js` loading

### DIFF
--- a/docs/source/_static/params.css
+++ b/docs/source/_static/params.css
@@ -1,9 +1,0 @@
-/* Mirrors the change in:
- *   https://github.com/sphinx-doc/sphinx/pull/5976
- * which is not showing up in our theme.
- */
-.classifier:before {
-    font-style: normal;
-    margin: 0.5em;
-    content: ":";
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,10 +193,11 @@ numpydoc_class_members_toctree = False
 
 
 def setup(app):
-    app.add_css_file('copybutton.css')
-    app.add_css_file('infoboxes.css')
-    app.add_css_file('params.css')
-    app.add_css_file('references.css')
+    app.add_css_file("copybutton.css")
+    app.add_css_file("infoboxes.css")
+    app.add_css_file("references.css")
+    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
+    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js", loading_method="defer")
 
 
 # The following is used by sphinx.ext.linkcode to provide links to github


### PR DESCRIPTION
This PR makes a switch to utilizing common `js` & `css` code and defer's loading of custom js.

