### PR TITLE
Update dependencies.yaml test_notebooks to include dask_ml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -360,10 +360,11 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
+          - dask-ml==2023.3.24
           - jupyter
           - matplotlib
           - numpy
           - pandas
           - *scikit_learn
           - seaborn
-          - dask_ml==2023.3.24
+          

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -366,4 +366,4 @@ dependencies:
           - pandas
           - *scikit_learn
           - seaborn
-          - dask_ml
+          - dask_ml==2023.3.24


### PR DESCRIPTION
Fixes a missing dependency for the kmeans_mnmg_demo notebook.