### PR TITLE
[REVIEW] Updated forest inference to new dask worker api for 23.04

### DIFF
--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -503,16 +503,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def worker_init(model_file='xgb.model'):   \n",
-    "   worker = get_worker()\n",
-    "\n",
-    "   worker.data[\"fil_model\"] = ForestInference.load(\n",
+    "def worker_init(dask_worker, model_file='xgb.model'):\n",
+    "   dask_worker.data[\"fil_model\"] = ForestInference.load(\n",
     "       filename=model_file,\n",
     "       algo='BATCH_TREE_REORG',\n",
     "       output_class=True,\n",
     "       threshold=0.50,\n",
     "       model_type='xgboost'\n",
-    "   )"
+    "    )"
    ]
   },
   {
@@ -582,7 +580,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "total_samples = len(df)\n",
@@ -593,7 +593,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -607,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes forest inference notebook in 23.04, as `get_workers` has been deprecated, and this is the new way to assign data to workers. @dantegd @aravenel for awareness