### PR TITLE
Automate C++ include file grouping and ordering using clang-format

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -15,7 +15,7 @@ AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true 
+AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
@@ -27,7 +27,7 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments:  false       
+BinPackArguments:  false
 BinPackParameters: false
 BraceWrapping:
   AfterClass:            false
@@ -71,8 +71,26 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks: Preserve
-IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^"' # quoted includes
+    Priority:        1
+  - Regex:           '^<(common|benchmarks|tests)/' # benchmark/test includes
+    Priority:        2
+  - Regex:           '^<cuml/' # cuML includes
+    Priority:        3
+  - Regex:           '^<(cudf|raft|kvikio|cumlprims)' # Other RAPIDS includes
+    Priority:        4
+  - Regex:           '^<rmm/' # RMM includes
+    Priority:        5
+  - Regex:           '^<(thrust|cub|cuda)/' # CCCL includes
+    Priority:        6
+  - Regex:           '^<(cooperative_groups|cuco|cuda|device_types|driver_types|math_constants|nvtx3)' # CUDA includes
+    Priority:        6
+  - Regex:           '^<.*\..*' # other system includes (e.g. with a '.')
+    Priority:        7
+  - Regex:           '^<[^.]+' # STL includes (no '.')
+    Priority:        8
 IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth:     2

--- a/cpp/bench/common/ml_benchmark.hpp
+++ b/cpp/bench/common/ml_benchmark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,18 @@
 
 #pragma once
 
-#include <benchmark/benchmark.h>
-#include <cuda_runtime.h>
 #include <cuml/common/logger.hpp>
 #include <cuml/common/utils.hpp>
-#include <memory>
+
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <cuda_runtime.h>
+
+#include <benchmark/benchmark.h>
+
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/cpp/bench/sg/arima_loglikelihood.cu
+++ b/cpp/bench/sg/arima_loglikelihood.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-#include <thrust/execution_policy.h>
-#include <thrust/for_each.h>
-#include <thrust/iterator/counting_iterator.h>
+#include "benchmark.cuh"
 
 #include <cuml/tsa/arima_common.h>
 #include <cuml/tsa/batched_arima.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
