### PR TITLE
Support innerproduct distance in the pairwise_distance API

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -93,7 +93,7 @@ endfunction()
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
                         FORK             rapidsai
-			PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
+                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
                         EXCLUDE_FROM_ALL ${CUML_EXCLUDE_RAFT_FROM_ALL}
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory

--- a/cpp/src/hdbscan/detail/soft_clustering.cuh
+++ b/cpp/src/hdbscan/detail/soft_clustering.cuh
@@ -91,16 +91,16 @@ void all_points_dist_membership_vector(const raft::handle_t& handle,
     case raft::distance::DistanceType::L2SqrtExpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2SqrtExpanded, value_t, value_t, value_t, int>(
-          X, exemplars_dense.data(), dist.data(), m, n_exemplars, n, stream, true);
+          handle, X, exemplars_dense.data(), dist.data(), m, n_exemplars, n, true);
       break;
     case raft::distance::DistanceType::L1:
       raft::distance::distance<raft::distance::DistanceType::L1, value_t, value_t, value_t, int>(
-        X, exemplars_dense.data(), dist.data(), m, n_exemplars, n, stream, true);
+        handle, X, exemplars_dense.data(), dist.data(), m, n_exemplars, n, true);
       break;
     case raft::distance::DistanceType::CosineExpanded:
       raft::distance::
         distance<raft::distance::DistanceType::CosineExpanded, value_t, value_t, value_t, int>(
-          X, exemplars_dense.data(), dist.data(), m, n_exemplars, n, stream, true);
+          handle, X, exemplars_dense.data(), dist.data(), m, n_exemplars, n, true);
       break;
     default: ASSERT(false, "Incorrect metric passed!");
   }

