### PR TITLE
Ensure `pytest` is run from relevant directories in GH Actions

### DIFF
--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -8,7 +8,7 @@ rapids-logger "pytest cuml-dask"
 pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml" \
-  --cov-config=python/.coveragerc \
+  --cov-config=../../../.coveragerc \
   --cov=cuml_dask \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-dask-coverage.xml" \
   --cov-report=term \

--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -5,7 +5,7 @@
 source "$(dirname "$0")/test_python_common.sh"
 
 rapids-logger "pytest cuml-dask"
-pushd python/cuml/tests/dask
+cd python/cuml/tests/dask
 pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml" \

--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -5,6 +5,7 @@
 source "$(dirname "$0")/test_python_common.sh"
 
 rapids-logger "pytest cuml-dask"
+pushd python/cuml/tests/dask
 pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml" \
@@ -12,4 +13,4 @@ pytest \
   --cov=cuml_dask \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-dask-coverage.xml" \
   --cov-report=term \
-  python/cuml/tests/dask
+  .

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -5,6 +5,7 @@
 source "$(dirname "$0")/test_python_common.sh"
 
 rapids-logger "pytest cuml single GPU"
+pushd python/cuml/tests
 pytest \
   --numprocesses=8 \
   --ignore=dask \
@@ -14,4 +15,4 @@ pytest \
   --cov=cuml \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml" \
   --cov-report=term \
-  python/cuml/tests
+  .

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -5,7 +5,7 @@
 source "$(dirname "$0")/test_python_common.sh"
 
 rapids-logger "pytest cuml single GPU"
-pushd python/cuml/tests
+cd python/cuml/tests
 pytest \
   --numprocesses=8 \
   --ignore=dask \

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -7,7 +7,7 @@ source "$(dirname "$0")/test_python_common.sh"
 rapids-logger "pytest cuml single GPU"
 pytest \
   --numprocesses=8 \
-  --ignore=python/cuml/tests/dask \
+  --ignore=dask \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \
   --cov-config=../../.coveragerc \

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -10,7 +10,7 @@ pytest \
   --ignore=python/cuml/tests/dask \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \
-  --cov-config=python/.coveragerc \
+  --cov-config=../../.coveragerc \
   --cov=cuml \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml" \
   --cov-report=term \


### PR DESCRIPTION
This PR undoes some erroneous changes I made in #5075.

According to @bdice, it's necessary to `cd` into the relevant directories when running `pytest` to avoid issues with `codecov`.