### PR TITLE
Remove outdated macOS deployment target from build script.

### DIFF
--- a/conda/recipes/libcuml/build.sh
+++ b/conda/recipes/libcuml/build.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
 # Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
-if [ -n "$MACOSX_DEPLOYMENT_TARGET" ]; then
-    # C++11 requires 10.9
-    # but cudatoolkit 8 is build for 10.11
-    export MACOSX_DEPLOYMENT_TARGET=10.11
-fi
-
 ./build.sh -n libcuml prims -v --allgpuarch


### PR DESCRIPTION
Small cleanup to remove `MACOSX_DEPLOYMENT_TARGET` references from a build script (macOS is not supported by RAPIDS).