### PR TITLE
Add support for Python 3.11, require NumPy 1.23+

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ To install cuML from source, ensure the following dependencies are met:
 It is recommended to use conda for environment/package management. If doing so, development environment .yaml files are located in `conda/environments/all_*.yaml`. These files contains most of the dependencies mentioned above (notable exceptions are `gcc` and `zlib`). To create a development environment named `cuml_dev`, you can use the follow commands:
 
 ```bash
-conda create -n cuml_dev python=3.10
+conda create -n cuml_dev python=3.11
 conda env update -n cuml_dev --file=conda/environments/all_cuda-118_arch-x86_64.yaml
 conda activate cuml_dev
 ```

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -58,7 +58,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytest==7.*
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - raft-dask==24.4.*
 - rapids-dask-dependency==24.4.*
 - recommonmark

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytest==7.*
-- python>=3.9,<3.11
+- python>=3.9,<3.12
 - raft-dask==24.4.*
 - rapids-dask-dependency==24.4.*
 - recommonmark

--- a/conda/recipes/cuml-cpu/meta.yaml
+++ b/conda/recipes/cuml-cpu/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - cython>=3.0.0
   run:
     - python x.x
-    - numpy
+    - numpy>=1.23
     - pandas
     - scikit-learn=1.2
     - hdbscan<=0.8.30

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -377,8 +377,12 @@ dependencies:
             packages:
               - python=3.10
           - matrix:
+              py: "3.11"
             packages:
-              - python>=3.9,<3.11
+              - python=3.11
+          - matrix:
+            packages:
+              - python>=3.9,<3.12
   test_libcuml:
     common:
       - output_types: conda

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,6 +72,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/3

This PR adds support for Python 3.11.

It also bumps uses of `NumPy` to `numpy>=1.23`, see https://github.com/rapidsai/build-planning/issues/3#issuecomment-1967952280.

## Notes for Reviewers

This is part of ongoing work to add Python 3.11 support across RAPIDS.

The Python 3.11 CI workflows introduced in https://github.com/rapidsai/shared-workflows/pull/176 are *optional*... they are not yet required to run successfully for PRs to be merged.

This PR can be merged once all jobs are running successfully (including the non-required jobs for Python 3.11). The CI logs should be verified that the jobs are building and testing with Python 3.11.

See https://github.com/rapidsai/shared-workflows/pull/176 for more details.
