### PR TITLE
DOC Add basic example gallery infrastructure and two examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ docs/source/*.model
 docs/source/*.pkl
 docs/source/*.tl
 
+# Example gallery related files
+docs/source/sg_execution_times.rst
+docs/source/modules/generated/
+docs/source/auto_examples/
+
 ## eclipse
 .project
 .cproject

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -76,4 +76,5 @@ dependencies:
 - umap-learn==0.5.3
 - pip:
   - dask-glm==0.3.0
+  - sphinx-gallery
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -72,4 +72,5 @@ dependencies:
 - umap-learn==0.5.3
 - pip:
   - dask-glm==0.3.0
+  - sphinx-gallery
 name: all_cuda-122_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -361,6 +361,8 @@ dependencies:
           - sphinx<6
           - sphinx-copybutton
           - sphinx-markdown-tables
+          - pip:
+              - sphinx-gallery
       - output_types: conda
         packages:
           - doxygen=1.9.1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,7 +52,7 @@ cuML provides experimental support for running selected estimators and operators
    * - Regression and Classification
      - Ridge
 
-If a CUDA-enabled GPU is available on the system, cuML will default to using it. Users can configure CPU or GPU execution for supported operators via context managers or global configuration. 
+If a CUDA-enabled GPU is available on the system, cuML will default to using it. Users can configure CPU or GPU execution for supported operators via context managers or global configuration.
 
 .. code-block:: python
 
@@ -150,6 +150,7 @@ Feature Scaling and Normalization (Single-GPU)
     :members:
 .. autoclass:: cuml.preprocessing.StandardScaler
     :members:
+.. include:: modules/generated/cuml.preprocessing.StandardScaler.examples
 .. autofunction:: cuml.preprocessing.maxabs_scale
 .. autofunction:: cuml.preprocessing.minmax_scale
 .. autofunction:: cuml.preprocessing.normalize
@@ -455,11 +456,15 @@ K-Means Clustering
 .. autoclass:: cuml.KMeans
     :members:
 
+.. include:: modules/generated/cuml.KMeans.examples
+
 DBSCAN
 ------
 
 .. autoclass:: cuml.DBSCAN
     :members:
+
+.. include:: modules/generated/cuml.DBSCAN.examples
 
 Agglomerative Clustering
 ------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,8 +51,20 @@ extensions = [
     "nbsphinx",
     "recommonmark",
     "sphinx_markdown_tables",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
+    "sphinx_gallery.gen_gallery",
 ]
+
+sphinx_gallery_conf = {
+     'examples_dirs': ['../../examples'],
+     'gallery_dirs': ['auto_examples'],
+     "doc_module": "cuml",
+     "backreferences_dir": os.path.join("modules", "generated"),
+     'reference_url': {
+         # The module you locally document uses None
+        'cuml': None,
+    },
+}
 
 ipython_mplbackend = "str"
 
@@ -93,10 +105,10 @@ release = f"{CUML_VERSION.major:02}.{CUML_VERSION.minor:02}.{CUML_VERSION.micro:
 # Usually you set "language" from the command line for these cases.
 language = 'en'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = []
+# sphinx-gallery generates several files per example, need to ignore
+# the notebook and ".md" files (which in reality are ".md5" files)
+# because Markdown and notebooks are valid document sources
+exclude_patterns = ["auto_examples/**/*.md", "auto_examples/**/*.ipynb"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ Support for Windows is possible in the near future.
    api.rst
    user_guide.rst
    cuml_blogs.rst
+   auto_examples/index.rst
 
 
 Indices and tables

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,4 @@
+Example gallery
+===============
+
+Below is a gallery of examples showing how to use cuml.

--- a/examples/cluster/README.rst
+++ b/examples/cluster/README.rst
@@ -1,0 +1,6 @@
+.. _cluster_examples:
+
+Clustering
+----------
+
+Examples concerning the :mod:`cuml.cluster` module.

