### PR TITLE
Use cudf.Index instead of cudf.GenericIndex.

### DIFF
--- a/python/cuml/preprocessing/encoders.py
+++ b/python/cuml/preprocessing/encoders.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ cudf = gpu_only_import("cudf")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
 
-GenericIndex = gpu_only_import_from("cudf", "GenericIndex")
+Index = gpu_only_import_from("cudf", "Index")
 
 
 class CheckFeaturesMixIn:
@@ -498,7 +498,7 @@ class OneHotEncoder(BaseEncoder):
                 dropped_class_idx = Series(self.drop_idx_[feature])
                 dropped_class_mask = Series(cats).isin(cats[dropped_class_idx])
                 if len(cats) == 1:
-                    inv = Series(GenericIndex(cats[0]).repeat(X.shape[0]))
+                    inv = Series(Index(cats[0]).repeat(X.shape[0]))
                     result[feature] = inv
                     continue
                 cats = cats[~dropped_class_mask]


### PR DESCRIPTION
I saw the cuml docs build failed, with the error below:

```
Failed to import cuml.compose.
Possible hints:
* AttributeError: module 'cudf' has no attribute 'GenericIndex'
* KeyError: 'cuml'
```

This is due to pandas 2 changes in cudf that need updated in cuml. This PR is unlikely to contain the full changeset of things needed for pandas 2 support, but it fixes one problem and we can let CI tell us the rest of the failures.