### PR TITLE
Use fit_predict rather than fit for KNeighborsClassifier and KNeighborsRegressor in benchmark utility

### DIFF
--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -432,6 +432,7 @@ def all_algorithms():
             name="KNeighborsClassifier",
             accepts_labels=True,
             accuracy_function=cuml.metrics.accuracy_score,
+            bench_func=fit_predict,
         ),
         AlgorithmPair(
             sklearn.neighbors.KNeighborsRegressor,
@@ -441,6 +442,7 @@ def all_algorithms():
             name="KNeighborsRegressor",
             accepts_labels=True,
             accuracy_function=cuml.metrics.r2_score,
+            bench_func=fit_predict,
         ),
         AlgorithmPair(
             sklearn.naive_bayes.MultinomialNB,


### PR DESCRIPTION
This PR:
- Switches the benchmark utility to use `fit_predict` rather than `fit` (the default) as the benchmark function for `KNeighborsRegressor` and `KNeighborsClassifier` (`fit` is a no-op).

We now get meaningful results for the time information.

```
(cuml_dev) nicholasb@nicholasb-HP-Z8-G4-Workstation:~/NVIDIA/cuml/python/cuml/benchmark$ python run_benchmarks.py     --dataset classification     --num-rows 100000     --input-dimensions 20     --csv classification-results.csv     KNeighborsClassifier
...
Running: 
 KNeighborsClassifier
Running KNeighborsClassifier...
Finished all benchmark runs
                   algo  input device  cuml_time  cpu_time  cuml_acc   cpu_acc    speedup  n_samples  n_features
0  KNeighborsClassifier  numpy    gpu    0.26183  6.697411  0.923049  0.923049  25.579224     100000          20
Saved results to classification-results.csv

```

This closes https://github.com/rapidsai/cuml/issues/5447