### PR TITLE
Test changes in raft#1337 (generic linalg::map)

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -92,8 +92,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-                        FORK             rapidsai
-                        PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
+                        FORK             achirkin
+                        PINNED_TAG       fea-generic-map-2
                         EXCLUDE_FROM_ALL ${CUML_EXCLUDE_RAFT_FROM_ALL}
                         # When PINNED_TAG above doesn't match cuml,
                         # force local raft clone in build directory


### PR DESCRIPTION
Test the changes in https://github.com/rapidsai/raft/pull/1337

The PR has small breaking changes in `raft::linalg` namespace.