### PR TITLE
Increase the numerical tolerance for test_pairwise_distances tests.

### DIFF
--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -1031,7 +1031,7 @@ def test_pairwise_distances(metric: str, matrix_size, is_col_major):
     rng = np.random.RandomState(0)
 
     # For fp64, compare at 13 decimals, (2 places less than the ~15 max)
-    compare_precision = 6
+    compare_precision = 4
 
     # Compare to sklearn, single input
     X = prep_dense_array(


### PR DESCRIPTION
Increase the tolerance for the test_pairwise_distances tests. Previous tolerance was set too low resulting in spurious test failures. Addresses current test failures observed in CI.