### PR TITLE
Update cuda architectures for threads per sm restriction

### DIFF
--- a/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
@@ -125,7 +125,7 @@ auto constexpr static const MAX_BLOCKS = index_type{65536};
 auto constexpr static const WARP_SIZE = index_type{32};
 auto constexpr static const MAX_THREADS_PER_BLOCK = index_type{256};
 #ifdef __CUDACC__
-#if __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860
+#if __CUDA_ARCH__ == 720 || __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 870
 auto constexpr static const MAX_THREADS_PER_SM = index_type{1024};
 #else
 auto constexpr static const MAX_THREADS_PER_SM = index_type{2048};


### PR DESCRIPTION
Update list of architectures for which we must restrict threads per sm to 1024