### PR TITLE
Use public cudf APIs where possible

### DIFF
--- a/python/cuml/tests/dask/test_dask_kneighbors_regressor.py
+++ b/python/cuml/tests/dask/test_dask_kneighbors_regressor.py
@@ -31,7 +31,7 @@ import dask.dataframe as dd
 from cuml.dask.common.dask_arr_utils import to_dask_cudf
 from cuml.internals.safe_imports import gpu_only_import_from
 
-DataFrame = gpu_only_import_from("cudf.core.dataframe", "DataFrame")
+DataFrame = gpu_only_import_from("cudf", "DataFrame")
 np = cpu_only_import("numpy")
 cudf = gpu_only_import("cudf")
 

--- a/python/cuml/tests/explainer/test_sampling.py
+++ b/python/cuml/tests/explainer/test_sampling.py
@@ -63,7 +63,7 @@ def test_kmeans_input(input_type):
         assert isinstance(summary[0], np.ndarray)
     elif input_type == "cudf-series":
         cp.testing.assert_array_equal(summary[0].values.tolist(), [23.0, 52.0])
-        assert isinstance(summary[0], cudf.core.series.Series)
+        assert isinstance(summary[0], cudf.Series)
     elif input_type == "pandas-series":
         cp.testing.assert_array_equal(
             summary[0].to_numpy().flatten(), [23.0, 52.0]

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -779,6 +779,7 @@ def test_logistic_regression_input_type_consistency(constructor, dtype):
     else:
         assert isinstance(clf.predict(X), type(X))
 
+
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("test_dtype", [np.float64, np.float32])
 def test_linreg_predict_convert_dtype(train_dtype, test_dtype):

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -769,19 +769,15 @@ def test_logistic_regression_predict_proba(
 @pytest.mark.parametrize("constructor", [np.array, cp.array, cudf.DataFrame])
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
 def test_logistic_regression_input_type_consistency(constructor, dtype):
-    from cudf.core.frame import Frame
-
     X = constructor([[5, 10], [3, 1], [7, 8]]).astype(dtype)
     y = constructor([0, 1, 1]).astype(dtype)
     clf = cuLog().fit(X, y, convert_dtype=True)
 
-    original_type = type(X)
+    assert isinstance(clf.predict_proba(X), type(X))
     if constructor == cudf.DataFrame:
-        original_type = Frame
-
-    assert isinstance(clf.predict_proba(X), original_type)
-    assert isinstance(clf.predict(X), original_type)
-
+        assert isinstance(clf.predict(X), cudf.Series)
+    else:
+        assert isinstance(clf.predict(X), type(X))
 
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("test_dtype", [np.float64, np.float32])

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -774,10 +774,8 @@ def test_logistic_regression_input_type_consistency(constructor, dtype):
     clf = cuLog().fit(X, y, convert_dtype=True)
 
     assert isinstance(clf.predict_proba(X), type(X))
-    if constructor == cudf.DataFrame:
-        assert isinstance(clf.predict(X), cudf.Series)
-    else:
-        assert isinstance(clf.predict(X), type(X))
+    expected_type = cudf.Series if constructor == cudf.DataFrame else type(X)
+    assert isinstance(clf.predict(X), expected_type)
 
 
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])


### PR DESCRIPTION
Avoiding `core` imports as they tend to be "private"