### PR TITLE
[REVIEW] [skip-ci] Assign python/ sub-directory to python-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 cpp/               @rapidsai/cuml-cpp-codeowners
 
 #python code owners
-python/cuml/       @rapidsai/cuml-python-codeowners
+python/            @rapidsai/cuml-python-codeowners
 
 #cmake code owners
 **/CMakeLists.txt  @rapidsai/cuml-cmake-codeowners


### PR DESCRIPTION
This ensures that all files within the python/ sub-directory have a codeowner assigned.

Special files like the python/setup.py file that is declared later will still be owned by @rapidsai/cuml-cmake-codeowners .