### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -1,8 +1,8 @@
 name: rapids_dev
 channels:
-- nvidia
 - conda-forge
 - rapidsai
+- nvidia
 dependencies:
 - cudatoolkit=10.0
 - clangdev

--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -1,12 +1,12 @@
 name: cuml_dev
 channels:
 - rapidsai
-- nvidia
 - rapidsai-nightly
 - conda-forge
+- nvidia
 dependencies:
 - cudatoolkit=11.0
-- cuda-python >=11.5,<11.7.1
+- cuda-python >=11.7.1,<12.0
 - rapids-build-env=22.10.*
 - rapids-notebook-env=22.10.*
 - rapids-doc-env=22.10.*

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - cudatoolkit=11.2
-- cuda-python >=11.5,<11.7.1
+- cuda-python >=11.7.1,<12.0
 - rapids-build-env=22.10.*
 - rapids-notebook-env=22.10.*
 - rapids-doc-env=22.10.*

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -1,12 +1,12 @@
 name: cuml_dev
 channels:
 - rapidsai
-- nvidia
 - rapidsai-nightly
 - conda-forge
+- nvidia
 dependencies:
 - cudatoolkit=11.4
-- cuda-python >=11.5,<11.7.1
+- cuda-python >=11.7.1,<12.0
 - rapids-build-env=22.10.*
 - rapids-notebook-env=22.10.*
 - rapids-doc-env=22.10.*

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -1,12 +1,12 @@
 name: cuml_dev
 channels:
 - rapidsai
-- nvidia
 - rapidsai-nightly
 - conda-forge
+- nvidia
 dependencies:
 - cudatoolkit=11.5
-- cuda-python >=11.5,<11.7.1
+- cuda-python >=11.7.1,<12.0
 - rapids-build-env=22.10.*
 - rapids-notebook-env=22.10.*
 - rapids-doc-env=22.10.*

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - cuda-python >=11.5,<11.7.1
+    - cuda-python >=11.7.1,<12.0
   run:
     - python x.x
     - cudf {{ minor_version }}
@@ -63,7 +63,7 @@ requirements:
     - distributed==2022.9.2
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-    - cuda-python >=11.5,<11.7.1
+    - cuda-python >=11.7.1,<12.0
 
 tests:                                 # [linux64]
   requirements:                        # [linux64]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.