### PR TITLE
Remove `CumlArray.copy()`

### DIFF
--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -349,19 +349,6 @@ class CumlArray(Buffer):
         frames = [CumlArray(f) for f in frames]
         return header, frames
 
-    @nvtx.annotate(message="common.CumlArray.copy", category="utils",
-                   domain="cuml_python")
-    def copy(self) -> Buffer:
-        """
-        Create a new Buffer containing a copy of the data contained
-        in this Buffer.
-        """
-        from rmm._lib.device_buffer import copy_device_to_ptr
-
-        out = Buffer(rmm.DeviceBuffer(size=self.size))
-        copy_device_to_ptr(self.ptr, out.ptr, self.size)
-        return out
-
     @nvtx.annotate(message="common.CumlArray.to_host_array", category="utils",
                    domain="cuml_python")
     def to_host_array(self):

--- a/python/cuml/common/array.py
+++ b/python/cuml/common/array.py
@@ -358,7 +358,7 @@ class CumlArray(Buffer):
         """
         from rmm._lib.device_buffer import copy_device_to_ptr
 
-        out = Buffer.empty(size=self.size)
+        out = Buffer(rmm.DeviceBuffer(size=self.size))
         copy_device_to_ptr(self.ptr, out.ptr, self.size)
         return out
 


### PR DESCRIPTION
cuDF's `Buffer` doesn't have `Buffer.empty()` since https://github.com/rapidsai/cudf/pull/11447. Can we remove `CumlArray.copy()`?
