### PR TITLE
Avoid deprecated API in notebook

### DIFF
--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -19,13 +19,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import cupy\n",
     "import os\n",

--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -19,6 +19,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import cupy\n",
     "import os\n",
@@ -456,9 +463,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = dask_cudf.from_dask_dataframe(\n",
-    "    dask.dataframe.from_array(x)\n",
-    ")"
+    "df = dask.dataframe.from_array(x).to_backend(\"cudf\")"
    ]
   },
   {


### PR DESCRIPTION
Minor notebook change. Motivated by https://github.com/rapidsai/cudf/pull/15592

@taureandyernv - Just an FYI: I'm sure there is plenty of example code/documentation floating around that uses `dask_cudf.to/from_dask_dataframe`. I will be looking for this, and changing it to `*.to_backend("cudf"/"pandas")`. Feel free to point out problem areas :)