### PR TITLE
Fix for hdbscan model serialization

### DIFF
--- a/python/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cluster/hdbscan/hdbscan.pyx
@@ -929,7 +929,7 @@ class HDBSCAN(Base, ClusterMixin, CMajorInputTagMixin):
         state = self.__dict__.copy()
         ptr_keys = []
         for k in state.keys():
-            if k.endswith("ptr"):
+            if "ptr" in k:
                 ptr_keys.append(k)
 
         for k in ptr_keys:
@@ -972,7 +972,6 @@ class HDBSCAN(Base, ClusterMixin, CMajorInputTagMixin):
                 <int*> parent_ptr, <int*> child_ptr,
                 <float*> lambdas_ptr, <int*> sizes_ptr)
 
-        print("Setting condensed_tree_ptr")
         self.condensed_tree_ptr = <size_t> condensed_tree
 
         cdef uintptr_t core_dists_ptr = self.core_dists.ptr

--- a/python/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cluster/hdbscan/hdbscan.pyx
@@ -925,6 +925,18 @@ class HDBSCAN(Base, ClusterMixin, CMajorInputTagMixin):
                           <int> self.max_cluster_size,
                           <float> self.cluster_selection_epsilon)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        ptr_keys = []
+        for k in state.keys():
+            if k.endswith("ptr"):
+                ptr_keys.append(k)
+
+        for k in ptr_keys:
+            del state[k]
+
+        return state
+
     def __setstate__(self, state):
         super(HDBSCAN, self).__init__(
             handle=state["handle"],
@@ -959,6 +971,8 @@ class HDBSCAN(Base, ClusterMixin, CMajorInputTagMixin):
                 <int>self.condensed_parent_.shape[0],
                 <int*> parent_ptr, <int*> child_ptr,
                 <float*> lambdas_ptr, <int*> sizes_ptr)
+
+        print("Setting condensed_tree_ptr")
         self.condensed_tree_ptr = <size_t> condensed_tree
 
         cdef uintptr_t core_dists_ptr = self.core_dists.ptr


### PR DESCRIPTION
It looks like there are still some attributes with `ptr` in their name that are being serialized with the hdbscan object and that's causing some segfaults when serialization is performed on a separate process. 

Closes https://github.com/rapidsai/cuml/issues/4986