### PR TITLE
Flatten cupy array before feeding to cudf.Series

### DIFF
--- a/python/cuml/tests/test_input_utils.py
+++ b/python/cuml/tests/test_input_utils.py
@@ -396,7 +396,7 @@ def get_input(
         result = cudf.DataFrame(rand_mat, index=index)
 
     if type == "cudf-series":
-        result = cudf.Series(rand_mat, index=index)
+        result = cudf.Series(rand_mat.reshape(nrows), index=index)
 
     if type == "pandas":
         result = pdDF(cp.asnumpy(rand_mat), index=index)


### PR DESCRIPTION
Previously it seems that cudf was silently flattening 2D arrays when passing them to the cudf.Series constructor, but that is no longer supported here so the test code needs to be updated.