### PR TITLE
Install test dependencies at the same time as cuml packages.

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -9,7 +9,23 @@ rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
   --file_key test_cpp \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee test.yaml
+
+rapids-logger "Downloading artifacts from previous jobs"
+CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+
+cat <<EOF | tee cuml.yaml
+name: cuml
+channels:
+  - ${CPP_CHANNEL}
+dependencies:
+  - libcuml
+  - libcuml-tests
+EOF
+
+# TODO: install conda-merge in the CI images
+pip install conda-merge
+conda-merge test.yaml cuml.yaml > env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
 
@@ -18,16 +34,10 @@ set +u
 conda activate test
 set -u
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+rapids-print-env
 
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
 mkdir -p "${RAPIDS_TESTS_DIR}"
-
-rapids-print-env
-
-rapids-mamba-retry install \
-  --channel "${CPP_CHANNEL}" \
-  libcuml libcuml-tests
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 set -euo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
@@ -8,7 +8,25 @@ rapids-logger "Generate Notebook testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
   --file_key test_notebooks \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee test.yaml
+
+rapids-logger "Downloading artifacts from previous jobs"
+CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+
+cat <<EOF | tee cuml.yaml
+name: cuml
+channels:
+  - ${CPP_CHANNEL}
+  - ${PYTHON_CHANNEL}
+dependencies:
+  - libcuml
+  - cuml
+EOF
+
+# TODO: install conda-merge in the CI images
+pip install conda-merge
+conda-merge test.yaml cuml.yaml > env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
 
@@ -17,16 +35,7 @@ set +u
 conda activate test
 set -u
 
-rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
-
 rapids-print-env
-
-rapids-mamba-retry install \
-  --channel "${CPP_CHANNEL}" \
-  --channel "${PYTHON_CHANNEL}" \
-  libcuml cuml
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -9,7 +9,25 @@ rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
   --file_key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee test.yaml
+
+rapids-logger "Downloading artifacts from previous jobs"
+CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+
+cat <<EOF | tee cuml.yaml
+name: cuml
+channels:
+  - ${CPP_CHANNEL}
+  - ${PYTHON_CHANNEL}
+dependencies:
+  - libcuml
+  - cuml
+EOF
+
+# TODO: install conda-merge in the CI images
+pip install conda-merge
+conda-merge test.yaml cuml.yaml > env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
 
@@ -18,20 +36,11 @@ set +u
 conda activate test
 set -u
 
-rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+rapids-print-env
 
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
-
-rapids-print-env
-
-rapids-mamba-retry install \
-  --channel "${CPP_CHANNEL}" \
-  --channel "${PYTHON_CHANNEL}" \
-  libcuml cuml
 
 rapids-logger "Check GPU usage"
 nvidia-smi


### PR DESCRIPTION
This PR creates a conda environment containing both test dependencies and cuml packages. This is a workaround for some issues seen with conda being unable to downgrade from Arrow 15 (in the initial environment with test dependencies) to Arrow 14 (currently pinned by cudf, which is a dependency of cuml).

This is a potential solution for https://github.com/rapidsai/build-planning/issues/22.