### PR TITLE
Ignore include/rapids/ in clang-tidy to avoid picking up libcudacxx.

### DIFF
--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -70,6 +70,12 @@ def parse_args():
         help="Regex used to select files for checking",
     )
     argparser.add_argument(
+        "-header-filter",
+        type=str,
+        default=None,
+        help="Regex used to filter headers from checking",
+    )
+    argparser.add_argument(
         "-j", type=int, default=-1, help="Number of parallel jobs to launch."
     )
     argparser.add_argument(
@@ -204,10 +210,11 @@ def run_clang_tidy(cmd, args):
     command, is_cuda = get_tidy_args(cmd, args.exe)
     tidy_cmd = [
         args.exe,
-        "-header-filter='.*cuml/cpp/(src|include|bench|comms).*'",
         cmd["file"],
         "--",
     ]
+    if args.header_filter is not None:
+        tidy_cmd.insert(1, f"-header-filter='{args.header_filter}'")
     tidy_cmd.extend(command)
     all_passed = True
     out = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ ignore = ['E501']
 
 
 [tool.run-clang-tidy]
-ignore = "[.]cu$|_deps|examples/kmeans/"
+ignore = "[.]cu$|include/rapids/|_deps|examples/kmeans/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,5 @@ ignore = ['E501']
 
 
 [tool.run-clang-tidy]
-ignore = "[.]cu$|include/rapids/|_deps|examples/kmeans/"
+ignore = "[.]cu$|_deps|examples/kmeans/"
+header-filter = ".*cuml/cpp/(src|include|bench|comms).*|.*include/rapids/.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,4 @@ ignore = ['E501']
 
 [tool.run-clang-tidy]
 ignore = "[.]cu$|_deps|examples/kmeans/"
-header-filter = ".*cuml/cpp/(src|include|bench|comms).*|.*include/rapids/.*"
+header_filter = ".*cuml/cpp/(src|include|bench|comms).*|.*include/rapids/.*"


### PR DESCRIPTION
After rmm#1095, cuml started picking up the rmm conda package's `libcudacxx` headers. This causes clang-tidy to fail. This PR adds an ignore for `include/rapids/` where all CCCL headers are packaged.