### PR TITLE
Support using `CountVectorizer` & `TfidVectorizer` in `cuml.pipeline.Pipeline` 

### DIFF
--- a/python/cuml/feature_extraction/_tfidf_vectorizer.py
+++ b/python/cuml/feature_extraction/_tfidf_vectorizer.py
@@ -218,7 +218,7 @@ class TfidfVectorizer(CountVectorizer):
         self._tfidf.fit(X)
         return self
 
-    def fit_transform(self, raw_documents):
+    def fit_transform(self, raw_documents, y=None):
         """Learn vocabulary and idf, return document-term matrix.
         This is equivalent to fit followed by transform, but more efficiently
         implemented.
@@ -227,6 +227,8 @@ class TfidfVectorizer(CountVectorizer):
         ----------
         raw_documents : cudf.Series or pd.Series
            A Series of string documents
+       y : None
+            Ignored.
 
         Returns
         -------

--- a/python/cuml/feature_extraction/_tfidf_vectorizer.py
+++ b/python/cuml/feature_extraction/_tfidf_vectorizer.py
@@ -227,7 +227,7 @@ class TfidfVectorizer(CountVectorizer):
         ----------
         raw_documents : cudf.Series or pd.Series
            A Series of string documents
-       y : None
+        y : None
             Ignored.
 
         Returns

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -518,7 +518,6 @@ class CountVectorizer(_VectorizerMixin):
 
         raw_documents : cudf.Series or pd.Series
             A Series of string documents
-
         y : None
             Ignored.
 
@@ -541,7 +540,6 @@ class CountVectorizer(_VectorizerMixin):
         ----------
         raw_documents : cudf.Series or pd.Series
            A Series of string documents
-
         y : None
             Ignored.
 

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -509,7 +509,7 @@ class CountVectorizer(_VectorizerMixin):
         preprocess = self.build_preprocessor()
         return preprocess(raw_documents)
 
-    def fit(self, raw_documents):
+    def fit(self, raw_documents, y=None):
         """
         Build a vocabulary of all tokens in the raw documents.
 
@@ -519,6 +519,9 @@ class CountVectorizer(_VectorizerMixin):
         raw_documents : cudf.Series or pd.Series
             A Series of string documents
 
+        y : None
+            Ignored.
+
         Returns
         -------
         self
@@ -527,7 +530,7 @@ class CountVectorizer(_VectorizerMixin):
         self.fit_transform(raw_documents)
         return self
 
-    def fit_transform(self, raw_documents):
+    def fit_transform(self, raw_documents, y=None):
         """
         Build the vocabulary and return document-term matrix.
 
@@ -538,6 +541,9 @@ class CountVectorizer(_VectorizerMixin):
         ----------
         raw_documents : cudf.Series or pd.Series
            A Series of string documents
+
+        y : None
+            Ignored.
 
         Returns
         -------


### PR DESCRIPTION
It's not possible to use the vectorizers with a pipeline, because the pipeline calls the method `fit_transform` with 3 arguments and only 2 are supported.

This fix is similar to the implementation in scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/feature_extraction/text.py#L2095
And has already been implemented for the `HashingVectorizer`: https://github.com/rapidsai/cuml/blob/50716cf98c4103aa8dbbcc4ea64897ccb7a70722/python/cuml/feature_extraction/_vectorizers.py#L867