### PR TITLE
Fix documentation source code links

### DIFF
--- a/docs/source/sphinxext/github_link.py
+++ b/docs/source/sphinxext/github_link.py
@@ -101,10 +101,9 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
         else:
             return
     else:
-        # Test if we are absolute or not (pyx are relative)
-        if (not os.path.isabs(fn)):
-            # Should be relative to docs right now
-            fn = os.path.abspath(os.path.join("..", "python", fn))
+        if (fn.endswith(".pyx")):
+            sp_path = next(x for x in sys.path if re.match(".*site-packages$", x))
+            fn = fn.replace("/opt/conda/conda-bld/work/python", sp_path)
 
         # Convert to relative from module root
         fn = os.path.relpath(fn,

--- a/docs/source/sphinxext/github_link.py
+++ b/docs/source/sphinxext/github_link.py
@@ -101,7 +101,7 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
         else:
             return
     else:
-        if (fn.endswith(".pyx")):
+        if fn.endswith(".pyx"):
             sp_path = next(x for x in sys.path if re.match(".*site-packages$", x))
             fn = fn.replace("/opt/conda/conda-bld/work/python", sp_path)
 


### PR DESCRIPTION
## Problem

@beckernick pointed out that some of the source code links in our documentation are broken.

For instance, the source code link here works:

https://docs.rapids.ai/api/cuml/stable/api/#cuml.internals.memory_utils.set_global_output_type

but it doesn't work here:

https://docs.rapids.ai/api/cuml/stable/api/#cuml.svm.SVC.decision_function

It seems that the broken links are all of the `.pyx` links.

## Cause

After some investigation, I found the [github_link.py](https://github.com/rapidsai/cuml/blob/5a1b9d2f6ac3832ee87d559692f451a34ca1f4f0/docs/source/sphinxext/github_link.py) file which is responsible for determining the source code URLs.

This file is used by the sphinx `linkcode` extension ([docs](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html)) in the `cuml` sphinx configuration file [here](https://github.com/rapidsai/cuml/blob/5a1b9d2f6ac3832ee87d559692f451a34ca1f4f0/docs/source/conf.py#L197-L200).

Specifically, the problem seems to be with this line: https://github.com/rapidsai/cuml/blob/5a1b9d2f6ac3832ee87d559692f451a34ca1f4f0/docs/source/sphinxext/github_link.py#L79 which returns different file paths for `.py` vs `.pyx` files.

For `.py` files, it returns file paths like this:

```
/opt/conda/envs/docs/lib/python3.10/site-packages/cuml/preprocessing/label.py
```

but for `.pyx` files, it returns paths like this:

```
/opt/conda/conda-bld/work/python/cuml/datasets/regression.pyx
```
## Solution

To resolve the file path discrepancy, I simply modified the existing conditional statement for `.pyx` files that was [here](https://github.com/rapidsai/cuml/blob/5a1b9d2f6ac3832ee87d559692f451a34ca1f4f0/docs/source/sphinxext/github_link.py#L104-L107) to make the file paths look identical.


## Additional Notes

I'm open to alternative solutions if there's a better way to resolve this. This seemed like the simplest way to fix it locally.

We'll also need to patch this in the other repos here: https://github.com/search?q=org%3Arapidsai%20path%3A**%2Fgithub_link.py&type=code.