### PR TITLE
Drop Python 3.7 handling for pickle protocol 4

### DIFF
--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -586,13 +586,6 @@ def test_serialize(inp, to_serialize_mem_type, from_serialize_mem_type):
 @settings(deadline=None)
 def test_pickle(protocol, inp, to_serialize_mem_type, from_serialize_mem_type):
     with using_memory_type(to_serialize_mem_type):
-        if protocol > pickle.HIGHEST_PROTOCOL:
-            pytest.skip(
-                f"Trying to test with pickle protocol {protocol},"
-                " but highest supported protocol is"
-                f" {pickle.HIGHEST_PROTOCOL}."
-            )
-
         # Generate CumlArray
         ary = CumlArray(data=inp)
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cuml/issues/5250

Now that Python 3.8 is the minimum supported version, drop the special casing for Python 3.7's `HIGHEST_PROTOCOL`, which was 4 (not 5). In Python 3.8+, `HIGHEST_PROTOCOL >= 5`. So none of these branches are needed any more.