### PR TITLE
Add multi-node-multi-gpu Logistic Regression in C++

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -524,6 +524,7 @@ if(BUILD_CUML_CPP_LIBRARY)
         src/glm/ols_mg.cu
         src/glm/preprocess_mg.cu
         src/glm/ridge_mg.cu
+        src/glm/qn_mg.cu
         src/kmeans/kmeans_mg.cu
         src/knn/knn_mg.cu
         src/knn/knn_classify_mg.cu

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -1,15 +1,7 @@
 #include <raft/core/comms.hpp>
-// #include <raft/core/handle.hpp>
-// #include <raft/core/device_mdarray.hpp>
-// #include <raft/util/cudart_utils.hpp>
-// #include <raft/comms/std_comms.hpp>
 #include <cuml/common/logger.hpp>
-#include <cuml/linear_model/qn.h> // to use qn_params
-
+#include <cuml/linear_model/qn.h> 
 #include <cuda_runtime.h>
-
-// #include <vector>
-#include <iostream>
 
 namespace ML {
 namespace GLM {
@@ -34,42 +26,6 @@ void qnFit(const raft::handle_t &handle,
            int n_samples,
            int rank,
            int n_ranks);
-
-/**
- * @brief Fit a GLM using quasi newton methods.
- *
- * @param cuml_handle   reference to raft::handle_t object
- * @param params        model parameters
- * @param X             device pointer to a contiguous feature matrix of dimension [N, D]
- * @param X_col_major   true if X is stored column-major
- * @param y             device pointer to label vector of length N
- * @param N             number of examples
- * @param D             number of features
- * @param C             number of outputs (number of classes or `1` for regression)
- * @param w0            device pointer of size (D + (fit_intercept ? 1 : 0)) * C with initial point,
- *                      overwritten by final result.
- * @param f             host pointer holding the final objective value
- * @param num_iters     host pointer holding the actual number of iterations taken
- * @param sample_weight device pointer to sample weight vector of length n_rows (nullptr
-   for uniform weights)
- * @param svr_eps       epsilon parameter for svr
- */
-/*
-template <typename T, typename I = int>
-void qnFit(const raft::handle_t& cuml_handle,
-           const qn_params& params,
-           float* X,
-           bool X_col_major,
-           float* y,
-           int N,
-           int D,
-           int C,
-           float* w0,
-           float* f,
-           int* num_iters,
-           float* sample_weight = nullptr,
-           T svr_eps        = 0);
-           */
 
 };  // namespace opg
 };  // namespace GLM

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -1,0 +1,78 @@
+#include <raft/core/comms.hpp>
+// #include <raft/core/handle.hpp>
+// #include <raft/core/device_mdarray.hpp>
+// #include <raft/util/cudart_utils.hpp>
+// #include <raft/comms/std_comms.hpp>
+#include <cuml/common/logger.hpp>
+#include <cuml/linear_model/qn.h> // to use qn_params
+
+#include <cuda_runtime.h>
+
+// #include <vector>
+#include <iostream>
+
+namespace ML {
+namespace GLM {
+namespace opg {
+
+void toy(const raft::handle_t &handle, 
+           float* X,
+           int N,
+           int D) ;
+
+void qnFit(const raft::handle_t &handle, 
+           float* X,
+           bool X_col_major,
+           float *y,
+           int N,
+           int D,
+           int C,
+           float* w0,
+           float* f,
+           int* num_iters,
+           int n_samples,
+           int rank,
+           int n_ranks);
+
+/**
+ * @brief Fit a GLM using quasi newton methods.
+ *
+ * @param cuml_handle   reference to raft::handle_t object
+ * @param params        model parameters
+ * @param X             device pointer to a contiguous feature matrix of dimension [N, D]
+ * @param X_col_major   true if X is stored column-major
+ * @param y             device pointer to label vector of length N
+ * @param N             number of examples
+ * @param D             number of features
+ * @param C             number of outputs (number of classes or `1` for regression)
+ * @param w0            device pointer of size (D + (fit_intercept ? 1 : 0)) * C with initial point,
+ *                      overwritten by final result.
+ * @param f             host pointer holding the final objective value
+ * @param num_iters     host pointer holding the actual number of iterations taken
+ * @param sample_weight device pointer to sample weight vector of length n_rows (nullptr
+   for uniform weights)
+ * @param svr_eps       epsilon parameter for svr
+ */
+/*
+template <typename T, typename I = int>
+void qnFit(const raft::handle_t& cuml_handle,
+           const qn_params& params,
+           float* X,
+           bool X_col_major,
+           float* y,
+           int N,
+           int D,
+           int C,
+           float* w0,
+           float* f,
+           int* num_iters,
+           float* sample_weight = nullptr,
+           T svr_eps        = 0);
+           */
+
+};  // namespace opg
+};  // namespace GLM
+};  // namespace ML
+
+
+

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -34,7 +34,7 @@ namespace opg {
  * @param[in] input_desc: PartDescriptor object for the input
  * @param[in] labels: labels data
  * @param[out] coef: learned coefficients
- * @param[in] params: model parameters
+ * @param[in] pams: model parameters
  * @param[in] X_col_major: true if X is stored column-major
  * @param[in] n_classes: number of outputs (number of classes or `1` for regression)
  * @param[out] f: host pointer holding the final objective value

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -19,10 +19,25 @@
 #include <cuml/linear_model/qn.h> 
 #include <cuda_runtime.h>
 
+#include <cumlprims/opg/matrix/data.hpp>
+#include <cumlprims/opg/matrix/part_descriptor.hpp>
+using namespace MLCommon;
+
 namespace ML {
 namespace GLM {
 namespace opg {
 
+void qnFit(raft::handle_t& handle,
+           std::vector<Matrix::Data<float>*>& input_data,
+           Matrix::PartDescriptor& input_desc,
+           std::vector<Matrix::Data<float>*>& labels,
+           float* coef,
+           const qn_params& pams,
+           bool X_col_major,
+           float* f,
+           int* num_iters);
+
+/*
 void qnFit(const raft::handle_t &handle, 
            const qn_params& pams,
            float* X,
@@ -37,6 +52,7 @@ void qnFit(const raft::handle_t &handle,
            int n_samples,
            int rank,
            int n_ranks);
+*/
 
 };  // namespace opg
 };  // namespace GLM

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <raft/core/comms.hpp>
-#include <cuml/common/logger.hpp>
-#include <cuml/linear_model/qn.h> 
 #include <cuda_runtime.h>
+#include <cuml/common/logger.hpp>
+#include <cuml/linear_model/qn.h>
+#include <raft/core/comms.hpp>
 
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -21,6 +21,7 @@ void toy(const raft::handle_t &handle,
            int D) ;
 
 void qnFit(const raft::handle_t &handle, 
+           const qn_params& pams,
            float* X,
            bool X_col_major,
            float *y,

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <raft/core/comms.hpp>
 #include <cuml/common/logger.hpp>
 #include <cuml/linear_model/qn.h> 
@@ -6,11 +22,6 @@
 namespace ML {
 namespace GLM {
 namespace opg {
-
-void toy(const raft::handle_t &handle, 
-           float* X,
-           int N,
-           int D) ;
 
 void qnFit(const raft::handle_t &handle, 
            const qn_params& pams,
@@ -30,6 +41,3 @@ void qnFit(const raft::handle_t &handle,
 };  // namespace opg
 };  // namespace GLM
 };  // namespace ML
-
-
-

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,19 @@ namespace ML {
 namespace GLM {
 namespace opg {
 
+/**
+ * @brief performs MNMG fit operation for the logistic regression using quasi newton methods
+ * @param[in] handle: the internal cuml handle object
+ * @param[in] input_data: vector holding all partitions for that rank
+ * @param[in] input_desc: PartDescriptor object for the input
+ * @param[in] labels: labels data
+ * @param[out] coef: learned coefficients
+ * @param[in] params: model parameters
+ * @param[in] X_col_major: true if X is stored column-major
+ * @param[in] n_classes: number of outputs (number of classes or `1` for regression)
+ * @param[out] f: host pointer holding the final objective value
+ * @param[out] num_iters: host pointer holding the actual number of iterations taken
+ */
 void qnFit(raft::handle_t& handle,
            std::vector<Matrix::Data<float>*>& input_data,
            Matrix::PartDescriptor& input_desc,
@@ -34,25 +47,9 @@ void qnFit(raft::handle_t& handle,
            float* coef,
            const qn_params& pams,
            bool X_col_major,
+           int n_classes,
            float* f,
            int* num_iters);
-
-/*
-void qnFit(const raft::handle_t &handle, 
-           const qn_params& pams,
-           float* X,
-           bool X_col_major,
-           float *y,
-           int N,
-           int D,
-           int C,
-           float* w0,
-           float* f,
-           int* num_iters,
-           int n_samples,
-           int rank,
-           int n_ranks);
-*/
 
 };  // namespace opg
 };  // namespace GLM

--- a/cpp/src/glm/qn/glm_base_mg.cuh
+++ b/cpp/src/glm/qn/glm_base_mg.cuh
@@ -68,24 +68,24 @@ inline void linearBwdMG(const raft::handle_t& handle,
   }
 }
 
+/**
+ * @brief Aggregates local gradient vectors and loss values from local training data. This
+ * class is the multi-node-multi-gpu version of GLMWithData.
+ *
+ * The implementation overrides existing GLMWithData::() function. The purpose is to
+ * aggregate local gradient vectors and loss values from distributed X, y, where X represents the
+ * input vectors and y represents labels.
+ *
+ * GLMWithData::() currently invokes three functions: linearFwd, getLossAndDz and linearBwd.
+ * linearFwd multiplies local input vectors with the coefficient vector (i.e. coef_), so does not
+ * require communication. getLossAndDz calculates local loss so requires allreduce to obtain a
+ * global loss. linearBwd calculates local gradient vector so requires allreduce to obtain a
+ * global gradient vector. The global loss and the global gradient vector will be used in
+ * min_lbfgs to update coefficient. The update runs individually on every GPU and when finished,
+ * all GPUs have the same value of coefficient.
+ */
 template <typename T, class GLMObjective>
 struct GLMWithDataMG : ML::GLM::detail::GLMWithData<T, GLMObjective> {
-  /**
-   * @brief Aggregates local gradient vectors and loss values from local training data. This
-   * class is the multi-node-multi-gpu version of GLMWithData.
-   *
-   * The implementation overrides existing GLMWithData::() function. The purpose is to
-   * aggregate local gradient vectors and loss values from distributed X, y, where X represents the
-   * input vectors and y represents labels.
-   *
-   * GLMWithData::() currently invokes three functions: linearFwd, getLossAndDz and linearBwd.
-   * linearFwd multiplies local input vectors with the coefficient vector (i.e. coef_), so does not
-   * require communication. getLossAndDz calculates local loss so requires allreduce to obtain a
-   * global loss. linearBwd calculates local gradient vector so requires allreduce to obtain a
-   * global gradient vector. The global loss and the global gradient vector will be used my
-   * min_lbfgs to update coefficient. The update runs individually on every GPU and when finished,
-   * all GPUs have the same value of coefficient.
-   */
   const raft::handle_t* handle_p;
   int rank;
   int64_t n_samples;

--- a/cpp/src/glm/qn/glm_base_mg.cuh
+++ b/cpp/src/glm/qn/glm_base_mg.cuh
@@ -1,0 +1,154 @@
+#include <raft/core/comms.hpp>
+#include <raft/util/cudart_utils.hpp>
+#include <raft/core/handle.hpp>
+#include <raft/linalg/multiply.cuh>
+
+// the following are for PCA
+#include "glm/qn/glm_base.cuh"
+#include "glm/qn/glm_logistic.cuh"
+#include "glm/qn/qn_util.cuh"
+#include "glm/qn/qn_solvers.cuh"
+#include "glm/qn/glm_regularizer.cuh"
+#include <vector>
+#include <iostream>
+
+namespace ML {
+namespace GLM {
+namespace opg {
+template<typename T>
+// multi-gpu version of linearBwd
+inline void linearBwdMG(const raft::handle_t& handle,
+                      SimpleDenseMat<T>& G,
+                      const SimpleMat<T>& X,
+                      const SimpleDenseMat<T>& dZ,
+                      bool setZero,
+                      const int64_t n_samples, 
+                      const int n_ranks)
+{
+  cudaStream_t stream = handle.get_stream();
+  // Backward pass:
+  // - compute G <- dZ * X.T
+  // - for bias: Gb = mean(dZ, 1)
+
+  const bool has_bias = X.n != G.n;
+  const int D         = X.n;
+  const T beta        = setZero ? T(0) : T(1);
+
+  if (has_bias) {
+
+    SimpleVec<T> Gbias;
+    SimpleDenseMat<T> Gweights;
+
+    col_ref(G, Gbias, D);
+
+    col_slice(G, Gweights, 0, D);
+
+    // TODO can this be fused somehow?
+    const SimpleDenseMat<T>* X_simple_p = (const SimpleDenseMat<T>*)(&X);
+    Gweights.assign_gemm(handle, 1.0 / n_samples, dZ, false, X, false, beta / n_ranks, stream);
+
+    // Stats::opg::mean(handle, mu_data, input_data, input_desc, streams, n_streams);
+
+    raft::stats::mean(Gbias.data, dZ.data, dZ.m, dZ.n, false, true, stream);
+    T bias_factor = 1.0 * dZ.n / n_samples;
+    raft::linalg::multiplyScalar(Gbias.data, Gbias.data, bias_factor, dZ.m, stream);
+
+  } else {
+    CUML_LOG_DEBUG("has bias not enabled");
+    G.assign_gemm(handle, 1.0 / n_samples, dZ, false, X, false, beta / n_ranks, stream);
+  }
+}
+
+template <typename T, class GLMObjective>
+struct GLMWithDataMG : ML::GLM::detail::GLMWithData<T, GLMObjective> {
+
+    const raft::handle_t* handle_p;
+    int rank;
+    int64_t n_samples;
+    int n_ranks;
+
+    GLMWithDataMG(raft::handle_t const &handle, int rank, int n_ranks, int64_t n_samples, GLMObjective* obj, const SimpleMat<T>& X, const SimpleVec<T>& y, SimpleDenseMat<T>& Z)
+        : ML::GLM::detail::GLMWithData<T, GLMObjective> (obj, X, y, Z)
+    {
+        this->handle_p = &handle;
+        this->rank = rank;
+        this->n_ranks = n_ranks;
+        this->n_samples = n_samples;
+    }
+
+    inline T operator()(const SimpleVec<T>& wFlat,
+                        SimpleVec<T>& gradFlat,
+                        T* dev_scalar,
+                        cudaStream_t stream)
+    {
+        SimpleDenseMat<T> W(wFlat.data, this->C, this->dims);
+        SimpleDenseMat<T> G(gradFlat.data, this->C, this->dims);
+        SimpleVec<T> lossVal(dev_scalar, 1);
+
+        // apply regularization
+        auto regularizer_obj = this->objective;
+        auto lossFunc = regularizer_obj->loss;
+        auto reg = regularizer_obj->reg;
+        G.fill(0, stream);
+        reg->reg_grad(dev_scalar, G, W, lossFunc->fit_intercept, stream);
+        float reg_host;
+        raft::update_host(&reg_host, dev_scalar, 1, stream);
+
+        // apply linearFwd, getLossAndDz, linearBwd
+        /*
+          inline void loss_grad(T* loss_val,
+                        Mat& G,
+                        const Mat& W,
+                        const SimpleMat<T>& Xb,
+                        const Vec& yb,
+                        Mat& Zb,
+                        cudaStream_t stream,
+                        bool initGradZero = true)
+        */
+        // call linearFwd, linearBwd, getLossAndDz
+        ML::GLM::detail::linearFwd(lossFunc->handle, *(this->Z), *(this->X), W);                  // linear part: forward pass
+
+        //raft::interruptible::synchronize(stream);
+        // raft::comms::comms_t const& communicator = raft::resource::get_comms(handle);   
+        raft::comms::comms_t const& communicator = raft::resource::get_comms(*(this->handle_p));   
+
+        lossFunc->getLossAndDZ(dev_scalar, *(this->Z), *(this->y), stream);  // loss specific part
+
+        // add normalization to distributed losses
+        float tmp_host = -1.0;
+        raft::update_host(&tmp_host, dev_scalar, 1, stream);
+        tmp_host = tmp_host * (*this->y).len / this->n_samples;
+        lossVal.fill(tmp_host, stream);
+        raft::interruptible::synchronize(stream);
+
+        communicator.allreduce(dev_scalar, dev_scalar, 1,                          
+            raft::comms::op_t::SUM, stream);                                                                 
+        raft::resource::sync_stream(*(this->handle_p));    
+        raft::interruptible::synchronize(stream);
+
+        //linearBwd(lossFunc->handle, G, *(this->X), *(this->Z), false);    // linear part: backward pass
+        linearBwdMG(lossFunc->handle, G, *(this->X), *(this->Z), false, n_samples, n_ranks);    // linear part: backward pass
+        raft::interruptible::synchronize(stream);
+
+        communicator.allreduce(G.data, G.data, this->C * this->dims,                          
+            raft::comms::op_t::SUM, stream);                                                                 
+        raft::resource::sync_stream(*(this->handle_p));    
+
+        float loss_host;
+        raft::update_host(&loss_host, dev_scalar, 1, stream);
+
+        raft::interruptible::synchronize(stream);
+
+
+        lossVal.fill(loss_host + reg_host, stream);
+        raft::update_host(&loss_host, dev_scalar, 1, stream);
+        raft::interruptible::synchronize(stream);
+
+        return loss_host;
+    }
+
+
+};
+};  // namespace OPG
+};  // namespace GLM
+};  // namespace ML

--- a/cpp/src/glm/qn/glm_base_mg.cuh
+++ b/cpp/src/glm/qn/glm_base_mg.cuh
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <raft/core/comms.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/core/handle.hpp>

--- a/cpp/src/glm/qn/glm_base_mg.cuh
+++ b/cpp/src/glm/qn/glm_base_mg.cuh
@@ -15,30 +15,28 @@
  */
 
 #include <raft/core/comms.hpp>
-#include <raft/util/cudart_utils.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/linalg/multiply.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include "glm/qn/glm_base.cuh"
-#include "glm/qn/glm_logistic.cuh"
-#include "glm/qn/qn_util.cuh"
-#include "glm/qn/qn_solvers.cuh"
-#include "glm/qn/glm_regularizer.cuh"
-#include <vector>
-#include <iostream>
+#include <glm/qn/glm_base.cuh>
+#include <glm/qn/glm_logistic.cuh>
+#include <glm/qn/glm_regularizer.cuh>
+#include <glm/qn/qn_solvers.cuh>
+#include <glm/qn/qn_util.cuh>
 
 namespace ML {
 namespace GLM {
 namespace opg {
-template<typename T>
+template <typename T>
 // multi-gpu version of linearBwd
 inline void linearBwdMG(const raft::handle_t& handle,
-                      SimpleDenseMat<T>& G,
-                      const SimpleMat<T>& X,
-                      const SimpleDenseMat<T>& dZ,
-                      bool setZero,
-                      const int64_t n_samples, 
-                      const int n_ranks)
+                        SimpleDenseMat<T>& G,
+                        const SimpleMat<T>& X,
+                        const SimpleDenseMat<T>& dZ,
+                        bool setZero,
+                        const int64_t n_samples,
+                        const int n_ranks)
 {
   cudaStream_t stream = handle.get_stream();
   // Backward pass:
@@ -50,7 +48,6 @@ inline void linearBwdMG(const raft::handle_t& handle,
   const T beta        = setZero ? T(0) : T(1);
 
   if (has_bias) {
-
     SimpleVec<T> Gbias;
     SimpleDenseMat<T> Gweights;
 
@@ -59,7 +56,6 @@ inline void linearBwdMG(const raft::handle_t& handle,
     col_slice(G, Gweights, 0, D);
 
     // TODO can this be fused somehow?
-    const SimpleDenseMat<T>* X_simple_p = (const SimpleDenseMat<T>*)(&X);
     Gweights.assign_gemm(handle, 1.0 / n_samples, dZ, false, X, false, beta / n_ranks, stream);
 
     raft::stats::mean(Gbias.data, dZ.data, dZ.m, dZ.n, false, true, stream);
@@ -74,86 +70,97 @@ inline void linearBwdMG(const raft::handle_t& handle,
 
 template <typename T, class GLMObjective>
 struct GLMWithDataMG : ML::GLM::detail::GLMWithData<T, GLMObjective> {
-    /**
-     * @brief Aggregates local gradient vectors and loss values from local training data. This
-     * class is the multi-node-multi-gpu version of GLMWithData.
-     *
-     * The implementation overrides existing GLMWithData::() function. The purpose is to 
-     * aggregate local gradient vectors and loss values from distributed X, y, where X represents the input vectors 
-     * and y represents labels. 
-     * 
-     * GLMWithData::() currently invokes three functions: linearFwd, getLossAndDz and linearBwd.
-     * linearFwd multiplies local input vectors with the coefficient vector (i.e. coef_), so does not require communication.
-     * getLossAndDz calculates local loss so requires allreduce to obtain a global loss.
-     * linearBwd calculates local gradient vector so requires allreduce to obtain a global gradient vector.
-     * The global loss and the global gradient vector will be used my min_lbfgs to update coefficient.
-     * The update runs individually on every GPU and when finished, all GPUs have the same value of coefficient.
-     */
-    const raft::handle_t* handle_p;
-    int rank;
-    int64_t n_samples;
-    int n_ranks;
+  /**
+   * @brief Aggregates local gradient vectors and loss values from local training data. This
+   * class is the multi-node-multi-gpu version of GLMWithData.
+   *
+   * The implementation overrides existing GLMWithData::() function. The purpose is to
+   * aggregate local gradient vectors and loss values from distributed X, y, where X represents the
+   * input vectors and y represents labels.
+   *
+   * GLMWithData::() currently invokes three functions: linearFwd, getLossAndDz and linearBwd.
+   * linearFwd multiplies local input vectors with the coefficient vector (i.e. coef_), so does not
+   * require communication. getLossAndDz calculates local loss so requires allreduce to obtain a
+   * global loss. linearBwd calculates local gradient vector so requires allreduce to obtain a
+   * global gradient vector. The global loss and the global gradient vector will be used my
+   * min_lbfgs to update coefficient. The update runs individually on every GPU and when finished,
+   * all GPUs have the same value of coefficient.
+   */
+  const raft::handle_t* handle_p;
+  int rank;
+  int64_t n_samples;
+  int n_ranks;
 
-    GLMWithDataMG(raft::handle_t const &handle, int rank, int n_ranks, int64_t n_samples, GLMObjective* obj, const SimpleMat<T>& X, const SimpleVec<T>& y, SimpleDenseMat<T>& Z)
-        : ML::GLM::detail::GLMWithData<T, GLMObjective> (obj, X, y, Z)
-    {
-        this->handle_p = &handle;
-        this->rank = rank;
-        this->n_ranks = n_ranks;
-        this->n_samples = n_samples;
-    }
+  GLMWithDataMG(raft::handle_t const& handle,
+                int rank,
+                int n_ranks,
+                int64_t n_samples,
+                GLMObjective* obj,
+                const SimpleMat<T>& X,
+                const SimpleVec<T>& y,
+                SimpleDenseMat<T>& Z)
+    : ML::GLM::detail::GLMWithData<T, GLMObjective>(obj, X, y, Z)
+  {
+    this->handle_p  = &handle;
+    this->rank      = rank;
+    this->n_ranks   = n_ranks;
+    this->n_samples = n_samples;
+  }
 
-    inline T operator()(const SimpleVec<T>& wFlat,
-                        SimpleVec<T>& gradFlat,
-                        T* dev_scalar,
-                        cudaStream_t stream)
-    {
-        SimpleDenseMat<T> W(wFlat.data, this->C, this->dims);
-        SimpleDenseMat<T> G(gradFlat.data, this->C, this->dims);
-        SimpleVec<T> lossVal(dev_scalar, 1);
+  inline T operator()(const SimpleVec<T>& wFlat,
+                      SimpleVec<T>& gradFlat,
+                      T* dev_scalar,
+                      cudaStream_t stream)
+  {
+    SimpleDenseMat<T> W(wFlat.data, this->C, this->dims);
+    SimpleDenseMat<T> G(gradFlat.data, this->C, this->dims);
+    SimpleVec<T> lossVal(dev_scalar, 1);
 
-        // apply regularization
-        auto regularizer_obj = this->objective;
-        auto lossFunc = regularizer_obj->loss;
-        auto reg = regularizer_obj->reg;
-        G.fill(0, stream);
-        reg->reg_grad(dev_scalar, G, W, lossFunc->fit_intercept, stream);
-        float reg_host;
-        raft::update_host(&reg_host, dev_scalar, 1, stream);
-        // note: avoid syncing here because there's a sync before reg_host is used.
+    // apply regularization
+    auto regularizer_obj = this->objective;
+    auto lossFunc        = regularizer_obj->loss;
+    auto reg             = regularizer_obj->reg;
+    G.fill(0, stream);
+    reg->reg_grad(dev_scalar, G, W, lossFunc->fit_intercept, stream);
+    float reg_host;
+    raft::update_host(&reg_host, dev_scalar, 1, stream);
+    // note: avoid syncing here because there's a sync before reg_host is used.
 
-        // apply linearFwd, getLossAndDz, linearBwd
-        ML::GLM::detail::linearFwd(lossFunc->handle, *(this->Z), *(this->X), W);                  // linear part: forward pass
+    // apply linearFwd, getLossAndDz, linearBwd
+    ML::GLM::detail::linearFwd(
+      lossFunc->handle, *(this->Z), *(this->X), W);  // linear part: forward pass
 
-        raft::comms::comms_t const& communicator = raft::resource::get_comms(*(this->handle_p));   
+    raft::comms::comms_t const& communicator = raft::resource::get_comms(*(this->handle_p));
 
-        lossFunc->getLossAndDZ(dev_scalar, *(this->Z), *(this->y), stream);  // loss specific part
+    lossFunc->getLossAndDZ(dev_scalar, *(this->Z), *(this->y), stream);  // loss specific part
 
-        // normalize local loss before allreduce sum 
-        T factor = 1.0 * (*this->y).len / this->n_samples;
-        raft::linalg::multiplyScalar(dev_scalar, dev_scalar, factor, 1, stream);
+    // normalize local loss before allreduce sum
+    T factor = 1.0 * (*this->y).len / this->n_samples;
+    raft::linalg::multiplyScalar(dev_scalar, dev_scalar, factor, 1, stream);
 
-        communicator.allreduce(dev_scalar, dev_scalar, 1,                          
-            raft::comms::op_t::SUM, stream);                                                                 
-        communicator.sync_stream(stream);
+    communicator.allreduce(dev_scalar, dev_scalar, 1, raft::comms::op_t::SUM, stream);
+    communicator.sync_stream(stream);
 
-        linearBwdMG(lossFunc->handle, G, *(this->X), *(this->Z), false, n_samples, n_ranks);    // linear part: backward pass
+    linearBwdMG(lossFunc->handle,
+                G,
+                *(this->X),
+                *(this->Z),
+                false,
+                n_samples,
+                n_ranks);  // linear part: backward pass
 
-        communicator.allreduce(G.data, G.data, this->C * this->dims,                          
-            raft::comms::op_t::SUM, stream);                                                                 
-        communicator.sync_stream(stream);
+    communicator.allreduce(G.data, G.data, this->C * this->dims, raft::comms::op_t::SUM, stream);
+    communicator.sync_stream(stream);
 
-        float loss_host;
-        raft::update_host(&loss_host, dev_scalar, 1, stream);
-        raft::resource::sync_stream(*(this->handle_p));    
-        loss_host += reg_host;
-        lossVal.fill(loss_host + reg_host, stream);
+    float loss_host;
+    raft::update_host(&loss_host, dev_scalar, 1, stream);
+    raft::resource::sync_stream(*(this->handle_p));
+    loss_host += reg_host;
+    lossVal.fill(loss_host + reg_host, stream);
 
-        return loss_host;
-    }
-
-
+    return loss_host;
+  }
 };
-};  // namespace OPG
+};  // namespace opg
 };  // namespace GLM
 };  // namespace ML

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -1,0 +1,132 @@
+#include <raft/core/comms.hpp>
+// #include <raft/core/device_mdarray.hpp>
+#include <raft/util/cudart_utils.hpp>
+// #include <raft/comms/std_comms.hpp>
+
+#include <cuml/common/logger.hpp>
+#include <cuml/linear_model/qn.h> // to use qn_params
+
+#include "glm/qn/glm_base.cuh"
+#include "glm/qn/glm_logistic.cuh"
+#include "glm/qn/qn_util.cuh"
+#include "glm/qn/qn_solvers.cuh"
+#include "glm/qn/glm_regularizer.cuh"
+
+#include <cuda_runtime.h>
+#include <iostream>
+
+#include "glm/qn/glm_base.cuh"
+#include "glm/qn/glm_logistic.cuh"
+#include "glm/qn/qn_util.cuh"
+#include "glm/qn/qn_solvers.cuh"
+#include "glm/qn/glm_regularizer.cuh"
+
+#include <cuml/linear_model/qn.h> // to use qn_params
+
+namespace ML {
+namespace GLM {
+namespace opg {
+
+void toy(const raft::handle_t &handle, 
+           float* X,
+           int N,
+           int D) 
+{
+  std::cout << "hello world from qnFit" << std::endl;
+
+  cudaStream_t stream = raft::resource::get_cuda_stream(handle);
+  // std::cout << raft::arr2Str(X, N * D, "X data", stream).c_str() << std::endl; 
+}
+
+template<typename T, typename I>
+void qnFit_impl(const raft::handle_t &handle, 
+                T* X,
+                bool X_col_major,
+                T *y,
+                I N,
+                I D,
+                I C,
+                T* w0,
+                T* f,
+                int* num_iters,
+                I n_samples,
+                int rank,
+                int n_ranks) 
+{
+  std::cout << "hello world from qnFit" << std::endl;
+
+  cudaStream_t stream = raft::resource::get_cuda_stream(handle);
+  std::cout << raft::arr2Str(X, N * D, "X data", stream).c_str() << std::endl;
+
+
+  //std::vector<T> res = {1.};
+  //raft::update_device(w0_data, res.data(), );
+}
+
+void qnFit(const raft::handle_t &handle, 
+           float* X,
+           bool X_col_major,
+           float *y,
+           int N,
+           int D,
+           int C,
+           float* w0,
+           float* f,
+           int* num_iters,
+           int n_samples,
+           int rank,
+           int n_ranks)
+{
+  qnFit_impl<float, int>(
+    handle,
+    X,
+    X_col_major,
+    y,
+    N,
+    D,
+    C,
+    w0,
+    f,
+    num_iters,
+    n_samples,
+    rank,
+    n_ranks);
+}
+
+};  // namespace OPG
+};  // namespace GLM
+};  // namespace ML
+
+// #include <raft/core/device_mdarray.hpp>
+//#include <iostream>
+//#include <vector>
+
+//#include <cuml/linear_model/qn_mg.hpp>
+
+/*
+namespace ML {
+namespace GLM {
+
+
+};  // namespace GLM
+};  // namespace ML
+*/
+
+/*
+template <typename T>
+void qnFit(const raft::handle_t& handle,
+           const qn_params& pams,
+           T* X_data,
+           bool X_col_major,
+           T* y_data,
+           int N,
+           int D,
+           int C,
+           T* w0_data,
+           T* f,
+           int* num_iters,
+           T* sample_weight = nullptr,
+           T svr_eps        = 0)
+{
+}
+*/

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -31,10 +31,8 @@ void toy(const raft::handle_t &handle,
            int N,
            int D) 
 {
-  std::cout << "hello world from qnFit" << std::endl;
 
   cudaStream_t stream = raft::resource::get_cuda_stream(handle);
-  // std::cout << raft::arr2Str(X, N * D, "X data", stream).c_str() << std::endl; 
 }
 
 template<typename T, typename I>
@@ -53,34 +51,17 @@ void qnFit_impl(const raft::handle_t &handle,
                 int rank,
                 int n_ranks) 
 {
-  std::cout << "hello world from qnFit" << std::endl;
-
   cudaStream_t stream = raft::resource::get_cuda_stream(handle);
 
   auto X_simple = SimpleDenseMat<T>(X, N, D, X_col_major? COL_MAJOR : ROW_MAJOR);
-  std::cout << raft::arr2Str(X_simple.data, N * D, "X data", stream).c_str() << std::endl;
 
   auto y_simple = SimpleVec<T>(y, N);
-  std::cout << raft::arr2Str(y_simple.data, N * 1, "y_sample data", stream).c_str() << std::endl;
 
   SimpleVec<T> coef_simple(w0, D + pams.fit_intercept);
 
-  std::cout << "DEBUG: before coef_simple arr2Str" << std::endl;
-  std::cout << "rank " << rank << ", D: " << D << ", fit_intercept: " << pams.fit_intercept << ", C: " << C << std::endl;
-
   auto coef_size = (D + pams.fit_intercept) * (C == 2 ? 1 : C); 
-  std::cout << "rank " << rank << ", coef_size: " << coef_size << std::endl;
-  std::cout << raft::arr2Str(coef_simple.data, 1 , "coef data[0]: ", stream).c_str() << std::endl;
-  std::cout << raft::arr2Str(coef_simple.data, coef_size, "coef data", stream).c_str() << std::endl;
-  std::cout << "DEBUG: after coef_simple arr2Str" << std::endl;
 
-  // prepare configs opt_param
-  //qn_params pams;
-  //pams.loss = QN_LOSS_LOGISTIC;
-  //pams.penalty_l2 = 1;
-  //pams.change_tol = 1e-6;
   ML::GLM::detail::LBFGSParam<T> opt_param(pams);
-
 
   // prepare regularizer regularizer_obj
   ML::GLM::detail::LogisticLoss<T> loss_func(handle, D, pams.fit_intercept);
@@ -108,7 +89,6 @@ void qnFit_impl(const raft::handle_t &handle,
 
   // call min_lbfgs
   min_lbfgs(opt_param, obj_function, coef_simple, fx, &k, workspace, stream, 5);
-  std::cout << raft::arr2Str(coef_simple.data, 3, "coef result", stream).c_str() << std::endl;
 
 }
 

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <raft/core/comms.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/core/handle.hpp>
@@ -15,15 +31,6 @@
 namespace ML {
 namespace GLM {
 namespace opg {
-
-void toy(const raft::handle_t &handle, 
-           float* X,
-           int N,
-           int D) 
-{
-
-  cudaStream_t stream = raft::resource::get_cuda_stream(handle);
-}
 
 template<typename T, typename I>
 void qnFit_impl(const raft::handle_t &handle, 

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -1,16 +1,8 @@
 #include <raft/core/comms.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/core/handle.hpp>
-
 #include <cuml/common/logger.hpp>
-
-//#include "glm/qn/glm_base.cuh"
-//#include "glm/qn/glm_logistic.cuh"
-//#include "glm/qn/qn_util.cuh"
-//#include "glm/qn/qn_solvers.cuh"
-//#include "glm/qn/glm_regularizer.cuh"
-
-#include <cuml/linear_model/qn.h> // to use qn_params
+#include <cuml/linear_model/qn.h> 
 #include "qn/simple_mat/dense.hpp"
 #include "qn/qn_util.cuh"
 #include "qn/glm_logistic.cuh"
@@ -19,8 +11,6 @@
 #include "qn/glm_base_mg.cuh"
 
 #include <cuda_runtime.h>
-#include <iostream>
-
 
 namespace ML {
 namespace GLM {
@@ -127,37 +117,3 @@ void qnFit(const raft::handle_t &handle,
 };  // namespace OPG
 };  // namespace GLM
 };  // namespace ML
-
-// #include <raft/core/device_mdarray.hpp>
-//#include <iostream>
-//#include <vector>
-
-//#include <cuml/linear_model/qn_mg.hpp>
-
-/*
-namespace ML {
-namespace GLM {
-
-
-};  // namespace GLM
-};  // namespace ML
-*/
-
-/*
-template <typename T>
-void qnFit(const raft::handle_t& handle,
-           const qn_params& pams,
-           T* X_data,
-           bool X_col_major,
-           T* y_data,
-           int N,
-           int D,
-           int C,
-           T* w0_data,
-           T* f,
-           int* num_iters,
-           T* sample_weight = nullptr,
-           T svr_eps        = 0)
-{
-}
-*/

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -22,6 +22,7 @@
 #include <cuml/linear_model/qn.h>
 #include <cuml/linear_model/qn_mg.hpp>
 #include <raft/core/comms.hpp>
+#include <raft/core/error.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
 using namespace MLCommon;
@@ -29,7 +30,6 @@ using namespace MLCommon;
 #include "qn/glm_base_mg.cuh"
 
 #include <cuda_runtime.h>
-#include <iostream>
 
 namespace ML {
 namespace GLM {
@@ -53,10 +53,12 @@ void qnFit_impl(const raft::handle_t& handle,
 {
   switch (pams.loss) {
     case QN_LOSS_LOGISTIC: {
-      ASSERT(C == 2, "qn_mg.cu: logistic loss invalid C");
+      RAFT_EXPECTS(
+        C == 2,
+        "qn_mg.cu: only the LOGISTIC loss is supported currently. The number of classes must be 2");
     } break;
     default: {
-      ASSERT(false, "qn_mg.cu: unknown loss function type (id = %d).", pams.loss);
+      RAFT_EXPECTS(false, "qn_mg.cu: unknown loss function type (id = %d).", pams.loss);
     }
   }
 
@@ -107,8 +109,9 @@ void qnFit_impl(raft::handle_t& handle,
                 T* f,
                 int* num_iters)
 {
-  ASSERT(input_data.size() == 1, "qn_mg.cu currently does not accept more than one input matrix");
-  ASSERT(labels.size() == input_data.size(), "labels size does not equal to input_data size");
+  RAFT_EXPECTS(input_data.size() == 1,
+               "qn_mg.cu currently does not accept more than one input matrix");
+  RAFT_EXPECTS(labels.size() == input_data.size(), "labels size does not equal to input_data size");
 
   auto data_X = input_data[0];
   auto data_y = labels[0];

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -149,40 +149,6 @@ void qnFit(raft::handle_t& handle,
     handle, input_data, input_desc, labels, coef, pams, X_col_major, n_classes, f, num_iters);
 }
 
-/*
-void qnFit(const raft::handle_t &handle,
-           const qn_params& pams,
-           float* X,
-           bool X_col_major,
-           float *y,
-           int N,
-           int D,
-           int C,
-           float* w0,
-           float* f,
-           int* num_iters,
-           int n_samples,
-           int rank,
-           int n_ranks)
-{
-  qnFit_impl<float, int>(
-    handle,
-    pams,
-    X,
-    X_col_major,
-    y,
-    N,
-    D,
-    C,
-    w0,
-    f,
-    num_iters,
-    n_samples,
-    rank,
-    n_ranks);
-}
-*/
-
 };  // namespace opg
 };  // namespace GLM
 };  // namespace ML

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -1,27 +1,26 @@
 #include <raft/core/comms.hpp>
-// #include <raft/core/device_mdarray.hpp>
 #include <raft/util/cudart_utils.hpp>
-// #include <raft/comms/std_comms.hpp>
+#include <raft/core/handle.hpp>
 
 #include <cuml/common/logger.hpp>
-#include <cuml/linear_model/qn.h> // to use qn_params
 
-#include "glm/qn/glm_base.cuh"
-#include "glm/qn/glm_logistic.cuh"
-#include "glm/qn/qn_util.cuh"
-#include "glm/qn/qn_solvers.cuh"
-#include "glm/qn/glm_regularizer.cuh"
+//#include "glm/qn/glm_base.cuh"
+//#include "glm/qn/glm_logistic.cuh"
+//#include "glm/qn/qn_util.cuh"
+//#include "glm/qn/qn_solvers.cuh"
+//#include "glm/qn/glm_regularizer.cuh"
+
+#include <cuml/linear_model/qn.h> // to use qn_params
+#include "qn/simple_mat/dense.hpp"
+#include "qn/qn_util.cuh"
+#include "qn/glm_logistic.cuh"
+#include "qn/glm_regularizer.cuh"
+
+#include "qn/glm_base_mg.cuh"
 
 #include <cuda_runtime.h>
 #include <iostream>
 
-#include "glm/qn/glm_base.cuh"
-#include "glm/qn/glm_logistic.cuh"
-#include "glm/qn/qn_util.cuh"
-#include "glm/qn/qn_solvers.cuh"
-#include "glm/qn/glm_regularizer.cuh"
-
-#include <cuml/linear_model/qn.h> // to use qn_params
 
 namespace ML {
 namespace GLM {
@@ -40,6 +39,7 @@ void toy(const raft::handle_t &handle,
 
 template<typename T, typename I>
 void qnFit_impl(const raft::handle_t &handle, 
+                const qn_params& pams,
                 T* X,
                 bool X_col_major,
                 T *y,
@@ -56,14 +56,64 @@ void qnFit_impl(const raft::handle_t &handle,
   std::cout << "hello world from qnFit" << std::endl;
 
   cudaStream_t stream = raft::resource::get_cuda_stream(handle);
-  std::cout << raft::arr2Str(X, N * D, "X data", stream).c_str() << std::endl;
+
+  auto X_simple = SimpleDenseMat<T>(X, N, D, X_col_major? COL_MAJOR : ROW_MAJOR);
+  std::cout << raft::arr2Str(X_simple.data, N * D, "X data", stream).c_str() << std::endl;
+
+  auto y_simple = SimpleVec<T>(y, N);
+  std::cout << raft::arr2Str(y_simple.data, N * 1, "y_sample data", stream).c_str() << std::endl;
+
+  SimpleVec<T> coef_simple(w0, D + pams.fit_intercept);
+
+  std::cout << "DEBUG: before coef_simple arr2Str" << std::endl;
+  std::cout << "rank " << rank << ", D: " << D << ", fit_intercept: " << pams.fit_intercept << ", C: " << C << std::endl;
+
+  auto coef_size = (D + pams.fit_intercept) * (C == 2 ? 1 : C); 
+  std::cout << "rank " << rank << ", coef_size: " << coef_size << std::endl;
+  std::cout << raft::arr2Str(coef_simple.data, 1 , "coef data[0]: ", stream).c_str() << std::endl;
+  std::cout << raft::arr2Str(coef_simple.data, coef_size, "coef data", stream).c_str() << std::endl;
+  std::cout << "DEBUG: after coef_simple arr2Str" << std::endl;
+
+  // prepare configs opt_param
+  //qn_params pams;
+  //pams.loss = QN_LOSS_LOGISTIC;
+  //pams.penalty_l2 = 1;
+  //pams.change_tol = 1e-6;
+  ML::GLM::detail::LBFGSParam<T> opt_param(pams);
 
 
-  //std::vector<T> res = {1.};
-  //raft::update_device(w0_data, res.data(), );
+  // prepare regularizer regularizer_obj
+  ML::GLM::detail::LogisticLoss<T> loss_func(handle, D, pams.fit_intercept);
+  T l1 = pams.penalty_l1;
+  T l2 = pams.penalty_l2;
+  if (pams.penalty_normalized) {
+      l1 /= n_samples; // l1 /= 1/X.m
+      l2 /= n_samples; // l2 /= 1/X.m
+  }
+  ML::GLM::detail::Tikhonov<T> reg(l2);
+  ML::GLM::detail::RegularizedGLM<T, ML::GLM::detail::LogisticLoss<T>, decltype(reg)> regularizer_obj(&loss_func, &reg);
+
+
+  // prepare GLMWithDataMG
+  int n_targets = C == 2 ? 1 : C;
+  rmm::device_uvector<T> tmp(n_targets * N, stream);
+  SimpleDenseMat<T> Z(tmp.data(), n_targets, N);
+  auto obj_function = GLMWithDataMG(handle, rank, n_ranks, n_samples, &regularizer_obj, X_simple, y_simple, Z);
+
+  // prepare temporary variables fx, k, workspace 
+  float fx = -1; 
+  int k = -1;
+  rmm::device_uvector<float> tmp_workspace(lbfgs_workspace_size(opt_param, coef_simple.len), stream);
+  SimpleVec<float> workspace(tmp_workspace.data(), tmp_workspace.size());
+
+  // call min_lbfgs
+  min_lbfgs(opt_param, obj_function, coef_simple, fx, &k, workspace, stream, 5);
+  std::cout << raft::arr2Str(coef_simple.data, 3, "coef result", stream).c_str() << std::endl;
+
 }
 
 void qnFit(const raft::handle_t &handle, 
+           const qn_params& pams,
            float* X,
            bool X_col_major,
            float *y,
@@ -79,6 +129,7 @@ void qnFit(const raft::handle_t &handle,
 {
   qnFit_impl<float, int>(
     handle,
+    pams,
     X,
     X_col_major,
     y,

--- a/python/cuml/dask/common/base.py
+++ b/python/cuml/dask/common/base.py
@@ -407,12 +407,13 @@ class SyncFitMixinLinearModel(object):
             ]
         )
 
+        fit_func = self._func_fit
         lin_fit = dict(
             [
                 (
                     worker_data[0],
                     self.client.submit(
-                        _func_fit,
+                        fit_func,
                         lin_models[data.worker_info[worker_data[0]]["rank"]],
                         worker_data[1],
                         data.total_rows,
@@ -434,9 +435,9 @@ class SyncFitMixinLinearModel(object):
         comms.destroy()
         return lin_models
 
-
-def _func_fit(f, data, n_rows, n_cols, partsToSizes, rank):
-    return f.fit(data, n_rows, n_cols, partsToSizes, rank)
+    @staticmethod
+    def _func_fit(f, data, n_rows, n_cols, partsToSizes, rank):
+        return f.fit(data, n_rows, n_cols, partsToSizes, rank)
 
 
 def mnmg_import(func):

--- a/python/cuml/dask/linear_model/__init__.py
+++ b/python/cuml/dask/linear_model/__init__.py
@@ -22,6 +22,7 @@ if has_dask():
     from cuml.dask.linear_model.ridge import Ridge
     from cuml.dask.linear_model.lasso import Lasso
     from cuml.dask.linear_model.elastic_net import ElasticNet
+    from cuml.dask.linear_model.logistic_regression import LogisticRegression
 else:
     warnings.warn(
         "Dask not found. All Dask-based multi-GPU operation is disabled."

--- a/python/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/dask/linear_model/logistic_regression.py
@@ -30,11 +30,8 @@ from cuml.internals.safe_imports import gpu_only_import
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 
-    
-class LogisticRegression(
-    BaseEstimator, SyncFitMixinLinearModel 
-):
 
+class LogisticRegression(BaseEstimator, SyncFitMixinLinearModel):
     def __init__(self, *, client=None, verbose=False, **kwargs):
         super().__init__(client=client, verbose=verbose, **kwargs)
 
@@ -51,8 +48,7 @@ class LogisticRegression(
         """
 
         models = self._fit(
-            model_func=LogisticRegression._create_model, 
-            data=(X, y)
+            model_func=LogisticRegression._create_model, data=(X, y)
         )
 
         self._set_internal_model(models[0])
@@ -65,12 +61,12 @@ class LogisticRegression(
     @staticmethod
     @mnmg_import
     def _create_model(sessionId, datatype, **kwargs):
-        from cuml.linear_model.logistic_regression_mg import LogisticRegressionMG
+        from cuml.linear_model.logistic_regression_mg import (
+            LogisticRegressionMG,
+        )
 
         handle = get_raft_comm_state(sessionId, get_worker())["handle"]
-        return LogisticRegressionMG(
-            handle=handle 
-        )
+        return LogisticRegressionMG(handle=handle)
 
     @staticmethod
     def _func_fit(f, data, n_rows, n_cols, partsToSizes, rank):

--- a/python/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/dask/linear_model/logistic_regression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/dask/linear_model/logistic_regression.py
@@ -30,39 +30,6 @@ from cuml.internals.safe_imports import gpu_only_import
 cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 
-## TODO, replace this class with existing SyncFitMixnLinearModel. 
-## This requires moving num_classes calculation to c++ fit
-#class SyncFitMixinLogisticModel(SyncFitMixinLinearModel):
-#
-#    @staticmethod
-#    @mnmg_import
-#    def _func_fit(sessionId, objs, datatype, has_weights, **kwargs):
-#        from cuml.cluster.kmeans_mg import KMeansMG as cumlKMeans
-#
-#        handle = get_raft_comm_state(sessionId, get_worker())["handle"]
-#
-#        if not has_weights:
-#            inp_data = concatenate(objs)
-#            inp_weights = None
-#        else:
-#            inp_data = concatenate([X for X, weights in objs])
-#            inp_weights = concatenate([weights for X, weights in objs])
-#
-#        return cumlKMeans(handle=handle, output_type=datatype, **kwargs).fit(
-#            inp_data, sample_weight=inp_weights
-#        )
-#
-#def _func_fit_lrmg(f, data, n_rows, n_cols, partsToSizes, rank):
-#            if not has_weights:
-#            inp_data = concatenate(objs)
-#            inp_weights = None
-#        else:
-#            inp_data = concatenate([X for X, weights in objs])
-#            inp_weights = concatenate([weights for X, weights in objs])
-#
-#    int n_ranks = partsToSizes
-#    return f.fit(data, n_rows, n_cols, partsToSizes, rank)
-
     
 class LogisticRegression(
     BaseEstimator, SyncFitMixinLinearModel 
@@ -107,11 +74,6 @@ class LogisticRegression(
 
     @staticmethod
     def _func_fit(f, data, n_rows, n_cols, partsToSizes, rank):
-        print("using logisticregression func_fit")
-        print(f"type(data) is {type(data)}")
-        print(f"len(data) is {len(data)}")
-        print(f"(data[0][0]) is {data[0][0]}")
-        print(f"(data[0][1]) is {data[0][1]}")
         inp_X = concatenate([X for X, _ in data])
         inp_y = concatenate([y for _, y in data])
         return f.fit([(inp_X, inp_y)], n_rows, n_cols, partsToSizes, rank)

--- a/python/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/dask/linear_model/logistic_regression.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from cuml.dask.common.base import BaseEstimator
+from cuml.dask.common.base import DelayedPredictionMixin
+from cuml.dask.common.base import mnmg_import
+from cuml.dask.common.base import SyncFitMixinLinearModel
+from raft_dask.common.comms import get_raft_comm_state
+from dask.distributed import get_worker
+
+from cuml.dask.common import parts_to_ranks
+from cuml.dask.common.input_utils import DistributedDataHandler, concatenate
+from raft_dask.common.comms import Comms
+from cuml.dask.common.utils import wait_and_raise_from_futures
+from cuml.internals.safe_imports import cpu_only_import
+from cuml.internals.safe_imports import gpu_only_import
+
+cp = gpu_only_import("cupy")
+np = cpu_only_import("numpy")
+
+## TODO, replace this class with existing SyncFitMixnLinearModel. 
+## This requires moving num_classes calculation to c++ fit
+#class SyncFitMixinLogisticModel(SyncFitMixinLinearModel):
+#
+#    @staticmethod
+#    @mnmg_import
+#    def _func_fit(sessionId, objs, datatype, has_weights, **kwargs):
+#        from cuml.cluster.kmeans_mg import KMeansMG as cumlKMeans
+#
+#        handle = get_raft_comm_state(sessionId, get_worker())["handle"]
+#
+#        if not has_weights:
+#            inp_data = concatenate(objs)
+#            inp_weights = None
+#        else:
+#            inp_data = concatenate([X for X, weights in objs])
+#            inp_weights = concatenate([weights for X, weights in objs])
+#
+#        return cumlKMeans(handle=handle, output_type=datatype, **kwargs).fit(
+#            inp_data, sample_weight=inp_weights
+#        )
+#
+#def _func_fit_lrmg(f, data, n_rows, n_cols, partsToSizes, rank):
+#            if not has_weights:
+#            inp_data = concatenate(objs)
+#            inp_weights = None
+#        else:
+#            inp_data = concatenate([X for X, weights in objs])
+#            inp_weights = concatenate([weights for X, weights in objs])
+#
+#    int n_ranks = partsToSizes
+#    return f.fit(data, n_rows, n_cols, partsToSizes, rank)
+
+    
+class LogisticRegression(
+    BaseEstimator, SyncFitMixinLinearModel 
+):
+
+    def __init__(self, *, client=None, verbose=False, **kwargs):
+        super().__init__(client=client, verbose=verbose, **kwargs)
+
+    def fit(self, X, y):
+        """
+        Fit the model with X and y.
+
+        Parameters
+        ----------
+        X : Dask cuDF dataframe  or CuPy backed Dask Array (n_rows, n_features)
+            Features for regression
+        y : Dask cuDF dataframe  or CuPy backed Dask Array (n_rows, 1)
+            Labels (outcome values)
+        """
+
+        models = self._fit(
+            model_func=LogisticRegression._create_model, 
+            data=(X, y)
+        )
+
+        self._set_internal_model(models[0])
+
+        return self
+
+    def get_param_names(self):
+        return list(self.kwargs.keys())
+
+    @staticmethod
+    @mnmg_import
+    def _create_model(sessionId, datatype, **kwargs):
+        from cuml.linear_model.logistic_regression_mg import LogisticRegressionMG
+
+        handle = get_raft_comm_state(sessionId, get_worker())["handle"]
+        return LogisticRegressionMG(
+            handle=handle 
+        )
+
+    @staticmethod
+    def _func_fit(f, data, n_rows, n_cols, partsToSizes, rank):
+        print("using logisticregression func_fit")
+        print(f"type(data) is {type(data)}")
+        print(f"len(data) is {len(data)}")
+        print(f"(data[0][0]) is {data[0][0]}")
+        print(f"(data[0][1]) is {data[0][1]}")
+        inp_X = concatenate([X for X, _ in data])
+        inp_y = concatenate([y for _, y in data])
+        return f.fit([(inp_X, inp_y)], n_rows, n_cols, partsToSizes, rank)

--- a/python/cuml/linear_model/CMakeLists.txt
+++ b/python/cuml/linear_model/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT SINGLEGPU)
   list(APPEND cython_sources
        base_mg.pyx
        linear_regression_mg.pyx
+       logistic_regression_mg.pyx
        ridge_mg.pyx
   )
 

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -34,7 +34,7 @@ from cuml.decomposition.utils cimport *
 class MGFitMixin(object):
 
     @cuml.internals.api_base_return_any_skipall
-    def fit(self, input_data, n_rows, n_cols, partsToSizes, rank):
+    def fit(self, input_data, n_rows, n_cols, partsToSizes, rank, order='F'):
         """
         Fit function for MNMG linear regression classes
         This not meant to be used as
@@ -58,7 +58,7 @@ class MGFitMixin(object):
                 check_dtype = self.dtype
 
             X_m, _, self.n_cols, _ = \
-                input_to_cuml_array(input_data[i][0], check_dtype=check_dtype)
+                input_to_cuml_array(input_data[i][0], check_dtype=check_dtype, order=order)
             X_arys.append(X_m)
 
             if i == 0:

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -148,6 +148,7 @@ class LogisticRegressionMG(LogisticRegression):
                 coef_size, dtype=self.dtype, order='C')
 
     def fit(self, X, y, rank, n_ranks, n_samples, n_classes, convert_dtype=False) -> "LogisticRegressionMG":
+        assert (n_classes == 2):
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle() 
 

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ cdef extern from "cuml/linear_model/qn_mg.hpp" namespace "ML::GLM::opg" nogil:
         float *coef,
         const qn_params& pams, 
         bool X_col_major,
+        int n_classes,
         float *f,
         int *num_iters) except +
 
@@ -178,7 +179,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         cdef int num_iters
 
 
-        self._num_classes = 2
+        self._num_classes = 2 # TODO: calculate _num_classes at runtime
         self.prepare_for_fit(self._num_classes)
         cdef uintptr_t mat_coef_ptr = self.coef_.ptr
 
@@ -192,6 +193,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
                 <float*>mat_coef_ptr,
                 qnpams,
                 self.is_col_major,
+                self._num_classes,
                 <float*> &objective32,
                 <int*> &num_iters)
 

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -89,7 +89,6 @@ class LogisticRegressionMG(LogisticRegression):
         super().__init__(handle=handle)
 
     def prepare_for_fit(self, n_classes):
-        print("debug start prepare for fit")
         self.qnparams = QNParams(
             loss=self.loss,
             penalty_l1=self.l1_strength,

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -1,0 +1,206 @@
+#
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# distutils: language = c++
+
+from cuml.internals.safe_imports import gpu_only_import
+cp = gpu_only_import('cupy')
+from cuml.internals.safe_imports import cpu_only_import
+np = cpu_only_import('numpy')
+
+from libcpp cimport bool
+from libc.stdint cimport uintptr_t
+
+from cuml.common import input_to_cuml_array
+import numpy as np
+
+from cuml.internals.array import CumlArray
+from cuml.internals.api_decorators import device_interop_preparation
+from cuml.linear_model import LogisticRegression 
+from cuml.solvers.qn import QN
+from cuml.solvers.qn import QNParams
+
+from pylibraft.common.handle cimport handle_t
+
+from cuml.solvers.qn import __is_col_major
+
+# the cdef was copied from cuml.linear_model.qn
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
+
+    cdef enum qn_loss_type "ML::GLM::qn_loss_type":
+        QN_LOSS_LOGISTIC "ML::GLM::QN_LOSS_LOGISTIC"
+        QN_LOSS_SQUARED  "ML::GLM::QN_LOSS_SQUARED"
+        QN_LOSS_SOFTMAX  "ML::GLM::QN_LOSS_SOFTMAX"
+        QN_LOSS_SVC_L1   "ML::GLM::QN_LOSS_SVC_L1"
+        QN_LOSS_SVC_L2   "ML::GLM::QN_LOSS_SVC_L2"
+        QN_LOSS_SVR_L1   "ML::GLM::QN_LOSS_SVR_L1"
+        QN_LOSS_SVR_L2   "ML::GLM::QN_LOSS_SVR_L2"
+        QN_LOSS_ABS      "ML::GLM::QN_LOSS_ABS"
+        QN_LOSS_UNKNOWN  "ML::GLM::QN_LOSS_UNKNOWN"
+
+
+cdef extern from "cuml/linear_model/qn_mg.hpp" namespace "ML::GLM::opg" nogil:
+
+    void toy(
+        const handle_t& handle,
+        float *X,
+        int N,
+        int D
+    ) except +
+
+    void qnFit(
+        const handle_t& handle,
+        float *X,
+        bool X_col_major,
+        float *y,
+        int N,
+        int D,
+        int C,
+        float *w0,
+        float *f,
+        int *num_iters,
+        int n_samples,
+        int rank,
+        int n_ranks) except +
+
+#class Tmp:
+#    def __init__(self) -> None:
+#        self.a = 10
+#
+#class SubTmp(Tmp):
+#    def __init__(self) -> None:
+#        super().__init__()
+#        print("subtmp self.a")
+#        print(self.a)
+
+class LogisticRegressionMG(QN):
+    
+    def __init__(self):
+        super().__init__()
+
+    def prepare_for_fit(self, y_m):
+        # fully copied code from qn.pyx::fit to prepare self.coef, self.qnparams etc.
+        # modified cdef qn_params qnpams = self.qnparams.params
+        # modifled qnpams.loss to qnpams['loss']
+        self.qnparams = QNParams(
+            loss=self.loss,
+            penalty_l1=self.l1_strength,
+            penalty_l2=self.l2_strength,
+            grad_tol=self.tol,
+            change_tol=self.delta
+            if self.delta is not None else (self.tol * 0.01),
+            max_iter=self.max_iter,
+            linesearch_max_iter=self.linesearch_max_iter,
+            lbfgs_memory=self.lbfgs_memory,
+            verbose=self.verbose,
+            fit_intercept=self.fit_intercept,
+            penalty_normalized=self.penalty_normalized
+        )
+
+        # modified
+        qnpams = self.qnparams.params
+
+        # modified qnp
+        solves_classification = qnpams['loss'] in {
+            qn_loss_type.QN_LOSS_LOGISTIC,
+            qn_loss_type.QN_LOSS_SOFTMAX,
+            qn_loss_type.QN_LOSS_SVC_L1,
+            qn_loss_type.QN_LOSS_SVC_L2
+        }
+        solves_multiclass = qnpams['loss'] in {
+            qn_loss_type.QN_LOSS_SOFTMAX
+        }
+
+        if solves_classification:
+            self._num_classes = len(cp.unique(y_m))
+        else:
+            self._num_classes = 1
+
+        if not solves_multiclass and self._num_classes > 2:
+            raise ValueError(
+                f"The selected solver ({self.loss}) does not support"
+                f" more than 2 classes ({self._num_classes} discovered).")
+
+        if qnpams['loss'] == qn_loss_type.QN_LOSS_SOFTMAX \
+           and self._num_classes <= 2:
+            raise ValueError("Two classes or less cannot be trained"
+                             "with softmax (multinomial).")
+
+        if solves_classification and not solves_multiclass:
+            self._num_classes_dim = self._num_classes - 1
+        else:
+            self._num_classes_dim = self._num_classes
+
+        if self.fit_intercept:
+            coef_size = (self.n_cols + 1, self._num_classes_dim)
+        else:
+            coef_size = (self.n_cols, self._num_classes_dim)
+
+        if self._coef_ is None or not self.warm_start:
+            self._coef_ = CumlArray.zeros(
+                coef_size, dtype=self.dtype, order='C')
+
+    def fit(self, X, y, rank, n_ranks, n_samples, convert_dtype=False) -> "LogisticRegressionMG":
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle() 
+
+        X_m, n_rows, self.n_cols, self.dtype = input_to_cuml_array(
+            X, check_dtype=[np.float32, np.float64], order = 'K'
+        ) 
+
+        y_m, label_rows, _, _ = input_to_cuml_array(
+            y, check_dtype=self.dtype,
+            convert_to_dtype=(self.dtype if convert_dtype else None),
+            check_rows=n_rows, check_cols=1
+        )
+
+        self.classes = cp.unique(y_m)
+        self._num_classes = len(self.classes)
+
+        cdef uintptr_t y_ptr = y_m.ptr
+        cdef float objective32
+        cdef int num_iters
+
+        #toy(
+        #    handle_[0],
+        #    <float*><uintptr_t> X_m.ptr,
+        #    <int> n_rows,
+        #    <int> self.n_cols
+        #)
+
+
+        self.prepare_for_fit(y_m)
+        cdef uintptr_t coef_ptr = self._coef_.ptr
+
+        if self.dtype == np.float32:
+            qnFit(
+                handle_[0],
+                <float*><uintptr_t> X_m.ptr,
+                <bool> __is_col_major(X_m),
+                <float*> y_ptr,
+                <int> n_rows,
+                <int> self.n_cols,
+                <int> self._num_classes,
+                <float*> coef_ptr,
+                <float*> &objective32,
+                <int*> &num_iters,
+                <int> n_samples,
+                <int> rank,
+                <int> n_ranks
+            )
+
+        self.handle.sync()
+        del X_m
+        del y_m
+        return self

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -39,6 +39,7 @@ from cuml.common.opg_data_utils_mg cimport *
 # the cdef was copied from cuml.linear_model.qn
 cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
 
+    # TODO: Use single-GPU version qn_loss_type and qn_params https://github.com/rapidsai/cuml/issues/5502
     cdef enum qn_loss_type "ML::GLM::qn_loss_type":
         QN_LOSS_LOGISTIC "ML::GLM::QN_LOSS_LOGISTIC"
         QN_LOSS_SQUARED  "ML::GLM::QN_LOSS_SQUARED"

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -148,7 +148,7 @@ class LogisticRegressionMG(LogisticRegression):
                 coef_size, dtype=self.dtype, order='C')
 
     def fit(self, X, y, rank, n_ranks, n_samples, n_classes, convert_dtype=False) -> "LogisticRegressionMG":
-        assert (n_classes == 2):
+        assert (n_classes == 2)
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle() 
 

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -142,21 +142,25 @@ def test_lr_fit_predict_score(
     probs_sk = sk_model.predict_proba(X)[:, 1]
     assert np.abs(probs_sk - probs_cuml.get()).max() <= 0.05
 
+
 @pytest.mark.mg
 @pytest.mark.parametrize("n_parts", [2])
 @pytest.mark.parametrize("datatype", [np.float32])
-def test_lbfgs_toy(
-    n_parts, datatype, client
-):
+def test_lbfgs_toy(n_parts, datatype, client):
     def imp():
         import cuml.comm.serialize  # NOQA
+
     client.run(imp)
 
     import numpy as np
+
     X = np.array([(1, 2), (1, 3), (2, 1), (3, 1)], datatype)
     y = np.array([1.0, 1.0, 0.0, 0.0], datatype)
 
-    from cuml.dask.linear_model.logistic_regression import LogisticRegression as cumlLBFGS_dask
+    from cuml.dask.linear_model.logistic_regression import (
+        LogisticRegression as cumlLBFGS_dask,
+    )
+
     X_df, y_df = _prep_training_data(client, X, y, n_parts)
 
     lr = cumlLBFGS_dask()
@@ -164,7 +168,7 @@ def test_lbfgs_toy(
     lr_coef = lr.coef_.to_numpy()
     lr_intercept = lr.intercept_.to_numpy()
 
-    assert len(lr_coef) == 1 
+    assert len(lr_coef) == 1
     assert lr_coef[0] == pytest.approx([-0.71483153, 0.7148315], abs=1e-6)
     assert lr_intercept == pytest.approx([-2.2614916e-08], abs=1e-6)
 
@@ -174,15 +178,15 @@ def test_lbfgs_toy(
 @pytest.mark.parametrize("ncols", [20])
 @pytest.mark.parametrize("n_parts", [2, 23])
 @pytest.mark.parametrize("datatype", [np.float32])
-def test_lbfgs(
-    nrows, ncols, n_parts, datatype, client
-):
+def test_lbfgs(nrows, ncols, n_parts, datatype, client):
     def imp():
         import cuml.comm.serialize  # NOQA
 
     client.run(imp)
 
-    from cuml.dask.linear_model.logistic_regression import LogisticRegression as cumlLBFGS_dask
+    from cuml.dask.linear_model.logistic_regression import (
+        LogisticRegression as cumlLBFGS_dask,
+    )
 
     n_info = 5
     nrows = int(nrows)
@@ -195,7 +199,6 @@ def test_lbfgs(
     lr.fit(X_df, y_df)
     lr_coef = lr.coef_.to_numpy()
     lr_intercept = lr.intercept_.to_numpy()
-
 
     sk_model = skLR()
     sk_model.fit(X, y)

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -172,7 +172,7 @@ def test_lbfgs_toy(
 @pytest.mark.mg
 @pytest.mark.parametrize("nrows", [1e5])
 @pytest.mark.parametrize("ncols", [20])
-@pytest.mark.parametrize("n_parts", [2])
+@pytest.mark.parametrize("n_parts", [2, 23])
 @pytest.mark.parametrize("datatype", [np.float32])
 def test_lbfgs(
     nrows, ncols, n_parts, datatype, client

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -152,8 +152,6 @@ def test_lbfgs_toy(n_parts, datatype, client):
 
     client.run(imp)
 
-    import numpy as np
-
     X = np.array([(1, 2), (1, 3), (2, 1), (3, 1)], datatype)
     y = np.array([1.0, 1.0, 0.0, 0.0], datatype)
 
@@ -190,6 +188,7 @@ def test_lbfgs(nrows, ncols, n_parts, datatype, client):
         LogisticRegression as cumlLBFGS_dask,
     )
 
+    # set n_informative variable for calling sklearn.datasets.make_classification
     n_info = 5
     nrows = int(nrows)
     ncols = int(ncols)

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -179,6 +179,8 @@ def test_lbfgs_toy(n_parts, datatype, client):
 @pytest.mark.parametrize("n_parts", [2, 23])
 @pytest.mark.parametrize("datatype", [np.float32])
 def test_lbfgs(nrows, ncols, n_parts, datatype, client):
+    tolerance = 0.005
+
     def imp():
         import cuml.comm.serialize  # NOQA
 
@@ -207,5 +209,5 @@ def test_lbfgs(nrows, ncols, n_parts, datatype, client):
 
     assert len(lr_coef) == len(sk_coef)
     for i in range(len(lr_coef)):
-        assert lr_coef[i] == pytest.approx(sk_coef[i], abs=1e-3)
-    assert lr_intercept == pytest.approx(sk_intercept, abs=1e-3)
+        assert lr_coef[i] == pytest.approx(sk_coef[i], abs=tolerance)
+    assert lr_intercept == pytest.approx(sk_intercept, abs=tolerance)


### PR DESCRIPTION
This PR enables multi-node-multi-gpu Logistic Regression and it mostly reuses existing codes (i.e. GLMWithData and min_lbfgs) of single-GPU Logistic Regression. No change to any existing codes. 

Added Pytest code for Spark cluster and the tests run successfully with 2 GPUs on a random dataset. The coef_ and intercept_ are the same as single-GPU cuml.LogisticRegression.fit. Pytest code can be found here: https://github.com/lijinf2/spark-rapids-ml/blob/lr/python/tests/test_logistic_regression.py