--- a/examples/cluster/plot_dbscan.py
+++ b/examples/cluster/plot_dbscan.py
@@ -1,0 +1,128 @@
+"""
+===================================
+Demo of DBSCAN clustering algorithm
+===================================
+
+Example adapted from `the scikit-learn gallery <https://scikit-learn.org/stable/auto_examples/cluster/plot_dbscan.html>`_.
+
+DBSCAN (Density-Based Spatial Clustering of Applications with Noise) finds core
+samples in regions of high density and expands clusters from them. This
+algorithm is good for data which contains clusters of similar density.
+
+"""
+
+# %%
+# Data generation
+# ---------------
+#
+# We use :class:`~sklearn.datasets.make_blobs` to create 3 synthetic clusters.
+
+import cupy as cp
+from cuml.datasets import make_blobs
+from cuml.preprocessing import StandardScaler
+
+centers = cp.array([[1, 1], [-1, -1], [1, -1]])
+X, labels_true = make_blobs(
+    n_samples=750, centers=centers, cluster_std=0.4, random_state=0
+)
+
+X = StandardScaler().fit_transform(X)
+
+# %%
+# We can visualize the resulting data:
+
+import matplotlib.pyplot as plt
+
+X_ = X.get()
+plt.scatter(X_[:, 0], X_[:, 1])
+plt.show()
+
+# %%
+# Compute DBSCAN
+# --------------
+#
+# One can access the labels assigned by :class:`~sklearn.cluster.DBSCAN` using
+# the `labels_` attribute. Noisy samples are given the label math:`-1`.
+
+import numpy as np
+
+from cuml import metrics
+from sklearn import metrics as sk_metrics
+from cuml.cluster import DBSCAN
+
+db = DBSCAN(eps=0.3, min_samples=10).fit(X)
+labels = db.labels_
+
+# Number of clusters in labels, ignoring noise if present.
+n_clusters_ = len(cp.unique(labels)) - (1 if -1 in labels else 0)
+n_noise_ = list(labels.get()).count(-1)
+
+print("Estimated number of clusters: %d" % n_clusters_)
+print("Estimated number of noise points: %d" % n_noise_)
+
+# %%
+# Clustering algorithms are fundamentally unsupervised learning methods.
+# However, since :class:`~sklearn.datasets.make_blobs` gives access to the true
+# labels of the synthetic clusters, it is possible to use evaluation metrics
+# that leverage this "supervised" ground truth information to quantify the
+# quality of the resulting clusters. Examples of such metrics are the
+# homogeneity, completeness, V-measure, Rand-Index, Adjusted Rand-Index and
+# Adjusted Mutual Information (AMI).
+#
+# If the ground truth labels are not known, evaluation can only be performed
+# using the model results itself. In that case, the Silhouette Coefficient comes
+# in handy.
+
+print(f"Homogeneity: {metrics.homogeneity_score(labels_true.astype(cp.int32), labels):.3f}")
+print(f"Completeness: {metrics.completeness_score(labels_true.astype(cp.int32), labels):.3f}")
+print(f"V-measure: {metrics.v_measure_score(labels_true.astype(cp.int32), labels):.3f}")
+print(f"Adjusted Rand Index: {metrics.adjusted_rand_score(labels_true.astype(cp.int32), labels):.3f}")
+print(
+    "Adjusted Mutual Information:"
+    f" {sk_metrics.adjusted_mutual_info_score(labels_true.astype(cp.int32).get(), labels.get()):.3f}"
+)
+print(f"Silhouette Coefficient: {sk_metrics.silhouette_score(X_, labels.get()):.3f}")
+
+# %%
+# Plot results
+# ------------
+#
+# Core samples (large dots) and non-core samples (small dots) are color-coded
+# according to the assigned cluster. Samples tagged as noise are represented in
+# black.
+
+unique_labels = cp.unique(labels)
+core_samples_mask = cp.zeros_like(labels, dtype=bool)
+core_samples_mask[db.core_sample_indices_] = True
+core_samples_mask = core_samples_mask.get()
+
+colors = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]
+for k, col in zip(unique_labels, colors):
+    if k == -1:
+        # Black used for noise.
+        col = [0, 0, 0, 1]
+
+    class_member_mask = (labels == k).get()
+
+    xy = X_[class_member_mask & core_samples_mask]
+    plt.plot(
+        xy[:, 0],
+        xy[:, 1],
+        "o",
+        markerfacecolor=tuple(col),
+        markeredgecolor="k",
+        markersize=14,
+    )
+
+    xy = X_[class_member_mask & ~core_samples_mask]
+    plt.plot(
+        xy[:, 0],
+        xy[:, 1],
+        "o",
+        markerfacecolor=tuple(col),
+        markeredgecolor="k",
+        markersize=6,
+    )
+
+plt.title(f"Estimated number of clusters: {n_clusters_}")
+plt.show()

