### PR TITLE
Use new rapids-cmake functionality for rpath handling.

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -73,6 +73,7 @@ else()
   set(cuml_FOUND OFF)
 endif()
 
+include(rapids-cython)
 
 if(NOT cuml_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
@@ -94,7 +95,8 @@ if(NOT cuml_FOUND)
   message(STATUS "installing packages")
   add_subdirectory(../cpp cuml-cpp)
 
-  install(TARGETS ${CUML_CPP_TARGET} DESTINATION cuml/library)
+  set(cython_lib_dir cuml)
+  install(TARGETS ${CUML_CPP_TARGET} DESTINATION ${cython_lib_dir})
 endif()
 
 set(cuml_sg_libraries cuml::${CUML_CPP_TARGET})
@@ -107,7 +109,6 @@ if(NOT SINGLEGPU)
   )
 endif()
 
-include(rapids-cython)
 rapids_cython_init()
 
 add_subdirectory(cuml/common)
@@ -133,3 +134,6 @@ add_subdirectory(cuml/tsa)
 add_subdirectory(cuml/experimental/common)
 add_subdirectory(cuml/experimental/linear_model)
 
+if(DEFINED cython_lib_dir)
+  rapids_cython_add_rpath_entries(TARGET cuml PATHS "${cython_lib_dir}")
+endif()

--- a/python/cuml/cluster/CMakeLists.txt
+++ b/python/cuml/cluster/CMakeLists.txt
@@ -32,8 +32,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES $<IF:$<BOOL:${SINGLE_GPU}>,${cuml_sg_libraries},${cuml_mg_libraries}>
   MODULE_PREFIX cluster_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/cluster/hdbscan/CMakeLists.txt
+++ b/python/cuml/cluster/hdbscan/CMakeLists.txt
@@ -21,8 +21,5 @@ rapids_cython_create_modules(
         SOURCE_FILES "${cython_sources}"
         LINKED_LIBRARIES ${cuml_sg_libraries}
         MODULE_PREFIX cluster_hdbscan_
+        ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/common/CMakeLists.txt
+++ b/python/cuml/common/CMakeLists.txt
@@ -31,11 +31,8 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES $<IF:$<BOOL:${SINGLE_GPU}>,${cuml_sg_libraries},${cuml_mg_libraries}>
   MODULE_PREFIX common_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()
 
 # todo: ml_cuda_utils.h should be in the include folder of cuML or the functionality
 # moved to another file, pointer_utils.pyx needs it

--- a/python/cuml/datasets/CMakeLists.txt
+++ b/python/cuml/datasets/CMakeLists.txt
@@ -22,8 +22,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX datasets_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/decomposition/CMakeLists.txt
+++ b/python/cuml/decomposition/CMakeLists.txt
@@ -31,9 +31,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES $<IF:$<BOOL:${SINGLE_GPU}>,${cuml_sg_libraries},${cuml_mg_libraries}>
   MODULE_PREFIX decomposition_
-
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/ensemble/CMakeLists.txt
+++ b/python/cuml/ensemble/CMakeLists.txt
@@ -30,8 +30,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
   MODULE_PREFIX ensemble_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/experimental/common/CMakeLists.txt
+++ b/python/cuml/experimental/common/CMakeLists.txt
@@ -23,8 +23,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX experimental_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/cuml/experimental/linear_model/CMakeLists.txt
+++ b/python/cuml/experimental/linear_model/CMakeLists.txt
@@ -23,8 +23,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX experimental_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/cuml/explainer/CMakeLists.txt
+++ b/python/cuml/explainer/CMakeLists.txt
@@ -26,8 +26,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX explainer_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/fil/CMakeLists.txt
+++ b/python/cuml/fil/CMakeLists.txt
@@ -23,8 +23,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX fil_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/internals/CMakeLists.txt
+++ b/python/cuml/internals/CMakeLists.txt
@@ -23,11 +23,8 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX internals_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()
 
 # We need to include for callbacks_implements.h in the internals folder
 target_include_directories(internals_internals PRIVATE ${CMAKE_CURRENT_LIST_DIR})

--- a/python/cuml/kernel_ridge/CMakeLists.txt
+++ b/python/cuml/kernel_ridge/CMakeLists.txt
@@ -23,8 +23,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX kernel_ridge_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/linear_model/CMakeLists.txt
+++ b/python/cuml/linear_model/CMakeLists.txt
@@ -37,8 +37,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES $<IF:$<BOOL:${SINGLE_GPU}>,${cuml_sg_libraries},${cuml_mg_libraries}>
   MODULE_PREFIX linear_model_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/manifold/CMakeLists.txt
+++ b/python/cuml/manifold/CMakeLists.txt
@@ -26,8 +26,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX manifold_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/metrics/CMakeLists.txt
+++ b/python/cuml/metrics/CMakeLists.txt
@@ -28,8 +28,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX metrics_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/metrics/cluster/CMakeLists.txt
+++ b/python/cuml/metrics/cluster/CMakeLists.txt
@@ -29,9 +29,6 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()
 

--- a/python/cuml/neighbors/CMakeLists.txt
+++ b/python/cuml/neighbors/CMakeLists.txt
@@ -33,12 +33,9 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES $<IF:$<BOOL:${SINGLE_GPU}>,${cuml_sg_libraries},${cuml_mg_libraries}>
   MODULE_PREFIX neighbors_
+  ASSOCIATED_TARGETS cuml
 )
 
 foreach(target IN LISTS targets_using_numpy)
   target_include_directories(${target} PRIVATE "${Python_NumPy_INCLUDE_DIRS}")
-endforeach()
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
 endforeach()

--- a/python/cuml/random_projection/CMakeLists.txt
+++ b/python/cuml/random_projection/CMakeLists.txt
@@ -23,8 +23,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX random_projection_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/solvers/CMakeLists.txt
+++ b/python/cuml/solvers/CMakeLists.txt
@@ -31,8 +31,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES $<IF:$<BOOL:${SINGLE_GPU}>,${cuml_sg_libraries},${cuml_mg_libraries}>
   MODULE_PREFIX solvers_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/svm/CMakeLists.txt
+++ b/python/cuml/svm/CMakeLists.txt
@@ -26,8 +26,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX svm_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cuml/tsa/CMakeLists.txt
+++ b/python/cuml/tsa/CMakeLists.txt
@@ -27,8 +27,5 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${cuml_sg_libraries}"
   MODULE_PREFIX tsa_
+  ASSOCIATED_TARGETS cuml
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()


### PR DESCRIPTION
The new functionality creates a single source of truth defining the location at which a library will be, allowing rapids-cmake to handle the necessary relative paths in the RPATH and avoiding the current error-prone approach that requires each CMakeLists.txt to correctly assign the relative path.