### PR TITLE
[LogisticRegressionMG][FEA] Support training when dataset contains only one class 

### DIFF
--- a/cpp/src/glm/qn/mg/qn_mg.cuh
+++ b/cpp/src/glm/qn/mg/qn_mg.cuh
@@ -101,7 +101,7 @@ inline void qn_fit_x_mg(const raft::handle_t& handle,
 
   switch (pams.loss) {
     case QN_LOSS_LOGISTIC: {
-      ASSERT(C == 2, "qn_mg.cuh: logistic loss invalid C");
+      ASSERT(C > 0, "qn_mg.cuh: logistic loss invalid C");
       ML::GLM::detail::LogisticLoss<T> loss(handle, D, pams.fit_intercept);
       ML::GLM::opg::qn_fit_mg<T, decltype(loss)>(
         handle, pams, loss, X, y, Z, w0_data, f, num_iters, n_samples, rank, n_ranks);

--- a/python/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/dask/linear_model/logistic_regression.py
@@ -195,6 +195,13 @@ class LogisticRegression(LinearRegression):
         for p in partsToSizes:
             aggregated_partsToSizes[p[0]][1] += p[1]
 
-        return f.fit(
+        ret_status = f.fit(
             [(inp_X, inp_y)], n_rows, n_cols, aggregated_partsToSizes, rank
         )
+
+        if len(f.classes_) == 1:
+            raise ValueError(
+                f"This solver needs samples of at least 2 classes in the data, but the data contains only one class: {f.classes_[0]}"
+            )
+
+        return ret_status

--- a/python/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/linear_model/base_mg.pyx
@@ -63,7 +63,6 @@ class MGFitMixin(object):
                 check_dtype = self.dtype
 
             if sparse_input:
-
                 X_m = SparseCumlArray(input_data[i][0], convert_index=np.int32)
                 _, self.n_cols = X_m.shape
             else:

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -170,12 +170,9 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
                              "with softmax (multinomial).")
 
         if solves_classification and not solves_multiclass:
-            self._num_classes_dim = self._num_classes - 1
+            self._num_classes_dim = 1
         else:
             self._num_classes_dim = self._num_classes
-
-        if solves_classification and self._num_classes == 1:
-            self._num_classes_dim = 1
 
         if self.fit_intercept:
             coef_size = (self.n_cols + 1, self._num_classes_dim)
@@ -188,7 +185,6 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
 
     def fit(self, input_data, n_rows, n_cols, parts_rank_size, rank, convert_dtype=False):
 
-        self.rank = rank
         assert len(input_data) == 1, f"Currently support only one (X, y) pair in the list. Received {len(input_data)} pairs."
         self.is_col_major = False
         order = 'F' if self.is_col_major else 'C'
@@ -215,7 +211,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
 
         cdef qn_params qnpams = self.solver_model.qnparams.params
 
-        sparse_input = True if isinstance(X, list) else False
+        sparse_input = isinstance(X, list)
 
         if self.dtype == np.float32:
             if sparse_input is False:

--- a/python/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/linear_model/logistic_regression_mg.pyx
@@ -174,6 +174,9 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         else:
             self._num_classes_dim = self._num_classes
 
+        if solves_classification and self._num_classes == 1:
+            self._num_classes_dim = 1
+
         if self.fit_intercept:
             coef_size = (self.n_cols + 1, self._num_classes_dim)
         else:
@@ -207,6 +210,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         self._num_classes = len(self.classes_)
         self.loss = "sigmoid" if self._num_classes <= 2 else "softmax"
         self.prepare_for_fit(self._num_classes)
+
         cdef uintptr_t mat_coef_ptr = self.coef_.ptr
 
         cdef qn_params qnpams = self.solver_model.qnparams.params

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -16,6 +16,7 @@
 from cuml.internals.safe_imports import gpu_only_import
 import pytest
 from cuml.dask.common import utils as dask_utils
+from functools import partial
 from sklearn.metrics import accuracy_score, mean_squared_error
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression as skLR
@@ -563,8 +564,6 @@ def test_sparse_from_dense(
     fit_intercept, regularization, datatype, n_classes, client
 ):
     penalty, C, l1_ratio = regularization
-
-    from functools import partial
 
     run_test = partial(
         test_lbfgs,

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -583,7 +583,7 @@ def test_sparse_from_dense(
     else:
         with pytest.raises(
             RuntimeError,
-            match="dtypes other than float32 are currently not supported yet. See issue: https://github.com/rapidsai/cuml/issues/5589",
+            match="dtypes other than float32 are currently not supported",
         ):
             test_lbfgs(
                 nrows=1e5,

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -558,47 +558,38 @@ def test_elasticnet(
     ],
 )
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
-@pytest.mark.parametrize("delayed", [True])
 @pytest.mark.parametrize("n_classes", [2, 8])
 def test_sparse_from_dense(
-    fit_intercept, regularization, datatype, delayed, n_classes, client
+    fit_intercept, regularization, datatype, n_classes, client
 ):
     penalty, C, l1_ratio = regularization
 
+    from functools import partial
+
+    run_test = partial(
+        test_lbfgs,
+        nrows=1e5,
+        ncols=20,
+        n_parts=2,
+        fit_intercept=fit_intercept,
+        datatype=datatype,
+        delayed=True,
+        client=client,
+        penalty=penalty,
+        n_classes=n_classes,
+        C=C,
+        l1_ratio=l1_ratio,
+        convert_to_sparse=True,
+    )
+
     if datatype == np.float32:
-        test_lbfgs(
-            nrows=1e5,
-            ncols=20,
-            n_parts=2,
-            fit_intercept=fit_intercept,
-            datatype=datatype,
-            delayed=delayed,
-            client=client,
-            penalty=penalty,
-            n_classes=n_classes,
-            C=C,
-            l1_ratio=l1_ratio,
-            convert_to_sparse=True,
-        )
+        run_test()
     else:
         with pytest.raises(
             RuntimeError,
             match="dtypes other than float32 are currently not supported",
         ):
-            test_lbfgs(
-                nrows=1e5,
-                ncols=20,
-                n_parts=2,
-                fit_intercept=fit_intercept,
-                datatype=datatype,
-                delayed=delayed,
-                client=client,
-                penalty=penalty,
-                n_classes=n_classes,
-                C=C,
-                l1_ratio=l1_ratio,
-                convert_to_sparse=True,
-            )
+            run_test()
 
 
 @pytest.mark.parametrize("dtype", [np.float32])


### PR DESCRIPTION
This pull request introduces functionality for C++ training on datasets with a single label. It helps Spark Rapids ML match Spark's behavior. Additionally, it updates the Dask class to generate an error message, consistent with Scikit-learn's behavior.

This PR depends on https://github.com/rapidsai/cuml/pull/5632