### PR TITLE
Suppress a hypothesis HealthCheck on test_split_datasets that fails in nightly CI.

### DIFF
--- a/python/cuml/tests/test_strategies.py
+++ b/python/cuml/tests/test_strategies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -98,7 +98,9 @@ def test_standard_datasets(dataset):
 
 
 @given(split_datasets(standard_datasets()))
-@settings(suppress_health_check=[HealthCheck.too_slow])
+@settings(
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large]
+)
 def test_split_datasets(split_dataset):
     X_train, X_test, y_train, y_test = split_dataset
 


### PR DESCRIPTION
Fixes a HealthCheck error in nightly CI on `test_split_datasets`:

```
_____________________________ test_split_datasets ______________________________
[gw0] linux -- Python 3.9.18 /opt/conda/envs/test/bin/python3.9

    @given(split_datasets(standard_datasets()))
>   @settings(suppress_health_check=[HealthCheck.too_slow])
E   hypothesis.errors.FailedHealthCheck: Examples routinely exceeded the max allowable size. (20 examples overran while generating 2 valid ones). Generating examples this large will usually lead to bad results. You could try setting max_size parameters on your collections and turning max_leaves down on recursive() calls.
E   See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.data_too_large to the suppress_health_check settings for this test.

test_strategies.py:101: FailedHealthCheck
```

Also, from a different run:
```
FAILED test_strategies.py::test_split_datasets - hypothesis.errors.FailedHealthCheck: Examples routinely exceeded the max allowable size. (20 examples overran while generating 3 valid ones). Generating examples this large will usually lead to bad results. You could try setting max_size parameters on your collections and turning max_leaves down on recursive() calls.
```
