### PR TITLE
Update build dependencies

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -25,6 +25,7 @@ dependencies:
 - gcc_linux-64=11.*
 - gmock>=1.13.0
 - graphviz
+- gtest>=1.13.0
 - hdbscan
 - hypothesis>=6.0,<7
 - ipykernel

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -49,6 +49,7 @@ dependencies:
 - nltk
 - numba>=0.57
 - numpydoc
+- nvcc_linux-64=11.8
 - pip
 - pydata-sphinx-theme
 - pylibraft==23.8.*

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -23,6 +23,7 @@ dependencies:
 - distributed>=2023.5.1
 - doxygen=1.8.20
 - gcc_linux-64=11.*
+- gmock>=1.13.0
 - graphviz
 - hdbscan
 - hypothesis>=6.0,<7

--- a/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
@@ -28,5 +28,6 @@ dependencies:
 - libraft==23.8.*
 - librmm==23.8.*
 - ninja
+- nvcc_linux-64=11.8
 - sysroot_linux-64==2.17
 name: cpp_all_cuda-118_arch-x86_64

--- a/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
@@ -12,6 +12,7 @@ dependencies:
 - cudatoolkit=11.8
 - cxx-compiler
 - gcc_linux-64=11.*
+- gmock>=1.13.0
 - libcublas-dev=11.11.3.6
 - libcublas=11.11.3.6
 - libcufft-dev=10.9.0.58

--- a/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
@@ -13,6 +13,7 @@ dependencies:
 - cxx-compiler
 - gcc_linux-64=11.*
 - gmock>=1.13.0
+- gtest>=1.13.0
 - libcublas-dev=11.11.3.6
 - libcublas=11.11.3.6
 - libcufft-dev=10.9.0.58

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -92,6 +92,7 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - gmock>=1.13.0
+          - gtest>=1.13.0
           - libcumlprims==23.8.*
           - libraft==23.8.*
           - libraft-headers==23.8.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,6 +109,18 @@ dependencies:
             packages:
               - gcc_linux-aarch64=11.*
               - sysroot_linux-aarch64==2.17
+      - output_types: conda
+        matrices:
+          - matrix:
+              arch: x86_64
+              cuda: "11.8"
+            packages:
+              - nvcc_linux-64=11.8
+          - matrix:
+              arch: aarch64
+              cuda: "11.8"
+            packages:
+              - nvcc_linux-aarch64=11.8
   py_build:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -91,6 +91,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
+          - gmock>=1.13.0
           - libcumlprims==23.8.*
           - libraft==23.8.*
           - libraft-headers==23.8.*


### PR DESCRIPTION
Add missing build dependencies: gtest, gmock, and nvcc.

Likely not noticed previously because of an implicit dependency.