### PR TITLE
Update Scikit-Learn pin in all dev envs

### DIFF
--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -32,7 +32,7 @@ dependencies:
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
 - umap-learn
-- scikit-learn=0.24
+- scikit-learn>=1.1
 - sphinx-markdown-tables
 - treelite=3.0.0
 - statsmodels

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -32,7 +32,7 @@ dependencies:
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
 - umap-learn
-- scikit-learn=0.24
+- scikit-learn>=1.1
 - sphinx-markdown-tables
 - treelite=3.0.0
 - statsmodels

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -32,7 +32,7 @@ dependencies:
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
 - umap-learn
-- scikit-learn=0.24
+- scikit-learn>=1.1
 - sphinx-markdown-tables
 - treelite=3.0.0
 - statsmodels

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -32,7 +32,7 @@ dependencies:
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
 - umap-learn
-- scikit-learn=0.24
+- scikit-learn>=1.1
 - sphinx-markdown-tables
 - treelite=3.0.0
 - statsmodels


### PR DESCRIPTION
Allow any Scikit-Learn version >=1.1 for consistency with the conda packages.

Resolve #4981