### PR TITLE
Remove use of cudf.core.column.full.

### DIFF
--- a/python/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
+++ b/python/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ def get_str_replacement_series(replacement, bool_mask):
     Get replacement series with replacement at
     Places marked by bool mask and empty other wise
     """
-    word_ser = cudf.Series(cudf.core.column.full(len(bool_mask), ""))
+    word_ser = cudf.Series([""] * len(bool_mask))
     word_ser.iloc[bool_mask] = replacement
 
     return word_ser


### PR DESCRIPTION
CI is failing because some functions use `cudf.core.column.full` which was recently removed. This PR changes that to a supported constructor.

xref: https://github.com/rapidsai/cudf/pull/14698

cc: @mroeschke @galipremsagar