### PR TITLE
Remove cupy.cusparse custom serialization

### DIFF
--- a/python/cuml/comm/serialize.py
+++ b/python/cuml/comm/serialize.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/comm/serialize.py
+++ b/python/cuml/comm/serialize.py
@@ -15,9 +15,6 @@
 #
 
 
-import copyreg
-
-import cupy as cp
 import cuml
 import cudf.comm.serialize  # noqa: F401
 

--- a/python/cuml/comm/serialize.py
+++ b/python/cuml/comm/serialize.py
@@ -22,10 +22,6 @@ import cuml
 import cudf.comm.serialize  # noqa: F401
 
 
-def serialize_mat_descriptor(m):
-    return cp.cusparse.MatDescriptor.create, ()
-
-
 try:
     from distributed.protocol import dask_deserialize, dask_serialize
     from distributed.protocol.serialize import pickle_dumps, pickle_loads
@@ -80,7 +76,6 @@ try:
     register_generic(MultinomialNB, 'dask',
                      dask_serialize, dask_deserialize)
 
-    copyreg.pickle(cp.cusparse.MatDescriptor, serialize_mat_descriptor)
 except ImportError:
     # distributed is probably not installed on the system
     pass


### PR DESCRIPTION
It should be safe to remove this now that https://github.com/cupy/cupy/issues/3061 has been fixed 