### PR TITLE
Fix conflicts in #5045

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,10 +53,10 @@ jobs:
       skbuild-configure-options: "-DCUML_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DCPM_cumlprims_mg_SOURCE=/project/cumlprims_mg/"
 
       # Always want to test against latest dask/distributed.
-      test-before-amd64: "pip install git+https://github.com/dask/dask.git@2022.11.1 git+https://github.com/dask/distributed.git@2022.11.1 git+https://github.com/rapidsai/dask-cuda.git@branch-22.12"
+      test-before-amd64: "pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-22.12"
       # On arm also need to install cupy from the specific webpage and CMake
       # because treelite needs to be compiled (no wheels available for arm).
-      test-before-arm64: "pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64 && pip install cmake && pip install git+https://github.com/dask/dask.git@2022.11.1 git+https://github.com/dask/distributed.git@2022.11.1 git+https://github.com/rapidsai/dask-cuda.git@branch-22.12"
+      test-before-arm64: "pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64 && pip install cmake && pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-22.12"
       test-extras: test
       test-unittest: "pytest -v ./python/cuml/tests -k 'not test_silhouette_score_batched'"
     secrets: inherit

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -39,10 +39,10 @@ export UCX_PY_VERSION='0.30.*'
 export NUMBA_THREADING_LAYER=workqueue
 
 # Whether to install dask nightly or stable packages
-export INSTALL_DASK_MAIN=0
+export INSTALL_DASK_MAIN=1
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2022.11.1"
+export DASK_STABLE_VERSION="2022.12.0"
 
 ################################################################################
 # SETUP - Check environment

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -16,8 +16,8 @@ dependencies:
 - dask-cuda=23.02.*
 - dask-cudf=23.02.*
 - dask-ml
-- dask==2022.11.1
-- distributed==2022.11.1
+- dask>=2022.12.0
+- distributed>=2022.12.0
 - doxygen=1.8.20
 - faiss-proc=*=cuda
 - gcc_linux-64=9.*

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -59,8 +59,8 @@ requirements:
     - nccl>=2.9.9
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - dask==2022.11.1
-    - distributed==2022.11.1
+    - dask>=2022.12.0
+    - distributed>=2022.12.0
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - cuda-python >=11.7.1,<12.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,8 +109,8 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - dask==2022.11.1
-          - distributed==2022.11.1
+          - dask>=2022.12.0
+          - distributed>=2022.12.0
           - joblib>=0.11
       - output_types: conda
         packages:


### PR DESCRIPTION
This PR fixes the conflicts in #5045. Additionally, it unpins `dask`/`distributed` for `branch-23.02` and therefore supersedes #5054.