### PR TITLE
Migrate to `{{ stdlib("c") }}`

### DIFF
--- a/conda/recipes/cuml-cpu/conda_build_config.yaml
+++ b/conda/recipes/cuml-cpu/conda_build_config.yaml
@@ -7,5 +7,8 @@ cxx_compiler_version:
 cmake_version:
   - ">=3.26.4"
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "=2.17"

--- a/conda/recipes/cuml-cpu/conda_build_config.yaml
+++ b/conda/recipes/cuml-cpu/conda_build_config.yaml
@@ -7,5 +7,5 @@ cxx_compiler_version:
 cmake_version:
   - ">=3.26.4"
 
-sysroot_version:
+c_stdlib_version:
   - "=2.17"

--- a/conda/recipes/cuml-cpu/meta.yaml
+++ b/conda/recipes/cuml-cpu/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cmake {{ cmake_version }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
     - ninja
   host:
     - python x.x

--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -13,6 +13,9 @@ cuda11_compiler:
 cmake_version:
   - ">=3.26.4"
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "=2.17"
 

--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -13,7 +13,7 @@ cuda11_compiler:
 cmake_version:
   - ">=3.26.4"
 
-sysroot_version:
+c_stdlib_version:
   - "=2.17"
 
 treelite_version:

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - cmake {{ cmake_version }}
     - ninja
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -10,6 +10,9 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "=2.17"
 

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -10,7 +10,7 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
-sysroot_version:
+c_stdlib_version:
   - "=2.17"
 
 cmake_version:

--- a/conda/recipes/libcuml/meta.yaml
+++ b/conda/recipes/libcuml/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - cmake {{ cmake_version }}
     - ninja
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}


### PR DESCRIPTION
The `sysroot*` syntax is getting phased out (conda-forge/conda-forge.github.io#2102).
The recommendation is to move to `{{ stdlib("c") }}`.

Ref https://github.com/rapidsai/build-planning/issues/39