### PR TITLE
Suppress all HealthChecks on test_split_datasets.

### DIFF
--- a/python/cuml/tests/test_strategies.py
+++ b/python/cuml/tests/test_strategies.py
@@ -98,9 +98,7 @@ def test_standard_datasets(dataset):
 
 
 @given(split_datasets(standard_datasets()))
-@settings(
-    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large]
-)
+@settings(suppress_health_check=list(HealthCheck))
 def test_split_datasets(split_dataset):
     X_train, X_test, y_train, y_test = split_dataset
 


### PR DESCRIPTION
Follow-up to #5790. We suppressed `HealthCheck.too_slow` and `HealthCheck.data_too_large`, but another failure appeared with `HealthCheck.filter_too_much`. Instead, we should just skip all health checks for this test.

```
=========================== short test summary info ============================
FAILED test_strategies.py::test_split_datasets - hypothesis.errors.FailedHealthCheck: It looks like your strategy is filtering out a lot of data. Health check found 50 filtered examples but only 4 good ones. This will make your tests much slower, and also will probably distort the data generation quite a lot. You should adapt your strategy to filter less. This can also be caused by a low max_leaves parameter in recursive() calls
See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.filter_too_much to the suppress_health_check settings for this test.
= 1 failed, 13454 passed, 5886 skipped, 632 xfailed, 54 xpassed, 10155 warnings in 1659.57s (0:27:39) =
```
