### PR TITLE
Handle binary classifier with all-0 labels

### DIFF
--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -264,7 +264,8 @@ void build_treelite_forest(TreeliteModelHandle* model_handle,
   }
 
   if constexpr (std::is_integral_v<L>) {
-    ASSERT(num_outputs > 1, "More than one variable expected for classification problem.");
+    num_outputs = std::max(num_outputs, 2);
+    // Ensure that num_outputs is at least 2
     model->task_type     = tl::TaskType::kMultiClf;
     model->postprocessor = "identity_multiclass";
   } else {


### PR DESCRIPTION
**Bug**: Currently, cuML RandomForestClassifier fails with error `More than one variable expected for classification problem` when the labels are all 0's. The error arises when the RandomForestClassifier object is translated into a Treelite object.

**Minimal reproducer**:

```python
from cuml.ensemble import RandomForestClassifier
import numpy as np

X = np.array([[3, 2], [2, 3]], dtype=np.float32)
y = np.array([0, 0], dtype=np.int32)

clf = RandomForestClassifier(max_depth=1)
clf.fit(X, y)
clf.predict(X)   # fails here
```

**Fix**. When RandomForestClassifier produces a single output, zero-pad it to length 2 before passing it to Treelite.