### PR TITLE
Add librmm to libcuml dependencies.

### DIFF
--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -56,6 +56,7 @@ requirements:
     - libcusparse-dev {{ libcusparse_host_version }}
     - libraft ={{ minor_version }}
     - libraft-headers ={{ minor_version }}
+    - librmm ={{ minor_version }}
     - treelite {{ treelite_version }}
 
 outputs:
@@ -81,6 +82,7 @@ outputs:
         - libcusparse-dev {{ libcusparse_run_version }}
         - libraft ={{ minor_version }}
         - libraft-headers ={{ minor_version }}
+        - librmm ={{ minor_version }}
         - treelite {{ treelite_version }}
     about:
       home: https://rapids.ai/


### PR DESCRIPTION
Following up on https://github.com/rapidsai/cuml/pull/5407#pullrequestreview-1419323021 to add a missing dependency from `libcuml` on `librmm`.