### PR TITLE
Remove CUDA_CHECK macro

### DIFF
--- a/cpp/test/sg/tsvd_test.cu
+++ b/cpp/test/sg/tsvd_test.cu
@@ -117,11 +117,11 @@ class TsvdTest : public ::testing::TestWithParam<TsvdInputs<T>> {
     int informative_len  = params.n_row2 * informative_cols;
 
     r.uniform(data2.data(), informative_len, T(-1.0), T(1.0), stream);
-    CUDA_CHECK(cudaMemcpyAsync(data2.data() + informative_len,
-                               data2.data(),
-                               redundant_len * sizeof(T),
-                               cudaMemcpyDeviceToDevice,
-                               stream));
+    RAFT_CUDA_TRY(cudaMemcpyAsync(data4.data() + informative_len,
+                                  data2.data(),
+                                  redundant_len * sizeof(T),
+                                  cudaMemcpyDeviceToDevice,
+                                  stream));
     rmm::device_uvector<T> data2_trans(prms.n_rows * prms.n_components, stream);
 
     int len_comp = params.n_col2 * prms.n_components;


### PR DESCRIPTION
One use of `CUDA_CHECK` failed my local build. It should be replaced with `RAFT_CUDA_TRY`.