### PR TITLE
[REVIEW] Adding a few of datasets for benchmarking

### DIFF
--- a/python/cuml/benchmark/algorithms.py
+++ b/python/cuml/benchmark/algorithms.py
@@ -337,7 +337,7 @@ def all_algorithms():
         AlgorithmPair(
             sklearn.ensemble.RandomForestClassifier,
             cuml.ensemble.RandomForestClassifier,
-            shared_args={"max_features": "sqrt", "n_estimators": 50},
+            shared_args={},
             cpu_args={"n_jobs": -1},
             name="RandomForestClassifier",
             accepts_labels=True,
@@ -348,7 +348,7 @@ def all_algorithms():
         AlgorithmPair(
             sklearn.ensemble.RandomForestRegressor,
             cuml.ensemble.RandomForestRegressor,
-            shared_args={"max_features": 1.0, "n_estimators": 50},
+            shared_args={},
             cpu_args={"n_jobs": -1},
             name="RandomForestRegressor",
             accepts_labels=True,

--- a/python/cuml/benchmark/runners.py
+++ b/python/cuml/benchmark/runners.py
@@ -149,6 +149,14 @@ class SpeedupComparisonRunner:
                 )
             )
 
+        if n_samples == 0:
+            # Update n_samples = training samples + testing samples
+            n_samples = data[0].shape[0] + data[2].shape[0]
+
+        if n_features == 0:
+            # Update n_features
+            n_features = data[0].shape[1]
+
         return dict(
             cuml_time=cu_elapsed,
             cpu_time=cpu_elapsed,
@@ -291,8 +299,6 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
             for rep in cpu_timer.benchmark_runs():
                 cpu_model = algo_pair.run_cpu(
                     data,
-                    **param_overrides,
-                    **cpu_param_overrides,
                     **setup_override,
                 )
             cpu_elapsed = np.min(cpu_timer.timings)
@@ -311,6 +317,14 @@ class AccuracyComparisonRunner(SpeedupComparisonRunner):
                 )
         else:
             cpu_elapsed = 0.0
+
+        if n_samples == 0:
+            # Update n_samples = training samples + testing samples
+            n_samples = data[0].shape[0] + data[2].shape[0]
+
+        if n_features == 0:
+            # Update n_features
+            n_features = data[0].shape[1]
 
         return dict(
             cuml_time=cu_elapsed,


### PR DESCRIPTION
This PR:
- Adds following datasets - Airline for classification and regression, Bosch, Cover type, Epsilon, Fraud and Year
- Removes default parameters for RF from algorithms.py since they are already set in the RF itself.
- Changes the meaning of `n_samples` argument for `gen_data`
- Adds logic for caching load of the datasets for faster benchmarking
- Supports `n_sample = 0` and `n_features = 0`, which causes loading of full dataset.