### PR TITLE
Remove unused `.conda` folder [skip gpuci]

### DIFF
--- a/.conda/environments.txt
+++ b/.conda/environments.txt
@@ -1,1 +1,0 @@
-/conda/envs/gdf


### PR DESCRIPTION
This PR removes the `.conda` folder, which seems to be unused/extraneous.