### PR TITLE
CI: Fix expected ValueError and dask-glm incompatibility

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -77,5 +77,5 @@ dependencies:
 - treelite==3.9.1
 - umap-learn==0.5.3
 - pip:
-  - git+https://github.com/dask/dask-glm@main
+  - dask-glm==0.3.0
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -73,5 +73,5 @@ dependencies:
 - treelite==3.9.1
 - umap-learn==0.5.3
 - pip:
-  - git+https://github.com/dask/dask-glm@main
+  - dask-glm==0.3.0
 name: all_cuda-120_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -346,15 +346,13 @@ dependencies:
         packages:
           - pip
           - pip:
-              # TODO: Figure out what to do with this dependency
-              # since the repo is now archived.
-              - git+https://github.com/dask/dask-glm@main
+              - dask-glm==0.3.0
           # TODO: remove pin once a release that includes fixes for the error
           # is released: https://github.com/rapidsai/cuml/issues/5514
           - hdbscan<=0.8.30
       - output_types: pyproject
         packages:
-          - dask-glm @ git+https://github.com/dask/dask-glm@main
+          - dask-glm==0.3.0
             # TODO: Can we stop pulling from the master branch now that there was a release in October?
           - hdbscan @ git+https://github.com/scikit-learn-contrib/hdbscan.git@master
   test_notebooks:

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -201,10 +201,10 @@ def test_array_init_from_bytes(data_type, dtype, shape, order, mem_type):
     mem_type=cuml_array_mem_types(),
 )
 @settings(deadline=None)
-def test_array_init_bad(input_type, dtype, shape, order, mem_type):
+def test_array_mem_type(input_type, dtype, shape, order, mem_type):
     """
-    This test ensures that we assert on incorrect combinations of arguments
-    when creating CumlArray
+    Test whether we can create CumlArray from all supported types and array
+    shapes on all supported mem types.
     """
     mem_type = MemoryType.from_str(mem_type)
 
@@ -213,13 +213,6 @@ def test_array_init_bad(input_type, dtype, shape, order, mem_type):
 
         # Ensure the array is creatable
         array = CumlArray(input_array)
-
-        with pytest.raises(ValueError):
-            bad_dtype = np.float16 if dtype != np.float16 else np.float32
-            CumlArray(input_array, dtype=bad_dtype)
-
-        with pytest.raises(ValueError):
-            CumlArray(input_array, shape=(*array.shape, 1))
 
         input_mem_type = determine_array_memtype(input_array)
         if input_mem_type.is_device_accessible:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -79,7 +79,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "dask-glm @ git+https://github.com/dask/dask-glm@main",
+    "dask-glm==0.3.0",
     "dask-ml",
     "hdbscan @ git+https://github.com/scikit-learn-contrib/hdbscan.git@master",
     "hypothesis>=6.0,<7",


### PR DESCRIPTION
- Expect all supported types and shapes to work with host mem type.
- Pin dask-glm to 0.3.0.