### PR TITLE
Use cuda-nvcc conda packages on aarch64 CUDA 12.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -145,8 +145,7 @@ dependencies:
             packages:
               - nvcc_linux-aarch64=11.8
           - matrix:
-              arch: x86_64
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
               - cuda-nvcc
   py_build:


### PR DESCRIPTION
The CUDA 12 compiler package `cuda-nvcc` is available for aarch64 and not just x86-64. This PR fixes `dependencies.yaml` so that ARM systems can generate environments properly.