### PR TITLE
Add environment-agnostic scripts for running ctests and pytests

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -3,8 +3,7 @@
 
 set -euo pipefail
 
-if [ -d "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/" ]; then
-    # Support customizing the ctests' install location
-    cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/"
-    ctest --output-on-failure "$@"
-fi
+# Support customizing the ctests' install location
+cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/"
+
+ctest --output-on-failure "$@"

--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+if [ -d "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/" ]; then
+    # Support customizing the ctests' install location
+    cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/"
+    ctest --output-on-failure "$@"
+fi

--- a/ci/run_cuml_dask_pytests.sh
+++ b/ci/run_cuml_dask_pytests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+# Support invoking run_cuml_dask_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/tests/dask
+
+pytest --cache-clear "$@" .

--- a/ci/run_cuml_singlegpu_memleak_pytests.sh
+++ b/ci/run_cuml_singlegpu_memleak_pytests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+# Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/tests
+
+pytest --cache-clear --ignore=dask -m "memleak" "$@" .

--- a/ci/run_cuml_singlegpu_pytests.sh
+++ b/ci/run_cuml_singlegpu_pytests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+# Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/tests
+
+pytest --cache-clear --ignore=dask -m "not memleak" "$@" .

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
+
+# Support invoking test_cpp.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
@@ -32,13 +35,10 @@ rapids-mamba-retry install \
 rapids-logger "Check GPU usage"
 nvidia-smi
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
-# Run libcuml gtests from libcuml-tests package
 rapids-logger "Run gtests"
-ctest -j9 --output-on-failure
+export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
+# Run libcuml gtests from libcuml-tests package
+./ci/run_ctests.sh -j9 && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+
+# Support invoking test_python_dask.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 # Common setup steps shared by Python test jobs
-source "$(dirname "$0")/test_python_common.sh"
+source ./ci/test_python_common.sh
 
 EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml-dask"
-cd python/cuml/tests/dask
-pytest \
-  --cache-clear \
+./ci/run_cuml_dask_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml" \
   --cov-config=../../../.coveragerc \
   --cov=cuml_dask \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-dask-coverage.xml" \
-  --cov-report=term \
-  .
+  --cov-report=term
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -1,40 +1,35 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+
+# Support invoking test_python_singlegpu.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 # Common setup steps shared by Python test jobs
-source "$(dirname "$0")/test_python_common.sh"
+source ./ci/test_python_common.sh
 
 EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml single GPU..."
-cd python/cuml/tests
-pytest \
+./ci/run_cuml_singlegpu_pytests.sh \
   --numprocesses=8 \
-  --ignore=dask \
-  --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \
   --cov-config=../../.coveragerc \
   --cov=cuml \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml" \
   --cov-report=term \
-  -m "not memleak" \
-  .
 
-  rapids-logger "memory leak pytests..."
+rapids-logger "memory leak pytests..."
 
-pytest \
+./ci/run_cuml_singlegpu_memleak_pytests.sh \
   --numprocesses=1 \
-  --ignore=dask \
-  --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-memleak.xml" \
   --cov-config=../../.coveragerc \
   --cov=cuml \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-memleak-coverage.xml" \
   --cov-report=term \
   -m "memleak" \
-  .
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
This PR adds environment-agnostic `run_*_{ctests,pytests}.sh` scripts, and updates `test_*_{cpp,python}.sh` to call them.

The `test_*_{cpp,python}.sh` scripts assume they're running in our CI environment, and they do more than just run the tests.

This PR allows devs and downstream consumers to only run the tests, and skip the unrelated logic in `test_*_{cpp,python}.sh`.
