### PR TITLE
Use numba>=0.57.

### DIFF
--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -19,5 +19,4 @@ sed -i "s/rmm/rmm${CUDA_SUFFIX}/g" python/pyproject.toml
 if [[ $CUDA_SUFFIX == "-cu12" ]]; then
     sed -i "s/cuda-python[<=>\.,0-9]*/cuda-python>=12.0,<13.0/g" python/pyproject.toml
     sed -i "s/cupy-cuda11x/cupy-cuda12x/g" python/pyproject.toml
-    sed -i "s/numba[<=>\.,0-9]*/numba>=0.57/g" python/pyproject.toml
 fi

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - nbsphinx
 - ninja
 - nltk
-- numba>=0.56.4,<0.57
+- numba>=0.57
 - numpydoc
 - pip
 - pydata-sphinx-theme

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -133,7 +133,7 @@ dependencies:
           - dask-cudf==23.6.*
           - distributed==2023.3.2.1
           - joblib>=0.11
-          - numba>=0.56.4,<0.57
+          - numba>=0.57
             # TODO: Are seaborn and scipy really hard dependencies, or should
             # we make them optional (i.e. an extra for pip
             # installation/run_constrained for conda)?

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "dask==2023.3.2",
     "distributed==2023.3.2.1",
     "joblib>=0.11",
-    "numba>=0.56.4,<0.57",
+    "numba>=0.57",
     "raft-dask==23.6.*",
     "scipy",
     "seaborn",


### PR DESCRIPTION
This updates to `numba>=0.57`, which is needed to avoid dependency conflicts with https://github.com/rapidsai/cudf/pull/13337/.

Please merge after https://github.com/rapidsai/cudf/pull/13337/.