### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/environments/cuml_dev_cuda11.0.yml
+++ b/conda/environments/cuml_dev_cuda11.0.yml
@@ -34,7 +34,7 @@ dependencies:
 - umap-learn
 - scikit-learn=0.24
 - sphinx-markdown-tables
-- treelite=3.0.0
+- treelite=3.0.1
 - statsmodels
 - seaborn
 - nltk

--- a/conda/environments/cuml_dev_cuda11.2.yml
+++ b/conda/environments/cuml_dev_cuda11.2.yml
@@ -34,7 +34,7 @@ dependencies:
 - umap-learn
 - scikit-learn=0.24
 - sphinx-markdown-tables
-- treelite=3.0.0
+- treelite=3.0.1
 - statsmodels
 - seaborn
 - nltk

--- a/conda/environments/cuml_dev_cuda11.4.yml
+++ b/conda/environments/cuml_dev_cuda11.4.yml
@@ -34,7 +34,7 @@ dependencies:
 - umap-learn
 - scikit-learn=0.24
 - sphinx-markdown-tables
-- treelite=3.0.0
+- treelite=3.0.1
 - statsmodels
 - seaborn
 - nltk

--- a/conda/environments/cuml_dev_cuda11.5.yml
+++ b/conda/environments/cuml_dev_cuda11.5.yml
@@ -34,7 +34,7 @@ dependencies:
 - umap-learn
 - scikit-learn=0.24
 - sphinx-markdown-tables
-- treelite=3.0.0
+- treelite=3.0.1
 - statsmodels
 - seaborn
 - nltk

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - setuptools
     - scikit-build>=0.13.1
     - cython>=0.29,<0.30
-    - treelite=3.0.0
+    - treelite=3.0.1
     - cudf {{ minor_version }}
     - libcuml={{ version }}
     - libcumlprims {{ minor_version }}
@@ -55,7 +55,7 @@ requirements:
     - pylibraft {{ minor_version }}
     - raft-dask {{ minor_version }}
     - cupy>=7.8.0,<12.0.0a0
-    - treelite=3.0.0
+    - treelite=3.0.1
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -20,7 +20,7 @@ ucx_version:
   - "1.13.0"
 
 treelite_version:
-  - "3.0.0"
+  - "3.0.1"
 
 gtest_version:
   - "1.10.0"

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -88,6 +88,6 @@ function(find_and_configure_treelite)
     rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
 endfunction()
 
-find_and_configure_treelite(VERSION     3.0.0
-                        PINNED_TAG  a8e688b7f0486227fe723229e4cbb77e3a669148
+find_and_configure_treelite(VERSION     3.0.1
+                        PINNED_TAG  cb09d539dce7e67f60cc33e4fac6b95b7185847a
                         BUILD_STATIC_LIBS ${CUML_USE_TREELITE_STATIC})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CUML_CPP_TARGET "cuml++")
 # If the user requested it,  we attempt to find cuml.
 if(FIND_CUML_CPP)
   include(rapids-cpm)
+  include(rapids-export)
   rapids_cpm_init()
   include(rapids-cuda)
   rapids_cuda_init_architectures(cuml-python)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.