### PR TITLE
Fix GHA build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
   docs-build:
-    if: ${{ startsWith(github.ref, 'refs/heads/branch-') }}
+    if: github.ref_type == 'branch' && github.event_name == 'push'
     needs: [python-build]
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.04


### PR DESCRIPTION
This PR fixes the condition to trigger docs-build workflow in build.yaml to:

- simplify the branch assertion
- ensure that it only runs on push events (as opposed to workflow_dispatch events which trigger the nightlies).

@ajschmidt8