### PR TITLE
Fix for umap-pytest issue in Rocky8 and wheels in GHA nightly tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,4 +53,4 @@ jobs:
       # On arm also need to install CMake because treelite needs to be compiled (no wheels available for arm).
       test-before-arm64: "pip install cmake && pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.06"
       # parallelization is based on current test memory usage
-      test-unittest: "pytest ./python/cuml/tests -k 'not test_sparse_pca_inputs' -n 8 --ignore=python/cuml/tests/dask && pytest ./python/cuml/tests -k 'test_sparse_pca_inputs' && pytest ./python/cuml/tests/dask"
+      test-unittest: "python -m pytest ./python/cuml/tests -k 'not test_sparse_pca_inputs' -n 8 --ignore=python/cuml/tests/dask && python -m pytest ./python/cuml/tests -k 'test_sparse_pca_inputs' && python -m pytest ./python/cuml/tests/dask"

--- a/python/cuml/internals/import_utils.py
+++ b/python/cuml/internals/import_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import platform
 
 from cuml.internals.safe_imports import gpu_only_import, UnavailableError
 from distutils.version import LooseVersion
@@ -70,6 +71,8 @@ def has_ucp():
 
 
 def has_umap():
+    if platform.processor() == "aarch64":
+        return False
     try:
         import umap  # NOQA
 

--- a/python/cuml/tests/test_device_selection.py
+++ b/python/cuml/tests/test_device_selection.py
@@ -34,7 +34,6 @@ from cuml.internals.mem_type import MemoryType
 from cuml.decomposition import PCA, TruncatedSVD
 from cuml.common.device_selection import DeviceType, using_device_type
 from hdbscan import HDBSCAN as refHDBSCAN
-from umap import UMAP as refUMAP
 from sklearn.neighbors import NearestNeighbors as skNearestNeighbors
 from sklearn.linear_model import Ridge as skRidge
 from sklearn.linear_model import ElasticNet as skElasticNet
@@ -60,6 +59,9 @@ cudf = gpu_only_import("cudf")
 
 
 IS_ARM = platform.processor() == "aarch64"
+
+if not IS_ARM:
+    from umap import UMAP as refUMAP
 
 
 def assert_membership_vectors(cu_vecs, sk_vecs):

--- a/python/cuml/tests/test_simpl_set.py
+++ b/python/cuml/tests/test_simpl_set.py
@@ -17,12 +17,9 @@ import platform
 from cuml.manifold.umap import (
     simplicial_set_embedding as cu_simplicial_set_embedding,
 )
-from umap.umap_ import simplicial_set_embedding as ref_simplicial_set_embedding
 from cuml.manifold.umap import fuzzy_simplicial_set as cu_fuzzy_simplicial_set
-from umap.umap_ import fuzzy_simplicial_set as ref_fuzzy_simplicial_set
 from cuml.neighbors import NearestNeighbors
 from cuml.manifold.umap import UMAP
-import umap.distances as dist
 from cuml.internals.safe_imports import gpu_only_import
 import pytest
 from cuml.datasets import make_blobs
@@ -33,6 +30,13 @@ cp = gpu_only_import("cupy")
 
 
 IS_ARM = platform.processor() == "aarch64"
+
+if not IS_ARM:
+    from umap.umap_ import (
+        simplicial_set_embedding as ref_simplicial_set_embedding,
+    )
+    from umap.umap_ import fuzzy_simplicial_set as ref_fuzzy_simplicial_set
+    import umap.distances as dist
 
 
 def correctness_dense(a, b, rtol=0.1, threshold=0.95):

--- a/python/cuml/tests/test_trustworthiness.py
+++ b/python/cuml/tests/test_trustworthiness.py
@@ -19,7 +19,6 @@ from sklearn.manifold import trustworthiness as sklearn_trustworthiness
 from cuml.metrics import trustworthiness as cuml_trustworthiness
 
 from sklearn.datasets import make_blobs
-from umap import UMAP
 
 from cuml.internals.safe_imports import gpu_only_import
 
@@ -28,6 +27,9 @@ np = cpu_only_import("numpy")
 
 
 IS_ARM = platform.processor() == "aarch64"
+
+if not IS_ARM:
+    from umap import UMAP
 
 
 @pytest.mark.parametrize("input_type", ["ndarray", "dataframe"])

--- a/python/cuml/tests/test_umap.py
+++ b/python/cuml/tests/test_umap.py
@@ -21,7 +21,6 @@ import platform
 import pytest
 import copy
 import joblib
-import umap
 from sklearn.metrics import adjusted_rand_score
 from sklearn.manifold import trustworthiness
 from sklearn.datasets import make_blobs
@@ -47,6 +46,9 @@ scipy_sparse = cpu_only_import("scipy.sparse")
 
 
 IS_ARM = platform.processor() == "aarch64"
+
+if not IS_ARM:
+    import umap
 
 
 dataset_names = ["iris", "digits", "wine", "blobs"]


### PR DESCRIPTION
There is an odd issue when importing umap-learn in our pytest suite as seen in https://github.com/rapidsai/cuml/actions/runs/5187945476/jobs/9350930883, this PR skips those tests there. It also changes usages of `pytest` to `python -m pytest` in GHA nightly runs to avoid a PYTHONPATH issue. 