### PR TITLE
assert GPU CPU intercept_ equal when fit_intercept is false in cuml.LogisticRegression

### DIFF
--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -103,7 +103,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         self.solver_model.coef_ = value
 
     def prepare_for_fit(self, n_classes):
-        self.qnparams = QNParams(
+        self.solver_model.qnparams = QNParams(
             loss=self.loss,
             penalty_l1=self.l1_strength,
             penalty_l2=self.l2_strength,
@@ -179,7 +179,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         self.prepare_for_fit(self._num_classes)
         cdef uintptr_t mat_coef_ptr = self.coef_.ptr
 
-        cdef qn_params qnpams = self.qnparams.params
+        cdef qn_params qnpams = self.solver_model.qnparams.params
 
         if self.dtype == np.float32:
             qnFit(

--- a/python/cuml/solvers/qn.pyx
+++ b/python/cuml/solvers/qn.pyx
@@ -930,8 +930,15 @@ class QN(Base,
 
         if self.fit_intercept:
             self.intercept_ = self._coef_[-1]
-        else:
+            return
+
+        _num_classes_dim, _ = self.coef_.shape
+        _num_classes = self.get_num_classes(_num_classes_dim)
+
+        if _num_classes == 2:
             self.intercept_ = CumlArray.zeros(shape=1)
+        else:
+            self.intercept_ = CumlArray.zeros(shape=_num_classes)
 
     def get_param_names(self):
         return super().get_param_names() + \

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -561,6 +561,9 @@ def test_logistic_regression(
     )
     assert len(np.unique(cu_preds)) == len(np.unique(y_test))
 
+    if fit_intercept is False:
+        assert np.array_equal(culog.intercept_, sklog.intercept_)
+
 
 @given(
     dtype=floating_dtypes(sizes=(32, 64)),


### PR DESCRIPTION
There is a discrepancy in intercept_ between cuml.linear_model.LogisticRegression and sklearn.linear_model.LogisticRegression. When fit_intercept=False and n_classes > 2, GPU intercept_ has shape (1, ) while CPU intercept_ has shape (n_classes,).  This PR revises QN class to resolve the discrepancy. 