### PR TITLE
Remove raft specializations includes.

### DIFF
--- a/cpp/bench/sg/kmeans.cu
+++ b/cpp/bench/sg/kmeans.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #include "benchmark.cuh"
 #include <cuml/cluster/kmeans.hpp>
 #include <cuml/common/logger.hpp>
-#include <raft/cluster/specializations.cuh>
 #include <raft/distance/distance_types.hpp>
 #include <raft/random/rng_state.hpp>
 #include <utility>

--- a/cpp/bench/sg/svc.cu
+++ b/cpp/bench/sg/svc.cu
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include "benchmark.cuh"
 #include <cmath>
 #include <cuml/svm/svc.hpp>

--- a/cpp/bench/sg/svr.cu
+++ b/cpp/bench/sg/svr.cu
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include "benchmark.cuh"
 #include <cmath>
 #include <cuml/svm/svc.hpp>

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -18,7 +18,7 @@ set(CUML_MIN_VERSION_raft "${CUML_VERSION_MAJOR}.${CUML_VERSION_MINOR}.00")
 set(CUML_BRANCH_VERSION_raft "${CUML_VERSION_MAJOR}.${CUML_VERSION_MINOR}")
 
 function(find_and_configure_raft)
-	set(oneValueArgs VERSION FORK PINNED_TAG EXCLUDE_FROM_ALL USE_RAFT_STATIC COMPILE_LIBRARY CLONE_ON_PIN NVTX)
+    set(oneValueArgs VERSION FORK PINNED_TAG EXCLUDE_FROM_ALL USE_RAFT_STATIC COMPILE_LIBRARY CLONE_ON_PIN NVTX)
     cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
             "${multiValueArgs}" ${ARGN} )
 

