### PR TITLE
Remove "Open In Colab" link from Estimator Intro notebook.

### DIFF
--- a/docs/source/estimator_intro.ipynb
+++ b/docs/source/estimator_intro.ipynb
@@ -16,10 +16,7 @@
     "1. Random Forest Classifier\n",
     "2. UMAP\n",
     "3. DBSCAN\n",
-    "4. Linear Regression\n",
-    "\n",
-    "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rapidsai/cuml/blob/branch-0.15/docs/source/estimator_intro.ipynb)"
+    "4. Linear Regression"
    ]
   },
   {


### PR DESCRIPTION
The "Open In Colab" feature no longer works. This PR removes the broken link (identified by external review).