### PR TITLE
Testing upcoming RAFT handle changes

### DIFF
--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -7,11 +7,13 @@ channels:
 - conda-forge
 - nvidia
 dependencies:
+- c-compiler
 - cmake>=3.23.1,!=3.25.0
 - cuda-python>=11.7.1,<12.0
 - cudatoolkit=11.5
 - cudf=23.02.*
 - cupy>=7.8.0,<12.0.0a0
+- cxx-compiler
 - cython>=0.29,<0.30
 - dask-cuda=23.02.*
 - dask-cudf=23.02.*

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -41,6 +41,7 @@ dependencies:
 - libraft-distance=23.02.*
 - libraft-headers=23.02.*
 - libraft-nn=23.02.*
+- ninja
 - nltk
 - numpydoc
 - nvcc_linux-64=11.5

--- a/conda/environments/cpp_all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-115_arch-x86_64.yaml
@@ -7,8 +7,10 @@ channels:
 - conda-forge
 - nvidia
 dependencies:
+- c-compiler
 - cmake>=3.23.1,!=3.25.0
 - cudatoolkit=11.5
+- cxx-compiler
 - faiss-proc=*=cuda
 - gcc_linux-64=9.*
 - libcublas-dev>=11.7.3.1,<=11.7.4.6

--- a/conda/environments/cpp_all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-115_arch-x86_64.yaml
@@ -28,6 +28,7 @@ dependencies:
 - libraft-distance=23.02.*
 - libraft-headers=23.02.*
 - libraft-nn=23.02.*
+- ninja
 - nvcc_linux-64=11.5
 - rmm=23.02.*
 - sysroot_linux-64==2.17

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -92,8 +92,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-                        FORK             rapidsai
-                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
+                        FORK             cjnolet
+                        PINNED_TAG       fea-2302-decouple_handle_resources
                         EXCLUDE_FROM_ALL ${CUML_EXCLUDE_RAFT_FROM_ALL}
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -72,6 +72,8 @@ dependencies:
           - libraft-distance=23.02.*
           - libraft-nn=23.02.*
           - rmm=23.02.*
+          - c-compiler
+          - cxx-compiler
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -65,15 +65,16 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cmake>=3.23.1,!=3.25.0
+          - ninja
       - output_types: conda
         packages:
+          - c-compiler
+          - cxx-compiler
           - libcumlprims=23.02.*
           - libraft-headers=23.02.*
           - libraft-distance=23.02.*
           - libraft-nn=23.02.*
           - rmm=23.02.*
-          - c-compiler
-          - cxx-compiler
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
This PR tests that some upcoming changes to the RAFT handle are backwards compatible and do not break cuML

Please refer to https://github.com/rapidsai/raft/pull/1111 for an in-depth description of the motive and design of the changes. 