### PR TITLE
[ENH] Let cuDF handle input types for label encoder.

### DIFF
--- a/python/cuml/_thirdparty/sklearn/utils/validation.py
+++ b/python/cuml/_thirdparty/sklearn/utils/validation.py
@@ -225,6 +225,8 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
         if not isinstance(attributes, (list, tuple)):
             attributes = [attributes]
         attrs = all_or_any([hasattr(estimator, attr) for attr in attributes])
+    elif hasattr(estimator, "__sklearn_is_fitted__"):
+        attrs = estimator.__sklearn_is_fitted__()
     else:
         attrs = [v for v in vars(estimator)
                  if v.endswith("_") and not v.startswith("__")]

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/preprocessing/LabelEncoder.py
@@ -184,11 +184,8 @@ class LabelEncoder(Base):
         self._validate_keywords()
 
         if _classes is None:
-            y = (
-                cudf.Series(y)
-                .drop_duplicates()
-                .sort_values(ignore_index=True)
-            )  # dedupe and sort
+            # dedupe and sort
+            y = cudf.Series(y).drop_duplicates().sort_values(ignore_index=True)
             self.classes_ = y
         else:
             self.classes_ = _classes

--- a/python/cuml/tests/test_label_encoder.py
+++ b/python/cuml/tests/test_label_encoder.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuml.common.exceptions import NotFittedError
 import pytest
-from cuml.internals.safe_imports import cpu_only_import
-from cuml.preprocessing.LabelEncoder import LabelEncoder
-from cuml.internals.safe_imports import gpu_only_import
 
+from cuml.common.exceptions import NotFittedError
+from cuml.internals.safe_imports import cpu_only_import, gpu_only_import
+from cuml.preprocessing.LabelEncoder import LabelEncoder
+
+pd = cpu_only_import("pandas")
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
@@ -187,12 +188,14 @@ def _array_to_similarity_mat(x):
 
 @pytest.mark.parametrize("length", [10, 1000])
 @pytest.mark.parametrize("cardinality", [5, 10, 50])
-@pytest.mark.parametrize("dtype", ["cupy", "numpy"])
-def test_labelencoder_fit_transform_cupy_numpy(length, cardinality, dtype):
+@pytest.mark.parametrize("dtype", ["cupy", "numpy", "pd"])
+def test_labelencoder_fit_transform_cupy_numpy_pd(length, cardinality, dtype):
     """Try encoding the cupy array"""
     x = cp.random.choice(cardinality, (length,))
     if dtype == "numpy":
         x = x.get()
+    elif dtype == "pd":
+        x = pd.Series(x.get())
     encoded = LabelEncoder().fit_transform(x)
 
     x_arr = _array_to_similarity_mat(x)


### PR DESCRIPTION
cuDF handles more types than the label encoder currently does (like torch tensor). This PR delegates the type checking to cuDF.

- Let cuDF handle input types for label encoder.
- Small cleanups.