### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 sysroot_version:
   - "2.17"

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -11,7 +11,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 nccl_version:
   - ">=2.9.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,6 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.23.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
 ]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.