### PR TITLE
Add upper bound to prevent usage of NumPy 2

### DIFF
--- a/conda/recipes/cuml-cpu/meta.yaml
+++ b/conda/recipes/cuml-cpu/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - cython>=3.0.0
   run:
     - python x.x
-    - numpy>=1.23
+    - numpy>=1.23,<2.0a0
     - pandas
     - scikit-learn=1.2
     - hdbscan<=0.8.30


### PR DESCRIPTION
NumPy 2 is expected to be released in the near future. For the RAPIDS 24.04 release, we will pin to `numpy>=1.23,<2.0a0`. This PR adds an upper bound to affected RAPIDS repositories.

xref: https://github.com/rapidsai/build-planning/issues/29
