### PR TITLE
Improve temporary directory handling in cuML

### DIFF
--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -16,16 +16,22 @@
 
 import os
 import sys
+import tempfile
 from subprocess import run
 import json
 
 
 class Profiler:
-    def __init__(self, tmp_path="/tmp/nsys_report"):
-        self.nsys_file = tmp_path + "/report.nsys-rep"
-        self.json_file = tmp_path + "/report.json"
-        self._execute(["rm", "-rf", tmp_path])
-        self._execute(["mkdir", "-p", tmp_path])
+    def __init__(self, tmp_path=None):
+        self.tmp_dir = tempfile.TemporaryDirectory(dir=tmp_path)
+        self.nsys_file = os.path.join(self.tmp_dir.name, "report.nsys-rep")
+        self.json_file = os.path.join(self.tmp_dir.name, "report.json")
+        self._execute(["rm", "-rf", self.tmp_dir.name])
+        self._execute(["mkdir", "-p", self.tmp_dir.name])
+
+    def __del__(self):
+        self.tmp_dir.cleanup()
+        self.tmp_dir = None
 
     @staticmethod
     def _execute(command):

--- a/python/cuml/tests/test_device_selection.py
+++ b/python/cuml/tests/test_device_selection.py
@@ -643,8 +643,8 @@ def test_train_gpu_infer_gpu(test_data):
     assert_func(cuml_output, test_data)
 
 
-def test_pickle_interop(test_data):
-    pickle_filepath = "/tmp/model.pickle"
+def test_pickle_interop(tmp_path, test_data):
+    pickle_filepath = tmp_path / "model.pickle"
 
     cuEstimator = test_data["cuEstimator"]
     if cuEstimator is UMAP:


### PR DESCRIPTION
Rely on `pytest` or `tempfile` to create temporary directories instead of hard-coding paths to `/tmp`. This will be more robust across runs and deployments.