### PR TITLE
Implement hypothesis strategies and tests for arrays

### DIFF
--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -60,21 +60,6 @@ _CUML_ARRAY_OUTPUT_TYPES = [
 ]
 
 
-_CUML_ARRAY_OUTPUT_DTYPES = [
-    np.float16,
-    np.float32,
-    np.float64,
-    np.int8,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-]
-
-
 UNSUPPORTED_CUDF_DTYPES = [
     np.uint8,
     np.uint16,
@@ -99,7 +84,7 @@ def cuml_array_output_types(draw):
 @composite
 def cuml_array_output_dtypes(draw):
     """Generates all cuml array supported output dtypes."""
-    return draw(sampled_from(_CUML_ARRAY_OUTPUT_DTYPES))
+    return draw(sampled_from(_CUML_ARRAY_DTYPES))
 
 
 @composite

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -90,7 +90,7 @@ def cuml_array_shapes(
     # return draw(one_of(shapes, just_size))
 
 
-def _create_cuml_array_input(input_type, dtype, shape, order):
+def create_cuml_array_input(input_type, dtype, shape, order):
     multidimensional = isinstance(shape, tuple) and \
         len([d for d in shape if d > 1]) > 1
     assume(
@@ -125,7 +125,7 @@ def cuml_arrays(
     shapes=array_shapes(max_dims=2),
     orders=cuml_array_orders()
 ):
-    array_input = _create_cuml_array_input(
+    array_input = create_cuml_array_input(
         draw(input_types), draw(dtypes), draw(shapes), draw(orders))
     return CumlArray(data=array_input)
 

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -25,9 +25,7 @@ from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 
 
-_CUML_ARRAY_INPUT_TYPES = [
-    'numpy', 'cupy', 'series', None,
-]
+_CUML_ARRAY_INPUT_TYPES = ['numpy', 'cupy', 'series']
 
 
 _CUML_ARRAY_DTYPES = [
@@ -178,10 +176,13 @@ def create_cuml_array_input(input_type, dtype, shape, order):
     elif input_type == 'series':
         return cudf.Series(array)
 
-    elif input_type is None or input_type == 'cupy':
+    elif input_type == 'cupy':
         return array
 
-    raise ValueError(f"Unknown input_type '{input_type}.")
+    raise ValueError(
+        "The value for 'input_type' must be "
+        f"one of {', '.join(_CUML_ARRAY_INPUT_TYPES)}."
+    )
 
 
 @composite

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -76,9 +76,12 @@ def cuml_array_shapes(
 ):
     max_side = 10 if max_side is None else max_side
 
-    # TODO: Raise ValueError for these:
-    assert 1 <= min_dims <= max_dims
-    assert 0 < min_side < max_side
+    if not (1 <= min_dims <= max_dims):
+        raise ValueError(
+            "Arguments violate condition 1 <= min_dims <= max_dims.")
+    if not (0 < min_side < max_side):
+        raise ValueError(
+            "Arguments violate condition 0 < min_side < max_side.")
 
     shapes = array_shapes(
         min_dims=min_dims, max_dims=max_dims,

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -26,7 +26,7 @@ from sklearn.model_selection import train_test_split
 
 
 _CUML_ARRAY_INPUT_TYPES = [
-    'numpy', 'numba', 'cupy', 'series', None,
+    'numpy', 'cupy', 'series', None,
 ]
 
 
@@ -107,9 +107,6 @@ def _create_cuml_array_input(input_type, dtype, shape, order):
 
     if input_type == 'numpy':
         return np.array(cp.asnumpy(array), dtype=dtype, order=order)
-
-    elif input_type == 'numba':
-        return cuda.as_cuda_array(array)
 
     elif input_type == 'series':
         return cudf.Series(array)

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -62,26 +62,31 @@ UNSUPPORTED_CUDF_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64,
 
 @composite
 def cuml_array_input_types(draw):
+    """Generates all supported cuml array input types."""
     return draw(sampled_from(_CUML_ARRAY_INPUT_TYPES))
 
 
 @composite
 def cuml_array_output_types(draw):
+    """Generates all cuml array supported output types."""
     return draw(sampled_from(_CUML_ARRAY_OUTPUT_TYPES))
 
 
 @composite
 def cuml_array_output_dtypes(draw):
+    """Generates all cuml array supported output dtypes."""
     return draw(sampled_from(_CUML_ARRAY_OUTPUT_DTYPES))
 
 
 @composite
 def cuml_array_dtypes(draw):
+    """Generates all supported cuml array dtypes."""
     return draw(sampled_from(_CUML_ARRAY_DTYPES))
 
 
 @composite
 def cuml_array_orders(draw):
+    """Generates all supported cuml array orders."""
     return draw(sampled_from(_CUML_ARRAY_ORDERS))
 
 
@@ -94,6 +99,26 @@ def cuml_array_shapes(
     min_side=1,
     max_side=None
 ):
+    """
+    Generates cuml array shapes.
+
+    See also: hypothesis.extra.numpy.array_shapes()
+
+    Parameters
+    ----------
+    min_dims: int, default=1
+        Returned shapes will have at least this number of dimensions.
+    max_dims: int, default=2
+        Returned shapes will have at most this number of dimensions.
+    min_side: int, default=1
+        Returned shapes will have at least this size in any dimension.
+    max_side: int | None, default=10
+        Returned shapes will have at most this size in any dimension.
+
+    Returns
+    -------
+    Shapes for cuml array inputs.
+    """
     max_side = 10 if max_side is None else max_side
 
     if not (1 <= min_dims <= max_dims):
@@ -112,6 +137,27 @@ def cuml_array_shapes(
 
 
 def create_cuml_array_input(input_type, dtype, shape, order):
+    """
+    Creates a valid cuml array input.
+
+    Parameters
+    ----------
+    input_type: str | None, default=cupy
+        Valid input types are "numpy", "cupy", "series".
+    dtype: Data type specifier
+        A numpy/cupy compatible data type, e.g., numpy.float64.
+    shape: int | tuple[int]
+        Dimensions of the array to generate.
+    order : str in {'C', 'F'}
+        Order of arrays to generate, either F- or C-major.
+
+    Returns
+    -------
+    A cuml array input array.
+    """
+
+    input_type = "cupy" if input_type is None else input_type
+
     multidimensional = isinstance(shape, tuple) and \
         len([d for d in shape if d > 1]) > 1
     assume(
@@ -146,6 +192,25 @@ def cuml_array_inputs(
     shapes=cuml_array_shapes(),
     orders=cuml_array_orders(),
 ):
+    """
+    Generates valid inputs for cuml arrays.
+
+    Parameters
+    ----------
+    input_types: SearchStrategy[("numpy", "cupy", "series")], \
+        default=cuml_array_input_tyes()
+        A search strategy for the type of array input.
+    dtypes: SearchStrategy[np.dtype], default=cuml_array_dtypes()
+        A search strategy for a numpy/cupy compatible data type.
+    shapes: SearchStrategy[int | tuple[int]], default=cuml_array_shapes()
+        A search strategy for array shapes.
+    orders : str in {'C', 'F'}, default=cuml_array_orders()
+        A search strategy for array orders.
+
+    Returns
+    -------
+    A strategy for valid cuml array inputs.
+    """
     return create_cuml_array_input(
         input_type=draw(input_types),
         dtype=draw(dtypes),
@@ -162,6 +227,25 @@ def cuml_arrays(
     shapes=cuml_array_shapes(),
     orders=cuml_array_orders()
 ):
+    """
+    Generates cuml arrays.
+
+    Parameters
+    ----------
+    input_types: SearchStrategy[("numpy", "cupy", "series")], \
+        default=cuml_array_input_tyes()
+        A search strategy for the type of array input.
+    dtypes: SearchStrategy[np.dtype], default=cuml_array_dtypes()
+        A search strategy for a numpy/cupy compatible data type.
+    shapes: SearchStrategy[int | tuple[int]], default=cuml_array_shapes()
+        A search strategy for array shapes.
+    orders : str in {'C', 'F'}, default=cuml_array_orders()
+        A search strategy for array orders.
+
+    Returns
+    -------
+    A strategy for cuml arrays.
+    """
     array_input = create_cuml_array_input(
         input_type=draw(input_types),
         dtype=draw(dtypes),

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -12,11 +12,125 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import cudf
+import cupy as cp
+import numpy as np
+from cuml.common.array import CumlArray
 from hypothesis import assume
-from hypothesis.extra.numpy import arrays, floating_dtypes
-from hypothesis.strategies import composite, integers, just, none, one_of
+from hypothesis.extra.numpy import arrays, floating_dtypes, array_shapes
+from hypothesis.strategies import (composite, integers, just, none,
+                                   one_of, sampled_from)
+from numba import cuda
 from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
+
+
+_CUML_ARRAY_INPUT_TYPES = [
+    'numpy', 'numba', 'cupy', 'series', None,
+]
+
+
+_CUML_ARRAY_DTYPES = [
+    np.float16, np.float32, np.float64,
+    np.int8, np.int16, np.int32, np.int64,
+    np.uint8, np.uint16, np.uint32, np.uint64
+]
+
+_CUML_ARRAY_ORDERS = ["F", "C"]
+
+
+_CUML_ARRAY_SUPPORTED_OUTPUT_DTYPES = [
+    np.float16, np.float32, np.float64,
+    np.int8, np.int16, np.int32, np.int64,
+    np.uint8, np.uint16, np.uint32, np.uint64
+]
+
+
+_UNSUPPORTED_CUDF_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64,
+                            np.float16]  # TODO: maybe not needed?
+
+
+@composite
+def cuml_array_input_types(draw):
+    return draw(sampled_from(_CUML_ARRAY_INPUT_TYPES))
+
+
+@composite
+def cuml_array_dtypes(draw):
+    return draw(sampled_from(_CUML_ARRAY_DTYPES))
+
+
+@composite
+def cuml_array_orders(draw):
+    return draw(sampled_from(_CUML_ARRAY_ORDERS))
+
+
+@composite
+def cuml_array_shapes(
+    draw,
+    *,
+    min_dims=1,
+    max_dims=2,
+    min_side=1,
+    max_side=None
+):
+    max_side = 10 if max_side is None else max_side
+
+    # TODO: Raise ValueError for these:
+    assert 1 <= min_dims <= max_dims
+    assert 0 < min_side < max_side
+
+    shapes = array_shapes(
+        min_dims=min_dims, max_dims=max_dims,
+        min_side=min_side, max_side=max_side,
+    )
+    return draw(shapes)
+
+    # just_size = integers(min_side, max_side)
+    # return draw(one_of(shapes, just_size))
+
+
+def _create_cuml_array_input(input_type, dtype, shape, order):
+    multidimensional = isinstance(shape, tuple) and \
+        len([d for d in shape if d > 1]) > 1
+    assume(
+        not (
+            input_type == "series"
+            and (
+                dtype in _UNSUPPORTED_CUDF_DTYPES
+                or multidimensional
+            )
+        )
+    )
+
+    array = cp.ones(shape, dtype=dtype, order=order)
+
+    if input_type == 'numpy':
+        return np.array(cp.asnumpy(array), dtype=dtype, order=order)
+
+    elif input_type == 'numba':
+        return cuda.as_cuda_array(array)
+
+    elif input_type == 'series':
+        return cudf.Series(array)
+
+    elif input_type is None or input_type == 'cupy':
+        return array
+
+    raise ValueError(f"Unknown input_type '{input_type}.")
+
+
+@composite
+def cuml_arrays(
+    draw,
+    input_types=cuml_array_input_types(),
+    dtypes=cuml_array_dtypes(),
+    shapes=array_shapes(max_dims=2),
+    orders=cuml_array_orders()
+):
+    array_input = _create_cuml_array_input(
+        draw(input_types), draw(dtypes), draw(shapes), draw(orders))
+    return CumlArray(data=array_input)
 
 
 @composite

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -110,14 +110,14 @@ def cuml_array_shapes(
         Returned shapes will have at most this number of dimensions.
     min_side: int, default=1
         Returned shapes will have at least this size in any dimension.
-    max_side: int | None, default=10
+    max_side: int | None, default=min_side + 9
         Returned shapes will have at most this size in any dimension.
 
     Returns
     -------
     Shapes for cuml array inputs.
     """
-    max_side = 10 if max_side is None else max_side
+    max_side = min_side + 9 if max_side is None else max_side
 
     if not (1 <= min_dims <= max_dims):
         raise ValueError(

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -87,10 +87,8 @@ def cuml_array_shapes(
         min_dims=min_dims, max_dims=max_dims,
         min_side=min_side, max_side=max_side,
     )
-    return draw(shapes)
-
-    # just_size = integers(min_side, max_side)
-    # return draw(one_of(shapes, just_size))
+    just_size = integers(min_side, max_side)
+    return draw(one_of(shapes, just_size))
 
 
 def create_cuml_array_input(input_type, dtype, shape, order):

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -15,23 +15,36 @@
 import cudf
 import cupy as cp
 import numpy as np
-from cuml.common.array import CumlArray
 from hypothesis import assume
-from hypothesis.extra.numpy import arrays, floating_dtypes, array_shapes
-from hypothesis.strategies import (composite, integers, just, none,
-                                   one_of, sampled_from)
-from numba import cuda
+from hypothesis.extra.numpy import array_shapes, arrays, floating_dtypes
+from hypothesis.strategies import (
+    composite,
+    integers,
+    just,
+    none,
+    one_of,
+    sampled_from,
+)
 from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 
+from cuml.common.array import CumlArray
 
-_CUML_ARRAY_INPUT_TYPES = ['numpy', 'cupy', 'series']
+_CUML_ARRAY_INPUT_TYPES = ["numpy", "cupy", "series"]
 
 
 _CUML_ARRAY_DTYPES = [
-    np.float16, np.float32, np.float64,
-    np.int8, np.int16, np.int32, np.int64,
-    np.uint8, np.uint16, np.uint32, np.uint64
+    np.float16,
+    np.float32,
+    np.float64,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
 ]
 
 _CUML_ARRAY_ORDERS = ["F", "C"]
@@ -48,14 +61,27 @@ _CUML_ARRAY_OUTPUT_TYPES = [
 
 
 _CUML_ARRAY_OUTPUT_DTYPES = [
-    np.float16, np.float32, np.float64,
-    np.int8, np.int16, np.int32, np.int64,
-    np.uint8, np.uint16, np.uint32, np.uint64
+    np.float16,
+    np.float32,
+    np.float64,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
 ]
 
 
-UNSUPPORTED_CUDF_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64,
-                           np.float16]
+UNSUPPORTED_CUDF_DTYPES = [
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float16,
+]
 
 
 @composite
@@ -90,12 +116,7 @@ def cuml_array_orders(draw):
 
 @composite
 def cuml_array_shapes(
-    draw,
-    *,
-    min_dims=1,
-    max_dims=2,
-    min_side=1,
-    max_side=None
+    draw, *, min_dims=1, max_dims=2, min_side=1, max_side=None
 ):
     """
     Generates cuml array shapes.
@@ -121,14 +142,18 @@ def cuml_array_shapes(
 
     if not (1 <= min_dims <= max_dims):
         raise ValueError(
-            "Arguments violate condition 1 <= min_dims <= max_dims.")
+            "Arguments violate condition 1 <= min_dims <= max_dims."
+        )
     if not (0 < min_side < max_side):
         raise ValueError(
-            "Arguments violate condition 0 < min_side < max_side.")
+            "Arguments violate condition 0 < min_side < max_side."
+        )
 
     shapes = array_shapes(
-        min_dims=min_dims, max_dims=max_dims,
-        min_side=min_side, max_side=max_side,
+        min_dims=min_dims,
+        max_dims=max_dims,
+        min_side=min_side,
+        max_side=max_side,
     )
     just_size = integers(min_side, max_side)
     return draw(one_of(shapes, just_size))
@@ -156,27 +181,25 @@ def create_cuml_array_input(input_type, dtype, shape, order):
 
     input_type = "cupy" if input_type is None else input_type
 
-    multidimensional = isinstance(shape, tuple) and \
-        len([d for d in shape if d > 1]) > 1
+    multidimensional = (
+        isinstance(shape, tuple) and len([d for d in shape if d > 1]) > 1
+    )
     assume(
         not (
             input_type == "series"
-            and (
-                dtype in UNSUPPORTED_CUDF_DTYPES
-                or multidimensional
-            )
+            and (dtype in UNSUPPORTED_CUDF_DTYPES or multidimensional)
         )
     )
 
     array = cp.ones(shape, dtype=dtype, order=order)
 
-    if input_type == 'numpy':
+    if input_type == "numpy":
         return np.array(cp.asnumpy(array), dtype=dtype, order=order)
 
-    elif input_type == 'series':
+    elif input_type == "series":
         return cudf.Series(array)
 
-    elif input_type == 'cupy':
+    elif input_type == "cupy":
         return array
 
     raise ValueError(
@@ -226,7 +249,7 @@ def cuml_arrays(
     input_types=cuml_array_input_types(),
     dtypes=cuml_array_dtypes(),
     shapes=cuml_array_shapes(),
-    orders=cuml_array_orders()
+    orders=cuml_array_orders(),
 ):
     """
     Generates cuml arrays.

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -139,6 +139,22 @@ def create_cuml_array_input(input_type, dtype, shape, order):
 
 
 @composite
+def cuml_array_inputs(
+    draw,
+    input_types=cuml_array_input_types(),
+    dtypes=cuml_array_dtypes(),
+    shapes=cuml_array_shapes(),
+    orders=cuml_array_orders(),
+):
+    return create_cuml_array_input(
+        input_type=draw(input_types),
+        dtype=draw(dtypes),
+        shape=draw(shapes),
+        order=draw(orders),
+    )
+
+
+@composite
 def cuml_arrays(
     draw,
     input_types=cuml_array_input_types(),

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -159,11 +159,15 @@ def cuml_arrays(
     draw,
     input_types=cuml_array_input_types(),
     dtypes=cuml_array_dtypes(),
-    shapes=array_shapes(max_dims=2),
+    shapes=cuml_array_shapes(),
     orders=cuml_array_orders()
 ):
     array_input = create_cuml_array_input(
-        draw(input_types), draw(dtypes), draw(shapes), draw(orders))
+        input_type=draw(input_types),
+        dtype=draw(dtypes),
+        shape=draw(shapes),
+        order=draw(orders),
+    )
     return CumlArray(data=array_input)
 
 

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -54,7 +54,7 @@ _CUML_ARRAY_OUTPUT_TYPES = [
     "cudf",
     "cupy",
     "dataframe",
-    "numba",  # TODO: is this still needed?
+    "numba",
     "numpy",
     "series",
 ]

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -39,20 +39,40 @@ _CUML_ARRAY_DTYPES = [
 _CUML_ARRAY_ORDERS = ["F", "C"]
 
 
-_CUML_ARRAY_SUPPORTED_OUTPUT_DTYPES = [
+_CUML_ARRAY_OUTPUT_TYPES = [
+    "cudf",
+    "cupy",
+    "dataframe",
+    "numba",  # TODO: is this still needed?
+    "numpy",
+    "series",
+]
+
+
+_CUML_ARRAY_OUTPUT_DTYPES = [
     np.float16, np.float32, np.float64,
     np.int8, np.int16, np.int32, np.int64,
     np.uint8, np.uint16, np.uint32, np.uint64
 ]
 
 
-_UNSUPPORTED_CUDF_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64,
-                            np.float16]  # TODO: maybe not needed?
+UNSUPPORTED_CUDF_DTYPES = [np.uint8, np.uint16, np.uint32, np.uint64,
+                           np.float16]
 
 
 @composite
 def cuml_array_input_types(draw):
     return draw(sampled_from(_CUML_ARRAY_INPUT_TYPES))
+
+
+@composite
+def cuml_array_output_types(draw):
+    return draw(sampled_from(_CUML_ARRAY_OUTPUT_TYPES))
+
+
+@composite
+def cuml_array_output_dtypes(draw):
+    return draw(sampled_from(_CUML_ARRAY_OUTPUT_DTYPES))
 
 
 @composite
@@ -98,7 +118,7 @@ def create_cuml_array_input(input_type, dtype, shape, order):
         not (
             input_type == "series"
             and (
-                dtype in _UNSUPPORTED_CUDF_DTYPES
+                dtype in UNSUPPORTED_CUDF_DTYPES
                 or multidimensional
             )
         )

--- a/python/cuml/testing/utils.py
+++ b/python/cuml/testing/utils.py
@@ -18,6 +18,7 @@ import cupy as cp
 import numpy as np
 import pandas as pd
 from copy import deepcopy
+from itertools import dropwhile
 
 from numba import cuda
 from numbers import Number
@@ -758,3 +759,24 @@ def svm_array_equal(a, b, tol=1e-6, relative_diff=True, report_summary=False):
         print('Avgdiff:', np.mean(diff), 'stddiyy:', np.std(diff), 'avgval:',
               np.mean(b))
     return equal
+
+
+def normalized_shape(shape):
+    """Normalize shape to tuple."""
+    return (shape, ) if isinstance(shape, int) else shape
+
+
+def squeezed_shape(shape):
+    """Remove all trailing axes of length 1 from shape.
+
+    Similar to, but not exactly like np.squeeze().
+    """
+    return tuple(reversed(list(dropwhile(lambda d: d == 1, reversed(shape)))))
+
+
+def series_squeezed_shape(shape):
+    """Remove all but one axes of length 1 from shape."""
+    if shape:
+        return tuple([d for d in normalized_shape(shape) if d != 1]) or (1,)
+    else:
+        return ()

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -134,7 +134,7 @@ def test_array_inputs(input_type, dtype, shape, order):
     shape=cuml_array_shapes(),
     order=cuml_array_orders(),
     force_gc=st.booleans())
-@settings(deadline=None, max_examples=1000)
+@settings(deadline=None)
 def test_array_init(input_type, dtype, shape, order, force_gc):
     input_array = create_cuml_array_input(input_type, dtype, shape, order)
     cuml_array = CumlArray(data=input_array)
@@ -248,7 +248,7 @@ def test_array_init_bad(input_type, dtype, shape, order):
     dtype=cuml_array_dtypes(),
     order=cuml_array_orders(),
 )
-@settings(deadline=None, max_examples=10000)
+@settings(deadline=None)
 def test_get_set_item(indices, dtype, order):
     inp = create_cuml_array_input("numpy", dtype, (10, 10), order)
     ary = CumlArray(data=inp)

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -38,9 +38,6 @@ from hypothesis import strategies as st
 from numba import cuda
 from rmm import DeviceBuffer
 
-test_input_types = [
-    'numpy', 'numba', 'cupy', 'series', None
-]
 
 _OUTPUT_TYPES_MAPPING = {
     'cupy': cp.ndarray,
@@ -49,25 +46,6 @@ _OUTPUT_TYPES_MAPPING = {
     'dataframe': cudf.DataFrame,
     'series': cudf.Series,
 }
-
-test_dtypes_all = [
-    np.float16, np.float32, np.float64,
-    np.int8, np.int16, np.int32, np.int64,
-    np.uint8, np.uint16, np.uint32, np.uint64
-]
-
-test_dtypes_output = [
-    np.float16, np.float32, np.float64,
-    np.int8, np.int16, np.int32, np.int64,
-    np.uint8, np.uint16, np.uint32, np.uint64
-]
-
-test_shapes = [10, (10,), (10, 1), (10, 5), (1, 10)]
-
-test_slices = [0, 5, 'left', 'right', 'both', 'bool_op']
-
-unsupported_cudf_dtypes = [np.uint8, np.uint16, np.uint32, np.uint64,
-                           np.float16]
 
 
 def _normalized_shape(shape):
@@ -608,19 +586,3 @@ def test_sliced_array_owner(order):
     # error on `cupy.cuda.runtime.pointerGetAttributes(cuml_slice.ptr)` in CUDA
     # < 11.0 or cudaErrorInvalidDevice in CUDA > 11.0 (unclear why it changed)
     assert (cp.all(cuml_slice.to_output('cupy') == cupy_slice))
-
-
-def create_input(input_type, dtype, shape, order):
-    rand_ary = cp.ones(shape, dtype=dtype, order=order)
-
-    if input_type == 'numpy':
-        return np.array(cp.asnumpy(rand_ary), dtype=dtype, order=order)
-
-    elif input_type == 'numba':
-        return cuda.as_cuda_array(rand_ary)
-
-    elif input_type == 'series':
-        return cudf.Series(rand_ary)
-
-    else:
-        return rand_ary

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -271,27 +271,36 @@ def test_create_empty(shape, dtype, order):
     assert isinstance(ary._owner.data.mem._owner, DeviceBuffer)
 
 
-@pytest.mark.parametrize('shape', test_shapes)
-@pytest.mark.parametrize('dtype', test_dtypes_all)
-@pytest.mark.parametrize('order', ['F', 'C'])
+@given(
+    shape=cuml_array_shapes(),
+    dtype=cuml_array_dtypes(),
+    order=cuml_array_orders(),
+)
+@settings(deadline=None)
 def test_create_zeros(shape, dtype, order):
     ary = CumlArray.zeros(shape=shape, dtype=dtype, order=order)
     test = cp.zeros(shape).astype(dtype)
     assert cp.all(test == cp.asarray(ary))
 
 
-@pytest.mark.parametrize('shape', test_shapes)
-@pytest.mark.parametrize('dtype', test_dtypes_all)
-@pytest.mark.parametrize('order', ['F', 'C'])
+@given(
+    shape=cuml_array_shapes(),
+    dtype=cuml_array_dtypes(),
+    order=cuml_array_orders(),
+)
+@settings(deadline=None)
 def test_create_ones(shape, dtype, order):
     ary = CumlArray.ones(shape=shape, dtype=dtype, order=order)
     test = cp.ones(shape).astype(dtype)
     assert cp.all(test == cp.asarray(ary))
 
 
-@pytest.mark.parametrize('shape', test_shapes)
-@pytest.mark.parametrize('dtype', test_dtypes_all)
-@pytest.mark.parametrize('order', ['F', 'C'])
+@given(
+    shape=cuml_array_shapes(),
+    dtype=cuml_array_dtypes(),
+    order=cuml_array_orders(),
+)
+@settings(deadline=None)
 def test_create_full(shape, dtype, order):
     value = cp.array([cp.random.randint(100)]).astype(dtype)
     ary = CumlArray.full(value=value[0], shape=shape, dtype=dtype, order=order)

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -317,7 +317,7 @@ def test_output_dtype(output_type, shape, dtype, order, out_dtype):
         assume(dtype not in UNSUPPORTED_CUDF_DTYPES)
         assume(out_dtype not in UNSUPPORTED_CUDF_DTYPES)
     if output_type == "series":
-        assume(len(squeezed_shape(normalized_shape(shape))) == 1)
+        assume(not _multidimensional(shape))
 
     # Perform conversion
     inp = create_cuml_array_input("numpy", dtype, shape, order)

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -123,7 +123,8 @@ def test_array_init(input_type, dtype, shape, order, force_gc):
         assert cuml_array.shape == _normalized_shape(shape)
 
     # Order is only well-defined (and preserved) for multidimensional arrays.
-    assert cuml_array.order == order if _multidimensional(shape) else "C"
+    md = isinstance(shape, tuple) and len([d for d in shape if d != 1]) > 1
+    assert cuml_array.order == order if md else "C"
 
     # Check input array and array equality.
     assert np.array_equal(

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -26,7 +26,7 @@ import pytest
 from cudf.core.buffer import Buffer
 from cuml.common.array import CumlArray
 from cuml.common.memory_utils import _get_size_from_shape, _strides_to_order
-from cuml.testing.strategies import (_create_cuml_array_input,
+from cuml.testing.strategies import (create_cuml_array_input,
                                      cuml_array_dtypes, cuml_array_input_types,
                                      cuml_array_orders, cuml_array_shapes)
 from hypothesis import given, settings, strategies as st
@@ -108,7 +108,7 @@ def _get_owner(curr):
     order=cuml_array_orders())
 @settings(deadline=None)
 def test_array_inputs(input_type, dtype, shape, order):
-    input_array = _create_cuml_array_input(input_type, dtype, shape, order)
+    input_array = create_cuml_array_input(input_type, dtype, shape, order)
     assert input_array.dtype == dtype
     if input_type == "series":
         assert input_array.shape == _series_normalized_shape(shape)
@@ -130,7 +130,7 @@ def test_array_inputs(input_type, dtype, shape, order):
     force_gc=st.booleans())
 @settings(deadline=None, max_examples=1000)
 def test_array_init(input_type, dtype, shape, order, force_gc):
-    input_array = _create_cuml_array_input(input_type, dtype, shape, order)
+    input_array = create_cuml_array_input(input_type, dtype, shape, order)
     cuml_array = CumlArray(data=input_array)
 
     # Test basic array properties
@@ -213,7 +213,7 @@ def test_array_init_bad(input_type, dtype, shape, order):
     when creating CumlArray
     """
 
-    input_array = _create_cuml_array_input(input_type, dtype, shape, order)
+    input_array = create_cuml_array_input(input_type, dtype, shape, order)
 
     # Ensure the array is creatable
     array = CumlArray(input_array)

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -428,12 +428,15 @@ def test_cuda_array_interface(dtype, shape, order):
     assert cp.all(inp == cp.asarray(ary))
 
 
-@pytest.mark.parametrize('input_type', test_input_types)
-def test_serialize(input_type):
-    if input_type == 'series':
-        inp = create_input(input_type, np.float32, (10, 1), 'C')
-    else:
-        inp = create_input(input_type, np.float32, (10, 5), 'F')
+@given(
+    input_type=cuml_array_input_types(),
+    dtype=cuml_array_dtypes(),
+    shape=cuml_array_shapes(),
+    order=cuml_array_orders(),
+)
+@settings(deadline=None)
+def test_serialize(input_type, dtype, shape, order):
+    inp = create_cuml_array_input(input_type, dtype, shape, order)
     ary = CumlArray(data=inp)
     header, frames = ary.serialize()
     ary2 = CumlArray.deserialize(header, frames)
@@ -460,19 +463,26 @@ def test_serialize(input_type):
         assert ary.order == ary2.order
 
 
-@pytest.mark.parametrize('input_type', test_input_types)
 @pytest.mark.parametrize('protocol', [4, 5])
-def test_pickle(input_type, protocol):
+@given(
+    input_type=cuml_array_input_types(),
+    dtype=cuml_array_dtypes(),
+    shape=cuml_array_shapes(),
+    order=cuml_array_orders(),
+)
+@settings(deadline=None)
+def test_pickle(protocol, input_type, dtype, shape, order):
     if protocol > pickle.HIGHEST_PROTOCOL:
         pytest.skip(
             f"Trying to test with pickle protocol {protocol},"
             f" but highest supported protocol is {pickle.HIGHEST_PROTOCOL}."
         )
-    if input_type == 'series':
-        inp = create_input(input_type, np.float32, (10, 1), 'C')
-    else:
-        inp = create_input(input_type, np.float32, (10, 5), 'F')
+
+    # Generate CumlArray
+    inp = create_cuml_array_input(input_type, dtype, shape, order)
     ary = CumlArray(data=inp)
+
+    # Prepare keyword arguments.
     dumps_kwargs = {"protocol": protocol}
     loads_kwargs = {}
     f = []
@@ -481,8 +491,12 @@ def test_pickle(input_type, protocol):
         dumps_kwargs["buffer_callback"] = f.append
         loads_kwargs["buffers"] = f
         len_f = 1
+
+    # Perform serialization and unserialization.
     a = pickle.dumps(ary, **dumps_kwargs)
     b = pickle.loads(a, **loads_kwargs)
+
+    # Check equality
     assert len(f) == len_f
     if input_type == 'numpy':
         assert np.all(inp == b.to_output('numpy'))
@@ -491,6 +505,7 @@ def test_pickle(input_type, protocol):
     else:
         assert cp.all(cp.asarray(inp) == cp.asarray(b))
 
+    # Check CUDA Array Interface match.
     assert ary.__cuda_array_interface__['shape'] == \
         b.__cuda_array_interface__['shape']
     assert ary.__cuda_array_interface__['strides'] == \

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -270,16 +270,16 @@ def test_get_set_item(indices, dtype, order):
     assert np.array_equal(inp, ary.to_output('numpy'))
 
 
-@pytest.mark.parametrize('shape', test_shapes)
-@pytest.mark.parametrize('dtype', test_dtypes_all)
-@pytest.mark.parametrize('order', ['C', 'F'])
+@given(
+    shape=cuml_array_shapes(),
+    dtype=cuml_array_dtypes(),
+    order=cuml_array_orders(),
+)
+@settings(deadline=None)
 def test_create_empty(shape, dtype, order):
     ary = CumlArray.empty(shape=shape, dtype=dtype, order=order)
     assert isinstance(ary.ptr, int)
-    if shape == 10:
-        assert ary.shape == (shape,)
-    else:
-        assert ary.shape == shape
+    assert ary.shape == _normalized_shape(shape)
     assert ary.dtype == np.dtype(dtype)
     # Temporarily disabled due to CUDA 11.0 issue
     # https://github.com/rapidsai/cuml/issues/4332

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -16,7 +16,7 @@
 
 import gc
 import operator
-import sys
+import pickle
 from copy import deepcopy
 
 import cudf
@@ -33,15 +33,6 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from numba import cuda
 from rmm import DeviceBuffer
-
-if sys.version_info < (3, 8):
-    try:
-        import pickle5 as pickle
-    except ImportError:
-        import pickle
-else:
-    import pickle
-
 
 test_input_types = [
     'numpy', 'numba', 'cupy', 'series', None

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -124,6 +124,7 @@ def test_array_init(input_type, dtype, shape, order, force_gc):
     shape=cuml_array_shapes(),
     order=cuml_array_orders(),
 )
+@settings(deadline=None)
 def test_array_init_from_bytes(data_type, dtype, shape, order):
     dtype = np.dtype(dtype)
     values = bytes(_get_size_from_shape(shape, dtype)[0])

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -331,15 +331,10 @@ def test_output_dtype(output_type, shape, dtype, order, out_dtype):
         res.dtype is out_dtype
 
 
-@given(
-    dtype=cuml_array_dtypes(),
-    shape=cuml_array_shapes(),
-    order=cuml_array_orders(),
-)
+@given(cuml_array_inputs(input_types=st.just("cupy")))
 @settings(deadline=None)
 @pytest.mark.xfail(reason="Fails for version and strides keys.")
-def test_cuda_array_interface(dtype, shape, order):
-    inp = create_cuml_array_input('cupy', dtype, shape, order)
+def test_cuda_array_interface(inp):
     ary = CumlArray(inp)
 
     inp_cai = inp.__cuda_array_interface__

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -158,11 +158,9 @@ def test_array_init(input_type, dtype, shape, order, force_gc):
     else:
         # Check that the original input array is part of the owner chain.
         current_owner = cuml_array
-
-        while current_owner is not None:
+        while (current_owner := _get_owner(current_owner)) is not None:
             if current_owner is input_array:
                 break
-            current_owner = _get_owner(current_owner)
         else:
             assert False, "Unable to find input array in owner chain."
 

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -32,11 +32,7 @@ from cuml.testing.strategies import (create_cuml_array_input,
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from numba import cuda
-
-# Temporarily disabled due to CUDA 11.0 issue
-# https://github.com/rapidsai/cuml/issues/4332
-# from rmm import DeviceBuffer
-
+from rmm import DeviceBuffer
 
 if sys.version_info < (3, 8):
     try:
@@ -281,9 +277,7 @@ def test_create_empty(shape, dtype, order):
     assert isinstance(ary.ptr, int)
     assert ary.shape == _normalized_shape(shape)
     assert ary.dtype == np.dtype(dtype)
-    # Temporarily disabled due to CUDA 11.0 issue
-    # https://github.com/rapidsai/cuml/issues/4332
-    # assert isinstance(ary._owner.data.mem._owner, DeviceBuffer)
+    assert isinstance(ary._owner.data.mem._owner, DeviceBuffer)
 
 
 @pytest.mark.parametrize('shape', test_shapes)

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -430,25 +430,19 @@ def test_pickle(protocol, inp):
         assert ary.order == b.order
 
 
-@given(
-    input_type=cuml_array_input_types(),
-    dtype=cuml_array_dtypes(),
-    shape=cuml_array_shapes(),
-    order=cuml_array_orders(),
-)
+@given(inp=cuml_array_inputs())
 @settings(deadline=None)
-def test_deepcopy(input_type, dtype, shape, order):
+def test_deepcopy(inp):
     # Generate CumlArray
-    inp = create_cuml_array_input(input_type, dtype, shape, order)
     ary = CumlArray(data=inp)
 
     # Perform deepcopy
     b = deepcopy(ary)
 
     # Check equality
-    if input_type == 'numpy':
+    if isinstance(inp, np.ndarray):
         assert np.all(inp == b.to_output('numpy'))
-    elif input_type == 'series':
+    elif isinstance(inp, (cudf.Series, pd.Series)):
         assert np.all(inp == b.to_output('series'))
     else:
         assert cp.all(cp.asarray(inp) == cp.asarray(b))
@@ -463,7 +457,7 @@ def test_deepcopy(input_type, dtype, shape, order):
     assert ary.__cuda_array_interface__['typestr'] == \
         b.__cuda_array_interface__['typestr']
 
-    if input_type != 'series':
+    if isinstance(inp, (cudf.Series, pd.Series)):
         # skipping one dimensional ary order test
         assert ary.order == b.order
 

--- a/python/cuml/tests/test_strategies.py
+++ b/python/cuml/tests/test_strategies.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import cupy as cp
+import numpy as np
+from cuml.common.array import CumlArray
 from cuml.testing.strategies import (
     create_cuml_array_input,
     cuml_array_dtypes,
     cuml_array_input_types,
+    cuml_array_inputs,
     cuml_array_orders,
     cuml_array_shapes,
     regression_datasets,
@@ -35,7 +39,7 @@ from hypothesis.extra.numpy import floating_dtypes
     shape=cuml_array_shapes(),
     order=cuml_array_orders())
 @settings(deadline=None)
-def test_array_inputs(input_type, dtype, shape, order):
+def test_cuml_array_input_elements(input_type, dtype, shape, order):
     input_array = create_cuml_array_input(input_type, dtype, shape, order)
     assert input_array.dtype == dtype
     if input_type == "series":
@@ -48,6 +52,16 @@ def test_array_inputs(input_type, dtype, shape, order):
         assert input_array.values.flags[layout_flag]
     else:
         assert input_array.flags[layout_flag]
+
+
+@given(cuml_array_inputs())
+@settings(deadline=None)
+def test_cuml_array_inputs(array_input):
+    array = CumlArray(data=array_input)
+    assert cp.array_equal(
+        cp.asarray(array_input), array.to_output("cupy"), equal_nan=True)
+    assert np.array_equal(
+        cp.asnumpy(array_input), array.to_output("numpy"), equal_nan=True)
 
 
 @given(standard_datasets())


### PR DESCRIPTION
Implements hypothesis strategies for `CumlArray` and extends the `test_array.py` test module to test them and refactors existing tests to test against the strategies instead of parametrized inputs.