+#include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
-#include "benchmark.cuh"
-#include <raft/util/cudart_utils.hpp>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
 
 namespace ML {
 namespace Bench {

--- a/cpp/bench/sg/benchmark.cuh
+++ b/cpp/bench/sg/benchmark.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@
 #include "../common/ml_benchmark.hpp"
 #include "dataset.cuh"
 #include "dataset_ts.cuh"
-#include <benchmark/benchmark.h>
-#include <cuda_runtime.h>
+
 #include <cuml/common/logger.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime.h>
+
+#include <benchmark/benchmark.h>
 
 namespace ML {
 namespace Bench {

--- a/cpp/bench/sg/dataset.cuh
+++ b/cpp/bench/sg/dataset.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,16 @@
 #pragma once
 
 #include <cuml/datasets/make_blobs.hpp>
-#include <fstream>
-#include <iostream>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/transpose.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/random/make_regression.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/cpp/bench/sg/dbscan.cu
+++ b/cpp/bench/sg/dbscan.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#include "benchmark.cuh"
+
 #include <cuml/cluster/dbscan.hpp>
 
-#include "benchmark.cuh"
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/fil.cu
+++ b/cpp/bench/sg/fil.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-#include <cuml/fil/fil.h>
-
 #include "benchmark.cuh"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/ensemble/randomforest.hpp>
+#include <cuml/fil/fil.h>
 #include <cuml/tree/algo_helper.h>
+
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
+
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/filex.cu
+++ b/cpp/bench/sg/filex.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
+#include "benchmark.cuh"
+
+#include <cuml/common/logger.hpp>
+#include <cuml/ensemble/randomforest.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
 #include <cuml/experimental/fil/tree_layout.hpp>
 #include <cuml/experimental/fil/treelite_importer.hpp>
 #include <cuml/fil/fil.h>
-
-#include "benchmark.cuh"
-#include <chrono>
-#include <cstdint>
-#include <cuml/common/logger.hpp>
-#include <cuml/ensemble/randomforest.hpp>
 #include <cuml/tree/algo_helper.h>
+
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
+
+#include <chrono>
+#include <cstdint>
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/kmeans.cu
+++ b/cpp/bench/sg/kmeans.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,13 @@
  */
 
 #include "benchmark.cuh"
+
 #include <cuml/cluster/kmeans.hpp>
 #include <cuml/common/logger.hpp>
+
 #include <raft/distance/distance_types.hpp>
 #include <raft/random/rng_state.hpp>
+
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/linkage.cu
+++ b/cpp/bench/sg/linkage.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,13 @@
  */
 
 #include "benchmark.cuh"
+
 #include <cuml/cluster/linkage.hpp>
 #include <cuml/common/logger.hpp>
+
 #include <raft/distance/distance_types.hpp>
 #include <raft/sparse/hierarchy/common.h>
+
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/rf_classifier.cu
+++ b/cpp/bench/sg/rf_classifier.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 
 #include "benchmark.cuh"
-#include <cmath>
+
 #include <cuml/ensemble/randomforest.hpp>
+
+#include <cmath>
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/rf_regressor.cu
+++ b/cpp/bench/sg/rf_regressor.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 
 #include "benchmark.cuh"
-#include <cmath>
+
 #include <cuml/ensemble/randomforest.hpp>
+
+#include <cmath>
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/svc.cu
+++ b/cpp/bench/sg/svc.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 
 #include "benchmark.cuh"
-#include <cmath>
+
 #include <cuml/svm/svc.hpp>
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
+
 #include <raft/distance/kernels.cuh>
+
+#include <cmath>
 #include <sstream>
 #include <utility>
 

--- a/cpp/bench/sg/svr.cu
+++ b/cpp/bench/sg/svr.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,15 @@
  */
 
 #include "benchmark.cuh"
-#include <cmath>
+
 #include <cuml/svm/svc.hpp>
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
 #include <cuml/svm/svr.hpp>
+
 #include <raft/distance/kernels.cuh>
+
+#include <cmath>
 #include <utility>
 
 namespace ML {

--- a/cpp/bench/sg/umap.cu
+++ b/cpp/bench/sg/umap.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 
 #include "benchmark.cuh"
+
 #include <cuml/manifold/umap.hpp>
 #include <cuml/manifold/umapparams.h>
+
 #include <raft/util/cuda_utils.cuh>
+
 #include <utility>
 
 namespace ML {

--- a/cpp/examples/dbscan/dbscan_example.cpp
+++ b/cpp/examples/dbscan/dbscan_example.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cuml/cluster/dbscan.hpp>
+
+#include <raft/core/handle.hpp>
+
+#include <cuda_runtime.h>
+
 #include <algorithm>
 #include <cmath>
-#include <cuda_runtime.h>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <vector>
-
-#include <raft/core/handle.hpp>
-
-#include <cuml/cluster/dbscan.hpp>
 
 #ifndef CUDA_RT_CALL
 #define CUDA_RT_CALL(call)                                                    \

--- a/cpp/examples/kmeans/kmeans_example.cpp
+++ b/cpp/examples/kmeans/kmeans_example.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cuml/cluster/kmeans.hpp>
+
+#include <raft/core/handle.hpp>
+
+#include <cuda_runtime.h>
+
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -20,11 +26,6 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
-
-#include <cuda_runtime.h>
-
-#include <cuml/cluster/kmeans.hpp>
-#include <raft/core/handle.hpp>
 
 #ifndef CUDA_RT_CALL
 #define CUDA_RT_CALL(call)                                                    \

--- a/cpp/examples/symreg/symreg_example.cpp
+++ b/cpp/examples/symreg/symreg_example.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
+#include <cuml/common/logger.hpp>
+#include <cuml/genetic/common.h>
+#include <cuml/genetic/genetic.h>
+#include <cuml/genetic/program.h>
+
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_scalar.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <fstream>
@@ -22,16 +33,6 @@
 #include <iterator>
 #include <sstream>
 #include <vector>
-
-#include <cuml/common/logger.hpp>
-#include <cuml/genetic/common.h>
-#include <cuml/genetic/genetic.h>
-#include <cuml/genetic/program.h>
-
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_scalar.hpp>
-#include <rmm/device_uvector.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
 
 // Namespace alias
 namespace cg = cuml::genetic;

--- a/cpp/include/cuml/cluster/dbscan.hpp
+++ b/cpp/include/cuml/cluster/dbscan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 #pragma once
 
+#include <cuml/common/log_levels.hpp>
+
 #include <raft/distance/distance_types.hpp>
 
-#include <cuml/common/log_levels.hpp>
+#include <cstddef>
+#include <cstdint>
 
 namespace raft {
 class handle_t;

--- a/cpp/include/cuml/cluster/hdbscan.hpp
+++ b/cpp/include/cuml/cluster/hdbscan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include <raft/distance/distance_types.hpp>
-
 #include <raft/core/handle.hpp>
+#include <raft/distance/distance_types.hpp>
 
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/include/cuml/cluster/kmeans.hpp
+++ b/cpp/include/cuml/cluster/kmeans.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/common/log_levels.hpp>
+
 #include <raft/cluster/kmeans_types.hpp>
 
 namespace raft {

--- a/cpp/include/cuml/cluster/linkage.hpp
+++ b/cpp/include/cuml/cluster/linkage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 
 #pragma once
 
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/sparse/hierarchy/common.h>
-
-#include <raft/core/handle.hpp>
 
 namespace raft {
 class handle_t;

--- a/cpp/include/cuml/common/logger.hpp
+++ b/cpp/include/cuml/common/logger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  */
 #pragma once
 
+#include <cuml/common/log_levels.hpp>
+
 #include <stdarg.h>
 
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
-
-#include <cuml/common/log_levels.hpp>
 
 namespace spdlog {
 class logger;

--- a/cpp/include/cuml/common/utils.hpp
+++ b/cpp/include/cuml/common/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,16 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
-#include <execinfo.h>
-#include <raft/util/cudart_utils.hpp>
-
-#include <cstdio>
+#include "logger.hpp"
 
 #include <raft/core/error.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime.h>
+
+#include <execinfo.h>
+
+#include <cstdio>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-
-#include "logger.hpp"

--- a/cpp/include/cuml/cuml_api.h
+++ b/cpp/include/cuml/cuml_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <cuda_runtime_api.h>
+
+#include <stddef.h>
 
 // Block inclusion of this header when compiling libcuml++.so. If this error is
 // shown during compilation, there is an issue with how the `#include` have

--- a/cpp/include/cuml/decomposition/pca_mg.hpp
+++ b/cpp/include/cuml/decomposition/pca_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #pragma once
 
+#include "pca.hpp"
+
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
-
-#include "pca.hpp"
 
 namespace ML {
 namespace PCA {

--- a/cpp/include/cuml/decomposition/tsvd_mg.hpp
+++ b/cpp/include/cuml/decomposition/tsvd_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #pragma once
 
+#include "tsvd.hpp"
+
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
-
-#include "tsvd.hpp"
 
 namespace ML {
 namespace TSVD {

--- a/cpp/include/cuml/experimental/fil/decision_forest.hpp
+++ b/cpp/include/cuml/experimental/fil/decision_forest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <algorithm>
-#include <cstddef>
 #include <cuml/experimental/fil/constants.hpp>
 #include <cuml/experimental/fil/detail/device_initialization.hpp>
 #include <cuml/experimental/fil/detail/forest.hpp>
@@ -30,10 +28,14 @@
 #include <cuml/experimental/fil/infer_kind.hpp>
 #include <cuml/experimental/fil/postproc_ops.hpp>
 #include <cuml/experimental/fil/tree_layout.hpp>
-#include <limits>
-#include <optional>
+
 #include <stddef.h>
 #include <stdint.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <optional>
 #include <variant>
 
 namespace ML {

--- a/cpp/include/cuml/experimental/fil/detail/bitset.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/bitset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 #pragma once
+#include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+#include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
 #include <cstddef>
+#include <type_traits>
+#include <variant>
+
 #ifndef __CUDACC__
 #include <math.h>
 #endif
-#include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
-#include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
-#include <stddef.h>
-#include <type_traits>
-#include <variant>
 
 namespace ML {
 namespace experimental {

--- a/cpp/include/cuml/experimental/fil/detail/decision_forest_builder.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/decision_forest_builder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <algorithm>
-#include <cmath>
-#include <cstddef>
 #include <cuml/experimental/fil/detail/bitset.hpp>
 #include <cuml/experimental/fil/detail/forest.hpp>
 #include <cuml/experimental/fil/detail/index_type.hpp>
@@ -26,9 +23,14 @@
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/exceptions.hpp>
 #include <cuml/experimental/fil/postproc_ops.hpp>
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
 #include <numeric>
 #include <optional>
-#include <stdint.h>
 #include <vector>
 
 namespace ML {

--- a/cpp/include/cuml/experimental/fil/detail/device_initialization.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/device_initialization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cuml/experimental/fil/detail/device_initialization/cpu.hpp>
+
 #include <variant>
 #ifdef CUML_ENABLE_GPU
 #include <cuml/experimental/fil/detail/device_initialization/gpu.hpp>

--- a/cpp/include/cuml/experimental/fil/detail/device_initialization/cpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/device_initialization/cpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 #pragma once
+
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
 #include <type_traits>
+
 namespace ML {
 namespace experimental {
 namespace fil {

--- a/cpp/include/cuml/experimental/fil/detail/device_initialization/gpu.cuh
+++ b/cpp/include/cuml/experimental/fil/detail/device_initialization/gpu.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include <cuda_runtime_api.h>
+
 #include <cuml/experimental/fil/constants.hpp>
 #include <cuml/experimental/fil/detail/forest.hpp>
 #include <cuml/experimental/fil/detail/gpu_introspection.hpp>
@@ -24,7 +24,11 @@
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
 #include <cuml/experimental/fil/detail/specializations/device_initialization_macros.hpp>
+
+#include <cuda_runtime_api.h>
+
 #include <type_traits>
+
 namespace ML {
 namespace experimental {
 namespace fil {

--- a/cpp/include/cuml/experimental/fil/detail/device_initialization/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/device_initialization/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 #pragma once
+
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_setter.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
 #include <type_traits>
+
 namespace ML {
 namespace experimental {
 namespace fil {

--- a/cpp/include/cuml/experimental/fil/detail/evaluate_tree.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/evaluate_tree.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <stdint.h>
+
 #include <type_traits>
 #ifndef __CUDACC__
 #include <math.h>

--- a/cpp/include/cuml/experimental/fil/detail/forest.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/forest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/node.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
 #include <stddef.h>
+
 #include <type_traits>
 
 namespace ML {

--- a/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 #pragma once
-#include <cuda_runtime_api.h>
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_check.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
+#include <cuda_runtime_api.h>
+
 #include <vector>
 
 namespace ML {

--- a/cpp/include/cuml/experimental/fil/detail/infer.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/infer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/infer/cpu.hpp>
-#include <cuml/experimental/fil/infer_kind.hpp>
-#include <iostream>
-#include <optional>
-#include <type_traits>
-#ifdef CUML_ENABLE_GPU
-#include <cuml/experimental/fil/detail/infer/gpu.hpp>
-#endif
 #include <cuml/experimental/fil/detail/postprocessor.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/exceptions.hpp>
+#include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <optional>
+#include <type_traits>
+
+#ifdef CUML_ENABLE_GPU
+#include <cuml/experimental/fil/detail/infer/gpu.hpp>
+#endif
+
 namespace ML {
 namespace experimental {
 namespace fil {

--- a/cpp/include/cuml/experimental/fil/detail/infer/cpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/infer/cpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
+
 #include <cuml/experimental/fil/constants.hpp>
 #include <cuml/experimental/fil/detail/cpu_introspection.hpp>
 #include <cuml/experimental/fil/detail/forest.hpp>
@@ -27,7 +27,10 @@
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
 #include <cuml/experimental/fil/detail/specializations/infer_macros.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
 #include <optional>
+
 namespace ML {
 namespace experimental {
 namespace fil {

--- a/cpp/include/cuml/experimental/fil/detail/infer/gpu.cuh
+++ b/cpp/include/cuml/experimental/fil/detail/infer/gpu.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/constants.hpp>
 #include <cuml/experimental/fil/detail/forest.hpp>
 #include <cuml/experimental/fil/detail/gpu_introspection.hpp>
@@ -31,6 +30,8 @@
 #include <cuml/experimental/fil/detail/specializations/infer_macros.hpp>
 #include <cuml/experimental/fil/exceptions.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
 #include <optional>
 #include <type_traits>
 

--- a/cpp/include/cuml/experimental/fil/detail/infer/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/infer/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstddef>
 #include <cuml/experimental/fil/detail/forest.hpp>
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/postprocessor.hpp>
@@ -21,6 +20,8 @@
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
 #include <optional>
 
 namespace ML {

--- a/cpp/include/cuml/experimental/fil/detail/infer_kernel/cpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/infer_kernel/cpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/detail/cpu_introspection.hpp>
 #include <cuml/experimental/fil/detail/evaluate_tree.hpp>
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/postprocessor.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/ceildiv.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
 #include <iostream>
 #include <new>
 #include <numeric>

--- a/cpp/include/cuml/experimental/fil/detail/infer_kernel/gpu.cuh
+++ b/cpp/include/cuml/experimental/fil/detail/infer_kernel/gpu.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/detail/evaluate_tree.hpp>
 #include <cuml/experimental/fil/detail/gpu_introspection.hpp>
 #include <cuml/experimental/fil/detail/index_type.hpp>
@@ -23,7 +22,10 @@
 #include <cuml/experimental/fil/detail/raft_proto/ceildiv.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/padding.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
 #include <stddef.h>
+
+#include <cstddef>
 
 namespace ML {
 namespace experimental {

--- a/cpp/include/cuml/experimental/fil/detail/infer_kernel/shared_memory_buffer.cuh
+++ b/cpp/include/cuml/experimental/fil/detail/infer_kernel/shared_memory_buffer.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/detail/index_type.hpp>
+
 #include <stddef.h>
+
+#include <cstddef>
 #include <type_traits>
 
 namespace ML {

--- a/cpp/include/cuml/experimental/fil/detail/node.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/node.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 #pragma once
+
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
 #include <cuml/experimental/fil/tree_layout.hpp>
+
 #include <iostream>
 #include <type_traits>
 

--- a/cpp/include/cuml/experimental/fil/detail/postprocessor.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/postprocessor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 #pragma once
-#ifndef __CUDACC__
-#include <math.h>
-#endif
+
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
 #include <cuml/experimental/fil/postproc_ops.hpp>
-#include <limits>
+
 #include <stddef.h>
+
+#include <limits>
 #include <type_traits>
+
+#ifndef __CUDACC__
+#include <math.h>
+#endif
 
 namespace ML {
 namespace experimental {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/buffer.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/detail/const_agnostic.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/detail/copy.hpp>
@@ -24,9 +23,12 @@
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/exceptions.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
+#include <stdint.h>
+
+#include <cstddef>
 #include <iterator>
 #include <memory>
-#include <stdint.h>
 #include <utility>
 #include <variant>
 

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/copy.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/copy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/detail/copy/cpu.hpp>
+
 #include <stdint.h>
 #ifdef CUML_ENABLE_GPU
 #include <cuml/experimental/fil/detail/raft_proto/detail/copy/gpu.hpp>

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/copy/cpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/copy/cpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 #pragma once
-#include <algorithm>
-#include <cstring>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
 #include <stdint.h>
+
+#include <algorithm>
+#include <cstring>
 
 namespace raft_proto {
 namespace detail {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/copy/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/copy/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 #pragma once
-#include <cuda_runtime_api.h>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_check.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
+
+#include <cuda_runtime_api.h>
+
 #include <stdint.h>
+
 #include <type_traits>
 
 namespace raft_proto {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/cuda_check/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/cuda_check/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 #pragma once
-#include <cuda_runtime_api.h>
 #include <cuml/experimental/fil/detail/raft_proto/detail/cuda_check/base.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/exceptions.hpp>
+
+#include <cuda_runtime_api.h>
 namespace raft_proto {
 namespace detail {
 

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/device_id/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/device_id/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include <cuml/experimental/fil/detail/raft_proto/cuda_check.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/detail/device_id/base.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <rmm/cuda_device.hpp>
 
 namespace raft_proto {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/device_setter/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/device_setter/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 #pragma once
-#include <cuda_runtime_api.h>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_check.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/detail/device_setter/base.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime_api.h>
 
 namespace raft_proto {
 namespace detail {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/non_owning_buffer/base.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/non_owning_buffer/base.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <memory>
 #include <type_traits>
 

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/base.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/base.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <type_traits>
 
 namespace raft_proto {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/cpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/cpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include <cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/base.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <memory>
 #include <type_traits>
 

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 #pragma once
-#include <cuda_runtime_api.h>
 #include <cuml/experimental/fil/detail/raft_proto/detail/owning_buffer/base.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_id.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_setter.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <rmm/device_buffer.hpp>
+
+#include <cuda_runtime_api.h>
+
 #include <type_traits>
 
 namespace raft_proto {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/device_id.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/device_id.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <cuml/experimental/fil/detail/raft_proto/detail/device_id/gpu.hpp>
 #endif
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
 #include <variant>
 
 namespace raft_proto {

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/gpu_support.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/gpu_support.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #pragma once
+#include <stdint.h>
+
 #include <cstddef>
 #include <exception>
-#include <stdint.h>
 
 namespace raft_proto {
 #ifdef CUML_ENABLE_GPU

--- a/cpp/include/cuml/experimental/fil/detail/raft_proto/handle.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/raft_proto/handle.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #pragma once
+#include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
+
 #include <algorithm>
 #include <cstddef>
-#include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #ifdef CUML_ENABLE_GPU
 #include <raft/core/handle.hpp>
 #endif

--- a/cpp/include/cuml/experimental/fil/detail/specialization_types.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/specialization_types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <cuml/experimental/fil/tree_layout.hpp>
+
 #include <cstddef>
 #include <cstdint>
-#include <cuml/experimental/fil/tree_layout.hpp>
 #include <type_traits>
 #include <variant>
+
 namespace ML {
 namespace experimental {
 namespace fil {

--- a/cpp/include/cuml/experimental/fil/detail/specializations/forest_macros.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/specializations/forest_macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cuml/experimental/fil/detail/forest.hpp>
 #include <cuml/experimental/fil/detail/specialization_types.hpp>
 #include <cuml/experimental/fil/tree_layout.hpp>
+
 #include <variant>
 
 /* Macro which, given a variant index, will extract the type of the

--- a/cpp/include/cuml/experimental/fil/detail/specializations/infer_macros.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/specializations/infer_macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/constants.hpp>
 #include <cuml/experimental/fil/detail/forest.hpp>
 #include <cuml/experimental/fil/detail/index_type.hpp>
@@ -25,6 +24,8 @@
 #include <cuml/experimental/fil/detail/specialization_types.hpp>
 #include <cuml/experimental/fil/detail/specializations/forest_macros.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
 #include <variant>
 
 /* Macro which expands to the valid arguments to an inference call for a forest

--- a/cpp/include/cuml/experimental/fil/forest_model.hpp
+++ b/cpp/include/cuml/experimental/fil/forest_model.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 #pragma once
-#include <cstddef>
 #include <cuml/experimental/fil/decision_forest.hpp>
 #include <cuml/experimental/fil/detail/index_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/buffer.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/gpu_support.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/handle.hpp>
 #include <cuml/experimental/fil/infer_kind.hpp>
+
+#include <cstddef>
 #include <type_traits>
 #include <variant>
 

--- a/cpp/include/cuml/experimental/fil/treelite_importer.hpp
+++ b/cpp/include/cuml/experimental/fil/treelite_importer.hpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <cmath>
-#include <cstddef>
 #include <cuml/experimental/fil/constants.hpp>
 #include <cuml/experimental/fil/decision_forest.hpp>
 #include <cuml/experimental/fil/detail/decision_forest_builder.hpp>
@@ -24,13 +22,17 @@
 #include <cuml/experimental/fil/forest_model.hpp>
 #include <cuml/experimental/fil/postproc_ops.hpp>
 #include <cuml/experimental/fil/tree_layout.hpp>
-#include <queue>
-#include <stack>
+
 #include <treelite/c_api.h>
 #include <treelite/enum/task_type.h>
 #include <treelite/enum/tree_node_type.h>
 #include <treelite/enum/typeinfo.h>
 #include <treelite/tree.h>
+
+#include <cmath>
+#include <cstddef>
+#include <queue>
+#include <stack>
 #include <variant>
 
 namespace ML {

--- a/cpp/include/cuml/explainer/tree_shap.hpp
+++ b/cpp/include/cuml/explainer/tree_shap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 #pragma once
 
+#include <cuml/ensemble/treelite_defs.hpp>
+
 #include <cstddef>
 #include <cstdint>
-#include <cuml/ensemble/treelite_defs.hpp>
 #include <memory>
 #include <variant>
 

--- a/cpp/include/cuml/fil/fil.h
+++ b/cpp/include/cuml/fil/fil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@
 
 #pragma once
 
+#include <cuml/ensemble/treelite_defs.hpp>
+
 #include <stddef.h>
 
 #include <variant>  // for std::get<>, std::variant<>
-
-#include <cuml/ensemble/treelite_defs.hpp>
 
 namespace raft {
 class handle_t;

--- a/cpp/include/cuml/genetic/genetic.h
+++ b/cpp/include/cuml/genetic/genetic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <raft/core/handle.hpp>
-
 #include "common.h"
 #include "program.h"
+
+#include <raft/core/handle.hpp>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/include/cuml/genetic/program.h
+++ b/cpp/include/cuml/genetic/program.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include <raft/core/handle.hpp>
-#include <random>
-
 #include "common.h"
+
+#include <raft/core/handle.hpp>
+
+#include <random>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/include/cuml/linear_model/glm_api.h
+++ b/cpp/include/cuml/linear_model/glm_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 #pragma once
 
+#include <cuml/cuml_api.h>
 #include <cuml/linear_model/qn.h>
 
-#include <cuml/cuml_api.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus

--- a/cpp/include/cuml/linear_model/ols_mg.hpp
+++ b/cpp/include/cuml/linear_model/ols_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/linear_model/glm.hpp>
+
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
 

--- a/cpp/include/cuml/linear_model/qn_mg.hpp
+++ b/cpp/include/cuml/linear_model/qn_mg.hpp
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-#include <cuda_runtime.h>
 #include <cuml/common/logger.hpp>
 #include <cuml/linear_model/qn.h>
-#include <raft/core/comms.hpp>
 
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
+#include <raft/core/comms.hpp>
+
+#include <cuda_runtime.h>
+
 #include <vector>
 using namespace MLCommon;
 

--- a/cpp/include/cuml/linear_model/ridge_mg.hpp
+++ b/cpp/include/cuml/linear_model/ridge_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #pragma once
 
+#include "glm.hpp"
+
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
-
-#include "glm.hpp"
 
 namespace ML {
 namespace Ridge {

--- a/cpp/include/cuml/manifold/tsne.h
+++ b/cpp/include/cuml/manifold/tsne.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/common/logger.hpp>
+
 #include <raft/distance/distance_types.hpp>
 
 namespace raft {

--- a/cpp/include/cuml/manifold/umap.hpp
+++ b/cpp/include/cuml/manifold/umap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 #pragma once
 
+#include <cuml/manifold/umapparams.h>
+
 #include <raft/sparse/coo.hpp>
 
 #include <cstddef>
 #include <cstdint>
-#include <cuml/manifold/umapparams.h>
 #include <memory>
 
 namespace raft {

--- a/cpp/include/cuml/manifold/umapparams.h
+++ b/cpp/include/cuml/manifold/umapparams.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include <cuml/common/callback.hpp>
 #include <cuml/common/logger.hpp>
+
 #include <raft/distance/distance_types.hpp>
 
 namespace ML {

--- a/cpp/include/cuml/neighbors/knn_api.h
+++ b/cpp/include/cuml/neighbors/knn_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/cuml_api.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/cpp/include/cuml/neighbors/knn_mg.hpp
+++ b/cpp/include/cuml/neighbors/knn_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include <raft/core/handle.hpp>
-#include <vector>
-
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
+#include <raft/core/handle.hpp>
+
+#include <vector>
 
 namespace ML {
 namespace KNN {

--- a/cpp/include/cuml/neighbors/knn_sparse.hpp
+++ b/cpp/include/cuml/neighbors/knn_sparse.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include <cusparse_v2.h>
-
 #include <cuml/neighbors/knn.hpp>
+
 #include <raft/distance/distance_types.hpp>
+
+#include <cusparse_v2.h>
 
 namespace raft {
 class handle_t;

--- a/cpp/include/cuml/random_projection/rproj_c.h
+++ b/cpp/include/cuml/random_projection/rproj_c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <raft/core/handle.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/include/cuml/solvers/cd_mg.hpp
+++ b/cpp/include/cuml/solvers/cd_mg.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/linear_model/glm.hpp>
+
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
 

--- a/cpp/include/cuml/svm/svc.hpp
+++ b/cpp/include/cuml/svm/svc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@
 
 #include "svm_model.h"
 #include "svm_parameter.h"
+
 #include <cuml/common/logger.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 

--- a/cpp/include/cuml/svm/svr.hpp
+++ b/cpp/include/cuml/svm/svr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <cublas_v2.h>
 #include <cuml/matrix/kernelparams.h>
+
+#include <cublas_v2.h>
 
 namespace ML {
 namespace SVM {

--- a/cpp/include/cuml/tsa/arima_common.h
+++ b/cpp/include/cuml/tsa/arima_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,16 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
-
-#include <algorithm>
-
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <cuda_runtime.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
+
+#include <algorithm>
 
 namespace ML {
 

--- a/cpp/include/cuml/tsa/holtwinters_api.h
+++ b/cpp/include/cuml/tsa/holtwinters_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cuml/cuml_api.h>
+
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/cpp/src/arima/batched_arima.cu
+++ b/cpp/src/arima/batched_arima.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <cmath>
-#include <iostream>
-#include <vector>
+#include <common/nvtx.hpp>
+
+#include <cuml/tsa/batched_arima.hpp>
+#include <cuml/tsa/batched_kalman.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/core/nvtx.hpp>
+#include <raft/linalg/matrix_vector_op.cuh>
+#include <raft/stats/information_criterion.cuh>
+#include <raft/stats/stats_types.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -26,21 +36,14 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
 
-#include <cuml/tsa/batched_arima.hpp>
-#include <cuml/tsa/batched_kalman.hpp>
-
-#include <common/nvtx.hpp>
 #include <linalg/batched/matrix.cuh>
-#include <raft/core/handle.hpp>
-#include <raft/core/nvtx.hpp>
-#include <raft/linalg/matrix_vector_op.cuh>
-#include <raft/stats/information_criterion.cuh>
-#include <raft/stats/stats_types.hpp>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
 #include <timeSeries/arima_helpers.cuh>
 #include <timeSeries/fillna.cuh>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
 
 namespace ML {
 

--- a/cpp/src/arima/batched_kalman.cu
+++ b/cpp/src/arima/batched_kalman.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,28 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <vector>
-
 #include <cuml/tsa/batched_kalman.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/linalg/add.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 
 #include <cub/cub.cuh>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
-#include <raft/core/handle.hpp>
-#include <raft/linalg/add.cuh>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
+#include <algorithm>
+#include <vector>
 // #TODO: Replace with public header when ready
+#include <raft/core/nvtx.hpp>
 #include <raft/linalg/detail/cublas_wrappers.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <linalg/batched/matrix.cuh>
 #include <linalg/block.cuh>
-#include <raft/core/nvtx.hpp>
 #include <timeSeries/arima_helpers.cuh>
 
 namespace ML {

--- a/cpp/src/common/cumlHandle.cpp
+++ b/cpp/src/common/cumlHandle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "cumlHandle.hpp"
 
 #include <cuml/common/logger.hpp>
+
 #include <raft/util/cudart_utils.hpp>
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cublas_wrappers.hpp>

--- a/cpp/src/common/logger.cpp
+++ b/cpp/src/common/logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 #define SPDLOG_HEADER_ONLY
+#include <cuml/common/callbackSink.hpp>
+#include <cuml/common/logger.hpp>
+
 #include <spdlog/sinks/stdout_color_sinks.h>  // NOLINT
 #include <spdlog/spdlog.h>                    // NOLINT
 
 #include <algorithm>
-#include <cuml/common/callbackSink.hpp>
-#include <cuml/common/logger.hpp>
 #include <memory>
 
 namespace ML {

--- a/cpp/src/datasets/make_arima.cu
+++ b/cpp/src/datasets/make_arima.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include <cuml/datasets/make_arima.hpp>
+
 #include <raft/core/handle.hpp>
+
 #include <random/make_arima.cuh>
 
 namespace ML {

--- a/cpp/src/datasets/make_blobs.cu
+++ b/cpp/src/datasets/make_blobs.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include <cuml/datasets/make_blobs.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/random/make_blobs.cuh>
 

--- a/cpp/src/datasets/make_regression.cu
+++ b/cpp/src/datasets/make_regression.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include <cuml/datasets/make_regression.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/random/make_regression.cuh>
 

--- a/cpp/src/dbscan/adjgraph/algo.cuh
+++ b/cpp/src/dbscan/adjgraph/algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 #pragma once
 
-#include <cooperative_groups.h>
-#include <thrust/device_ptr.h>
-#include <thrust/scan.h>
-
 #include "pack.h"
 
 #include <raft/core/handle.hpp>
 #include <raft/sparse/convert/csr.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
+
+#include <cooperative_groups.h>
+#include <thrust/device_ptr.h>
+#include <thrust/scan.h>
 
 namespace ML {
 namespace Dbscan {

--- a/cpp/src/dbscan/dbscan.cu
+++ b/cpp/src/dbscan/dbscan.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#include "dbscan.cuh"
+
 #include <cuml/cluster/dbscan.hpp>
 
-#include "dbscan.cuh"
 #include <raft/util/cudart_utils.hpp>
 
 namespace ML {

--- a/cpp/src/dbscan/dbscan.cuh
+++ b/cpp/src/dbscan/dbscan.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 
 #include "runner.cuh"
 
-#include <raft/core/nvtx.hpp>
-
 #include <cuml/cluster/dbscan.hpp>
 #include <cuml/common/logger.hpp>
+
+#include <raft/core/nvtx.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src/dbscan/dbscan_api.cpp
+++ b/cpp/src/dbscan/dbscan_api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/cluster/dbscan_api.h>
-
 #include <common/cumlHandle.hpp>
+
 #include <cuml/cluster/dbscan.hpp>
+#include <cuml/cluster/dbscan_api.h>
 #include <cuml/cuml_api.h>
 
 extern "C" {

--- a/cpp/src/dbscan/mergelabels/runner.cuh
+++ b/cpp/src/dbscan/mergelabels/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include <raft/label/merge_labels.cuh>
-
 #include <raft/core/handle.hpp>
+#include <raft/label/merge_labels.cuh>
 namespace ML {
 namespace Dbscan {
 namespace MergeLabels {

--- a/cpp/src/dbscan/mergelabels/tree_reduction.cuh
+++ b/cpp/src/dbscan/mergelabels/tree_reduction.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 #include "runner.cuh"
 
-#include <raft/core/nvtx.hpp>
-
 #include <cuml/common/logger.hpp>
+
+#include <raft/core/nvtx.hpp>
 
 namespace ML {
 namespace Dbscan {

--- a/cpp/src/dbscan/runner.cuh
+++ b/cpp/src/dbscan/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +22,15 @@
 #include "mergelabels/runner.cuh"
 #include "mergelabels/tree_reduction.cuh"
 #include "vertexdeg/runner.cuh"
+
 #include <common/nvtx.hpp>
-#include <raft/core/nvtx.hpp>
-#include <raft/label/classlabels.cuh>
-#include <raft/sparse/csr.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <cuml/common/logger.hpp>
 
 #include <raft/core/nvtx.hpp>
+#include <raft/label/classlabels.cuh>
+#include <raft/sparse/csr.hpp>
+#include <raft/util/cudart_utils.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>

--- a/cpp/src/dbscan/vertexdeg/algo.cuh
+++ b/cpp/src/dbscan/vertexdeg/algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,19 @@
 #pragma once
 
 #include "pack.h"
-#include <cuda_runtime.h>
-#include <math.h>
-#include <raft/neighbors/epsilon_neighborhood.cuh>
 
-#include "pack.h"
+#include <raft/distance/distance_types.hpp>
 #include <raft/linalg/coalesced_reduction.cuh>
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/norm.cuh>
+#include <raft/neighbors/epsilon_neighborhood.cuh>
 #include <raft/util/device_atomics.cuh>
+
 #include <rmm/device_uvector.hpp>
+
+#include <cuda_runtime.h>
+
+#include <math.h>
 
 namespace ML {
 namespace Dbscan {

--- a/cpp/src/dbscan/vertexdeg/precomputed.cuh
+++ b/cpp/src/dbscan/vertexdeg/precomputed.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,18 @@
 
 #pragma once
 
-#include <cub/cub.cuh>
-#include <cuda_runtime.h>
-#include <math.h>
+#include "pack.h"
+
 #include <raft/linalg/coalesced_reduction.cuh>
 #include <raft/linalg/reduce.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/util/device_atomics.cuh>
 
-#include "pack.h"
+#include <cub/cub.cuh>
+#include <cuda_runtime.h>
+
+#include <math.h>
 
 namespace ML {
 namespace Dbscan {

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,22 @@
 
 #pragma once
 
-#include <memory>
-#include <raft/core/handle.hpp>
-#include <rmm/device_uvector.hpp>
-
 #include "kernels/builder_kernels.cuh"
 
 #include <common/Timer.h>
+
 #include <cuml/common/pinned_host_vector.hpp>
+#include <cuml/tree/decisiontree.hpp>
 #include <cuml/tree/flatnode.h>
+
+#include <raft/core/handle.hpp>
+#include <raft/core/nvtx.hpp>
 #include <raft/util/cuda_utils.cuh>
 
+#include <rmm/device_uvector.hpp>
+
 #include <deque>
-#include <raft/core/nvtx.hpp>
+#include <memory>
 #include <utility>
 
 namespace ML {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,16 @@
  */
 #pragma once
 
-#include <cstdio>
+#include "builder_kernels.cuh"
 
 #include <common/grid_sync.cuh>
-#include <cub/cub.cuh>
+
 #include <raft/util/cuda_utils.cuh>
+
+#include <cub/cub.cuh>
 #include <thrust/binary_search.h>
 
-#include "builder_kernels.cuh"
+#include <cstdio>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/entropy-double.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/entropy-double.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/entropy-float.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/entropy-float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/gamma-double.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/gamma-double.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/gamma-float.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/gamma-float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/gini-double.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/gini-double.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/gini-float.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/gini-float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/inverse_gaussian-double.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/inverse_gaussian-double.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/inverse_gaussian-float.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/inverse_gaussian-float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/mse-double.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/mse-double.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/mse-float.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/mse-float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/poisson-double.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/poisson-double.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/poisson-float.cu
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/poisson-float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tree/flatnode.h>
-
 #include "../bins.cuh"
 #include "../objectives.cuh"
+
+#include <cuml/tree/flatnode.h>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@
 
 #include "dataset.h"
 #include "split.cuh"
+
 #include <cub/cub.cuh>
+
 #include <limits>
 
 namespace ML {

--- a/cpp/src/decisiontree/batched-levelalgo/quantiles.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/quantiles.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,20 @@
 
 #pragma once
 
-#include <cub/cub.cuh>
-#include <iostream>
-#include <memory>
+#include "quantiles.h"
+
 #include <raft/core/handle.hpp>
+#include <raft/core/nvtx.hpp>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cub/cub.cuh>
 #include <thrust/fill.h>
 
-#include <raft/core/nvtx.hpp>
-
-#include "quantiles.h"
+#include <iostream>
+#include <memory>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/decisiontree.cu
+++ b/cpp/src/decisiontree/decisiontree.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+#include "decisiontree.cuh"
+
 #include <cuml/tree/decisiontree.hpp>
 #include <cuml/tree/flatnode.h>
-#include <raft/core/handle.hpp>
 
-#include "decisiontree.cuh"
+#include <raft/core/handle.hpp>
 
 namespace ML {
 namespace DT {

--- a/cpp/src/decisiontree/decisiontree.cuh
+++ b/cpp/src/decisiontree/decisiontree.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 #pragma once
 
+#include "batched-levelalgo/builder.cuh"
+#include "batched-levelalgo/quantiles.cuh"
+#include "treelite_util.h"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/tree/flatnode.h>
 
 #include <raft/core/handle.hpp>
+#include <raft/core/nvtx.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-#include "treelite_util.h"
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
 
@@ -32,12 +36,8 @@
 #include <locale>
 #include <map>
 #include <numeric>
-#include <raft/core/nvtx.hpp>
 #include <random>
 #include <vector>
-
-#include "batched-levelalgo/builder.cuh"
-#include "batched-levelalgo/quantiles.cuh"
 
 /** check for treelite runtime API errors and assert accordingly */
 

--- a/cpp/src/explainer/kernel_shap.cu
+++ b/cpp/src/explainer/kernel_shap.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+#include <cuml/explainer/kernel_shap.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
-
-#include <cuml/explainer/kernel_shap.hpp>
 
 #include <curand.h>
 #include <curand_kernel.h>

--- a/cpp/src/explainer/permutation_shap.cu
+++ b/cpp/src/explainer/permutation_shap.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+#include <cuml/explainer/permutation_shap.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
-
-#include <cuml/explainer/permutation_shap.hpp>
 
 namespace ML {
 namespace Explainer {

--- a/cpp/src/explainer/tree_shap.cu
+++ b/cpp/src/explainer/tree_shap.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,34 @@
  * limitations under the License.
  */
 
-#include <GPUTreeShap/gpu_treeshap.h>
-#include <algorithm>
-#include <bitset>
-#include <cstddef>
-#include <cstdint>
 #include <cuml/explainer/tree_shap.hpp>
-#include <iostream>
-#include <limits>
-#include <memory>
-#include <numeric>
+
 #include <raft/core/error.hpp>
 #include <raft/core/span.hpp>
+
 #include <rmm/device_uvector.hpp>
+
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/memory.h>
+
+#include <GPUTreeShap/gpu_treeshap.h>
 #include <treelite/enum/operator.h>
 #include <treelite/enum/task_type.h>
 #include <treelite/enum/tree_node_type.h>
 #include <treelite/tree.h>
+
+#include <algorithm>
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <numeric>
 #include <type_traits>
 #include <variant>
 #include <vector>

--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,19 @@
 /** @file common.cuh Common GPU functionality */
 #pragma once
 
-#include <cub/cub.cuh>
-#include <stdexcept>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string>
+#include "internal.cuh"
 
 #include <cuml/fil/fil.h>
+
 #include <raft/util/cuda_utils.cuh>
 
-#include "internal.cuh"
+#include <cub/cub.cuh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <stdexcept>
+#include <string>
 
 namespace ML {
 namespace fil {

--- a/cpp/src/fil/fil.cu
+++ b/cpp/src/fil/fil.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ creation and prediction (the main inference kernel is defined in infer.cu). */
 #include <raft/core/error.hpp>         // for ASSERT
 #include <raft/core/handle.hpp>        // for handle_t
 #include <raft/util/cudart_utils.hpp>  // for RAFT_CUDA_TRY, cudaStream_t,
-#include <rmm/device_uvector.hpp>      // for device_uvector
-#include <thrust/host_vector.h>        // for host_vector
+
+#include <rmm/device_uvector.hpp>  // for device_uvector
+
+#include <thrust/host_vector.h>  // for host_vector
 
 #include <cmath>    // for expf
 #include <cstddef>  // for size_t

--- a/cpp/src/fil/infer.cu
+++ b/cpp/src/fil/infer.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 #include "common.cuh"
-
 #include "internal.cuh"
 
 #include <cuml/fil/multi_sum.cuh>

--- a/cpp/src/fil/internal.cuh
+++ b/cpp/src/fil/internal.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,20 @@
 /** @file internal.cuh cuML-internal interface to Forest Inference Library. */
 
 #pragma once
-#include <bitset>
-#include <cstdint>
 #include <cuml/fil/fil.h>
-#include <iostream>
-#include <numeric>
+
 #include <raft/core/error.hpp>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
+
 #include <treelite/c_api.h>
 #include <treelite/tree.h>
+
+#include <bitset>
+#include <cstdint>
+#include <iostream>
+#include <numeric>
 #include <utility>
 #include <vector>
 

--- a/cpp/src/fil/treelite_import.cu
+++ b/cpp/src/fil/treelite_import.cu
@@ -28,12 +28,11 @@
 #include <raft/core/handle.hpp>        // for handle_t
 #include <raft/util/cudart_utils.hpp>  // for RAFT_CUDA_TRY
 
+#include <omp.h>                           // for omp
 #include <treelite/c_api.h>                // for TreeliteModelHandle
 #include <treelite/enum/operator.h>        // for Operator
 #include <treelite/enum/tree_node_type.h>  // for TreeNodeType
 #include <treelite/tree.h>                 // for Tree, Model, ModelPreset
-
-#include <omp.h>  // for omp
 
 #include <algorithm>    // for std::max
 #include <bitset>       // for std::bitset

--- a/cpp/src/genetic/fitness.cuh
+++ b/cpp/src/genetic/fitness.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <raft/core/handle.hpp>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/strided_reduction.cuh>
@@ -24,9 +25,11 @@
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/adjacent_difference.h>
 #include <thrust/copy.h>
@@ -39,8 +42,6 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-
-#include <raft/util/cudart_utils.hpp>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/src/genetic/genetic.cu
+++ b/cpp/src/genetic/genetic.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #include "constants.h"
 #include "node.cuh"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/genetic/common.h>
 #include <cuml/genetic/genetic.h>
@@ -27,14 +28,15 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
+#include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+
+#include <device_launch_parameters.h>
+
 #include <algorithm>
 #include <numeric>
 #include <random>
 #include <stack>
-
-#include <device_launch_parameters.h>
-#include <rmm/device_uvector.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/src/genetic/node.cu
+++ b/cpp/src/genetic/node.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include "node.cuh"
+
 #include <cuml/common/utils.hpp>
 
 namespace cuml {

--- a/cpp/src/genetic/node.cuh
+++ b/cpp/src/genetic/node.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/genetic/node.h>
+
 #include <raft/util/cuda_utils.cuh>
 
 namespace cuml {

--- a/cpp/src/genetic/program.cu
+++ b/cpp/src/genetic/program.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
+#include "constants.h"
+#include "fitness.cuh"
+#include "node.cuh"
+#include "reg_stack.cuh"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/genetic/node.h>
 #include <cuml/genetic/program.h>
+
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <algorithm>
 #include <numeric>
 #include <random>
 #include <stack>
-
-#include "constants.h"
-#include "fitness.cuh"
-#include "node.cuh"
-#include "reg_stack.cuh"
 
 namespace cuml {
 namespace genetic {

--- a/cpp/src/glm/glm.cu
+++ b/cpp/src/glm/glm.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "ols.cuh"
 #include "qn/qn.cuh"
 #include "ridge.cuh"
+
 #include <cuml/linear_model/glm.hpp>
 
 namespace raft {

--- a/cpp/src/glm/glm_api.cpp
+++ b/cpp/src/glm/glm_api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include <common/cumlHandle.hpp>
+
+#include <cuml/linear_model/glm.hpp>
 #include <cuml/linear_model/glm_api.h>
 #include <cuml/linear_model/qn.h>
-
-#include <common/cumlHandle.hpp>
-#include <cuml/linear_model/glm.hpp>
 
 namespace ML::GLM {
 

--- a/cpp/src/glm/ols.cuh
+++ b/cpp/src/glm/ols.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "preprocess.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/gemv.cuh>
 #include <raft/linalg/lstsq.cuh>
@@ -29,9 +31,8 @@
 #include <raft/stats/mean_center.cuh>
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
-#include <rmm/device_uvector.hpp>
 
-#include "preprocess.cuh"
+#include <rmm/device_uvector.hpp>
 
 namespace ML {
 namespace GLM {

--- a/cpp/src/glm/ols_mg.cu
+++ b/cpp/src/glm/ols_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <cumlprims/opg/linalg/lstsq.hpp>
 #include <cumlprims/opg/stats/mean.hpp>
-
 #include <raft/core/comms.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/gemm.cuh>

--- a/cpp/src/glm/preprocess.cuh
+++ b/cpp/src/glm/preprocess.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <raft/core/handle.hpp>
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/norm.cuh>
+#include <raft/linalg/subtract.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
 #include <raft/stats/mean.cuh>
@@ -27,6 +28,7 @@
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/weighted_mean.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src/glm/preprocess_mg.cu
+++ b/cpp/src/glm/preprocess_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <raft/matrix/math.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 using namespace MLCommon;

--- a/cpp/src/glm/qn/glm_base.cuh
+++ b/cpp/src/glm/qn/glm_base.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "simple_mat.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/map.cuh>
 #include <raft/linalg/map_then_reduce.cuh>
@@ -28,6 +29,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 #include <thrust/reduce.h>
+
 #include <vector>
 
 namespace ML {

--- a/cpp/src/glm/qn/glm_linear.cuh
+++ b/cpp/src/glm/qn/glm_linear.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "glm_base.cuh"
 #include "simple_mat.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/util/cuda_utils.cuh>
 

--- a/cpp/src/glm/qn/glm_logistic.cuh
+++ b/cpp/src/glm/qn/glm_logistic.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "glm_base.cuh"
 #include "simple_mat.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/util/cuda_utils.cuh>
 

--- a/cpp/src/glm/qn/glm_regularizer.cuh
+++ b/cpp/src/glm/qn/glm_regularizer.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "simple_mat.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/stats/mean.cuh>

--- a/cpp/src/glm/qn/glm_softmax.cuh
+++ b/cpp/src/glm/qn/glm_softmax.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "glm_base.cuh"
 #include "simple_mat.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/util/cuda_utils.cuh>
 

--- a/cpp/src/glm/qn/glm_svm.cuh
+++ b/cpp/src/glm/qn/glm_svm.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "glm_base.cuh"
 #include "simple_mat.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/util/cuda_utils.cuh>
 

--- a/cpp/src/glm/qn/mg/glm_base_mg.cuh
+++ b/cpp/src/glm/qn/mg/glm_base_mg.cuh
@@ -20,11 +20,10 @@
 #include <raft/linalg/multiply.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-#include <glm/qn/mg/standardization.cuh>
-
 #include <glm/qn/glm_base.cuh>
 #include <glm/qn/glm_logistic.cuh>
 #include <glm/qn/glm_regularizer.cuh>
+#include <glm/qn/mg/standardization.cuh>
 #include <glm/qn/qn_solvers.cuh>
 #include <glm/qn/qn_util.cuh>
 

--- a/cpp/src/glm/qn/mg/qn_mg.cuh
+++ b/cpp/src/glm/qn/mg/qn_mg.cuh
@@ -17,15 +17,16 @@
 #include "glm_base_mg.cuh"
 #include "standardization.cuh"
 
+#include <cuml/linear_model/qn.h>
+
+#include <rmm/device_uvector.hpp>
+
 #include <glm/qn/glm_logistic.cuh>
 #include <glm/qn/glm_regularizer.cuh>
 #include <glm/qn/glm_softmax.cuh>
 #include <glm/qn/glm_svm.cuh>
 #include <glm/qn/qn_solvers.cuh>
 #include <glm/qn/qn_util.cuh>
-
-#include <cuml/linear_model/qn.h>
-#include <rmm/device_uvector.hpp>
 
 namespace ML {
 namespace GLM {

--- a/cpp/src/glm/qn/mg/standardization.cuh
+++ b/cpp/src/glm/qn/mg/standardization.cuh
@@ -16,15 +16,11 @@
 
 #pragma once
 
-#include <vector>
-
-#include <glm/qn/simple_mat/dense.hpp>
-#include <glm/qn/simple_mat/sparse.hpp>
+#include <cuml/common/logger.hpp>
 
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/core/operators.hpp>
-
 #include <raft/linalg/binary_op.cuh>
 #include <raft/linalg/divide.cuh>
 #include <raft/linalg/multiply.cuh>
@@ -34,7 +30,10 @@
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
 
-#include <cuml/common/logger.hpp>
+#include <glm/qn/simple_mat/dense.hpp>
+#include <glm/qn/simple_mat/sparse.hpp>
+
+#include <vector>
 
 namespace ML {
 namespace GLM {

--- a/cpp/src/glm/qn/qn.cuh
+++ b/cpp/src/glm/qn/qn.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 #include <cuml/linear_model/qn.h>
 
 #include <raft/matrix/math.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/glm/qn/qn_solvers.cuh
+++ b/cpp/src/glm/qn/qn_solvers.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,11 @@
 #include "qn_linesearch.cuh"
 #include "qn_util.cuh"
 #include "simple_mat.cuh"
+
 #include <cuml/common/logger.hpp>
+
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/glm/qn/qn_util.cuh
+++ b/cpp/src/glm/qn/qn_util.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 #pragma once
 
+#include <cuml/common/logger.hpp>
 #include <cuml/linear_model/qn.h>
 
-#include <cuml/common/logger.hpp>
-#include <limits>
 #include <raft/util/cuda_utils.cuh>
+
+#include <limits>
 
 namespace ML {
 namespace GLM {

--- a/cpp/src/glm/qn/simple_mat/dense.hpp
+++ b/cpp/src/glm/qn/simple_mat/dense.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,22 @@
  */
 #pragma once
 
-#include <iostream>
-#include <vector>
-
 #include "base.hpp"
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/ternary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <iostream>
+#include <vector>
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/linalg/norm.cuh>
 #include <raft/linalg/unary_op.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/glm/qn/simple_mat/sparse.hpp
+++ b/cpp/src/glm/qn/simple_mat/sparse.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,22 @@
  */
 #pragma once
 
-#include <iostream>
-#include <vector>
-
 #include "base.hpp"
-#include <raft/core/handle.hpp>
-#include <raft/linalg/ternary_op.cuh>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/linalg/norm.cuh>
+#include <raft/linalg/ternary_op.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/sparse/detail/cusparse_wrappers.h>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
-#include <raft/sparse/detail/cusparse_wrappers.h>
+#include <iostream>
+#include <vector>
 
 namespace ML {
 

--- a/cpp/src/glm/qn_mg.cu
+++ b/cpp/src/glm/qn_mg.cu
@@ -17,10 +17,11 @@
 #include "qn/mg/qn_mg.cuh"
 #include "qn/mg/standardization.cuh"
 #include "qn/simple_mat/dense.hpp"
-#include <cuda_runtime.h>
+
 #include <cuml/common/logger.hpp>
 #include <cuml/linear_model/qn.h>
 #include <cuml/linear_model/qn_mg.hpp>
+
 #include <raft/core/comms.hpp>
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/error.hpp>
@@ -35,6 +36,9 @@
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime.h>
+
 #include <vector>
 using namespace MLCommon;
 

--- a/cpp/src/glm/ridge.cuh
+++ b/cpp/src/glm/ridge.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "preprocess.cuh"
+
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/map.cuh>
@@ -28,9 +30,8 @@
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
 
-#include "preprocess.cuh"
+#include <rmm/device_uvector.hpp>
 
 namespace ML {
 namespace GLM {

--- a/cpp/src/glm/ridge_mg.cu
+++ b/cpp/src/glm/ridge_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 #include <cumlprims/opg/linalg/mv_aTb.hpp>
 #include <cumlprims/opg/linalg/svd.hpp>
 #include <cumlprims/opg/stats/mean.hpp>
-
 #include <raft/core/comms.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/gemm.cuh>

--- a/cpp/src/hdbscan/condensed_hierarchy.cu
+++ b/cpp/src/hdbscan/condensed_hierarchy.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-#include <raft/label/classlabels.cuh>
-
-#include <cub/cub.cuh>
-
+#include <cuml/cluster/hdbscan.hpp>
 #include <cuml/common/logger.hpp>
+
+#include <raft/label/classlabels.cuh>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
-
+#include <cub/cub.cuh>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -38,8 +37,6 @@
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
-
-#include <cuml/cluster/hdbscan.hpp>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/src/hdbscan/detail/condense.cuh
+++ b/cpp/src/hdbscan/detail/condense.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,16 @@
 
 #include "kernels/condense.cuh"
 
-#include <cub/cub.cuh>
+#include <cuml/cluster/hdbscan.hpp>
 
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
-
-#include <cuml/cluster/hdbscan.hpp>
-
+#include <cub/cub.cuh>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/hdbscan/detail/extract.cuh
+++ b/cpp/src/hdbscan/detail/extract.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,9 @@
 #include "stabilities.cuh"
 #include "utils.h"
 
-#include <raft/label/classlabels.cuh>
-
 #include <cuml/cluster/hdbscan.hpp>
 
+#include <raft/label/classlabels.cuh>
 #include <raft/sparse/convert/csr.cuh>
 #include <raft/sparse/op/sort.cuh>
 #include <raft/util/cudart_utils.hpp>
@@ -32,6 +31,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/extrema.h>
@@ -39,8 +39,6 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-
-#include <cub/cub.cuh>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src/hdbscan/detail/membership.cuh
+++ b/cpp/src/hdbscan/detail/membership.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,17 @@
 #include "kernels/membership.cuh"
 #include "utils.h"
 
-#include <cub/cub.cuh>
-
-#include <raft/util/cudart_utils.hpp>
-
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
-
 #include <cuml/cluster/hdbscan.hpp>
 
 #include <raft/label/classlabels.cuh>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <algorithm>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
@@ -40,8 +38,7 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
+#include <algorithm>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/src/hdbscan/detail/reachability.cuh
+++ b/cpp/src/hdbscan/detail/reachability.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,18 @@
 
 #pragma once
 
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
+#include <cuml/neighbors/knn.hpp>
 
+#include <raft/distance/distance.cuh>
 #include <raft/linalg/unary_op.cuh>
-
 #include <raft/neighbors/brute_force.cuh>
 #include <raft/sparse/convert/csr.cuh>
 #include <raft/sparse/linalg/symmetrize.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
-
-#include <cuml/neighbors/knn.hpp>
-#include <raft/distance/distance.cuh>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>

--- a/cpp/src/hdbscan/detail/select.cuh
+++ b/cpp/src/hdbscan/detail/select.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,17 @@
 #include "kernels/select.cuh"
 #include "utils.h"
 
-#include <cub/cub.cuh>
-
-#include <raft/util/cudart_utils.hpp>
-
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
-
 #include <cuml/cluster/hdbscan.hpp>
 
 #include <raft/label/classlabels.cuh>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <algorithm>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
@@ -45,8 +43,7 @@
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
 
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
+#include <algorithm>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/src/hdbscan/detail/soft_clustering.cuh
+++ b/cpp/src/hdbscan/detail/soft_clustering.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,9 @@
 #include "kernels/soft_clustering.cuh"
 #include "select.cuh"
 #include "utils.h"
-#include <cuml/common/logger.hpp>
-
-#include <cub/cub.cuh>
-
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
 
 #include <cuml/cluster/hdbscan.hpp>
+#include <cuml/common/logger.hpp>
 
 #include <raft/core/device_mdspan.hpp>
 #include <raft/distance/distance.cuh>
@@ -38,17 +30,22 @@
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/matrix/argmax.cuh>
 #include <raft/matrix/matrix.cuh>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 #include <raft/util/fast_int_div.cuh>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cub/cub.cuh>
+#include <thrust/execution_policy.h>
+#include <thrust/transform.h>
 
 #include <algorithm>
 #include <cmath>
 #include <limits>
-
-#include <thrust/execution_policy.h>
-#include <thrust/transform.h>
-
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/src/hdbscan/detail/stabilities.cuh
+++ b/cpp/src/hdbscan/detail/stabilities.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,17 @@
 #include "kernels/stabilities.cuh"
 #include "utils.h"
 
-#include <cub/cub.cuh>
-
-#include <raft/util/cudart_utils.hpp>
-
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
-
 #include <cuml/cluster/hdbscan.hpp>
 
 #include <raft/label/classlabels.cuh>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <algorithm>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
@@ -42,8 +40,7 @@
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
+#include <algorithm>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/src/hdbscan/detail/utils.h
+++ b/cpp/src/hdbscan/detail/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,9 @@
 
 #pragma once
 
-#include <cub/cub.cuh>
+#include "../condensed_hierarchy.cu"
 
-#include <raft/util/cudart_utils.hpp>
-
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/op/sort.cuh>
+#include <common/fast_int_div.cuh>
 
 #include <cuml/cluster/hdbscan.hpp>
 
@@ -29,12 +26,14 @@
 #include <raft/label/classlabels.cuh>
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/norm.cuh>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/op/sort.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <algorithm>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
-#include "../condensed_hierarchy.cu"
-#include <common/fast_int_div.cuh>
-
+#include <cub/cub.cuh>
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
@@ -46,8 +45,7 @@
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
 
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
+#include <algorithm>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/src/hdbscan/hdbscan.cu
+++ b/cpp/src/hdbscan/hdbscan.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 #include "detail/condense.cuh"
 #include "detail/predict.cuh"
+#include "runner.h"
+
 #include <cuml/cluster/hdbscan.hpp>
 
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
-
-#include "runner.h"
 
 namespace ML {
 

--- a/cpp/src/hdbscan/prediction_data.cu
+++ b/cpp/src/hdbscan/prediction_data.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,15 @@
 
 #include "detail/utils.h"
 
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-
 #include <cuml/cluster/hdbscan.hpp>
 
 #include <raft/sparse/convert/csr.cuh>
 #include <raft/sparse/op/sort.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <algorithm>
-#include <cmath>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -35,8 +34,8 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
+#include <algorithm>
+#include <cmath>
 namespace ML {
 namespace HDBSCAN {
 namespace Common {

--- a/cpp/src/hdbscan/runner.h
+++ b/cpp/src/hdbscan/runner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,23 @@
 
 #pragma once
 
-#include <raft/core/resource/thrust_policy.hpp>
-#include <raft/util/cudart_utils.hpp>
-
-#include <raft/core/handle.hpp>
-#include <raft/core/kvp.hpp>
-#include <rmm/device_uvector.hpp>
-
-#include <cuml/common/logger.hpp>
-
-#include <raft/cluster/detail/agglomerative.cuh>
-#include <raft/cluster/detail/mst.cuh>
-#include <raft/sparse/coo.hpp>
-
 #include "detail/condense.cuh"
 #include "detail/extract.cuh"
 #include "detail/reachability.cuh"
 #include "detail/soft_clustering.cuh"
+
 #include <cuml/cluster/hdbscan.hpp>
+#include <cuml/common/logger.hpp>
+
+#include <raft/cluster/detail/agglomerative.cuh>
+#include <raft/cluster/detail/mst.cuh>
+#include <raft/core/handle.hpp>
+#include <raft/core/kvp.hpp>
+#include <raft/core/resource/thrust_policy.hpp>
+#include <raft/sparse/coo.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/extrema.h>

--- a/cpp/src/holtwinters/holtwinters.cu
+++ b/cpp/src/holtwinters/holtwinters.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include "runner.cuh"
+
 #include <cuml/tsa/holtwinters.h>
 
 namespace ML {

--- a/cpp/src/holtwinters/holtwinters_api.cpp
+++ b/cpp/src/holtwinters/holtwinters_api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/tsa/holtwinters_api.h>
-
 #include <common/cumlHandle.hpp>
+
 #include <cuml/tsa/holtwinters.h>
+#include <cuml/tsa/holtwinters_api.h>
 
 extern "C" {
 

--- a/cpp/src/holtwinters/internal/hw_decompose.cuh
+++ b/cpp/src/holtwinters/internal/hw_decompose.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,12 @@
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 // #TODO: Replace with public header when ready
+#include "hw_utils.cuh"
+
 #include <raft/linalg/detail/cusolver_wrappers.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
-
-#include "hw_utils.cuh"
 
 // optimize, maybe im2col ?
 // https://github.com/rapidsai/cuml/issues/891

--- a/cpp/src/holtwinters/internal/hw_utils.cuh
+++ b/cpp/src/holtwinters/internal/hw_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 
 #pragma once
-#include <cuda_runtime.h>
 #include <cuml/tsa/holtwinters_params.h>
-#include <iostream>
+
 #include <raft/linalg/eltwise.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime.h>
+
+#include <iostream>
 #include <vector>
 
 #define IDX(n, m, N) (n + (m) * (N))

--- a/cpp/src/holtwinters/runner.cuh
+++ b/cpp/src/holtwinters/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,14 @@
 #include "internal/hw_eval.cuh"
 #include "internal/hw_forecast.cuh"
 #include "internal/hw_optim.cuh"
+
 #include <cuml/tsa/holtwinters_params.h>
+
 #include <raft/util/cudart_utils.hpp>
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/transpose.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/kmeans/kmeans_fit_predict.cu
+++ b/cpp/src/kmeans/kmeans_fit_predict.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <raft/core/handle.hpp>
-
 #include <raft/cluster/kmeans.cuh>
 #include <raft/cluster/kmeans_types.hpp>
+#include <raft/core/handle.hpp>
 
 namespace ML {
 namespace kmeans {

--- a/cpp/src/kmeans/kmeans_mg.cu
+++ b/cpp/src/kmeans/kmeans_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include "kmeans_mg_impl.cuh"
+
 #include <cuml/cluster/kmeans_mg.hpp>
+
 #include <raft/cluster/kmeans_types.hpp>
 
 namespace ML {

--- a/cpp/src/kmeans/kmeans_mg_impl.cuh
+++ b/cpp/src/kmeans/kmeans_mg_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <cuml/common/logger.hpp>
+
 #include <raft/cluster/kmeans.cuh>
 #include <raft/cluster/kmeans_types.hpp>
 #include <raft/core/device_mdarray.hpp>
@@ -23,16 +24,18 @@
 #include <raft/core/host_mdarray.hpp>
 #include <raft/matrix/gather.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
-#include <ml_cuda_utils.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
+
+#include <ml_cuda_utils.h>
 
 #include <cstdint>
 

--- a/cpp/src/kmeans/kmeans_predict.cu
+++ b/cpp/src/kmeans/kmeans_predict.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <raft/core/handle.hpp>
-
 #include <raft/cluster/kmeans.cuh>
 #include <raft/cluster/kmeans_types.hpp>
+#include <raft/core/handle.hpp>
 
 namespace ML {
 namespace kmeans {

--- a/cpp/src/kmeans/kmeans_transform.cu
+++ b/cpp/src/kmeans/kmeans_transform.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <raft/core/handle.hpp>
-
 #include <raft/cluster/kmeans.cuh>
 #include <raft/cluster/kmeans_types.hpp>
+#include <raft/core/handle.hpp>
 
 namespace ML {
 namespace kmeans {

--- a/cpp/src/knn/knn.cu
+++ b/cpp/src/knn/knn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-#include <cuda_runtime.h>
+#include <cuml/common/logger.hpp>
+#include <cuml/neighbors/knn.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/label/classlabels.cuh>
 #include <raft/spatial/knn/ann.cuh>
 #include <raft/spatial/knn/ball_cover.cuh>
+#include <raft/spatial/knn/knn.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-#include <raft/spatial/knn/knn.cuh>
 #include <rmm/device_uvector.hpp>
 
-#include <cuml/common/logger.hpp>
-#include <cuml/neighbors/knn.hpp>
+#include <cuda_runtime.h>
+
 #include <ml_mg_utils.cuh>
 #include <selection/knn.cuh>
 

--- a/cpp/src/knn/knn_api.cpp
+++ b/cpp/src/knn/knn_api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <cuml/neighbors/knn_api.h>
-
 #include <common/cumlHandle.hpp>
+
 #include <cuml/neighbors/knn.hpp>
+#include <cuml/neighbors/knn_api.h>
 
 #include <vector>
 

--- a/cpp/src/knn/knn_opg_common.cuh
+++ b/cpp/src/knn/knn_opg_common.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,15 @@
 #include <cuml/common/logger.hpp>
 #include <cuml/neighbors/knn_mg.hpp>
 
-#include <selection/knn.cuh>
-
 #include <cumlprims/opg/matrix/data.hpp>
 #include <cumlprims/opg/matrix/part_descriptor.hpp>
-
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/spatial/knn/knn.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <selection/knn.cuh>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/src/knn/knn_sparse.cu
+++ b/cpp/src/knn/knn_sparse.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 
 #include <cuml/neighbors/knn_sparse.hpp>
-#include <raft/core/handle.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/sparse/selection/knn.cuh>
 
 namespace ML {

--- a/cpp/src/metrics/accuracy_score.cu
+++ b/cpp/src/metrics/accuracy_score.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/accuracy.cuh>
 

--- a/cpp/src/metrics/adjusted_rand_index.cu
+++ b/cpp/src/metrics/adjusted_rand_index.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/adjusted_rand_index.cuh>
 

--- a/cpp/src/metrics/completeness_score.cu
+++ b/cpp/src/metrics/completeness_score.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/homogeneity_score.cuh>
 

--- a/cpp/src/metrics/entropy.cu
+++ b/cpp/src/metrics/entropy.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/entropy.cuh>
 

--- a/cpp/src/metrics/homogeneity_score.cu
+++ b/cpp/src/metrics/homogeneity_score.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/homogeneity_score.cuh>
 

--- a/cpp/src/metrics/kl_divergence.cu
+++ b/cpp/src/metrics/kl_divergence.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/kl_divergence.cuh>
 

--- a/cpp/src/metrics/mutual_info_score.cu
+++ b/cpp/src/metrics/mutual_info_score.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-#include <raft/core/handle.hpp>
-
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/mutual_info_score.cuh>
 

--- a/cpp/src/metrics/pairwise_distance.cu
+++ b/cpp/src/metrics/pairwise_distance.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@
 #include "pairwise_distance_l1.cuh"
 #include "pairwise_distance_minkowski.cuh"
 #include "pairwise_distance_russell_rao.cuh"
+
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
 #include <raft/sparse/distance/distance.cuh>

--- a/cpp/src/metrics/pairwise_distance_canberra.cu
+++ b/cpp/src/metrics/pairwise_distance_canberra.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_canberra.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_chebyshev.cu
+++ b/cpp/src/metrics/pairwise_distance_chebyshev.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_chebyshev.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 namespace ML {
 

--- a/cpp/src/metrics/pairwise_distance_correlation.cu
+++ b/cpp/src/metrics/pairwise_distance_correlation.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_correlation.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_cosine.cu
+++ b/cpp/src/metrics/pairwise_distance_cosine.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_cosine.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_euclidean.cu
+++ b/cpp/src/metrics/pairwise_distance_euclidean.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_euclidean.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_hamming.cu
+++ b/cpp/src/metrics/pairwise_distance_hamming.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_hamming.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_hellinger.cu
+++ b/cpp/src/metrics/pairwise_distance_hellinger.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_hellinger.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_jensen_shannon.cu
+++ b/cpp/src/metrics/pairwise_distance_jensen_shannon.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_jensen_shannon.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_kl_divergence.cu
+++ b/cpp/src/metrics/pairwise_distance_kl_divergence.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_kl_divergence.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_l1.cu
+++ b/cpp/src/metrics/pairwise_distance_l1.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_l1.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_minkowski.cu
+++ b/cpp/src/metrics/pairwise_distance_minkowski.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_minkowski.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/pairwise_distance_russell_rao.cu
+++ b/cpp/src/metrics/pairwise_distance_russell_rao.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
  */
 
 #include "pairwise_distance_russell_rao.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace ML {

--- a/cpp/src/metrics/r2_score.cu
+++ b/cpp/src/metrics/r2_score.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/r2_score.cuh>
 

--- a/cpp/src/metrics/rand_index.cu
+++ b/cpp/src/metrics/rand_index.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-#include <raft/core/handle.hpp>
-
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/rand_index.cuh>
 

--- a/cpp/src/metrics/silhouette_score.cu
+++ b/cpp/src/metrics/silhouette_score.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/stats/silhouette_score.cuh>

--- a/cpp/src/metrics/silhouette_score_batched_double.cu
+++ b/cpp/src/metrics/silhouette_score_batched_double.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/stats/silhouette_score.cuh>

--- a/cpp/src/metrics/silhouette_score_batched_float.cu
+++ b/cpp/src/metrics/silhouette_score_batched_float.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/stats/silhouette_score.cuh>

--- a/cpp/src/metrics/trustworthiness.cu
+++ b/cpp/src/metrics/trustworthiness.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-#include <raft/stats/trustworthiness_score.cuh>
-
 #include <cuml/metrics/metrics.hpp>
-#include <raft/core/handle.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+#include <raft/stats/trustworthiness_score.cuh>
 
 namespace ML {
 namespace Metrics {

--- a/cpp/src/metrics/v_measure.cu
+++ b/cpp/src/metrics/v_measure.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/stats/v_measure.cuh>
 

--- a/cpp/src/ml_cuda_utils.h
+++ b/cpp/src/ml_cuda_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
 #include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime.h>
 
 namespace ML {
 

--- a/cpp/src/pca/pca.cu
+++ b/cpp/src/pca/pca.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include "pca.cuh"
+
 #include <cuml/decomposition/pca.hpp>
+
 #include <raft/core/handle.hpp>
 
 namespace ML {

--- a/cpp/src/pca/pca.cuh
+++ b/cpp/src/pca/pca.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/decomposition/params.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/eig.cuh>
 #include <raft/linalg/eltwise.cuh>
@@ -27,7 +28,9 @@
 #include <raft/stats/mean.cuh>
 #include <raft/stats/mean_center.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
+
 #include <tsvd/tsvd.cuh>
 
 namespace ML {

--- a/cpp/src/pca/pca_mg.cu
+++ b/cpp/src/pca/pca_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 #include <cumlprims/opg/stats/cov.hpp>
 #include <cumlprims/opg/stats/mean.hpp>
 #include <cumlprims/opg/stats/mean_center.hpp>
-
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/linalg/transpose.cuh>

--- a/cpp/src/pca/sign_flip_mg.cu
+++ b/cpp/src/pca/sign_flip_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 #include <cuml/decomposition/sign_flip_mg.hpp>
-#include <thrust/device_vector.h>
-#include <thrust/execution_policy.h>
 
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>

--- a/cpp/src/random_projection/rproj.cu
+++ b/cpp/src/random_projection/rproj.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include "rproj.cuh"
+
 #include <cuml/random_projection/rproj_c.h>
+
 #include <raft/core/handle.hpp>
 
 namespace ML {

--- a/cpp/src/random_projection/rproj_utils.cuh
+++ b/cpp/src/random_projection/rproj_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
+#include "randomforest.cuh"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/ensemble/randomforest.hpp>
 #include <cuml/tree/flatnode.h>
+
+#include <raft/core/error.hpp>
 #include <raft/core/handle.hpp>
 
 #include <treelite/c_api.h>
 #include <treelite/enum/task_type.h>
 #include <treelite/tree.h>
-
-#include <raft/core/error.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -37,8 +39,6 @@
 #include <type_traits>
 #include <variant>
 #include <vector>
-
-#include "randomforest.cuh"
 
 namespace ML {
 

--- a/cpp/src/randomforest/randomforest.cuh
+++ b/cpp/src/randomforest/randomforest.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,11 @@
 
 #pragma once
 
-#include <decisiontree/batched-levelalgo/quantiles.cuh>
-#include <decisiontree/decisiontree.cuh>
-#include <decisiontree/treelite_util.h>
-
-#include <raft/random/permute.cuh>
+#include <cuml/ensemble/randomforest.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/nvtx.hpp>
+#include <raft/random/permute.cuh>
 #include <raft/random/rng.cuh>
 #include <raft/stats/accuracy.cuh>
 #include <raft/stats/regression_metrics.cuh>
@@ -31,6 +28,10 @@
 
 #include <thrust/execution_policy.h>
 #include <thrust/sequence.h>
+
+#include <decisiontree/batched-levelalgo/quantiles.cuh>
+#include <decisiontree/decisiontree.cuh>
+#include <decisiontree/treelite_util.h>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,9 @@
 #pragma once
 
 #include "shuffle.h"
+
 #include <cuml/solvers/params.hpp>
-#include <functions/linearReg.cuh>
-#include <functions/penalty.cuh>
-#include <functions/softThres.cuh>
-#include <glm/preprocess.cuh>
+
 #include <raft/core/handle.hpp>
 #include <raft/core/nvtx.hpp>
 #include <raft/linalg/add.cuh>
@@ -40,6 +38,11 @@
 #include <raft/stats/sum.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <functions/linearReg.cuh>
+#include <functions/penalty.cuh>
+#include <functions/softThres.cuh>
+#include <glm/preprocess.cuh>
 
 namespace ML {
 namespace Solver {

--- a/cpp/src/solver/cd_mg.cu
+++ b/cpp/src/solver/cd_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,8 @@
 #include <cuml/linear_model/preprocess_mg.hpp>
 #include <cuml/solvers/cd_mg.hpp>
 
-#include <functions/softThres.cuh>
-
 #include <cumlprims/opg/linalg/mv_aTb.hpp>
 #include <cumlprims/opg/linalg/norm.hpp>
-
-#include "shuffle.h"
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
@@ -36,6 +32,8 @@
 #include <raft/matrix/matrix.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <functions/softThres.cuh>
 
 #include <cstddef>
 

--- a/cpp/src/solver/lars.cu
+++ b/cpp/src/solver/lars.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include "lars_impl.cuh"
+
 #include <cuml/solvers/lars.hpp>
+
 #include <raft/core/handle.hpp>
 
 namespace ML {

--- a/cpp/src/solver/lars_impl.cuh
+++ b/cpp/src/solver/lars_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,30 @@
 
 #pragma once
 
-#include <iostream>
-#include <limits>
-#include <numeric>
-#include <vector>
-
-#include <cub/cub.cuh>
 #include <cuml/common/logger.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/cholesky_r1_update.cuh>
 #include <raft/util/cache_util.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <cub/cub.cuh>
+
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <vector>
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/gemv.cuh>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/linalg/unary_op.cuh>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/solver/learning_rate.h
+++ b/cpp/src/solver/learning_rate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/solvers/params.hpp>
+
 #include <math.h>
 
 namespace ML {

--- a/cpp/src/solver/sgd.cuh
+++ b/cpp/src/solver/sgd.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,9 @@
 
 #include "learning_rate.h"
 #include "shuffle.h"
+
 #include <cuml/solvers/params.hpp>
-#include <functions/hinge.cuh>
-#include <functions/linearReg.cuh>
-#include <functions/logisticReg.cuh>
-#include <glm/preprocess.cuh>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eltwise.cuh>
@@ -35,7 +33,13 @@
 #include <raft/stats/mean_center.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <functions/hinge.cuh>
+#include <functions/linearReg.cuh>
+#include <functions/logisticReg.cuh>
+#include <glm/preprocess.cuh>
 
 namespace ML {
 namespace Solver {

--- a/cpp/src/solver/solver.cu
+++ b/cpp/src/solver/solver.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 #include "cd.cuh"
 #include "sgd.cuh"
+
 #include <cuml/solvers/params.hpp>
 #include <cuml/solvers/solver.hpp>
+
 #include <raft/core/handle.hpp>
 
 namespace ML {

--- a/cpp/src/spectral/spectral.cu
+++ b/cpp/src/spectral/spectral.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-#include <raft/sparse/coo.hpp>
-
 #include <raft/core/handle.hpp>
+#include <raft/sparse/coo.hpp>
 #include <raft/sparse/linalg/spectral.cuh>
 
 namespace raft {

--- a/cpp/src/svm/kernelcache.cuh
+++ b/cpp/src/svm/kernelcache.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,27 +17,27 @@
 #pragma once
 
 #include "sparse_util.cuh"
+
+#include <cuml/common/logger.hpp>
 #include <cuml/svm/svm_parameter.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/kernels.cuh>
+#include <raft/linalg/gemm.cuh>
 #include <raft/linalg/init.cuh>
 #include <raft/util/cache.cuh>
 #include <raft/util/cache_util.cuh>
-
-#include <raft/linalg/gemm.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/reverse.h>
-
-#include <cuml/common/logger.hpp>
-
-#include <cub/cub.cuh>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src/svm/linear.cu
+++ b/cpp/src/svm/linear.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-#include <random>
-#include <type_traits>
-
 #include <common/nvtx.hpp>
-#include <cublas_v2.h>
+
 #include <cuml/linear_model/glm.hpp>
+#include <cuml/svm/linear.hpp>
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
-#include <omp.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/core/nvtx.hpp>
 #include <raft/distance/kernels.cuh>
@@ -34,8 +32,10 @@
 #include <raft/linalg/transpose.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -43,7 +43,11 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tuple.h>
 
-#include <cuml/svm/linear.hpp>
+#include <cublas_v2.h>
+#include <omp.h>
+
+#include <random>
+#include <type_traits>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/results.cuh
+++ b/cpp/src/svm/results.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,11 @@
 
 #pragma once
 
-#include <iostream>
-#include <limits>
-#include <math.h>
-#include <memory>
-
 #include "sparse_util.cuh"
 #include "ws_util.cuh"
-#include <cub/device/device_select.cuh>
+
 #include <cuml/svm/svm_model.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/init.cuh>
@@ -32,8 +28,17 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <cub/device/device_select.cuh>
+
+#include <math.h>
+
+#include <iostream>
+#include <limits>
+#include <memory>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/smoblocksolve.cuh
+++ b/cpp/src/svm/smoblocksolve.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,11 @@
 #pragma once
 
 #include "smo_sets.cuh"
+
 #include <cuml/svm/svm_parameter.h>
+
 #include <raft/util/cuda_utils.cuh>
+
 #include <selection/kselection.cuh>
 #include <stdlib.h>
 

--- a/cpp/src/svm/smosolver.cuh
+++ b/cpp/src/svm/smosolver.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,44 +19,38 @@
 #include <cuml/common/logger.hpp>
 
 // #TODO: Replace with public header when ready
+#include "kernelcache.cuh"
+#include "results.cuh"
+#include "smo_sets.cuh"
+#include "smoblocksolve.cuh"
+#include "workingset.cuh"
+#include "ws_util.cuh"
+
+#include <raft/core/handle.hpp>
+#include <raft/distance/distance_types.hpp>
+#include <raft/distance/kernels.cuh>
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/gemv.cuh>
 #include <raft/linalg/unary_op.cuh>
-
-#include <iostream>
-#include <limits>
-#include <raft/core/handle.hpp>
+#include <raft/sparse/linalg/norm.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <string>
+
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/sequence.h>
-#include <type_traits>
 
-#include "kernelcache.cuh"
-#include "smo_sets.cuh"
-#include "smoblocksolve.cuh"
-#include "workingset.cuh"
-#include "ws_util.cuh"
-#include <raft/distance/distance_types.hpp>
-#include <raft/distance/kernels.cuh>
-#include <raft/linalg/gemv.cuh>
-#include <raft/linalg/unary_op.cuh>
-#include <raft/sparse/linalg/norm.cuh>
-
-#include "results.cuh"
 #include <cassert>
-#include <sstream>
-#include <string>
-
 #include <chrono>
 #include <cstdlib>
-#include <thrust/copy.h>
-#include <thrust/device_ptr.h>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <type_traits>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/sparse_util.cuh
+++ b/cpp/src/svm/sparse_util.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@
 #include <raft/distance/kernels.cuh>
 #include <raft/matrix/matrix.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
+
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/constant_iterator.h>

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-#include <iostream>
-
 #include "kernelcache.cuh"
 #include "smosolver.cuh"
 #include "svc_impl.cuh"
+
 #include <cuml/svm/svc.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/distance/kernels.cuh>
 #include <raft/label/classlabels.cuh>
 #include <raft/linalg/unary_op.cuh>
+
+#include <iostream>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/svc_impl.cuh
+++ b/cpp/src/svm/svc_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,23 +21,28 @@
  * classifier, and predict with it.
  */
 
-#include <iostream>
-
 #include "kernelcache.cuh"
 #include "smosolver.cuh"
-#include <cublas_v2.h>
+
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/kernels.cuh>
 #include <raft/label/classlabels.cuh>
 #include <raft/linalg/gemv.cuh>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
+
+#include <cublas_v2.h>
+
+#include <iostream>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/svm_api.cpp
+++ b/cpp/src/svm/svm_api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+#include <common/cumlHandle.hpp>
+
+#include <cuml/svm/svc.hpp>
 #include <cuml/svm/svm_api.h>
 
-#include <common/cumlHandle.hpp>
-#include <cuml/svm/svc.hpp>
 #include <raft/distance/distance_types.hpp>
+
 #include <tuple>
 
 extern "C" {

--- a/cpp/src/svm/svr.cu
+++ b/cpp/src/svm/svr.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-#include <iostream>
-
 #include "kernelcache.cuh"
 #include "smosolver.cuh"
 #include "svr_impl.cuh"
+
 #include <cuml/svm/svc.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/distance/kernels.cuh>
 #include <raft/label/classlabels.cuh>
 #include <raft/linalg/unary_op.cuh>
+
+#include <iostream>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/svr_impl.cuh
+++ b/cpp/src/svm/svr_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,24 @@
  * @brief Implementation of the stateless C++ functions to fit an SVM regressor.
  */
 
-#include <iostream>
-
 #include "kernelcache.cuh"
 #include "smosolver.cuh"
 #include "svc_impl.cuh"
-#include <cublas_v2.h>
+
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/kernels.cuh>
 #include <raft/linalg/unary_op.cuh>
+
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/iterator/counting_iterator.h>
+
+#include <cublas_v2.h>
+
+#include <iostream>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/svm/workingset.cuh
+++ b/cpp/src/svm/workingset.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,26 +22,20 @@
 #include <cuml/common/logger.hpp>
 #include <cuml/svm/svm_parameter.h>
 
-#include <raft/linalg/init.cuh>
-
-#include "smo_sets.cuh"
-#include "ws_util.cuh"
-#include <cub/cub.cuh>
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
+#include <raft/linalg/init.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
-#include <thrust/device_ptr.h>
-#include <thrust/iterator/permutation_iterator.h>
 
+#include <cub/cub.cuh>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/permutation_iterator.h>
-
-#include <cub/cub.cuh>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src/svm/ws_util.cu
+++ b/cpp/src/svm/ws_util.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-#include <cub/cub.cuh>
-#include <limits.h>
 #include <raft/util/cuda_utils.cuh>
+
+#include <cub/cub.cuh>
+
+#include <limits.h>
 
 namespace ML {
 namespace SVM {

--- a/cpp/src/tsa/auto_arima.cu
+++ b/cpp/src/tsa/auto_arima.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <raft/core/handle.hpp>
-
 #include "auto_arima.cuh"
 
 #include <cuml/tsa/auto_arima.h>
+
+#include <raft/core/handle.hpp>
 
 namespace ML {
 

--- a/cpp/src/tsa/auto_arima.cuh
+++ b/cpp/src/tsa/auto_arima.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,15 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
+#include <common/fast_int_div.cuh>
+
+#include <raft/core/interruptible.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
 
 #include <cub/cub.cuh>
+#include <cuda_runtime.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/functional.h>
@@ -26,10 +32,6 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
-
-#include <common/fast_int_div.cuh>
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
 
 namespace ML {
 namespace TimeSeries {

--- a/cpp/src/tsa/stationarity.cu
+++ b/cpp/src/tsa/stationarity.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include <cuml/tsa/stationarity.h>
 
 #include <raft/core/handle.hpp>
+
 #include <timeSeries/stationarity.cuh>
 
 namespace ML {

--- a/cpp/src/tsne/barnes_hut_kernels.cuh
+++ b/cpp/src/tsne/barnes_hut_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,14 @@
  */
 
 #pragma once
+
+#include "utils.cuh"
+
+#include <raft/util/cudart_utils.hpp>
+#include <raft/util/device_atomics.cuh>
+
+#include <cfloat>
+
 #define restrict __restrict__
 
 #define THREADS1 512
@@ -32,10 +40,6 @@
 #define FACTOR5 2
 #define FACTOR6 2
 #define FACTOR7 1
-
-#include <float.h>
-#include <raft/util/cudart_utils.hpp>
-#include <raft/util/device_atomics.cuh>
 
 namespace ML {
 namespace TSNE {

--- a/cpp/src/tsne/barnes_hut_tsne.cuh
+++ b/cpp/src/tsne/barnes_hut_tsne.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,15 @@
 
 #include "barnes_hut_kernels.cuh"
 #include "utils.cuh"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/manifold/tsne.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_scalar.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>

--- a/cpp/src/tsne/cannylab/bh.cu
+++ b/cpp/src/tsne/cannylab/bh.cu
@@ -39,6 +39,7 @@ Emerald Edition, pp. 75-92. January 2011.
 */
 
 #include <cuda.h>
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/cpp/src/tsne/distances.cuh
+++ b/cpp/src/tsne/distances.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,12 @@
 
 #pragma once
 
+#include "utils.cuh"
+
+#include <cuml/manifold/common.hpp>
 #include <cuml/neighbors/knn_sparse.hpp>
+
+#include <raft/core/error.hpp>
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/linalg/eltwise.cuh>
@@ -24,19 +29,14 @@
 #include <raft/sparse/linalg/symmetrize.cuh>
 #include <raft/sparse/selection/knn.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <selection/knn.cuh>
-
-#include <cuml/manifold/common.hpp>
-
-#include <raft/core/error.hpp>
-
-#include "utils.cuh"
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/functional.h>
 #include <thrust/transform_reduce.h>
+
+#include <selection/knn.cuh>
 
 namespace ML {
 namespace TSNE {

--- a/cpp/src/tsne/exact_kernels.cuh
+++ b/cpp/src/tsne/exact_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 #pragma once
 
-#include <float.h>
-#include <math.h>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/util/cudart_utils.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>
+
+#include <float.h>
+#include <math.h>
 
 #define restrict __restrict__
 

--- a/cpp/src/tsne/exact_tsne.cuh
+++ b/cpp/src/tsne/exact_tsne.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 
 #include "exact_kernels.cuh"
 #include "utils.cuh"
+
 #include <cuml/common/logger.hpp>
+
 #include <raft/util/cudart_utils.hpp>
 
 #include <thrust/device_ptr.h>

--- a/cpp/src/tsne/fft_tsne.cuh
+++ b/cpp/src/tsne/fft_tsne.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,13 @@
 
 #include "fft_kernels.cuh"
 #include "utils.cuh"
-#include <cmath>
+
 #include <common/device_utils.cuh>
-#include <cufft_utils.h>
+
 #include <raft/linalg/eltwise.cuh>
 #include <raft/linalg/init.cuh>
 #include <raft/stats/sum.cuh>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -39,6 +40,10 @@
 #include <thrust/functional.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
+
+#include <cufft_utils.h>
+
+#include <cmath>
 
 namespace ML {
 namespace TSNE {

--- a/cpp/src/tsne/tsne.cu
+++ b/cpp/src/tsne/tsne.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 #include "tsne_runner.cuh"
-#include <cuml/manifold/tsne.h>
-#include <raft/core/handle.hpp>
 
+#include <cuml/manifold/tsne.h>
+
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 
 namespace ML {

--- a/cpp/src/tsne/tsne_runner.cuh
+++ b/cpp/src/tsne/tsne_runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,23 @@
  */
 
 #pragma once
+#include "barnes_hut_tsne.cuh"
 #include "distances.cuh"
 #include "exact_kernels.cuh"
+#include "exact_tsne.cuh"
+#include "fft_tsne.cuh"
 #include "utils.cuh"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/manifold/common.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/transform.h>
-
-#include "barnes_hut_tsne.cuh"
-#include "exact_tsne.cuh"
-#include "fft_tsne.cuh"
 
 namespace ML {
 

--- a/cpp/src/tsne/utils.cuh
+++ b/cpp/src/tsne/utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,31 +15,31 @@
  */
 
 #pragma once
+#include <cuml/common/logger.hpp>
+
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/norm.cuh>
+#include <raft/random/rng.cuh>
+#include <raft/stats/sum.cuh>
+#include <raft/util/device_atomics.cuh>
+
+#include <rmm/exec_policy.hpp>
+
+#include <cuda_runtime.h>
+#include <thrust/device_ptr.h>
+#include <thrust/reduce.h>
+#include <thrust/transform.h>
+
 #include <assert.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
-
-#include <cuml/common/logger.hpp>
-#include <raft/linalg/eltwise.cuh>
-#include <raft/linalg/norm.cuh>
-
-#include <cuda_runtime.h>
-
-#include <thrust/device_ptr.h>
-#include <thrust/reduce.h>
-#include <thrust/transform.h>
-
-#include <raft/random/rng.cuh>
-#include <raft/stats/sum.cuh>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include <chrono>
 #include <iostream>
-#include <unistd.h>
-
-#include <raft/util/device_atomics.cuh>
 
 /**
  * @brief Performs P + P.T.

--- a/cpp/src/tsvd/tsvd.cu
+++ b/cpp/src/tsvd/tsvd.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include "tsvd.cuh"
+
 #include <cuml/decomposition/tsvd.hpp>
+
 #include <raft/core/handle.hpp>
 
 namespace ML {

--- a/cpp/src/tsvd/tsvd.cuh
+++ b/cpp/src/tsvd/tsvd.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/decomposition/params.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eig.cuh>
@@ -30,9 +31,11 @@
 #include <raft/stats/stddev.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
+
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>

--- a/cpp/src/tsvd/tsvd_mg.cu
+++ b/cpp/src/tsvd/tsvd_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,8 @@
 #include <cumlprims/opg/stats/mean.hpp>
 #include <cumlprims/opg/stats/mean_center.hpp>
 #include <cumlprims/opg/stats/stddev.hpp>
-#include <raft/core/handle.hpp>
-
 #include <raft/core/comms.hpp>
+#include <raft/core/handle.hpp>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/matrix/math.cuh>
 #include <raft/stats/mean_center.cuh>

--- a/cpp/src/umap/fuzzy_simpl_set/naive.cuh
+++ b/cpp/src/umap/fuzzy_simpl_set/naive.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,17 @@
 #include <cuml/manifold/umapparams.h>
 #include <cuml/neighbors/knn.hpp>
 
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/linalg/symmetrize.cuh>
 #include <raft/sparse/op/sort.cuh>
 #include <raft/stats/mean.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 
 #include <cuda_runtime.h>
 
 #include <stdio.h>
+
 #include <string>
 
 namespace UMAPAlgo {

--- a/cpp/src/umap/fuzzy_simpl_set/runner.cuh
+++ b/cpp/src/umap/fuzzy_simpl_set/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "naive.cuh"
+
 #include <cuml/manifold/umapparams.h>
 
 #include <raft/sparse/coo.hpp>

--- a/cpp/src/umap/init_embed/random_algo.cuh
+++ b/cpp/src/umap/init_embed/random_algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/manifold/umapparams.h>
+
 #include <raft/random/rng.cuh>
 
 namespace UMAPAlgo {

--- a/cpp/src/umap/init_embed/runner.cuh
+++ b/cpp/src/umap/init_embed/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 #pragma once
 
+#include "random_algo.cuh"
+#include "spectral_algo.cuh"
+
 #include <cuml/manifold/umapparams.h>
 
 #include <raft/sparse/coo.hpp>
-
-#include "random_algo.cuh"
-#include "spectral_algo.cuh"
 
 namespace UMAPAlgo {
 

--- a/cpp/src/umap/init_embed/spectral_algo.cuh
+++ b/cpp/src/umap/init_embed/spectral_algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <cuml/cluster/spectral.hpp>
 #include <cuml/manifold/umapparams.h>
 
+#include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/transpose.cuh>
 #include <raft/random/rng.cuh>

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@
 #include <cuml/manifold/common.hpp>
 #include <cuml/manifold/umapparams.h>
 #include <cuml/neighbors/knn_sparse.hpp>
-#include <iostream>
+
+#include <raft/core/error.hpp>
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/sparse/selection/knn.cuh>
-
 #include <raft/spatial/knn/knn.cuh>
-
 #include <raft/util/cudart_utils.hpp>
 
-#include <raft/core/error.hpp>
+#include <iostream>
 
 namespace UMAPAlgo {
 namespace kNNGraph {

--- a/cpp/src/umap/knn_graph/runner.cuh
+++ b/cpp/src/umap/knn_graph/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "algo.cuh"
+
 #include <cuml/manifold/common.hpp>
 
 namespace UMAPAlgo {

--- a/cpp/src/umap/optimize.cuh
+++ b/cpp/src/umap/optimize.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/stats/mean.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <cuda_runtime.h>

--- a/cpp/src/umap/runner.cuh
+++ b/cpp/src/umap/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,29 @@
 
 #pragma once
 
+#include "fuzzy_simpl_set/runner.cuh"
+#include "init_embed/runner.cuh"
+#include "knn_graph/runner.cuh"
 #include "optimize.cuh"
+#include "simpl_set_embed/runner.cuh"
 #include "supervised.cuh"
+
+#include <common/nvtx.hpp>
+
 #include <cuml/common/logger.hpp>
 #include <cuml/manifold/common.hpp>
 #include <cuml/manifold/umapparams.h>
 
-#include "fuzzy_simpl_set/runner.cuh"
-#include "init_embed/runner.cuh"
-#include "knn_graph/runner.cuh"
-#include "simpl_set_embed/runner.cuh"
+#include <raft/core/handle.hpp>
+#include <raft/core/nvtx.hpp>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/coo.hpp>
+#include <raft/sparse/linalg/norm.cuh>
+#include <raft/sparse/op/filter.cuh>
+#include <raft/sparse/op/sort.cuh>
+#include <raft/util/cuda_utils.cuh>
 
-#include <memory>
-
+#include <cuda_runtime.h>
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -37,18 +47,7 @@
 #include <thrust/scan.h>
 #include <thrust/system/cuda/execution_policy.h>
 
-#include <raft/core/handle.hpp>
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/coo.hpp>
-#include <raft/sparse/linalg/norm.cuh>
-#include <raft/sparse/op/filter.cuh>
-#include <raft/sparse/op/sort.cuh>
-
-#include <raft/util/cuda_utils.cuh>
-
-#include <common/nvtx.hpp>
-#include <cuda_runtime.h>
-#include <raft/core/nvtx.hpp>
+#include <memory>
 
 namespace UMAPAlgo {
 

--- a/cpp/src/umap/simpl_set_embed/algo.cuh
+++ b/cpp/src/umap/simpl_set_embed/algo.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,31 @@
 
 #pragma once
 
+#include "optimize_batch_kernel.cuh"
+
+#include <common/fast_int_div.cuh>
+
 #include <cuml/common/logger.hpp>
 #include <cuml/manifold/umapparams.h>
+
+#include <raft/linalg/unary_op.cuh>
+#include <raft/sparse/coo.hpp>
+#include <raft/sparse/op/filter.cuh>
+#include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <curand.h>
-#include <math.h>
-
-#include <common/fast_int_div.cuh>
-#include <cstdlib>
-
-#include <raft/linalg/unary_op.cuh>
-#include <raft/sparse/coo.hpp>
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
-
-#include "optimize_batch_kernel.cuh"
-#include <string>
-
-#include <raft/sparse/op/filter.cuh>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/system/cuda/execution_policy.h>
+
+#include <curand.h>
+#include <math.h>
+
+#include <cstdlib>
+#include <string>
 
 namespace UMAPAlgo {
 namespace SimplSetEmbed {

--- a/cpp/src/umap/simpl_set_embed/runner.cuh
+++ b/cpp/src/umap/simpl_set_embed/runner.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "algo.cuh"
+
 #include <cuml/manifold/umapparams.h>
 
 #include <raft/sparse/coo.hpp>

--- a/cpp/src/umap/supervised.cuh
+++ b/cpp/src/umap/supervised.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,27 @@
 
 #pragma once
 
-#include "optimize.cuh"
-#include <cuml/common/logger.hpp>
-#include <cuml/manifold/umapparams.h>
-#include <cuml/neighbors/knn.hpp>
-#include <raft/core/handle.hpp>
-
 #include "fuzzy_simpl_set/runner.cuh"
 #include "init_embed/runner.cuh"
 #include "knn_graph/runner.cuh"
+#include "optimize.cuh"
 #include "simpl_set_embed/runner.cuh"
+
+#include <cuml/common/logger.hpp>
+#include <cuml/manifold/umapparams.h>
+#include <cuml/neighbors/knn.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/sparse/convert/csr.cuh>
+#include <raft/sparse/coo.hpp>
+#include <raft/sparse/linalg/add.cuh>
+#include <raft/sparse/linalg/norm.cuh>
+#include <raft/sparse/linalg/symmetrize.cuh>
+#include <raft/sparse/op/filter.cuh>
+#include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
+#include <cuda_runtime.h>
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
@@ -35,17 +44,6 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <thrust/system/cuda/execution_policy.h>
-
-#include <raft/sparse/convert/csr.cuh>
-#include <raft/sparse/coo.hpp>
-#include <raft/sparse/linalg/add.cuh>
-#include <raft/sparse/linalg/norm.cuh>
-#include <raft/sparse/linalg/symmetrize.cuh>
-#include <raft/sparse/op/filter.cuh>
-
-#include <raft/util/cuda_utils.cuh>
-
-#include <cuda_runtime.h>
 
 namespace UMAPAlgo {
 

--- a/cpp/src/umap/umap.cu
+++ b/cpp/src/umap/umap.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
  */
 
 #include "runner.cuh"
+
 #include <cuml/manifold/common.hpp>
 #include <cuml/manifold/umap.hpp>
 #include <cuml/manifold/umapparams.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 

--- a/cpp/src_prims/common/device_utils.cuh
+++ b/cpp/src_prims/common/device_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <raft/util/cuda_utils.cuh>
+
 #include <utility>  // pair
 
 namespace MLCommon {

--- a/cpp/src_prims/common/fast_int_div.cuh
+++ b/cpp/src_prims/common/fast_int_div.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <raft/util/cuda_utils.cuh>
+
 #include <stdint.h>
 
 namespace MLCommon {

--- a/cpp/src_prims/cufft_utils.h
+++ b/cpp/src_prims/cufft_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <cufft.h>
 #include <raft/core/error.hpp>
+
+#include <cufft.h>
 
 // TODO move to raft https://github.com/rapidsai/raft/issues/91
 namespace raft {

--- a/cpp/src_prims/functions/hinge.cuh
+++ b/cpp/src_prims/functions/hinge.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "penalty.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eltwise.cuh>
@@ -28,6 +29,7 @@
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace MLCommon {

--- a/cpp/src_prims/functions/linearReg.cuh
+++ b/cpp/src_prims/functions/linearReg.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "penalty.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eltwise.cuh>
@@ -27,6 +28,7 @@
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace MLCommon {

--- a/cpp/src_prims/functions/logisticReg.cuh
+++ b/cpp/src_prims/functions/logisticReg.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "penalty.cuh"
 #include "sigmoid.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eltwise.cuh>
@@ -28,6 +29,7 @@
 #include <raft/stats/mean.cuh>
 #include <raft/stats/sum.cuh>
 #include <raft/util/cuda_utils.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 namespace MLCommon {

--- a/cpp/src_prims/functions/penalty.cuh
+++ b/cpp/src_prims/functions/penalty.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@
 #pragma once
 
 #include "sign.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/linalg/norm.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src_prims/linalg/batched/matrix.cuh
+++ b/cpp/src_prims/linalg/batched/matrix.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <cuml/common/utils.hpp>
-
 #include <common/fast_int_div.cuh>
+
+#include <cuml/common/utils.hpp>
 
 #include <raft/linalg/add.cuh>
 #include <raft/util/cuda_utils.cuh>
@@ -26,6 +26,7 @@
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/unary_op.cuh>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/execution_policy.h>

--- a/cpp/src_prims/linalg/block.cuh
+++ b/cpp/src_prims/linalg/block.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include <cub/cub.cuh>
-
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/util/device_loads_stores.cuh>
+
+#include <cub/cub.cuh>
 
 // Anonymous namespace for internal auxiliary functions
 namespace {

--- a/cpp/src_prims/random/make_arima.cuh
+++ b/cpp/src_prims/random/make_arima.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,17 @@
 
 #pragma once
 
-#include <random>
+#include <cuml/tsa/arima_common.h>
+
+#include <raft/random/rng.cuh>
 
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
-#include <cuml/tsa/arima_common.h>
-#include <raft/random/rng.cuh>
 #include <timeSeries/arima_helpers.cuh>
+
+#include <random>
 
 namespace MLCommon {
 namespace Random {

--- a/cpp/src_prims/selection/knn.cuh
+++ b/cpp/src_prims/selection/knn.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 
 #pragma once
 
-#include <raft/label/classlabels.cuh>
-
 #include <cuml/neighbors/knn.hpp>
-#include <raft/core/handle.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
 #include <raft/distance/distance_types.hpp>
+#include <raft/label/classlabels.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 

--- a/cpp/src_prims/selection/kselection.cuh
+++ b/cpp/src_prims/selection/kselection.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 #pragma once
 
-#include <limits>
 #include <raft/util/cuda_utils.cuh>
+
 #include <stdlib.h>
+
+#include <limits>
 
 namespace MLCommon {
 namespace Selection {

--- a/cpp/src_prims/sparse/batched/csr.cuh
+++ b/cpp/src_prims/sparse/batched/csr.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,14 +28,16 @@
 
 #include <cuml/common/utils.hpp>
 
-#include <linalg/batched/matrix.cuh>
 #include <raft/core/cusolver_macros.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
+
+#include <linalg/batched/matrix.cuh>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src_prims/timeSeries/arima_helpers.cuh
+++ b/cpp/src_prims/timeSeries/arima_helpers.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,18 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
-
 #include "jones_transform.cuh"
+
 #include <cuml/tsa/arima_common.h>
-#include <linalg/batched/matrix.cuh>
+
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <cuda_runtime.h>
+
+#include <linalg/batched/matrix.cuh>
 
 // Private helper functions and kernels in the anonymous namespace
 namespace {

--- a/cpp/src_prims/timeSeries/fillna.cuh
+++ b/cpp/src_prims/timeSeries/fillna.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,21 @@
 
 #pragma once
 
-#include <cub/cub.cuh>
-#include <cuda_runtime.h>
-
 #include "jones_transform.cuh"
+
 #include <cuml/tsa/arima_common.h>
-#include <linalg/batched/matrix.cuh>
+
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <cub/cub.cuh>
+#include <cuda_runtime.h>
+
+#include <linalg/batched/matrix.cuh>
 
 // Auxiliary functions in anonymous namespace
 namespace {

--- a/cpp/src_prims/timeSeries/jones_transform.cuh
+++ b/cpp/src_prims/timeSeries/jones_transform.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@
 
 #pragma once
 
-#include <math.h>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <math.h>
 
 namespace MLCommon {
 

--- a/cpp/test/mg/kmeans_test.cu
+++ b/cpp/test/mg/kmeans_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,27 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <nccl.h>
-#include <raft/comms/std_comms.hpp>
-#include <raft/core/handle.hpp>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
-#include <stdio.h>
-#include <test_utils.h>
-#include <vector>
-
 #include <cuml/cluster/kmeans.hpp>
 #include <cuml/cluster/kmeans_mg.hpp>
 #include <cuml/common/logger.hpp>
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/metrics/metrics.hpp>
+
+#include <raft/comms/std_comms.hpp>
+#include <raft/core/handle.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+
 #include <thrust/fill.h>
+
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdio.h>
+#include <test_utils.h>
+
+#include <vector>
 
 #define NCCLCHECK(cmd)                                                                        \
   do {                                                                                        \

--- a/cpp/test/mg/knn.cu
+++ b/cpp/test/mg/knn.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,18 @@
 
 #include "../prims/test_utils.h"
 #include "test_opg_utils.h"
+
 #include <cuml/neighbors/knn_mg.hpp>
-#include <gtest/gtest.h>
-#include <memory>
-#include <raft/random/make_blobs.cuh>
 
 #include <raft/comms/mpi_comms.hpp>
-
+#include <raft/random/make_blobs.cuh>
 #include <raft/util/cuda_utils.cuh>
 
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
 
 namespace ML {
 namespace KNN {

--- a/cpp/test/mg/knn_test_helper.cuh
+++ b/cpp/test/mg/knn_test_helper.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,18 @@
 
 #include "../prims/test_utils.h"
 #include "test_opg_utils.h"
+
 #include <cuml/neighbors/knn_mg.hpp>
-#include <gtest/gtest.h>
-#include <memory>
-#include <raft/random/make_blobs.cuh>
 
 #include <raft/comms/mpi_comms.hpp>
-
 #include <raft/linalg/reduce_rows_by_key.cuh>
+#include <raft/random/make_blobs.cuh>
+#include <raft/util/cuda_utils.cuh>
+
+#include <gtest/gtest.h>
 #include <selection/knn.cuh>
 
-#include <raft/util/cuda_utils.cuh>
+#include <memory>
 
 namespace ML {
 namespace KNN {

--- a/cpp/test/mg/main.cu
+++ b/cpp/test/mg/main.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
 #include "test_opg_utils.h"
+
+#include <gtest/gtest.h>
 
 int main(int argc, char** argv)
 {

--- a/cpp/test/mg/pca.cu
+++ b/cpp/test/mg/pca.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,18 @@
  */
 
 #include "test_opg_utils.h"
+
 #include <cuml/common/logger.hpp>
 #include <cuml/decomposition/pca_mg.hpp>
+
 #include <cumlprims/opg/linalg/gemm.hpp>
 #include <cumlprims/opg/matrix/matrix_utils.hpp>
-#include <gtest/gtest.h>
+#include <raft/comms/mpi_comms.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <test_utils.h>
 
-#include <raft/comms/mpi_comms.hpp>
+#include <gtest/gtest.h>
+#include <test_utils.h>
 
 namespace MLCommon {
 namespace Test {

--- a/cpp/test/mg/test_opg_utils.h
+++ b/cpp/test/mg/test_opg_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 #pragma once
 
+#include <raft/util/cuda_utils.cuh>
+
 #include <gtest/gtest.h>
 #include <mpi.h>
-#include <raft/util/cuda_utils.cuh>
 
 namespace MLCommon {
 namespace Test {

--- a/cpp/test/prims/add_sub_dev_scalar.cu
+++ b/cpp/test/prims/add_sub_dev_scalar.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,17 @@
  */
 
 #include "test_utils.h"
-#include <gtest/gtest.h>
+
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/subtract.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 
 namespace raft {
 namespace linalg {

--- a/cpp/test/prims/batched/csr.cu
+++ b/cpp/test/prims/batched/csr.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-#include <linalg_naive.h>
-#include <test_utils.h>
-
-#include <linalg/batched/matrix.cuh>
-#include <sparse/batched/csr.cuh>
-
 #include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
+#include <linalg/batched/matrix.cuh>
+#include <linalg_naive.h>
+#include <sparse/batched/csr.cuh>
+#include <test_utils.h>
 
 #include <cstddef>
 #include <random>

--- a/cpp/test/prims/batched/gemv.cu
+++ b/cpp/test/prims/batched/gemv.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include "../test_utils.h"
-#include <gtest/gtest.h>
-#include <linalg/batched/gemv.cuh>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <linalg/batched/gemv.cuh>
 #include <test_utils.h>
 
 namespace MLCommon {

--- a/cpp/test/prims/batched/make_symm.cu
+++ b/cpp/test/prims/batched/make_symm.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 
 #include "../test_utils.h"
-#include <gtest/gtest.h>
-#include <linalg/batched/make_symm.cuh>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
+#include <linalg/batched/make_symm.cuh>
 #include <test_utils.h>
 
 namespace MLCommon {

--- a/cpp/test/prims/batched/matrix.cu
+++ b/cpp/test/prims/batched/matrix.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-#include <linalg_naive.h>
-#include <test_utils.h>
-
-#include <linalg/batched/matrix.cuh>
-
+#include <raft/core/math.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <linalg/batched/matrix.cuh>
+#include <linalg_naive.h>
+#include <test_utils.h>
 
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <gtest/gtest.h>
-#include <raft/core/math.hpp>
 #include <random>
 #include <vector>
 

--- a/cpp/test/prims/decoupled_lookback.cu
+++ b/cpp/test/prims/decoupled_lookback.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 
 #include "test_utils.h"
-#include <decoupled_lookback.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/core/interruptible.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <decoupled_lookback.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 

--- a/cpp/test/prims/device_utils.cu
+++ b/cpp/test/prims/device_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,15 @@
  */
 
 #include "test_utils.h"
+
 #include <common/device_utils.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/core/interruptible.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 

--- a/cpp/test/prims/dist_adj.cu
+++ b/cpp/test/prims/dist_adj.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,13 @@
  */
 
 #include "test_utils.h"
-#include <distance/distance.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <distance/distance.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Distance {

--- a/cpp/test/prims/distance_base.cuh
+++ b/cpp/test/prims/distance_base.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,15 @@
  */
 
 #include "test_utils.h"
-#include <distance/distance.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <distance/distance.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Distance {

--- a/cpp/test/prims/eltwise2d.cu
+++ b/cpp/test/prims/eltwise2d.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include "test_utils.h"
-#include <gtest/gtest.h>
-#include <linalg/eltwise2d.cuh>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <linalg/eltwise2d.cuh>
 
 namespace MLCommon {
 namespace LinAlg {

--- a/cpp/test/prims/fast_int_div.cu
+++ b/cpp/test/prims/fast_int_div.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,14 @@
  */
 
 #include "test_utils.h"
+
 #include <common/fast_int_div.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 

--- a/cpp/test/prims/fillna.cu
+++ b/cpp/test/prims/fillna.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
-#include <random>
-#include <vector>
+#include "test_utils.h"
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
-#include "test_utils.h"
-
+#include <gtest/gtest.h>
 #include <timeSeries/fillna.cuh>
+
+#include <random>
+#include <vector>
 
 namespace MLCommon {
 namespace TimeSeries {

--- a/cpp/test/prims/grid_sync.cu
+++ b/cpp/test/prims/grid_sync.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,14 @@
  */
 
 #include "test_utils.h"
+
 #include <common/grid_sync.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 

--- a/cpp/test/prims/hinge.cu
+++ b/cpp/test/prims/hinge.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include "test_utils.h"
-#include <functions/hinge.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <functions/hinge.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Functions {

--- a/cpp/test/prims/jones_transform.cu
+++ b/cpp/test/prims/jones_transform.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION. *
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION. *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,14 +13,18 @@
  * limitations under the License.
  */
 #include "test_utils.h"
-#include <algorithm>
-#include <gtest/gtest.h>
-#include <iostream>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
-#include <random>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <timeSeries/jones_transform.cuh>
+
+#include <algorithm>
+#include <iostream>
+#include <random>
 
 namespace MLCommon {
 namespace TimeSeries {

--- a/cpp/test/prims/knn_classify.cu
+++ b/cpp/test/prims/knn_classify.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,19 @@
  */
 
 #include "test_utils.h"
-#include <gtest/gtest.h>
-#include <iostream>
+
 #include <raft/label/classlabels.cuh>
 #include <raft/random/make_blobs.cuh>
 #include <raft/spatial/knn/knn.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <selection/knn.cuh>
+
+#include <iostream>
 #include <vector>
 
 namespace MLCommon {

--- a/cpp/test/prims/knn_regression.cu
+++ b/cpp/test/prims/knn_regression.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,7 @@
 
 #include "test_utils.h"
 
-#include <gtest/gtest.h>
-
 #include <raft/label/classlabels.cuh>
-
 #include <raft/linalg/reduce.cuh>
 #include <raft/random/rng.cuh>
 #include <raft/spatial/knn/knn.cuh>
@@ -28,11 +25,12 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <selection/knn.cuh>
-
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/extrema.h>
+
+#include <gtest/gtest.h>
+#include <selection/knn.cuh>
 
 #include <iostream>
 #include <vector>

--- a/cpp/test/prims/kselection.cu
+++ b/cpp/test/prims/kselection.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <gtest/gtest.h>
-#include <limits>
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
 #include <selection/kselection.cuh>
 #include <stdlib.h>
+
+#include <algorithm>
+#include <limits>
 
 namespace MLCommon {
 namespace Selection {

--- a/cpp/test/prims/linalg_block.cu
+++ b/cpp/test/prims/linalg_block.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include "test_utils.h"
 
-#include <random>
-#include <vector>
+#include <cuml/common/logger.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-#include "test_utils.h"
-
-#include <cuml/common/logger.hpp>
-
+#include <gtest/gtest.h>
 #include <linalg/block.cuh>
+
+#include <random>
+#include <vector>
 
 namespace MLCommon {
 namespace LinAlg {

--- a/cpp/test/prims/linearReg.cu
+++ b/cpp/test/prims/linearReg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include "test_utils.h"
-#include <functions/linearReg.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <functions/linearReg.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Functions {

--- a/cpp/test/prims/log.cu
+++ b/cpp/test/prims/log.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,13 @@
  */
 
 #include "test_utils.h"
+
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+
 #include <functions/log.cuh>
 #include <gtest/gtest.h>
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
 
 namespace MLCommon {
 namespace Functions {

--- a/cpp/test/prims/logisticReg.cu
+++ b/cpp/test/prims/logisticReg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include "test_utils.h"
-#include <functions/logisticReg.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <functions/logisticReg.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Functions {

--- a/cpp/test/prims/make_arima.cu
+++ b/cpp/test/prims/make_arima.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <thrust/count.h>
-#include <thrust/device_vector.h>
-
 #include "test_utils.h"
+
 #include <raft/core/interruptible.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+
+#include <gtest/gtest.h>
 #include <random/make_arima.cuh>
 
 namespace MLCommon {

--- a/cpp/test/prims/penalty.cu
+++ b/cpp/test/prims/penalty.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include "test_utils.h"
-#include <functions/penalty.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <functions/penalty.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Functions {

--- a/cpp/test/prims/sigmoid.cu
+++ b/cpp/test/prims/sigmoid.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 
 #include "test_utils.h"
-#include <functions/sigmoid.cuh>
-#include <gtest/gtest.h>
+
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <functions/sigmoid.cuh>
+#include <gtest/gtest.h>
 
 namespace MLCommon {
 namespace Functions {

--- a/cpp/test/prims/test_utils.h
+++ b/cpp/test/prims/test_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
  */
 
 #pragma once
-#include <gtest/gtest.h>
-#include <iostream>
-#include <memory>
 #include <raft/core/interruptible.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <memory>
 
 namespace MLCommon {
 

--- a/cpp/test/sg/cd_test.cu
+++ b/cpp/test/sg/cd_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,17 @@
 
 #include <cuml/solvers/params.hpp>
 #include <cuml/solvers/solver.hpp>
-#include <gtest/gtest.h>
-#include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
-#include <rmm/device_uvector.hpp>
-#include <test_utils.h>
 
+#include <raft/core/handle.hpp>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/meanvar.cuh>
 #include <raft/stats/stddev.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
+#include <test_utils.h>
 
 namespace ML {
 namespace Solver {

--- a/cpp/test/sg/dbscan_test.cu
+++ b/cpp/test/sg/dbscan_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <vector>
-
 #include <cuml/cluster/dbscan.hpp>
+#include <cuml/common/logger.hpp>
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/metrics/metrics.hpp>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
 #include <raft/distance/distance_types.hpp>
@@ -27,9 +26,10 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
+#include <gtest/gtest.h>
 #include <test_utils.h>
 
-#include <cuml/common/logger.hpp>
+#include <vector>
 
 namespace ML {
 

--- a/cpp/test/sg/experimental/fil/raft_proto/buffer.cpp
+++ b/cpp/test/sg/experimental/fil/raft_proto/buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/exceptions.hpp>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/cpp/test/sg/experimental/fil/raft_proto/buffer.cu
+++ b/cpp/test/sg/experimental/fil/raft_proto/buffer.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-#include <cuda_runtime_api.h>
 #include <cuml/experimental/fil/detail/raft_proto/buffer.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_check.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/cuda_stream.hpp>
 #include <cuml/experimental/fil/detail/raft_proto/device_type.hpp>
+
+#include <cuda_runtime_api.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include <iostream>
 
 namespace raft_proto {

--- a/cpp/test/sg/fil_child_index_test.cu
+++ b/cpp/test/sg/fil_child_index_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #include "../../src/fil/internal.cuh"
 
-#include <test_utils.h>
-
 #include <cuml/fil/fil.h>
+
 #include <gtest/gtest.h>
+#include <test_utils.h>
 
 #include <cmath>
 #include <cstdio>

--- a/cpp/test/sg/fil_test.cu
+++ b/cpp/test/sg/fil_test.cu
@@ -16,28 +16,26 @@
 
 #include "../../src/fil/internal.cuh"
 
-#include <test_utils.h>
-
 #include <cuml/fil/fil.h>
 
 #include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <test_utils.h>
+
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+#include <gtest/gtest.h>
+#include <test_utils.h>
 #include <treelite/c_api.h>
 #include <treelite/enum/operator.h>
 #include <treelite/enum/task_type.h>
 #include <treelite/enum/typeinfo.h>
 #include <treelite/model_builder.h>
 #include <treelite/tree.h>
-
-#include <gtest/gtest.h>
 
 #include <cmath>
 #include <cstdio>

--- a/cpp/test/sg/fnv_hash_test.cpp
+++ b/cpp/test/sg/fnv_hash_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 
 #include <cuml/fil/fnv_hash.h>
-#include <gtest/gtest.h>
+
 #include <raft/core/error.hpp>
+
+#include <gtest/gtest.h>
 
 struct fnv_vec_t {
   std::vector<char> input;

--- a/cpp/test/sg/genetic/evolution_test.cu
+++ b/cpp/test/sg/genetic/evolution_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <cmath>
 #include <cuml/common/logger.hpp>
 #include <cuml/genetic/common.h>
 #include <cuml/genetic/genetic.h>
 #include <cuml/genetic/node.h>
 #include <cuml/genetic/program.h>
-#include <gtest/gtest.h>
-#include <iostream>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
 #include <vector>
 
 namespace cuml {

--- a/cpp/test/sg/genetic/node_test.cpp
+++ b/cpp/test/sg/genetic/node_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 
 #include <cuml/genetic/node.h>
-#include <gtest/gtest.h>
+
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
 
 namespace cuml {
 namespace genetic {

--- a/cpp/test/sg/genetic/param_test.cu
+++ b/cpp/test/sg/genetic/param_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include "../../prims/test_utils.h"
+
 #include <cuml/genetic/common.h>
+
 #include <gtest/gtest.h>
 
 namespace cuml {

--- a/cpp/test/sg/genetic/program_test.cu
+++ b/cpp/test/sg/genetic/program_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-#include <cmath>
 #include <cuml/common/logger.hpp>
 #include <cuml/genetic/common.h>
 #include <cuml/genetic/node.h>
 #include <cuml/genetic/program.h>
-#include <gtest/gtest.h>
-#include <iostream>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <cmath>
+#include <iostream>
 #include <vector>
 
 namespace cuml {

--- a/cpp/test/sg/handle_test.cu
+++ b/cpp/test/sg/handle_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <cuml/cuml_api.h>
+
 #include <raft/core/handle.hpp>
 
-#include <cuml/cuml_api.h>
+#include <gtest/gtest.h>
 
 TEST(HandleTest, CreateHandleAndDestroy)
 {

--- a/cpp/test/sg/hdbscan_inputs.hpp
+++ b/cpp/test/sg/hdbscan_inputs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuml/cluster/hdbscan.hpp>
+
 #include <datasets/digits.h>
 
 #include <vector>

--- a/cpp/test/sg/hdbscan_test.cu
+++ b/cpp/test/sg/hdbscan_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,33 +14,32 @@
  * limitations under the License.
  */
 
+#include "../prims/test_utils.h"
 #include "hdbscan_inputs.hpp"
-#include <raft/core/handle.hpp>
-
-#include <gtest/gtest.h>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-#include <vector>
 
 #include <cuml/cluster/hdbscan.hpp>
-#include <hdbscan/detail/condense.cuh>
-#include <hdbscan/detail/extract.cuh>
-#include <hdbscan/detail/reachability.cuh>
-
-#include <raft/stats/adjusted_rand_index.cuh>
 
 #include <raft/cluster/detail/agglomerative.cuh>
-
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/linalg/transpose.cuh>
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/op/sort.cuh>
+#include <raft/stats/adjusted_rand_index.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
 
-#include "../prims/test_utils.h"
+#include <gtest/gtest.h>
+#include <hdbscan/detail/condense.cuh>
+#include <hdbscan/detail/extract.cuh>
+#include <hdbscan/detail/reachability.cuh>
+
+#include <vector>
 
 namespace ML {
 namespace HDBSCAN {

--- a/cpp/test/sg/holtwinters_test.cu
+++ b/cpp/test/sg/holtwinters_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,21 @@
  */
 
 #include "time_series_datasets.h"
-#include <algorithm>
-#include <raft/core/handle.hpp>
 
 #include <cuml/common/logger.hpp>
 #include <cuml/tsa/holtwinters.h>
-#include <gtest/gtest.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/core/math.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <algorithm>
 
 namespace ML {
 

--- a/cpp/test/sg/knn_test.cu
+++ b/cpp/test/sg/knn_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <iostream>
-#include <raft/core/handle.hpp>
+#include <cuml/datasets/make_blobs.hpp>
+#include <cuml/neighbors/knn.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <iostream>
 #include <vector>
-
-#include <cuml/datasets/make_blobs.hpp>
-
-#include <cuml/neighbors/knn.hpp>
 
 namespace ML {
 

--- a/cpp/test/sg/lars_test.cu
+++ b/cpp/test/sg/lars_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <iomanip>
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+
+#include <iomanip>
 // #TODO: Replace with public header when ready
 #include <raft/linalg/detail/cusolver_wrappers.hpp>
 #include <raft/random/rng.cuh>
+
 #include <rmm/device_uvector.hpp>
+
 #include <solver/lars_impl.cuh>
-#include <sstream>
 #include <test_utils.h>
+
+#include <sstream>
 #include <vector>
 
 namespace ML {

--- a/cpp/test/sg/linear_svm_test.cu
+++ b/cpp/test/sg/linear_svm_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-#include <cmath>
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/datasets/make_regression.hpp>
 #include <cuml/svm/linear.hpp>
-#include <raft/core/handle.hpp>
 
-#include <gtest/gtest.h>
+#include <raft/core/handle.hpp>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/linalg/reduce.cuh>
 #include <raft/linalg/transpose.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/random/rng.cuh>
+
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <cmath>
 
 namespace ML {
 namespace SVM {

--- a/cpp/test/sg/linkage_test.cu
+++ b/cpp/test/sg/linkage_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <raft/core/handle.hpp>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-#include <vector>
-
 #include <cuml/cluster/linkage.hpp>
+#include <cuml/common/logger.hpp>
 #include <cuml/datasets/make_blobs.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/linalg/transpose.cuh>
 #include <raft/sparse/coo.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <cuml/common/logger.hpp>
-
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <vector>
 
 namespace ML {
 

--- a/cpp/test/sg/logger.cpp
+++ b/cpp/test/sg/logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 
 #include <cuml/common/logger.hpp>
+
 #include <gtest/gtest.h>
+
 #include <string>
 
 namespace ML {

--- a/cpp/test/sg/multi_sum_test.cu
+++ b/cpp/test/sg/multi_sum_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-#include <test_utils.h>
-
 #include <cuml/fil/multi_sum.cuh>
-#include <raft/core/handle.hpp>
 
+#include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
@@ -28,6 +26,7 @@
 #include <thrust/host_vector.h>
 
 #include <gtest/gtest.h>
+#include <test_utils.h>
 
 #include <cstddef>
 

--- a/cpp/test/sg/ols.cu
+++ b/cpp/test/sg/ols.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,17 @@
  */
 
 #include <cuml/linear_model/glm.hpp>
-#include <gtest/gtest.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
 #include <vector>
 
 namespace ML {

--- a/cpp/test/sg/pca_test.cu
+++ b/cpp/test/sg/pca_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,16 @@
  */
 
 #include <cuml/decomposition/params.hpp>
-#include <gtest/gtest.h>
-#include <pca/pca.cuh>
+
 #include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <pca/pca.cuh>
 #include <test_utils.h>
+
 #include <vector>
 
 namespace ML {

--- a/cpp/test/sg/quasi_newton.cu
+++ b/cpp/test/sg/quasi_newton.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,18 @@
  */
 
 #include <cuml/linear_model/glm.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/linalg/transpose.cuh>
+#include <raft/util/cudart_utils.hpp>
+
 #include <glm/qn/glm_linear.cuh>
 #include <glm/qn/glm_logistic.cuh>
 #include <glm/qn/glm_softmax.cuh>
 #include <glm/qn/qn.cuh>
 #include <gtest/gtest.h>
-#include <raft/core/handle.hpp>
-#include <raft/linalg/transpose.cuh>
-#include <raft/util/cudart_utils.hpp>
 #include <test_utils.h>
+
 #include <vector>
 
 namespace ML {

--- a/cpp/test/sg/rf_test.cu
+++ b/cpp/test/sg/rf_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 #include <cuml/common/logger.hpp>
-#include <test_utils.h>
-
-#include <decisiontree/batched-levelalgo/kernels/builder_kernels.cuh>
-#include <decisiontree/batched-levelalgo/quantiles.cuh>
-#include <raft/core/handle.hpp>
-
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/ensemble/randomforest.hpp>
 #include <cuml/fil/fil.h>
 #include <cuml/tree/algo_helper.h>
-#include <raft/random/rng.cuh>
 
 #include <raft/core/handle.hpp>
 #include <raft/linalg/transpose.cuh>
+#include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
@@ -44,7 +38,10 @@
 #include <thrust/shuffle.h>
 #include <thrust/transform.h>
 
+#include <decisiontree/batched-levelalgo/kernels/builder_kernels.cuh>
+#include <decisiontree/batched-levelalgo/quantiles.cuh>
 #include <gtest/gtest.h>
+#include <test_utils.h>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/test/sg/ridge.cu
+++ b/cpp/test/sg/ridge.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 
 #include <cuml/linear_model/glm.hpp>
-#include <gtest/gtest.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
 
 namespace ML {

--- a/cpp/test/sg/rproj_test.cu
+++ b/cpp/test/sg/rproj_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,18 @@
 
 #include <cuml/metrics/metrics.hpp>
 #include <cuml/random_projection/rproj_c.h>
-#include <gtest/gtest.h>
-#include <iostream>
+
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
 #include <raft/linalg/transpose.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <random>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
+
+#include <iostream>
+#include <random>
 #include <vector>
 
 namespace ML {

--- a/cpp/test/sg/sgd.cu
+++ b/cpp/test/sg/sgd.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
 #include <solver/sgd.cuh>
 #include <test_utils.h>
 

--- a/cpp/test/sg/shap_kernel.cu
+++ b/cpp/test/sg/shap_kernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 
 #include <cuml/explainer/kernel_shap.hpp>
 
-#include <test_utils.h>
-
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/count.h>

--- a/cpp/test/sg/svc_test.cu
+++ b/cpp/test/sg/svc_test.cu
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-#include <cub/cub.cuh>
 #include <cuml/common/logger.hpp>
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/svm/svc.hpp>
 #include <cuml/svm/svm_model.h>
 #include <cuml/svm/svm_parameter.h>
 #include <cuml/svm/svr.hpp>
-#include <gtest/gtest.h>
-#include <iostream>
+
 #include <raft/core/math.hpp>
 #include <raft/distance/kernels.cuh>
 #include <raft/linalg/add.cuh>
@@ -31,12 +29,10 @@
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
-#include <string>
-#include <svm/smoblocksolve.cuh>
-#include <svm/smosolver.cuh>
-#include <svm/workingset.cuh>
-#include <test_utils.h>
+
+#include <cub/cub.cuh>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
@@ -44,6 +40,15 @@
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
+
+#include <gtest/gtest.h>
+#include <svm/smoblocksolve.cuh>
+#include <svm/smosolver.cuh>
+#include <svm/workingset.cuh>
+#include <test_utils.h>
+
+#include <iostream>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/cpp/test/sg/trustworthiness_test.cu
+++ b/cpp/test/sg/trustworthiness_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 #include <cuml/metrics/metrics.hpp>
 
-#include <gtest/gtest.h>
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
+
+#include <gtest/gtest.h>
+
 #include <vector>
 
 using namespace ML::Metrics;

--- a/cpp/test/sg/tsne_test.cu
+++ b/cpp/test/sg/tsne_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,29 @@
  * limitations under the License.
  */
 
+#include <cuml/common/logger.hpp>
 #include <cuml/manifold/tsne.h>
 #include <cuml/metrics/metrics.hpp>
+
+#include <raft/core/handle.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/linalg/map.cuh>
+#include <raft/util/cudart_utils.hpp>
 
-#include <cuml/common/logger.hpp>
+#include <thrust/reduce.h>
+
 #include <datasets/boston.h>
 #include <datasets/breast_cancer.h>
 #include <datasets/diabetes.h>
 #include <datasets/digits.h>
 #include <gtest/gtest.h>
-#include <iostream>
-#include <raft/core/handle.hpp>
-
-#include <raft/util/cudart_utils.hpp>
 #include <stdio.h>
 #include <stdlib.h>
-#include <thrust/reduce.h>
 #include <tsne/distances.cuh>
 #include <tsne/tsne_runner.cuh>
 #include <tsne/utils.cuh>
+
+#include <iostream>
 #include <vector>
 
 using namespace MLCommon;

--- a/cpp/test/sg/tsvd_test.cu
+++ b/cpp/test/sg/tsvd_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,15 @@
  */
 
 #include <cuml/decomposition/params.hpp>
-#include <gtest/gtest.h>
+
 #include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
 #include <test_utils.h>
 #include <tsvd/tsvd.cuh>
+
 #include <vector>
 
 namespace ML {

--- a/cpp/test/sg/umap_parametrizable_test.cu
+++ b/cpp/test/sg/umap_parametrizable_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,23 @@
  * limitations under the License.
  */
 
-#include <test_utils.h>
-
-#include <raft/core/handle.hpp>
-#include <umap/runner.cuh>
-
 #include <cuml/datasets/make_blobs.hpp>
 #include <cuml/manifold/umap.hpp>
 #include <cuml/manifold/umapparams.h>
 #include <cuml/metrics/metrics.hpp>
 #include <cuml/neighbors/knn.hpp>
-#include <datasets/digits.h>
-
-#include <test_utils.h>
-
-#include <datasets/digits.h>
-#include <raft/linalg/reduce_rows_by_key.cuh>
-#include <raft/spatial/knn/knn.cuh>
 
 #include <raft/core/handle.hpp>
 #include <raft/distance/distance.cuh>
+#include <raft/linalg/reduce_rows_by_key.cuh>
+#include <raft/spatial/knn/knn.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
-#include <umap/runner.cuh>
 
+#include <datasets/digits.h>
 #include <gtest/gtest.h>
+#include <test_utils.h>
+#include <umap/runner.cuh>
 
 #include <cstddef>
 #include <iostream>


### PR DESCRIPTION
## Description
This uses the `IncludeCategories` settings in` .clang-format` to automate include ordering and grouping and to make include ordering more consistent with the rest of RAPIDS. For discussion, see https://github.com/rapidsai/cudf/pull/15063. This PR uses a similar set of header grouping categories used in that PR, adapted for cuML.

One purpose of this is to make it easier to automate injection of a header change with an upcoming RMM refactoring (and in the future).

The header reordering in this PR uncovered multiple places where headers were not included where they are used. Most commonly this was a missing `#include <raft/core/handle.hpp>`

Closes #5779
