### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
             pass_filenames: false
             language: python
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.5.1
+      rev: v1.8.0
       hooks:
           - id: rapids-dependency-file-generator
             args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,8 @@ files:
       arch: [x86_64]
     includes:
       - common_build
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - docs
       - py_build
       - py_run
@@ -20,7 +21,8 @@ files:
       arch: [x86_64]
     includes:
       - common_build
-      - cudatoolkit
+      - cuda
+      - cuda_version
   checks:
     output: none
     includes:
@@ -34,28 +36,29 @@ files:
     includes:
       - clang_tidy
       - common_build
-      - cudatoolkit
+      - cuda
+      - cuda_version
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - docs
       - py_version
   test_cpp:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - test_cpp
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python
   test_notebooks:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_run
       - py_version
       - test_notebooks
@@ -146,7 +149,6 @@ dependencies:
               cuda: "12.0"
             packages:
               - cuda-nvcc
-              - cuda-version=12.0
   py_build:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -252,14 +254,37 @@ dependencies:
               - *pylibraft_conda
               - *raft_dask_conda
               - *rmm_conda
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
           - matrix:
+              cuda: "11.2"
+            packages:
+              - cuda-version=11.2
+          - matrix:
+              cuda: "11.4"
+            packages:
+              - cuda-version=11.4
+          - matrix:
+              cuda: "11.5"
+            packages:
+              - cuda-version=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cuda-version=11.8
+          - matrix:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
+  cuda:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
               - cuda-cudart-dev
               - cuda-profiler-api
               - libcublas-dev
@@ -270,7 +295,6 @@ dependencies:
           - matrix:
               cuda: "11.8"
             packages:
-              - cuda-version=11.8
               - cudatoolkit
               - libcublas-dev=11.11.3.6
               - libcublas=11.11.3.6
@@ -285,7 +309,6 @@ dependencies:
           - matrix:
               cuda: "11.5"
             packages:
-              - cuda-version=11.5
               - cudatoolkit
               - libcublas-dev>=11.7.3.1,<=11.7.4.6
               - libcublas>=11.7.3.1,<=11.7.4.6
@@ -300,7 +323,6 @@ dependencies:
           - matrix:
               cuda: "11.4"
             packages:
-              - cuda-version=11.4
               - cudatoolkit
               - &libcublas_dev114 libcublas-dev>=11.5.2.43,<=11.6.5.2
               - &libcublas114 libcublas>=11.5.2.43,<=11.6.5.2
@@ -315,7 +337,6 @@ dependencies:
           - matrix:
               cuda: "11.2"
             packages:
-              - cuda-version=11.2
               - cudatoolkit
               # The NVIDIA channel doesn't publish pkgs older than 11.4 for these libs,
               # so 11.2 uses 11.4 packages (the oldest available).


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI