### PR TITLE
CI: Add isort to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,13 @@
 # Copyright (c) 2023, NVIDIA CORPORATION.
 
 repos:
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.10.1
+      hooks:
+          - id: isort
+            args: [--config-root=python/, --resolve-all-configs]
+            files: python/.*
+            types_or: [python, cython, pyi]
     - repo: https://github.com/psf/black
       rev: 22.10.0
       hooks:
@@ -20,6 +27,15 @@ repos:
             additional_dependencies: [flake8-force]
     - repo: local
       hooks:
+          - id: isort-safe-imports
+            name: isort-safe-imports
+            entry: python ./ci/isort_safe_imports.py --in-place
+            language: python
+            additional_dependencies: [click, isort]
+            # Use the config file specific to each subproject so that each
+            # project can specify its own first/third-party packages.
+            files: python/.*
+            types_or: [python]
           - id: no-deprecationwarning
             name: no-deprecationwarning
             description: 'Enforce that DeprecationWarning is not introduced (use FutureWarning instead)'

--- a/ci/isort_safe_imports.py
+++ b/ci/isort_safe_imports.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+import ast
+import re
+import typing
+from pathlib import Path
+
+import click
+import isort
+
+RE_SAFE_IMPORT_CALL = r"(?:safe_import|(:?cpu|gpu)_only_import)(?P<from>_from)?"
+
+RE_SAFE_IMPORT = r"\S+\s=\s*" + RE_SAFE_IMPORT_CALL
+
+
+def find_root_imports(source: str):
+    """Identify root import statements in the source code."""
+
+    tree = ast.parse(source)
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            yield node
+
+
+def is_safe_import(node):
+    """Identify safe import assignments in the source code."""
+
+    def func_name(call):
+        try:
+            return call.func.id
+        except AttributeError:
+            return call.func.attr
+
+    return (
+        isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and re.match(RE_SAFE_IMPORT_CALL, func_name(node.value))
+    )
+
+
+def find_root_safe_imports(source: str):
+    """Find all root safe import assignments in source."""
+
+    tree = ast.parse(source)
+    for node in ast.iter_child_nodes(tree):
+        if is_safe_import(node):
+            yield node
+
+
+def extract_safe_imports(source: str) -> typing.Tuple[str, list[str], int]:
+    """Extract all safe import assignments and return them separately."""
+
+    safe_import_nodes = list(find_root_safe_imports(source))
+
+    # Extract source code for safe import assignments ...
+    safe_imports = []
+    for node in safe_import_nodes:
+        safe_imports.append(ast.get_source_segment(source, node))
+
+    # ... and remove them from the current source code.
+    lines = source.split("\n")
+    for node in reversed(safe_import_nodes):
+        for i in reversed(range(node.lineno - 1, node.end_lineno)):
+            lines.pop(i)
+
+    # We identify the line number of the first safe import assignment which can
+    # be used as a location to re-insert the block again later after
+    # reformatting.
+    lineno_first_safe_import = i if safe_import_nodes else -1
+
+    return "\n".join(lines), safe_imports, lineno_first_safe_import
+
+
+def _unwrap_safe_import(
+    node: ast.Assign,
+) -> typing.Union[ast.Import, ast.ImportFrom]:
+    """Translate a safe import assignment into a standard import statement."""
+
+    module = node.value.args[0].value
+
+    assert len(node.targets) == 1
+    target = node.targets[0]
+    identifier = target.id
+
+    if "from" in node.value.func.id:
+        symbol = node.value.args[1].value
+        if identifier == symbol:
+            name = ast.alias(symbol)
+        else:
+            name = ast.alias(symbol, identifier)
+        return ast.ImportFrom(
+            module=module,
+            names=[name],
+            level=0,
+        )
+    else:
+        if module == identifier:
+            name = ast.alias(module)
+        else:
+            name = ast.alias(module, identifier)
+        return ast.Import(names=[name])
+
+
+class SafeImportUnwrapper(ast.NodeTransformer):
+    def visit_Assign(self, node: ast.Assign) -> typing.Any:
+        if is_safe_import(node):
+            return _unwrap_safe_import(node)
+        return node
+
+
+def unwrap_safe_import(source: str) -> str:
+    return ast.unparse(SafeImportUnwrapper().visit(ast.parse(source)))
+
+
+def isort_safe_imports(safe_imports: list[str]) -> str:
+    """Sort a list of safe import assignments with isort."""
+
+    # Translate all safe import assignments to standard import statements.
+    mapping = dict()
+    for safe_import_stmt in safe_imports:
+        mapping[unwrap_safe_import(safe_import_stmt)] = safe_import_stmt
+
+    # Reformat the standard import statements with isort.
+    standard_import_stmts = "\n".join(mapping.keys())
+    isorted_standard_import_stmts = isort.code(standard_import_stmts, line_length=1e6)
+
+    # Replace the isorted standard import statements with safe import assignments.
+    reformatted_src = isorted_standard_import_stmts
+    for std_import_stmt, safe_import_stmt in mapping.items():
+        reformatted_src = reformatted_src.replace(std_import_stmt, safe_import_stmt)
+
+    return reformatted_src
+
+
+def format_safe_imports_block(source: str) -> typing.Optional[str]:
+    """Format a block of safe import assignments with isort.
+
+    For example, the following block:
+
+        np = cpu_only_import("numpy")
+        host_xpy = safe_import("numpy", alt=cp)
+        cp = gpu_only_import("cupy")
+        cudf = gpu_only_import("cudf")
+        cached_property = safe_import_from(
+            "functools", "cached_property", alt=null_decorator
+        )
+
+    will be reformatted to
+
+        cached_property = safe_import_from(
+            "functools", "cached_property", alt=null_decorator
+        )
+
+        cudf = gpu_only_import("cudf")
+        cp = gpu_only_import("cupy")
+        np = cpu_only_import("numpy")
+    """
+
+    source_wo_safe_imports, safe_imports, block_start = extract_safe_imports(source)
+    if not safe_imports:
+        return
+
+    # Split source w/o safe imports on line-breaks while preserving the terminal
+    # line.
+    lines = source_wo_safe_imports.split("\n")
+
+    # Override block_start with first line after root module imports if possible.
+    root_imports = list(find_root_imports(source_wo_safe_imports))
+    if root_imports:
+        block_start = max(node.end_lineno for node in root_imports)
+
+    # Remove all pre-existing whitespace after block start.
+    while block_start < len(lines) and not lines[block_start].strip():
+        lines.pop(block_start)
+
+    # Sort the safe_imports block with isort.
+    isorted_safe_imports = isort_safe_imports(safe_imports).splitlines()
+
+    # Insert safe imports block into source code with two following empty lines.
+    # Note that the insertion is done in reverse order to avoid the need to
+    # shift the insertion index (block_start).
+    lines.insert(block_start, "")
+    lines.insert(block_start, "")
+    for line in reversed(isorted_safe_imports):
+        lines.insert(block_start, line)
+
+    # Insert one empty line before block if needed.
+    if block_start > 0 and lines[block_start - 1].strip():
+        lines.insert(block_start, "")
+
+    return "\n".join(lines)
+
+
+@click.command()
+@click.argument("input", type=click.Path(exists=True, dir_okay=False), nargs=-1)
+@click.option("-i", "--in-place", is_flag=True)
+def main(input, in_place):
+    for inp in input:
+        path = Path(inp)
+        source = path.read_text()
+
+        try:
+            reformatted_source = format_safe_imports_block(source)
+        except SyntaxError:
+            raise RuntimeError(f"Unable to parse {inp} .")
+        except Exception as error:
+            raise RuntimeError(f"Unable to reformat {inp} due to error: {error}")
+
+        if reformatted_source and reformatted_source != source:
+            if in_place:
+                path.write_text(reformatted_source)
+            else:
+                click.echo(reformatted_source)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cuml/__init__.py
+++ b/python/cuml/__init__.py
@@ -14,100 +14,78 @@
 # limitations under the License.
 #
 
-from cuml.internals.base import Base, UniversalBase
-
-# GPU only packages
-
 import cuml.common.cuda as cuda
-from cuml.common.handle import Handle
-
-from cuml.cluster.dbscan import DBSCAN
-from cuml.cluster.kmeans import KMeans
+import cuml.feature_extraction
 from cuml.cluster.agglomerative import AgglomerativeClustering
+from cuml.cluster.dbscan import DBSCAN
 from cuml.cluster.hdbscan import HDBSCAN
-
+from cuml.cluster.kmeans import KMeans
+from cuml.common.handle import Handle
+from cuml.common.pointer_utils import device_of_gpu_matrix
 from cuml.datasets.arima import make_arima
 from cuml.datasets.blobs import make_blobs
-from cuml.datasets.regression import make_regression
 from cuml.datasets.classification import make_classification
-
+from cuml.datasets.regression import make_regression
+from cuml.decomposition.incremental_pca import IncrementalPCA
 from cuml.decomposition.pca import PCA
 from cuml.decomposition.tsvd import TruncatedSVD
-from cuml.decomposition.incremental_pca import IncrementalPCA
-
-from cuml.fil.fil import ForestInference
-
 from cuml.ensemble.randomforestclassifier import RandomForestClassifier
 from cuml.ensemble.randomforestregressor import RandomForestRegressor
-
 from cuml.explainer.kernel_shap import KernelExplainer
 from cuml.explainer.permutation_shap import PermutationExplainer
 from cuml.explainer.tree_shap import TreeExplainer
-
-import cuml.feature_extraction
 from cuml.fil import fil
-
+from cuml.fil.fil import ForestInference
+from cuml.internals.base import Base, UniversalBase
 from cuml.internals.global_settings import (
     GlobalSettings,
     _global_settings_data,
 )
-
+from cuml.internals.memory_utils import (
+    set_global_output_type,
+    using_output_type,
+)
 from cuml.kernel_ridge.kernel_ridge import KernelRidge
-
 from cuml.linear_model.elastic_net import ElasticNet
 from cuml.linear_model.lasso import Lasso
+from cuml.linear_model.linear_regression import LinearRegression
 from cuml.linear_model.logistic_regression import LogisticRegression
 from cuml.linear_model.mbsgd_classifier import MBSGDClassifier
 from cuml.linear_model.mbsgd_regressor import MBSGDRegressor
 from cuml.linear_model.ridge import Ridge
-
 from cuml.manifold.t_sne import TSNE
 from cuml.manifold.umap import UMAP
 from cuml.metrics.accuracy import accuracy_score
 from cuml.metrics.cluster.adjusted_rand_index import adjusted_rand_score
 from cuml.metrics.regression import r2_score
 from cuml.model_selection import train_test_split
-
 from cuml.naive_bayes.naive_bayes import MultinomialNB
-
-from cuml.neighbors.nearest_neighbors import NearestNeighbors
 from cuml.neighbors.kernel_density import KernelDensity
 from cuml.neighbors.kneighbors_classifier import KNeighborsClassifier
 from cuml.neighbors.kneighbors_regressor import KNeighborsRegressor
-
+from cuml.neighbors.nearest_neighbors import NearestNeighbors
 from cuml.preprocessing.LabelEncoder import LabelEncoder
-
-from cuml.random_projection.random_projection import GaussianRandomProjection
-from cuml.random_projection.random_projection import SparseRandomProjection
 from cuml.random_projection.random_projection import (
+    GaussianRandomProjection,
+    SparseRandomProjection,
     johnson_lindenstrauss_min_dim,
 )
-
 from cuml.solvers.cd import CD
-from cuml.solvers.sgd import SGD
 from cuml.solvers.qn import QN
-from cuml.svm import SVC
-from cuml.svm import SVR
-from cuml.svm import LinearSVC
-from cuml.svm import LinearSVR
-
+from cuml.solvers.sgd import SGD
+from cuml.svm import SVC, SVR, LinearSVC, LinearSVR
 from cuml.tsa import stationarity
 from cuml.tsa.arima import ARIMA
 from cuml.tsa.auto_arima import AutoARIMA
 from cuml.tsa.holtwinters import ExponentialSmoothing
 
-from cuml.common.pointer_utils import device_of_gpu_matrix
-from cuml.internals.memory_utils import (
-    set_global_output_type,
-    using_output_type,
-)
-
-# Universal packages
-
-from cuml.linear_model.linear_regression import LinearRegression
-
 # Import verion. Remove at end of file
 from ._version import get_versions
+
+# GPU only packages
+
+
+# Universal packages
 
 
 # Version configuration

--- a/python/cuml/_thirdparty/sklearn/preprocessing/__init__.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/__init__.py
@@ -3,35 +3,35 @@
 # This code is under BSD 3 clause license.
 
 
-from ._data import Binarizer
-from ._data import KernelCenterer
-from ._data import MinMaxScaler
-from ._data import MaxAbsScaler
-from ._data import Normalizer
-from ._data import PolynomialFeatures
-from ._data import PowerTransformer
-from ._data import QuantileTransformer
-from ._data import RobustScaler
-from ._data import StandardScaler
-from ._data import add_dummy_feature
-from ._data import binarize
-from ._data import normalize
-from ._data import scale
-from ._data import robust_scale
-from ._data import maxabs_scale
-from ._data import minmax_scale
-from ._data import power_transform
-from ._data import quantile_transform
-
-from ._imputation import SimpleImputer
-from ._imputation import MissingIndicator
+from ._column_transformer import (
+    ColumnTransformer,
+    make_column_selector,
+    make_column_transformer,
+)
+from ._data import (
+    Binarizer,
+    KernelCenterer,
+    MaxAbsScaler,
+    MinMaxScaler,
+    Normalizer,
+    PolynomialFeatures,
+    PowerTransformer,
+    QuantileTransformer,
+    RobustScaler,
+    StandardScaler,
+    add_dummy_feature,
+    binarize,
+    maxabs_scale,
+    minmax_scale,
+    normalize,
+    power_transform,
+    quantile_transform,
+    robust_scale,
+    scale,
+)
 from ._discretization import KBinsDiscretizer
-
 from ._function_transformer import FunctionTransformer
-
-from ._column_transformer import ColumnTransformer, \
-    make_column_transformer, make_column_selector
-
+from ._imputation import MissingIndicator, SimpleImputer
 
 __all__ = [
     'Binarizer',

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -9,42 +9,50 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from ..preprocessing import FunctionTransformer
-from ....thirdparty_adapters import check_array
-from ..utils.validation import check_is_fitted
-from ..utils.skl_dependencies import TransformerMixin, BaseComposition, \
-    BaseEstimator
+import functools
+import numbers
+import timeit
+from itertools import chain, compress
+
+from joblib import Parallel
+
+import cuml
 from cuml.internals import _deprecate_pos_args
 from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.global_settings import _global_settings_data
-import cuml
-from itertools import chain
-from itertools import compress
-from joblib import Parallel
-import functools
-import timeit
-import numbers
 from cuml.internals.import_utils import has_sklearn
+
+from ....thirdparty_adapters import check_array
+from ..preprocessing import FunctionTransformer
+from ..utils.skl_dependencies import (
+    BaseComposition,
+    BaseEstimator,
+    TransformerMixin,
+)
+from ..utils.validation import check_is_fitted
 
 if has_sklearn():
     from sklearn.base import clone
     from sklearn.utils import Bunch
-from contextlib import contextmanager
-from collections import defaultdict
+
 import warnings
+from collections import defaultdict
+from contextlib import contextmanager
 
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
-cpu_np = cpu_only_import('numpy')
-cu_sparse = gpu_only_import_from('cupyx.scipy', 'sparse')
+cudf = gpu_only_import('cudf')
 np = gpu_only_import('cupy')
 numba = gpu_only_import('numba')
+cpu_np = cpu_only_import('numpy')
 pd = cpu_only_import('pandas')
+cu_sparse = gpu_only_import_from('cupyx.scipy', 'sparse')
 sp_sparse = cpu_only_import_from('scipy', 'sparse')
-cudf = gpu_only_import('cudf')
 
 
 _ERR_MSG_1DCOLUMN = ("1D data passed to a transformer that expects 2D data. "

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -15,39 +15,52 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from ....internals.memory_utils import using_output_type
-from ....internals import _deprecate_pos_args
-from ....internals import api_return_generic
-from ....common.array_descriptor import CumlArrayDescriptor
-from ....internals.array_sparse import SparseCumlArray
-from ....internals.array import CumlArray
-from ....thirdparty_adapters.sparsefuncs_fast import \
-    (inplace_csr_row_normalize_l1, inplace_csr_row_normalize_l2,
-     csr_polynomial_expansion)
-from ..utils.sparsefuncs import (inplace_column_scale,
-                                 min_max_axis,
-                                 mean_variance_axis)
-from ..utils.validation import (check_is_fitted, FLOAT_DTYPES,
-                                check_random_state)
-from ..utils.extmath import _incremental_mean_and_var
-from ..utils.extmath import row_norms
-from ....thirdparty_adapters import check_array
-from cuml.internals.mixins import AllowNaNTagMixin, SparseInputTagMixin, \
-    StatelessTagMixin
-from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
-from scipy.special import boxcox
-from scipy import optimize
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
-from itertools import chain, combinations
 import numbers
 import warnings
+from itertools import chain, combinations
 from itertools import combinations_with_replacement as combinations_w_r
 
-from cuml.internals.safe_imports import cpu_only_import
-cpu_np = cpu_only_import('numpy')
+from scipy import optimize
+from scipy.special import boxcox
+
+from cuml.internals.mixins import (
+    AllowNaNTagMixin,
+    SparseInputTagMixin,
+    StatelessTagMixin,
+)
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+
+from ....common.array_descriptor import CumlArrayDescriptor
+from ....internals import _deprecate_pos_args, api_return_generic
+from ....internals.array import CumlArray
+from ....internals.array_sparse import SparseCumlArray
+from ....internals.memory_utils import using_output_type
+from ....thirdparty_adapters import check_array
+from ....thirdparty_adapters.sparsefuncs_fast import (
+    csr_polynomial_expansion,
+    inplace_csr_row_normalize_l1,
+    inplace_csr_row_normalize_l2,
+)
+from ..utils.extmath import _incremental_mean_and_var, row_norms
+from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
+from ..utils.sparsefuncs import (
+    inplace_column_scale,
+    mean_variance_axis,
+    min_max_axis,
+)
+from ..utils.validation import (
+    FLOAT_DTYPES,
+    check_is_fitted,
+    check_random_state,
+)
+
 np = gpu_only_import('cupy')
+cpu_np = cpu_only_import('numpy')
 sparse = gpu_only_import_from('cupyx.scipy', 'sparse')
 stats = cpu_only_import_from('scipy', 'stats')
 

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -11,21 +11,22 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from ....internals import _deprecate_pos_args
-from ....internals.memory_utils import using_output_type
-from ....common.array_descriptor import CumlArrayDescriptor
-from ....internals.array_sparse import SparseCumlArray
-from ....thirdparty_adapters import check_array
-from ..utils.validation import FLOAT_DTYPES
-from ..utils.validation import check_is_fitted
-from cuml.internals.mixins import SparseInputTagMixin
-from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
-from cuml.cluster import KMeans
-from cuml.preprocessing import OneHotEncoder
-import warnings
-from cuml.internals.safe_imports import cpu_only_import
 import numbers
-from cuml.internals.safe_imports import gpu_only_import
+import warnings
+
+from cuml.cluster import KMeans
+from cuml.internals.mixins import SparseInputTagMixin
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.preprocessing import OneHotEncoder
+
+from ....common.array_descriptor import CumlArrayDescriptor
+from ....internals import _deprecate_pos_args
+from ....internals.array_sparse import SparseCumlArray
+from ....internals.memory_utils import using_output_type
+from ....thirdparty_adapters import check_array
+from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
+from ..utils.validation import FLOAT_DTYPES, check_is_fitted
+
 np = gpu_only_import('cupy')
 cpu_np = cpu_only_import('numpy')
 

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -7,10 +7,11 @@
 import warnings
 
 import cuml
-from ....internals.array_sparse import SparseCumlArray
-from ..utils.skl_dependencies import TransformerMixin, BaseEstimator
-from ..utils.validation import _allclose_dense_sparse
+
 from ....internals import _deprecate_pos_args
+from ....internals.array_sparse import SparseCumlArray
+from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
+from ..utils.validation import _allclose_dense_sparse
 
 
 def _identity(X):

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -10,27 +10,35 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from ....internals import _deprecate_pos_args
-from ....common.array_descriptor import CumlArrayDescriptor
-from ....internals.array_sparse import SparseCumlArray
-from ..utils.validation import FLOAT_DTYPES
-from ..utils.validation import check_is_fitted
-from cuml.internals.mixins import AllowNaNTagMixin, SparseInputTagMixin, \
-    StringInputTagMixin
-from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
-from ....thirdparty_adapters import (_get_mask,
-                                     _masked_column_median,
-                                     _masked_column_mean,
-                                     _masked_column_mode)
-from cuml.internals.safe_imports import gpu_only_import_from
-import cuml
-from cuml.internals.safe_imports import gpu_only_import
 import numbers
 import warnings
 
-from cuml.internals.safe_imports import cpu_only_import
-numpy = cpu_only_import('numpy')
+import cuml
+from cuml.internals.mixins import (
+    AllowNaNTagMixin,
+    SparseInputTagMixin,
+    StringInputTagMixin,
+)
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+
+from ....common.array_descriptor import CumlArrayDescriptor
+from ....internals import _deprecate_pos_args
+from ....internals.array_sparse import SparseCumlArray
+from ....thirdparty_adapters import (
+    _get_mask,
+    _masked_column_mean,
+    _masked_column_median,
+    _masked_column_mode,
+)
+from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
+from ..utils.validation import FLOAT_DTYPES, check_is_fitted
+
 np = gpu_only_import('cupy')
+numpy = cpu_only_import('numpy')
 sparse = gpu_only_import_from('cupyx.scipy', 'sparse')
 
 

--- a/python/cuml/_thirdparty/sklearn/utils/__init__.py
+++ b/python/cuml/_thirdparty/sklearn/utils/__init__.py
@@ -3,5 +3,4 @@
 # This code is under BSD 3 clause license.
 
 
-from . import validation
-from . import extmath
+from . import extmath, validation

--- a/python/cuml/_thirdparty/sklearn/utils/extmath.py
+++ b/python/cuml/_thirdparty/sklearn/utils/extmath.py
@@ -16,8 +16,8 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import gpu_only_import, gpu_only_import_from
+
 np = gpu_only_import('cupy')
 cupyx = gpu_only_import('cupyx')
 sparse = gpu_only_import_from('cupyx.scipy', 'sparse')

--- a/python/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
+++ b/python/cuml/_thirdparty/sklearn/utils/skl_dependencies.py
@@ -10,9 +10,10 @@
 
 
 from cuml.internals.array_sparse import SparseCumlArray
+
 from ....internals.base import Base
-from ..utils.validation import check_X_y
 from ....thirdparty_adapters import check_array
+from ..utils.validation import check_X_y
 
 
 class BaseEstimator(Base):

--- a/python/cuml/_thirdparty/sklearn/utils/sparsefuncs.py
+++ b/python/cuml/_thirdparty/sklearn/utils/sparsefuncs.py
@@ -12,17 +12,24 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+
+from ....thirdparty_adapters.sparsefuncs_fast import (
+    csc_mean_variance_axis0 as _csc_mean_var_axis0,
+)
 from ....thirdparty_adapters.sparsefuncs_fast import (
     csr_mean_variance_axis0 as _csr_mean_var_axis0,
-    csc_mean_variance_axis0 as _csc_mean_var_axis0)
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import_from
-cpu_sp = cpu_only_import_from('scipy', 'sparse')
-gpu_sp = gpu_only_import_from('cupyx.scipy', 'sparse')
+)
+
 np = gpu_only_import('cupy')
 cpu_np = cpu_only_import('numpy')
+gpu_sp = gpu_only_import_from('cupyx.scipy', 'sparse')
+cpu_sp = cpu_only_import_from('scipy', 'sparse')
 
 
 def iscsr(X):

--- a/python/cuml/_thirdparty/sklearn/utils/validation.py
+++ b/python/cuml/_thirdparty/sklearn/utils/validation.py
@@ -15,15 +15,17 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from ....thirdparty_adapters import check_array
-from ....common.exceptions import NotFittedError
-from inspect import isclass
-from cuml.internals.safe_imports import gpu_only_import
 import numbers
-from cuml.internals.safe_imports import cpu_only_import
-np = cpu_only_import('numpy')
+from inspect import isclass
+
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
+from ....common.exceptions import NotFittedError
+from ....thirdparty_adapters import check_array
+
 cp = gpu_only_import('cupy')
 sp = gpu_only_import('cupyx.scipy.sparse')
+np = cpu_only_import('numpy')
 
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)

--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -13,54 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import treelite_runtime
-import treelite
-from cuml.benchmark.bench_helper_funcs import (
-    fit,
-    transform,
-    predict,
-    fit_transform,
-    fit_predict,
-    fit_kneighbors,
-    _build_cpu_skl_classifier,
-    _build_fil_skl_classifier,
-    _build_fil_classifier,
-    _build_treelite_classifier,
-    _treelite_fil_accuracy_score,
-    _build_mnmg_umap,
-)
-from cuml.preprocessing import (
-    StandardScaler,
-    MinMaxScaler,
-    MaxAbsScaler,
-    Normalizer,
-    SimpleImputer,
-    RobustScaler,
-    PolynomialFeatures,
-)
 import tempfile
-import cuml
 
 import sklearn
 import sklearn.cluster
-import sklearn.neighbors
 import sklearn.ensemble
-import sklearn.random_projection
 import sklearn.naive_bayes
+import sklearn.neighbors
+import sklearn.random_projection
+import treelite
+import treelite_runtime
 from sklearn import metrics
 from sklearn.impute import SimpleImputer as skSimpleImputer
-import cuml.metrics
+
+import cuml
 import cuml.decomposition
+import cuml.metrics
 import cuml.naive_bayes
-from cuml.dask import (
-    neighbors,
+from cuml.benchmark.bench_helper_funcs import (
+    _build_cpu_skl_classifier,
+    _build_fil_classifier,
+    _build_fil_skl_classifier,
+    _build_mnmg_umap,
+    _build_treelite_classifier,
+    _treelite_fil_accuracy_score,
+    fit,
+    fit_kneighbors,
+    fit_predict,
+    fit_transform,
+    predict,
+    transform,
+)
+from cuml.dask import (  # noqa: F401
     cluster,
-    manifold,
     decomposition,
     linear_model,
-)  # noqa: F401
+    manifold,
+    neighbors,
+)
 from cuml.internals.import_utils import has_umap
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.preprocessing import (
+    MaxAbsScaler,
+    MinMaxScaler,
+    Normalizer,
+    PolynomialFeatures,
+    RobustScaler,
+    SimpleImputer,
+    StandardScaler,
+)
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/benchmark/automated/bench_classification.py
+++ b/python/cuml/benchmark/automated/bench_classification.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from .utils.utils import _benchmark_algo, fixture_generation_helper
-from .utils.utils import bench_step  # noqa: F401
+
 from .. import datagen
+from .utils.utils import bench_step  # noqa: F401
+from .utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/bench_dimensionality_reduction.py
+++ b/python/cuml/benchmark/automated/bench_dimensionality_reduction.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from .utils.utils import _benchmark_algo, fixture_generation_helper
-from .utils.utils import bench_step  # noqa: F401
+
 from .. import datagen
+from .utils.utils import bench_step  # noqa: F401
+from .utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/bench_preprocessing.py
+++ b/python/cuml/benchmark/automated/bench_preprocessing.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from .utils.utils import _benchmark_algo
-from .utils.utils import bench_step  # noqa: F401
+
 from .. import datagen
+from .utils.utils import bench_step  # noqa: F401
+from .utils.utils import _benchmark_algo
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/bench_random_forest.py
+++ b/python/cuml/benchmark/automated/bench_random_forest.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from .utils.utils import _benchmark_algo, fixture_generation_helper
-from .utils.utils import bench_step  # noqa: F401
+
 from .. import datagen
+from .utils.utils import bench_step  # noqa: F401
+from .utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/bench_regression.py
+++ b/python/cuml/benchmark/automated/bench_regression.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from .utils.utils import _benchmark_algo, fixture_generation_helper
-from .utils.utils import bench_step  # noqa: F401
+
 from .. import datagen
+from .utils.utils import bench_step  # noqa: F401
+from .utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/dask/bench_mnmg_classification.py
+++ b/python/cuml/benchmark/automated/dask/bench_mnmg_classification.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from ..utils.utils import _benchmark_algo, fixture_generation_helper
-from ..utils.utils import bench_step  # noqa: F401
+
 from ... import datagen
+from ..utils.utils import bench_step  # noqa: F401
+from ..utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/dask/bench_mnmg_dimensionality_reduction.py
+++ b/python/cuml/benchmark/automated/dask/bench_mnmg_dimensionality_reduction.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from ..utils.utils import _benchmark_algo, fixture_generation_helper
-from ..utils.utils import bench_step  # noqa: F401
+
 from ... import datagen
+from ..utils.utils import bench_step  # noqa: F401
+from ..utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/dask/bench_mnmg_regression.py
+++ b/python/cuml/benchmark/automated/dask/bench_mnmg_regression.py
@@ -15,9 +15,10 @@
 #
 
 import pytest
-from ..utils.utils import _benchmark_algo, fixture_generation_helper
-from ..utils.utils import bench_step  # noqa: F401
+
 from ... import datagen
+from ..utils.utils import bench_step  # noqa: F401
+from ..utils.utils import _benchmark_algo, fixture_generation_helper
 
 #
 # Core tests

--- a/python/cuml/benchmark/automated/dask/conftest.py
+++ b/python/cuml/benchmark/automated/dask/conftest.py
@@ -15,10 +15,8 @@
 #
 
 import pytest
-
-from dask_cuda import initialize
-from dask_cuda import LocalCUDACluster
 from dask.distributed import Client
+from dask_cuda import LocalCUDACluster, initialize
 
 enable_tcp_over_ucx = True
 enable_nvlink = False

--- a/python/cuml/benchmark/automated/utils/auto_nvtx_bench.py
+++ b/python/cuml/benchmark/automated/utils/auto_nvtx_bench.py
@@ -16,7 +16,8 @@
 
 import argparse
 import json
