### PR TITLE
Update rapids-cmake functions to non-deprecated signatures

### DIFF
--- a/cpp/cmake/thirdparty/get_gputreeshap.cmake
+++ b/cpp/cmake/thirdparty/get_gputreeshap.cmake
@@ -62,7 +62,7 @@ function(find_and_configure_gputreeshap)
 
     # Tell cmake where it can find the generated gputreeshap-config.cmake we wrote.
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD GPUTreeShap [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
+    rapids_export_find_package_root(BUILD GPUTreeShap [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET cuml-exports)
 
     set(GPUTreeShap_ADDED ${GPUTreeShap_ADDED} PARENT_SCOPE)
 

--- a/cpp/cmake/thirdparty/get_treelite.cmake
+++ b/cpp/cmake/thirdparty/get_treelite.cmake
@@ -87,7 +87,7 @@ function(find_and_configure_treelite)
 
     # Tell cmake where it can find the generated treelite-config.cmake we wrote.
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
+    rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET cuml-exports)
 endfunction()
 
 find_and_configure_treelite(VERSION     3.9.1


### PR DESCRIPTION
Update to use non deprecated signatures for `rapids_export` functions