### PR TITLE
Disable HistGradientBoosting support for now

### DIFF
--- a/python/cuml/experimental/fil/fil.pyx
+++ b/python/cuml/experimental/fil/fil.pyx
@@ -966,6 +966,9 @@ class ForestInference(UniversalBase, CMajorInputTagMixin):
             For GPU execution, the RAFT handle containing the stream or stream
             pool to use during loading and inference.
         """
+        # TODO(hcho3): Remove this check when https://github.com/dmlc/treelite/issues/544 is fixed
+        if isinstance(skl_model, (HistGradientBoostingR, HistGradientBoostingC)):
+            raise NotImplementedError("HistGradientBoosting estimators are not yet supported")
         tl_model = treelite.sklearn.import_model(skl_model)
         if default_chunk_size is None:
             default_chunk_size = threads_per_tree

--- a/python/cuml/experimental/fil/fil.pyx
+++ b/python/cuml/experimental/fil/fil.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import warnings
 from libcpp cimport bool
 from libc.stdint cimport uint32_t, uintptr_t
 
+from cuml.internals.import_utils import has_sklearn
 from cuml.common.device_selection import using_device_type
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.safe_imports import (
@@ -967,8 +968,15 @@ class ForestInference(UniversalBase, CMajorInputTagMixin):
             pool to use during loading and inference.
         """
         # TODO(hcho3): Remove this check when https://github.com/dmlc/treelite/issues/544 is fixed
-        if isinstance(skl_model, (HistGradientBoostingR, HistGradientBoostingC)):
-            raise NotImplementedError("HistGradientBoosting estimators are not yet supported")
+        if has_sklearn():
+            from sklearn.ensemble import (
+                HistGradientBoostingClassifier as HistGradientBoostingC,
+            )
+            from sklearn.ensemble import (
+                HistGradientBoostingRegressor as HistGradientBoostingR,
+            )
+            if isinstance(skl_model, (HistGradientBoostingR, HistGradientBoostingC)):
+                raise NotImplementedError("HistGradientBoosting estimators are not yet supported")
         tl_model = treelite.sklearn.import_model(skl_model)
         if default_chunk_size is None:
             default_chunk_size = threads_per_tree

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -881,6 +881,9 @@ class ForestInference(Base,
         logger.warn("Treelite currently does not support float64 model"
                     " parameters. Accuracy may degrade slightly relative to"
                     " native sklearn invocation.")
+        # TODO(hcho3): Remove this check when https://github.com/dmlc/treelite/issues/544 is fixed
+        if isinstance(skl_model, (HistGradientBoostingR, HistGradientBoostingC)):
+            raise NotImplementedError("HistGradientBoosting estimators are not yet supported")
         tl_model = tl_skl.import_model(skl_model)
         cuml_fm.load_from_treelite_model(
             model=tl_model,

--- a/python/cuml/fil/fil.pyx
+++ b/python/cuml/fil/fil.pyx
@@ -29,6 +29,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdlib cimport free
 
 import cuml.internals
+from cuml.internals.import_utils import has_sklearn
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from pylibraft.common.handle cimport handle_t
@@ -882,8 +883,15 @@ class ForestInference(Base,
                     " parameters. Accuracy may degrade slightly relative to"
                     " native sklearn invocation.")
         # TODO(hcho3): Remove this check when https://github.com/dmlc/treelite/issues/544 is fixed
-        if isinstance(skl_model, (HistGradientBoostingR, HistGradientBoostingC)):
-            raise NotImplementedError("HistGradientBoosting estimators are not yet supported")
+        if has_sklearn():
+            from sklearn.ensemble import (
+                HistGradientBoostingClassifier as HistGradientBoostingC,
+            )
+            from sklearn.ensemble import (
+                HistGradientBoostingRegressor as HistGradientBoostingR,
+            )
+            if isinstance(skl_model, (HistGradientBoostingR, HistGradientBoostingC)):
+                raise NotImplementedError("HistGradientBoosting estimators are not yet supported")
         tl_model = tl_skl.import_model(skl_model)
         cuml_fm.load_from_treelite_model(
             model=tl_model,


### PR DESCRIPTION
Treelite 4.0 added support for `HistGradientBoostingClassifier` and `HistGradientBoostingRegressor`. However, it does not yet work with the latest scikit-learn (1.4.0), as it changed the internals of `HistGradientBoostingClassifier` / `HistGradientBoostingRegressor` estimators.

For now, throw an exception for HistGradientBoosting estimators.