### PR TITLE
Updating python to use pylibraft

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -202,6 +202,7 @@ else
     pip install "git+https://github.com/dask/distributed.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask-glm@main" --force-reinstall --no-deps
+    pip install "git+https://github.com/hdbscan/hdbscan.git@master" --upgrade --no-deps
     pip install sparse
 
     set +x

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -127,6 +127,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     set -x
     pip install "git+https://github.com/dask/distributed.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask.git@2022.7.1" --upgrade --no-deps
+    pip install "git+https://github.com/hdbscan/hdbscan.git@master" --upgrade --no-deps
     set +x
 
     gpuci_logger "Python pytest for cuml"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,7 +61,8 @@ gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "libraft-headers=${MINOR_VERSION}" \
       "libraft-distance=${MINOR_VERSION}" \
       "libraft-nn=${MINOR_VERSION}" \
-      "pyraft=${MINOR_VERSION}" \
+      "pylibraft=${MINOR_VERSION}" \
+      "raft-dask=${MINOR_VERSION}" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${UCX_PY_VERSION}" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -127,7 +127,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     set -x
     pip install "git+https://github.com/dask/distributed.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask.git@2022.7.1" --upgrade --no-deps
-    pip install "git+https://github.com/hdbscan/hdbscan.git@master" --upgrade --no-deps
+    pip install "git+https://github.com/hdbscan/hdbscan.git@master" --force-reinstall --upgrade --no-deps
     set +x
 
     gpuci_logger "Python pytest for cuml"
@@ -202,7 +202,7 @@ else
     pip install "git+https://github.com/dask/distributed.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask-glm@main" --force-reinstall --no-deps
-    pip install "git+https://github.com/scikit-learn-contrib/hdbscan.git@master" --upgrade --no-deps
+    pip install "git+https://github.com/scikit-learn-contrib/hdbscan.git@master" --force-reinstall --upgrade --no-deps
     pip install sparse
 
     set +x

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -202,7 +202,7 @@ else
     pip install "git+https://github.com/dask/distributed.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask.git@2022.7.1" --upgrade --no-deps
     pip install "git+https://github.com/dask/dask-glm@main" --force-reinstall --no-deps
-    pip install "git+https://github.com/hdbscan/hdbscan.git@master" --upgrade --no-deps
+    pip install "git+https://github.com/scikit-learn-contrib/hdbscan.git@master" --upgrade --no-deps
     pip install sparse
 
     set +x

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -34,14 +34,15 @@ dependencies:
 - treelite=2.4.0
 - statsmodels
 - seaborn
-- hdbscan
 - nltk
 - pip
 - pip:
     - git+https://github.com/dask/dask.git@2022.7.1
     - git+https://github.com/dask/distributed.git@2022.7.1
     - git+https://github.com/dask/dask-glm@main
+    - git+https://github.com/hdbscan/hdbscan.git@master
     - sparse
+
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -17,7 +17,8 @@ dependencies:
 - libraft-headers=22.10.*
 - libraft-distance=22.10.*
 - libraft-nn=22.10.*
-- pyraft=22.10.*
+- raft-dask=22.10.*
+- pylibraft=22.10.*
 - dask-cudf=22.10.*
 - dask-cuda=22.10.*
 - ucx>=1.13.0

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -34,13 +34,13 @@ dependencies:
 - treelite=2.4.0
 - statsmodels
 - seaborn
-- hdbscan
 - nltk
 - pip
 - pip:
     - git+https://github.com/dask/dask.git@2022.7.1
     - git+https://github.com/dask/distributed.git@2022.7.1
     - git+https://github.com/dask/dask-glm@main
+    - git+https://github.com/hdbscan/hdbscan.git@master
     - sparse
 
 # rapids-build-env, notebook-env and doc-env are defined in

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -17,7 +17,8 @@ dependencies:
 - libraft-headers=22.10.*
 - libraft-distance=22.10.*
 - libraft-nn=22.10.*
-- pyraft=22.10.*
+- raft-dask=22.10.*
+- pylibraft=22.10.*
 - dask-cudf=22.10.*
 - dask-cuda=22.10.*
 - ucx>=1.13.0

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -34,13 +34,13 @@ dependencies:
 - treelite=2.4.0
 - statsmodels
 - seaborn
-- hdbscan
 - nltk
 - pip
 - pip:
     - git+https://github.com/dask/dask.git@2022.7.1
     - git+https://github.com/dask/distributed.git@2022.7.1
     - git+https://github.com/dask/dask-glm.git@main
+    - git+https://github.com/hdbscan/hdbscan.git@master
     - sparse
 
 # rapids-build-env, notebook-env and doc-env are defined in

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -17,7 +17,8 @@ dependencies:
 - libraft-headers=22.10.*
 - libraft-distance=22.10.*
 - libraft-nn=22.10.*
-- pyraft=22.10.*
+- raft-dask=22.10.*
+- pylibraft=22.10.*
 - dask-cudf=22.10.*
 - dask-cuda=22.10.*
 - ucx>=1.13.0

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -34,13 +34,13 @@ dependencies:
 - treelite=2.4.0
 - statsmodels
 - seaborn
