### PR TITLE
Use Python builtins to prep benchmark `tmp_dir`

### DIFF
--- a/python/cuml/benchmark/nvtx_benchmark.py
+++ b/python/cuml/benchmark/nvtx_benchmark.py
@@ -15,6 +15,7 @@
 #
 
 import os
+import shutil
 import sys
 import tempfile
 from subprocess import run
@@ -26,8 +27,8 @@ class Profiler:
         self.tmp_dir = tempfile.TemporaryDirectory(dir=tmp_path)
         self.nsys_file = os.path.join(self.tmp_dir.name, "report.nsys-rep")
         self.json_file = os.path.join(self.tmp_dir.name, "report.json")
-        self._execute(["rm", "-rf", self.tmp_dir.name])
-        self._execute(["mkdir", "-p", self.tmp_dir.name])
+        shutil.rmtree(self.tmp_dir.name)
+        os.makedirs(self.tmp_dir.name, exist_ok=True)
 
     def __del__(self):
         self.tmp_dir.cleanup()


### PR DESCRIPTION
There are equivalent Python builtin functions for each of these operations. So run them instead of using a `subprocess`, which is a bit heavy weight