### PR TITLE
Document that minimum required CMake version is now 3.23.1

### DIFF
--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.20.1,!=3.23.0"
+  - ">=3.23.1"
 
 sysroot_version:
   - "2.17"

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -11,7 +11,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.20.1,!=3.23.0"
+  - ">=3.23.1"
 
 nccl_version:
   - ">=2.9.9"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 include(../fetch_rapids.cmake)
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -15,7 +15,7 @@ The `test` directory has subdirectories that reflect this distinction between th
 ## Setup
 ### Dependencies
 
-1. cmake (>= 3.20.1)
+1. cmake (>= 3.23.1)
 2. CUDA (>= 11.0)
 3. gcc (>=9.3.0)
 4. clang-format (= 11.1.0) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=11` and `clang-tools=11` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.

--- a/cpp/examples/dbscan/CMakeLists_standalone.txt
+++ b/cpp/examples/dbscan/CMakeLists_standalone.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/examples/dbscan/CMakeLists_standalone.txt
+++ b/cpp/examples/dbscan/CMakeLists_standalone.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 project(dbscan_example LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp/examples/kmeans/CMakeLists_standalone.txt
+++ b/cpp/examples/kmeans/CMakeLists_standalone.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/examples/kmeans/CMakeLists_standalone.txt
+++ b/cpp/examples/kmeans/CMakeLists_standalone.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 project(kmeans_example LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 include(../fetch_rapids.cmake)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,6 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.20.1,!=3.23.0",
+    "cmake>=3.23.1",
     "ninja",
 ]


### PR DESCRIPTION
With rapids-cmake now requiring CMake 3.23.1 update consumers to correctly express this requirement