### PR TITLE
Remove uses-setup-env-vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,6 @@ jobs:
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
 
       skbuild-configure-options: "-DCUML_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DDISABLE_DEPRECATION_WARNINGS=ON -DCPM_cumlprims_mg_SOURCE=/project/cumlprims_mg/"
-      uses-setup-env-vars: false
   wheel-publish-cuml:
     needs: wheel-build-cuml
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,7 +93,6 @@ jobs:
       extra-repo-sha: branch-23.02
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       skbuild-configure-options: "-DCUML_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DDISABLE_DEPRECATION_WARNINGS=ON -DCPM_cumlprims_mg_SOURCE=/project/cumlprims_mg/"
-      uses-setup-env-vars: false
   wheel-tests-cuml:
     needs: wheel-build-cuml
     secrets: inherit


### PR DESCRIPTION
This setting now matches the default behavior of the shared-action-workflows repo
