### PR TITLE
FIX Clean up "clean" step of build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -222,10 +222,6 @@ if (( ${CLEAN} == 1 )); then
             rmdir ${bd} || true
         fi
     done
-
-    cd ${REPODIR}/python
-    python setup.py clean --all
-    cd ${REPODIR}
 fi
 
 


### PR DESCRIPTION
This is related to #5844. It removes the command that runs `python setup.py clean` from `build.sh`. From the fact that `setup.py` no longer exists I deduce that we don't need this anymore.