--- a/cpp/src/metrics/pairwise_distance_canberra.cu
+++ b/cpp/src/metrics/pairwise_distance_canberra.cu
@@ -35,7 +35,7 @@ void pairwise_distance_canberra(const raft::handle_t& handle,
 {
   // Call the distance function
   raft::distance::distance<raft::distance::DistanceType::Canberra, double, double, double, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_canberra(const raft::handle_t& handle,
@@ -50,7 +50,7 @@ void pairwise_distance_canberra(const raft::handle_t& handle,
 {
   // Call the distance function
   raft::distance::distance<raft::distance::DistanceType::Canberra, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_chebyshev.cu
+++ b/cpp/src/metrics/pairwise_distance_chebyshev.cu
@@ -34,7 +34,7 @@ void pairwise_distance_chebyshev(const raft::handle_t& handle,
 {
   // Call the distance function
   raft::distance::distance<raft::distance::DistanceType::Linf, double, double, double, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_chebyshev(const raft::handle_t& handle,
@@ -49,7 +49,7 @@ void pairwise_distance_chebyshev(const raft::handle_t& handle,
 {
   // Call the distance function
   raft::distance::distance<raft::distance::DistanceType::Linf, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_correlation.cu
+++ b/cpp/src/metrics/pairwise_distance_correlation.cu
@@ -36,7 +36,7 @@ void pairwise_distance_correlation(const raft::handle_t& handle,
   // Call the distance function
   raft::distance::
     distance<raft::distance::DistanceType::CorrelationExpanded, double, double, double, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_correlation(const raft::handle_t& handle,
@@ -52,7 +52,7 @@ void pairwise_distance_correlation(const raft::handle_t& handle,
   // Call the distance function
   raft::distance::
     distance<raft::distance::DistanceType::CorrelationExpanded, float, float, float, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_cosine.cu
+++ b/cpp/src/metrics/pairwise_distance_cosine.cu
@@ -36,7 +36,7 @@ void pairwise_distance_cosine(const raft::handle_t& handle,
   // Call the distance function
   raft::distance::
     distance<raft::distance::DistanceType::CosineExpanded, double, double, double, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_cosine(const raft::handle_t& handle,
@@ -51,7 +51,7 @@ void pairwise_distance_cosine(const raft::handle_t& handle,
 {
   // Call the distance function
   raft::distance::distance<raft::distance::DistanceType::CosineExpanded, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_euclidean.cu
+++ b/cpp/src/metrics/pairwise_distance_euclidean.cu
@@ -39,22 +39,22 @@ void pairwise_distance_euclidean(const raft::handle_t& handle,
     case raft::distance::DistanceType::L2Expanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2Expanded, double, double, double, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     case raft::distance::DistanceType::L2SqrtExpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2SqrtExpanded, double, double, double, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     case raft::distance::DistanceType::L2Unexpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2Unexpanded, double, double, double, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     case raft::distance::DistanceType::L2SqrtUnexpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2SqrtUnexpanded, double, double, double, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     default: THROW("Unknown or unsupported distance metric '%d'!", (int)metric);
   }
@@ -75,22 +75,22 @@ void pairwise_distance_euclidean(const raft::handle_t& handle,
   switch (metric) {
     case raft::distance::DistanceType::L2Expanded:
       raft::distance::distance<raft::distance::DistanceType::L2Expanded, float, float, float, int>(
-        x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+        handle, x, y, dist, m, n, k, isRowMajor);
       break;
     case raft::distance::DistanceType::L2SqrtExpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2SqrtExpanded, float, float, float, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     case raft::distance::DistanceType::L2Unexpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2Unexpanded, float, float, float, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     case raft::distance::DistanceType::L2SqrtUnexpanded:
       raft::distance::
         distance<raft::distance::DistanceType::L2SqrtUnexpanded, float, float, float, int>(
-          x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+          handle, x, y, dist, m, n, k, isRowMajor);
       break;
     default: THROW("Unknown or unsupported distance metric '%d'!", (int)metric);
   }

--- a/cpp/src/metrics/pairwise_distance_hamming.cu
+++ b/cpp/src/metrics/pairwise_distance_hamming.cu
@@ -36,7 +36,7 @@ void pairwise_distance_hamming(const raft::handle_t& handle,
   // Call the distance function
   raft::distance::
     distance<raft::distance::DistanceType::HammingUnexpanded, double, double, double, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_hamming(const raft::handle_t& handle,
@@ -52,7 +52,7 @@ void pairwise_distance_hamming(const raft::handle_t& handle,
   // Call the distance function
   raft::distance::
     distance<raft::distance::DistanceType::HammingUnexpanded, float, float, float, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_hellinger.cu
+++ b/cpp/src/metrics/pairwise_distance_hellinger.cu
@@ -36,7 +36,7 @@ void pairwise_distance_hellinger(const raft::handle_t& handle,
   // Call the distance function
   raft::distance::
     distance<raft::distance::DistanceType::HellingerExpanded, double, double, double, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_hellinger(const raft::handle_t& handle,
@@ -51,7 +51,7 @@ void pairwise_distance_hellinger(const raft::handle_t& handle,
 {
   raft::distance::
     distance<raft::distance::DistanceType::HellingerExpanded, float, float, float, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_jensen_shannon.cu
+++ b/cpp/src/metrics/pairwise_distance_jensen_shannon.cu
@@ -35,7 +35,7 @@ void pairwise_distance_jensen_shannon(const raft::handle_t& handle,
 {
   raft::distance::
     distance<raft::distance::DistanceType::JensenShannon, double, double, double, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_jensen_shannon(const raft::handle_t& handle,
@@ -49,7 +49,7 @@ void pairwise_distance_jensen_shannon(const raft::handle_t& handle,
                                       float metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::JensenShannon, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_kl_divergence.cu
+++ b/cpp/src/metrics/pairwise_distance_kl_divergence.cu
@@ -34,7 +34,7 @@ void pairwise_distance_kl_divergence(const raft::handle_t& handle,
                                      double metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::KLDivergence, double, double, double, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_kl_divergence(const raft::handle_t& handle,
@@ -48,7 +48,7 @@ void pairwise_distance_kl_divergence(const raft::handle_t& handle,
                                      float metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::KLDivergence, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_l1.cu
+++ b/cpp/src/metrics/pairwise_distance_l1.cu
@@ -34,7 +34,7 @@ void pairwise_distance_l1(const raft::handle_t& handle,
                           double metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::L1, double, double, double, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_l1(const raft::handle_t& handle,
@@ -48,7 +48,7 @@ void pairwise_distance_l1(const raft::handle_t& handle,
                           float metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::L1, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+    handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_minkowski.cu
+++ b/cpp/src/metrics/pairwise_distance_minkowski.cu
@@ -34,7 +34,7 @@ void pairwise_distance_minkowski(const raft::handle_t& handle,
                                  double metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::LpUnexpanded, double, double, double, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor, metric_arg);
+    handle, x, y, dist, m, n, k, isRowMajor, metric_arg);
 }
 
 void pairwise_distance_minkowski(const raft::handle_t& handle,
@@ -48,7 +48,7 @@ void pairwise_distance_minkowski(const raft::handle_t& handle,
                                  float metric_arg)
 {
   raft::distance::distance<raft::distance::DistanceType::LpUnexpanded, float, float, float, int>(
-    x, y, dist, m, n, k, handle.get_stream(), isRowMajor, metric_arg);
+    handle, x, y, dist, m, n, k, isRowMajor, metric_arg);
 }
 
 }  // namespace Metrics

--- a/cpp/src/metrics/pairwise_distance_russell_rao.cu
+++ b/cpp/src/metrics/pairwise_distance_russell_rao.cu
@@ -35,7 +35,7 @@ void pairwise_distance_russell_rao(const raft::handle_t& handle,
 {
   raft::distance::
     distance<raft::distance::DistanceType::RusselRaoExpanded, double, double, double, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 void pairwise_distance_russell_rao(const raft::handle_t& handle,
@@ -50,7 +50,7 @@ void pairwise_distance_russell_rao(const raft::handle_t& handle,
 {
   raft::distance::
     distance<raft::distance::DistanceType::RusselRaoExpanded, float, float, float, int>(
-      x, y, dist, m, n, k, handle.get_stream(), isRowMajor);
+      handle, x, y, dist, m, n, k, isRowMajor);
 }
 
 }  // namespace Metrics

--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -52,8 +52,6 @@
 using namespace ML;
 using namespace ML::Metrics;
 
-using namespace std;
-
 using namespace MLCommon;
 using namespace MLCommon::Datasets::Digits;
 

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -68,7 +68,7 @@ if has_scipy():
     import scipy.sparse
 
 
-cdef extern from "raft/spatial/knn/ball_cover_common.h" \
+cdef extern from "raft/spatial/knn/ball_cover_types.hpp" \
         namespace "raft::spatial::knn":
     cdef cppclass BallCoverIndex[int64_t, float, uint32_t]:
         BallCoverIndex(const handle_t &handle,


### PR DESCRIPTION
Fixes for supporting InnerProduct distance in the pairwise_distance api - required to handle the changes in https://github.com/rapidsai/raft/pull/1226.

Also resolves #4078. That fix was necessary to tack on to this PR due to upstream RAPIDS updates to the spdlog version (in rmm via rapids-cmake).