### PR TITLE
Remove unused cuDF imports

### DIFF
--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 import cupy as cp
 

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 import rmm
 import warnings

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 import warnings
 

--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -17,7 +17,6 @@
 
 
 import ctypes
-import cudf
 import numpy as np
 
 import rmm

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 import cupy as cp
 import cupyx

--- a/python/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/decomposition/pca_mg.pyx
@@ -17,7 +17,6 @@
 
 
 import ctypes
-import cudf
 import numpy as np
 from enum import IntEnum
 

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 
 from enum import IntEnum

--- a/python/cuml/decomposition/tsvd_mg.pyx
+++ b/python/cuml/decomposition/tsvd_mg.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 
 import rmm

--- a/python/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/experimental/linear_model/lars.pyx
@@ -20,7 +20,6 @@
 # cython: language_level = 3
 
 import ctypes
-import cudf
 import numpy as np
 import cupy as cp
 import warnings

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import copy
-import cudf
 import ctypes
 import math
 import numpy as np

--- a/python/cuml/linear_model/base.pyx
+++ b/python/cuml/linear_model/base.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import cuml.internals
 import numpy as np
 import warnings

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -17,7 +17,6 @@
 
 
 import ctypes
-import cudf
 import cuml.common.opg_data_utils_mg as opg
 import numpy as np
 import rmm

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 import warnings
 

--- a/python/cuml/linear_model/linear_regression_mg.pyx
+++ b/python/cuml/linear_model/linear_regression_mg.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import cuml.common.opg_data_utils_mg as opg
 import numpy as np
 import rmm

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 from collections import defaultdict
 from numba import cuda

--- a/python/cuml/linear_model/ridge_mg.pyx
+++ b/python/cuml/linear_model/ridge_mg.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 
 import rmm

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -18,7 +18,6 @@
 # cython: boundscheck = False
 # cython: wraparound = False
 
-import cudf
 import ctypes
 import numpy as np
 import inspect

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -17,7 +17,6 @@
 # distutils: language = c++
 
 import typing
-import cudf
 import ctypes
 import numpy as np
 import pandas as pd

--- a/python/cuml/metrics/accuracy.pyx
+++ b/python/cuml/metrics/accuracy.pyx
@@ -20,7 +20,6 @@ import numpy as np
 
 from libc.stdint cimport uintptr_t
 
-import cudf
 
 import cuml.internals
 

--- a/python/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/metrics/trustworthiness.pyx
@@ -16,7 +16,6 @@
 
 # distutils: language = c++
 
-import cudf
 import numpy as np
 import warnings
 

--- a/python/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier.pyx
@@ -31,7 +31,6 @@ from cuml.common.mixins import FMajorInputTagMixin
 import numpy as np
 import cupy as cp
 
-import cudf
 
 from cython.operator cimport dereference as deref
 

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -28,7 +28,6 @@ from cuml.common.mixins import FMajorInputTagMixin
 
 import numpy as np
 
-import cudf
 
 from cython.operator cimport dereference as deref
 

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -21,7 +21,6 @@ import typing
 import numpy as np
 import cupy as cp
 import cupyx
-import cudf
 import ctypes
 import warnings
 import math

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -16,7 +16,6 @@
 
 # distutils: language = c++
 
-import cudf
 import numpy as np
 
 from libc.stdint cimport uintptr_t

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 
 from numba import cuda

--- a/python/cuml/solvers/cd_mg.pyx
+++ b/python/cuml/solvers/cd_mg.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import numpy as np
 import rmm
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -15,7 +15,6 @@
 
 # distutils: language = c++
 
-import cudf
 import cupy as cp
 import numpy as np
 

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -18,7 +18,6 @@
 import typing
 
 import ctypes
-import cudf
 import numpy as np
 import cupy as cp
 

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import cupy
 import numpy as np
 

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -16,7 +16,6 @@
 # distutils: language = c++
 
 import ctypes
-import cudf
 import cupy
 import numpy as np
 


### PR DESCRIPTION
For housekeeping, this PR removes unused cuDF imports across a variety of files.

It does not refactor any code that currently relies on cuDF.