### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -16,8 +16,8 @@
 
 import gc
 import operator
+import pickle
 import pytest
-import sys
 from copy import deepcopy
 from cuml.internals.array import (
     CumlArray,
@@ -76,14 +76,6 @@ np_array = gpu_only_import_from("numpy", "ndarray")
 numba_array = gpu_only_import_from(
     "numba.cuda.cudadrv.devicearray", "DeviceNDArray"
 )
-
-if sys.version_info < (3, 8):
-    try:
-        import pickle5 as pickle
-    except ImportError:
-        import pickle
-else:
-    import pickle
 
 
 test_input_types = ["numpy", "numba", "cupy", "series", None]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.