### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-build-cuml:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -74,7 +74,7 @@ jobs:
   wheel-publish-cuml:
     needs: wheel-build-cuml
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-publish.yml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-publish.yml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,7 +71,7 @@ jobs:
   wheel-build-cuml:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@cuda-118
     with:
       build_type: pull-request
       package-name: cuml
@@ -83,7 +83,7 @@ jobs:
   wheel-tests-cuml:
     needs: wheel-build-cuml
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@cuda-118
     with:
       build_type: pull-request
       package-name: cuml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
       test_script: "ci/test_python_dask.sh"
   wheel-tests-cuml:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@cuda-118
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/python/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
+++ b/python/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
@@ -83,6 +83,7 @@ def subtract_valid(input_array, valid_bool_array, sub_val):
             input_array[pos] = input_array[pos] - sub_val
 
 
+@cudf.core.buffer.acquire_spill_lock()
 def get_stem_series(word_str_ser, suffix_len, can_replace_mask):
     """
         word_str_ser: input string column
@@ -95,8 +96,8 @@ def get_stem_series(word_str_ser, suffix_len, can_replace_mask):
     start_series = cudf.Series(cp.zeros(len(word_str_ser), dtype=cp.int32))
     end_ser = word_str_ser.str.len()
 
-    end_ar = end_ser._column.data_array_view
-    can_replace_mask_ar = can_replace_mask._column.data_array_view
+    end_ar = end_ser._column.data_array_view(mode="read")
+    can_replace_mask_ar = can_replace_mask._column.data_array_view(mode="read")
 
     subtract_valid[NBLCK, NTHRD](end_ar, can_replace_mask_ar, suffix_len)
     return word_str_ser.str.slice_from(

--- a/python/cuml/tests/test_input_utils.py
+++ b/python/cuml/tests/test_input_utils.py
@@ -333,7 +333,11 @@ def check_numpy_order(ary, order):
 def check_ptr(a, b, input_type):
     if input_type == 'cudf':
         for (_, col_a), (_, col_b) in zip(a._data.items(), b._data.items()):
-            assert col_a.base_data.ptr == col_b.base_data.ptr
+            with cudf.core.buffer.acquire_spill_lock():
+                assert (
+                    col_a.base_data.get_ptr(mode="read") ==
+                    col_b.base_data.get_ptr(mode="read")
+                )
     else:
         def get_ptr(x):
             try:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.