### PR TITLE
Test benchmark 1.8.0 from rapids-cmake.

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -12,6 +12,8 @@
 # the License.
 # =============================================================================
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUML_RAPIDS.cmake)
+  set(rapids-cmake-repo vyasr/rapids-cmake)
+  set(rapids-cmake-branch fix/benchmark_name)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.08/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/CUML_RAPIDS.cmake
   )


### PR DESCRIPTION
This PR is meant to test https://github.com/rapidsai/rapids-cmake/pull/425/ downstream in cuml.