### PR TITLE
Use drop_duplicates instead of unique for cudf's pandas compatibility mode

### DIFF
--- a/python/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/feature_extraction/_vectorizers.py
@@ -598,7 +598,9 @@ class CountVectorizer(_VectorizerMixin):
         if self._fixed_vocabulary:
             self.vocabulary_ = self.vocabulary
         else:
-            self.vocabulary_ = tokenized_df["token"].unique().sort_values()
+            self.vocabulary_ = (
+                tokenized_df["token"].drop_duplicates().sort_values()
+            )
 
         count_df = self._count_vocab(tokenized_df)
 

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -180,7 +180,7 @@ class LabelEncoder(Base):
         if _classes is not None:
             self.classes_ = _classes
         else:
-            self.classes_ = y.unique().sort_values(
+            self.classes_ = y.drop_duplicates().sort_values(
                 ignore_index=True
             )  # dedupe and sort
 


### PR DESCRIPTION
In pandas, `Series.unique` returns a numpy array (for non-extension types) while `Series.drop_duplicates` returns a `Series`. The two results should otherwise contain the same set of values. In cudf, historically both methods returned a `Series`, and at these stages in cuml's pipeline it knows that it is working with cudf objects. However, if cudf has pandas compatibility mode enabled, then `unique` will return an array to match pandas behavior. In this scenario, the method chaining no longer works because cupy is calling methods on the result of `unique` assuming that it will be a `Series`. To fix this, cuml needs to call `drop_duplicates` instead.