### PR TITLE
Add missing includes

### DIFF
--- a/cpp/include/cuml/datasets/make_blobs.hpp
+++ b/cpp/include/cuml/datasets/make_blobs.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace raft {
 class handle_t;
 }

--- a/cpp/include/cuml/datasets/make_regression.hpp
+++ b/cpp/include/cuml/datasets/make_regression.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace raft {
 class handle_t;
 }

--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace ML {
 
 /**


### PR DESCRIPTION
These includes are probably being transitively included by parts of the standard library, but they are missing in older versions of glibcxx and glibc.