### PR TITLE
Build concurrency for nightly and merge triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ on:
         default: nightly
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR separates the concurrency groups for nightly and PR merge triggers, ensuring that nightlies aren't interrupted by PR merges canceling jobs.

See https://github.com/rapidsai/ops/issues/2932.
