### PR TITLE
build.sh switch to use `RAPIDS` magic value

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -240,7 +240,7 @@ if completeBuild || hasArg libcuml || hasArg prims || hasArg bench || hasArg pri
         CUML_CMAKE_CUDA_ARCHITECTURES="NATIVE"
         echo "Building for the architecture of the GPU in the system..."
     else
-        CUML_CMAKE_CUDA_ARCHITECTURES="ALL"
+        CUML_CMAKE_CUDA_ARCHITECTURES="RAPIDS"
         echo "Building for *ALL* supported GPU architectures..."
     fi
 


### PR DESCRIPTION
rapids-cmake 23.02 is deprecating the magic value of `ALL` since it doesn't cleanly map to the cmake magic value of `all`. Instead we use `RAPIDS` which better represents the architectures we are building for.