### PR TITLE
[ENH] Add missing includes of rmm/mr/device/per_device_resource.hpp

### DIFF
--- a/cpp/bench/common/ml_benchmark.hpp
+++ b/cpp/bench/common/ml_benchmark.hpp
@@ -22,6 +22,7 @@
 #include <cuml/common/utils.hpp>
 #include <memory>
 #include <raft/util/cudart_utils.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/cpp/examples/symreg/symreg_example.cpp
+++ b/cpp/examples/symreg/symreg_example.cpp
@@ -31,6 +31,7 @@
 #include <raft/util/cudart_utils.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 // Namespace alias
 namespace cg = cuml::genetic;

--- a/cpp/include/cuml/tsa/arima_common.h
+++ b/cpp/include/cuml/tsa/arima_common.h
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 #include <raft/util/cudart_utils.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/genetic/genetic.cu
+++ b/cpp/src/genetic/genetic.cu
@@ -34,6 +34,7 @@
 
 #include <device_launch_parameters.h>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/src/svm/linear.cu
+++ b/cpp/src/svm/linear.cu
@@ -40,6 +40,7 @@
 #include <raft/matrix/matrix.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>

--- a/cpp/test/mg/knn.cu
+++ b/cpp/test/mg/knn.cu
@@ -25,6 +25,8 @@
 
 #include <raft/util/cuda_utils.cuh>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 namespace ML {
 namespace KNN {
 namespace opg {

--- a/cpp/test/sg/genetic/evolution_test.cu
+++ b/cpp/test/sg/genetic/evolution_test.cu
@@ -26,6 +26,7 @@
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <test_utils.h>
 #include <vector>
 

--- a/cpp/test/sg/genetic/program_test.cu
+++ b/cpp/test/sg/genetic/program_test.cu
@@ -24,6 +24,7 @@
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <test_utils.h>
 #include <vector>
 


### PR DESCRIPTION
Some files use `rmm::mr::get_current_device_resource()` but not do not include `rmm/mr/device/per_device_resource.hpp` . This PR fixes that.

The missing include was surfaced by https://github.com/rapidsai/cuml/pull/5363. 

This PR is necessary to prevent breakage when https://github.com/rapidsai/raft/pull/1415 is merged.