### PR TITLE
Make doctest resilient to changes in cupy reprs

### DIFF
--- a/python/cuml/common/memory_utils.py
+++ b/python/cuml/common/memory_utils.py
@@ -523,8 +523,8 @@ def using_output_type(output_type):
     >>> # cuML default output
     >>> dbscan_float2.labels_
     array([0, 1, 2], dtype=int32)
-    >>> type(dbscan_float2.labels_)
-    <class 'cupy.ndarray'>
+    >>> isinstance(dbscan_float2.labels_, cp.ndarray)
+    True
 
     """
     prev_output_type = cuml.global_settings.output_type


### PR DESCRIPTION
Depending on the cupy package in use (varies by version, architecture, etc) the exact name of the `ndarray` object may be `cupy.ndarray` or something like `cupy._core.core.ndarray` instead. Using `isinstance` avoids doctest failures due to those sorts of instabilities.