### PR TITLE
Use pytest_cases.fixture to fix warnings.

### DIFF
--- a/python/cuml/tests/test_device_selection.py
+++ b/python/cuml/tests/test_device_selection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ from sklearn.linear_model import LinearRegression as skLinearRegression
 from sklearn.decomposition import PCA as skPCA
 from sklearn.decomposition import TruncatedSVD as skTruncatedSVD
 from sklearn.datasets import make_regression, make_blobs
-from pytest_cases import fixture_union, fixture_plus
+from pytest_cases import fixture_union, fixture
 from importlib import import_module
 import inspect
 import pickle
@@ -195,7 +195,7 @@ def fixture_generation_helper(params):
     return {"scope": "session", "params": param_combis, "ids": ids}
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -232,7 +232,7 @@ def linreg_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -274,7 +274,7 @@ def logreg_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -314,7 +314,7 @@ def lasso_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -354,7 +354,7 @@ def elasticnet_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -389,7 +389,7 @@ def ridge_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["cupy"],
@@ -437,7 +437,7 @@ def umap_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -477,7 +477,7 @@ def pca_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
@@ -516,7 +516,7 @@ def tsvd_test_data(request):
     }
 
 
-@fixture_plus(
+@fixture(
     **fixture_generation_helper(
         {
             "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],


### PR DESCRIPTION
This PR fixes some warnings in tests by using `pytest_cases.fixture` instead of `pytest_cases.fixture_plus`.

```
test_device_selection.py:198
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:198: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:235
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:235: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:277
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:277: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:317
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:317: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:357
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:357: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:392
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:392: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:440
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:440: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:480
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:480: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(

test_device_selection.py:519
  /__w/cuml/cuml/python/cuml/tests/test_device_selection.py:519: DeprecationWarning: `pytest_fixture_plus` and `fixture_plus` are deprecated. Please use the new alias `fixture`. See https://github.com/pytest-dev/pytest/issues/6475
    @fixture_plus(
```
