### PR TITLE
[REVIEW] Fix cuml local cpp docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ docs/source/*.tl
 
 ## doxygen build check inside ci/checks/style.sh
 doxygen_check/
+
+## Doxygen
+cpp/html
+cpp/Doxyfile

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -767,5 +767,5 @@ endif()
 
 include(cmake/doxygen.cmake)
 add_doxygen_target(IN_DOXYFILE Doxyfile.in
-  OUT_DOXYFILE ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-  CWD ${CMAKE_CURRENT_BINARY_DIR})
+  OUT_DOXYFILE ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
+  CWD ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This PR fixes the following error that shows up during local cpp docs build:
```
[1/1] Generate doxygen docs
FAILED: CMakeFiles/docs_cuml /home/whicks/proj_cuml/cuml/cpp/build/CMakeFiles/docs_cuml 
cd /home/whicks/proj_cuml/cuml/cpp/build && /home/whicks/miniconda3/envs/cuml_dev/bin/doxygen /home/whicks/proj_cuml/cuml/cpp/build/Doxyfile
error: tag HTML_HEADER: header file 'header.html' does not exist
Exiting...
```