-- hdbscan
 - nltk
 - pip
 - pip:
     - git+https://github.com/dask/dask.git@2022.7.1
     - git+https://github.com/dask/distributed.git@2022.7.1
     - git+https://github.com/dask/dask-glm@main
+    - git+https://github.com/hdbscan/hdbscan.git@master
     - sparse
 
 # rapids-build-env, notebook-env and doc-env are defined in

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -17,7 +17,8 @@ dependencies:
 - libraft-headers=22.10.*
 - libraft-distance=22.10.*
 - libraft-nn=22.10.*
-- pyraft=22.10.*
+- raft-dask=22.10.*
+- pylibraft=22.10.*
 - dask-cudf=22.10.*
 - dask-cuda=22.10.*
 - ucx>=1.13.0

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - python x.x
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
-    - joblib<=1.2.0
+    - joblib<=1.1.0
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - pylibraft {{ minor_version }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - python x.x
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
+    - joblib<=1.2.0
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - pylibraft {{ minor_version }}

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - ucx-proc=*=gpu
     - dask==2022.7.1
     - distributed==2022.7.1
-    - joblib >=0.11, <1.2.0
+    - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - cuda-python >=11.5,<11.7.1
 

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -50,7 +50,6 @@ requirements:
     - python x.x
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
-    - joblib<=1.1.0
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
     - pylibraft {{ minor_version }}
@@ -62,7 +61,7 @@ requirements:
     - ucx-proc=*=gpu
     - dask==2022.7.1
     - distributed==2022.7.1
-    - joblib >=0.11
+    - joblib >=0.11, <1.2.0
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - cuda-python >=11.5,<11.7.1
 

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - pyraft {{ minor_version }}
+    - pylibraft {{ minor_version }}
+    - raft-dask {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
@@ -51,7 +52,8 @@ requirements:
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
-    - pyraft {{ minor_version }}
+    - pylibraft {{ minor_version }}
+    - raft-dask {{ minor_version }}
     - cupy>=7.8.0,<12.0.0a0
     - treelite=2.4.0
     - nccl>=2.9.9

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -81,8 +81,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-                        FORK             rapidsai
-                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
+                        FORK             cjnolet
+                        PINNED_TAG       imp-2210-host_device_mdspan
 
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -81,8 +81,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-                        FORK             cjnolet
-                        PINNED_TAG       imp-2210-host_device_mdspan
+                        FORK             rapidsai
+                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
 
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory

--- a/cpp/src/hdbscan/detail/reachability.cuh
+++ b/cpp/src/hdbscan/detail/reachability.cuh
@@ -24,7 +24,6 @@
 #include <raft/linalg/unary_op.cuh>
 
 #include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/hierarchy/detail/connectivities.cuh>
 #include <raft/sparse/linalg/symmetrize.cuh>
 #include <raft/sparse/selection/knn_graph.cuh>
 

--- a/cpp/src/hdbscan/runner.h
+++ b/cpp/src/hdbscan/runner.h
@@ -24,8 +24,8 @@
 #include <cuml/common/logger.hpp>
 
 #include <raft/sparse/coo.hpp>
-#include <raft/sparse/hierarchy/detail/agglomerative.cuh>
-#include <raft/sparse/hierarchy/detail/mst.cuh>
+#include <raft/cluster/detail/agglomerative.cuh>
+#include <raft/cluster/detail/mst.cuh>
 
 #include "detail/condense.cuh"
 #include "detail/extract.cuh"
@@ -160,7 +160,7 @@ void build_linkage(const raft::handle_t& handle,
   rmm::device_uvector<value_idx> color(m, stream);
   FixConnectivitiesRedOp<value_idx, value_t> red_op(color.data(), core_dists, m);
   // during knn graph connection
-  raft::hierarchy::detail::build_sorted_mst(handle,
+  raft::cluster::detail::build_sorted_mst(handle,
                                             X,
                                             mutual_reachability_indptr.data(),
                                             mutual_reachability_coo.cols(),
@@ -181,7 +181,7 @@ void build_linkage(const raft::handle_t& handle,
    */
   size_t n_edges = m - 1;
 
-  raft::hierarchy::detail::build_dendrogram_host(handle,
+  raft::cluster::detail::build_dendrogram_host(handle,
                                                  out.get_mst_src(),
                                                  out.get_mst_dst(),
                                                  out.get_mst_weights(),

--- a/cpp/src/hdbscan/runner.h
+++ b/cpp/src/hdbscan/runner.h
@@ -23,9 +23,9 @@
 
 #include <cuml/common/logger.hpp>
 
-#include <raft/sparse/coo.hpp>
 #include <raft/cluster/detail/agglomerative.cuh>
 #include <raft/cluster/detail/mst.cuh>
+#include <raft/sparse/coo.hpp>
 
 #include "detail/condense.cuh"
 #include "detail/extract.cuh"
@@ -161,20 +161,20 @@ void build_linkage(const raft::handle_t& handle,
   FixConnectivitiesRedOp<value_idx, value_t> red_op(color.data(), core_dists, m);
   // during knn graph connection
   raft::cluster::detail::build_sorted_mst(handle,
-                                            X,
-                                            mutual_reachability_indptr.data(),
-                                            mutual_reachability_coo.cols(),
-                                            mutual_reachability_coo.vals(),
-                                            m,
-                                            n,
-                                            out.get_mst_src(),
-                                            out.get_mst_dst(),
-                                            out.get_mst_weights(),
-                                            color.data(),
-                                            mutual_reachability_coo.nnz,
-                                            red_op,
-                                            metric,
-                                            (size_t)10);
+                                          X,
+                                          mutual_reachability_indptr.data(),
+                                          mutual_reachability_coo.cols(),
+                                          mutual_reachability_coo.vals(),
+                                          m,
+                                          n,
+                                          out.get_mst_src(),
+                                          out.get_mst_dst(),
+                                          out.get_mst_weights(),
+                                          color.data(),
+                                          mutual_reachability_coo.nnz,
+                                          red_op,
+                                          metric,
+                                          (size_t)10);
 
   /**
    * Perform hierarchical labeling
@@ -182,13 +182,13 @@ void build_linkage(const raft::handle_t& handle,
   size_t n_edges = m - 1;
 
   raft::cluster::detail::build_dendrogram_host(handle,
-                                                 out.get_mst_src(),
-                                                 out.get_mst_dst(),
-                                                 out.get_mst_weights(),
-                                                 n_edges,
-                                                 out.get_children(),
-                                                 out.get_deltas(),
-                                                 out.get_sizes());
+                                               out.get_mst_src(),
+                                               out.get_mst_dst(),
+                                               out.get_mst_weights(),
+                                               n_edges,
+                                               out.get_children(),
+                                               out.get_deltas(),
+                                               out.get_sizes());
 }
 
 template <typename value_idx = int64_t, typename value_t = float>

--- a/cpp/src/hierarchy/linkage.cu
+++ b/cpp/src/hierarchy/linkage.cu
@@ -16,7 +16,7 @@
 
 #include "pw_dist_graph.cuh"
 #include <cuml/cluster/linkage.hpp>
-#include <raft/sparse/hierarchy/single_linkage.cuh>
+#include <raft/cluster/single_linkage.cuh>
 
 namespace raft {
 class handle_t;
@@ -28,11 +28,11 @@ void single_linkage_pairwise(const raft::handle_t& handle,
                              const float* X,
                              size_t m,
                              size_t n,
-                             raft::hierarchy::linkage_output<int, float>* out,
+                             raft::cluster::linkage_output<int, float>* out,
                              raft::distance::DistanceType metric,
                              int n_clusters)
 {
-  raft::hierarchy::single_linkage<int, float, raft::hierarchy::LinkageDistance::PAIRWISE>(
+  raft::cluster::single_linkage<int, float, raft::cluster::LinkageDistance::PAIRWISE>(
     handle, X, m, n, metric, out, 0, n_clusters);
 }
 
@@ -40,22 +40,22 @@ void single_linkage_neighbors(const raft::handle_t& handle,
                               const float* X,
                               size_t m,
                               size_t n,
-                              raft::hierarchy::linkage_output<int, float>* out,
+                              raft::cluster::linkage_output<int, float>* out,
                               raft::distance::DistanceType metric,
                               int c,
                               int n_clusters)
 {
-  raft::hierarchy::single_linkage<int, float, raft::hierarchy::LinkageDistance::KNN_GRAPH>(
+  raft::cluster::single_linkage<int, float, raft::cluster::LinkageDistance::KNN_GRAPH>(
     handle, X, m, n, metric, out, c, n_clusters);
 }
 
 struct distance_graph_impl_int_float
-  : public raft::hierarchy::detail::
-      distance_graph_impl<raft::hierarchy::LinkageDistance::PAIRWISE, int, float> {
+  : public raft::cluster::detail::
+      distance_graph_impl<raft::cluster::LinkageDistance::PAIRWISE, int, float> {
 };
 struct distance_graph_impl_int_double
-  : public raft::hierarchy::detail::
-      distance_graph_impl<raft::hierarchy::LinkageDistance::PAIRWISE, int, double> {
+  : public raft::cluster::detail::
+      distance_graph_impl<raft::cluster::LinkageDistance::PAIRWISE, int, double> {
 };
 
 };  // end namespace ML

--- a/cpp/src/hierarchy/pw_dist_graph.cuh
+++ b/cpp/src/hierarchy/pw_dist_graph.cuh
@@ -28,8 +28,8 @@
 
 // TODO: Not a good strategy for pluggability but will be
 // removed once our dense pairwise distance API is in RAFT
-#include <raft/sparse/hierarchy/common.h>
-#include <raft/sparse/hierarchy/detail/connectivities.cuh>
+#include <raft/cluster/detail/connectivities.cuh>
+#include <raft/cluster/single_linkage_types.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -44,7 +44,7 @@
 #include <limits>
 
 namespace raft {
-namespace hierarchy {
+namespace cluster {
 namespace detail {
 
 template <typename value_idx>
@@ -117,7 +117,7 @@ void pairwise_distances(const raft::handle_t& handle,
  * @tparam value_t
  */
 template <typename value_idx, typename value_t>
-struct distance_graph_impl<raft::hierarchy::LinkageDistance::PAIRWISE, value_idx, value_t> {
+struct distance_graph_impl<raft::cluster::LinkageDistance::PAIRWISE, value_idx, value_t> {
   void run(const raft::handle_t& handle,
            const value_t* X,
            size_t m,
@@ -140,5 +140,5 @@ struct distance_graph_impl<raft::hierarchy::LinkageDistance::PAIRWISE, value_idx
 };
 
 };  // namespace detail
-};  // end namespace hierarchy
+};  // namespace cluster
 };  // end namespace raft

--- a/cpp/test/sg/hdbscan_test.cu
+++ b/cpp/test/sg/hdbscan_test.cu
@@ -31,7 +31,7 @@
 
 #include <metrics/adjusted_rand_index.cuh>
 
-#include <raft/sparse/hierarchy/detail/agglomerative.cuh>
+#include <raft/cluster/detail/agglomerative.cuh>
 
 #include <raft/distance/distance_type.hpp>
 #include <raft/linalg/transpose.cuh>
@@ -177,14 +177,14 @@ class ClusterCondensingTest : public ::testing::TestWithParam<ClusterCondensingI
     /**
      * Build dendrogram of MST
      */
-    raft::hierarchy::detail::build_dendrogram_host(handle,
-                                                   mst_src.data(),
-                                                   mst_dst.data(),
-                                                   mst_data.data(),
-                                                   params.n_row - 1,
-                                                   out_children.data(),
-                                                   out_delta.data(),
-                                                   out_size.data());
+    raft::cluster::detail::build_dendrogram_host(handle,
+                                                 mst_src.data(),
+                                                 mst_dst.data(),
+                                                 mst_data.data(),
+                                                 params.n_row - 1,
+                                                 out_children.data(),
+                                                 out_delta.data(),
+                                                 out_size.data());
 
     /**
      * Condense Hierarchy

--- a/python/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cluster/agglomerative.pyx
@@ -23,7 +23,7 @@ import numpy as np
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.mixins import ClusterMixin

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -27,7 +27,7 @@ from libc.stdlib cimport calloc, malloc, free
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.common.array_descriptor import CumlArrayDescriptor

--- a/python/cuml/cluster/hdbscan.pyx
+++ b/python/cuml/cluster/hdbscan.pyx
@@ -26,9 +26,9 @@ import cupy as cp
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.mixins import ClusterMixin

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -34,7 +34,7 @@ from cuml.common.mixins import ClusterMixin
 from cuml.common.mixins import CMajorInputTagMixin
 from cuml.common import input_to_cuml_array
 from cuml.cluster.kmeans_utils cimport *
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans":
 

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -28,7 +28,7 @@ from libc.stdlib cimport calloc, malloc, free
 
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 
 from cuml.cluster import KMeans

--- a/python/cuml/cluster/prediction.pyx
+++ b/python/cuml/cluster/prediction.pyx
@@ -25,9 +25,9 @@ import cupy as cp
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.mixins import ClusterMixin

--- a/python/cuml/common/base.pyx
+++ b/python/cuml/common/base.pyx
@@ -24,7 +24,7 @@ import cuml.common
 import cuml.common.cuda
 import cuml.common.logger as logger
 import cuml.internals
-import raft.common.handle
+import pylibraft.common.handle
 import cuml.common.input_utils
 
 from cuml.common.doc_utils import generate_docstring
@@ -164,7 +164,7 @@ class Base(TagsMixin,
         Constructor. All children must call init method of this base class.
 
         """
-        self.handle = raft.common.handle.Handle() if handle is None \
+        self.handle = pylibraft.common.handle.Handle() if handle is None \
             else handle
 
         # Internally, self.verbose follows the spdlog/c++ standard of

--- a/python/cuml/common/handle.pyx
+++ b/python/cuml/common/handle.pyx
@@ -16,6 +16,6 @@
 
 # distutils: language = c++
 
-from raft.common.handle import Handle as raftHandle
+from pylibraft.common.handle import Handle as raftHandle
 
 Handle = raftHandle

--- a/python/cuml/dask/cluster/dbscan.py
+++ b/python/cuml/dask/cluster/dbscan.py
@@ -20,8 +20,8 @@ from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import DelayedTransformMixin
 from cuml.dask.common.base import mnmg_import
 
-from raft.dask.common.comms import Comms
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import Comms
+from raft_dask.common.comms import get_raft_comm_state
 
 from cuml.dask.common.utils import wait_and_raise_from_futures
 

--- a/python/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/dask/cluster/kmeans.py
@@ -23,8 +23,8 @@ from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.input_utils import concatenate
 from cuml.dask.common.input_utils import DistributedDataHandler
 
-from raft.dask.common.comms import Comms
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import Comms
+from raft_dask.common.comms import get_raft_comm_state
 
 from cuml.dask.common.utils import wait_and_raise_from_futures
 

--- a/python/cuml/dask/common/base.py
+++ b/python/cuml/dask/common/base.py
@@ -25,7 +25,7 @@ from cuml.dask.common.utils import get_client
 from cuml import Base
 from cuml.common.array import CumlArray
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft.dask.common.comms import Comms
+from raft_dask.common.comms import Comms
 from cuml.dask.common.input_utils import DistributedDataHandler
 from cuml.dask.common import parts_to_ranks
 from cuml.internals import BaseMetaClass

--- a/python/cuml/dask/decomposition/base.py
+++ b/python/cuml/dask/decomposition/base.py
@@ -14,8 +14,8 @@
 #
 
 from cuml.dask.common import raise_exception_from_futures
-from raft.dask.common.comms import get_raft_comm_state
-from raft.dask.common.comms import Comms
+from raft_dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import Comms
 
 from cuml.dask.common.input_utils import to_output
 from cuml.dask.common import parts_to_ranks

--- a/python/cuml/dask/linear_model/linear_regression.py
+++ b/python/cuml/dask/linear_model/linear_regression.py
@@ -17,7 +17,7 @@ from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.base import SyncFitMixinLinearModel
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import get_raft_comm_state
 
 
 class LinearRegression(BaseEstimator,

--- a/python/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/dask/linear_model/ridge.py
@@ -17,7 +17,7 @@ from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.base import SyncFitMixinLinearModel
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import get_raft_comm_state
 
 
 class Ridge(BaseEstimator,

--- a/python/cuml/dask/neighbors/kneighbors_classifier.py
+++ b/python/cuml/dask/neighbors/kneighbors_classifier.py
@@ -20,7 +20,7 @@ from cuml.dask.common import parts_to_ranks
 from cuml.dask.common import flatten_grouped_results
 from cuml.dask.common.utils import raise_mg_import_exception
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import get_raft_comm_state
 from cuml.dask.neighbors import NearestNeighbors
 from dask.dataframe import Series as DaskSeries
 import dask.array as da

--- a/python/cuml/dask/neighbors/kneighbors_regressor.py
+++ b/python/cuml/dask/neighbors/kneighbors_regressor.py
@@ -20,7 +20,7 @@ from cuml.dask.common import parts_to_ranks
 from cuml.dask.common import flatten_grouped_results
 from cuml.dask.common.utils import raise_mg_import_exception
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import get_raft_comm_state
 from cuml.dask.neighbors import NearestNeighbors
 import dask.array as da
 from uuid import uuid1

--- a/python/cuml/dask/neighbors/nearest_neighbors.py
+++ b/python/cuml/dask/neighbors/nearest_neighbors.py
@@ -19,8 +19,8 @@ from cuml.dask.common import flatten_grouped_results
 from cuml.dask.common import raise_mg_import_exception
 from cuml.dask.common.base import BaseEstimator
 
-from raft.dask.common.comms import get_raft_comm_state
-from raft.dask.common.comms import Comms
+from raft_dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import Comms
 from cuml.dask.common.input_utils import to_output
 from cuml.dask.common.input_utils import DistributedDataHandler
 

--- a/python/cuml/dask/solvers/cd.py
+++ b/python/cuml/dask/solvers/cd.py
@@ -17,7 +17,7 @@ from cuml.dask.common.base import BaseEstimator
 from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.base import SyncFitMixinLinearModel
-from raft.dask.common.comms import get_raft_comm_state
+from raft_dask.common.comms import get_raft_comm_state
 
 
 class CD(BaseEstimator,

--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -22,8 +22,8 @@ import numpy as np
 
 from cuml.common.array import CumlArray as cumlArray
 import cuml.internals
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 from cuml.tsa.arima cimport ARIMAOrder
 
 from libc.stdint cimport uint64_t, uintptr_t

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -23,8 +23,8 @@ import numpy as np
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 
 from libcpp cimport bool
 from libc.stdint cimport uint64_t, uintptr_t

--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -31,7 +31,7 @@ from cuml.common.array import CumlArray
 import cuml.common.opg_data_utils_mg as opg
 import cuml.internals
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 from cuml.decomposition.utils_mg cimport *
 from cuml.common import input_to_cuml_array

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -35,8 +35,8 @@ import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 import cuml.common.logger as logger
 from cuml.decomposition.utils cimport *
 from cuml.common.input_utils import input_to_cuml_array

--- a/python/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/decomposition/pca_mg.pyx
@@ -32,7 +32,7 @@ from cuml.common.array import CumlArray
 import cuml.common.opg_data_utils_mg as opg
 import cuml.internals
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 from cuml.common.base import Base
 from cuml.common.opg_data_utils_mg cimport *

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -29,7 +29,7 @@ from libc.stdint cimport uintptr_t
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor

--- a/python/cuml/decomposition/tsvd_mg.pyx
+++ b/python/cuml/decomposition/tsvd_mg.pyx
@@ -26,7 +26,7 @@ from libcpp cimport bool
 from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 import cuml.internals
 import cuml.common.opg_data_utils_mg as opg

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -23,7 +23,7 @@ from inspect import signature
 import numpy as np
 from cuml import ForestInference
 from cuml.fil.fil import TreeliteModel
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
 from cuml.common.exceptions import NotFittedError

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -25,10 +25,10 @@ from libc.stdlib cimport calloc, malloc, free
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from cuml import ForestInference
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 cdef extern from "treelite/c_api.h":

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -29,7 +29,7 @@ from cuml.common.mixins import ClassifierMixin
 import cuml.internals
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.doc_utils import insert_into_docstring
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 
 from cuml.ensemble.randomforest_common import BaseRandomForestModel
@@ -47,7 +47,7 @@ from libc.stdlib cimport calloc, malloc, free
 
 from numba import cuda
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 cimport cython

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -30,7 +30,7 @@ import cuml.internals
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.doc_utils import insert_into_docstring
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 
 from cuml.ensemble.randomforest_common import BaseRandomForestModel
@@ -48,7 +48,7 @@ from libc.stdlib cimport calloc, malloc, free
 
 from numba import cuda
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 cimport cython

--- a/python/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/experimental/linear_model/lars.pyx
@@ -38,7 +38,7 @@ from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.exceptions import NotFittedError
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 cdef extern from "cuml/solvers/lars.hpp" namespace "ML::Solver::Lars":
 

--- a/python/cuml/explainer/base.pyx
+++ b/python/cuml/explainer/base.pyx
@@ -33,7 +33,7 @@ from cuml.explainer.common import get_tag_from_model_func
 from cuml.explainer.common import model_func_call
 from cuml.explainer.common import output_list_shap_values
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 
@@ -89,7 +89,7 @@ class SHAPBase():
         (as CuPy arrays), otherwise it will use NumPy arrays to call `model`.
         Set to True to force the explainer to use GPU data,  set to False to
         force the Explainer to use NumPy data.
-    handle : raft.common.handle
+    handle : pylibraft.common.handle
         Specifies the handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
         stream that will be used for the model's computations, so users can

--- a/python/cuml/explainer/common.py
+++ b/python/cuml/explainer/common.py
@@ -16,7 +16,7 @@
 
 import cuml
 import cupy as cp
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 from cuml.common.input_utils import input_to_cupy_array
 

--- a/python/cuml/explainer/kernel_shap.pyx
+++ b/python/cuml/explainer/kernel_shap.pyx
@@ -27,13 +27,13 @@ from cuml.explainer.common import model_func_call
 from cuml.explainer.common import output_list_shap_values
 from cuml.linear_model import Lasso
 from cuml.linear_model import LinearRegression
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 from functools import lru_cache
 from itertools import combinations
 from numbers import Number
 from random import randint
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from libc.stdint cimport uint64_t
 
@@ -134,7 +134,7 @@ class KernelExplainer(SHAPBase):
         (as CuPy arrays), otherwise it will use NumPy arrays to call `model`.
         Set to True to force the explainer to use GPU data,  set to False to
         force the Explainer to use NumPy data.
-    handle : raft.common.handle (default = None)
+    handle : pylibraft.common.handle (default = None)
         Specifies the handle that holds internal CUDA state for
         computations in this model, a new one is created if it is None.
         Most importantly, this specifies the CUDA stream that will be used for

--- a/python/cuml/explainer/permutation_shap.pyx
+++ b/python/cuml/explainer/permutation_shap.pyx
@@ -30,7 +30,7 @@ from cuml.explainer.common import model_func_call
 from numba import cuda
 from pandas import DataFrame as pd_df
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 
@@ -139,7 +139,7 @@ class PermutationExplainer(SHAPBase):
         (as CuPy arrays), otherwise it will use NumPy arrays to call `model`.
         Set to True to force the explainer to use GPU data,  set to False to
         force the Explainer to use NumPy data.
-    handle : raft.common.handle (default = None)
+    handle : pylibraft.common.handle (default = None)
         Specifies the handle that holds internal CUDA state for
         computations in this model, a new one is created if it is None.
         Most importantly, this specifies the CUDA stream that will be used for

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -33,7 +33,7 @@ from libc.stdlib cimport calloc, malloc, free
 import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array, logger
 from cuml.common.mixins import CMajorInputTagMixin
 from cuml.common.doc_utils import _parameters_docstrings

--- a/python/cuml/linear_model/base.pyx
+++ b/python/cuml/linear_model/base.pyx
@@ -33,7 +33,7 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -27,7 +27,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -34,7 +34,7 @@ from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.linear_model.base import LinearPredictMixin
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/linear_model/linear_regression_mg.pyx
+++ b/python/cuml/linear_model/linear_regression_mg.pyx
@@ -29,7 +29,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -32,7 +32,7 @@ from cuml.common.mixins import RegressorMixin
 from cuml.common.array import CumlArray
 from cuml.common.doc_utils import generate_docstring
 from cuml.linear_model.base import LinearPredictMixin
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/linear_model/ridge_mg.pyx
+++ b/python/cuml/linear_model/ridge_mg.pyx
@@ -29,7 +29,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/manifold/simpl_set.pyx
@@ -27,8 +27,8 @@ from cuml.common.base import Base
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.common.array import CumlArray
 
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport free

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -28,7 +28,7 @@ import cupy
 import cuml.internals
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 import cuml.common.logger as logger
 
 from cuml.common.array import CumlArray

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -39,7 +39,7 @@ from cupyx.scipy.sparse import csr_matrix as cp_csr_matrix,\
 import cuml.internals
 from cuml.common import using_output_type
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.doc_utils import generate_docstring
 from cuml.common import logger
 from cuml.common.input_utils import input_to_cuml_array

--- a/python/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/manifold/umap_utils.pyx
@@ -17,7 +17,7 @@
 # distutils: language = c++
 
 from rmm._lib.memory_resource cimport get_current_device_resource
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.manifold.umap_utils cimport *
 from libcpp.utility cimport move
 import numpy as np

--- a/python/cuml/metrics/accuracy.pyx
+++ b/python/cuml/metrics/accuracy.pyx
@@ -24,8 +24,8 @@ from libc.stdint cimport uintptr_t
 import cuml.internals
 
 from cuml.common.input_utils import input_to_cuml_array
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 cimport cuml.common.cuda
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -22,9 +22,9 @@ import warnings
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 cimport cuml.common.cuda
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/completeness_score.pyx
+++ b/python/cuml/metrics/cluster/completeness_score.pyx
@@ -17,10 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/entropy.pyx
+++ b/python/cuml/metrics/cluster/entropy.pyx
@@ -24,10 +24,10 @@ import cupy as cp
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import CumlArray
 from cuml.common.input_utils import input_to_cupy_array
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 cimport cuml.common.cuda
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/homogeneity_score.pyx
+++ b/python/cuml/metrics/cluster/homogeneity_score.pyx
@@ -17,10 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/mutual_info_score.pyx
+++ b/python/cuml/metrics/cluster/mutual_info_score.pyx
@@ -17,11 +17,11 @@
 # distutils: language = c++
 
 import cuml.internals
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/metrics/cluster/silhouette_score.pyx
@@ -21,8 +21,8 @@ from libc.stdint cimport uintptr_t
 
 from cuml.common import input_to_cuml_array
 from cuml.metrics.pairwise_distances import _determine_metric
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 from cuml.metrics.distance_type cimport DistanceType
 from cuml.prims.label.classlabels import make_monotonic, check_labels
 

--- a/python/cuml/metrics/cluster/v_measure.pyx
+++ b/python/cuml/metrics/cluster/v_measure.pyx
@@ -17,10 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libc.stdint cimport uintptr_t
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/kl_divergence.pyx
+++ b/python/cuml/metrics/kl_divergence.pyx
@@ -20,8 +20,8 @@ import cuml.internals
 from cuml.common.input_utils import determine_array_type
 from cuml.common import (input_to_cuml_array, CumlArray, logger)
 from libc.stdint cimport uintptr_t
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
     double c_kl_divergence "ML::Metrics::kl_divergence"(

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -20,8 +20,8 @@ import warnings
 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 import cupy as cp
 import numpy as np
 import pandas as pd

--- a/python/cuml/metrics/regression.pxd
+++ b/python/cuml/metrics/regression.pxd
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
 

--- a/python/cuml/metrics/regression.pyx
+++ b/python/cuml/metrics/regression.pyx
@@ -23,8 +23,8 @@ from libc.stdint cimport uintptr_t
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from raft.common.handle import Handle
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
 from cuml.metrics cimport regression
 from cuml.common.input_utils import input_to_cuml_array
 

--- a/python/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/metrics/trustworthiness.pyx
@@ -24,8 +24,8 @@ from numba import cuda
 from libc.stdint cimport uintptr_t
 import cuml.internals
 from cuml.common.input_utils import input_to_cuml_array
-from raft.common.handle import Handle
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
 
 cdef extern from "raft/distance/distance_type.hpp" namespace "raft::distance":
 

--- a/python/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier.pyx
@@ -34,7 +34,7 @@ import cupy as cp
 
 from cython.operator cimport dereference as deref
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from libcpp.vector cimport vector
 
 from libcpp cimport bool

--- a/python/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -23,7 +23,7 @@ from cuml.internals import api_base_return_generic_skipall
 
 from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common import input_to_cuml_array
 

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -33,7 +33,7 @@ from cython.operator cimport dereference as deref
 
 from libcpp.vector cimport vector
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr

--- a/python/cuml/neighbors/kneighbors_regressor_mg.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor_mg.pyx
@@ -23,7 +23,7 @@ from cuml.internals import api_base_return_generic_skipall
 
 from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 
 from libcpp cimport bool

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -41,7 +41,7 @@ from cuml.common.sparse_utils import is_dense
 from cuml.metrics.distance_type cimport DistanceType
 
 from cuml.neighbors.ann cimport *
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 from cython.operator cimport dereference as deref
 

--- a/python/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -25,7 +25,7 @@ import cuml.common.logger as logger
 
 from cuml.neighbors import NearestNeighbors
 
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common.opg_data_utils_mg import _build_part_inputs
 

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -24,7 +24,7 @@ from libcpp cimport bool
 import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from raft.common.handle cimport *
+from pylibraft.common.handle cimport *
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -28,7 +28,7 @@ from cuml.common import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/solvers/cd_mg.pyx
+++ b/python/cuml/solvers/cd_mg.pyx
@@ -26,7 +26,7 @@ from cython.operator cimport dereference as deref
 import cuml.internals
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.common.input_utils import input_to_cuml_array
 from cuml.decomposition.utils cimport *

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -27,7 +27,7 @@ from cuml.common.base import Base
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.array_sparse import SparseCumlArray
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 from cuml.common.sparse_utils import is_sparse

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -32,7 +32,7 @@ from cuml.common.base import Base
 from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common.mixins import FMajorInputTagMixin
 

--- a/python/cuml/svm/linear.pyx
+++ b/python/cuml/svm/linear.pyx
@@ -29,8 +29,8 @@ from cuml.internals.base_helpers import BaseMetaClass
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
-from raft.common.interruptible import cuda_interruptible
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.interruptible import cuda_interruptible
 from cuml.common import input_to_cuml_array
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool as cppbool

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -34,8 +34,8 @@ from cuml.common.mixins import ClassifierMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.logger import warn
-from raft.common.handle cimport handle_t
-from raft.common.interruptible import cuda_interruptible
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.interruptible import cuda_interruptible
 from cuml.common import input_to_cuml_array, input_to_host_array, with_cupy_rmm
 from cuml.common.input_utils import input_to_cupy_array
 from cuml.preprocessing import LabelEncoder

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -29,7 +29,7 @@ from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
 from cuml.common.exceptions import NotFittedError
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.common.logger import warn

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -29,7 +29,7 @@ from cuml.common.base import Base
 from cuml.common.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.metrics import r2_score
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common import input_to_cuml_array
 from libcpp cimport bool, nullptr
 from cuml.svm.svm_base import SVMBase

--- a/python/cuml/testing/utils.py
+++ b/python/cuml/testing/utils.py
@@ -24,7 +24,7 @@ from numba.cuda.cudadrv.devicearray import DeviceNDArray
 
 from sklearn.datasets import make_regression as skl_make_reg
 
-from raft.common.cuda import Stream
+from pylibraft.common.cuda import Stream
 
 from sklearn import datasets
 from sklearn.datasets import make_classification, make_regression

--- a/python/cuml/tests/explainer/test_explainer_base.py
+++ b/python/cuml/tests/explainer/test_explainer_base.py
@@ -19,7 +19,7 @@ import cupy as cp
 import numpy as np
 import pytest
 
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 from cuml.explainer.base import SHAPBase
 from cuml import LinearRegression as cuLR

--- a/python/cuml/tests/explainer/test_explainer_common.py
+++ b/python/cuml/tests/explainer/test_explainer_common.py
@@ -32,7 +32,7 @@ from cuml.testing.utils import ClassEnumerator
 from cuml.datasets import make_regression
 from sklearn.linear_model import LinearRegression as skreg
 
-from raft.common.handle import Handle
+from pylibraft.common.handle import Handle
 
 
 models_config = ClassEnumerator(module=cuml)

--- a/python/cuml/tests/explainer/test_shap_plotting.py
+++ b/python/cuml/tests/explainer/test_shap_plotting.py
@@ -87,6 +87,8 @@ def test_dependence_plot(explainer, exact_shap_regression_dataset):
     shap.dependence_plot(0, shap_values, data, show=show_plots)
 
 
+@pytest.mark.skip(reason="matplotlib has been updated. "
+                         "ref: https://github.com/rapidsai/cuml/issues/4893")
 def test_heatmap(explainer, exact_shap_regression_dataset):
     shap = pytest.importorskip("shap")
     shap_values, _ = get_shap_values(explainer=explainer,

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -19,7 +19,7 @@ import cuml
 import pytest
 import numpydoc.docscrape
 
-from raft.common.cuda import Stream
+from pylibraft.common.cuda import Stream
 
 from cuml.testing.utils import \
     get_classes_from_package, \

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -30,7 +30,7 @@ import cuml.internals
 from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.base import Base
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 import cuml.common.logger as logger
 from cuml.common import has_scipy

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -33,8 +33,8 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.array import CumlArray
 from cuml.common.base import Base
 from cuml.internals import _deprecate_pos_args
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 from cuml.common import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.common.input_utils import determine_array_dtype

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -27,7 +27,7 @@ from cuml.common import using_output_type
 from cuml.common.base import Base
 from cuml.common.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 
 cdef extern from "cuml/tsa/holtwinters_params.h" namespace "ML":
     enum SeasonalType:

--- a/python/cuml/tsa/seasonality.pyx
+++ b/python/cuml/tsa/seasonality.pyx
@@ -19,7 +19,7 @@ import numpy as np
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
+from pylibraft.common.handle cimport handle_t
 from cuml.common.input_utils import input_to_host_array, input_to_cuml_array
 
 # TODO: #2234 and #2235

--- a/python/cuml/tsa/stationarity.pyx
+++ b/python/cuml/tsa/stationarity.pyx
@@ -22,8 +22,8 @@ from libcpp cimport bool as boolcpp
 
 import cuml.internals
 from cuml.common.array import CumlArray
-from raft.common.handle cimport handle_t
-from raft.common.handle import Handle
+from pylibraft.common.handle cimport handle_t
+from pylibraft.common.handle import Handle
 from cuml.common.input_utils import input_to_cuml_array
 
 


### PR DESCRIPTION
This is a fairly sizable PR but it needs to be done before the `22.10` release as `pyraft` will not longer be released. 