### PR TITLE
Update gputreeshap to use rapids-cmake.

### DIFF
--- a/cpp/cmake/thirdparty/get_gputreeshap.cmake
+++ b/cpp/cmake/thirdparty/get_gputreeshap.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,4 +68,4 @@ function(find_and_configure_gputreeshap)
 
 endfunction()
 
-find_and_configure_gputreeshap(PINNED_TAG 78e3548cda5e7c263d125e8c10e733ebf2c4ebbd)
+find_and_configure_gputreeshap(PINNED_TAG ae946908b4cdc2bf498deefc426a3656761166f5)


### PR DESCRIPTION
This PR bumps the gputreeshap tag to include recent changes in https://github.com/rapidsai/gputreeshap/pull/38 and https://github.com/rapidsai/gputreeshap/pull/39. This resolves a cuml build issue with Google Benchmark, described in https://github.com/rapidsai/gputreeshap/pull/38.