### PR TITLE
Use int instead of float in random.randint

### DIFF
--- a/python/cuml/datasets/arima.pyx
+++ b/python/cuml/datasets/arima.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
     cdef uintptr_t out_ptr = <uintptr_t> out.ptr
 
     if random_state is None:
-        random_state = randint(0, 1e18)
+        random_state = randint(0, 10**18)
 
     if dtype == np.float32:
         cpp_make_arima(handle_[0], <float*> out_ptr, <int> batch_size,

--- a/python/cuml/datasets/regression.pyx
+++ b/python/cuml/datasets/regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ def make_regression(
         coef_ptr = coefs.ptr
 
     if random_state is None:
-        random_state = randint(0, 1e18)
+        random_state = randint(0, 10**18)
 
     if dtype == np.float32:
         cpp_make_regression(handle_[0], <float*> out_ptr,

--- a/python/cuml/explainer/kernel_shap.pyx
+++ b/python/cuml/explainer/kernel_shap.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -340,7 +340,7 @@ class KernelExplainer(SHAPBase):
         x_ptr = get_cai_ptr(self._mask)
 
         if self.random_state is None:
-            self.random_state = randint(0, 1e18)
+            self.random_state = randint(0, 10**18)
 
         # we default to float32 unless self.dtype is specifically np.float64
         if self.dtype == np.float64:

--- a/python/cuml/tests/test_kmeans.py
+++ b/python/cuml/tests/test_kmeans.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ def get_data_consistency_test():
 
 @pytest.fixture
 def random_state():
-    random_state = random.randint(0, 1e6)
+    random_state = random.randint(0, 10**6)
     with logger.set_level(logger.level_debug):
         logger.debug("Random seed: {}".format(random_state))
     return random_state

--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ IS_ARM = platform.processor() == "aarch64"
 
 @pytest.fixture(scope="module")
 def random_state():
-    random_state = random.randint(0, 1e6)
+    random_state = random.randint(0, 10**6)
     with logger.set_level(logger.level_debug):
         logger.debug("Random seed: {}".format(random_state))
     return random_state

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -473,7 +473,7 @@ def test_rf_classification_seed(small_clf, datatype):
     )
 
     for i in range(8):
-        seed = random.randint(100, 1e5)
+        seed = random.randint(100, 10**5)
         # Initialize, fit and predict using cuML's
         # random forest classification model
         cu_class = curfc(random_state=seed, n_streams=1)


### PR DESCRIPTION
Split from https://github.com/rapidsai/cuml/pull/5799

Non-integer arguments are deprecated to this method