### PR TITLE
[bug] fix DBSCAN with CosineExpanded

### DIFF
--- a/cpp/src/dbscan/vertexdeg/algo.cuh
+++ b/cpp/src/dbscan/vertexdeg/algo.cuh
@@ -68,7 +68,7 @@ void launcher(const raft::handle_t& handle,
                           raft::linalg::NormType::L2Norm,
                           true,
                           stream,
-                          [] __device__(value_t in) { return sqrtf(in); });
+                          [] __device__(value_t in) { return (in > FLT_EPSILON) ? sqrtf(in) : FLT_EPSILON; });
 
     /* Cast away constness because the output matrix for normalization cannot be of const type.
      * Input matrix will be modified due to normalization.
@@ -80,7 +80,7 @@ void launcher(const raft::handle_t& handle,
       k,
       m,
       true,
-      true,
+      false,
       [] __device__(value_t mat_in, value_t vec_in) { return mat_in / vec_in; },
       stream);
 
@@ -99,7 +99,7 @@ void launcher(const raft::handle_t& handle,
       k,
       m,
       true,
-      true,
+      false,
       [] __device__(value_t mat_in, value_t vec_in) { return mat_in * vec_in; },
       stream);
   } else {


### PR DESCRIPTION
Hi experts,

I want to open this draft MR to discuss the issue #5360. I think it should calculate the normalization by crossing rows instead of doing it along rows.

Other related issues: issue #4930 and issue #4938.