### PR TITLE
Pin pyarrow

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -412,6 +412,7 @@ dependencies:
           - dask-glm==0.3.0
             # TODO: Can we stop pulling from the master branch now that there was a release in October?
           - hdbscan @ git+https://github.com/scikit-learn-contrib/hdbscan.git@master
+          - pyarrow==14.0.2.* # Need to pin pyarrow version matching with `cudf` for `cuml` installs to happen successfully
   test_notebooks:
     common:
       - output_types: [conda, requirements]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -82,7 +82,7 @@ test = [
     "hypothesis>=6.0,<7",
     "nltk",
     "numpydoc",
-    "pyarrow==14.0.2.*", # Need to pin pyarrow version matching with `cudf` for `cuml` installs to happen successfully
+    "pyarrow==14.0.2.*",
     "pynndescent==0.5.8",
     "pytest-benchmark",
     "pytest-cases",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -82,6 +82,7 @@ test = [
     "hypothesis>=6.0,<7",
     "nltk",
     "numpydoc",
+    "pyarrow==14.0.2.*", # Need to pin pyarrow version matching with `cudf` for `cuml` installs to happen successfully
     "pynndescent==0.5.8",
     "pytest-benchmark",
     "pytest-cases",


### PR DESCRIPTION
This PR pins `pyarrow` to `14.0.2` to match with `cudf`. The reason we need this pinning here and can't rely on implicit dependency from `cudf` is because we are creating a new environment before installing `cuml` and this has lead to an inconsistent environment where arrow-15 is unable to downgrade to arrow-14.0.2. 