### PR TITLE
Upgrade to Treelite 3.2.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -67,7 +67,7 @@ dependencies:
 - sphinx<6
 - statsmodels
 - sysroot_linux-64==2.17
-- treelite=3.1.0
+- treelite=3.2.0
 - umap-learn
 - pip:
   - git+https://github.com/dask/dask-glm@main

--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -30,4 +30,4 @@ libcusparse_host_version:
   - "=11.7.5.86"
 
 treelite_version:
-  - "=3.1.0"
+  - "=3.2.0"

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -14,7 +14,7 @@ cmake_version:
   - ">=3.23.1,!=3.25.0"
 
 treelite_version:
-  - "=3.1.0"
+  - "=3.2.0"
 
 gtest_version:
   - "=1.10.0"

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -90,7 +90,7 @@ function(find_and_configure_treelite)
     rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
 endfunction()
 
-find_and_configure_treelite(VERSION     3.1.0
-                        PINNED_TAG  4103ed090f17ad16596c3b46357b810a5ccc3969
+find_and_configure_treelite(VERSION     3.2.0
+                        PINNED_TAG  ee697b3b58d5f51623dd3b308f290581b58dbe5d
                         EXCLUDE_FROM_ALL  ${CUML_EXCLUDE_TREELITE_FROM_ALL}
                         BUILD_STATIC_LIBS ${CUML_USE_TREELITE_STATIC})

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,7 +97,7 @@ dependencies:
           - cuda-python>=11.7.1,<12.0
           - scikit-build>=0.13.1
           - cython>=0.29,<0.30
-          - treelite=3.1.0
+          - treelite=3.2.0
       - output_types: conda
         packages:
           - cudf=23.04.*

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,8 +20,8 @@ requires = [
     "scikit-build>=0.13.1",
     "cmake>=3.23.1,!=3.25.0",
     "ninja",
-    "treelite==3.1.0",
-    "treelite_runtime==3.1.0",
+    "treelite==3.2.0",
+    "treelite_runtime==3.2.0",
     "rmm==23.4.*",
     "pylibraft==23.4.*"
 ]
@@ -59,8 +59,8 @@ dependencies = [
     "numba",
     "scipy",
     "seaborn",
-    "treelite==3.1.0",
-    "treelite_runtime==3.1.0",
+    "treelite==3.2.0",
+    "treelite_runtime==3.2.0",
     "cudf==23.4.*",
     "dask-cudf==23.4.*",
     "pylibraft==23.4.*",


### PR DESCRIPTION
Pick up new features implemented in Treelite, including:
* `predict_per_tree`, `predict_leaf` in `treelite.gtil`
* Ability to import Treelite models from JSON strings