--- a/examples/cluster/plot_kmeans_digits.py
+++ b/examples/cluster/plot_kmeans_digits.py
@@ -1,0 +1,205 @@
+"""
+===========================================================
+A demo of K-Means clustering on the handwritten digits data
+===========================================================
+
+Example adapted from `the scikit-learn gallery <https://scikit-learn.org/stable/auto_examples/cluster/plot_kmeans_digits.html>`_.
+
+In this example we compare the various initialization strategies for K-means in
+terms of runtime and quality of the results.
+
+As the ground truth is known here, we also apply different cluster quality
+metrics to judge the goodness of fit of the cluster labels to the ground truth.
+
+Cluster quality metrics evaluated:
+
+=========== ========================================================
+Shorthand    full name
+=========== ========================================================
+homo         homogeneity score
+compl        completeness score
+v-meas       V measure
+ARI          adjusted Rand index
+AMI          adjusted mutual information
+silhouette   silhouette coefficient
+=========== ========================================================
+
+"""
+
+# %%
+# Load the dataset
+# ----------------
+#
+# We will start by loading the `digits` dataset. This dataset contains
+# handwritten digits from 0 to 9. In the context of clustering, one would like
+# to group images such that the handwritten digits on the image are the same.
+
+import numpy as np
+
+from sklearn.datasets import load_digits
+
+data, labels = load_digits(return_X_y=True)
+(n_samples, n_features), n_digits = data.shape, np.unique(labels).size
+
+print(f"# digits: {n_digits}; # samples: {n_samples}; # features {n_features}")
+
+# %%
+# Define our evaluation benchmark
+# -------------------------------
+#
+# We will first our evaluation benchmark. During this benchmark, we intend to
+# compare different initialization methods for KMeans. Our benchmark will:
+#
+# * create a pipeline which will scale the data using a
+#   :class:`~sklearn.preprocessing.StandardScaler`;
+# * train and time the pipeline fitting;
+# * measure the performance of the clustering obtained via different metrics.
+from time import time
+
+from cuml import metrics
+from sklearn import metrics as sk_metrics
+from sklearn.pipeline import make_pipeline
+from cuml.preprocessing import StandardScaler
+
+
+def bench_k_means(kmeans, name, data, labels):
+    """Benchmark to evaluate the KMeans initialization methods.
+
+    Parameters
+    ----------
+    kmeans : KMeans instance
+        A :class:`~sklearn.cluster.KMeans` instance with the initialization
+        already set.
+    name : str
+        Name given to the strategy. It will be used to show the results in a
+        table.
+    data : ndarray of shape (n_samples, n_features)
+        The data to cluster.
+    labels : ndarray of shape (n_samples,)
+        The labels used to compute the clustering metrics which requires some
+        supervision.
+    """
+    t0 = time()
+    estimator = make_pipeline(StandardScaler(), kmeans).fit(data)
+    fit_time = time() - t0
+    results = [name, fit_time, estimator[-1].inertia_]
+
+    # Define the metrics which require only the true labels and estimator
+    # labels
+    clustering_metrics = [
+        metrics.homogeneity_score,
+        metrics.completeness_score,
+        metrics.v_measure_score,
+        metrics.adjusted_rand_score,
+        sk_metrics.adjusted_mutual_info_score,
+    ]
+    results += [m(labels, estimator[-1].labels_.astype(labels.dtype)) for m in clustering_metrics]
+
+    # The silhouette score requires the full dataset
+    results += [
+        sk_metrics.silhouette_score(
+            data,
+            estimator[-1].labels_,
+            metric="euclidean",
+            sample_size=300,
+        )
+    ]
+
+    # Show the results
+    formatter_result = (
+        "{:9s}\t{:.3f}s\t{:.0f}\t{:.3f}\t{:.3f}\t{:.3f}\t{:.3f}\t{:.3f}\t{:.3f}"
+    )
+    print(formatter_result.format(*results))
+
+
+# %%
+# Run the benchmark
+# -----------------
+#
+# We will compare three approaches:
+#
+# * an initialization using `k-means++`. This method is stochastic and we will
+#   run the initialization 4 times;
+# * a random initialization. This method is stochastic as well and we will run
+#   the initialization 4 times;
+# * an initialization based on a :class:`~sklearn.decomposition.PCA`
+#   projection. Indeed, we will use the components of the
+#   :class:`~sklearn.decomposition.PCA` to initialize KMeans. This method is
+#   deterministic and a single initialization suffice.
+from cuml import KMeans
+from cuml import PCA
+
+print(82 * "_")
+print("init\t\ttime\tinertia\thomo\tcompl\tv-meas\tARI\tAMI\tsilhouette")
+
+kmeans = KMeans(init="k-means++", n_clusters=n_digits, n_init=4, random_state=0)
+bench_k_means(kmeans=kmeans, name="k-means++", data=data, labels=labels)
+
+kmeans = KMeans(init="random", n_clusters=n_digits, n_init=4, random_state=0)
+bench_k_means(kmeans=kmeans, name="random", data=data, labels=labels)
+
+pca = PCA(n_components=n_digits).fit(data)
+kmeans = KMeans(init=pca.components_, n_clusters=n_digits, n_init=1)
+bench_k_means(kmeans=kmeans, name="PCA-based", data=data, labels=labels)
+
+print(82 * "_")
+
+# %%
+# Visualize the results on PCA-reduced data
+# -----------------------------------------
+#
+# :class:`~sklearn.decomposition.PCA` allows to project the data from the
+# original 64-dimensional space into a lower dimensional space. Subsequently,
+# we can use :class:`~sklearn.decomposition.PCA` to project into a
+# 2-dimensional space and plot the data and the clusters in this new space.
+import matplotlib.pyplot as plt
+
+reduced_data = PCA(n_components=2).fit_transform(data)
+kmeans = KMeans(init="k-means++", n_clusters=n_digits, n_init=4)
+kmeans.fit(reduced_data)
+
+# Step size of the mesh. Decrease to increase the quality of the VQ.
+h = 0.02  # point in the mesh [x_min, x_max]x[y_min, y_max].
+
+# Plot the decision boundary. For that, we will assign a color to each
+x_min, x_max = reduced_data[:, 0].min() - 1, reduced_data[:, 0].max() + 1
+y_min, y_max = reduced_data[:, 1].min() - 1, reduced_data[:, 1].max() + 1
+xx, yy = np.meshgrid(np.arange(x_min, x_max, h), np.arange(y_min, y_max, h))
+
+# Obtain labels for each point in mesh. Use last trained model.
+Z = kmeans.predict(np.c_[xx.ravel(), yy.ravel()])
+
+# Put the result into a color plot
+Z = Z.reshape(xx.shape)
+plt.figure(1)
+plt.clf()
+plt.imshow(
+    Z,
+    interpolation="nearest",
+    extent=(xx.min(), xx.max(), yy.min(), yy.max()),
+    cmap=plt.cm.Paired,
+    aspect="auto",
+    origin="lower",
+)
+
+plt.plot(reduced_data[:, 0], reduced_data[:, 1], "k.", markersize=2)
+# Plot the centroids as a white X
+centroids = kmeans.cluster_centers_
+plt.scatter(
+    centroids[:, 0],
+    centroids[:, 1],
+    marker="x",
+    s=169,
+    linewidths=3,
+    color="w",
+    zorder=10,
+)
+plt.title(
+    "K-means clustering on the digits dataset (PCA-reduced data)\n"
+    "Centroids are marked with white cross"
+)
+plt.xlim(x_min, x_max)
+plt.ylim(y_min, y_max)
+plt.xticks(())
+plt.yticks(())
+plt.show()


### PR DESCRIPTION
I have been looking at [the scikit-learn gallery](https://scikit-learn.org/stable/auto_examples/index.html) and attempting to "translate" examples from it to use RAPIDS projects where possible. Mostly this is an exercise in learning how such transformations look, what changes are common, etc

I thought it could be nice to add these examples to the cuml gallery, realised there was none and hence this PR.

It adds basic infrastructure to make a gallery work. The gallery is a new section in the documentation and examples are cross linked from the API docs of a class (at the bottom of `KMeans` it shows a thumbnail for the example that uses `KMeans`).

What do people think of this?

It would be ideal to somehow be able to highlight the differences between the "cuml" and "scikit-learn" versions of an example. That way readers could more easily see the bits that are relevant to "I have CPU code and want to move to GPU". However, I don't know how to do that :D

I plan to translate a few more examples, but not all of them. I think getting this merged even with a "slim" gallery to start would be good, that way others could also add examples (instead of having one mega PR that is essentially blocked on one person and unreviewable)