### PR TITLE
When using CUDA 12.4+ use zstd compression

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -37,6 +37,10 @@ endif()
 
 # make sure we produce smallest binary size
 list(APPEND CUML_CUDA_FLAGS -Xfatbin=-compress-all)
+if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
+   CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.4.0)
+  list(APPEND CUML_CUDA_FLAGS -Xfatbin=-compress-algo=5)
+endif()
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
 if(CUDA_ENABLE_LINE_INFO)


### PR DESCRIPTION
The zsd compression with nvcc 12.4 produces significantly ( 20-40% ) smaller
binaries with no impact on runtime or compile time performance.
