### PR TITLE
Temporarily pin libcumlprims to 22.12

### DIFF
--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -14,7 +14,7 @@ dependencies:
 - scikit-build>=0.13.1
 - cudf=23.02.*
 - rmm=23.02.*
-- libcumlprims=23.02.*
+- libcumlprims=22.12.*
 - libraft-headers=23.02.*
 - libraft-distance=23.02.*
 - libraft-nn=23.02.*

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -14,7 +14,7 @@ dependencies:
 - scikit-build>=0.13.1
 - cudf=23.02.*
 - rmm=23.02.*
-- libcumlprims=23.02.*
+- libcumlprims=22.12.*
 - libraft-headers=23.02.*
 - libraft-distance=23.02.*
 - libraft-nn=23.02.*

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -14,7 +14,7 @@ dependencies:
 - scikit-build>=0.13.1
 - cudf=23.02.*
 - rmm=23.02.*
-- libcumlprims=23.02.*
+- libcumlprims=22.12.*
 - libraft-headers=23.02.*
 - libraft-distance=23.02.*
 - libraft-nn=23.02.*

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -14,7 +14,7 @@ dependencies:
 - scikit-build>=0.13.1
 - cudf=23.02.*
 - rmm=23.02.*
-- libcumlprims=23.02.*
+- libcumlprims=22.12.*
 - libraft-headers=23.02.*
 - libraft-distance=23.02.*
 - libraft-nn=23.02.*

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - treelite=3.0.0
     - cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims {{ minor_version }}
+    - libcumlprims==22.12.*
     - pylibraft {{ minor_version }}
     - raft-dask {{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
@@ -51,7 +51,7 @@ requirements:
     - cudf {{ minor_version }}
     - dask-cudf {{ minor_version }}
     - libcuml={{ version }}
-    - libcumlprims {{ minor_version }}
+    - libcumlprims==22.12.*
     - pylibraft {{ minor_version }}
     - raft-dask {{ minor_version }}
     - cupy>=7.8.0,<12.0.0a0

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - ucx {{ ucx_version }}
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - libcumlprims {{ minor_version }}
+    - libcumlprims==22.12.*
     - libraft-headers {{ minor_version }}
     - libraft-distance {{ minor_version }}
     - libraft-nn {{ minor_version }}
@@ -69,7 +69,7 @@ outputs:
         - cmake {{ cmake_version }}
       run:
         - cudatoolkit {{ cuda_spec }}
-        - libcumlprims {{ minor_version }}
+        - libcumlprims==22.12.*
         - libraft-headers {{ minor_version }}
         - libraft-distance {{ minor_version }}
         - libraft-nn {{ minor_version }}

--- a/cpp/cmake/thirdparty/get_cumlprims_mg.cmake
+++ b/cpp/cmake/thirdparty/get_cumlprims_mg.cmake
@@ -48,9 +48,9 @@ endfunction()
 # cumlprims_mg as part of building cuml itself, set the CMake variable
 # `-D CPM_cumlprims_mg_SOURCE=/path/to/cumlprims_mg`
 ###
-find_and_configure_cumlprims_mg(VERSION    ${CUML_MIN_VERSION_cumlprims_mg}
+find_and_configure_cumlprims_mg(VERSION    22.12
                                 FORK       rapidsai
-                                PINNED_TAG branch-${CUML_BRANCH_VERSION_cumlprims_mg}
+                                PINNED_TAG branch-22.12
                                 # When PINNED_TAG above doesn't match cuml,
                                 # force local cumlprims_mg clone in build directory
                                 # even if it's already installed.


### PR DESCRIPTION
To avoid CI failure.