--- a/cpp/include/cuml/neighbors/knn.hpp
+++ b/cpp/include/cuml/neighbors/knn.hpp
@@ -43,9 +43,9 @@ namespace ML {
  * @param[in] rowMajorIndex are the index arrays in row-major order?
  * @param[in] rowMajorQuery are the query arrays in row-major order?
  * @param[in] metric distance metric to use. Euclidean (L2) is used by
- * 			   default
+ *            default
  * @param[in] metric_arg the value of `p` for Minkowski (l-p) distances. This
- * 					 is ignored if the metric_type is not Minkowski.
+ *            is ignored if the metric_type is not Minkowski.
  */
 void brute_force_knn(const raft::handle_t& handle,
                      std::vector<float*>& input,

--- a/cpp/include/cuml/neighbors/knn_api.h
+++ b/cpp/include/cuml/neighbors/knn_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +42,12 @@ extern "C" {
  * @param[in] rowMajorIndex is the index array in row major layout?
  * @param[in] rowMajorQuery is the query array in row major layout?
  * @param[in] metric_type the type of distance metric to use. This corresponds
- * 					  to the value in the raft::distance::DistanceType enum.
- * 					  Default is Euclidean (L2).
+ *            to the value in the raft::distance::DistanceType enum.
+ *            Default is Euclidean (L2).
  * @param[in] metric_arg the value of `p` for Minkowski (l-p) distances. This
- * 					 is ignored if the metric_type is not Minkowski.
+ *            is ignored if the metric_type is not Minkowski.
  * @param[in] expanded should lp-based distances be returned in their expanded
- * 					 form (e.g., without raising to the 1/p power).
+ *            form (e.g., without raising to the 1/p power).
  */
 cumlError_t knn_search(const cumlHandle_t handle,
                        float** input,

--- a/cpp/src/hdbscan/detail/reachability.cuh
+++ b/cpp/src/hdbscan/detail/reachability.cuh
@@ -31,10 +31,6 @@
 #include <cuml/neighbors/knn.hpp>
 #include <raft/distance/distance.cuh>
 
-#if defined RAFT_COMPILED
-#include <raft/neighbors/specializations.cuh>
-#endif
-
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>

--- a/cpp/src/hdbscan/hdbscan.cu
+++ b/cpp/src/hdbscan/hdbscan.cu
@@ -17,7 +17,6 @@
 #include "detail/condense.cuh"
 #include "detail/predict.cuh"
 #include <cuml/cluster/hdbscan.hpp>
-#include <raft/spatial/knn/specializations.cuh>
 
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>

--- a/cpp/src/hierarchy/linkage.cu
+++ b/cpp/src/hierarchy/linkage.cu
@@ -18,7 +18,6 @@
 
 #include <raft/cluster/single_linkage.cuh>
 #include <raft/core/handle.hpp>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/kmeans/kmeans_fit_predict.cu
+++ b/cpp/src/kmeans/kmeans_fit_predict.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <raft/cluster/specializations.cuh>
 #include <raft/core/handle.hpp>
 
 #include <raft/cluster/kmeans.cuh>

--- a/cpp/src/kmeans/kmeans_mg.cu
+++ b/cpp/src/kmeans/kmeans_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include <raft/cluster/specializations.cuh>
 
 #include "kmeans_mg_impl.cuh"
 #include <cuml/cluster/kmeans_mg.hpp>

--- a/cpp/src/kmeans/kmeans_predict.cu
+++ b/cpp/src/kmeans/kmeans_predict.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <raft/cluster/specializations.cuh>
 #include <raft/core/handle.hpp>
 
 #include <raft/cluster/kmeans.cuh>

--- a/cpp/src/kmeans/kmeans_transform.cu
+++ b/cpp/src/kmeans/kmeans_transform.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <raft/cluster/specializations.cuh>
 #include <raft/core/handle.hpp>
 
 #include <raft/cluster/kmeans.cuh>

--- a/cpp/src/knn/knn.cu
+++ b/cpp/src/knn/knn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 #include <raft/util/cuda_utils.cuh>
 
 #include <raft/spatial/knn/knn.cuh>
-#include <raft/spatial/knn/specializations.cuh>
 #include <rmm/device_uvector.hpp>
 
 #include <cuml/common/logger.hpp>

--- a/cpp/src/knn/knn_opg_common.cuh
+++ b/cpp/src/knn/knn_opg_common.cuh
@@ -27,12 +27,6 @@
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/spatial/knn/knn.cuh>
-#ifdef RAFT_NN_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
-#ifdef RAFT_DISTANCE_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 

--- a/cpp/src/knn/knn_sparse.cu
+++ b/cpp/src/knn/knn_sparse.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 #include <raft/core/handle.hpp>
 
 #include <raft/sparse/selection/knn.cuh>
-#include <raft/spatial/knn/specializations.cuh>
 
 namespace ML {
 namespace Sparse {

--- a/cpp/src/metrics/pairwise_distance.cu
+++ b/cpp/src/metrics/pairwise_distance.cu
@@ -30,7 +30,6 @@
 #include <cuml/metrics/metrics.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 #include <raft/sparse/distance/distance.cuh>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_canberra.cuh
+++ b/cpp/src/metrics/pairwise_distance_canberra.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_chebyshev.cuh
+++ b/cpp/src/metrics/pairwise_distance_chebyshev.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_correlation.cuh
+++ b/cpp/src/metrics/pairwise_distance_correlation.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_cosine.cuh
+++ b/cpp/src/metrics/pairwise_distance_cosine.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_euclidean.cuh
+++ b/cpp/src/metrics/pairwise_distance_euclidean.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #pragma once
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_hamming.cuh
+++ b/cpp/src/metrics/pairwise_distance_hamming.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_hellinger.cuh
+++ b/cpp/src/metrics/pairwise_distance_hellinger.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_jensen_shannon.cuh
+++ b/cpp/src/metrics/pairwise_distance_jensen_shannon.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_kl_divergence.cuh
+++ b/cpp/src/metrics/pairwise_distance_kl_divergence.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_l1.cuh
+++ b/cpp/src/metrics/pairwise_distance_l1.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_minkowski.cuh
+++ b/cpp/src/metrics/pairwise_distance_minkowski.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_russell_rao.cuh
+++ b/cpp/src/metrics/pairwise_distance_russell_rao.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/distance/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/src/metrics/silhouette_score.cu
+++ b/cpp/src/metrics/silhouette_score.cu
@@ -18,9 +18,6 @@
 #include <cuml/metrics/metrics.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
-#ifdef RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
 #include <raft/stats/silhouette_score.cuh>
 
 namespace ML {

--- a/cpp/src/metrics/silhouette_score_batched_double.cu
+++ b/cpp/src/metrics/silhouette_score_batched_double.cu
@@ -18,9 +18,6 @@
 #include <cuml/metrics/metrics.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
-#ifdef RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
 #include <raft/stats/silhouette_score.cuh>
 
 namespace ML {

--- a/cpp/src/metrics/silhouette_score_batched_float.cu
+++ b/cpp/src/metrics/silhouette_score_batched_float.cu
@@ -18,9 +18,6 @@
 #include <cuml/metrics/metrics.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
-#ifdef RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
 #include <raft/stats/silhouette_score.cuh>
 
 namespace ML {

--- a/cpp/src/metrics/trustworthiness.cu
+++ b/cpp/src/metrics/trustworthiness.cu
@@ -19,14 +19,6 @@
 #include <cuml/metrics/metrics.hpp>
 #include <raft/core/handle.hpp>
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
-#if defined RAFT_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
-
 #include <raft/distance/distance.cuh>
 
 namespace ML {

--- a/cpp/src/svm/linear.cu
+++ b/cpp/src/svm/linear.cu
@@ -17,10 +17,6 @@
 #include <random>
 #include <type_traits>
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include <common/nvtx.hpp>
 #include <cublas_v2.h>
 #include <cuml/linear_model/glm.hpp>

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -16,10 +16,6 @@
 
 #include <iostream>
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include "kernelcache.cuh"
 #include "smosolver.cuh"
 #include "svc_impl.cuh"

--- a/cpp/src/svm/svr.cu
+++ b/cpp/src/svm/svr.cu
@@ -16,10 +16,6 @@
 
 #include <iostream>
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include "kernelcache.cuh"
 #include "smosolver.cuh"
 #include "svr_impl.cuh"

--- a/cpp/src/tsne/tsne.cu
+++ b/cpp/src/tsne/tsne.cu
@@ -18,10 +18,6 @@
 #include <cuml/manifold/tsne.h>
 #include <raft/core/handle.hpp>
 
-#if defined RAFT_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
-
 #include <raft/distance/distance_types.hpp>
 
 namespace ML {

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -24,10 +24,6 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/sparse/selection/knn.cuh>
 
-#if defined RAFT_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
-
 #include <raft/spatial/knn/knn.cuh>
 
 #include <raft/util/cudart_utils.hpp>

--- a/cpp/src/umap/umap.cu
+++ b/cpp/src/umap/umap.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include <cuml/manifold/umap.hpp>
 #include <cuml/manifold/umapparams.h>
 #include <raft/core/handle.hpp>
-#include <raft/spatial/knn/specializations.cuh>
 #include <raft/util/cuda_utils.cuh>
 
 #include <iostream>

--- a/cpp/src_prims/linalg/block.cuh
+++ b/cpp/src_prims/linalg/block.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 #include <cub/cub.cuh>
 
-#include <raft/common/device_loads_stores.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+#include <raft/util/device_loads_stores.cuh>
 
 // Anonymous namespace for internal auxiliary functions
 namespace {

--- a/cpp/test/prims/knn_classify.cu
+++ b/cpp/test/prims/knn_classify.cu
@@ -20,9 +20,6 @@
 #include <raft/label/classlabels.cuh>
 #include <raft/random/make_blobs.cuh>
 #include <raft/spatial/knn/knn.cuh>
-#ifdef RAFT_NN_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 #include <rmm/device_uvector.hpp>

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -23,9 +23,6 @@
 #include <raft/linalg/reduce.cuh>
 #include <raft/random/rng.cuh>
 #include <raft/spatial/knn/knn.cuh>
-#ifdef RAFT_NN_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 

--- a/cpp/test/sg/hdbscan_test.cu
+++ b/cpp/test/sg/hdbscan_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@
 #include <hdbscan/detail/extract.cuh>
 #include <hdbscan/detail/reachability.cuh>
 
-#include <raft/spatial/knn/specializations.cuh>
 #include <raft/stats/adjusted_rand_index.cuh>
 
 #include <raft/cluster/detail/agglomerative.cuh>

--- a/cpp/test/sg/knn_test.cu
+++ b/cpp/test/sg/knn_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@
 #include <cuml/datasets/make_blobs.hpp>
 
 #include <cuml/neighbors/knn.hpp>
-#include <raft/spatial/knn/specializations.cuh>
 
 namespace ML {
 

--- a/cpp/test/sg/linear_svm_test.cu
+++ b/cpp/test/sg/linear_svm_test.cu
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include <cmath>
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/datasets/make_regression.hpp>

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
-
 #include <cub/cub.cuh>
 #include <cuml/common/logger.hpp>
 #include <cuml/datasets/make_blobs.hpp>

--- a/cpp/test/sg/tsne_test.cu
+++ b/cpp/test/sg/tsne_test.cu
@@ -28,10 +28,6 @@
 #include <iostream>
 #include <raft/core/handle.hpp>
 
-#if defined RAFT_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
-
 #include <raft/util/cudart_utils.hpp>
 #include <stdio.h>
 #include <stdlib.h>

--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -26,10 +26,6 @@
 #include <cuml/neighbors/knn.hpp>
 #include <datasets/digits.h>
 
-#if defined RAFT_COMPILED
-#include <raft/spatial/knn/specializations.cuh>
-#endif
-
 #include <test_utils.h>
 
 #include <datasets/digits.h>


### PR DESCRIPTION
This PR begins to address a large number of deprecations in RAFT that cause large build logs for libcuml. I tackled only the easiest ones in this PR, where it was a simple change or removal of an `#include`. It seems like the work for the other deprecations will be more substantial.

This fixes deprecations like the one below. I will file a separate issue for the remaining deprecations.

```
.../raft/cpp/include/raft/spatial/knn/specializations.cuh:18:296: note: '#pragma message: .../raft/cpp/include/raft/spatial/knn/specializations.cuh is deprecated and will be removed. Including specializations is not necessary any more. For more information, see: https://docs.rapids.ai/api/raft/nightly/using_libraft.html'
```