-from cuml.benchmark import datagen, algorithms
+
+from cuml.benchmark import algorithms, datagen
 from cuml.benchmark.automated.utils.utils import setup_bench
 
 parser = argparse.ArgumentParser(

--- a/python/cuml/benchmark/automated/utils/utils.py
+++ b/python/cuml/benchmark/automated/utils/utils.py
@@ -32,36 +32,36 @@ except ImportError:
         pass
 
 
-import os
-import json
-import time
-import math
 import itertools as it
+import json
+import math
+import os
+import time
 import warnings
-from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
-
-import pytest
-from cuml.benchmark import datagen, algorithms
-from cuml.benchmark.nvtx_benchmark import Profiler
-from dask.distributed import wait
-import dask.array as da
-import dask.dataframe as df
 from copy import copy
 
+import dask.array as da
+import dask.dataframe as df
+import pytest
+from dask.distributed import wait
+
+from cuml.benchmark import algorithms, datagen
 from cuml.benchmark.bench_helper_funcs import (
-    pass_func,
     fit,
-    predict,
-    transform,
-    kneighbors,
+    fit_kneighbors,
     fit_predict,
     fit_transform,
-    fit_kneighbors,
+    kneighbors,
+    pass_func,
+    predict,
+    transform,
 )
+from cuml.benchmark.nvtx_benchmark import Profiler
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
-np = cpu_only_import("numpy")
-cp = gpu_only_import("cupy")
 cudf = gpu_only_import("cudf")
+cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 def distribute(client, data):

--- a/python/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/benchmark/bench_helper_funcs.py
@@ -13,20 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.manifold import UMAP
-from cuml.benchmark import datagen
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
-import sklearn.ensemble as skl_ensemble
-import pickle as pickle
 import os
-import cuml
-from cuml.internals import input_utils
-from cuml.internals.safe_imports import cpu_only_import
+import pickle as pickle
 
+import sklearn.ensemble as skl_ensemble
+
+import cuml
+from cuml.benchmark import datagen
+from cuml.internals import input_utils
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.manifold import UMAP
+
+cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-cudf = gpu_only_import("cudf")
 cuda = gpu_only_import_from("numba", "cuda")
 
 
@@ -212,9 +216,10 @@ def _build_cpu_skl_classifier(m, data, args, tmpdir):
 
 def _build_treelite_classifier(m, data, args, tmpdir):
     """Setup function for treelite classification benchmarking"""
-    from cuml.internals.import_utils import has_xgboost
     import treelite
     import treelite_runtime
+
+    from cuml.internals.import_utils import has_xgboost
 
     if has_xgboost():
         import xgboost as xgb

--- a/python/cuml/benchmark/ci_benchmark.py
+++ b/python/cuml/benchmark/ci_benchmark.py
@@ -18,8 +18,8 @@
 NOTE: This is currently experimental as the ops team builds out the CI
 platform to support benchmark reporting.
 """
-from cuml.benchmark.runners import run_variations
 from cuml.benchmark import algorithms
+from cuml.benchmark.runners import run_variations
 from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
@@ -47,8 +47,9 @@ def report_asv(
     output_dir : str
       Directory for ASV output database
     """
-    import asvdb
     import platform
+
+    import asvdb
     import psutil
 
     uname = platform.uname()

--- a/python/cuml/benchmark/datagen.py
+++ b/python/cuml/benchmark/datagen.py
@@ -34,24 +34,26 @@ GPU arrays directly instead.
 
 """
 
-from cuml.internals.import_utils import has_scipy
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals import input_utils
-from urllib.request import urlretrieve
-import sklearn.model_selection
-import cuml.datasets
-from cuml.internals.safe_imports import cpu_only_import
-import os
 import functools
 import gzip
-from cuml.internals.safe_imports import gpu_only_import
+import os
+from urllib.request import urlretrieve
+
+import sklearn.model_selection
+
+import cuml.datasets
+from cuml.internals import input_utils
+from cuml.internals.import_utils import has_scipy
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cudf = gpu_only_import("cudf")
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-
-
 cuda = gpu_only_import_from("numba", "cuda")
 
 

--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
+import json
 import os
 import sys
 from subprocess import run
-import json
 
 
 class Profiler:

--- a/python/cuml/benchmark/run_benchmarks.py
+++ b/python/cuml/benchmark/run_benchmarks.py
@@ -16,6 +16,7 @@
 """Command-line ML benchmark runner"""
 
 import json
+
 from cuml.benchmark import algorithms, datagen, runners
 from cuml.internals.safe_imports import cpu_only_import
 

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -15,16 +15,15 @@
 #
 """Wrappers to run ML benchmarks"""
 
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.benchmark import datagen
-import warnings
-import time
 import itertools
-from cuml.internals.safe_imports import cpu_only_import
+import time
+import warnings
+
+from cuml.benchmark import datagen
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import_from
 
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-
 Series = gpu_only_import_from("cudf", "Series")
 
 

--- a/python/cuml/cluster/__init__.py
+++ b/python/cuml/cluster/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
 # limitations under the License.
 #
 
-from cuml.cluster.dbscan import DBSCAN
-from cuml.cluster.kmeans import KMeans
 from cuml.cluster.agglomerative import AgglomerativeClustering
+from cuml.cluster.dbscan import DBSCAN
 from cuml.cluster.hdbscan import HDBSCAN
 
 # TODO: These need to be deprecated and moved to hdbscan namespace
-from cuml.cluster.hdbscan.prediction import all_points_membership_vectors
-from cuml.cluster.hdbscan.prediction import approximate_predict
+from cuml.cluster.hdbscan.prediction import (
+    all_points_membership_vectors,
+    approximate_predict,
+)
+from cuml.cluster.kmeans import KMeans

--- a/python/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cluster/agglomerative.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,16 +19,18 @@
 from libc.stdint cimport uintptr_t
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.common.doc_utils import generate_docstring
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.mixins import ClusterMixin
-from cuml.internals.mixins import CMajorInputTagMixin
+from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
 from cuml.metrics.distance_type cimport DistanceType
 

--- a/python/cuml/cluster/cpp/kmeans.pxd
+++ b/python/cuml/cluster/cpp/kmeans.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,16 +16,18 @@
 
 # distutils: language = c++
 
-from libc.stdint cimport uintptr_t, int64_t
-
-from cuml.metrics.distance_type cimport DistanceType
+from libc.stdint cimport int64_t, uintptr_t
 from pylibraft.common.handle cimport handle_t
 
+from cuml.metrics.distance_type cimport DistanceType
+
 import ctypes
+
 from libcpp cimport bool
 
-from cuml.metrics.distance_type cimport DistanceType
 from cuml.common.rng_state cimport RngState
+from cuml.metrics.distance_type cimport DistanceType
+
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace \
         "ML::kmeans::KMeansParams":

--- a/python/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cluster/dbscan.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,27 +17,32 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
-from libc.stdint cimport uintptr_t, int64_t
-from libc.stdlib cimport calloc, malloc, free
 
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.common.doc_utils import generate_docstring
+
 from pylibraft.common.handle cimport handle_t
-from cuml.common import input_to_cuml_array
-from cuml.common import using_output_type
+
+from cuml.common import input_to_cuml_array, using_output_type
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.mixins import ClusterMixin
-from cuml.internals.mixins import CMajorInputTagMixin
+from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+
 from cuml.metrics.distance_type cimport DistanceType
 
 from collections import defaultdict
+
 
 cdef extern from "cuml/cluster/dbscan.hpp" \
         namespace "ML::Dbscan":

--- a/python/cuml/cluster/hdbscan/__init__.py
+++ b/python/cuml/cluster/hdbscan/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.cluster.hdbscan.hdbscan import HDBSCAN
-from cuml.cluster.hdbscan.hdbscan import condense_hierarchy
-
-from cuml.cluster.hdbscan.prediction import all_points_membership_vectors
-from cuml.cluster.hdbscan.prediction import approximate_predict
+from cuml.cluster.hdbscan.hdbscan import HDBSCAN, condense_hierarchy
+from cuml.cluster.hdbscan.prediction import (
+    all_points_membership_vectors,
+    approximate_predict,
+)

--- a/python/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cluster/hdbscan/hdbscan.pyx
@@ -15,36 +15,42 @@
 
 # distutils: language = c++
 
-from libc.stdint cimport uintptr_t
-from libcpp cimport bool
-from libc.stdlib cimport free
-
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uintptr_t
+from libc.stdlib cimport free
+from libcpp cimport bool
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from warnings import warn
 
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
-from cuml.common.doc_utils import generate_docstring
+
 from pylibraft.common.handle cimport handle_t
 from rmm._lib.device_uvector cimport device_uvector
 
 from pylibraft.common.handle import Handle
-from cuml.common import input_to_cuml_array
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
-from cuml.internals.mixins import ClusterMixin
-from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.internals import logger
-from cuml.internals.import_utils import has_hdbscan_plots
-from cuml.internals.import_utils import has_hdbscan_prediction
 
 import cuml
+from cuml.common import input_to_cuml_array
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals import logger
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
+from cuml.internals.import_utils import (
+    has_hdbscan_plots,
+    has_hdbscan_prediction,
+)
+from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+
 from cuml.metrics.distance_type cimport DistanceType
 
 
@@ -602,8 +608,8 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
 
         if self.prediction_data_obj is None:
             if has_hdbscan_prediction():
-                from sklearn.neighbors import KDTree, BallTree
                 from hdbscan.prediction import PredictionData
+                from sklearn.neighbors import BallTree, KDTree
 
                 FAST_METRICS = KDTree.valid_metrics + \
                     BallTree.valid_metrics + ["cosine", "arccos"]

--- a/python/cuml/cluster/hdbscan/prediction.pyx
+++ b/python/cuml/cluster/hdbscan/prediction.pyx
@@ -15,35 +15,36 @@
 
 # distutils: language = c++
 
+from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
 
-from cython.operator cimport dereference as deref
-
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.common.doc_utils import generate_docstring
+
 from pylibraft.common.handle cimport handle_t
 
 from pylibraft.common.handle import Handle
-from cuml.common import (
-    input_to_cuml_array,
-    input_to_host_array
-)
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.available_devices import is_cuda_available
-from cuml.internals.device_type import DeviceType
-from cuml.internals.mixins import ClusterMixin
-from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.internals import logger
-from cuml.internals.import_utils import has_hdbscan_plots
-from cuml.internals.import_utils import has_hdbscan_prediction
 
 import cuml
+from cuml.common import input_to_cuml_array, input_to_host_array
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals import logger
+from cuml.internals.available_devices import is_cuda_available
+from cuml.internals.device_type import DeviceType
+from cuml.internals.import_utils import (
+    has_hdbscan_plots,
+    has_hdbscan_prediction,
+)
+from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+
 from cuml.metrics.distance_type cimport DistanceType
 
 
@@ -145,8 +146,9 @@ def all_points_membership_vectors(clusterer):
     # cpu infer, cpu/gpu train
     if device_type == DeviceType.host:
         assert has_hdbscan_prediction()
-        from hdbscan.prediction import all_points_membership_vectors \
-            as cpu_all_points_membership_vectors
+        from hdbscan.prediction import (
+            all_points_membership_vectors as cpu_all_points_membership_vectors,
+        )
 
         # trained on gpu
         if not hasattr(clusterer, "_cpu_model"):
@@ -248,8 +250,9 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
     # cpu infer, cpu/gpu train
     if device_type == DeviceType.host:
         assert has_hdbscan_prediction()
-        from hdbscan.prediction import approximate_predict \
-            as cpu_approximate_predict
+        from hdbscan.prediction import (
+            approximate_predict as cpu_approximate_predict,
+        )
 
         # trained on gpu
         if not hasattr(clusterer, "_cpu_model"):

--- a/python/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cluster/kmeans.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,34 +17,37 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
-import warnings
 import typing
+import warnings
 
 from cython.operator cimport dereference as deref
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
-from libc.stdint cimport uintptr_t, int64_t
-from libc.stdlib cimport calloc, malloc, free
 
+from cuml.cluster.cpp.kmeans cimport InitMethod, KMeansParams
 from cuml.cluster.cpp.kmeans cimport fit_predict as cpp_fit_predict
 from cuml.cluster.cpp.kmeans cimport predict as cpp_predict
 from cuml.cluster.cpp.kmeans cimport transform as cpp_transform
-from cuml.cluster.cpp.kmeans cimport KMeansParams
-from cuml.cluster.cpp.kmeans cimport InitMethod
 
-from cuml.internals.array import CumlArray
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import Base
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import ClusterMixin
-from cuml.internals.mixins import CMajorInputTagMixin
 from cuml.common import input_to_cuml_array
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+
+from pylibraft.common.handle cimport handle_t
+
 from cuml.cluster.kmeans_utils cimport *
 from cuml.metrics.distance_type cimport DistanceType
-from pylibraft.common.handle cimport handle_t
 
 
 class KMeans(Base,

--- a/python/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cluster/kmeans_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,24 +17,29 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import warnings
 
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
 from cython.operator cimport dereference as deref
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
-from libc.stdint cimport uintptr_t, int64_t
-from libc.stdlib cimport calloc, malloc, free
 
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
-from cuml.common import input_to_cuml_array
 
 from cuml.cluster import KMeans
+from cuml.common import input_to_cuml_array
+
 from cuml.cluster.kmeans_utils cimport *
 
 

--- a/python/cuml/cluster/kmeans_utils.pxd
+++ b/python/cuml/cluster/kmeans_utils.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
 #
 
 import ctypes
+
 from libcpp cimport bool
 
-from cuml.metrics.distance_type cimport DistanceType
 from cuml.common.rng_state cimport RngState
+from cuml.metrics.distance_type cimport DistanceType
+
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace \
         "ML::kmeans::KMeansParams":

--- a/python/cuml/comm/serialize.py
+++ b/python/cuml/comm/serialize.py
@@ -15,22 +15,21 @@
 #
 
 
-import cuml
 import cudf.comm.serialize  # noqa: F401
 
+import cuml
 
 try:
-    from distributed.protocol import dask_deserialize, dask_serialize
-    from distributed.protocol.serialize import pickle_dumps, pickle_loads
+    from distributed.protocol import (
+        dask_deserialize,
+        dask_serialize,
+        register_generic,
+    )
     from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
+    from distributed.protocol.serialize import pickle_dumps, pickle_loads
 
-    from distributed.protocol import register_generic
-
+    from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
     from cuml.internals.array_sparse import SparseCumlArray
-
-    from cuml.ensemble import RandomForestRegressor
-    from cuml.ensemble import RandomForestClassifier
-
     from cuml.naive_bayes import MultinomialNB
 
     # Registering RF Regressor and Classifier to use pickling even when

--- a/python/cuml/common/__init__.py
+++ b/python/cuml/common/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,34 +17,37 @@
 # from cuml.internals.array import CumlArray
 # from cuml.internals.array_sparse import SparseCumlArray
 
+from cuml.common.device_selection import using_device_type
+from cuml.common.pointer_utils import device_of_gpu_matrix
+from cuml.common.timing_utils import timed
+from cuml.internals import logger
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals.import_utils import (
+    check_min_cupy_version,
+    check_min_numba_version,
+    has_cupy,
+    has_dask,
+    has_scipy,
+)
+from cuml.internals.input_utils import (
+    input_to_cuml_array,
+    input_to_host_array,
+    sparse_scipy_to_cp,
+)
+from cuml.internals.memory_utils import (
+    rmm_cupy_ary,
+    set_global_output_type,
+    using_memory_type,
+    using_output_type,
+    with_cupy_rmm,
+)
 
 # utils
 
-from cuml.internals import logger
-from cuml.internals.import_utils import has_cupy
-from cuml.internals.import_utils import has_dask
-from cuml.internals.import_utils import check_min_numba_version
-from cuml.internals.import_utils import check_min_cupy_version, has_scipy
-
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.input_utils import input_to_host_array
-
-from cuml.internals.memory_utils import rmm_cupy_ary
-from cuml.internals.memory_utils import set_global_output_type
-from cuml.internals.memory_utils import using_memory_type
-from cuml.internals.memory_utils import using_output_type
-from cuml.internals.memory_utils import with_cupy_rmm
-from cuml.common.device_selection import using_device_type
-
-
-from cuml.common.pointer_utils import device_of_gpu_matrix
 
 # legacy to be removed after complete CumlAray migration
 
-from cuml.internals.input_utils import sparse_scipy_to_cp
-from cuml.common.timing_utils import timed
 
 __all__ = [
     "CumlArray",

--- a/python/cuml/common/array_descriptor.py
+++ b/python/cuml/common/array_descriptor.py
@@ -15,11 +15,12 @@
 #
 
 from dataclasses import dataclass, field
-from cuml.internals.array import CumlArray
+
 import cuml
+from cuml.internals.array import CumlArray
 from cuml.internals.input_utils import (
-    input_to_cuml_array,
     determine_array_type,
+    input_to_cuml_array,
 )
 
 

--- a/python/cuml/common/device_selection.py
+++ b/python/cuml/common/device_selection.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #
 
 
-from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.device_type import DeviceType
+from cuml.internals.global_settings import GlobalSettings
 
 
 def set_global_device_type(device_type):

--- a/python/cuml/common/doc_utils.py
+++ b/python/cuml/common/doc_utils.py
@@ -38,9 +38,8 @@ cuml.dask datatype version of the docstrings will come in a future update.
 
 """
 
-from inspect import signature
 import inspect
-
+from inspect import signature
 
 _parameters_docstrings = {
     "dense": "{name} : array-like (device or host) shape = {shape}\n"

--- a/python/cuml/common/kernel_utils.py
+++ b/python/cuml/common/kernel_utils.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-import cuml.internals.logger as logger
-from uuid import uuid1
 import functools
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from uuid import uuid1
+
+import cuml.internals.logger as logger
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/common/numba_utils.py
+++ b/python/cuml/common/numba_utils.py
@@ -18,6 +18,7 @@
 # remaining usages: blobs.pyx, regression.pyx
 
 from numba.cuda.cudadrv.driver import driver
+
 from cuml.internals.safe_imports import gpu_only_import_from
 
 cuda = gpu_only_import_from("numba", "cuda")

--- a/python/cuml/common/opg_data_utils_mg.pyx
+++ b/python/cuml/common/opg_data_utils_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,18 @@
 #
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdlib cimport free, malloc
+
 from cuml.common.opg_data_utils_mg cimport *
-from libc.stdlib cimport malloc, free
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
+
 from cuml.common import input_to_cuml_array
+
 from cython.operator cimport dereference as deref
+
 from cuml.internals.array import CumlArray
 
 

--- a/python/cuml/common/rng_state.pxd
+++ b/python/cuml/common/rng_state.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
 #
 
 import ctypes
-from libcpp cimport bool
+
 from libc.stdint cimport uint64_t
+from libcpp cimport bool
+
 
 cdef extern from "raft/random/rng_state.hpp" namespace \
         "raft::random":

--- a/python/cuml/common/sparse_utils.py
+++ b/python/cuml/common/sparse_utils.py
@@ -19,6 +19,7 @@ from cuml.internals.safe_imports import gpu_only_import
 
 cupyx = gpu_only_import("cupyx")
 
+
 if has_scipy():
     import scipy.sparse
 

--- a/python/cuml/common/sparsefuncs.py
+++ b/python/cuml/common/sparsefuncs.py
@@ -15,25 +15,28 @@
 #
 
 import math
+
 import cuml
+from cuml.common.kernel_utils import cuda_kernel_factory
+from cuml.internals.import_utils import has_scipy
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.internals.memory_utils import with_cupy_rmm
-from cuml.internals.import_utils import has_scipy
-from cuml.common.kernel_utils import cuda_kernel_factory
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import gpu_only_import_from
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
-cp_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
+np = cpu_only_import("numpy")
 cp_coo_matrix = gpu_only_import_from("cupyx.scipy.sparse", "coo_matrix")
 cp_csc_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csc_matrix")
+cp_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
 
 
 if has_scipy():
-    from scipy.sparse import csr_matrix, coo_matrix, csc_matrix
+    from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
 else:
     from cuml.common.import_utils import DummyClass
 

--- a/python/cuml/compose/__init__.py
+++ b/python/cuml/compose/__init__.py
@@ -16,10 +16,9 @@
 
 from cuml._thirdparty.sklearn.preprocessing import (
     ColumnTransformer,
-    make_column_transformer,
     make_column_selector,
+    make_column_transformer,
 )
-
 
 __all__ = [
     # Classes

--- a/python/cuml/dask/__init__.py
+++ b/python/cuml/dask/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,19 +13,21 @@
 # limitations under the License.
 #
 
-from cuml.dask import cluster
-from cuml.dask import common
-from cuml.dask import datasets
-from cuml.dask import decomposition
-from cuml.dask import ensemble
-from cuml.dask import feature_extraction
-from cuml.dask import linear_model
-from cuml.dask import manifold
-from cuml.dask import metrics
-from cuml.dask import naive_bayes
-from cuml.dask import neighbors
-from cuml.dask import preprocessing
-from cuml.dask import solvers
+from cuml.dask import (
+    cluster,
+    common,
+    datasets,
+    decomposition,
+    ensemble,
+    feature_extraction,
+    linear_model,
+    manifold,
+    metrics,
+    naive_bayes,
+    neighbors,
+    preprocessing,
+    solvers,
+)
 
 __all__ = [
     "cluster",

--- a/python/cuml/dask/cluster/dbscan.py
+++ b/python/cuml/dask/cluster/dbscan.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 #
 
-from cuml.internals.memory_utils import with_cupy_rmm
+from raft_dask.common.comms import Comms, get_raft_comm_state
+
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedPredictionMixin,
+    DelayedTransformMixin,
+    mnmg_import,
+)
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft_dask.common.comms import get_raft_comm_state
-from raft_dask.common.comms import Comms
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.dask.common.base import BaseEstimator
+from cuml.internals.memory_utils import with_cupy_rmm
 from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")

--- a/python/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/dask/cluster/kmeans.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 #
 
-from cuml.internals.memory_utils import with_cupy_rmm
+from raft_dask.common.comms import Comms, get_raft_comm_state
+
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedPredictionMixin,
+    DelayedTransformMixin,
+    mnmg_import,
+)
+from cuml.dask.common.input_utils import DistributedDataHandler, concatenate
 from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft_dask.common.comms import get_raft_comm_state
-from raft_dask.common.comms import Comms
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.dask.common.input_utils import concatenate
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.dask.common.base import BaseEstimator
+from cuml.internals.memory_utils import with_cupy_rmm
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/dask/common/__init__.py
+++ b/python/cuml/dask/common/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +15,14 @@
 #
 
 from cuml.dask.common.dask_arr_utils import to_sparse_dask_array
-
-from cuml.dask.common.dask_df_utils import get_meta
-from cuml.dask.common.dask_df_utils import to_dask_cudf
-from cuml.dask.common.dask_df_utils import to_dask_df
-
-from cuml.dask.common.part_utils import flatten_grouped_results
-from cuml.dask.common.part_utils import hosts_to_parts
-from cuml.dask.common.part_utils import parts_to_ranks
-from cuml.dask.common.part_utils import workers_to_parts
-
-from cuml.dask.common.utils import raise_exception_from_futures
-from cuml.dask.common.utils import raise_mg_import_exception
+from cuml.dask.common.dask_df_utils import get_meta, to_dask_cudf, to_dask_df
+from cuml.dask.common.part_utils import (
+    flatten_grouped_results,
+    hosts_to_parts,
+    parts_to_ranks,
+    workers_to_parts,
+)
+from cuml.dask.common.utils import (
+    raise_exception_from_futures,
+    raise_mg_import_exception,
+)

--- a/python/cuml/dask/common/base.py
+++ b/python/cuml/dask/common/base.py
@@ -13,29 +13,30 @@
 # limitations under the License.
 #
 
-from distributed.client import Future
+from collections.abc import Iterable
 from functools import wraps
+
+import cudf.comm.serialize  # noqa: F401
+import dask
 from dask_cudf.core import Series as dcSeries
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.base import Base
-from cuml.internals import BaseMetaClass
+from distributed.client import Future
+from raft_dask.common.comms import Comms
+from toolz import first
+
 from cuml.dask.common import parts_to_ranks
 from cuml.dask.common.input_utils import DistributedDataHandler
-from raft_dask.common.comms import Comms
-from cuml.dask.common.utils import wait_and_raise_from_futures
+from cuml.dask.common.utils import get_client, wait_and_raise_from_futures
+from cuml.internals import BaseMetaClass
 from cuml.internals.array import CumlArray
-from cuml.dask.common.utils import get_client
-from collections.abc import Iterable
-from toolz import first
-from cuml.internals.safe_imports import cpu_only_import
-import dask
-import cudf.comm.serialize  # noqa: F401
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.base import Base
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-
-
 dcDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
 
 

--- a/python/cuml/dask/common/dask_arr_utils.py
+++ b/python/cuml/dask/common/dask_arr_utils.py
@@ -14,20 +14,20 @@
 #
 
 
-from cuml.common import rmm_cupy_ary, has_scipy
-from cuml.dask.common.part_utils import _extract_partitions
-from dask.distributed import default_client
-from cuml.dask.common.dask_df_utils import to_dask_cudf as df_to_dask_cudf
-from cuml.internals.memory_utils import with_cupy_rmm
-import dask.dataframe as dd
 import dask
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
+import dask.dataframe as dd
+from dask.distributed import default_client
 
-np = cpu_only_import("numpy")
+from cuml.common import has_scipy, rmm_cupy_ary
+from cuml.dask.common.dask_df_utils import to_dask_cudf as df_to_dask_cudf
+from cuml.dask.common.part_utils import _extract_partitions
+from cuml.internals.memory_utils import with_cupy_rmm
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
-cudf = gpu_only_import("cudf")
+np = cpu_only_import("numpy")
 
 
 def validate_dask_array(darray, client=None):

--- a/python/cuml/dask/common/dask_df_utils.py
+++ b/python/cuml/dask/common/dask_df_utils.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 #
 
-import cuml.internals.logger as logger
 import dask.dataframe as dd
-
 from dask.distributed import default_client
+
+import cuml.internals.logger as logger
 
 
 def get_meta(df):

--- a/python/cuml/dask/common/func.py
+++ b/python/cuml/dask/common/func.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 #
 
-import cuml.internals.logger as logger
 import dask
-
-from cuml.dask.common.utils import get_client
-from cuml.dask.common.part_utils import hosts_to_parts
-from cuml.dask.common.part_utils import workers_to_parts
 from dask.delayed import Delayed
 from dask.distributed import wait
 from toolz import first
+
+import cuml.internals.logger as logger
+from cuml.dask.common.part_utils import hosts_to_parts, workers_to_parts
+from cuml.dask.common.utils import get_client
 
 
 def reduce(futures, func, client=None):

--- a/python/cuml/dask/common/input_utils.py
+++ b/python/cuml/dask/common/input_utils.py
@@ -15,33 +15,34 @@
 #
 
 
-import dask.dataframe as dd
+from collections import OrderedDict
+from collections.abc import Sequence
 from functools import reduce
+
+import dask.array as da
+import dask.dataframe as dd
+from cudf import Series
+from dask.dataframe import DataFrame as daskDataFrame
+from dask.dataframe import Series as daskSeries
+from dask.distributed import default_client, wait
+from dask_cudf.core import Series as dcSeries
 from toolz import first
-from dask.distributed import default_client
-from dask.distributed import wait
-from cuml.dask.common.part_utils import _extract_partitions
+
+import cuml.internals.logger as logger
 from cuml.dask.common.dask_arr_utils import validate_dask_array
 from cuml.dask.common.dask_df_utils import to_dask_cudf
+from cuml.dask.common.part_utils import _extract_partitions
 from cuml.dask.common.utils import get_client
-from dask_cudf.core import Series as dcSeries
-from dask.dataframe import Series as daskSeries
-from dask.dataframe import DataFrame as daskDataFrame
-from cudf import Series
-from cuml.internals.safe_imports import gpu_only_import_from
-from collections import OrderedDict
 from cuml.internals.memory_utils import with_cupy_rmm
-from collections.abc import Sequence
-import dask.array as da
-from cuml.internals.safe_imports import cpu_only_import
-import cuml.internals.logger as logger
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-
-
 DataFrame = gpu_only_import_from("cudf", "DataFrame")
 dcDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
 

--- a/python/cuml/dask/common/part_utils.py
+++ b/python/cuml/dask/common/part_utils.py
@@ -13,23 +13,22 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.utils import parse_host_port
-from dask_cudf.core import Series as dcSeries
-from cuml.internals.safe_imports import gpu_only_import_from
-from dask.dataframe import Series as daskSeries
-from dask.dataframe import DataFrame as daskDataFrame
-from dask.array.core import Array as daskArray
-from toolz import first
-from dask.distributed import futures_of, default_client, wait
-from collections.abc import Sequence
-from tornado import gen
-from functools import reduce
 from collections import OrderedDict
-from cuml.internals.safe_imports import cpu_only_import
+from collections.abc import Sequence
+from functools import reduce
+
+from dask.array.core import Array as daskArray
+from dask.dataframe import DataFrame as daskDataFrame
+from dask.dataframe import Series as daskSeries
+from dask.distributed import default_client, futures_of, wait
+from dask_cudf.core import Series as dcSeries
+from toolz import first
+from tornado import gen
+
+from cuml.dask.common.utils import parse_host_port
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import_from
 
 np = cpu_only_import("numpy")
-
-
 dcDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
 
 

--- a/python/cuml/dask/common/utils.py
+++ b/python/cuml/dask/common/utils.py
@@ -13,16 +13,18 @@
 # limitations under the License.
 #
 
-from threading import Lock
-from asyncio import InvalidStateError
-from cuml.internals.import_utils import check_min_dask_version
-from cuml.common import device_of_gpu_matrix
-from dask.distributed import default_client, wait
-import time
-import random
-import dask
 import logging
 import os
+import random
+import time
+from asyncio import InvalidStateError
+from threading import Lock
+
+import dask
+from dask.distributed import default_client, wait
+
+from cuml.common import device_of_gpu_matrix
+from cuml.internals.import_utils import check_min_dask_version
 from cuml.internals.safe_imports import gpu_only_import
 
 numba_cuda = gpu_only_import("numba.cuda")

--- a/python/cuml/dask/datasets/__init__.py
+++ b/python/cuml/dask/datasets/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #
 
 from cuml.dask.datasets.blobs import make_blobs
-from cuml.dask.datasets.regression import make_regression
 from cuml.dask.datasets.classification import make_classification
+from cuml.dask.datasets.regression import make_regression
 
 __all__ = [
     "make_blobs",

--- a/python/cuml/dask/datasets/blobs.py
+++ b/python/cuml/dask/datasets/blobs.py
@@ -15,19 +15,17 @@
 #
 
 
-import cuml.internals.logger as logger
+import math
+
 import dask.array as da
 
+import cuml.internals.logger as logger
+from cuml.common import with_cupy_rmm
+from cuml.dask.common.utils import get_client
+from cuml.dask.datasets.utils import _create_delayed, _get_labels, _get_X
 from cuml.datasets.blobs import _get_centers
 from cuml.datasets.blobs import make_blobs as sg_make_blobs
-from cuml.common import with_cupy_rmm
 from cuml.datasets.utils import _create_rs_generator
-from cuml.dask.datasets.utils import _get_X
-from cuml.dask.datasets.utils import _get_labels
-from cuml.dask.datasets.utils import _create_delayed
-from cuml.dask.common.utils import get_client
-
-import math
 
 
 def _create_local_data(

--- a/python/cuml/dask/datasets/classification.py
+++ b/python/cuml/dask/datasets/classification.py
@@ -13,21 +13,17 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import cpu_only_import
+import dask.array as da
+
+from cuml.common import with_cupy_rmm
+from cuml.dask.common.utils import get_client
+from cuml.dask.datasets.utils import _create_delayed, _get_labels, _get_X
 from cuml.datasets.classification import _generate_hypercube
 from cuml.datasets.classification import (
     make_classification as sg_make_classification,
 )
 from cuml.datasets.utils import _create_rs_generator
-from cuml.dask.datasets.utils import _get_X
-from cuml.dask.datasets.utils import _get_labels
-from cuml.dask.datasets.utils import _create_delayed
-from cuml.dask.common.utils import get_client
-from cuml.common import with_cupy_rmm
-
-import dask.array as da
-
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/dask/datasets/regression.py
+++ b/python/cuml/dask/datasets/regression.py
@@ -14,18 +14,16 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.utils import get_client
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.common import with_cupy_rmm
-from cuml.dask.datasets.utils import _create_delayed
-from cuml.dask.datasets.utils import _get_labels
-from cuml.dask.datasets.utils import _get_X
-from cuml.internals.safe_imports import gpu_only_import
 import dask.array as da
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
+from cuml.common import with_cupy_rmm
+from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.common.utils import get_client
+from cuml.dask.datasets.utils import _create_delayed, _get_labels, _get_X
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 def _create_rs_generator(random_state):

--- a/python/cuml/dask/datasets/utils.py
+++ b/python/cuml/dask/datasets/utils.py
@@ -16,6 +16,7 @@
 
 import dask.array as da
 import dask.delayed
+
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/dask/decomposition/base.py
+++ b/python/cuml/dask/decomposition/base.py
@@ -13,19 +13,13 @@
 # limitations under the License.
 #
 
-from cuml.dask.common import raise_exception_from_futures
-from raft_dask.common.comms import get_raft_comm_state
-from raft_dask.common.comms import Comms
-
-from cuml.dask.common.input_utils import to_output
-from cuml.dask.common import parts_to_ranks
-
-from cuml.dask.common.part_utils import flatten_grouped_results
-
 from dask.distributed import wait
+from raft_dask.common.comms import Comms, get_raft_comm_state
 
+from cuml.dask.common import parts_to_ranks, raise_exception_from_futures
 from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.common.input_utils import DistributedDataHandler, to_output
+from cuml.dask.common.part_utils import flatten_grouped_results
 
 
 class BaseDecomposition(BaseEstimator):

--- a/python/cuml/dask/decomposition/pca.py
+++ b/python/cuml/dask/decomposition/pca.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 #
 
-from cuml.dask.decomposition.base import BaseDecomposition
-from cuml.dask.decomposition.base import DecompositionSyncFitMixin
-
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.base import DelayedInverseTransformMixin
+from cuml.dask.common.base import (
+    DelayedInverseTransformMixin,
+    DelayedTransformMixin,
+    mnmg_import,
+)
+from cuml.dask.decomposition.base import (
+    BaseDecomposition,
+    DecompositionSyncFitMixin,
+)
 
 
 class PCA(

--- a/python/cuml/dask/decomposition/tsvd.py
+++ b/python/cuml/dask/decomposition/tsvd.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 #
 
-from cuml.dask.decomposition.base import BaseDecomposition
-from cuml.dask.decomposition.base import DecompositionSyncFitMixin
-
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.base import DelayedInverseTransformMixin
+from cuml.dask.common.base import (
+    DelayedInverseTransformMixin,
+    DelayedTransformMixin,
+    mnmg_import,
+)
+from cuml.dask.decomposition.base import (
+    BaseDecomposition,
+    DecompositionSyncFitMixin,
+)
 
 
 class TruncatedSVD(

--- a/python/cuml/dask/ensemble/__init__.py
+++ b/python/cuml/dask/ensemble/__init__.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 #
 
-from cuml.internals.import_utils import has_dask
 import warnings
+
+from cuml.internals.import_utils import has_dask
 
 if has_dask():
     from cuml.dask.ensemble.randomforestclassifier import (

--- a/python/cuml/dask/ensemble/base.py
+++ b/python/cuml/dask/ensemble/base.py
@@ -13,21 +13,22 @@
 # limitations under the License.
 #
 
-from cuml.fil.fil import TreeliteModel
-from cuml.dask.common.utils import get_client, wait_and_raise_from_futures
-from cuml.dask.common.input_utils import DistributedDataHandler, concatenate
-from dask.distributed import Future
-from collections.abc import Iterable
-from cuml import using_output_type
-import warnings
-from cuml.internals.safe_imports import gpu_only_import
-import dask
 import json
 import math
-from cuml.internals.safe_imports import cpu_only_import
+import warnings
+from collections.abc import Iterable
 
-np = cpu_only_import("numpy")
+import dask
+from dask.distributed import Future
+
+from cuml import using_output_type
+from cuml.dask.common.input_utils import DistributedDataHandler, concatenate
+from cuml.dask.common.utils import get_client, wait_and_raise_from_futures
+from cuml.fil.fil import TreeliteModel
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 class BaseRandomForestModel(object):

--- a/python/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/dask/ensemble/randomforestclassifier.py
@@ -16,19 +16,19 @@
 
 import dask
 from dask.distributed import default_client
-from cuml.dask.ensemble.base import BaseRandomForestModel
+
 from cuml.dask.common.base import (
+    BaseEstimator,
     DelayedPredictionMixin,
     DelayedPredictionProbaMixin,
 )
 from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.ensemble.base import BaseRandomForestModel
 from cuml.ensemble import RandomForestClassifier as cuRFC
-from cuml.dask.common.base import BaseEstimator
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 class RandomForestClassifier(

--- a/python/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/dask/ensemble/randomforestregressor.py
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.ensemble import RandomForestRegressor as cuRFR
-from cuml.dask.ensemble.base import BaseRandomForestModel
-from cuml.dask.common.base import BaseEstimator
-
 import dask
+
+from cuml.dask.common.base import BaseEstimator, DelayedPredictionMixin
+from cuml.dask.ensemble.base import BaseRandomForestModel
+from cuml.ensemble import RandomForestRegressor as cuRFR
 
 
 class RandomForestRegressor(

--- a/python/cuml/dask/extended/linear_model/__init__.py
+++ b/python/cuml/dask/extended/linear_model/__init__.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-from cuml.internals.import_utils import has_daskglm
 import warnings
+
+from cuml.internals.import_utils import has_daskglm
 
 if has_daskglm():
     from cuml.dask.extended.linear_model.logistic_regression import (

--- a/python/cuml/dask/extended/linear_model/logistic_regression.py
+++ b/python/cuml/dask/extended/linear_model/logistic_regression.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 #
 
-from dask.utils import is_dataframe_like, is_series_like, is_arraylike
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.dask.common.base import BaseEstimator
+from dask.utils import is_arraylike, is_dataframe_like, is_series_like
+
 from cuml.common import with_cupy_rmm
+from cuml.dask.common.base import BaseEstimator
 from cuml.internals.import_utils import has_daskglm
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
-from cuml.internals.safe_imports import gpu_only_import
-
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-cudf = gpu_only_import("cudf")
 
 
 class LogisticRegression(BaseEstimator):

--- a/python/cuml/dask/feature_extraction/text/tfidf_transformer.py
+++ b/python/cuml/dask/feature_extraction/text/tfidf_transformer.py
@@ -15,16 +15,14 @@
 #
 
 import dask
-from toolz import first
 import dask.array
+from toolz import first
 
 from cuml.common import with_cupy_rmm
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.utils import wait_and_raise_from_futures
+from cuml.dask.common.base import BaseEstimator, DelayedTransformMixin
 from cuml.dask.common.func import reduce
 from cuml.dask.common.input_utils import DistributedDataHandler
-
+from cuml.dask.common.utils import wait_and_raise_from_futures
 from cuml.feature_extraction.text import TfidfTransformer as s_TfidfTransformer
 
 

--- a/python/cuml/dask/linear_model/__init__.py
+++ b/python/cuml/dask/linear_model/__init__.py
@@ -14,14 +14,15 @@
 # limitations under the License.
 #
 
-from cuml.internals.import_utils import has_dask
 import warnings
 
+from cuml.internals.import_utils import has_dask
+
 if has_dask():
+    from cuml.dask.linear_model.elastic_net import ElasticNet
+    from cuml.dask.linear_model.lasso import Lasso
     from cuml.dask.linear_model.linear_regression import LinearRegression
     from cuml.dask.linear_model.ridge import Ridge
-    from cuml.dask.linear_model.lasso import Lasso
-    from cuml.dask.linear_model.elastic_net import ElasticNet
 else:
     warnings.warn(
         "Dask not found. All Dask-based multi-GPU operation is disabed."

--- a/python/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/dask/linear_model/elastic_net.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.dask.solvers import CD
 from cuml.dask.common.base import BaseEstimator
+from cuml.dask.solvers import CD
 
 
 class ElasticNet(BaseEstimator):

--- a/python/cuml/dask/linear_model/lasso.py
+++ b/python/cuml/dask/linear_model/lasso.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.dask.solvers import CD
 from cuml.dask.common.base import BaseEstimator
+from cuml.dask.solvers import CD
 
 
 class Lasso(BaseEstimator):

--- a/python/cuml/dask/linear_model/linear_regression.py
+++ b/python/cuml/dask/linear_model/linear_regression.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import SyncFitMixinLinearModel
 from raft_dask.common.comms import get_raft_comm_state
+
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedPredictionMixin,
+    SyncFitMixinLinearModel,
+    mnmg_import,
+)
 
 
 class LinearRegression(

--- a/python/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/dask/linear_model/ridge.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import SyncFitMixinLinearModel
 from raft_dask.common.comms import get_raft_comm_state
+
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedPredictionMixin,
+    SyncFitMixinLinearModel,
+    mnmg_import,
+)
 
 
 class Ridge(BaseEstimator, SyncFitMixinLinearModel, DelayedPredictionMixin):

--- a/python/cuml/dask/metrics/__init__.py
+++ b/python/cuml/dask/metrics/__init__.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-from cuml.internals.import_utils import has_dask
 import warnings
+
+from cuml.internals.import_utils import has_dask
 
 if has_dask():
     from cuml.dask.metrics.confusion_matrix import confusion_matrix

--- a/python/cuml/dask/metrics/confusion_matrix.py
+++ b/python/cuml/dask/metrics/confusion_matrix.py
@@ -14,17 +14,16 @@
 # limitations under the License.
 #
 
-from cuml.prims.label import make_monotonic
+from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.common.utils import get_client
 from cuml.dask.metrics.utils import sorted_unique_labels
 from cuml.internals.memory_utils import with_cupy_rmm
-from cuml.dask.common.utils import get_client
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.prims.label import make_monotonic
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 
 
 @with_cupy_rmm

--- a/python/cuml/dask/naive_bayes/naive_bayes.py
+++ b/python/cuml/dask/naive_bayes/naive_bayes.py
@@ -14,19 +14,17 @@
 # limitations under the License.
 #
 
-from cuml.naive_bayes import MultinomialNB as MNB
-from cuml.common import rmm_cupy_ary
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.dask.common.func import tree_reduce
-from cuml.dask.common.func import reduce
-from cuml.dask.common.utils import wait_and_raise_from_futures
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.dask.common.base import BaseEstimator
-from cuml.common import with_cupy_rmm
+import dask
 import dask.array
 from toolz import first
-import dask
+
+from cuml.common import rmm_cupy_ary, with_cupy_rmm
+from cuml.dask.common.base import BaseEstimator, DelayedPredictionMixin
+from cuml.dask.common.func import reduce, tree_reduce
+from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.common.utils import wait_and_raise_from_futures
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.naive_bayes import MultinomialNB as MNB
 
 cp = gpu_only_import("cupy")
 

--- a/python/cuml/dask/neighbors/__init__.py
+++ b/python/cuml/dask/neighbors/__init__.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 #
 
-from cuml.internals.import_utils import has_dask
 import warnings
 
+from cuml.internals.import_utils import has_dask
+
 if has_dask():
-    from cuml.dask.neighbors.nearest_neighbors import NearestNeighbors
     from cuml.dask.neighbors.kneighbors_classifier import KNeighborsClassifier
     from cuml.dask.neighbors.kneighbors_regressor import KNeighborsRegressor
+    from cuml.dask.neighbors.nearest_neighbors import NearestNeighbors
 else:
     warnings.warn(
         "Dask not found. All Dask-based multi-GPU operation is disabed."

--- a/python/cuml/dask/neighbors/kneighbors_classifier.py
+++ b/python/cuml/dask/neighbors/kneighbors_classifier.py
@@ -14,23 +14,24 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.dask.common.input_utils import to_output
-from cuml.dask.common import parts_to_ranks
-from cuml.dask.common import flatten_grouped_results
-from cuml.dask.common.utils import raise_mg_import_exception
-from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft_dask.common.comms import get_raft_comm_state
-from cuml.dask.neighbors import NearestNeighbors
-from dask.dataframe import Series as DaskSeries
-import dask.array as da
 from uuid import uuid1
-from cuml.internals.safe_imports import cpu_only_import
 
+import dask.array as da
+from dask.dataframe import Series as DaskSeries
+from raft_dask.common.comms import get_raft_comm_state
+
+from cuml.dask.common import flatten_grouped_results, parts_to_ranks
+from cuml.dask.common.input_utils import DistributedDataHandler, to_output
+from cuml.dask.common.utils import (
+    raise_mg_import_exception,
+    wait_and_raise_from_futures,
+)
+from cuml.dask.neighbors import NearestNeighbors
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
+cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-cudf = gpu_only_import("cudf")
 
 
 class KNeighborsClassifier(NearestNeighbors):

--- a/python/cuml/dask/neighbors/kneighbors_regressor.py
+++ b/python/cuml/dask/neighbors/kneighbors_regressor.py
@@ -14,16 +14,18 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.dask.common.input_utils import to_output
-from cuml.dask.common import parts_to_ranks
-from cuml.dask.common import flatten_grouped_results
-from cuml.dask.common.utils import raise_mg_import_exception
-from cuml.dask.common.utils import wait_and_raise_from_futures
-from raft_dask.common.comms import get_raft_comm_state
-from cuml.dask.neighbors import NearestNeighbors
-import dask.array as da
 from uuid import uuid1
+
+import dask.array as da
+from raft_dask.common.comms import get_raft_comm_state
+
+from cuml.dask.common import flatten_grouped_results, parts_to_ranks
+from cuml.dask.common.input_utils import DistributedDataHandler, to_output
+from cuml.dask.common.utils import (
+    raise_mg_import_exception,
+    wait_and_raise_from_futures,
+)
+from cuml.dask.neighbors import NearestNeighbors
 
 
 class KNeighborsRegressor(NearestNeighbors):

--- a/python/cuml/dask/neighbors/nearest_neighbors.py
+++ b/python/cuml/dask/neighbors/nearest_neighbors.py
@@ -13,18 +13,18 @@
 # limitations under the License.
 #
 
-from cuml.dask.common import parts_to_ranks
-from cuml.dask.common.utils import wait_and_raise_from_futures
-from cuml.dask.common import flatten_grouped_results
-from cuml.dask.common import raise_mg_import_exception
-from cuml.dask.common.base import BaseEstimator
-
-from raft_dask.common.comms import get_raft_comm_state
-from raft_dask.common.comms import Comms
-from cuml.dask.common.input_utils import to_output
-from cuml.dask.common.input_utils import DistributedDataHandler
-
 from uuid import uuid1
+
+from raft_dask.common.comms import Comms, get_raft_comm_state
+
+from cuml.dask.common import (
+    flatten_grouped_results,
+    parts_to_ranks,
+    raise_mg_import_exception,
+)
+from cuml.dask.common.base import BaseEstimator
+from cuml.dask.common.input_utils import DistributedDataHandler, to_output
+from cuml.dask.common.utils import wait_and_raise_from_futures
 
 
 class NearestNeighbors(BaseEstimator):

--- a/python/cuml/dask/preprocessing/LabelEncoder.py
+++ b/python/cuml/dask/preprocessing/LabelEncoder.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.preprocessing import LabelEncoder as LE
-from cuml.common.exceptions import NotFittedError
-from dask_cudf.core import Series as daskSeries
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.base import DelayedInverseTransformMixin
+from collections.abc import Sequence
 
+from dask_cudf.core import Series as daskSeries
 from toolz import first
 
-from collections.abc import Sequence
+from cuml.common.exceptions import NotFittedError
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedInverseTransformMixin,
+    DelayedTransformMixin,
+)
 from cuml.internals.safe_imports import gpu_only_import_from
+from cuml.preprocessing import LabelEncoder as LE
 
 dcDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
 

--- a/python/cuml/dask/preprocessing/__init__.py
+++ b/python/cuml/dask/preprocessing/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-from cuml.dask.preprocessing.label import LabelBinarizer
 from cuml.dask.preprocessing.encoders import OneHotEncoder
+from cuml.dask.preprocessing.label import LabelBinarizer
 from cuml.dask.preprocessing.LabelEncoder import LabelEncoder
 
 __all__ = [

--- a/python/cuml/dask/preprocessing/encoders.py
+++ b/python/cuml/dask/preprocessing/encoders.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections.abc import Sequence
+
 from dask_cudf.core import Series as daskSeries
-from cuml.common import with_cupy_rmm
-
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedTransformMixin
-from cuml.dask.common.base import DelayedInverseTransformMixin
-
 from toolz import first
 
-from collections.abc import Sequence
+from cuml.common import with_cupy_rmm
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedInverseTransformMixin,
+    DelayedTransformMixin,
+)
 from cuml.internals.safe_imports import gpu_only_import_from
 
 dcDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")

--- a/python/cuml/dask/preprocessing/label.py
+++ b/python/cuml/dask/preprocessing/label.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 #
 
-from cuml.preprocessing.label import LabelBinarizer as LB
-from cuml.dask.common.input_utils import _extract_partitions
-from cuml.dask.common.base import BaseEstimator
+import dask
 
 from cuml.common import rmm_cupy_ary
-
-import dask
+from cuml.dask.common.base import BaseEstimator
+from cuml.dask.common.input_utils import _extract_partitions
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.preprocessing.label import LabelBinarizer as LB
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/dask/solvers/__init__.py
+++ b/python/cuml/dask/solvers/__init__.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 #
 
-from cuml.internals.import_utils import has_dask
 import warnings
+
+from cuml.internals.import_utils import has_dask
 
 if has_dask():
     from cuml.dask.solvers.cd import CD  # NOQA

--- a/python/cuml/dask/solvers/cd.py
+++ b/python/cuml/dask/solvers/cd.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedPredictionMixin
-from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import SyncFitMixinLinearModel
 from raft_dask.common.comms import get_raft_comm_state
+
+from cuml.dask.common.base import (
+    BaseEstimator,
+    DelayedPredictionMixin,
+    SyncFitMixinLinearModel,
+    mnmg_import,
+)
 
 
 class CD(BaseEstimator, SyncFitMixinLinearModel, DelayedPredictionMixin):

--- a/python/cuml/datasets/__init__.py
+++ b/python/cuml/datasets/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 
 from cuml.datasets.arima import make_arima
 from cuml.datasets.blobs import make_blobs
-from cuml.datasets.regression import make_regression
 from cuml.datasets.classification import make_classification
+from cuml.datasets.regression import make_regression

--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,15 +19,19 @@
 import warnings
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
-from cuml.internals.array import CumlArray as cumlArray
 import cuml.internals
+from cuml.internals.array import CumlArray as cumlArray
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
-from cuml.tsa.arima cimport ARIMAOrder
 
 from libc.stdint cimport uint64_t, uintptr_t
+
+from cuml.tsa.arima cimport ARIMAOrder
 
 from random import randint
 

--- a/python/cuml/datasets/blobs.py
+++ b/python/cuml/datasets/blobs.py
@@ -15,13 +15,14 @@
 #
 
 
-from cuml.datasets.utils import _create_rs_generator
-import cuml.internals
-from cuml.internals.safe_imports import cpu_only_import
-import nvtx
 import numbers
 from collections.abc import Iterable
-from cuml.internals.safe_imports import gpu_only_import
+
+import nvtx
+
+import cuml.internals
+from cuml.datasets.utils import _create_rs_generator
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/datasets/classification.py
+++ b/python/cuml/datasets/classification.py
@@ -14,12 +14,11 @@
 #
 
 import nvtx
-from cuml.internals.safe_imports import cpu_only_import
-import cuml.internals
-from cuml.internals.import_utils import has_sklearn
-from cuml.datasets.utils import _create_rs_generator
 
-from cuml.internals.safe_imports import gpu_only_import
+import cuml.internals
+from cuml.datasets.utils import _create_rs_generator
+from cuml.internals.import_utils import has_sklearn
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +17,25 @@
 # distutils: language = c++
 
 import typing
+
 import nvtx
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 import cuml.internals
 from cuml.internals.array import CumlArray
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
 
-from libcpp cimport bool
 from libc.stdint cimport uint64_t, uintptr_t
+from libcpp cimport bool
 
 from random import randint
+
 
 cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML":
     void cpp_make_regression "ML::Datasets::make_regression" (

--- a/python/cuml/decomposition/__init__.py
+++ b/python/cuml/decomposition/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
+from cuml.decomposition.incremental_pca import IncrementalPCA
 from cuml.decomposition.pca import PCA
 from cuml.decomposition.tsvd import TruncatedSVD
-from cuml.decomposition.incremental_pca import IncrementalPCA

--- a/python/cuml/decomposition/base_mg.pyx
+++ b/python/cuml/decomposition/base_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,26 +17,32 @@
 
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libc.stdlib cimport malloc, free
-
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdlib cimport free, malloc
+from libcpp cimport bool
 
-from cuml.internals.array import CumlArray
 import cuml.common.opg_data_utils_mg as opg
 import cuml.internals
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.decomposition.utils cimport *
 from cuml.decomposition.utils_mg cimport *
+
 from cuml.common import input_to_cuml_array
+
 from cuml.common.opg_data_utils_mg cimport *
 
 from enum import IntEnum

--- a/python/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/decomposition/incremental_pca.py
@@ -14,16 +14,15 @@
 # limitations under the License.
 #
 
-from cuml.decomposition import PCA
-from cuml.internals.array import CumlArray
-import cuml.internals
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.common import input_to_cuml_array
-from cuml import Base
-from cuml.internals.safe_imports import cpu_only_import
 import numbers
 
-from cuml.internals.safe_imports import gpu_only_import
+import cuml.internals
+from cuml import Base
+from cuml.common import input_to_cuml_array
+from cuml.decomposition import PCA
+from cuml.internals.array import CumlArray
+from cuml.internals.input_utils import input_to_cupy_array
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/decomposition/pca.pyx
+++ b/python/cuml/decomposition/pca.pyx
@@ -17,9 +17,12 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 cupyx = gpu_only_import('cupyx')
 scipy = cpu_only_import('scipy')
@@ -28,30 +31,37 @@ from enum import IntEnum
 
 rmm = gpu_only_import('rmm')
 
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t
-
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uintptr_t
+from libcpp cimport bool
 
 import cuml.internals
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
-from cuml.common.doc_utils import generate_docstring
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 import cuml.internals.logger as logger
+
 from cuml.decomposition.utils cimport *
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.common.array_descriptor import CumlArrayDescriptor
+
 from cuml.common import using_output_type
-from cuml.prims.stats import cov
-from cuml.internals.input_utils import sparse_scipy_to_cp
+from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.exceptions import NotFittedError
-from cuml.internals.mixins import FMajorInputTagMixin
-from cuml.internals.mixins import SparseInputTagMixin
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
+from cuml.internals.input_utils import (
+    input_to_cuml_array,
+    input_to_cupy_array,
+    sparse_scipy_to_cp,
+)
+from cuml.internals.mixins import FMajorInputTagMixin, SparseInputTagMixin
+from cuml.prims.stats import cov
 
 
 cdef extern from "cuml/decomposition/pca.hpp" namespace "ML":

--- a/python/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/decomposition/pca_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,29 +17,34 @@
 
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from enum import IntEnum
 
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libc.stdlib cimport malloc, free
-
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdlib cimport free, malloc
+from libcpp cimport bool
 
-from cuml.internals.array import CumlArray
 import cuml.common.opg_data_utils_mg as opg
 import cuml.internals
+from cuml.internals.array import CumlArray
 
 from pylibraft.common.handle cimport handle_t
 
 from cuml.internals.base import Base
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.decomposition import PCA
 from cuml.decomposition.base_mg import BaseDecompositionMG, MGSolver
+
 from cuml.decomposition.utils cimport *
 from cuml.decomposition.utils_mg cimport *
 

--- a/python/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/decomposition/tsvd.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,27 +17,34 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from enum import IntEnum
 
 from cuml.internals.safe_imports import gpu_only_import
-rmm = gpu_only_import('rmm')
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t
 
+rmm = gpu_only_import('rmm')
+from libc.stdint cimport uintptr_t
+from libcpp cimport bool
 
 from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.decomposition.utils cimport *
+
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
 from cuml.internals.mixins import FMajorInputTagMixin
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
 
 from cython.operator cimport dereference as deref
 

--- a/python/cuml/decomposition/tsvd_mg.pyx
+++ b/python/cuml/decomposition/tsvd_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,30 +16,32 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libc.stdlib cimport malloc, free
-
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
-
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdlib cimport free, malloc
+from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
-import cuml.internals
 import cuml.common.opg_data_utils_mg as opg
-
+import cuml.internals
 from cuml.internals.base import Base
+
 from cuml.common.opg_data_utils_mg cimport *
 from cuml.decomposition.utils cimport *
 from cuml.decomposition.utils_mg cimport *
 
 from cuml.decomposition import TruncatedSVD
 from cuml.decomposition.base_mg import BaseDecompositionMG
+
 
 cdef extern from "cuml/decomposition/tsvd_mg.hpp" namespace "ML::TSVD::opg":
 

--- a/python/cuml/decomposition/utils_mg.pxd
+++ b/python/cuml/decomposition/utils_mg.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 from libcpp cimport bool
+
 from cuml.decomposition.utils cimport *
+
 
 cdef extern from "cuml/decomposition/params.hpp" namespace "ML" nogil:
 

--- a/python/cuml/ensemble/__init__.py
+++ b/python/cuml/ensemble/__init__.py
@@ -15,9 +15,9 @@
 #
 
 
-from cuml.ensemble.randomforestclassifier import RandomForestClassifier
-from cuml.ensemble.randomforestregressor import RandomForestRegressor
 from cuml.ensemble.randomforest_common import (
     _check_fil_parameter_validity,
     _obtain_fil_model,
 )
+from cuml.ensemble.randomforestclassifier import RandomForestClassifier
+from cuml.ensemble.randomforestregressor import RandomForestRegressor

--- a/python/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/ensemble/randomforest_common.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,31 +14,39 @@
 # limitations under the License.
 #
 import ctypes
+
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 import math
-import warnings
 import typing
+import warnings
 from inspect import signature
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
-from cuml import ForestInference
-from cuml.fil.fil import TreeliteModel
 from pylibraft.common.handle import Handle
-from cuml.internals.base import Base
-from cuml.internals.array import CumlArray
-from cuml.common.exceptions import NotFittedError
+
 import cuml.internals
+from cuml import ForestInference
+from cuml.common.exceptions import NotFittedError
+from cuml.fil.fil import TreeliteModel
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
 
 from cython.operator cimport dereference as deref
 
-from cuml.ensemble.randomforest_shared import treelite_serialize, \
-    treelite_deserialize
+from cuml.ensemble.randomforest_shared import (
+    treelite_deserialize,
+    treelite_serialize,
+)
+
 from cuml.ensemble.randomforest_shared cimport *
+
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.prims.label.classlabels import make_monotonic, check_labels
+from cuml.prims.label.classlabels import check_labels, make_monotonic
 
 
 class BaseRandomForestModel(Base):

--- a/python/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/ensemble/randomforest_shared.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,20 +16,25 @@
 
 import ctypes
 import math
-import numpy as np
 import warnings
 
+import numpy as np
+
+from libc.stdint cimport uint64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint64_t
-from libc.stdlib cimport calloc, malloc, free
-from libcpp.vector cimport vector
 from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 from pylibraft.common.handle import Handle
+
 from cuml import ForestInference
 from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 cimport cuml.common.cuda
+
 
 cdef extern from "treelite/c_api.h":
     ctypedef void* ModelHandle

--- a/python/cuml/ensemble/randomforest_shared.pyx
+++ b/python/cuml/ensemble/randomforest_shared.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 # distutils: language = c++
 
-from libcpp.vector cimport vector
-from cython.operator cimport dereference as deref, preincrement as inc
 from cpython.object cimport PyObject
+from cython.operator cimport dereference as deref
+from cython.operator cimport preincrement as inc
 from libc.stdint cimport uintptr_t
 from libcpp.memory cimport unique_ptr
-from typing import Tuple, Dict, List, Union
+from libcpp.vector cimport vector
+
+from typing import Dict, List, Tuple, Union
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 cdef extern from "treelite/tree.h" namespace "treelite":

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -1,6 +1,6 @@
 
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,44 +17,48 @@
 
 # distutils: language = c++
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import nvtx
+
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 import warnings
 
-import cuml.internals.logger as logger
+from pylibraft.common.handle import Handle
 
+import cuml.internals
+import cuml.internals.logger as logger
 from cuml import ForestInference
+from cuml.common import input_to_cuml_array
+from cuml.common.doc_utils import generate_docstring, insert_into_docstring
+from cuml.ensemble.randomforest_common import (
+    BaseRandomForestModel,
+    _obtain_fil_model,
+)
 from cuml.internals.array import CumlArray
 from cuml.internals.mixins import ClassifierMixin
-import cuml.internals
-from cuml.common.doc_utils import generate_docstring
-from cuml.common.doc_utils import insert_into_docstring
-from pylibraft.common.handle import Handle
-from cuml.common import input_to_cuml_array
 
-from cuml.ensemble.randomforest_common import BaseRandomForestModel
-from cuml.ensemble.randomforest_common import _obtain_fil_model
 from cuml.ensemble.randomforest_shared cimport *
 
 from cuml.fil.fil import TreeliteModel
 
 from cython.operator cimport dereference as deref
-
+from libc.stdint cimport uint64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
 from libcpp.vector cimport vector
-from libc.stdint cimport uintptr_t, uint64_t
-from libc.stdlib cimport calloc, malloc, free
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 from cuml.prims.label.classlabels import check_labels, invert_labels
 
-from pylibraft.common.handle cimport handle_t
-cimport cuml.common.cuda
-
 cimport cython
+from pylibraft.common.handle cimport handle_t
+
+cimport cuml.common.cuda
 
 
 cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":

--- a/python/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/ensemble/randomforestregressor.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,44 +17,47 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import nvtx
+
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 import warnings
 
-import cuml.internals.logger as logger
-
-from cuml import ForestInference
-from cuml.internals.array import CumlArray
-import cuml.internals
-
-from cuml.internals.mixins import RegressorMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.common.doc_utils import insert_into_docstring
 from pylibraft.common.handle import Handle
-from cuml.common import input_to_cuml_array
 
-from cuml.ensemble.randomforest_common import BaseRandomForestModel
-from cuml.ensemble.randomforest_common import _obtain_fil_model
+import cuml.internals
+import cuml.internals.logger as logger
+from cuml import ForestInference
+from cuml.common import input_to_cuml_array
+from cuml.common.doc_utils import generate_docstring, insert_into_docstring
+from cuml.ensemble.randomforest_common import (
+    BaseRandomForestModel,
+    _obtain_fil_model,
+)
+from cuml.internals.array import CumlArray
+from cuml.internals.mixins import RegressorMixin
+
 from cuml.ensemble.randomforest_shared cimport *
 
 from cuml.fil.fil import TreeliteModel
 
 from cython.operator cimport dereference as deref
-
+from libc.stdint cimport uint64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
 from libcpp.vector cimport vector
-from libc.stdint cimport uintptr_t, uint64_t
-from libc.stdlib cimport calloc, malloc, free
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
-from pylibraft.common.handle cimport handle_t
-cimport cuml.common.cuda
-
 cimport cython
+from pylibraft.common.handle cimport handle_t
+
+cimport cuml.common.cuda
 
 
 cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":

--- a/python/cuml/experimental/hyperopt_utils/plotting_utils.py
+++ b/python/cuml/experimental/hyperopt_utils/plotting_utils.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-import seaborn as sns
 import matplotlib.pyplot as plt
+import seaborn as sns
+
 from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")

--- a/python/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/experimental/linear_model/lars.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,27 +20,32 @@
 # cython: language_level = 3
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 import warnings
-import cuml.internals.logger as logger
-import cuml.internals
-
 from collections import defaultdict
 
-from libcpp cimport bool, nullptr
+import cuml.internals
+import cuml.internals.logger as logger
+
 from libc.stdint cimport uintptr_t
+from libcpp cimport bool, nullptr
 
 from cuml.common import input_to_cuml_array
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import Base
-from cuml.internals.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.exceptions import NotFittedError
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+from cuml.internals.mixins import RegressorMixin
+
 from pylibraft.common.handle cimport handle_t
+
 
 cdef extern from "cuml/solvers/lars.hpp" namespace "ML::Solver::Lars":
 

--- a/python/cuml/explainer/base.pyx
+++ b/python/cuml/explainer/base.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,30 +15,33 @@
 #
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cudf = gpu_only_import('cudf')
 import cuml.internals
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 pandas = cpu_only_import('pandas')
 
 import cuml.internals.logger as logger
+from cuml.explainer.common import (
+    get_dtype_from_model_func,
+    get_handle_from_cuml_model_func,
+    get_link_fn_from_str_or_fn,
+    get_tag_from_model_func,
+    model_func_call,
+    output_list_shap_values,
+)
 from cuml.internals.import_utils import has_shap
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.internals.input_utils import input_to_host_array
-from cuml.internals.logger import debug
-from cuml.internals.logger import warn
-from cuml.explainer.common import get_dtype_from_model_func
-from cuml.explainer.common import get_handle_from_cuml_model_func
-from cuml.explainer.common import get_link_fn_from_str_or_fn
-from cuml.explainer.common import get_tag_from_model_func
-from cuml.explainer.common import model_func_call
-from cuml.explainer.common import output_list_shap_values
+from cuml.internals.input_utils import input_to_cupy_array, input_to_host_array
+from cuml.internals.logger import debug, warn
 
-from pylibraft.common.handle cimport handle_t
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
 
 
 cdef extern from "cuml/explainer/permutation_shap.hpp" namespace "ML":

--- a/python/cuml/explainer/common.py
+++ b/python/cuml/explainer/common.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
+from pylibraft.common.handle import Handle
+
 from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cupy_array
-from pylibraft.common.handle import Handle
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/explainer/kernel_shap.pyx
+++ b/python/cuml/explainer/kernel_shap.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,28 +16,31 @@
 
 import cuml.internals.logger as logger
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import time
-
-from cuml.internals.import_utils import has_sklearn
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.explainer.base import SHAPBase
-from cuml.explainer.common import get_cai_ptr
-from cuml.explainer.common import model_func_call
-from cuml.explainer.common import output_list_shap_values
-from cuml.linear_model import Lasso
-from cuml.linear_model import LinearRegression
-from pylibraft.common.handle import Handle
 from functools import lru_cache
 from itertools import combinations
 from numbers import Number
 from random import randint
 
+from pylibraft.common.handle import Handle
+
+from cuml.explainer.base import SHAPBase
+from cuml.explainer.common import (
+    get_cai_ptr,
+    model_func_call,
+    output_list_shap_values,
+)
+from cuml.internals.import_utils import has_sklearn
+from cuml.internals.input_utils import input_to_cupy_array
+from cuml.linear_model import Lasso, LinearRegression
+
+from libc.stdint cimport uint64_t, uintptr_t
 from pylibraft.common.handle cimport handle_t
-from libc.stdint cimport uintptr_t
-from libc.stdint cimport uint64_t
 
 
 cdef extern from "cuml/explainer/kernel_shap.hpp" namespace "ML":

--- a/python/cuml/explainer/permutation_shap.pyx
+++ b/python/cuml/explainer/permutation_shap.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,27 +16,34 @@
 
 import cuml
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import time
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cu_df = gpu_only_import_from('cudf', 'DataFrame')
+from cuml.explainer.base import SHAPBase
+from cuml.explainer.common import (
+    get_cai_ptr,
+    get_dtype_from_model_func,
+    get_tag_from_model_func,
+    model_func_call,
+)
 from cuml.internals.array import CumlArray
 from cuml.internals.input_utils import input_to_cupy_array
-from cuml.explainer.base import SHAPBase
-from cuml.explainer.common import get_cai_ptr
-from cuml.explainer.common import get_dtype_from_model_func
-from cuml.explainer.common import get_tag_from_model_func
-from cuml.explainer.common import model_func_call
+
 cuda = gpu_only_import_from('numba', 'cuda')
 from cuml.internals.safe_imports import cpu_only_import_from
+
 pd_df = cpu_only_import_from('pandas', 'DataFrame')
 
-from pylibraft.common.handle cimport handle_t
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
 
 
 cdef extern from "cuml/explainer/permutation_shap.hpp" namespace "ML":

--- a/python/cuml/explainer/sampling.py
+++ b/python/cuml/explainer/sampling.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.preprocessing import SimpleImputer
+import cuml
+from cuml import KMeans
 from cuml.internals.input_utils import (
     determine_array_type,
     get_supported_input_type,
 )
-from cuml import KMeans
-import cuml
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import_from, gpu_only_import
+from cuml.preprocessing import SimpleImputer
 
 cp = gpu_only_import("cupy")
 issparse = cpu_only_import_from("scipy.sparse", "issparse")

--- a/python/cuml/explainer/tree_shap.pyx
+++ b/python/cuml/explainer/tree_shap.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,22 +15,25 @@
 #
 
 from cuml.common import input_to_cuml_array
+from cuml.ensemble import RandomForestClassifier as curfc
+from cuml.ensemble import RandomForestRegressor as curfr
+from cuml.fil.fil import TreeliteModel
 from cuml.internals.array import CumlArray
 from cuml.internals.import_utils import has_sklearn
 from cuml.internals.input_utils import determine_array_type
-from cuml.fil.fil import TreeliteModel
-from cuml.ensemble import RandomForestRegressor as curfr
-from cuml.ensemble import RandomForestClassifier as curfc
 
 from libc.stdint cimport uintptr_t
+
 import re
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import treelite
 
 if has_sklearn():
-    from sklearn.ensemble import RandomForestRegressor as sklrfr
     from sklearn.ensemble import RandomForestClassifier as sklrfc
+    from sklearn.ensemble import RandomForestRegressor as sklrfr
 else:
     sklrfr = object
     sklrfc = object

--- a/python/cuml/feature_extraction/__init__.py
+++ b/python/cuml/feature_extraction/__init__.py
@@ -16,5 +16,4 @@
 
 from . import text
 
-
 __all__ = ["text"]

--- a/python/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/feature_extraction/_tfidf.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml import Base
-from cuml.internals.array import CumlArray
-from cuml.common.sparsefuncs import csr_diag_mul
-from cuml.common.sparsefuncs import csr_row_normalize_l1, csr_row_normalize_l2
 import cuml.internals
+from cuml import Base
 from cuml.common.exceptions import NotFittedError
+from cuml.common.sparsefuncs import (
+    csr_diag_mul,
+    csr_row_normalize_l1,
+    csr_row_normalize_l2,
+)
+from cuml.internals.array import CumlArray
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/feature_extraction/_tfidf_vectorizer.py
+++ b/python/cuml/feature_extraction/_tfidf_vectorizer.py
@@ -26,9 +26,8 @@
 #    License: BSD 3 clause
 #
 
-from cuml.feature_extraction._vectorizers import CountVectorizer
 from cuml.feature_extraction._tfidf import TfidfTransformer
-
+from cuml.feature_extraction._vectorizers import CountVectorizer
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -12,24 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.internals.safe_imports import cpu_only_import
-import cuml.internals.logger as logger
-from cudf.utils.dtypes import min_signed_type
-from cuml.internals.type_utils import CUPY_SPARSE_DTYPES
 import numbers
-from cuml.internals.safe_imports import gpu_only_import
 from functools import partial
-from cuml.common.sparsefuncs import create_csr_matrix_from_count_df
-from cuml.common.sparsefuncs import csr_row_normalize_l1, csr_row_normalize_l2
-from cuml.feature_extraction._stop_words import ENGLISH_STOP_WORDS
+
+from cudf.utils.dtypes import min_signed_type
+
+import cuml.internals.logger as logger
 from cuml.common.exceptions import NotFittedError
-from cuml.internals.safe_imports import gpu_only_import_from
+from cuml.common.sparsefuncs import (
+    create_csr_matrix_from_count_df,
+    csr_row_normalize_l1,
+    csr_row_normalize_l2,
+)
+from cuml.feature_extraction._stop_words import ENGLISH_STOP_WORDS
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.internals.type_utils import CUPY_SPARSE_DTYPES
 
-Series = gpu_only_import_from("cudf", "Series")
-
-cp = gpu_only_import("cupy")
 cudf = gpu_only_import("cudf")
+cp = gpu_only_import("cupy")
 pd = cpu_only_import("pandas")
+Series = gpu_only_import_from("cudf", "Series")
 
 
 def _preprocess(

--- a/python/cuml/feature_extraction/text.py
+++ b/python/cuml/feature_extraction/text.py
@@ -18,19 +18,16 @@
 The following imports are needed so that we can import those classes
 from cuml.feature_extraction.text just like scikit-learn. Do not remove.
 """
-from cuml.feature_extraction._tfidf import (
+from cuml.feature_extraction._tfidf import (  # noqa # pylint: disable=unused-import
     TfidfTransformer,
-)  # noqa # pylint: disable=unused-import
-from cuml.feature_extraction._tfidf_vectorizer import (
+)
+from cuml.feature_extraction._tfidf_vectorizer import (  # noqa # pylint: disable=unused-import
     TfidfVectorizer,
-)  # noqa # pylint: disable=unused-import
-from cuml.feature_extraction._vectorizers import (
+)
+from cuml.feature_extraction._vectorizers import (  # noqa # pylint: disable=unused-import
     CountVectorizer,
-)  # noqa # pylint: disable=unused-import
-from cuml.feature_extraction._vectorizers import (
     HashingVectorizer,
-)  # noqa # pylint: disable=unused-import
-
+)
 
 __all__ = [
     "CountVectorizer",

--- a/python/cuml/fil/__init__.py
+++ b/python/cuml/fil/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-from cuml.fil.fil import ForestInference
 from cuml.fil import fil
+from cuml.fil.fil import ForestInference

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,34 +19,44 @@
 import copy
 import ctypes
 import math
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import warnings
+
 pd = cpu_only_import('pandas')
 from inspect import getdoc
 
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdlib cimport calloc, free, malloc
+from libcpp cimport bool
 
 import cuml.internals
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common import input_to_cuml_array
+from cuml.common.doc_utils import _parameters_docstrings
 from cuml.internals import logger
 from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.common.doc_utils import _parameters_docstrings
-from rmm._lib.memory_resource cimport DeviceMemoryResource
-from rmm._lib.memory_resource cimport get_current_device_resource
+
+from rmm._lib.memory_resource cimport (
+    DeviceMemoryResource,
+    get_current_device_resource,
+)
 
 import treelite
 import treelite.sklearn as tl_skl
 
 cimport cuml.common.cuda
+
 
 cdef extern from "treelite/c_api.h":
     ctypedef void* ModelHandle

--- a/python/cuml/internals/__init__.py
+++ b/python/cuml/internals/__init__.py
@@ -14,16 +14,20 @@
 # limitations under the License.
 #
 
-from cuml.internals.base_helpers import BaseMetaClass, _tags_class_and_instance
+from cuml.internals.api_context_managers import (
+    in_internal_api,
+    set_api_output_dtype,
+    set_api_output_type,
+)
 from cuml.internals.api_decorators import (
     _deprecate_pos_args,
     api_base_fit_transform,
-    api_base_return_any_skipall,
     api_base_return_any,
-    api_base_return_array_skipall,
+    api_base_return_any_skipall,
     api_base_return_array,
-    api_base_return_generic_skipall,
+    api_base_return_array_skipall,
     api_base_return_generic,
+    api_base_return_generic_skipall,
     api_base_return_sparse_array,
     api_return_any,
     api_return_array,
@@ -31,10 +35,6 @@ from cuml.internals.api_decorators import (
     api_return_sparse_array,
     exit_internal_api,
 )
-from cuml.internals.api_context_managers import (
-    in_internal_api,
-    set_api_output_dtype,
-    set_api_output_type,
-)
-from cuml.internals.internals import GraphBasedDimRedCallback
+from cuml.internals.base_helpers import BaseMetaClass, _tags_class_and_instance
 from cuml.internals.constants import CUML_WRAPPED_FLAG
+from cuml.internals.internals import GraphBasedDimRedCallback

--- a/python/cuml/internals/api_context_managers.py
+++ b/python/cuml/internals/api_context_managers.py
@@ -25,16 +25,16 @@ except ImportError:
 
 import cuml.internals.input_utils
 import cuml.internals.memory_utils
-
 from cuml.internals.array_sparse import SparseCumlArray
 
 if TYPE_CHECKING:
     from cuml.internals.base import Base
+
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.safe_imports import (
-    gpu_only_import_from,
     UnavailableNullContext,
+    gpu_only_import_from,
 )
 
 cupy_using_allocator = gpu_only_import_from(

--- a/python/cuml/internals/api_decorators.py
+++ b/python/cuml/internals/api_decorators.py
@@ -22,22 +22,24 @@ import warnings
 
 # TODO: Try to resolve circular import that makes this necessary:
 from cuml.internals import input_utils as iu
-from cuml.internals.api_context_managers import BaseReturnAnyCM
-from cuml.internals.api_context_managers import BaseReturnArrayCM
-from cuml.internals.api_context_managers import BaseReturnGenericCM
-from cuml.internals.api_context_managers import BaseReturnSparseArrayCM
-from cuml.internals.api_context_managers import InternalAPIContextBase
-from cuml.internals.api_context_managers import ReturnAnyCM
-from cuml.internals.api_context_managers import ReturnArrayCM
-from cuml.internals.api_context_managers import ReturnGenericCM
-from cuml.internals.api_context_managers import ReturnSparseArrayCM
-from cuml.internals.api_context_managers import set_api_output_dtype
-from cuml.internals.api_context_managers import set_api_output_type
+from cuml.internals import logger
+from cuml.internals.api_context_managers import (
+    BaseReturnAnyCM,
+    BaseReturnArrayCM,
+    BaseReturnGenericCM,
+    BaseReturnSparseArrayCM,
+    InternalAPIContextBase,
+    ReturnAnyCM,
+    ReturnArrayCM,
+    ReturnGenericCM,
+    ReturnSparseArrayCM,
+    set_api_output_dtype,
+    set_api_output_type,
+)
 from cuml.internals.constants import CUML_WRAPPED_FLAG
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.memory_utils import using_output_type
 from cuml.internals.type_utils import _DecoratorType, wraps_typed
-from cuml.internals import logger
 
 
 def _wrap_once(wrapped, *args, **kwargs):

--- a/python/cuml/internals/array.py
+++ b/python/cuml/internals/array.py
@@ -18,6 +18,7 @@
 import copy
 import operator
 import pickle
+from typing import Tuple
 
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.logger import debug
@@ -33,34 +34,33 @@ from cuml.internals.safe_imports import (
     safe_import,
     safe_import_from,
 )
-from typing import Tuple
+
+cached_property = safe_import_from(
+    "functools", "cached_property", alt=null_decorator
+)
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-rmm = gpu_only_import("rmm")
 host_xpy = safe_import("numpy", alt=cp)
-
-cuda = gpu_only_import_from("numba", "cuda")
-cached_property = safe_import_from(
-    "functools", "cached_property", alt=null_decorator
-)
-CudfBuffer = gpu_only_import_from("cudf.core.buffer", "Buffer")
+rmm = gpu_only_import("rmm")
 CudfDataFrame = gpu_only_import_from("cudf", "DataFrame")
 CudfIndex = gpu_only_import_from("cudf", "Index")
 CudfSeries = gpu_only_import_from("cudf", "Series")
-DaskCudfDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
-DaskCudfSeries = gpu_only_import_from("dask_cudf.core", "Series")
+CudfBuffer = gpu_only_import_from("cudf.core.buffer", "Buffer")
 DaskDataFrame = gpu_only_import_from("dask.dataframe", "DataFrame")
 DaskSeries = gpu_only_import_from("dask.dataframe", "Series")
-DeviceBuffer = gpu_only_import_from("rmm", "DeviceBuffer")
+DaskCudfDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
+DaskCudfSeries = gpu_only_import_from("dask_cudf.core", "Series")
+cuda = gpu_only_import_from("numba", "cuda")
+is_numba_array = gpu_only_import_from(
+    "numba.cuda", "is_cuda_array", alt=return_false
+)
 nvtx_annotate = gpu_only_import_from("nvtx", "annotate", alt=null_decorator)
 PandasDataFrame = cpu_only_import_from("pandas", "DataFrame")
 PandasIndex = cpu_only_import_from("pandas", "Index")
 PandasSeries = cpu_only_import_from("pandas", "Series")
-is_numba_array = gpu_only_import_from(
-    "numba.cuda", "is_cuda_array", alt=return_false
-)
+DeviceBuffer = gpu_only_import_from("rmm", "DeviceBuffer")
 
 
 def _order_to_strides(order, shape, dtype):

--- a/python/cuml/internals/array_sparse.py
+++ b/python/cuml/internals/array_sparse.py
@@ -15,20 +15,21 @@
 #
 from cuml.internals.array import CumlArray
 from cuml.internals.global_settings import GlobalSettings
+from cuml.internals.logger import debug
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.memory_utils import class_with_cupy_rmm
-from cuml.internals.logger import debug
 from cuml.internals.safe_imports import (
+    UnavailableError,
     cpu_only_import,
     gpu_only_import,
     gpu_only_import_from,
     null_decorator,
-    UnavailableError,
 )
 
 cpx_sparse = gpu_only_import("cupyx.scipy.sparse")
-nvtx_annotate = gpu_only_import_from("nvtx", "annotate", alt=null_decorator)
 scipy_sparse = cpu_only_import("scipy.sparse")
+nvtx_annotate = gpu_only_import_from("nvtx", "annotate", alt=null_decorator)
+
 
 sparse_matrix_classes = []
 try:

--- a/python/cuml/internals/available_devices.py
+++ b/python/cuml/internals/available_devices.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 from cuml.internals.device_support import GPU_ENABLED
-from cuml.internals.safe_imports import gpu_only_import_from, UnavailableError
+from cuml.internals.safe_imports import UnavailableError, gpu_only_import_from
+
+get_cuda_count = gpu_only_import_from("rmm._cuda.gpu", "getDeviceCount")
+
 
 try:
     from functools import cache  # requires Python >= 3.9
@@ -22,9 +25,6 @@ except ImportError:
     from functools import lru_cache
 
     cache = lru_cache(maxsize=None)
-
-
-get_cuda_count = gpu_only_import_from("rmm._cuda.gpu", "getDeviceCount")
 
 
 @cache

--- a/python/cuml/internals/base.pyx
+++ b/python/cuml/internals/base.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,43 +16,45 @@
 
 # distutils: language = c++
 
-import os
 import inspect
+import os
 from importlib import import_module
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
-import nvtx
 import typing
+
+import nvtx
+import pylibraft.common.handle
 
 import cuml
 import cuml.common
 import cuml.common.cuda
-import cuml.internals.logger as logger
 import cuml.internals
-import pylibraft.common.handle
 import cuml.internals.input_utils
+import cuml.internals.logger as logger
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.available_devices import is_cuda_available
 from cuml.internals.device_type import DeviceType
 from cuml.internals.input_utils import (
     determine_array_type,
     input_to_cuml_array,
-    input_to_host_array
+    input_to_host_array,
 )
-from cuml.internals.memory_utils import determine_array_memtype
 from cuml.internals.mem_type import MemoryType
-from cuml.internals.memory_utils import using_memory_type
+from cuml.internals.memory_utils import (
+    determine_array_memtype,
+    using_memory_type,
+)
+from cuml.internals.mixins import TagsMixin
 from cuml.internals.output_type import (
     INTERNAL_VALID_OUTPUT_TYPES,
-    VALID_OUTPUT_TYPES
+    VALID_OUTPUT_TYPES,
 )
-from cuml.internals.array import CumlArray
-from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.safe_imports import (
-    gpu_only_import, gpu_only_import_from
-)
-
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import TagsMixin
+from cuml.internals.safe_imports import gpu_only_import, gpu_only_import_from
 
 cp_ndarray = gpu_only_import_from('cupy', 'ndarray')
 cp = gpu_only_import('cupy')

--- a/python/cuml/internals/base_helpers.py
+++ b/python/cuml/internals/base_helpers.py
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
-from inspect import Parameter, signature
 import typing
+from inspect import Parameter, signature
 
 from cuml.internals.api_decorators import (
-    api_base_return_generic,
-    api_base_return_array,
-    api_base_return_sparse_array,
-    api_base_return_any,
-    api_return_any,
     _deprecate_pos_args,
+    api_base_return_any,
+    api_base_return_array,
+    api_base_return_generic,
+    api_base_return_sparse_array,
+    api_return_any,
 )
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray

--- a/python/cuml/internals/base_return_types.py
+++ b/python/cuml/internals/base_return_types.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-import cuml.internals
 import typing
 
+import cuml.internals
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
 

--- a/python/cuml/internals/device_type.py
+++ b/python/cuml/internals/device_type.py
@@ -16,6 +16,7 @@
 
 
 from enum import Enum, auto
+
 from cuml.internals.mem_type import MemoryType
 
 

--- a/python/cuml/internals/global_settings.py
+++ b/python/cuml/internals/global_settings.py
@@ -16,6 +16,7 @@
 
 import os
 import threading
+
 from cuml.internals.available_devices import is_cuda_available
 from cuml.internals.device_type import DeviceType
 from cuml.internals.logger import warn

--- a/python/cuml/internals/import_utils.py
+++ b/python/cuml/internals/import_utils.py
@@ -15,9 +15,9 @@
 #
 
 
-from cuml.internals.safe_imports import gpu_only_import, UnavailableError
 from distutils.version import LooseVersion
 
+from cuml.internals.safe_imports import UnavailableError, gpu_only_import
 
 numba = gpu_only_import("numba")
 
@@ -25,8 +25,8 @@ numba = gpu_only_import("numba")
 def has_dask():
     try:
         import dask  # NOQA
-        import dask.distributed  # NOQA
         import dask.dataframe  # NOQA
+        import dask.distributed  # NOQA
 
         return True
     except ImportError:

--- a/python/cuml/internals/input_utils.py
+++ b/python/cuml/internals/input_utils.py
@@ -21,49 +21,51 @@ from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.safe_imports import (
+    UnavailableError,
     cpu_only_import,
     cpu_only_import_from,
     gpu_only_import,
     gpu_only_import_from,
-    safe_import,
-    safe_import_from,
     null_decorator,
     return_false,
-    UnavailableError,
+    safe_import,
+    safe_import_from,
 )
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
-global_settings = GlobalSettings()
 numba_cuda = gpu_only_import("numba.cuda")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
 scipy_sparse = safe_import(
     "scipy.sparse", msg="Optional dependency scipy is not installed"
 )
-
-cp_ndarray = gpu_only_import_from("cupy", "ndarray")
-CudfSeries = gpu_only_import_from("cudf", "Series")
 CudfDataFrame = gpu_only_import_from("cudf", "DataFrame")
-DaskCudfSeries = gpu_only_import_from("dask_cudf.core", "Series")
+CudfSeries = gpu_only_import_from("cudf", "Series")
+cp_ndarray = gpu_only_import_from("cupy", "ndarray")
+cupyx_isspmatrix = gpu_only_import_from(
+    "cupyx.scipy.sparse", "isspmatrix", alt=return_false
+)
 DaskCudfDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
-np_ndarray = cpu_only_import_from("numpy", "ndarray")
+DaskCudfSeries = gpu_only_import_from("dask_cudf.core", "Series")
 numba_devicearray = gpu_only_import_from("numba.cuda", "devicearray")
+np_ndarray = cpu_only_import_from("numpy", "ndarray")
+nvtx_annotate = gpu_only_import_from("nvtx", "annotate", alt=null_decorator)
+PandasDataFrame = cpu_only_import_from("pandas", "DataFrame")
+PandasSeries = cpu_only_import_from("pandas", "Series")
+scipy_isspmatrix = safe_import_from(
+    "scipy.sparse", "isspmatrix", alt=return_false
+)
+
+
+global_settings = GlobalSettings()
+
 try:
     NumbaDeviceNDArrayBase = numba_devicearray.DeviceNDArrayBase
 except UnavailableError:
     NumbaDeviceNDArrayBase = numba_devicearray
-scipy_isspmatrix = safe_import_from(
-    "scipy.sparse", "isspmatrix", alt=return_false
-)
-cupyx_isspmatrix = gpu_only_import_from(
-    "cupyx.scipy.sparse", "isspmatrix", alt=return_false
-)
 
-nvtx_annotate = gpu_only_import_from("nvtx", "annotate", alt=null_decorator)
-PandasSeries = cpu_only_import_from("pandas", "Series")
-PandasDataFrame = cpu_only_import_from("pandas", "DataFrame")
 
 cuml_array = namedtuple("cuml_array", "array n_rows n_cols dtype")
 

--- a/python/cuml/internals/logger.pyx
+++ b/python/cuml/internals/logger.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 
 import sys
 
-from libcpp.string cimport string
 from libcpp cimport bool
+from libcpp.string cimport string
 
 
 cdef extern from "cuml/common/logger.hpp" namespace "ML" nogil:

--- a/python/cuml/internals/mem_type.py
+++ b/python/cuml/internals/mem_type.py
@@ -16,6 +16,7 @@
 
 
 from enum import Enum, auto
+
 from cuml.internals.device_support import GPU_ENABLED
 from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 

--- a/python/cuml/internals/memory_utils.py
+++ b/python/cuml/internals/memory_utils.py
@@ -19,26 +19,26 @@ import operator
 import re
 from functools import wraps
 
-from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.device_support import GPU_ENABLED
+from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.output_type import (
     INTERNAL_VALID_OUTPUT_TYPES,
     VALID_OUTPUT_TYPES,
 )
 from cuml.internals.safe_imports import (
+    UnavailableNullContext,
     cpu_only_import_from,
     gpu_only_import_from,
-    UnavailableNullContext,
 )
 
-CudfSeries = gpu_only_import_from("cudf", "Series")
 CudfDataFrame = gpu_only_import_from("cudf", "DataFrame")
+CudfSeries = gpu_only_import_from("cudf", "Series")
 cupy_using_allocator = gpu_only_import_from(
     "cupy.cuda", "using_allocator", alt=UnavailableNullContext
 )
-PandasSeries = cpu_only_import_from("pandas", "Series")
 PandasDataFrame = cpu_only_import_from("pandas", "DataFrame")
+PandasSeries = cpu_only_import_from("pandas", "Series")
 rmm_cupy_allocator = gpu_only_import_from("rmm", "rmm_cupy_allocator")
 
 

--- a/python/cuml/internals/mixins.py
+++ b/python/cuml/internals/mixins.py
@@ -15,13 +15,14 @@
 #
 
 import inspect
-
 from copy import deepcopy
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.api_decorators import api_base_return_any_skipall
-from cuml.internals.base_helpers import _tags_class_and_instance
-from cuml.internals.api_decorators import enable_device_interop
 
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.api_decorators import (
+    api_base_return_any_skipall,
+    enable_device_interop,
+)
+from cuml.internals.base_helpers import _tags_class_and_instance
 
 ###############################################################################
 #                          Tag Functionality Mixin                            #

--- a/python/cuml/internals/safe_imports.py
+++ b/python/cuml/internals/safe_imports.py
@@ -17,8 +17,9 @@
 
 import importlib
 import traceback
-from cuml.internals.device_support import CPU_ENABLED, GPU_ENABLED
+
 from cuml.internals import logger
+from cuml.internals.device_support import CPU_ENABLED, GPU_ENABLED
 
 
 class UnavailableError(Exception):

--- a/python/cuml/internals/type_utils.py
+++ b/python/cuml/internals/type_utils.py
@@ -20,6 +20,7 @@ from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")
 
+
 # Those are the only data types supported by cupyx.scipy.sparse matrices.
 CUPY_SPARSE_DTYPES = [cp.float32, cp.float64, cp.complex64, cp.complex128]
 

--- a/python/cuml/kernel_ridge/kernel_ridge.pyx
+++ b/python/cuml/kernel_ridge/kernel_ridge.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,17 +16,20 @@
 
 # distutils: language = c++
 
-from cuml.internals.safe_imports import cpu_only_import
 import warnings
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
-from cupyx import lapack, geterr, seterr
+
+from cupyx import geterr, lapack, seterr
+
+from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.base import Base
 from cuml.internals.mixins import RegressorMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.common import input_to_cuml_array
-
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 from cuml.metrics import pairwise_kernels
 
 cp = gpu_only_import('cupy')

--- a/python/cuml/linear_model/base.pyx
+++ b/python/cuml/linear_model/base.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,29 +17,36 @@
 # distutils: language = c++
 
 import ctypes
+
 import cuml.internals
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 import warnings
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 from collections import defaultdict
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdlib cimport calloc, free, malloc
+from libcpp cimport bool
 
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.mixins import RegressorMixin
-from cuml.common.doc_utils import generate_docstring
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.internals.api_decorators import enable_device_interop
+
 
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
 

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,21 +17,28 @@
 
 
 import ctypes
+
 import cuml.common.opg_data_utils_mg as opg
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libc.stdint cimport uintptr_t
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from cuml.internals.base import Base
 from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.internals.input_utils import input_to_cuml_array
+
 from cuml.decomposition.utils cimport *
 
 

--- a/python/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/linear_model/elastic_net.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,16 +18,18 @@
 
 from inspect import signature
 
-from cuml.solvers import CD, QN
-from cuml.internals.base import UniversalBase
-from cuml.internals.mixins import RegressorMixin, FMajorInputTagMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
+from cuml.internals.array import CumlArray
+from cuml.internals.base import UniversalBase
 from cuml.internals.logger import warn
+from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.linear_model.base import LinearPredictMixin
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.solvers import CD, QN
 
 
 class ElasticNet(UniversalBase,

--- a/python/cuml/linear_model/lasso.py
+++ b/python/cuml/linear_model/lasso.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.linear_model.elastic_net import ElasticNet
 from cuml.internals.api_decorators import device_interop_preparation
+from cuml.linear_model.elastic_net import ElasticNet
 
 
 class Lasso(ElasticNet):

--- a/python/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/linear_model/linear_regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,32 +17,42 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 import warnings
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 from collections import defaultdict
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdlib cimport calloc, free, malloc
+from libcpp cimport bool
 
 from cuml import Handle
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import UniversalBase
-from cuml.internals.mixins import RegressorMixin, FMajorInputTagMixin
 from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.base import UniversalBase
+from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.linear_model.base import LinearPredictMixin
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 from cuml.common import input_to_cuml_array
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
+
 
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
 

--- a/python/cuml/linear_model/linear_regression_mg.pyx
+++ b/python/cuml/linear_model/linear_regression_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,24 +16,30 @@
 # distutils: language = c++
 
 import ctypes
+
 import cuml.common.opg_data_utils_mg as opg
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libc.stdlib cimport malloc, free
-
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdlib cimport free, malloc
+from libcpp cimport bool
 
 import cuml.internals
-from cuml.internals.base import Base
 from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.common import input_to_cuml_array
+
 from cuml.decomposition.utils cimport *
 
 from cuml.linear_model import LinearRegression

--- a/python/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/linear_model/logistic_regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,23 @@
 
 # distutils: language = c++
 
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
 import pprint
 
 import cuml.internals
-from cuml.solvers import QN
+import cuml.internals.logger as logger
+from cuml.common import input_to_cuml_array, using_output_type
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
+from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
 from cuml.internals.mixins import ClassifierMixin, FMajorInputTagMixin
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array import CumlArray
-from cuml.common.doc_utils import generate_docstring
-import cuml.internals.logger as logger
-from cuml.common import input_to_cuml_array
-from cuml.common import using_output_type
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.solvers import QN
+
 cp = gpu_only_import('cupy')
 np = cpu_only_import('numpy')
 

--- a/python/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/linear_model/mbsgd_classifier.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.mixins import ClassifierMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import FMajorInputTagMixin
+from cuml.internals.mixins import ClassifierMixin, FMajorInputTagMixin
 from cuml.solvers import SGD
 
 

--- a/python/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/linear_model/mbsgd_regressor.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@
 # distutils: language = c++
 
 import cuml.internals
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.mixins import RegressorMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import FMajorInputTagMixin
+from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.solvers import SGD
 
 

--- a/python/cuml/linear_model/ridge.pyx
+++ b/python/cuml/linear_model/ridge.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,27 +17,36 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from collections import defaultdict
+
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 import warnings
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdlib cimport calloc, free, malloc
+from libcpp cimport bool
 
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import UniversalBase
-from cuml.internals.mixins import RegressorMixin, FMajorInputTagMixin
-from cuml.internals.array import CumlArray
 from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.base import UniversalBase
+from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.linear_model.base import LinearPredictMixin
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common import input_to_cuml_array
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
+
 
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
 

--- a/python/cuml/linear_model/ridge_mg.pyx
+++ b/python/cuml/linear_model/ridge_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,28 +16,35 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libc.stdlib cimport malloc, free
-
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libc.stdlib cimport free, malloc
+from libcpp cimport bool
 
 import cuml.internals
-from cuml.internals.base import Base
 from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.common import input_to_cuml_array
+
 from cuml.decomposition.utils cimport *
 
 from cuml.linear_model import Ridge
 from cuml.linear_model.base_mg import MGFitMixin
+
 
 cdef extern from "cuml/linear_model/ridge_mg.hpp" namespace "ML::Ridge::opg":
 

--- a/python/cuml/manifold/__init__.py
+++ b/python/cuml/manifold/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-from cuml.manifold.umap import UMAP
 from cuml.manifold.t_sne import TSNE
+from cuml.manifold.umap import UMAP

--- a/python/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/manifold/simpl_set.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,19 +17,22 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 from cuml.manifold.umap_utils cimport *
-from cuml.manifold.umap_utils import GraphHolder, find_ab_params
 
 import cuml.internals
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.array import CumlArray
+from cuml.manifold.umap_utils import GraphHolder, find_ab_params
 
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
 
 from libc.stdint cimport uintptr_t

--- a/python/cuml/manifold/t_sne.pyx
+++ b/python/cuml/manifold/t_sne.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,38 +19,46 @@
 # cython: wraparound = False
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import inspect
+
 pd = cpu_only_import('pandas')
 import warnings
+
 from cuml.internals.safe_imports import gpu_only_import
+
 cupy = gpu_only_import('cupy')
 
 import cuml.internals
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.base import Base
-from pylibraft.common.handle cimport handle_t
-import cuml.internals.logger as logger
 
+from pylibraft.common.handle cimport handle_t
+
+import cuml.internals.logger as logger
+from cuml.common import input_to_cuml_array
+from cuml.common.doc_utils import generate_docstring
+from cuml.common.sparse_utils import is_sparse
+from cuml.common.sparsefuncs import extract_knn_infos
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.common.sparse_utils import is_sparse
-from cuml.common.doc_utils import generate_docstring
-from cuml.common import input_to_cuml_array
 from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.common.sparsefuncs import extract_knn_infos
+
 from cuml.metrics.distance_type cimport DistanceType
+
 rmm = gpu_only_import('rmm')
 
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t
-from libc.stdint cimport int64_t
-from libc.stdlib cimport free
-from libcpp.memory cimport shared_ptr
 from cython.operator cimport dereference as deref
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport free
+from libcpp cimport bool
+from libcpp.memory cimport shared_ptr
 
 cimport cuml.common.cuda
+
 
 cdef extern from "cuml/manifold/tsne.h" namespace "ML":
 

--- a/python/cuml/manifold/umap.pyx
+++ b/python/cuml/manifold/umap.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 # distutils: language = c++
 
-import typing
 import ctypes
+import typing
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 pd = cpu_only_import('pandas')
 import warnings
@@ -26,16 +28,18 @@ import warnings
 import joblib
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cupy = gpu_only_import('cupy')
 cupyx = gpu_only_import('cupyx')
 
 cuda = gpu_only_import('numba.cuda')
 
 from cuml.manifold.umap_utils cimport *
-from cuml.manifold.umap_utils import GraphHolder, find_ab_params
 
 from cuml.common.sparsefuncs import extract_knn_infos
 from cuml.internals.safe_imports import gpu_only_import_from
+from cuml.manifold.umap_utils import GraphHolder, find_ab_params
+
 cp_csr_matrix = gpu_only_import_from('cupyx.scipy.sparse', 'csr_matrix')
 cp_coo_matrix = gpu_only_import_from('cupyx.scipy.sparse', 'coo_matrix')
 cp_csc_matrix = gpu_only_import_from('cupyx.scipy.sparse', 'csc_matrix')
@@ -43,33 +47,39 @@ cp_csc_matrix = gpu_only_import_from('cupyx.scipy.sparse', 'csc_matrix')
 import cuml.internals
 from cuml.common import using_output_type
 from cuml.internals.base import UniversalBase
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.doc_utils import generate_docstring
+from cuml.common.sparse_utils import is_sparse
 from cuml.internals import logger
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.memory_utils import using_output_type
-from cuml.internals.import_utils import has_scipy
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals.import_utils import has_scipy
+from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.memory_utils import using_output_type
 from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.common.sparse_utils import is_sparse
+
 from cuml.metrics.distance_type cimport DistanceType
 
-from cuml.manifold.simpl_set import fuzzy_simplicial_set, \
-    simplicial_set_embedding
+from cuml.manifold.simpl_set import (
+    fuzzy_simplicial_set,
+    simplicial_set_embedding,
+)
 
 if has_scipy(True):
     import scipy.sparse
 
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
 
 rmm = gpu_only_import('rmm')
 
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport free
-
 from libcpp.memory cimport shared_ptr
 
 cimport cuml.common.cuda

--- a/python/cuml/manifold/umap_utils.pxd
+++ b/python/cuml/manifold/umap_utils.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 # distutils: language = c++
 
-from rmm._lib.memory_resource cimport DeviceMemoryResource
-from rmm._lib.cuda_stream_view cimport cuda_stream_view
-from libcpp.memory cimport unique_ptr
-
-from libc.stdint cimport uint64_t, uintptr_t, int64_t
+from libc.stdint cimport int64_t, uint64_t, uintptr_t
 from libcpp cimport bool
-from libcpp.memory cimport shared_ptr
+from libcpp.memory cimport shared_ptr, unique_ptr
+from rmm._lib.cuda_stream_view cimport cuda_stream_view
+from rmm._lib.memory_resource cimport DeviceMemoryResource
+
 from cuml.metrics.distance_type cimport DistanceType
+
 
 cdef extern from "cuml/manifold/umapparams.h" namespace "ML::UMAPParams":
 

--- a/python/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/manifold/umap_utils.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 # distutils: language = c++
 
-from rmm._lib.memory_resource cimport get_current_device_resource
-from pylibraft.common.handle cimport handle_t
-from cuml.manifold.umap_utils cimport *
 from libcpp.utility cimport move
+from pylibraft.common.handle cimport handle_t
+from rmm._lib.memory_resource cimport get_current_device_resource
+
+from cuml.manifold.umap_utils cimport *
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 

--- a/python/cuml/metrics/__init__.py
+++ b/python/cuml/metrics/__init__.py
@@ -14,37 +14,42 @@
 # limitations under the License.
 #
 
-from cuml.metrics.trustworthiness import trustworthiness
-from cuml.metrics.regression import r2_score
-from cuml.metrics.regression import mean_squared_error
-from cuml.metrics.regression import mean_squared_log_error
-from cuml.metrics.regression import mean_absolute_error
+from cuml.metrics._classification import log_loss
+from cuml.metrics._ranking import precision_recall_curve, roc_auc_score
 from cuml.metrics.accuracy import accuracy_score
 from cuml.metrics.cluster.adjusted_rand_index import adjusted_rand_score
-from cuml.metrics._ranking import roc_auc_score
-from cuml.metrics._ranking import precision_recall_curve
-from cuml.metrics._classification import log_loss
-from cuml.metrics.cluster.homogeneity_score import (
-    cython_homogeneity_score as homogeneity_score,
-)
 from cuml.metrics.cluster.completeness_score import (
     cython_completeness_score as completeness_score,
+)
+from cuml.metrics.cluster.entropy import cython_entropy as entropy
+from cuml.metrics.cluster.homogeneity_score import (
+    cython_homogeneity_score as homogeneity_score,
 )
 from cuml.metrics.cluster.mutual_info_score import (
     cython_mutual_info_score as mutual_info_score,
 )
+from cuml.metrics.cluster.v_measure import cython_v_measure as v_measure_score
 from cuml.metrics.confusion_matrix import confusion_matrix
-from cuml.metrics.cluster.entropy import cython_entropy as entropy
-from cuml.metrics.pairwise_distances import pairwise_distances
-from cuml.metrics.pairwise_distances import sparse_pairwise_distances
-from cuml.metrics.pairwise_distances import nan_euclidean_distances
-from cuml.metrics.pairwise_distances import PAIRWISE_DISTANCE_METRICS
-from cuml.metrics.pairwise_distances import PAIRWISE_DISTANCE_SPARSE_METRICS
-from cuml.metrics.pairwise_kernels import pairwise_kernels
-from cuml.metrics.pairwise_kernels import PAIRWISE_KERNEL_FUNCTIONS
 from cuml.metrics.hinge_loss import hinge_loss
 from cuml.metrics.kl_divergence import kl_divergence
-from cuml.metrics.cluster.v_measure import cython_v_measure as v_measure_score
+from cuml.metrics.pairwise_distances import (
+    PAIRWISE_DISTANCE_METRICS,
+    PAIRWISE_DISTANCE_SPARSE_METRICS,
+    nan_euclidean_distances,
+    pairwise_distances,
+    sparse_pairwise_distances,
+)
+from cuml.metrics.pairwise_kernels import (
+    PAIRWISE_KERNEL_FUNCTIONS,
+    pairwise_kernels,
+)
+from cuml.metrics.regression import (
+    mean_absolute_error,
+    mean_squared_error,
+    mean_squared_log_error,
+    r2_score,
+)
+from cuml.metrics.trustworthiness import trustworthiness
 
 __all__ = [
     "trustworthiness",

--- a/python/cuml/metrics/_classification.py
+++ b/python/cuml/metrics/_classification.py
@@ -14,10 +14,9 @@
 # limitations under the License.
 #
 
-from cuml.internals.input_utils import input_to_cupy_array
 import cuml.internals
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.input_utils import input_to_cupy_array
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/metrics/_ranking.py
+++ b/python/cuml/metrics/_ranking.py
@@ -15,12 +15,12 @@
 #
 
 import math
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.internals.array import CumlArray
-import cuml.internals
-from cuml.internals.safe_imports import cpu_only_import
 import typing
-from cuml.internals.safe_imports import gpu_only_import
+
+import cuml.internals
+from cuml.internals.array import CumlArray
+from cuml.internals.input_utils import input_to_cupy_array
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/metrics/accuracy.pyx
+++ b/python/cuml/metrics/accuracy.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,20 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from libc.stdint cimport uintptr_t
 
-
 import cuml.internals
-
 from cuml.internals.input_utils import input_to_cuml_array
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 cimport cuml.common.cuda
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
 

--- a/python/cuml/metrics/cluster/__init__.py
+++ b/python/cuml/metrics/cluster/__init__.py
@@ -15,20 +15,20 @@
 #
 
 from cuml.metrics.cluster.adjusted_rand_index import adjusted_rand_score
-from cuml.metrics.cluster.homogeneity_score import (
-    cython_homogeneity_score as homogeneity_score,
-)
 from cuml.metrics.cluster.completeness_score import (
     cython_completeness_score as completeness_score,
+)
+from cuml.metrics.cluster.entropy import cython_entropy as entropy
+from cuml.metrics.cluster.homogeneity_score import (
+    cython_homogeneity_score as homogeneity_score,
 )
 from cuml.metrics.cluster.mutual_info_score import (
     cython_mutual_info_score as mutual_info_score,
 )
-from cuml.metrics.cluster.entropy import cython_entropy as entropy
-from cuml.metrics.cluster.silhouette_score import (
-    cython_silhouette_score as silhouette_score,
-)
 from cuml.metrics.cluster.silhouette_score import (
     cython_silhouette_samples as silhouette_samples,
+)
+from cuml.metrics.cluster.silhouette_score import (
+    cython_silhouette_score as silhouette_score,
 )
 from cuml.metrics.cluster.v_measure import cython_v_measure as v_measure_score

--- a/python/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,16 +17,22 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 import warnings
 
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
+
 from pylibraft.common.handle cimport handle_t
-from cuml.common import input_to_cuml_array
+
 from pylibraft.common.handle import Handle
+
+from cuml.common import input_to_cuml_array
+
 cimport cuml.common.cuda
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
 

--- a/python/cuml/metrics/cluster/completeness_score.pyx
+++ b/python/cuml/metrics/cluster/completeness_score.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 # distutils: language = c++
 
 import cuml.internals
-from pylibraft.common.handle cimport handle_t
+
 from libc.stdint cimport uintptr_t
-from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
+from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
+from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/entropy.pyx
+++ b/python/cuml/metrics/cluster/entropy.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,18 +19,25 @@ import math
 import typing
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
+
 from pylibraft.common.handle cimport handle_t
+
+from pylibraft.common.handle import Handle
+
 from cuml.common import CumlArray
 from cuml.internals.input_utils import input_to_cupy_array
-from pylibraft.common.handle import Handle
+
 cimport cuml.common.cuda
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
     double entropy(const handle_t &handle,

--- a/python/cuml/metrics/cluster/homogeneity_score.pyx
+++ b/python/cuml/metrics/cluster/homogeneity_score.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 # distutils: language = c++
 
 import cuml.internals
-from pylibraft.common.handle cimport handle_t
+
 from libc.stdint cimport uintptr_t
-from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
+from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
+from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/mutual_info_score.pyx
+++ b/python/cuml/metrics/cluster/mutual_info_score.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 # distutils: language = c++
 
 import cuml.internals
-from pylibraft.common.handle cimport handle_t
+
 from libc.stdint cimport uintptr_t
+from pylibraft.common.handle cimport handle_t
+
+from pylibraft.common.handle import Handle
 
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
-from pylibraft.common.handle import Handle
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/metrics/cluster/silhouette_score.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,18 +15,25 @@
 #
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from libc.stdint cimport uintptr_t
 
 from cuml.common import input_to_cuml_array
 from cuml.metrics.pairwise_distances import _determine_metric
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 from cuml.metrics.distance_type cimport DistanceType
-from cuml.prims.label.classlabels import make_monotonic, check_labels
+
+from cuml.prims.label.classlabels import check_labels, make_monotonic
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics::Batched":
     float silhouette_score(

--- a/python/cuml/metrics/cluster/utils.pyx
+++ b/python/cuml/metrics/cluster/utils.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 # distutils: language = c++
 
-from cuml.internals.safe_imports import gpu_only_import
-
 import cuml.internals
+from cuml.common import input_to_cuml_array
+from cuml.internals.safe_imports import gpu_only_import
 from cuml.metrics.utils import sorted_unique_labels
 from cuml.prims.label import make_monotonic
-from cuml.common import input_to_cuml_array
+
 cp = gpu_only_import('cupy')
 
 

--- a/python/cuml/metrics/cluster/v_measure.pyx
+++ b/python/cuml/metrics/cluster/v_measure.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 # distutils: language = c++
 
 import cuml.internals
-from pylibraft.common.handle cimport handle_t
+
 from libc.stdint cimport uintptr_t
-from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
+from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
+from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":

--- a/python/cuml/metrics/confusion_matrix.py
+++ b/python/cuml/metrics/confusion_matrix.py
@@ -14,19 +14,17 @@
 # limitations under the License.
 #
 
-from cuml.prims.label import make_monotonic
-from cuml.metrics.utils import sorted_unique_labels
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.internals.array import CumlArray
-from cuml.common import using_output_type
-from cuml.common import input_to_cuml_array
 import cuml.internals
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.common import input_to_cuml_array, using_output_type
+from cuml.internals.array import CumlArray
+from cuml.internals.input_utils import input_to_cupy_array
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.metrics.utils import sorted_unique_labels
+from cuml.prims.label import make_monotonic
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 
 
 @cuml.internals.api_return_any()

--- a/python/cuml/metrics/hinge_loss.pyx
+++ b/python/cuml/metrics/hinge_loss.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
 import cuml.internals
 from cuml.internals.input_utils import determine_array_type
-from cuml.preprocessing import LabelEncoder, LabelBinarizer
+from cuml.internals.safe_imports import gpu_only_import
+from cuml.preprocessing import LabelBinarizer, LabelEncoder
 
 cp = gpu_only_import('cupy')
 cudf = gpu_only_import('cudf')

--- a/python/cuml/metrics/kl_divergence.pyx
+++ b/python/cuml/metrics/kl_divergence.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,21 @@
 #
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import cuml.internals
-from cuml.internals.input_utils import determine_array_type
-from cuml.common import (input_to_cuml_array, CumlArray)
+from cuml.common import CumlArray, input_to_cuml_array
 from cuml.internals import logger
+from cuml.internals.input_utils import determine_array_type
+
 from libc.stdint cimport uintptr_t
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
     double c_kl_divergence "ML::Metrics::kl_divergence"(

--- a/python/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/metrics/pairwise_distances.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,28 +18,35 @@
 
 import warnings
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
+from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 pd = cpu_only_import('pandas')
 cudf = gpu_only_import('cudf')
 scipy = cpu_only_import('scipy')
 cupyx = gpu_only_import('cupyx')
 import cuml.internals
-from cuml.internals.base import _determine_stateless_output_type
-from cuml.common import (input_to_cuml_array, CumlArray)
-from cuml.internals import logger
-from cuml.internals.input_utils import sparse_scipy_to_cp
+from cuml.common import CumlArray, input_to_cuml_array
 from cuml.common.sparse_utils import is_sparse
+from cuml.internals import logger
 from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals.base import _determine_stateless_output_type
+from cuml.internals.input_utils import sparse_scipy_to_cp
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
+
 from cuml.metrics.distance_type cimport DistanceType
+
 from cuml.thirdparty_adapters import _get_mask
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
     void pairwise_distance(const handle_t &handle, const double *x,

--- a/python/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/metrics/pairwise_kernels.py
@@ -13,17 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.metrics import pairwise_distances
-import cuml.internals
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
 import inspect
-from cuml.internals.safe_imports import gpu_only_import_from
 
-cuda = gpu_only_import_from("numba", "cuda")
+import cuml.internals
+from cuml.internals.input_utils import input_to_cupy_array
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.metrics import pairwise_distances
+
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
+cuda = gpu_only_import_from("numba", "cuda")
 
 
 def linear_kernel(X, Y):

--- a/python/cuml/metrics/regression.pxd
+++ b/python/cuml/metrics/regression.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #
 
 from pylibraft.common.handle cimport handle_t
+
 
 cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
 

--- a/python/cuml/metrics/regression.pyx
+++ b/python/cuml/metrics/regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,23 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 from libc.stdint cimport uintptr_t
 
+from pylibraft.common.handle import Handle
+
 import cuml.internals
 from cuml.internals.array import CumlArray
-from pylibraft.common.handle import Handle
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.metrics cimport regression
+
 from cuml.internals.input_utils import input_to_cuml_array
 
 

--- a/python/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/metrics/trustworthiness.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,23 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import warnings
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
 from libc.stdint cimport uintptr_t
+
+from pylibraft.common.handle import Handle
+
 import cuml.internals
 from cuml.internals.input_utils import input_to_cuml_array
-from pylibraft.common.handle import Handle
+
 from pylibraft.common.handle cimport handle_t
+
 
 cdef extern from "raft/distance/distance_type.hpp" namespace "raft::distance":
 

--- a/python/cuml/model_selection/__init__.py
+++ b/python/cuml/model_selection/__init__.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.model_selection._split import train_test_split
-from cuml.model_selection._split import StratifiedKFold
 from cuml.internals.import_utils import has_sklearn
+from cuml.model_selection._split import StratifiedKFold, train_test_split
 
 if has_sklearn():
     from sklearn.model_selection import GridSearchCV

--- a/python/cuml/model_selection/_split.py
+++ b/python/cuml/model_selection/_split.py
@@ -14,17 +14,19 @@
 #
 
 from typing import Union
-from cuml.internals.safe_imports import gpu_only_import_from
+
 from cuml.common import input_to_cuml_array
 from cuml.internals.array import array_to_memory_order
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
 np = cpu_only_import("numpy")
-
 cuda = gpu_only_import_from("numba", "cuda")
 
 

--- a/python/cuml/multiclass/__init__.py
+++ b/python/cuml/multiclass/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,11 @@
 # limitations under the License.
 #
 
-from cuml.multiclass.multiclass import OneVsOneClassifier
-from cuml.multiclass.multiclass import OneVsRestClassifier
-from cuml.multiclass.multiclass import MulticlassClassifier
+from cuml.multiclass.multiclass import (
+    MulticlassClassifier,
+    OneVsOneClassifier,
+    OneVsRestClassifier,
+)
 
 __all__ = [
     "OneVsOneClassifier",

--- a/python/cuml/multiclass/multiclass.py
+++ b/python/cuml/multiclass/multiclass.py
@@ -14,14 +14,13 @@
 #
 
 import cuml.internals
-
+from cuml.common import input_to_host_array
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals import _deprecate_pos_args
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.import_utils import has_sklearn
 from cuml.internals.mixins import ClassifierMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.common import input_to_host_array
-from cuml.internals import _deprecate_pos_args
 
 
 class MulticlassClassifier(Base, ClassifierMixin):

--- a/python/cuml/naive_bayes/__init__.py
+++ b/python/cuml/naive_bayes/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
 # limitations under the License.
 #
 
-from cuml.naive_bayes.naive_bayes import MultinomialNB
-from cuml.naive_bayes.naive_bayes import BernoulliNB
-from cuml.naive_bayes.naive_bayes import GaussianNB
-from cuml.naive_bayes.naive_bayes import ComplementNB
-from cuml.naive_bayes.naive_bayes import CategoricalNB
+from cuml.naive_bayes.naive_bayes import (
+    BernoulliNB,
+    CategoricalNB,
+    ComplementNB,
+    GaussianNB,
+    MultinomialNB,
+)
 
 __all__ = [
     "MultinomialNB",

--- a/python/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/naive_bayes/naive_bayes.py
@@ -13,23 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.common.kernel_utils import cuda_kernel_factory
-from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
-from cuml.prims.array import binarize
-from cuml.prims.label import invert_labels
-from cuml.prims.label import check_labels
-from cuml.prims.label import make_monotonic
-from cuml.internals.import_utils import has_scipy
-from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import ClassifierMixin
-from cuml.internals.base import Base
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.common import CumlArray
 import math
 import warnings
+
 import nvtx
 
+from cuml.common import CumlArray
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
+from cuml.common.kernel_utils import cuda_kernel_factory
+from cuml.internals.base import Base
+from cuml.internals.import_utils import has_scipy
+from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
+from cuml.internals.mixins import ClassifierMixin
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.prims.array import binarize
+from cuml.prims.label import check_labels, invert_labels, make_monotonic
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/neighbors/__init__.py
+++ b/python/cuml/neighbors/__init__.py
@@ -15,16 +15,14 @@
 #
 
 from cuml.internals.import_utils import has_dask
-
-from cuml.neighbors.nearest_neighbors import NearestNeighbors
-from cuml.neighbors.nearest_neighbors import kneighbors_graph
-from cuml.neighbors.kneighbors_classifier import KNeighborsClassifier
-from cuml.neighbors.kneighbors_regressor import KNeighborsRegressor
 from cuml.neighbors.kernel_density import (
-    KernelDensity,
     VALID_KERNELS,
+    KernelDensity,
     logsumexp_kernel,
 )
+from cuml.neighbors.kneighbors_classifier import KNeighborsClassifier
+from cuml.neighbors.kneighbors_regressor import KNeighborsRegressor
+from cuml.neighbors.nearest_neighbors import NearestNeighbors, kneighbors_graph
 
 VALID_METRICS = {
     "brute": set(

--- a/python/cuml/neighbors/kernel_density.py
+++ b/python/cuml/neighbors/kernel_density.py
@@ -14,20 +14,23 @@
 # limitations under the License.
 #
 
-from cuml.common.exceptions import NotFittedError
-from cuml.internals.import_utils import has_scipy
-from cuml.metrics import pairwise_distances
-from cuml.internals.base import Base
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.internals.safe_imports import gpu_only_import_from
 import math
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+
+from cuml.common.exceptions import NotFittedError
+from cuml.internals.base import Base
+from cuml.internals.import_utils import has_scipy
+from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.metrics import pairwise_distances
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 cuda = gpu_only_import_from("numba", "cuda")
+
 
 if has_scipy():
     from scipy.special import gammainc

--- a/python/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,37 +18,33 @@
 
 import typing
 
-from cuml.neighbors.nearest_neighbors import NearestNeighbors
-
 import cuml.internals
-from cuml.internals.array import CumlArray
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.mixins import ClassifierMixin
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import FMajorInputTagMixin
-
+from cuml.internals.array import CumlArray
+from cuml.internals.mixins import ClassifierMixin, FMajorInputTagMixin
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.neighbors.nearest_neighbors import NearestNeighbors
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 
 from cython.operator cimport dereference as deref
-
-from pylibraft.common.handle cimport handle_t
-from libcpp.vector cimport vector
-
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
+from libcpp.vector cimport vector
+from pylibraft.common.handle cimport handle_t
 
 rmm = gpu_only_import('rmm')
-from libc.stdlib cimport malloc, free
-
-from libc.stdint cimport uintptr_t, int64_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
 cimport cuml.common.cuda

--- a/python/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,21 +17,23 @@
 # distutils: language = c++
 
 import typing
-from cuml.internals.array import CumlArray
+
 import cuml.internals.logger as logger
 from cuml.internals import api_base_return_generic_skipall
-
+from cuml.internals.array import CumlArray
 from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG
 
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.common import input_to_cuml_array
 
+from cython.operator cimport dereference as deref
+from libc.stdint cimport uintptr_t
+from libc.stdlib cimport free
 from libcpp cimport bool
 from libcpp.vector cimport vector
-from libc.stdint cimport uintptr_t
-from cython.operator cimport dereference as deref
-from libc.stdlib cimport free
 
 
 cdef extern from "cuml/neighbors/knn_mg.hpp" namespace \

--- a/python/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,37 +16,32 @@
 
 # distutils: language = c++
 
-from cuml.neighbors.nearest_neighbors import NearestNeighbors
-
 import cuml.internals
-from cuml.internals.array import CumlArray
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.mixins import RegressorMixin
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.mixins import FMajorInputTagMixin
-
+from cuml.internals.array import CumlArray
+from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.neighbors.nearest_neighbors import NearestNeighbors
+
 np = cpu_only_import('numpy')
 
 
 from cython.operator cimport dereference as deref
-
-from libcpp.vector cimport vector
-
-from pylibraft.common.handle cimport handle_t
-
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
+from libcpp.vector cimport vector
+from pylibraft.common.handle cimport handle_t
 
 from cuml.internals.safe_imports import gpu_only_import
-rmm = gpu_only_import('rmm')
-from libc.stdlib cimport malloc, free
 
-from libc.stdint cimport uintptr_t, int64_t
-from libc.stdlib cimport calloc, malloc, free
+rmm = gpu_only_import('rmm')
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 import rmm
 

--- a/python/cuml/neighbors/kneighbors_regressor_mg.pyx
+++ b/python/cuml/neighbors/kneighbors_regressor_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +17,20 @@
 # distutils: language = c++
 
 import typing
-from cuml.internals.array import CumlArray
+
 import cuml.internals.logger as logger
 from cuml.internals import api_base_return_generic_skipall
-
+from cuml.internals.array import CumlArray
 from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG
 
-from pylibraft.common.handle cimport handle_t
-from cuml.common.opg_data_utils_mg cimport *
-
+from cython.operator cimport dereference as deref
+from libc.stdint cimport uintptr_t
+from libc.stdlib cimport free
 from libcpp cimport bool
 from libcpp.vector cimport vector
-from libc.stdint cimport uintptr_t
-from cython.operator cimport dereference as deref
-from libc.stdlib cimport free
+from pylibraft.common.handle cimport handle_t
+
+from cuml.common.opg_data_utils_mg cimport *
 
 
 cdef extern from "cuml/neighbors/knn_mg.hpp" namespace \

--- a/python/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/neighbors/nearest_neighbors.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,50 +19,51 @@
 import typing
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 cupyx = gpu_only_import('cupyx')
 import ctypes
-import warnings
 import math
+import warnings
 
 import cuml.internals
-from cuml.internals.base import UniversalBase
+from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring, insert_into_docstring
+from cuml.common.sparse_utils import is_dense, is_sparse
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.common.doc_utils import generate_docstring
-from cuml.common.doc_utils import insert_into_docstring
+from cuml.internals.base import UniversalBase
 from cuml.internals.import_utils import has_scipy
-from cuml.internals.mixins import CMajorInputTagMixin
 from cuml.internals.input_utils import input_to_cupy_array
-from cuml.common import input_to_cuml_array
-from cuml.common.sparse_utils import is_sparse
-from cuml.common.sparse_utils import is_dense
-from cuml.metrics.distance_type cimport DistanceType
-from cuml.internals.api_decorators import device_interop_preparation
-from cuml.internals.api_decorators import enable_device_interop
+from cuml.internals.mixins import CMajorInputTagMixin
 
-from cuml.neighbors.ann cimport *
-from pylibraft.common.handle cimport handle_t
+from cuml.metrics.distance_type cimport DistanceType
+
+from cuml.internals.api_decorators import (
+    device_interop_preparation,
+    enable_device_interop,
+)
 
 from cython.operator cimport dereference as deref
-
+from libc.stdint cimport int64_t, uint32_t, uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
-
-from libc.stdint cimport uintptr_t, int64_t, uint32_t
-from libc.stdlib cimport calloc, malloc, free
-
 from libcpp.vector cimport vector
+from pylibraft.common.handle cimport handle_t
+
+from cuml.neighbors.ann cimport *
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 rmm = gpu_only_import('rmm')
 
 cimport cuml.common.cuda
-
 
 if has_scipy():
     import scipy.sparse

--- a/python/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,24 +17,27 @@
 # distutils: language = c++
 
 import typing
+
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cudfDataFrame = gpu_only_import_from('cudf', 'DataFrame')
-from cuml.internals.array import CumlArray
+import cuml.internals.logger as logger
 from cuml.common import input_to_cuml_array
 from cuml.internals import api_base_return_generic_skipall
-import cuml.internals.logger as logger
-
+from cuml.internals.array import CumlArray
 from cuml.neighbors import NearestNeighbors
 
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.common.opg_data_utils_mg import _build_part_inputs
 
+from cython.operator cimport dereference as deref
+from libc.stdint cimport uintptr_t
+from libc.stdlib cimport calloc, free, malloc
 from libcpp cimport bool
 from libcpp.vector cimport vector
-from libc.stdint cimport uintptr_t
-from cython.operator cimport dereference as deref
-from libc.stdlib cimport calloc, malloc, free
 
 
 cdef extern from "cuml/neighbors/knn_mg.hpp" namespace \

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 #
 
-from cuml.common.exceptions import NotFittedError
-from cuml.internals.safe_imports import cpu_only_import_from
 from cuml import Base
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.common.exceptions import NotFittedError
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+)
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/preprocessing/TargetEncoder.py
+++ b/python/cuml/preprocessing/TargetEncoder.py
@@ -15,14 +15,14 @@
 #
 
 import warnings
+
 from cuml.common.exceptions import NotFittedError
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
-pandas = cpu_only_import("pandas")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
+pandas = cpu_only_import("pandas")
 
 
 def get_stat_func(stat):

--- a/python/cuml/preprocessing/__init__.py
+++ b/python/cuml/preprocessing/__init__.py
@@ -13,13 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.model_selection import train_test_split
-from cuml.preprocessing.LabelEncoder import LabelEncoder
-from cuml.preprocessing.label import LabelBinarizer, label_binarize
-from cuml.preprocessing.encoders import OneHotEncoder
-from cuml.preprocessing.TargetEncoder import TargetEncoder
-from cuml.preprocessing import text
-
 from cuml._thirdparty.sklearn.preprocessing import (
     Binarizer,
     FunctionTransformer,
@@ -35,9 +28,6 @@ from cuml._thirdparty.sklearn.preprocessing import (
     RobustScaler,
     SimpleImputer,
     StandardScaler,
-)
-
-from cuml._thirdparty.sklearn.preprocessing import (
     add_dummy_feature,
     binarize,
     maxabs_scale,
@@ -49,6 +39,12 @@ from cuml._thirdparty.sklearn.preprocessing import (
     scale,
 )
 
+from cuml.model_selection import train_test_split
+from cuml.preprocessing import text
+from cuml.preprocessing.encoders import OneHotEncoder
+from cuml.preprocessing.label import LabelBinarizer, label_binarize
+from cuml.preprocessing.LabelEncoder import LabelEncoder
+from cuml.preprocessing.TargetEncoder import TargetEncoder
 
 __all__ = [
     # Classes

--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -13,19 +13,22 @@
 # limitations under the License.
 #
 import warnings
-import cuml.internals.logger as logger
-from cuml.internals.safe_imports import gpu_only_import_from
+
 from cudf import DataFrame, Series
-from cuml.preprocessing import LabelEncoder
+
+import cuml.internals.logger as logger
 from cuml import Base
 from cuml.common.exceptions import NotFittedError
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.preprocessing import LabelEncoder
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
-
+np = cpu_only_import("numpy")
 GenericIndex = gpu_only_import_from("cudf", "GenericIndex")
 
 

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 #
 
-from cuml.prims.label import check_labels, invert_labels, make_monotonic
-from cuml.internals.array_sparse import SparseCumlArray
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.common import CumlArray, has_scipy
 import cuml.internals
 from cuml import Base
+from cuml.common import CumlArray, has_scipy
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.prims.label import check_labels, invert_labels, make_monotonic
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/preprocessing/onehotencoder_mg.py
+++ b/python/cuml/preprocessing/onehotencoder_mg.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.preprocessing.encoders import OneHotEncoder
 import dask
-from cuml.internals.safe_imports import gpu_only_import
+
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
+from cuml.internals.safe_imports import gpu_only_import, gpu_only_import_from
+from cuml.preprocessing.encoders import OneHotEncoder
 
 cp = gpu_only_import("cupy")
 DataFrame = gpu_only_import_from("cudf", "DataFrame")

--- a/python/cuml/preprocessing/text/stem/__init__.py
+++ b/python/cuml/preprocessing/text/stem/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from cuml.preprocessing.text.stem.porter_stemmer import PorterStemmer
 import cuml.preprocessing.text.stem.porter_stemmer_utils
+from cuml.preprocessing.text.stem.porter_stemmer import PorterStemmer
 
 __all__ = ["PorterStemmer"]

--- a/python/cuml/preprocessing/text/stem/porter_stemmer.py
+++ b/python/cuml/preprocessing/text/stem/porter_stemmer.py
@@ -14,32 +14,30 @@
 # limitations under the License.
 #
 
-from .porter_stemmer_utils.measure_utils import (
-    has_positive_measure,
-    measure_gt_n,
-    measure_eq_n,
-)
-from .porter_stemmer_utils.len_flags_utils import (
-    len_eq_n,
-    len_gt_n,
-)
+from cuml.internals.safe_imports import gpu_only_import
+
 from .porter_stemmer_utils.consonant_vowel_utils import (
     contains_vowel,
     is_consonant,
 )
+from .porter_stemmer_utils.len_flags_utils import len_eq_n, len_gt_n
+from .porter_stemmer_utils.measure_utils import (
+    has_positive_measure,
+    measure_eq_n,
+    measure_gt_n,
+)
 from .porter_stemmer_utils.porter_stemmer_rules import (
-    ends_with_suffix,
-    ends_with_double_constant,
-    last_char_not_in,
-    last_char_in,
     ends_cvc,
+    ends_with_double_constant,
+    ends_with_suffix,
+    last_char_in,
+    last_char_not_in,
 )
 from .porter_stemmer_utils.suffix_utils import (
     get_stem_series,
     get_str_replacement_series,
     replace_suffix,
 )
-from cuml.internals.safe_imports import gpu_only_import
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/preprocessing/text/stem/porter_stemmer_utils/porter_stemmer_rules.py
+++ b/python/cuml/preprocessing/text/stem/porter_stemmer_utils/porter_stemmer_rules.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-from .consonant_vowel_utils import is_vowel, is_consonant
-from .len_flags_utils import len_gt_n, len_eq_n
 from cuml.internals.safe_imports import gpu_only_import
+
+from .consonant_vowel_utils import is_consonant, is_vowel
+from .len_flags_utils import len_eq_n, len_gt_n
 
 cudf = gpu_only_import("cudf")
 

--- a/python/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
+++ b/python/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
@@ -14,14 +14,16 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import gpu_only_import_from
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
-cuda = gpu_only_import_from("numba", "cuda")
 cudf = gpu_only_import("cudf")
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
+cuda = gpu_only_import_from("numba", "cuda")
 
 
 def get_str_replacement_series(replacement, bool_mask):

--- a/python/cuml/prims/array.py
+++ b/python/cuml/prims/array.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-from cuml.common.kernel_utils import cuda_kernel_factory
 import math
+
+from cuml.common.kernel_utils import cuda_kernel_factory
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/prims/label/__init__.py
+++ b/python/cuml/prims/label/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-from cuml.prims.label.classlabels import make_monotonic  # NOQA
 from cuml.prims.label.classlabels import check_labels  # NOQA
 from cuml.prims.label.classlabels import invert_labels  # NOQA
+from cuml.prims.label.classlabels import make_monotonic  # NOQA

--- a/python/cuml/prims/label/classlabels.py
+++ b/python/cuml/prims/label/classlabels.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 #
 
-from cuml.common.kernel_utils import cuda_kernel_factory
-from cuml.internals.array import CumlArray
-import cuml.internals
-from cuml.internals.input_utils import input_to_cupy_array
 import math
 import typing
+
+import cuml.internals
+from cuml.common.kernel_utils import cuda_kernel_factory
+from cuml.internals.array import CumlArray
+from cuml.internals.input_utils import input_to_cupy_array
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/prims/stats/covariance.py
+++ b/python/cuml/prims/stats/covariance.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-from cuml.common.kernel_utils import cuda_kernel_factory
-import cuml.internals
 import math
+
+import cuml.internals
+from cuml.common.kernel_utils import cuda_kernel_factory
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/random_projection/__init__.py
+++ b/python/cuml/random_projection/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.random_projection.random_projection import GaussianRandomProjection
-from cuml.random_projection.random_projection import SparseRandomProjection
 from cuml.random_projection.random_projection import (
+    GaussianRandomProjection,
+    SparseRandomProjection,
     johnson_lindenstrauss_min_dim,
 )

--- a/python/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/random_projection/random_projection.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from libc.stdint cimport uintptr_t
@@ -25,11 +26,14 @@ from libcpp cimport bool
 import cuml.internals
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport *
+
 from cuml.common import input_to_cuml_array
 from cuml.internals.mixins import FMajorInputTagMixin
 
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
+
 
 cdef extern from "cuml/random_projection/rproj_c.h" namespace "ML":
 

--- a/python/cuml/solvers/__init__.py
+++ b/python/cuml/solvers/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,5 +15,5 @@
 #
 
 from cuml.solvers.cd import CD
-from cuml.solvers.sgd import SGD
 from cuml.solvers.qn import QN
+from cuml.solvers.sgd import SGD

--- a/python/cuml/solvers/cd.pyx
+++ b/python/cuml/solvers/cd.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,21 +16,26 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdlib cimport calloc, free, malloc
+from libcpp cimport bool
 
 from cuml.common import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import Base
 from cuml.common.doc_utils import generate_docstring
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.mixins import FMajorInputTagMixin
 

--- a/python/cuml/solvers/cd_mg.pyx
+++ b/python/cuml/solvers/cd_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,24 +16,33 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 rmm = gpu_only_import('rmm')
 
-from libcpp cimport bool
-from libc.stdint cimport uintptr_t, uint32_t, uint64_t
 from cython.operator cimport dereference as deref
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t
+from libcpp cimport bool
 
 import cuml.internals
-from cuml.internals.base import Base
 from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common.opg_data_utils_mg cimport *
+
 from cuml.internals.input_utils import input_to_cuml_array
+
 from cuml.decomposition.utils cimport *
+
 from cuml.linear_model.base_mg import MGFitMixin
 from cuml.solvers import CD
+
 
 cdef extern from "cuml/solvers/cd_mg.hpp" namespace "ML::CD::opg":
 

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,24 +16,28 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
+from libcpp cimport bool
 
 import cuml.internals
-from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.global_settings import GlobalSettings
 from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals.base import Base
+from cuml.internals.global_settings import GlobalSettings
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common import input_to_cuml_array
-from cuml.internals.mixins import FMajorInputTagMixin
 from cuml.common.sparse_utils import is_sparse
+from cuml.internals.mixins import FMajorInputTagMixin
 from cuml.metrics import accuracy_score
 
 

--- a/python/cuml/solvers/sgd.pyx
+++ b/python/cuml/solvers/sgd.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,29 +15,35 @@
 
 # distutils: language = c++
 
+import ctypes
 import typing
 
-import ctypes
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
-from libcpp cimport bool
 from libc.stdint cimport uintptr_t
-from libc.stdlib cimport calloc, malloc, free
+from libc.stdlib cimport calloc, free, malloc
+from libcpp cimport bool
 
 import cuml.internals
-from cuml.internals.base import Base
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common import input_to_cuml_array
 from cuml.internals.mixins import FMajorInputTagMixin
+
 
 cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
 

--- a/python/cuml/svm/__init__.py
+++ b/python/cuml/svm/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.svm.svc import SVC
-from cuml.svm.svr import SVR
 from cuml.svm.linear_svc import LinearSVC
 from cuml.svm.linear_svr import LinearSVR
+from cuml.svm.svc import SVC
+from cuml.svm.svr import SVR

--- a/python/cuml/svm/linear.pyx
+++ b/python/cuml/svm/linear.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,32 +15,39 @@
 
 # distutils: language = c++
 
-import re
 import inspect
+import re
 import typing
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 import cuml
 
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
 
 from collections import OrderedDict
+
 from cython.operator cimport dereference as deref
-from cuml.internals.base_helpers import BaseMetaClass
+
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+from cuml.internals.base_helpers import BaseMetaClass
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.interruptible import cuda_interruptible
+
 from cuml.common import input_to_cuml_array
+
+from cuda.ccudart cimport (
+    cudaMemcpyAsync,
+    cudaMemcpyDeviceToDevice,
+    cudaMemcpyKind,
+)
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool as cppbool
-from cuda.ccudart cimport(
-    cudaMemcpyAsync,
-    cudaMemcpyKind,
-    cudaMemcpyDeviceToDevice
-)
-
 
 __all__ = ['LinearSVM', 'LinearSVM_defaults']
 

--- a/python/cuml/svm/svc.pyx
+++ b/python/cuml/svm/svc.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,42 +15,52 @@
 
 # distutils: language = c++
 
+import ctypes
 import typing
 
-import ctypes
 from cuml.internals.safe_imports import gpu_only_import
+
 cudf = gpu_only_import('cudf')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
 from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.mixins import ClassifierMixin
-from cuml.common.doc_utils import generate_docstring
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.logger import warn
+from cuml.internals.mixins import ClassifierMixin
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.interruptible import cuda_interruptible
+
 from cuml.common import input_to_cuml_array, input_to_host_array, with_cupy_rmm
 from cuml.internals.input_utils import input_to_cupy_array
 from cuml.preprocessing import LabelEncoder
+
 from libcpp cimport bool, nullptr
-from cuml.svm.svm_base import SVMBase
+
 from cuml.internals.import_utils import has_sklearn
 from cuml.internals.mixins import FMajorInputTagMixin
+from cuml.svm.svm_base import SVMBase
 
 if has_sklearn():
-    from cuml.multiclass import MulticlassClassifier
     from sklearn.calibration import CalibratedClassifierCV
+
+    from cuml.multiclass import MulticlassClassifier
 
 cdef extern from "raft/distance/distance_types.hpp" \
         namespace "raft::distance::kernels":

--- a/python/cuml/svm/svm_base.pyx
+++ b/python/cuml/svm/svm_base.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,27 +16,33 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import gpu_only_import
+
 cupy = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
 from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import Base
 from cuml.common.exceptions import NotFittedError
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
-from cuml.common import input_to_cuml_array
-from cuml.common import using_output_type
+
+from cuml.common import input_to_cuml_array, using_output_type
 from cuml.internals.logger import warn
 from cuml.internals.mixins import FMajorInputTagMixin
+
 from libcpp cimport bool
 
 

--- a/python/cuml/svm/svr.pyx
+++ b/python/cuml/svm/svr.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,26 +16,35 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import gpu_only_import
+
 cupy = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import_from
+
 cuda = gpu_only_import_from('numba', 'cuda')
 
 from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
 
+from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.mixins import RegressorMixin
-from cuml.common.doc_utils import generate_docstring
 from cuml.metrics import r2_score
+
 from pylibraft.common.handle cimport handle_t
+
 from cuml.common import input_to_cuml_array
+
 from libcpp cimport bool, nullptr
+
 from cuml.svm.svm_base import SVMBase
+
 
 cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":
     enum KernelType:

--- a/python/cuml/testing/dask/utils.py
+++ b/python/cuml/testing/dask/utils.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
-from sklearn.datasets import fetch_20newsgroups
-from cuml.dask.common import to_sparse_dask_array
-from sklearn.feature_extraction.text import HashingVectorizer
 import dask
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.feature_extraction.text import HashingVectorizer
+
+from cuml.dask.common import to_sparse_dask_array
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/testing/plugins/quick_run_plugin.py
+++ b/python/cuml/testing/plugins/quick_run_plugin.py
@@ -16,8 +16,8 @@
 
 import typing
 
-import pytest
 import _pytest.python
+import pytest
 
 
 def pytest_addoption(parser):

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.internals.array import CumlArray
-from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from hypothesis import assume
 from hypothesis.extra.numpy import (
     array_shapes,
@@ -31,6 +29,9 @@ from hypothesis.strategies import (
 )
 from sklearn.datasets import make_classification, make_regression
 from sklearn.model_selection import train_test_split
+
+from cuml.internals.array import CumlArray
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/testing/test_preproc_utils.py
+++ b/python/cuml/testing/test_preproc_utils.py
@@ -13,26 +13,27 @@
 # limitations under the License.
 #
 
-from cuml.common import input_to_cuml_array
+import pytest
+from cupyx.scipy.sparse import coo_matrix as gpu_coo_matrix
 from scipy.sparse import coo_matrix as cpu_coo_matrix
 from scipy.sparse import csc_matrix as cpu_csc_matrix
-from cupyx.scipy.sparse import coo_matrix as gpu_coo_matrix
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
 
-from cuml.datasets import make_classification, make_blobs
-from cuml.internals.safe_imports import cpu_only_import_from
+from cuml.common import input_to_cuml_array
+from cuml.datasets import make_blobs, make_classification
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
-np_assert_allclose = cpu_only_import_from("numpy.testing", "assert_allclose")
-
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 gpu_sparse = gpu_only_import("cupyx.scipy.sparse")
+np = cpu_only_import("numpy")
 cpu_sparse = cpu_only_import("scipy.sparse")
-gpu_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
 gpu_csc_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csc_matrix")
+gpu_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
+np_assert_allclose = cpu_only_import_from("numpy.testing", "assert_allclose")
 cpu_csr_matrix = cpu_only_import_from("scipy.sparse", "csr_matrix")
 
 

--- a/python/cuml/testing/utils.py
+++ b/python/cuml/testing/utils.py
@@ -11,36 +11,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
-from cuml.internals.mem_type import MemoryType
-from cuml.internals.input_utils import input_to_cuml_array, is_array_like
-from cuml.internals.base import Base
-import cuml
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import mean_squared_error, brier_score_loss
-from sklearn.datasets import make_classification, make_regression
-from sklearn import datasets
-from pylibraft.common.cuda import Stream
-from sklearn.datasets import make_regression as skl_make_reg
-from numba.cuda.cudadrv.devicearray import DeviceNDArray
-from numbers import Number
-from cuml.internals.safe_imports import gpu_only_import_from
-from itertools import dropwhile
-from copy import deepcopy
-from cuml.internals.safe_imports import cpu_only_import
 import inspect
+from copy import deepcopy
+from itertools import dropwhile
+from numbers import Number
 from textwrap import dedent, indent
 
-from cuml.internals.safe_imports import gpu_only_import
+import pytest
+from numba.cuda.cudadrv.devicearray import DeviceNDArray
+from pylibraft.common.cuda import Stream
+from sklearn import datasets
+from sklearn.datasets import make_classification
+from sklearn.datasets import make_regression
+from sklearn.datasets import make_regression as skl_make_reg
+from sklearn.metrics import brier_score_loss, mean_squared_error
+from sklearn.model_selection import train_test_split
 
+import cuml
+from cuml.internals.base import Base
+from cuml.internals.input_utils import input_to_cuml_array, is_array_like
+from cuml.internals.mem_type import MemoryType
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-
 cuda = gpu_only_import_from("numba", "cuda")
-
-
-cudf = gpu_only_import("cudf")
 
 
 def array_difference(a, b, with_sign=True):
@@ -468,8 +469,8 @@ def get_classes_from_package(package, import_sub_packages=False):
     """
 
     if import_sub_packages:
-        import os
         import importlib
+        import os
 
         # First, find all __init__.py files in subdirectories of this package
         root_dir = os.path.dirname(package.__file__)

--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -14,27 +14,26 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import create_synthetic_dataset
-from sklearn.feature_extraction.text import CountVectorizer
-from sklearn import datasets
-from sklearn.datasets import make_regression as skl_make_reg
-from sklearn.datasets import make_classification as skl_make_clas
-from sklearn.datasets import fetch_california_housing
-from sklearn.datasets import fetch_20newsgroups
-from sklearn.utils import Bunch
-from datetime import timedelta
-from math import ceil
-import hypothesis
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
 import os
 import subprocess
+from datetime import timedelta
+from math import ceil
+
+import hypothesis
 import pandas as pd
+import pytest
+from sklearn import datasets
+from sklearn.datasets import fetch_20newsgroups, fetch_california_housing
+from sklearn.datasets import make_classification as skl_make_clas
+from sklearn.datasets import make_regression as skl_make_reg
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.utils import Bunch
 
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import create_synthetic_dataset
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 # Add the import here for any plugins that should be loaded EVERY TIME

--- a/python/cuml/tests/dask/conftest.py
+++ b/python/cuml/tests/dask/conftest.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import pytest
-
-from dask_cuda import initialize
-from dask_cuda import LocalCUDACluster
 from dask.distributed import Client
+from dask_cuda import LocalCUDACluster, initialize
 
 enable_tcp_over_ucx = True
 enable_nvlink = False

--- a/python/cuml/tests/dask/test_dask_arr_utils.py
+++ b/python/cuml/tests/dask/test_dask_arr_utils.py
@@ -13,19 +13,18 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.part_utils import _extract_partitions
 import dask
-from cuml.dask.common.dask_arr_utils import validate_dask_array
 import pytest
 
+from cuml.dask.common.dask_arr_utils import validate_dask_array
+from cuml.dask.common.part_utils import _extract_partitions
+from cuml.internals.safe_imports import gpu_only_import
 from cuml.testing.utils import array_equal
 
-from cuml.internals.safe_imports import gpu_only_import
-
-dask_cudf = gpu_only_import("dask_cudf")
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+dask_cudf = gpu_only_import("dask_cudf")
 
 
 @pytest.mark.parametrize(

--- a/python/cuml/tests/dask/test_dask_base.py
+++ b/python/cuml/tests/dask/test_dask_base.py
@@ -13,25 +13,24 @@
 # limitations under the License.
 #
 
-from sklearn.model_selection import train_test_split
-from cuml.dask.datasets import make_regression
-from cuml.dask.linear_model import LinearRegression
-from cuml.internals.safe_imports import cpu_only_import_from
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
-import cuml
-from cuml.dask.datasets import make_blobs
-from cuml.testing.dask.utils import load_text_corpus
-from cuml.dask.naive_bayes.naive_bayes import MultinomialNB
-from cuml.dask.cluster import KMeans
 from dask_ml.wrappers import ParallelPostFit
-from cuml.internals.safe_imports import gpu_only_import
+from sklearn.model_selection import train_test_split
+
+import cuml
+from cuml.dask.cluster import KMeans
+from cuml.dask.datasets import make_blobs, make_regression
+from cuml.dask.linear_model import LinearRegression
+from cuml.dask.naive_bayes.naive_bayes import MultinomialNB
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+)
+from cuml.testing.dask.utils import load_text_corpus
 
 cupy = gpu_only_import("cupy")
-
-
 np = cpu_only_import("numpy")
-
 assert_equal = cpu_only_import_from("numpy.testing", "assert_equal")
 
 

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -16,12 +16,10 @@
 import pytest
 
 from cuml.dask.datasets import make_regression
-from cuml.dask.linear_model import ElasticNet
-from cuml.dask.linear_model import Lasso
-from cuml.metrics import r2_score
-from cuml.testing.utils import unit_param, quality_param, stress_param
-
+from cuml.dask.linear_model import ElasticNet, Lasso
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.metrics import r2_score
+from cuml.testing.utils import quality_param, stress_param, unit_param
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/dask/test_dask_datasets.py
+++ b/python/cuml/tests/dask/test_dask_datasets.py
@@ -14,18 +14,17 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.part_utils import _extract_partitions
-from cuml.testing.utils import unit_param, quality_param, stress_param
-from cuml.dask.common.input_utils import DistributedDataHandler
-from cuml.dask.datasets.blobs import make_blobs
-from cuml.internals.safe_imports import gpu_only_import
+import dask.array as da
 import pytest
 
-import dask.array as da
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.common.part_utils import _extract_partitions
+from cuml.dask.datasets.blobs import make_blobs
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import quality_param, stress_param, unit_param
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize(

--- a/python/cuml/tests/dask/test_dask_dbscan.py
+++ b/python/cuml/tests/dask/test_dask_dbscan.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 #
 
-from sklearn.preprocessing import StandardScaler
-from sklearn.metrics import pairwise_distances
-from sklearn.datasets import make_blobs
+import pytest
 from sklearn.cluster import DBSCAN as skDBSCAN
+from sklearn.datasets import make_blobs
+from sklearn.metrics import pairwise_distances
+from sklearn.preprocessing import StandardScaler
+
+from cuml.internals.safe_imports import cpu_only_import
 from cuml.testing.utils import (
-    get_pattern,
-    unit_param,
-    quality_param,
-    stress_param,
     array_equal,
     assert_dbscan_equal,
+    get_pattern,
+    quality_param,
+    stress_param,
+    unit_param,
 )
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/dask/test_dask_doctest.py
+++ b/python/cuml/tests/dask/test_dask_doctest.py
@@ -13,20 +13,20 @@
 # limitations under the License.
 #
 
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 import contextlib
 import doctest
 import inspect
 import io
 
+import pytest
+
 import cuml
 import cuml.dask
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
+cudf = gpu_only_import("cudf")
 dask_cudf = gpu_only_import("dask_cudf")
 np = cpu_only_import("numpy")
-cudf = gpu_only_import("cudf")
 
 
 def _name_in_all(parent, name):

--- a/python/cuml/tests/dask/test_dask_func.py
+++ b/python/cuml/tests/dask/test_dask_func.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 #
 
-from dask import delayed
 import pytest
+from dask import delayed
 
-from cuml.dask.common.func import reduce
-from cuml.dask.common.func import tree_reduce
+from cuml.dask.common.func import reduce, tree_reduce
 
 
 @pytest.mark.parametrize("n_parts", [1, 2, 10, 15])

--- a/python/cuml/tests/dask/test_dask_global_settings.py
+++ b/python/cuml/tests/dask/test_dask_global_settings.py
@@ -24,9 +24,9 @@ import cuml
 from cuml import set_global_output_type, using_output_type
 from cuml.internals.api_context_managers import _using_mirror_output_type
 from cuml.internals.global_settings import (
+    GlobalSettings,
     _global_settings_data,
     _GlobalSettingsData,
-    GlobalSettings,
 )
 
 test_output_types_str = ("numpy", "numba", "cupy", "cudf")

--- a/python/cuml/tests/dask/test_dask_input_utils.py
+++ b/python/cuml/tests/dask/test_dask_input_utils.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-import pytest
-from cuml.dask.datasets.blobs import make_blobs
-from cuml.dask.common.input_utils import DistributedDataHandler
 import dask.array as da
+import pytest
+
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
+from cuml.dask.common.input_utils import DistributedDataHandler
+from cuml.dask.datasets.blobs import make_blobs
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")

--- a/python/cuml/tests/dask/test_dask_kmeans.py
+++ b/python/cuml/tests/dask/test_dask_kmeans.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-from sklearn.metrics import adjusted_rand_score as sk_adjusted_rand_score
-from cuml.metrics import adjusted_rand_score
 import dask.array as da
-from cuml.testing.utils import stress_param
-from cuml.testing.utils import quality_param
-from cuml.testing.utils import unit_param
 import pytest
+from sklearn.metrics import adjusted_rand_score as sk_adjusted_rand_score
+
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.metrics import adjusted_rand_score
+from cuml.testing.utils import quality_param, stress_param, unit_param
 
 cp = gpu_only_import("cupy")
 
@@ -44,7 +43,6 @@ def test_end_to_end(
 ):
 
     from cuml.dask.cluster import KMeans as cumlKMeans
-
     from cuml.dask.datasets import make_blobs
 
     X, y = make_blobs(
@@ -144,7 +142,6 @@ def test_large_data_no_overflow(nrows_per_part, ncols, nclusters, client):
 def test_weighted_kmeans(nrows, ncols, nclusters, n_parts, client):
     cluster_std = 10000.0
     from cuml.dask.cluster import KMeans as cumlKMeans
-
     from cuml.dask.datasets import make_blobs
 
     # Using fairly high variance between points in clusters
@@ -214,7 +211,6 @@ def test_weighted_kmeans(nrows, ncols, nclusters, n_parts, client):
 def test_transform(nrows, ncols, nclusters, n_parts, input_type, client):
 
     from cuml.dask.cluster import KMeans as cumlKMeans
-
     from cuml.dask.datasets import make_blobs
 
     X, y = make_blobs(
@@ -281,7 +277,6 @@ def test_transform(nrows, ncols, nclusters, n_parts, input_type, client):
 def test_score(nrows, ncols, nclusters, n_parts, input_type, client):
 
     from cuml.dask.cluster import KMeans as cumlKMeans
-
     from cuml.dask.datasets import make_blobs
 
     X, y = make_blobs(

--- a/python/cuml/tests/dask/test_dask_kneighbors_classifier.py
+++ b/python/cuml/tests/dask/test_dask_kneighbors_classifier.py
@@ -13,26 +13,28 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
-from cuml.testing.utils import unit_param, quality_param, stress_param
-
-from cuml.neighbors import KNeighborsClassifier as lKNNClf
-from cuml.dask.neighbors import KNeighborsClassifier as dKNNClf
-
-from sklearn.datasets import make_multilabel_classification
-from sklearn.datasets import make_classification
-from sklearn.model_selection import train_test_split
-
 import dask.array as da
 import dask.dataframe as dd
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-from cuml.internals.safe_imports import gpu_only_import_from
+import pytest
+from sklearn.datasets import (
+    make_classification,
+    make_multilabel_classification,
+)
+from sklearn.model_selection import train_test_split
 
-DataFrame = gpu_only_import_from("cudf", "DataFrame")
-np = cpu_only_import("numpy")
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
+from cuml.dask.neighbors import KNeighborsClassifier as dKNNClf
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.neighbors import KNeighborsClassifier as lKNNClf
+from cuml.testing.utils import quality_param, stress_param, unit_param
+
 cudf = gpu_only_import("cudf")
+np = cpu_only_import("numpy")
+DataFrame = gpu_only_import_from("cudf", "DataFrame")
 
 
 def generate_dask_array(np_array, n_parts):

--- a/python/cuml/tests/dask/test_dask_kneighbors_regressor.py
+++ b/python/cuml/tests/dask/test_dask_kneighbors_regressor.py
@@ -13,27 +13,26 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
-from cuml.testing.utils import unit_param, quality_param, stress_param
-
-from cuml.neighbors import KNeighborsRegressor as lKNNReg
-from cuml.dask.neighbors import KNeighborsRegressor as dKNNReg
-
-from sklearn.datasets import make_multilabel_classification
-from sklearn.datasets import make_regression
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import r2_score
-
 import dask.array as da
 import dask.dataframe as dd
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-from cuml.internals.safe_imports import gpu_only_import_from
+import pytest
+from sklearn.datasets import make_multilabel_classification, make_regression
+from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
 
-DataFrame = gpu_only_import_from("cudf.core.dataframe", "DataFrame")
-np = cpu_only_import("numpy")
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
+from cuml.dask.neighbors import KNeighborsRegressor as dKNNReg
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.neighbors import KNeighborsRegressor as lKNNReg
+from cuml.testing.utils import quality_param, stress_param, unit_param
+
 cudf = gpu_only_import("cudf")
+np = cpu_only_import("numpy")
+DataFrame = gpu_only_import_from("cudf.core.dataframe", "DataFrame")
 
 
 def generate_dask_array(np_array, n_parts):

--- a/python/cuml/tests/dask/test_dask_label_binarizer.py
+++ b/python/cuml/tests/dask/test_dask_label_binarizer.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuml.internals.safe_imports import gpu_only_import
+import dask
 import pytest
+
 from cuml.dask.preprocessing import LabelBinarizer
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.testing.utils import array_equal
 
-import dask
-from cuml.internals.safe_imports import cpu_only_import
-
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize(

--- a/python/cuml/tests/dask/test_dask_label_encoder.py
+++ b/python/cuml/tests/dask/test_dask_label_encoder.py
@@ -11,17 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from cuml.common.exceptions import NotFittedError
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+
 import cuml
+from cuml.common.exceptions import NotFittedError
 from cuml.dask.preprocessing.LabelEncoder import LabelEncoder
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
-np = cpu_only_import("numpy")
-dask_cudf = gpu_only_import("dask_cudf")
 cp = gpu_only_import("cupy")
+dask_cudf = gpu_only_import("dask_cudf")
+np = cpu_only_import("numpy")
 
 
 def _arr_to_similarity_mat(arr):

--- a/python/cuml/tests/dask/test_dask_linear_regression.py
+++ b/python/cuml/tests/dask/test_dask_linear_regression.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.dask.common import utils as dask_utils
-from sklearn.metrics import mean_squared_error
 from sklearn.datasets import make_regression
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.metrics import mean_squared_error
 
-pd = cpu_only_import("pandas")
-np = cpu_only_import("numpy")
-dask_cudf = gpu_only_import("dask_cudf")
+from cuml.dask.common import utils as dask_utils
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cudf = gpu_only_import("cudf")
+dask_cudf = gpu_only_import("dask_cudf")
+np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
+
 
 pytestmark = pytest.mark.mg
 

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -13,19 +13,20 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.dask.common import utils as dask_utils
-from sklearn.metrics import accuracy_score
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression as skLR
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.metrics import accuracy_score
 
-pd = cpu_only_import("pandas")
-np = cpu_only_import("numpy")
+from cuml.dask.common import utils as dask_utils
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 dask_cudf = gpu_only_import("dask_cudf")
-cudf = gpu_only_import("cudf")
+np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
+
 
 pytestmark = pytest.mark.mg
 

--- a/python/cuml/tests/dask/test_dask_metrics.py
+++ b/python/cuml/tests/dask/test_dask_metrics.py
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import dask.array as da
-from cuml.dask.metrics import confusion_matrix
-from cuml.testing.utils import stress_param, generate_random_labels
-from sklearn.metrics import confusion_matrix as sk_confusion_matrix
-import pytest
-from cuml.internals.safe_imports import gpu_only_import
 from itertools import chain, permutations
 
-from cuml.internals.safe_imports import cpu_only_import
+import dask.array as da
+import pytest
+from sklearn.metrics import confusion_matrix as sk_confusion_matrix
 
-np = cpu_only_import("numpy")
+from cuml.dask.metrics import confusion_matrix
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import generate_random_labels, stress_param
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.mg

--- a/python/cuml/tests/dask/test_dask_naive_bayes.py
+++ b/python/cuml/tests/dask/test_dask_naive_bayes.py
@@ -14,13 +14,14 @@
 # limitations under the License.
 #
 
-from sklearn.metrics import accuracy_score
-from cuml.testing.dask.utils import load_text_corpus
-from cuml.naive_bayes.naive_bayes import MultinomialNB as SGNB
-from cuml.dask.naive_bayes import MultinomialNB
-import pytest
 import dask.array
+import pytest
+from sklearn.metrics import accuracy_score
+
+from cuml.dask.naive_bayes import MultinomialNB
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.naive_bayes.naive_bayes import MultinomialNB as SGNB
+from cuml.testing.dask.utils import load_text_corpus
 
 cp = gpu_only_import("cupy")
 

--- a/python/cuml/tests/dask/test_dask_nearest_neighbors.py
+++ b/python/cuml/tests/dask/test_dask_nearest_neighbors.py
@@ -13,22 +13,23 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import array_equal
-from sklearn.neighbors import KNeighborsClassifier
-from cuml.testing.utils import unit_param, quality_param, stress_param
-from cuml.dask.common import utils as dask_utils
-from cuml.common import has_scipy
-from cuml.internals.safe_imports import cpu_only_import
 import pytest
+from sklearn.neighbors import KNeighborsClassifier
 
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.common import has_scipy
+from cuml.dask.common import utils as dask_utils
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import (
+    array_equal,
+    quality_param,
+    stress_param,
+    unit_param,
+)
 
 cudf = gpu_only_import("cudf")
 dask_cudf = gpu_only_import("dask_cudf")
-
-pd = cpu_only_import("pandas")
-
 np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
 
 
 def predict(neigh_ind, _y, n_neighbors):
@@ -97,9 +98,9 @@ def test_compare_skl(
     client,
 ):
 
-    from cuml.dask.neighbors import NearestNeighbors as daskNN
-
     from sklearn.datasets import make_blobs
+
+    from cuml.dask.neighbors import NearestNeighbors as daskNN
 
     nrows = _scale_rows(client, nrows)
 
@@ -158,9 +159,9 @@ def test_batch_size(nrows, ncols, n_parts, batch_size, client):
 
     n_neighbors = 10
     n_clusters = 5
-    from cuml.dask.neighbors import NearestNeighbors as daskNN
-
     from sklearn.datasets import make_blobs
+
+    from cuml.dask.neighbors import NearestNeighbors as daskNN
 
     nrows = _scale_rows(client, nrows)
 
@@ -196,9 +197,9 @@ def test_return_distance(client):
     n_feats = 50
     k = 5
 
-    from cuml.dask.neighbors import NearestNeighbors as daskNN
-
     from sklearn.datasets import make_blobs
+
+    from cuml.dask.neighbors import NearestNeighbors as daskNN
 
     n_samples = _scale_rows(client, n_samples)
 
@@ -227,12 +228,12 @@ def test_default_n_neighbors(client):
     n_feats = 50
     k = 15
 
+    from sklearn.datasets import make_blobs
+
     from cuml.dask.neighbors import NearestNeighbors as daskNN
     from cuml.neighbors.nearest_neighbors_mg import (
         NearestNeighborsMG as cumlNN,
     )
-
-    from sklearn.datasets import make_blobs
 
     n_samples = _scale_rows(client, n_samples)
 
@@ -258,8 +259,8 @@ def test_default_n_neighbors(client):
 
 
 def test_one_query_partition(client):
-    from cuml.dask.neighbors import NearestNeighbors as daskNN
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.neighbors import NearestNeighbors as daskNN
 
     X_train, _ = make_blobs(n_samples=4000, n_features=16, n_parts=8)
 

--- a/python/cuml/tests/dask/test_dask_one_hot_encoder.py
+++ b/python/cuml/tests/dask/test_dask_one_hot_encoder.py
@@ -12,23 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.internals.safe_imports import cpu_only_import_from
+import dask.array as da
+import pytest
+from cudf import DataFrame, Series
 from sklearn.preprocessing import OneHotEncoder as SkOneHotEncoder
+
+from cuml.dask.preprocessing import OneHotEncoder
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+)
 from cuml.testing.utils import (
-    stress_param,
-    generate_inputs_from_categories,
     assert_inverse_equal,
     from_df_to_numpy,
+    generate_inputs_from_categories,
+    stress_param,
 )
-from cuml.dask.preprocessing import OneHotEncoder
-import dask.array as da
-from cuml.internals.safe_imports import cpu_only_import
-from cudf import DataFrame, Series
-import pytest
-from cuml.internals.safe_imports import gpu_only_import
 
-dask_cudf = gpu_only_import("dask_cudf")
 cp = gpu_only_import("cupy")
+dask_cudf = gpu_only_import("dask_cudf")
 np = cpu_only_import("numpy")
 assert_frame_equal = cpu_only_import_from(
     "pandas.testing", "assert_frame_equal"

--- a/python/cuml/tests/dask/test_dask_pca.py
+++ b/python/cuml/tests/dask/test_dask_pca.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.mg
@@ -29,10 +29,10 @@ cp = gpu_only_import("cupy")
 @pytest.mark.parametrize("input_type", ["dataframe", "array"])
 def test_pca_fit(nrows, ncols, n_parts, input_type, client):
 
-    from cuml.dask.decomposition import PCA as daskPCA
     from sklearn.decomposition import PCA
 
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import PCA as daskPCA
 
     X, _ = make_blobs(
         n_samples=nrows,
@@ -85,8 +85,8 @@ def test_pca_fit(nrows, ncols, n_parts, input_type, client):
 @pytest.mark.parametrize("n_parts", [46])
 def test_pca_fit_transform_fp32(nrows, ncols, n_parts, client):
 
-    from cuml.dask.decomposition import PCA as daskPCA
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import PCA as daskPCA
 
     X_cudf, _ = make_blobs(
         n_samples=nrows,
@@ -110,8 +110,8 @@ def test_pca_fit_transform_fp32(nrows, ncols, n_parts, client):
 @pytest.mark.parametrize("n_parts", [33])
 def test_pca_fit_transform_fp64(nrows, ncols, n_parts, client):
 
-    from cuml.dask.decomposition import PCA as daskPCA
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import PCA as daskPCA
 
     X_cudf, _ = make_blobs(
         n_samples=nrows,
@@ -135,8 +135,8 @@ def test_pca_fit_transform_fp64(nrows, ncols, n_parts, client):
 @pytest.mark.parametrize("n_parts", [28])
 def test_pca_fit_transform_fp32_noncomponents(nrows, ncols, n_parts, client):
     # Tests the case when n_components is not passed for MG scenarios
-    from cuml.dask.decomposition import PCA as daskPCA
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import PCA as daskPCA
 
     X_cudf, _ = make_blobs(
         n_samples=nrows,

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -29,26 +29,26 @@
 # limitations under the License.
 #
 
-from dask.distributed import Client
-from sklearn.ensemble import RandomForestClassifier as skrfc
-from sklearn.metrics import accuracy_score, r2_score, mean_squared_error
-from sklearn.model_selection import train_test_split
-from sklearn.datasets import make_regression, make_classification
-from dask.array import from_array
-from cuml.ensemble import RandomForestRegressor as cuRFR_sg
-from cuml.ensemble import RandomForestClassifier as cuRFC_sg
-from cuml.dask.common import utils as dask_utils
-from cuml.dask.ensemble import RandomForestRegressor as cuRFR_mg
-from cuml.dask.ensemble import RandomForestClassifier as cuRFC_mg
-from cuml.internals.safe_imports import cpu_only_import
 import json
+
 import pytest
-from cuml.internals.safe_imports import gpu_only_import
+from dask.array import from_array
+from dask.distributed import Client
+from sklearn.datasets import make_classification, make_regression
+from sklearn.ensemble import RandomForestClassifier as skrfc
+from sklearn.metrics import accuracy_score, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from cuml.dask.common import utils as dask_utils
+from cuml.dask.ensemble import RandomForestClassifier as cuRFC_mg
+from cuml.dask.ensemble import RandomForestRegressor as cuRFR_mg
+from cuml.ensemble import RandomForestClassifier as cuRFC_sg
+from cuml.ensemble import RandomForestRegressor as cuRFR_sg
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 dask_cudf = gpu_only_import("dask_cudf")
-
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
 

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.dask.common import utils as dask_utils
-from sklearn.metrics import mean_squared_error
 from sklearn.datasets import make_regression
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.metrics import mean_squared_error
 
-pd = cpu_only_import("pandas")
-np = cpu_only_import("numpy")
-dask_cudf = gpu_only_import("dask_cudf")
+from cuml.dask.common import utils as dask_utils
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cudf = gpu_only_import("cudf")
+dask_cudf = gpu_only_import("dask_cudf")
+np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
+
 
 pytestmark = pytest.mark.mg
 

--- a/python/cuml/tests/dask/test_dask_serialization.py
+++ b/python/cuml/tests/dask/test_dask_serialization.py
@@ -14,9 +14,10 @@
 #
 
 from distributed.protocol.serialize import serialize
-from cuml.naive_bayes.naive_bayes import MultinomialNB
+
 from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.naive_bayes.naive_bayes import MultinomialNB
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/tests/dask/test_dask_sql.py
+++ b/python/cuml/tests/dask/test_dask_sql.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 #
 
-from sklearn.model_selection import train_test_split
+import pytest
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
-from cuml.internals.import_utils import has_dask_sql
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
+from sklearn.model_selection import train_test_split
+
 import cuml
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.import_utils import has_dask_sql
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
 dask_cudf = gpu_only_import("dask_cudf")

--- a/python/cuml/tests/dask/test_dask_tfidf.py
+++ b/python/cuml/tests/dask/test_dask_tfidf.py
@@ -13,22 +13,25 @@
 # limitations under the License.
 #
 
+import dask
+import dask.array as da
+import pytest
 from sklearn.feature_extraction.text import (
     TfidfTransformer as SkTfidfTransformer,
 )
-from cuml.dask.feature_extraction.text import TfidfTransformer
-import dask
-import dask.array as da
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
+from cuml.dask.feature_extraction.text import TfidfTransformer
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+
 cp = gpu_only_import("cupy")
-scipy_csr_matrix = cpu_only_import_from("scipy.sparse", "csr_matrix")
+np = cpu_only_import("numpy")
 cp_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
+scipy_csr_matrix = cpu_only_import_from("scipy.sparse", "csr_matrix")
 
 
 # Testing Util Functions

--- a/python/cuml/tests/dask/test_dask_tsvd.py
+++ b/python/cuml/tests/dask/test_dask_tsvd.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.dask_arr_utils import to_dask_cudf
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.testing.utils import array_equal, unit_param, stress_param
 import pytest
 
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.dask.common.dask_arr_utils import to_dask_cudf
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import array_equal, stress_param, unit_param
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.mg
@@ -43,10 +42,10 @@ def test_pca_fit(data_info, input_type, client):
                 "Re-run with 'CUML_ADAPT_STRESS_TESTS=True'"
             )
 
-    from cuml.dask.decomposition import TruncatedSVD as daskTPCA
     from sklearn.decomposition import TruncatedSVD
 
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import TruncatedSVD as daskTPCA
 
     X, _ = make_blobs(
         n_samples=nrows,
@@ -98,8 +97,8 @@ def test_pca_fit(data_info, input_type, client):
 def test_pca_fit_transform_fp32(data_info, client):
 
     nrows, ncols, n_parts = data_info
-    from cuml.dask.decomposition import TruncatedSVD as daskTPCA
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import TruncatedSVD as daskTPCA
 
     X_cudf, _ = make_blobs(
         n_samples=nrows,
@@ -124,8 +123,8 @@ def test_pca_fit_transform_fp64(data_info, client):
 
     nrows, ncols, n_parts = data_info
 
-    from cuml.dask.decomposition import TruncatedSVD as daskTPCA
     from cuml.dask.datasets import make_blobs
+    from cuml.dask.decomposition import TruncatedSVD as daskTPCA
 
     X_cudf, _ = make_blobs(
         n_samples=nrows,

--- a/python/cuml/tests/dask/test_dask_umap.py
+++ b/python/cuml/tests/dask/test_dask_umap.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 #
 
-from sklearn.datasets import load_iris
-from sklearn.datasets import load_digits
 import math
-from cuml.metrics import trustworthiness
-from cuml.internals import logger
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
 
-from cuml.internals.safe_imports import gpu_only_import
+import pytest
+from sklearn.datasets import load_digits, load_iris
+
+from cuml.internals import logger
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.metrics import trustworthiness
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
@@ -72,8 +71,8 @@ def _umap_mnmg_trustworthiness(
     parallel, report trustworthiness
     """
     import dask.array as da
-    from cuml.dask.manifold import UMAP as MNMG_UMAP
 
+    from cuml.dask.manifold import UMAP as MNMG_UMAP
     from cuml.manifold import UMAP
 
     local_model = UMAP(n_neighbors=n_neighbors, random_state=42, init="random")

--- a/python/cuml/tests/dask/test_dask_utils.py
+++ b/python/cuml/tests/dask/test_dask_utils.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 import pytest
-
 from dask.distributed import wait
+
 from cuml.dask.common import raise_exception_from_futures
 
 

--- a/python/cuml/tests/explainer/test_explainer_base.py
+++ b/python/cuml/tests/explainer/test_explainer_base.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
+import pytest
+from pylibraft.common.handle import Handle
+
 from cuml import LinearRegression as cuLR
 from cuml.explainer.base import SHAPBase
-from pylibraft.common.handle import Handle
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/tests/explainer/test_explainer_common.py
+++ b/python/cuml/tests/explainer/test_explainer_common.py
@@ -14,23 +14,25 @@
 # limitations under the License.
 #
 
+import pytest
 from pylibraft.common.handle import Handle
 from sklearn.linear_model import LinearRegression as skreg
-from cuml.datasets import make_regression
-from cuml.testing.utils import ClassEnumerator
-from cuml.explainer.common import model_func_call
-from cuml.explainer.common import link_dict
-from cuml.explainer.common import get_tag_from_model_func
-from cuml.explainer.common import get_link_fn_from_str_or_fn
-from cuml.explainer.common import get_handle_from_cuml_model_func
-from cuml.explainer.common import get_dtype_from_model_func
-from cuml.explainer.common import get_cai_ptr
+
+import cuml
 from cuml import PCA
 from cuml import LinearRegression as reg
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
-import cuml
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.datasets import make_regression
+from cuml.explainer.common import (
+    get_cai_ptr,
+    get_dtype_from_model_func,
+    get_handle_from_cuml_model_func,
+    get_link_fn_from_str_or_fn,
+    get_tag_from_model_func,
+    link_dict,
+    model_func_call,
+)
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import ClassEnumerator
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -14,23 +14,22 @@
 # limitations under the License.
 #
 
+import math
+
+import pytest
+import sklearn.neighbors
 from sklearn.model_selection import train_test_split
+
+import cuml
+from cuml import KernelExplainer, Lasso
+from cuml.datasets import make_regression
+from cuml.internals.import_utils import has_scipy, has_shap
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.testing.utils import (
-    create_synthetic_dataset,
     ClassEnumerator,
+    create_synthetic_dataset,
     get_shap_values,
 )
-from cuml.datasets import make_regression
-from cuml.internals.import_utils import has_shap
-from cuml.internals.import_utils import has_scipy
-from cuml import KernelExplainer
-from cuml import Lasso
-import sklearn.neighbors
-import pytest
-import math
-from cuml.internals.safe_imports import cpu_only_import
-import cuml
-from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/explainer/test_explainer_permutation_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_permutation_shap.py
@@ -15,17 +15,17 @@
 #
 
 
+import pytest
+import sklearn.neighbors
+
+import cuml
+from cuml import PermutationExplainer
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.testing.utils import (
     ClassEnumerator,
-    get_shap_values,
     create_synthetic_dataset,
+    get_shap_values,
 )
-from cuml import PermutationExplainer
-import sklearn.neighbors
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
-import cuml
-from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -14,25 +14,27 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import as_type
-import cuml
-from cuml.ensemble import RandomForestClassifier as curfc
-from cuml.ensemble import RandomForestRegressor as curfr
-from cuml.common.exceptions import NotFittedError
-from cuml.internals.import_utils import has_sklearn
-from cuml.internals.import_utils import has_lightgbm, has_shap
-from cuml.explainer.tree_shap import TreeExplainer
-from hypothesis import given, settings, assume, HealthCheck, strategies as st
-from cuml.internals.safe_imports import gpu_only_import
 import json
+
 import pytest
 import treelite
-from cuml.internals.safe_imports import cpu_only_import
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
 
+import cuml
+from cuml.common.exceptions import NotFittedError
+from cuml.ensemble import RandomForestClassifier as curfc
+from cuml.ensemble import RandomForestRegressor as curfr
+from cuml.explainer.tree_shap import TreeExplainer
+from cuml.internals.import_utils import has_lightgbm, has_shap, has_sklearn
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import as_type
+
+cudf = gpu_only_import("cudf")
+cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-cp = gpu_only_import("cupy")
-cudf = gpu_only_import("cudf")
+
 
 pytestmark = pytest.mark.skip
 
@@ -50,9 +52,9 @@ if has_lightgbm():
 if has_shap():
     import shap
 if has_sklearn():
-    from sklearn.datasets import make_regression, make_classification
-    from sklearn.ensemble import RandomForestRegressor as sklrfr
+    from sklearn.datasets import make_classification, make_regression
     from sklearn.ensemble import RandomForestClassifier as sklrfc
+    from sklearn.ensemble import RandomForestRegressor as sklrfr
 
 
 def make_classification_with_categorical(

--- a/python/cuml/tests/explainer/test_sampling.py
+++ b/python/cuml/tests/explainer/test_sampling.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.explainer.sampling import kmeans_sampling
-from cuml.internals.safe_imports import gpu_only_import_from
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+
+from cuml.explainer.sampling import kmeans_sampling
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/tests/explainer/test_shap_plotting.py
+++ b/python/cuml/tests/explainer/test_shap_plotting.py
@@ -19,7 +19,6 @@ import pytest
 from cuml import KernelExplainer as cuKE
 from cuml import LinearRegression
 
-
 # set this variable to True if you want to see the charts
 show_plots = False
 

--- a/python/cuml/tests/stemmer_tests/test_len_utils.py
+++ b/python/cuml/tests/stemmer_tests/test_len_utils.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 #
 
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.preprocessing.text.stem.porter_stemmer_utils.len_flags_utils import (
     len_eq_n,
     len_gt_n,
 )
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
 
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/stemmer_tests/test_porter_stemmer_rules.py
+++ b/python/cuml/tests/stemmer_tests/test_porter_stemmer_rules.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.preprocessing.text.stem.porter_stemmer_utils import (
     porter_stemmer_rules,
 )
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
 
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/stemmer_tests/test_stemmer.py
+++ b/python/cuml/tests/stemmer_tests/test_stemmer.py
@@ -15,8 +15,9 @@
 #
 
 from nltk import stem as nltk_stem
-from cuml.preprocessing.text import stem as rapids_stem
+
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.preprocessing.text import stem as rapids_stem
 
 cudf = gpu_only_import("cudf")
 

--- a/python/cuml/tests/stemmer_tests/test_steps.py
+++ b/python/cuml/tests/stemmer_tests/test_steps.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.preprocessing.text.stem.porter_stemmer import PorterStemmer
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.preprocessing.text.stem.porter_stemmer import PorterStemmer
 
 cudf = gpu_only_import("cudf")
 

--- a/python/cuml/tests/stemmer_tests/test_suffix_utils.py
+++ b/python/cuml/tests/stemmer_tests/test_suffix_utils.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
+from cuml.internals.safe_imports import gpu_only_import
 from cuml.preprocessing.text.stem.porter_stemmer_utils.suffix_utils import (
     get_stem_series,
     replace_suffix,
 )
-from cuml.internals.safe_imports import gpu_only_import
 
 cudf = gpu_only_import("cudf")
 

--- a/python/cuml/tests/test_adapters.py
+++ b/python/cuml/tests/test_adapters.py
@@ -15,29 +15,32 @@
 #
 
 import platform
+
+import pytest
 from sklearn.preprocessing import normalize as sk_normalize
+from sklearn.utils._mask import _get_mask as sk_get_mask
+
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 from cuml.testing.test_preproc_utils import assert_allclose
+from cuml.thirdparty_adapters.adapters import _get_mask as cu_get_mask
+from cuml.thirdparty_adapters.adapters import (
+    _masked_column_mean,
+    _masked_column_median,
+    _masked_column_mode,
+    check_array,
+)
 from cuml.thirdparty_adapters.sparsefuncs_fast import (
-    csr_mean_variance_axis0,
-    csc_mean_variance_axis0,
     _csc_mean_variance_axis0,
+    csc_mean_variance_axis0,
+    csr_mean_variance_axis0,
     inplace_csr_row_normalize_l1,
     inplace_csr_row_normalize_l2,
 )
-from sklearn.utils._mask import _get_mask as sk_get_mask
-from cuml.thirdparty_adapters.adapters import (
-    check_array,
-    _get_mask as cu_get_mask,
-    _masked_column_median,
-    _masked_column_mean,
-    _masked_column_mode,
-)
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
-
-from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")
 cpx = gpu_only_import("cupyx")

--- a/python/cuml/tests/test_agglomerative.py
+++ b/python/cuml/tests/test_agglomerative.py
@@ -14,15 +14,12 @@
 #
 
 import pytest
+from sklearn import cluster
 
 from cuml.cluster import AgglomerativeClustering
 from cuml.datasets import make_blobs
-
-from cuml.metrics import adjusted_rand_score
-
-from sklearn import cluster
-
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.metrics import adjusted_rand_score
 
 cp = gpu_only_import("cupy")
 

--- a/python/cuml/tests/test_allocator.py
+++ b/python/cuml/tests/test_allocator.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
-from cuml.internals.input_utils import sparse_scipy_to_cp
-from cuml.testing.utils import small_classification_dataset
-from cuml.naive_bayes import MultinomialNB
-from cuml import LogisticRegression
-from cuml.internals.safe_imports import cpu_only_import
 import pytest
 
-from cuml.internals.safe_imports import gpu_only_import
+from cuml import LogisticRegression
+from cuml.internals.input_utils import sparse_scipy_to_cp
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.naive_bayes import MultinomialNB
+from cuml.testing.utils import small_classification_dataset
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_api.py
+++ b/python/cuml/tests/test_api.py
@@ -14,15 +14,16 @@
 # limitations under the License.
 #
 
-from sklearn.datasets import make_classification
-from cuml.testing.utils import ClassEnumerator
-from cuml.internals.base import Base
-from cuml.internals.safe_imports import cpu_only_import
 import inspect
+
 import pytest
+from sklearn.datasets import make_classification
+
 import cuml
 import cuml.internals.mixins as cumix
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.base import Base
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import ClassEnumerator
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_arima.py
+++ b/python/cuml/tests/test_arima.py
@@ -30,27 +30,28 @@
 # Note that there are significant differences between our implementation and
 # the reference, and perfect parity cannot be expected for integration tests.
 
-from cuml.testing.utils import stress_param
-from cuml.internals.input_utils import input_to_host_array
-import cuml.tsa.arima as arima
-from cuml.internals.safe_imports import gpu_only_import
+import os
+import warnings
+
+import pytest
 import statsmodels.api as sm
 from sklearn.model_selection import train_test_split
-from cuml.internals.safe_imports import cpu_only_import_from
-import warnings
-import os
-import pytest
 
-from cuml.internals.safe_imports import cpu_only_import
+import cuml.tsa.arima as arima
+from cuml.internals.input_utils import input_to_host_array
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+)
+from cuml.testing.utils import stress_param
 
+cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
-
 pd = cpu_only_import("pandas")
 approx_fprime = cpu_only_import_from(
     "scipy.optimize.optimize", "approx_fprime"
 )
-
-cudf = gpu_only_import("cudf")
 
 
 ###############################################################################

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -16,15 +16,19 @@
 
 import gc
 import operator
-import pytest
 import sys
 from copy import deepcopy
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from cuml import global_settings
 from cuml.internals.array import (
     CumlArray,
     _order_to_strides,
     array_to_memory_order,
 )
-from cuml import global_settings
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.memory_utils import (
     _get_size_from_shape,
@@ -47,10 +51,10 @@ from cuml.testing.strategies import (
     cuml_array_dtypes,
     cuml_array_input_types,
     cuml_array_inputs,
+    cuml_array_mem_types,
     cuml_array_orders,
     cuml_array_output_types,
     cuml_array_shapes,
-    cuml_array_mem_types,
 )
 from cuml.testing.utils import (
     normalized_shape,
@@ -58,24 +62,22 @@ from cuml.testing.utils import (
     squeezed_shape,
     to_nparray,
 )
-from hypothesis import assume, given, settings
-from hypothesis import strategies as st
 
-cp = gpu_only_import("cupy")
 cudf = gpu_only_import("cudf")
+cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-
-cuda = gpu_only_import_from("numba", "cuda")
 CudfDataFrame = gpu_only_import_from("cudf", "DataFrame")
 CudfSeries = gpu_only_import_from("cudf", "Series")
-PandasSeries = cpu_only_import_from("pandas", "Series")
-PandasDataFrame = cpu_only_import_from("pandas", "DataFrame")
 cp_array = gpu_only_import_from("cupy", "ndarray")
-np_array = gpu_only_import_from("numpy", "ndarray")
+cuda = gpu_only_import_from("numba", "cuda")
 numba_array = gpu_only_import_from(
     "numba.cuda.cudadrv.devicearray", "DeviceNDArray"
 )
+np_array = gpu_only_import_from("numpy", "ndarray")
+PandasDataFrame = cpu_only_import_from("pandas", "DataFrame")
+PandasSeries = cpu_only_import_from("pandas", "Series")
+
 
 if sys.version_info < (3, 8):
     try:

--- a/python/cuml/tests/test_array_sparse.py
+++ b/python/cuml/tests/test_array_sparse.py
@@ -14,17 +14,16 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
 
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
-from cuml.internals.safe_imports import cpu_only_import
-
-scipy_sparse = cpu_only_import("scipy.sparse")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+scipy_sparse = cpu_only_import("scipy.sparse")
+
 
 test_input_types = ["cupy", "scipy"]
 

--- a/python/cuml/tests/test_auto_arima.py
+++ b/python/cuml/tests/test_auto_arima.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.tsa import auto_arima
 import pytest
 
+from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.tsa import auto_arima
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -15,18 +15,17 @@
 
 import inspect
 
-import cuml
-import pytest
 import numpydoc.docscrape
-
+import pytest
+from cuml._thirdparty.sklearn.utils.skl_dependencies import (
+    BaseEstimator as sklBaseEstimator,
+)
 from pylibraft.common.cuda import Stream
 
+import cuml
 from cuml.testing.utils import (
     get_classes_from_package,
     small_classification_dataset,
-)
-from cuml._thirdparty.sklearn.utils.skl_dependencies import (
-    BaseEstimator as sklBaseEstimator,
 )
 
 all_base_children = get_classes_from_package(cuml, import_sub_packages=True)

--- a/python/cuml/tests/test_batched_lbfgs.py
+++ b/python/cuml/tests/test_batched_lbfgs.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_benchmark.py
+++ b/python/cuml/tests/test_benchmark.py
@@ -12,28 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.benchmark.bench_helper_funcs import fit, fit_predict
 import time
-from sklearn import metrics
-from cuml.internals.safe_imports import gpu_only_import_from
+
 import pytest
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.benchmark import datagen, algorithms
-from cuml.benchmark.bench_helper_funcs import _training_data_to_numpy
+from sklearn import metrics
+
+from cuml.benchmark import algorithms, datagen
+from cuml.benchmark.bench_helper_funcs import (
+    _training_data_to_numpy,
+    fit,
+    fit_predict,
+)
 from cuml.benchmark.runners import (
     AccuracyComparisonRunner,
     SpeedupComparisonRunner,
     run_variations,
 )
-from cuml.internals.import_utils import has_umap
-from cuml.internals.import_utils import has_xgboost
+from cuml.internals.import_utils import has_umap, has_xgboost
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
-from cuml.internals.safe_imports import cpu_only_import
-
-np = cpu_only_import("numpy")
 cudf = gpu_only_import("cudf")
-cuda = gpu_only_import_from("numba", "cuda")
+np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
+cuda = gpu_only_import_from("numba", "cuda")
 
 
 pytestmark = pytest.mark.skip

--- a/python/cuml/tests/test_class_enumerator.py
+++ b/python/cuml/tests/test_class_enumerator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import cuml
-
 from cuml.testing.utils import ClassEnumerator
 
 

--- a/python/cuml/tests/test_compose.py
+++ b/python/cuml/tests/test_compose.py
@@ -14,45 +14,40 @@
 #
 
 
-from cuml.testing.test_preproc_utils import assert_allclose
-from sklearn.preprocessing import (
-    StandardScaler as skStandardScaler,
-    Normalizer as skNormalizer,
-    PolynomialFeatures as skPolynomialFeatures,
-    OneHotEncoder as skOneHotEncoder,
-)
-from cuml.preprocessing import (
-    StandardScaler as cuStandardScaler,
-    Normalizer as cuNormalizer,
-    PolynomialFeatures as cuPolynomialFeatures,
-    OneHotEncoder as cuOneHotEncoder,
-)
-from sklearn.compose import (
-    ColumnTransformer as skColumnTransformer,
-    make_column_transformer as sk_make_column_transformer,
-    make_column_selector as sk_make_column_selector,
-)
-from cuml.compose import (
-    ColumnTransformer as cuColumnTransformer,
-    make_column_transformer as cu_make_column_transformer,
-    make_column_selector as cu_make_column_selector,
-)
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import
 import pytest
+from sklearn.compose import ColumnTransformer as skColumnTransformer
+from sklearn.compose import make_column_selector as sk_make_column_selector
+from sklearn.compose import (
+    make_column_transformer as sk_make_column_transformer,
+)
+from sklearn.preprocessing import Normalizer as skNormalizer
+from sklearn.preprocessing import OneHotEncoder as skOneHotEncoder
+from sklearn.preprocessing import PolynomialFeatures as skPolynomialFeatures
+from sklearn.preprocessing import StandardScaler as skStandardScaler
 
-from cuml.internals.safe_imports import gpu_only_import
-
-from cuml.testing.test_preproc_utils import (
+from cuml.compose import ColumnTransformer as cuColumnTransformer
+from cuml.compose import make_column_selector as cu_make_column_selector
+from cuml.compose import make_column_transformer as cu_make_column_transformer
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.preprocessing import Normalizer as cuNormalizer
+from cuml.preprocessing import OneHotEncoder as cuOneHotEncoder
+from cuml.preprocessing import PolynomialFeatures as cuPolynomialFeatures
+from cuml.preprocessing import StandardScaler as cuStandardScaler
+from cuml.testing.test_preproc_utils import (  # noqa: F401
+    assert_allclose,
     clf_dataset,
     sparse_clf_dataset,
-)  # noqa: F401
+)
 
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
-pdDataFrame = cpu_only_import_from("pandas", "DataFrame")
 cuDataFrame = gpu_only_import_from("cudf", "DataFrame")
+pdDataFrame = cpu_only_import_from("pandas", "DataFrame")
 
 
 @pytest.mark.parametrize("remainder", ["drop", "passthrough"])

--- a/python/cuml/tests/test_coordinate_descent.py
+++ b/python/cuml/tests/test_coordinate_descent.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 #
 
-from sklearn.model_selection import train_test_split
-from sklearn.datasets import make_regression
-from sklearn.linear_model import Lasso, ElasticNet
-from cuml.testing.utils import unit_param, quality_param, stress_param
-from cuml.metrics import r2_score
-from cuml.linear_model import ElasticNet as cuElasticNet
-from cuml import Lasso as cuLasso
 import pytest
+from sklearn.datasets import make_regression
+from sklearn.linear_model import ElasticNet, Lasso
+from sklearn.model_selection import train_test_split
+
+from cuml import Lasso as cuLasso
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.linear_model import ElasticNet as cuElasticNet
+from cuml.metrics import r2_score
+from cuml.testing.utils import quality_param, stress_param, unit_param
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_cuml_descr_decor.py
+++ b/python/cuml/tests/test_cuml_descr_decor.py
@@ -13,21 +13,24 @@
 # limitations under the License.
 #
 
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.input_utils import determine_array_type
-from cuml.internals.input_utils import determine_array_dtype
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array import CumlArray
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 import pickle
+
+import pytest
 
 import cuml
 import cuml.internals
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals.array import CumlArray
+from cuml.internals.input_utils import (
+    determine_array_dtype,
+    determine_array_type,
+    input_to_cuml_array,
+)
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
+
 
 test_input_types = ["numpy", "numba", "cupy", "cudf"]
 

--- a/python/cuml/tests/test_dataset_generator_types.py
+++ b/python/cuml/tests/test_dataset_generator_types.py
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
+import pytest
+
+import cuml
 from cuml.datasets import (
     make_arima,
     make_blobs,
     make_classification,
     make_regression,
 )
-import cuml
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/tests/test_dbscan.py
+++ b/python/cuml/tests/test_dbscan.py
@@ -13,23 +13,23 @@
 # limitations under the License.
 #
 
-from sklearn.preprocessing import StandardScaler
-from sklearn.metrics import pairwise_distances
-from sklearn.datasets import make_blobs
+import pytest
 from sklearn.cluster import DBSCAN as skDBSCAN
+from sklearn.datasets import make_blobs
+from sklearn.metrics import pairwise_distances
+from sklearn.preprocessing import StandardScaler
+
+from cuml import DBSCAN as cuDBSCAN
+from cuml.internals.safe_imports import cpu_only_import, cpu_only_import_from
 from cuml.testing.utils import (
-    get_pattern,
-    unit_param,
-    quality_param,
-    stress_param,
     array_equal,
     assert_dbscan_equal,
+    get_handle,
+    get_pattern,
+    quality_param,
+    stress_param,
+    unit_param,
 )
-from cuml import DBSCAN as cuDBSCAN
-from cuml.testing.utils import get_handle
-import pytest
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
 assert_raises = cpu_only_import_from("numpy.testing", "assert_raises")

--- a/python/cuml/tests/test_device_selection.py
+++ b/python/cuml/tests/test_device_selection.py
@@ -13,14 +13,32 @@
 # limitations under the License.
 #
 
-from cuml.testing.test_preproc_utils import to_output_type
-from cuml.testing.utils import array_equal
+import inspect
+import itertools as it
+import pickle
+from importlib import import_module
 
+import pytest
+from hdbscan import HDBSCAN as refHDBSCAN
+from pytest_cases import fixture_union, pytest_fixture_plus
+from sklearn.datasets import make_blobs, make_regression
+from sklearn.decomposition import PCA as skPCA
+from sklearn.decomposition import TruncatedSVD as skTruncatedSVD
+from sklearn.linear_model import ElasticNet as skElasticNet
+from sklearn.linear_model import Lasso as skLasso
+from sklearn.linear_model import LinearRegression as skLinearRegression
+from sklearn.linear_model import LogisticRegression as skLogisticRegression
+from sklearn.linear_model import Ridge as skRidge
+from sklearn.neighbors import NearestNeighbors as skNearestNeighbors
+from umap import UMAP as refUMAP
+
+import cuml
 from cuml.cluster.hdbscan import HDBSCAN
-from cuml.neighbors import NearestNeighbors
-from cuml.metrics import trustworthiness
-from cuml.metrics import adjusted_rand_score
-from cuml.manifold import UMAP
+from cuml.common.device_selection import DeviceType, using_device_type
+from cuml.decomposition import PCA, TruncatedSVD
+from cuml.internals.mem_type import MemoryType
+from cuml.internals.memory_utils import using_memory_type
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.linear_model import (
     ElasticNet,
     Lasso,
@@ -28,34 +46,15 @@ from cuml.linear_model import (
     LogisticRegression,
     Ridge,
 )
-from cuml.internals.memory_utils import using_memory_type
-from cuml.internals.mem_type import MemoryType
-from cuml.decomposition import PCA, TruncatedSVD
-from cuml.common.device_selection import DeviceType, using_device_type
-from hdbscan import HDBSCAN as refHDBSCAN
-from umap import UMAP as refUMAP
-from sklearn.neighbors import NearestNeighbors as skNearestNeighbors
-from sklearn.linear_model import Ridge as skRidge
-from sklearn.linear_model import ElasticNet as skElasticNet
-from sklearn.linear_model import Lasso as skLasso
-from sklearn.linear_model import LogisticRegression as skLogisticRegression
-from sklearn.linear_model import LinearRegression as skLinearRegression
-from sklearn.decomposition import PCA as skPCA
-from sklearn.decomposition import TruncatedSVD as skTruncatedSVD
-from sklearn.datasets import make_regression, make_blobs
-from pytest_cases import fixture_union, pytest_fixture_plus
-from importlib import import_module
-import inspect
-import pickle
-from cuml.internals.safe_imports import gpu_only_import
-import itertools as it
-import pytest
-import cuml
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.manifold import UMAP
+from cuml.metrics import adjusted_rand_score, trustworthiness
+from cuml.neighbors import NearestNeighbors
+from cuml.testing.test_preproc_utils import to_output_type
+from cuml.testing.utils import array_equal
 
+cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
-cudf = gpu_only_import("cudf")
 
 
 def assert_membership_vectors(cu_vecs, sk_vecs):
@@ -891,6 +890,8 @@ def test_hdbscan_methods(train_device, infer_device):
 
     from hdbscan.prediction import (
         all_points_membership_vectors as cpu_all_points_membership_vectors,
+    )
+    from hdbscan.prediction import (
         approximate_predict as cpu_approximate_predict,
     )
 

--- a/python/cuml/tests/test_doctest.py
+++ b/python/cuml/tests/test_doctest.py
@@ -13,18 +13,18 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
 import contextlib
 import doctest
 import inspect
 import io
 
-import cuml
-from cuml.internals.safe_imports import cpu_only_import
+import pytest
 
-np = cpu_only_import("numpy")
+import cuml
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cudf = gpu_only_import("cudf")
+np = cpu_only_import("numpy")
 
 
 def _name_in_all(parent, name):

--- a/python/cuml/tests/test_fil.py
+++ b/python/cuml/tests/test_fil.py
@@ -13,32 +13,35 @@
 # limitations under the License.
 #
 
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, mean_squared_error
+import os
+from math import ceil
+
+import pytest
+from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import (
+    ExtraTreesClassifier,
+    ExtraTreesRegressor,
     GradientBoostingClassifier,
     GradientBoostingRegressor,
     RandomForestClassifier,
     RandomForestRegressor,
-    ExtraTreesClassifier,
-    ExtraTreesRegressor,
 )
-from sklearn.datasets import make_classification, make_regression
+from sklearn.metrics import accuracy_score, mean_squared_error
+from sklearn.model_selection import train_test_split
+
+from cuml import ForestInference
 from cuml.internals.import_utils import has_xgboost
+from cuml.internals.safe_imports import cpu_only_import
 from cuml.testing.utils import (
     array_equal,
-    unit_param,
     quality_param,
     stress_param,
+    unit_param,
 )
-from cuml import ForestInference
-from math import ceil
-import os
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
 pd = cpu_only_import("pandas")
+
 
 # from cuml.internals.import_utils import has_lightgbm
 

--- a/python/cuml/tests/test_hdbscan.py
+++ b/python/cuml/tests/test_hdbscan.py
@@ -13,31 +13,25 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
-from sklearn.model_selection import train_test_split
-from sklearn import datasets
-from hdbscan.plots import CondensedTree
 import hdbscan
-from cuml.internals import logger
 import pytest
-
+from hdbscan.plots import CondensedTree
+from sklearn import datasets
+from sklearn.datasets import make_blobs
+from sklearn.model_selection import train_test_split
 
 from cuml.cluster.hdbscan import HDBSCAN, condense_hierarchy
 from cuml.cluster.hdbscan.prediction import (
     all_points_membership_vectors,
     approximate_predict,
 )
-from sklearn.datasets import make_blobs
-
+from cuml.internals import logger
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.metrics import adjusted_rand_score
-from cuml.testing.utils import get_pattern, array_equal
-
-from cuml.internals.safe_imports import cpu_only_import
-
-np = cpu_only_import("numpy")
-
+from cuml.testing.utils import array_equal, get_pattern
 
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 dataset_names = ["noisy_circles", "noisy_moons", "varied"]

--- a/python/cuml/tests/test_holtwinters.py
+++ b/python/cuml/tests/test_holtwinters.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from sklearn.metrics import r2_score
 from statsmodels.tsa.holtwinters import ExponentialSmoothing as sm_ES
-from cuml.tsa.holtwinters import ExponentialSmoothing as cuml_ES
-import pytest
+
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.tsa.holtwinters import ExponentialSmoothing as cuml_ES
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_incremental_pca.py
+++ b/python/cuml/tests/test_incremental_pca.py
@@ -14,14 +14,15 @@
 # limitations under the License.
 #
 
-from cuml.common.exceptions import NotFittedError
-from cuml.testing.utils import array_equal
-from cuml.decomposition.incremental_pca import _svd_flip
-from cuml.decomposition import IncrementalPCA as cuIPCA
-from cuml.datasets import make_blobs
-from sklearn.decomposition import IncrementalPCA as skIPCA
 import pytest
+from sklearn.decomposition import IncrementalPCA as skIPCA
+
+from cuml.common.exceptions import NotFittedError
+from cuml.datasets import make_blobs
+from cuml.decomposition import IncrementalPCA as cuIPCA
+from cuml.decomposition.incremental_pca import _svd_flip
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.testing.utils import array_equal
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/tests/test_input_utils.py
+++ b/python/cuml/tests/test_input_utils.py
@@ -14,23 +14,26 @@
 # limitations under the License.
 #
 
-from pandas import Series as pdSeries
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.input_utils import convert_dtype
-from cuml.common import has_cupy
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.common import input_to_host_array
-from cuml.common import input_to_cuml_array, CumlArray
-from cuml.internals.safe_imports import cpu_only_import
 import pytest
+from pandas import Series as pdSeries
 
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.common import (
+    CumlArray,
+    has_cupy,
+    input_to_cuml_array,
+    input_to_host_array,
+)
+from cuml.internals.input_utils import convert_dtype, input_to_cupy_array
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-
 nbcuda = gpu_only_import_from("numba", "cuda")
 pdDF = cpu_only_import_from("pandas", "DataFrame")
 

--- a/python/cuml/tests/test_internals_api.py
+++ b/python/cuml/tests/test_internals_api.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import pytest
-from cuml.manifold import UMAP
-from cuml.internals import GraphBasedDimRedCallback
 from sklearn.datasets import load_digits
+
+from cuml.internals import GraphBasedDimRedCallback
+from cuml.manifold import UMAP
 
 digits = load_digits()
 data, target = digits.data, digits.target

--- a/python/cuml/tests/test_kernel_density.py
+++ b/python/cuml/tests/test_kernel_density.py
@@ -14,16 +14,18 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import as_type
-from sklearn.model_selection import GridSearchCV
 import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
-from hypothesis import given, settings, assume, strategies as st
-from cuml.neighbors import KernelDensity, VALID_KERNELS, logsumexp_kernel
-from cuml.common.exceptions import NotFittedError
 from sklearn.metrics import pairwise_distances as skl_pairwise_distances
+from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors._ball_tree import kernel_norm
+
+from cuml.common.exceptions import NotFittedError
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.neighbors import VALID_KERNELS, KernelDensity, logsumexp_kernel
+from cuml.testing.utils import as_type
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -12,23 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.testing.utils import as_type
-from hypothesis.extra.numpy import arrays
-from hypothesis import given, settings, assume, strategies as st
-from sklearn.kernel_ridge import KernelRidge as sklKernelRidge
 import inspect
 import math
+
 import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
+from sklearn.kernel_ridge import KernelRidge as sklKernelRidge
 from sklearn.metrics.pairwise import pairwise_kernels as skl_pairwise_kernels
-from cuml.metrics import pairwise_kernels, PAIRWISE_KERNEL_FUNCTIONS
+
 from cuml import KernelRidge as cuKernelRidge
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.metrics import PAIRWISE_KERNEL_FUNCTIONS, pairwise_kernels
+from cuml.testing.utils import as_type
 
 cp = gpu_only_import("cupy")
-linalg = gpu_only_import_from("cupy", "linalg")
 np = cpu_only_import("numpy")
+linalg = gpu_only_import_from("cupy", "linalg")
 cuda = gpu_only_import_from("numba", "cuda")
 
 

--- a/python/cuml/tests/test_kmeans.py
+++ b/python/cuml/tests/test_kmeans.py
@@ -13,29 +13,27 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
-from sklearn.preprocessing import StandardScaler
-from sklearn.metrics import adjusted_rand_score
-from sklearn import cluster
-from cuml.testing.utils import (
-    get_pattern,
-    unit_param,
-    quality_param,
-    stress_param,
-    array_equal,
-)
-from cuml.datasets import make_blobs
-import pytest
 import random
+
+import pytest
+from sklearn import cluster
+from sklearn.metrics import adjusted_rand_score
+from sklearn.preprocessing import StandardScaler
 
 import cuml
 import cuml.internals.logger as logger
-from cuml.internals.safe_imports import cpu_only_import
-
-np = cpu_only_import("numpy")
-
+from cuml.datasets import make_blobs
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import (
+    array_equal,
+    get_pattern,
+    quality_param,
+    stress_param,
+    unit_param,
+)
 
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 dataset_names = ["blobs", "noisy_circles", "noisy_moons", "varied", "aniso"]

--- a/python/cuml/tests/test_kneighbors_classifier.py
+++ b/python/cuml/tests/test_kneighbors_classifier.py
@@ -13,23 +13,19 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import array_equal
-from cuml.internals.safe_imports import cpu_only_import
+import pytest
 from sklearn.datasets import make_blobs
 from sklearn.neighbors import KNeighborsClassifier as skKNN
-from cuml.neighbors import KNeighborsClassifier as cuKNN
-import cuml
-import pytest
 
-from cuml.internals.safe_imports import gpu_only_import
+import cuml
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.neighbors import KNeighborsClassifier as cuKNN
+from cuml.testing.utils import array_equal
 
 cudf = gpu_only_import("cudf")
-
-
-np = cpu_only_import("numpy")
-
-pd = cpu_only_import("pandas")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
 
 
 def _build_train_test_data(X, y, datatype, train_ratio=0.9):

--- a/python/cuml/tests/test_kneighbors_regressor.py
+++ b/python/cuml/tests/test_kneighbors_regressor.py
@@ -13,28 +13,25 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import array_equal
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import cpu_only_import_from
+import pytest
+from sklearn.datasets import make_blobs
 from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_random_state
-from sklearn.datasets import make_blobs
-from cuml.neighbors import KNeighborsRegressor as cuKNN
-import pytest
 
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+)
+from cuml.neighbors import KNeighborsRegressor as cuKNN
+from cuml.testing.utils import array_equal
 
 cudf = gpu_only_import("cudf")
-
-
+cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 assert_array_almost_equal = cpu_only_import_from(
     "numpy.testing", "assert_array_almost_equal"
 )
-
-np = cpu_only_import("numpy")
-
-
-cp = gpu_only_import("cupy")
 
 
 def test_kneighbors_regressor(

--- a/python/cuml/tests/test_label_binarizer.py
+++ b/python/cuml/tests/test_label_binarizer.py
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.preprocessing import LabelBinarizer
-from cuml.testing.utils import array_equal
-from cuml.common import has_scipy
-
 from sklearn.preprocessing import LabelBinarizer as skLB
 
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.common import has_scipy
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.preprocessing import LabelBinarizer
+from cuml.testing.utils import array_equal
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize(

--- a/python/cuml/tests/test_label_encoder.py
+++ b/python/cuml/tests/test_label_encoder.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuml.common.exceptions import NotFittedError
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+
+from cuml.common.exceptions import NotFittedError
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.preprocessing.LabelEncoder import LabelEncoder
-from cuml.internals.safe_imports import gpu_only_import
 
 cudf = gpu_only_import("cudf")
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 def _df_to_similarity_mat(df):

--- a/python/cuml/tests/test_lars.py
+++ b/python/cuml/tests/test_lars.py
@@ -13,29 +13,28 @@
 # limitations under the License.
 #
 
-import sklearn
+import sys
 
-from sklearn.linear_model import Lars as skLars
+import pytest
+import sklearn
 from sklearn.datasets import fetch_california_housing
+from sklearn.linear_model import Lars as skLars
+
+from cuml.experimental.linear_model import Lars as cuLars
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.testing.utils import (
     array_equal,
-    unit_param,
     quality_param,
     stress_param,
+    unit_param,
 )
-from cuml.experimental.linear_model import Lars as cuLars
-import sys
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
-
-cp = gpu_only_import("cupy")
-np = cpu_only_import("numpy")
-
 
 # As tests directory is not a module, we need to add it to the path
 sys.path.insert(0, ".")
 from test_linear_model import make_regression_dataset  # noqa: E402
+
+cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 def normalize_data(X, y):

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -17,6 +17,25 @@ from functools import lru_cache
 
 import pytest
 import sklearn
+from hypothesis import assume, example, given, note
+from hypothesis import strategies as st
+from hypothesis import target
+from hypothesis.extra.numpy import floating_dtypes
+from sklearn.datasets import (
+    load_breast_cancer,
+    load_digits,
+    make_classification,
+    make_regression,
+)
+from sklearn.linear_model import LinearRegression as skLinearRegression
+from sklearn.linear_model import LogisticRegression as skLog
+from sklearn.linear_model import Ridge as skRidge
+from sklearn.model_selection import train_test_split
+
+from cuml import ElasticNet as cuElasticNet
+from cuml import LinearRegression as cuLinearRegression
+from cuml import LogisticRegression as cuLog
+from cuml import Ridge as cuRidge
 from cuml.internals.array import elements_in_representable_range
 from cuml.internals.safe_imports import (
     cpu_only_import,
@@ -38,31 +57,11 @@ from cuml.testing.utils import (
     stress_param,
     unit_param,
 )
-from hypothesis import assume, example, given, note
-from hypothesis import strategies as st
-from hypothesis import target
-from hypothesis.extra.numpy import floating_dtypes
-from sklearn.datasets import (
-    load_breast_cancer,
-    load_digits,
-    make_classification,
-    make_regression,
-)
-from sklearn.linear_model import LinearRegression as skLinearRegression
-from sklearn.linear_model import LogisticRegression as skLog
-from sklearn.linear_model import Ridge as skRidge
-from sklearn.model_selection import train_test_split
 
-from cuml import ElasticNet as cuElasticNet
-from cuml import LinearRegression as cuLinearRegression
-from cuml import LogisticRegression as cuLog
-from cuml import Ridge as cuRidge
-
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-cudf = gpu_only_import("cudf")
 rmm = gpu_only_import("rmm")
-
 csr_matrix = cpu_only_import_from("scipy.sparse", "csr_matrix")
 
 

--- a/python/cuml/tests/test_linear_svm.py
+++ b/python/cuml/tests/test_linear_svm.py
@@ -13,21 +13,22 @@
 # limitations under the License.
 #
 
-import cuml.internals.logger as logger
-import cuml
-import cuml.svm as cu
-import sklearn.svm as sk
-from cuml.testing.utils import unit_param, quality_param, stress_param
-from queue import Empty
-import cuml.model_selection as dsel
-import cuml.datasets as data
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 import gc
+import math
 import multiprocessing as mp
 import time
-import math
-from cuml.internals.safe_imports import gpu_only_import
+from queue import Empty
+
+import pytest
+import sklearn.svm as sk
+
+import cuml
+import cuml.datasets as data
+import cuml.internals.logger as logger
+import cuml.model_selection as dsel
+import cuml.svm as cu
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import quality_param, stress_param, unit_param
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_logger.py
+++ b/python/cuml/tests/test_logger.py
@@ -15,8 +15,9 @@
 #
 
 from contextlib import redirect_stdout
+from io import BytesIO, StringIO, TextIOWrapper
+
 import cuml.internals.logger as logger
-from io import StringIO, TextIOWrapper, BytesIO
 
 
 def test_logger():

--- a/python/cuml/tests/test_make_arima.py
+++ b/python/cuml/tests/test_make_arima.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 
-import cuml
 import pytest
 
+import cuml
 
 # Note: this test is not really strict, it only checks that the function
 # supports the given parameters and returns an output in the correct form.

--- a/python/cuml/tests/test_make_blobs.py
+++ b/python/cuml/tests/test_make_blobs.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 #
 
-import cuml
 import pytest
+
+import cuml
 from cuml.internals.safe_imports import gpu_only_import
 
 cp = gpu_only_import("cupy")
+
 
 # Testing parameters for scalar parameter tests
 

--- a/python/cuml/tests/test_make_classification.py
+++ b/python/cuml/tests/test_make_classification.py
@@ -14,15 +14,16 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import array_equal
-from cuml.datasets.classification import make_classification
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
 from functools import partial
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
+import pytest
+
+from cuml.datasets.classification import make_classification
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.utils import array_equal
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize("n_samples", [500, 1000])

--- a/python/cuml/tests/test_make_regression.py
+++ b/python/cuml/tests/test_make_regression.py
@@ -17,9 +17,9 @@
 # and cover all the parameters.
 # See the C++ test for an actual correction test
 
-import cuml
 import pytest
 
+import cuml
 
 # Testing parameters
 

--- a/python/cuml/tests/test_mbsgd_classifier.py
+++ b/python/cuml/tests/test_mbsgd_classifier.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score
-from cuml.datasets import make_classification
-from sklearn.linear_model import SGDClassifier
-from cuml.testing.utils import unit_param, quality_param, stress_param
-from cuml.linear_model import MBSGDClassifier as cumlMBSGClassifier
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.linear_model import SGDClassifier
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
 
-np = cpu_only_import("numpy")
+from cuml.datasets import make_classification
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.linear_model import MBSGDClassifier as cumlMBSGClassifier
+from cuml.testing.utils import quality_param, stress_param, unit_param
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.fixture(

--- a/python/cuml/tests/test_mbsgd_regressor.py
+++ b/python/cuml/tests/test_mbsgd_regressor.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sklearn.model_selection import train_test_split
-from cuml.datasets import make_regression
-from sklearn.linear_model import SGDRegressor
-from cuml.testing.utils import unit_param, quality_param, stress_param
-from cuml.metrics import r2_score
-from cuml.linear_model import MBSGDRegressor as cumlMBSGRegressor
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.linear_model import SGDRegressor
+from sklearn.model_selection import train_test_split
 
-np = cpu_only_import("numpy")
+from cuml.datasets import make_regression
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.linear_model import MBSGDRegressor as cumlMBSGRegressor
+from cuml.metrics import r2_score
+from cuml.testing.utils import quality_param, stress_param, unit_param
+
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 @pytest.fixture(

--- a/python/cuml/tests/test_meta_estimators.py
+++ b/python/cuml/tests/test_meta_estimators.py
@@ -14,17 +14,17 @@
 # limitations under the License.
 #
 
-from cuml.svm import SVC
-from cuml.preprocessing import StandardScaler
-from sklearn.datasets import load_iris
-from cuml.model_selection import train_test_split
-from cuml.datasets import make_regression, make_classification
-from cuml.testing.utils import ClassEnumerator
-from cuml.model_selection import GridSearchCV
-from cuml.pipeline import Pipeline, make_pipeline
 import pytest
+from sklearn.datasets import load_iris
+
 import cuml
+from cuml.datasets import make_classification, make_regression
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.model_selection import GridSearchCV, train_test_split
+from cuml.pipeline import Pipeline, make_pipeline
+from cuml.preprocessing import StandardScaler
+from cuml.svm import SVC
+from cuml.testing.utils import ClassEnumerator
 
 cupy = gpu_only_import("cupy")
 

--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -15,93 +15,94 @@
 #
 
 import platform
-from cuml.metrics.cluster import v_measure_score
-from sklearn.metrics.cluster import v_measure_score as sklearn_v_measure_score
+import random
+from functools import partial
+from itertools import chain, permutations
+
+import pytest
 from scipy.special import rel_entr as scipy_kl_divergence
+from sklearn import preprocessing
+from sklearn.datasets import make_blobs, make_classification
+from sklearn.metrics import accuracy_score as sk_acc_score
+from sklearn.metrics import confusion_matrix as sk_confusion_matrix
+from sklearn.metrics import hinge_loss as sk_hinge
+from sklearn.metrics import log_loss as sklearn_log_loss
+from sklearn.metrics import mean_absolute_error as sklearn_mae
+from sklearn.metrics import mean_squared_error as sklearn_mse
+from sklearn.metrics import mean_squared_log_error as sklearn_msle
 from sklearn.metrics import pairwise_distances as sklearn_pairwise_distances
-from cuml.metrics import (
-    pairwise_distances,
-    sparse_pairwise_distances,
-    PAIRWISE_DISTANCE_METRICS,
-    PAIRWISE_DISTANCE_SPARSE_METRICS,
-)
 from sklearn.metrics import (
     precision_recall_curve as sklearn_precision_recall_curve,
 )
 from sklearn.metrics import roc_auc_score as sklearn_roc_auc_score
-from cuml.metrics import log_loss
-from cuml.metrics import precision_recall_curve
-from cuml.metrics import roc_auc_score
-from cuml.common.sparsefuncs import csr_row_normalize_l1
-from cuml.common import has_scipy
-from sklearn.metrics import mean_squared_log_error as sklearn_msle
-from sklearn.metrics import mean_absolute_error as sklearn_mae
-from cuml.metrics import confusion_matrix
-from sklearn.metrics import confusion_matrix as sk_confusion_matrix
-from sklearn.metrics import mean_squared_error as sklearn_mse
-from cuml.metrics.regression import (
-    mean_squared_error,
-    mean_squared_log_error,
-    mean_absolute_error,
-)
-from cuml.model_selection import train_test_split
-from cuml.metrics.cluster import entropy
-from cuml.metrics import kl_divergence as cu_kl_divergence
-from cuml.metrics import hinge_loss as cuml_hinge
-from cuml import LogisticRegression as cu_log
-from sklearn import preprocessing
-from sklearn.preprocessing import StandardScaler
-from sklearn.metrics.cluster import silhouette_samples as sk_silhouette_samples
-from sklearn.metrics.cluster import silhouette_score as sk_silhouette_score
-from sklearn.metrics.cluster import mutual_info_score as sk_mutual_info_score
+from sklearn.metrics.cluster import adjusted_rand_score as sk_ars
 from sklearn.metrics.cluster import completeness_score as sk_completeness_score
 from sklearn.metrics.cluster import homogeneity_score as sk_homogeneity_score
-from sklearn.metrics.cluster import adjusted_rand_score as sk_ars
-from sklearn.metrics import log_loss as sklearn_log_loss
-from sklearn.metrics import accuracy_score as sk_acc_score
-from sklearn.datasets import make_classification, make_blobs
-from sklearn.metrics import hinge_loss as sk_hinge
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.testing.utils import (
-    get_handle,
-    get_pattern,
-    array_equal,
-    unit_param,
-    quality_param,
-    stress_param,
-    generate_random_labels,
-    score_labeling_with_handle,
-)
-from cuml.metrics.cluster import silhouette_samples as cu_silhouette_samples
-from cuml.metrics.cluster import silhouette_score as cu_silhouette_score
-from cuml.metrics import accuracy_score as cu_acc_score
-from cuml.metrics.cluster import adjusted_rand_score as cu_ars
-from cuml.ensemble import RandomForestClassifier as curfc
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
-
-import random
-from itertools import chain, permutations
-from functools import partial
+from sklearn.metrics.cluster import mutual_info_score as sk_mutual_info_score
+from sklearn.metrics.cluster import silhouette_samples as sk_silhouette_samples
+from sklearn.metrics.cluster import silhouette_score as sk_silhouette_score
+from sklearn.metrics.cluster import v_measure_score as sklearn_v_measure_score
+from sklearn.preprocessing import StandardScaler
 
 import cuml
 import cuml.internals.logger as logger
-from cuml.internals.safe_imports import gpu_only_import
+from cuml import LogisticRegression as cu_log
+from cuml.common import has_scipy
+from cuml.common.sparsefuncs import csr_row_normalize_l1
+from cuml.ensemble import RandomForestClassifier as curfc
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.metrics import (
+    PAIRWISE_DISTANCE_METRICS,
+    PAIRWISE_DISTANCE_SPARSE_METRICS,
+)
+from cuml.metrics import accuracy_score as cu_acc_score
+from cuml.metrics import confusion_matrix
+from cuml.metrics import hinge_loss as cuml_hinge
+from cuml.metrics import kl_divergence as cu_kl_divergence
+from cuml.metrics import (
+    log_loss,
+    pairwise_distances,
+    precision_recall_curve,
+    roc_auc_score,
+    sparse_pairwise_distances,
+)
+from cuml.metrics.cluster import adjusted_rand_score as cu_ars
+from cuml.metrics.cluster import entropy
+from cuml.metrics.cluster import silhouette_samples as cu_silhouette_samples
+from cuml.metrics.cluster import silhouette_score as cu_silhouette_score
+from cuml.metrics.cluster import v_measure_score
+from cuml.metrics.regression import (
+    mean_absolute_error,
+    mean_squared_error,
+    mean_squared_log_error,
+)
+from cuml.model_selection import train_test_split
+from cuml.testing.utils import (
+    array_equal,
+    generate_random_labels,
+    get_handle,
+    get_pattern,
+    quality_param,
+    score_labeling_with_handle,
+    stress_param,
+    unit_param,
+)
 
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
 np = cpu_only_import("numpy")
-cudf = gpu_only_import("cudf")
-
-
 cuda = gpu_only_import_from("numba", "cuda")
 assert_almost_equal = cpu_only_import_from(
     "numpy.testing", "assert_almost_equal"
 )
-
-
 scipy_pairwise_distances = cpu_only_import_from("scipy.spatial", "distance")
+
 
 IS_ARM = platform.processor() == "aarch64"
 
@@ -165,11 +166,12 @@ def test_r2_score(datatype, use_handle):
 
 def test_sklearn_search():
     """Test ensures scoring function works with sklearn machinery"""
-    import numpy as np
-    from cuml import Ridge as cumlRidge
     import cudf
+    import numpy as np
     from sklearn import datasets
-    from sklearn.model_selection import train_test_split, GridSearchCV
+    from sklearn.model_selection import GridSearchCV, train_test_split
+
+    from cuml import Ridge as cumlRidge
 
     diabetes = datasets.load_diabetes()
     X_train, X_test, y_train, y_test = train_test_split(

--- a/python/cuml/tests/test_module_config.py
+++ b/python/cuml/tests/test_module_config.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 #
 
-from numba.cuda import is_cuda_array, as_cuda_array
-from cuml.internals.safe_imports import cpu_only_import
-import cuml
 import pytest
+from numba.cuda import as_cuda_array, is_cuda_array
 
-from cuml.internals.safe_imports import gpu_only_import
+import cuml
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/tests/test_multiclass.py
+++ b/python/cuml/tests/test_multiclass.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+
+import pytest
+
 from cuml import LogisticRegression as cuLog
 from cuml import multiclass as cu_multiclass
-import sys
-import pytest
 from cuml.internals.safe_imports import cpu_only_import
-
-np = cpu_only_import("numpy")
-
 
 # As tests directory is not a module, we need to add it to the path
 sys.path.insert(0, ".")
 from test_linear_model import make_classification_dataset  # noqa: E402
+
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize("strategy", ["ovr", "ovo"])

--- a/python/cuml/tests/test_naive_bayes.py
+++ b/python/cuml/tests/test_naive_bayes.py
@@ -14,29 +14,34 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import cpu_only_import
 import math
-from sklearn.naive_bayes import GaussianNB as skGNB
-from sklearn.naive_bayes import ComplementNB as skComplementNB
-from sklearn.naive_bayes import CategoricalNB as skCNB
+
+import pytest
+from numpy.testing import (
+    assert_allclose,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_raises,
+)
+from sklearn.metrics import accuracy_score
 from sklearn.naive_bayes import BernoulliNB as skBNB
+from sklearn.naive_bayes import CategoricalNB as skCNB
+from sklearn.naive_bayes import ComplementNB as skComplementNB
+from sklearn.naive_bayes import GaussianNB as skGNB
 from sklearn.naive_bayes import MultinomialNB as skNB
-from numpy.testing import assert_array_almost_equal, assert_raises
-from numpy.testing import assert_allclose, assert_array_equal
+
 from cuml.datasets import make_classification
 from cuml.internals.input_utils import sparse_scipy_to_cp
-from cuml.naive_bayes import GaussianNB
-from cuml.naive_bayes import ComplementNB
-from cuml.naive_bayes import CategoricalNB
-from cuml.naive_bayes import BernoulliNB
-from cuml.naive_bayes import MultinomialNB
-from sklearn.metrics import accuracy_score
-import pytest
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.naive_bayes import (
+    BernoulliNB,
+    CategoricalNB,
+    ComplementNB,
+    GaussianNB,
+    MultinomialNB,
+)
 
 cp = gpu_only_import("cupy")
-
-
 np = cpu_only_import("numpy")
 
 

--- a/python/cuml/tests/test_nearest_neighbors.py
+++ b/python/cuml/tests/test_nearest_neighbors.py
@@ -15,38 +15,37 @@
 #
 
 import gc
-from cuml.common import has_scipy
-import cuml
-import sklearn
-from cuml.internals.safe_imports import cpu_only_import_from
-from numpy.testing import assert_array_equal, assert_allclose
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
 import math
 
+import pytest
+import sklearn
+from numpy.testing import assert_allclose, assert_array_equal
+from sklearn.metrics import pairwise_distances
+from sklearn.neighbors import NearestNeighbors as skKNN
+
+import cuml
+from cuml.common import has_scipy
+from cuml.datasets import make_blobs
+from cuml.internals import logger
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+)
+from cuml.metrics import pairwise_distances as cuPW
+from cuml.neighbors import NearestNeighbors as cuKNN
 from cuml.testing.utils import (
     array_equal,
-    unit_param,
     quality_param,
     stress_param,
+    unit_param,
 )
-from cuml.neighbors import NearestNeighbors as cuKNN
 
-from sklearn.neighbors import NearestNeighbors as skKNN
-from cuml.datasets import make_blobs
-
-from sklearn.metrics import pairwise_distances
-from cuml.metrics import pairwise_distances as cuPW
-
-from cuml.internals import logger
-
-from cuml.internals.safe_imports import gpu_only_import
-
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
-cudf = gpu_only_import("cudf")
-pd = cpu_only_import("pandas")
 np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
 isspmatrix_csr = cpu_only_import_from("scipy.sparse", "isspmatrix_csr")
 
 

--- a/python/cuml/tests/test_one_hot_encoder.py
+++ b/python/cuml/tests/test_one_hot_encoder.py
@@ -11,20 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from sklearn.preprocessing import OneHotEncoder as SkOneHotEncoder
-from cuml.testing.utils import (
-    stress_param,
-    from_df_to_numpy,
-    assert_inverse_equal,
-    generate_inputs_from_categories,
-)
-from cuml.preprocessing import OneHotEncoder
-from cuml.internals.safe_imports import gpu_only_import_from
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 import math
 
-from cuml.internals.safe_imports import gpu_only_import
+import pytest
+from sklearn.preprocessing import OneHotEncoder as SkOneHotEncoder
+
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.preprocessing import OneHotEncoder
+from cuml.testing.utils import (
+    assert_inverse_equal,
+    from_df_to_numpy,
+    generate_inputs_from_categories,
+    stress_param,
+)
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_pca.py
+++ b/python/cuml/tests/test_pca.py
@@ -13,26 +13,25 @@
 # limitations under the License.
 #
 
-from cuml.common.exceptions import NotFittedError
-from sklearn.datasets import make_blobs
-from sklearn.decomposition import PCA as skPCA
-from sklearn.datasets import make_multilabel_classification
+import pytest
 from sklearn import datasets
+from sklearn.datasets import make_blobs, make_multilabel_classification
+from sklearn.decomposition import PCA as skPCA
+
+from cuml import PCA as cuPCA
+from cuml.common.exceptions import NotFittedError
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.testing.utils import (
-    get_handle,
     array_equal,
-    unit_param,
+    get_handle,
     quality_param,
     stress_param,
+    unit_param,
 )
-from cuml import PCA as cuPCA
-import pytest
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -13,24 +13,26 @@
 # limitations under the License.
 #
 
-from sklearn.model_selection import train_test_split
-from sklearn.manifold import trustworthiness
-from sklearn.datasets import load_iris, make_classification, make_regression
-from sklearn.base import clone
-from cuml.testing.utils import (
-    array_equal,
-    unit_param,
-    stress_param,
-    ClassEnumerator,
-    get_classes_from_package,
-    compare_svm,
-    compare_probabilistic_svm,
-)
-from cuml.tsa.arima import ARIMA
-import pytest
 import pickle
+
+import pytest
+from sklearn.base import clone
+from sklearn.datasets import load_iris, make_classification, make_regression
+from sklearn.manifold import trustworthiness
+from sklearn.model_selection import train_test_split
+
 import cuml
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.testing.utils import (
+    ClassEnumerator,
+    array_equal,
+    compare_probabilistic_svm,
+    compare_svm,
+    get_classes_from_package,
+    stress_param,
+    unit_param,
+)
+from cuml.tsa.arima import ARIMA
 
 np = cpu_only_import("numpy")
 
@@ -611,8 +613,10 @@ def test_agglomerative_pickle(tmpdir, datatype, keys, data_size):
 @pytest.mark.parametrize("prediction_data", [True, False])
 def test_hdbscan_pickle(tmpdir, datatype, keys, data_size, prediction_data):
     result = {}
-    from cuml.cluster.hdbscan.prediction import all_points_membership_vectors
-    from cuml.cluster.hdbscan.prediction import approximate_predict
+    from cuml.cluster.hdbscan.prediction import (
+        all_points_membership_vectors,
+        approximate_predict,
+    )
 
     def create_mod():
         nrows, ncols, n_info = data_size

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -13,87 +13,74 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
 import sklearn
+from sklearn.impute import MissingIndicator as skMissingIndicator
+from sklearn.impute import SimpleImputer as skSimpleImputer
+from sklearn.preprocessing import Binarizer as skBinarizer
+from sklearn.preprocessing import FunctionTransformer as skFunctionTransformer
+from sklearn.preprocessing import KBinsDiscretizer as skKBinsDiscretizer
+from sklearn.preprocessing import KernelCenterer as skKernelCenterer
+from sklearn.preprocessing import MaxAbsScaler as skMaxAbsScaler
+from sklearn.preprocessing import MinMaxScaler as skMinMaxScaler
+from sklearn.preprocessing import Normalizer as skNormalizer
+from sklearn.preprocessing import PolynomialFeatures as skPolynomialFeatures
+from sklearn.preprocessing import PowerTransformer as skPowerTransformer
+from sklearn.preprocessing import QuantileTransformer as skQuantileTransformer
+from sklearn.preprocessing import RobustScaler as skRobustScaler
+from sklearn.preprocessing import StandardScaler as skStandardScaler
+from sklearn.preprocessing import add_dummy_feature as sk_add_dummy_feature
+from sklearn.preprocessing import binarize as sk_binarize
+from sklearn.preprocessing import maxabs_scale as sk_maxabs_scale
+from sklearn.preprocessing import minmax_scale as sk_minmax_scale
+from sklearn.preprocessing import normalize as sk_normalize
+from sklearn.preprocessing import power_transform as sk_power_transform
+from sklearn.preprocessing import quantile_transform as sk_quantile_transform
+from sklearn.preprocessing import robust_scale as sk_robust_scale
+from sklearn.preprocessing import scale as sk_scale
 
-from cuml.preprocessing import (
-    Binarizer as cuBinarizer,
-    FunctionTransformer as cuFunctionTransformer,
-    KBinsDiscretizer as cuKBinsDiscretizer,
-    KernelCenterer as cuKernelCenterer,
-    MaxAbsScaler as cuMaxAbsScaler,
-    MinMaxScaler as cuMinMaxScaler,
-    MissingIndicator as cuMissingIndicator,
-    Normalizer as cuNormalizer,
-    PolynomialFeatures as cuPolynomialFeatures,
-    PowerTransformer as cuPowerTransformer,
-    QuantileTransformer as cuQuantileTransformer,
-    RobustScaler as cuRobustScaler,
-    SimpleImputer as cuSimpleImputer,
-    StandardScaler as cuStandardScaler,
-)
-from cuml.preprocessing import (
-    add_dummy_feature as cu_add_dummy_feature,
-    binarize as cu_binarize,
-    maxabs_scale as cu_maxabs_scale,
-    minmax_scale as cu_minmax_scale,
-    normalize as cu_normalize,
-    power_transform as cu_power_transform,
-    quantile_transform as cu_quantile_transform,
-    robust_scale as cu_robust_scale,
-    scale as cu_scale,
-)
-from sklearn.preprocessing import (
-    Binarizer as skBinarizer,
-    FunctionTransformer as skFunctionTransformer,
-    KBinsDiscretizer as skKBinsDiscretizer,
-    KernelCenterer as skKernelCenterer,
-    MaxAbsScaler as skMaxAbsScaler,
-    MinMaxScaler as skMinMaxScaler,
-    Normalizer as skNormalizer,
-    PolynomialFeatures as skPolynomialFeatures,
-    PowerTransformer as skPowerTransformer,
-    QuantileTransformer as skQuantileTransformer,
-    RobustScaler as skRobustScaler,
-    StandardScaler as skStandardScaler,
-)
-from sklearn.preprocessing import (
-    add_dummy_feature as sk_add_dummy_feature,
-    binarize as sk_binarize,
-    maxabs_scale as sk_maxabs_scale,
-    minmax_scale as sk_minmax_scale,
-    normalize as sk_normalize,
-    power_transform as sk_power_transform,
-    quantile_transform as sk_quantile_transform,
-    robust_scale as sk_robust_scale,
-    scale as sk_scale,
-)
-from sklearn.impute import (
-    MissingIndicator as skMissingIndicator,
-    SimpleImputer as skSimpleImputer,
-)
-
-from cuml.testing.test_preproc_utils import (
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.metrics import pairwise_kernels
+from cuml.preprocessing import Binarizer as cuBinarizer
+from cuml.preprocessing import FunctionTransformer as cuFunctionTransformer
+from cuml.preprocessing import KBinsDiscretizer as cuKBinsDiscretizer
+from cuml.preprocessing import KernelCenterer as cuKernelCenterer
+from cuml.preprocessing import MaxAbsScaler as cuMaxAbsScaler
+from cuml.preprocessing import MinMaxScaler as cuMinMaxScaler
+from cuml.preprocessing import MissingIndicator as cuMissingIndicator
+from cuml.preprocessing import Normalizer as cuNormalizer
+from cuml.preprocessing import PolynomialFeatures as cuPolynomialFeatures
+from cuml.preprocessing import PowerTransformer as cuPowerTransformer
+from cuml.preprocessing import QuantileTransformer as cuQuantileTransformer
+from cuml.preprocessing import RobustScaler as cuRobustScaler
+from cuml.preprocessing import SimpleImputer as cuSimpleImputer
+from cuml.preprocessing import StandardScaler as cuStandardScaler
+from cuml.preprocessing import add_dummy_feature as cu_add_dummy_feature
+from cuml.preprocessing import binarize as cu_binarize
+from cuml.preprocessing import maxabs_scale as cu_maxabs_scale
+from cuml.preprocessing import minmax_scale as cu_minmax_scale
+from cuml.preprocessing import normalize as cu_normalize
+from cuml.preprocessing import power_transform as cu_power_transform
+from cuml.preprocessing import quantile_transform as cu_quantile_transform
+from cuml.preprocessing import robust_scale as cu_robust_scale
+from cuml.preprocessing import scale as cu_scale
+from cuml.testing.test_preproc_utils import (  # noqa: F401
+    assert_allclose,
+    blobs_dataset,
     clf_dataset,
     int_dataset,
-    blobs_dataset,
     nan_filled_positive,
-    sparse_nan_filled_positive,
-    sparse_clf_dataset,
     sparse_blobs_dataset,
-    sparse_int_dataset,
-    sparse_imputer_dataset,
+    sparse_clf_dataset,
     sparse_dataset_with_coo,
-)  # noqa: F401
-from cuml.testing.test_preproc_utils import assert_allclose
-from cuml.metrics import pairwise_kernels
+    sparse_imputer_dataset,
+    sparse_int_dataset,
+    sparse_nan_filled_positive,
+)
 
-from cuml.internals.safe_imports import cpu_only_import
-
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cpx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 scipy = cpu_only_import("scipy")
 
 

--- a/python/cuml/tests/test_prims.py
+++ b/python/cuml/tests/test_prims.py
@@ -13,16 +13,11 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.prims.label import make_monotonic
-from cuml.prims.label import invert_labels
-from cuml.prims.label import check_labels
-
-from cuml.testing.utils import array_equal
-
 import pytest
 
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.prims.label import check_labels, invert_labels, make_monotonic
+from cuml.testing.utils import array_equal
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_qn.py
+++ b/python/cuml/tests/test_qn.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 #
 
-from cuml.metrics import accuracy_score
+import pytest
+
 from cuml.datasets.classification import make_classification
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.metrics import accuracy_score
 from cuml.model_selection import train_test_split
 from cuml.solvers import QN as cuQN
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 # todo: add util functions to better compare against precomputed solutions

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -13,46 +13,48 @@
 # limitations under the License.
 #
 
+import json
+import os
+import random
+import warnings
+
+import pytest
 import treelite
-from sklearn.model_selection import train_test_split
 from sklearn.datasets import (
     fetch_california_housing,
+    load_breast_cancer,
+    load_iris,
     make_classification,
     make_regression,
-    load_iris,
-    load_breast_cancer,
 )
+from sklearn.ensemble import RandomForestClassifier as skrfc
+from sklearn.ensemble import RandomForestRegressor as skrfr
 from sklearn.metrics import (
     accuracy_score,
     mean_squared_error,
     mean_tweedie_deviance,
 )
-from sklearn.ensemble import RandomForestRegressor as skrfr
-from sklearn.ensemble import RandomForestClassifier as skrfc
+from sklearn.model_selection import train_test_split
+
+import cuml
 import cuml.internals.logger as logger
-from cuml.testing.utils import (
-    get_handle,
-    unit_param,
-    quality_param,
-    stress_param,
+from cuml.ensemble import RandomForestClassifier as curfc
+from cuml.ensemble import RandomForestRegressor as curfr
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
 )
 from cuml.metrics import r2_score
-from cuml.ensemble import RandomForestRegressor as curfr
-from cuml.ensemble import RandomForestClassifier as curfc
-import cuml
-from cuml.internals.safe_imports import gpu_only_import_from
-import os
-import json
-import random
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
-
-import warnings
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.testing.utils import (
+    get_handle,
+    quality_param,
+    stress_param,
+    unit_param,
+)
 
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
-
 cuda = gpu_only_import_from("numba", "cuda")
 
 

--- a/python/cuml/tests/test_random_projection.py
+++ b/python/cuml/tests/test_random_projection.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 #
 
-from cuml.common import has_scipy
+import pytest
 from sklearn.datasets import make_blobs
 from sklearn.random_projection import (
     johnson_lindenstrauss_min_dim as sklearn_johnson_lindenstrauss_min_dim,
 )
-from cuml.random_projection import (
-    johnson_lindenstrauss_min_dim as cuml_johnson_lindenstrauss_min_dim,
-)
+
+from cuml.common import has_scipy
+from cuml.internals.safe_imports import cpu_only_import
 from cuml.random_projection import (
     GaussianRandomProjection,
     SparseRandomProjection,
 )
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.random_projection import (
+    johnson_lindenstrauss_min_dim as cuml_johnson_lindenstrauss_min_dim,
+)
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_serialize.py
+++ b/python/cuml/tests/test_serialize.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 #
 
-from distributed.protocol.serialize import serialize as ser
-from cuml.naive_bayes.naive_bayes import MultinomialNB
 import pickle
+
+from distributed.protocol.serialize import serialize as ser
+
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.naive_bayes.naive_bayes import MultinomialNB
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/tests/test_sgd.py
+++ b/python/cuml/tests/test_sgd.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 #
 
-from sklearn.model_selection import train_test_split
-from sklearn.datasets import make_blobs
-from cuml.solvers import SGD as cumlSGD
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.datasets import make_blobs
+from sklearn.model_selection import train_test_split
 
-np = cpu_only_import("numpy")
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.solvers import SGD as cumlSGD
 
 cudf = gpu_only_import("cudf")
+np = cpu_only_import("numpy")
 
 
 @pytest.mark.parametrize("lrate", ["constant", "invscaling", "adaptive"])

--- a/python/cuml/tests/test_simpl_set.py
+++ b/python/cuml/tests/test_simpl_set.py
@@ -13,22 +13,22 @@
 # limitations under the License.
 #
 
+import pytest
+import umap.distances as dist
+from umap.umap_ import fuzzy_simplicial_set as ref_fuzzy_simplicial_set
+from umap.umap_ import simplicial_set_embedding as ref_simplicial_set_embedding
+
+from cuml.datasets import make_blobs
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.manifold.umap import UMAP
+from cuml.manifold.umap import fuzzy_simplicial_set as cu_fuzzy_simplicial_set
 from cuml.manifold.umap import (
     simplicial_set_embedding as cu_simplicial_set_embedding,
 )
-from umap.umap_ import simplicial_set_embedding as ref_simplicial_set_embedding
-from cuml.manifold.umap import fuzzy_simplicial_set as cu_fuzzy_simplicial_set
-from umap.umap_ import fuzzy_simplicial_set as ref_fuzzy_simplicial_set
 from cuml.neighbors import NearestNeighbors
-from cuml.manifold.umap import UMAP
-import umap.distances as dist
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
-from cuml.datasets import make_blobs
-from cuml.internals.safe_imports import cpu_only_import
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
 
 
 def correctness_dense(a, b, rtol=0.1, threshold=0.95):

--- a/python/cuml/tests/test_solver_attributes.py
+++ b/python/cuml/tests/test_solver_attributes.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuml.linear_model import MBSGDRegressor as cumlMBSGRegressor
-from cuml.linear_model import MBSGDClassifier as cumlMBSGClassifier
 from cuml import LogisticRegression as cuLog
+from cuml.datasets import make_blobs
 from cuml.linear_model import ElasticNet as cumlElastic
 from cuml.linear_model import Lasso as cumlLasso
-
-from cuml.datasets import make_blobs
+from cuml.linear_model import MBSGDClassifier as cumlMBSGClassifier
+from cuml.linear_model import MBSGDRegressor as cumlMBSGRegressor
 
 
 def test_mbsgd_regressor_attributes():

--- a/python/cuml/tests/test_sparsefuncs.py
+++ b/python/cuml/tests/test_sparsefuncs.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.common.sparsefuncs import csr_row_normalize_l1
-from cuml.common.sparsefuncs import csr_row_normalize_l2
-from sklearn.utils.sparsefuncs_fast import inplace_csr_row_normalize_l1
-from sklearn.utils.sparsefuncs_fast import inplace_csr_row_normalize_l2
-
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.utils.sparsefuncs_fast import (
+    inplace_csr_row_normalize_l1,
+    inplace_csr_row_normalize_l2,
+)
 
-np = cpu_only_import("numpy")
-sp = cpu_only_import("scipy.sparse")
+from cuml.common.sparsefuncs import csr_row_normalize_l1, csr_row_normalize_l2
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
+sp = cpu_only_import("scipy.sparse")
 
 
 @pytest.mark.parametrize(

--- a/python/cuml/tests/test_stationarity.py
+++ b/python/cuml/tests/test_stationarity.py
@@ -15,12 +15,13 @@
 
 # TODO: update!
 
-from cuml.tsa import stationarity
-from statsmodels.tsa import stattools
 import warnings
+
 import pytest
+from statsmodels.tsa import stattools
 
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.tsa import stationarity
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_stats.py
+++ b/python/cuml/tests/test_stats.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 #
 
-from cuml.testing.utils import array_equal
-from cuml.prims.stats import cov
 import pytest
+
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.prims.stats import cov
+from cuml.testing.utils import array_equal
 
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")

--- a/python/cuml/tests/test_strategies.py
+++ b/python/cuml/tests/test_strategies.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import floating_dtypes, integer_dtypes
+
 from cuml.internals.array import CumlArray
 from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.testing.strategies import (
@@ -28,9 +32,6 @@ from cuml.testing.strategies import (
     standard_regression_datasets,
 )
 from cuml.testing.utils import normalized_shape, series_squeezed_shape
-from hypothesis import HealthCheck, given, settings
-from hypothesis import strategies as st
-from hypothesis.extra.numpy import floating_dtypes, integer_dtypes
 
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_stratified_kfold.py
+++ b/python/cuml/tests/test_stratified_kfold.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 #
 
-from cuml.model_selection import StratifiedKFold
 import pytest
+
 from cuml.internals.safe_imports import gpu_only_import
+from cuml.model_selection import StratifiedKFold
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -14,35 +14,43 @@
 #
 
 import platform
-from sklearn.preprocessing import StandardScaler
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import mean_squared_error
-from sklearn.datasets import make_classification, make_gaussian_quantiles
-from sklearn.datasets import make_regression, make_friedman1
-from sklearn.datasets import load_iris, make_blobs
+
+import pytest
 from sklearn import svm
+from sklearn.datasets import (
+    load_iris,
+    make_blobs,
+    make_classification,
+    make_friedman1,
+    make_gaussian_quantiles,
+    make_regression,
+)
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+import cuml
+import cuml.svm as cu_svm
+from cuml.common import input_to_cuml_array
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 from cuml.testing.utils import (
-    unit_param,
+    compare_probabilistic_svm,
+    compare_svm,
     quality_param,
     stress_param,
-    compare_svm,
-    compare_probabilistic_svm,
     svm_array_equal,
+    unit_param,
 )
-from cuml.common import input_to_cuml_array
-import cuml.svm as cu_svm
-import cuml
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import cpu_only_import
-import pytest
-from cuml.internals.safe_imports import gpu_only_import
 
+cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 cuda = gpu_only_import_from("numba", "cuda")
 
-
-cudf = gpu_only_import("cudf")
 
 IS_ARM = platform.processor() == "aarch64"
 

--- a/python/cuml/tests/test_target_encoder.py
+++ b/python/cuml/tests/test_target_encoder.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import pytest
-from cuml.testing.utils import array_equal
-from cuml.internals.safe_imports import cpu_only_import
+
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
 from cuml.preprocessing.TargetEncoder import TargetEncoder
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.testing.utils import array_equal
 
 cudf = gpu_only_import("cudf")
-pandas = cpu_only_import("pandas")
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
+pandas = cpu_only_import("pandas")
 
 
 def test_targetencoder_fit_transform():

--- a/python/cuml/tests/test_text_feature_extraction.py
+++ b/python/cuml/tests/test_text_feature_extraction.py
@@ -15,26 +15,30 @@
 #
 
 
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import cpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import_from
-from sklearn.feature_extraction.text import TfidfVectorizer as SkTfidfVect
-from sklearn.feature_extraction.text import HashingVectorizer as SkHashVect
-from sklearn.feature_extraction.text import CountVectorizer as SkCountVect
 import pytest
-from cuml.feature_extraction.text import CountVectorizer
-from cuml.feature_extraction.text import TfidfVectorizer
-from cuml.feature_extraction.text import HashingVectorizer
-from cuml.internals.safe_imports import gpu_only_import
+from sklearn.feature_extraction.text import CountVectorizer as SkCountVect
+from sklearn.feature_extraction.text import HashingVectorizer as SkHashVect
+from sklearn.feature_extraction.text import TfidfVectorizer as SkTfidfVect
+
+from cuml.feature_extraction.text import (
+    CountVectorizer,
+    HashingVectorizer,
+    TfidfVectorizer,
+)
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
 cp = gpu_only_import("cupy")
-
+np = cpu_only_import("numpy")
+pd = cpu_only_import("pandas")
 Series = gpu_only_import_from("cudf", "Series")
 assert_array_equal = cpu_only_import_from(
     "numpy.testing", "assert_array_equal"
 )
-np = cpu_only_import("numpy")
-pd = cpu_only_import("pandas")
 
 
 def test_count_vectorizer():

--- a/python/cuml/tests/test_tfidf.py
+++ b/python/cuml/tests/test_tfidf.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 #
 
-from sklearn.feature_extraction.text import TfidfTransformer as SkTfidfTransfo
-from cuml.feature_extraction.text import TfidfTransformer
-from cuml.internals.safe_imports import gpu_only_import
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
+from sklearn.feature_extraction.text import TfidfTransformer as SkTfidfTransfo
 
-np = cpu_only_import("numpy")
+from cuml.feature_extraction.text import TfidfTransformer
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 
 
 # data_ids correspond to data, order is important

--- a/python/cuml/tests/test_thirdparty.py
+++ b/python/cuml/tests/test_thirdparty.py
@@ -13,38 +13,51 @@
 # limitations under the License.
 #
 
-from cuml.testing.test_preproc_utils import assert_allclose
-from sklearn.utils.sparsefuncs import (
-    inplace_csr_column_scale as sk_inplace_csr_column_scale,
-    inplace_csr_row_scale as sk_inplace_csr_row_scale,
-    inplace_column_scale as sk_inplace_column_scale,
-    mean_variance_axis as sk_mean_variance_axis,
-    min_max_axis as sk_min_max_axis,
+import pytest
+from cuml._thirdparty.sklearn.utils.extmath import (
+    _incremental_mean_and_var as cu_incremental_mean_and_var,
+)
+from cuml._thirdparty.sklearn.utils.extmath import row_norms as cu_row_norms
+from cuml._thirdparty.sklearn.utils.sparsefuncs import (
+    inplace_column_scale as cu_inplace_column_scale,
 )
 from cuml._thirdparty.sklearn.utils.sparsefuncs import (
     inplace_csr_column_scale as cu_inplace_csr_column_scale,
+)
+from cuml._thirdparty.sklearn.utils.sparsefuncs import (
     inplace_csr_row_scale as cu_inplace_csr_row_scale,
-    inplace_column_scale as cu_inplace_column_scale,
+)
+from cuml._thirdparty.sklearn.utils.sparsefuncs import (
     mean_variance_axis as cu_mean_variance_axis,
+)
+from cuml._thirdparty.sklearn.utils.sparsefuncs import (
     min_max_axis as cu_min_max_axis,
 )
+from cuml._thirdparty.sklearn.utils.validation import check_X_y
 from sklearn.utils.extmath import (
-    row_norms as sk_row_norms,
     _incremental_mean_and_var as sk_incremental_mean_and_var,
 )
-from cuml._thirdparty.sklearn.utils.extmath import (
-    row_norms as cu_row_norms,
-    _incremental_mean_and_var as cu_incremental_mean_and_var,
+from sklearn.utils.extmath import row_norms as sk_row_norms
+from sklearn.utils.sparsefuncs import (
+    inplace_column_scale as sk_inplace_column_scale,
 )
-from cuml._thirdparty.sklearn.utils.validation import check_X_y
-from cuml.internals.safe_imports import gpu_only_import
-import pytest
+from sklearn.utils.sparsefuncs import (
+    inplace_csr_column_scale as sk_inplace_csr_column_scale,
+)
+from sklearn.utils.sparsefuncs import (
+    inplace_csr_row_scale as sk_inplace_csr_row_scale,
+)
+from sklearn.utils.sparsefuncs import (
+    mean_variance_axis as sk_mean_variance_axis,
+)
+from sklearn.utils.sparsefuncs import min_max_axis as sk_min_max_axis
 
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.testing.test_preproc_utils import assert_allclose
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cpx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 
 
 @pytest.fixture(scope="session")

--- a/python/cuml/tests/test_train_test_split.py
+++ b/python/cuml/tests/test_train_test_split.py
@@ -13,18 +13,21 @@
 # limitations under the License.
 #
 
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.datasets import make_classification
-from cuml.model_selection import train_test_split
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
+
+from cuml.datasets import make_classification
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    gpu_only_import,
+    gpu_only_import_from,
+)
+from cuml.model_selection import train_test_split
 
 cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
-
 cuda = gpu_only_import_from("numba", "cuda")
+
 
 test_array_input_types = ["numba", "cupy"]
 

--- a/python/cuml/tests/test_trustworthiness.py
+++ b/python/cuml/tests/test_trustworthiness.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuml.internals.safe_imports import cpu_only_import
 import pytest
-from sklearn.manifold import trustworthiness as sklearn_trustworthiness
-from cuml.metrics import trustworthiness as cuml_trustworthiness
-
 from sklearn.datasets import make_blobs
+from sklearn.manifold import trustworthiness as sklearn_trustworthiness
 from umap import UMAP
 
-from cuml.internals.safe_imports import gpu_only_import
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.metrics import trustworthiness as cuml_trustworthiness
 
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")

--- a/python/cuml/tests/test_tsne.py
+++ b/python/cuml/tests/test_tsne.py
@@ -14,21 +14,21 @@
 #
 
 import pytest
-from sklearn.manifold import TSNE as skTSNE
 from sklearn import datasets
-from sklearn.manifold import trustworthiness
 from sklearn.datasets import make_blobs
+from sklearn.manifold import TSNE as skTSNE
+from sklearn.manifold import trustworthiness
 from sklearn.neighbors import NearestNeighbors
-from cuml.manifold import TSNE
-from cuml.neighbors import NearestNeighbors as cuKNN
-from cuml.metrics import pairwise_distances
-from cuml.testing.utils import array_equal, stress_param
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
 
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.manifold import TSNE
+from cuml.metrics import pairwise_distances
+from cuml.neighbors import NearestNeighbors as cuKNN
+from cuml.testing.utils import array_equal, stress_param
+
+cupyx = gpu_only_import("cupyx")
 np = cpu_only_import("numpy")
 scipy = cpu_only_import("scipy")
-cupyx = gpu_only_import("cupyx")
 
 
 pytestmark = pytest.mark.filterwarnings(

--- a/python/cuml/tests/test_tsvd.py
+++ b/python/cuml/tests/test_tsvd.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sklearn.utils import check_random_state
-from sklearn.decomposition import TruncatedSVD as skTSVD
+import pytest
 from sklearn.datasets import make_blobs
+from sklearn.decomposition import TruncatedSVD as skTSVD
+from sklearn.utils import check_random_state
+
+from cuml import TruncatedSVD as cuTSVD
+from cuml.internals.safe_imports import cpu_only_import
 from cuml.testing.utils import (
     array_equal,
-    unit_param,
+    get_handle,
     quality_param,
     stress_param,
+    unit_param,
 )
-from cuml.testing.utils import get_handle
-from cuml import TruncatedSVD as cuTSVD
-import pytest
-from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/tests/test_umap.py
+++ b/python/cuml/tests/test_umap.py
@@ -17,31 +17,32 @@
 # Please install UMAP before running the code
 # use 'conda install -c conda-forge umap-learn' command to install it
 
-import pytest
 import copy
+
 import joblib
+import pytest
 import umap
-from sklearn.metrics import adjusted_rand_score
-from sklearn.manifold import trustworthiness
-from sklearn.datasets import make_blobs
-from sklearn.cluster import KMeans
-from sklearn.neighbors import NearestNeighbors
 from sklearn import datasets
+from sklearn.cluster import KMeans
+from sklearn.datasets import make_blobs
+from sklearn.manifold import trustworthiness
+from sklearn.metrics import adjusted_rand_score
+from sklearn.neighbors import NearestNeighbors
+
 from cuml.internals import logger
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.manifold.umap import UMAP as cuUMAP
 from cuml.metrics import pairwise_distances
 from cuml.testing.utils import (
     array_equal,
-    unit_param,
     quality_param,
     stress_param,
+    unit_param,
 )
-from cuml.manifold.umap import UMAP as cuUMAP
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.internals.safe_imports import gpu_only_import
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
+np = cpu_only_import("numpy")
 scipy_sparse = cpu_only_import("scipy.sparse")
 
 

--- a/python/cuml/tests/test_utils.py
+++ b/python/cuml/tests/test_utils.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
+from hypothesis import given, note
+from hypothesis import strategies as st
+from hypothesis import target
 from hypothesis.extra.numpy import (
     array_shapes,
     arrays,
     floating_dtypes,
     integer_dtypes,
 )
-from hypothesis import target
-from hypothesis import strategies as st
-from hypothesis import given, note
-from cuml.testing.utils import array_equal, assert_array_equal
-import pytest
+
 from cuml.internals.safe_imports import cpu_only_import
+from cuml.testing.utils import array_equal, assert_array_equal
 
 np = cpu_only_import("numpy")
 

--- a/python/cuml/thirdparty_adapters/__init__.py
+++ b/python/cuml/thirdparty_adapters/__init__.py
@@ -14,9 +14,9 @@
 #
 
 from .adapters import (
-    check_array,
     _get_mask,
-    _masked_column_median,
     _masked_column_mean,
+    _masked_column_median,
     _masked_column_mode,
+    check_array,
 )

--- a/python/cuml/thirdparty_adapters/adapters.py
+++ b/python/cuml/thirdparty_adapters/adapters.py
@@ -15,25 +15,28 @@
 #
 
 from cupyx.scipy import sparse as gpu_sparse
+from cupyx.scipy.sparse import csc_matrix as gpu_coo_matrix
 from scipy import sparse as cpu_sparse
 from scipy.sparse import csc_matrix as cpu_coo_matrix
 from scipy.sparse import csc_matrix as cpu_csc_matrix
-from cuml.internals.safe_imports import cpu_only_import_from
-from cupyx.scipy.sparse import csc_matrix as gpu_coo_matrix
-from cuml.internals.safe_imports import gpu_only_import_from
+
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.input_utils import input_to_cupy_array, input_to_host_array
-from cuml.internals.safe_imports import gpu_only_import
-from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import (
+    cpu_only_import,
+    cpu_only_import_from,
+    gpu_only_import,
+    gpu_only_import_from,
+)
 
-np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
-gpu_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
+np = cpu_only_import("numpy")
+cuDataFrame = gpu_only_import_from("cudf", "DataFrame")
 gpu_csc_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csc_matrix")
+gpu_csr_matrix = gpu_only_import_from("cupyx.scipy.sparse", "csr_matrix")
+pdDataFrame = cpu_only_import_from("pandas", "DataFrame")
 cpu_csr_matrix = cpu_only_import_from("scipy.sparse", "csr_matrix")
 
-pdDataFrame = cpu_only_import_from("pandas", "DataFrame")
-cuDataFrame = gpu_only_import_from("cudf", "DataFrame")
 
 numeric_types = [
     np.int8,

--- a/python/cuml/thirdparty_adapters/sparsefuncs_fast.py
+++ b/python/cuml/thirdparty_adapters/sparsefuncs_fast.py
@@ -16,8 +16,8 @@
 
 
 from math import ceil
-from cuml.internals.safe_imports import gpu_only_import_from
-from cuml.internals.safe_imports import gpu_only_import
+
+from cuml.internals.safe_imports import gpu_only_import, gpu_only_import_from
 
 cp = gpu_only_import("cupy")
 cpx = gpu_only_import("cupyx")

--- a/python/cuml/tsa/__init__.py
+++ b/python/cuml/tsa/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from cuml.tsa.holtwinters import ExponentialSmoothing
 from cuml.tsa.arima import ARIMA
+from cuml.tsa.holtwinters import ExponentialSmoothing

--- a/python/cuml/tsa/arima.pyx
+++ b/python/cuml/tsa/arima.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,29 +17,37 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
+import ctypes
 import sys
+
 import nvtx
 
-import ctypes
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool
 from libcpp.vector cimport vector
-from typing import List, Tuple, Dict, Mapping, Optional, Union
+
+from typing import Dict, List, Mapping, Optional, Tuple, Union
 
 import cuml.internals
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+
 from pylibraft.common.handle cimport handle_t
-from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
+
+import warnings
+
 import cuml.internals.logger as logger
 from cuml.common import has_scipy
-from cuml.internals.input_utils import determine_array_dtype
-from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals.input_utils import input_to_host_array
 from cuml.internals import _deprecate_pos_args
-import warnings
+from cuml.internals.input_utils import (
+    determine_array_dtype,
+    input_to_cuml_array,
+    input_to_host_array,
+)
+from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 
 
 cdef extern from "cuml/tsa/arima_common.h" namespace "ML":

--- a/python/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/tsa/auto_arima.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,35 +16,39 @@
 
 # distutils: language = c++
 
-import typing
-
 import ctypes
 import itertools
+import typing
+
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool
 from libcpp.vector cimport vector
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 
 import cuml.internals
-from cuml.internals import logger
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals import _deprecate_pos_args, logger
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals import _deprecate_pos_args
+
 from pylibraft.common.handle cimport handle_t
+
+import warnings
+
 from pylibraft.common.handle import Handle
-from cuml.common import input_to_cuml_array
-from cuml.common import using_output_type
+
+from cuml.common import input_to_cuml_array, using_output_type
 from cuml.internals.input_utils import determine_array_dtype
 from cuml.tsa.arima import ARIMA
 from cuml.tsa.seasonality import seas_test
 from cuml.tsa.stationarity import kpss_test
-import warnings
-
 
 # TODO:
 # - Box-Cox transformations? (parameter lambda)

--- a/python/cuml/tsa/batched_lbfgs.py
+++ b/python/cuml/tsa/batched_lbfgs.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-from cuml.common import has_scipy
 import nvtx
+
 import cuml.internals.logger as logger
+from cuml.common import has_scipy
 from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")

--- a/python/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/tsa/holtwinters.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,21 +16,26 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import gpu_only_import
+
 cudf = gpu_only_import('cudf')
 from cuml.internals.safe_imports import gpu_only_import
+
 cp = gpu_only_import('cupy')
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from libc.stdint cimport uintptr_t
 
 import cuml.internals
-from cuml.internals.input_utils import input_to_cupy_array
-from cuml.internals import _deprecate_pos_args
 from cuml.common import using_output_type
-from cuml.internals.base import Base
-from cuml.internals.array import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals import _deprecate_pos_args
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base
+from cuml.internals.input_utils import input_to_cupy_array
+
 from pylibraft.common.handle cimport handle_t
+
 
 cdef extern from "cuml/tsa/holtwinters_params.h" namespace "ML":
     enum SeasonalType:

--- a/python/cuml/tsa/seasonality.pyx
+++ b/python/cuml/tsa/seasonality.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 # distutils: language = c++
 
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 
 import cuml.internals
 from cuml.internals.array import CumlArray
+
 from pylibraft.common.handle cimport handle_t
-from cuml.internals.input_utils import input_to_host_array, input_to_cuml_array
+
+from cuml.internals.input_utils import input_to_cuml_array, input_to_host_array
 
 # TODO: #2234 and #2235
 

--- a/python/cuml/tsa/stationarity.pyx
+++ b/python/cuml/tsa/stationarity.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,15 +16,20 @@
 # distutils: language = c++
 
 import ctypes
+
 from cuml.internals.safe_imports import cpu_only_import
+
 np = cpu_only_import('numpy')
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool as boolcpp
 
 import cuml.internals
 from cuml.internals.array import CumlArray
+
 from pylibraft.common.handle cimport handle_t
+
 from pylibraft.common.handle import Handle
+
 from cuml.internals.input_utils import input_to_cuml_array
 
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,18 @@
 # Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
+[isort]
+profile = black
+line_length = 79
+known_first_party=
+   cuml
+known_third_party=
+   cuml._thirdparty
+filter_files=true
+skip=
+   _version.py
+   thirdparty
+   versioneer.py
+
 [flake8]
 filename = *.py, *.pyx, *.pxd
 exclude =

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,9 +20,8 @@ import shutil
 import sys
 from pathlib import Path
 
-from setuptools import find_packages
-
 import versioneer
+from setuptools import find_packages
 from skbuild import setup
 
 


### PR DESCRIPTION
Also includes a custom `isort-safe-imports` hook that implements isort for cuml's cross-device compatible "safe imports".