### PR TITLE
Update ucx to 0.30 in dev envs

### DIFF
--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - sysroot_linux-64==2.17
 - treelite=3.0.1
 - ucx-proc=*=gpu
-- ucx-py=0.29.*
+- ucx-py=0.30.*
 - ucx>=1.13.0
 - umap-learn
 - pip:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -118,7 +118,7 @@ dependencies:
           - dask-cuda=23.02.*
           - dask-cudf=23.02.*
           - ucx>=1.13.0
-          - ucx-py=0.29.*
+          - ucx-py=0.30.*
           - ucx-proc=*=gpu
     specific:
       - output_types: requirements


### PR DESCRIPTION
PR unblocks creating developer environments by updating ucx-py to 0.30. 