### PR TITLE
CI: Pin clang-tidy to 15.0.7.

### DIFF
--- a/conda/environments/clang_tidy_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-118_arch-x86_64.yaml
@@ -8,8 +8,8 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
-- clang-tools==16.0.6
-- clang==16.0.6
+- clang-tools==15.0.7
+- clang==15.0.7
 - cmake>=3.26.4
 - cuda-version=11.8
 - cudatoolkit

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import tomli
 
-EXPECTED_VERSION = "16.0.6"
+EXPECTED_VERSION = "15.0.7"
 VERSION_REGEX = re.compile(r"  LLVM version ([0-9.]+)")
 GPU_ARCH_REGEX = re.compile(r"sm_(\d+)")
 SPACES = re.compile(r"\s+")

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -95,8 +95,9 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - clang==16.0.6
-          - clang-tools==16.0.6
+          # clang 15 required by libcudacxx.
+          - clang==15.0.7
+          - clang-tools==15.0.7
           - ninja
           - tomli
   common_build:


### PR DESCRIPTION
Most recent supported version by libcudacxx.

Compilation introduced as a transitive dependency from rmm.