### PR TITLE
Fix deprecated positional arg usage

### DIFF
--- a/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+
 # This code originates from the Scikit-Learn library,
 # it was since modified to allow GPU acceleration.
 # This code is under BSD 3 clause license.
@@ -63,7 +65,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
     --------
     >>> import cupy as cp
     >>> from cuml.preprocessing import FunctionTransformer
-    >>> transformer = FunctionTransformer(cp.log1p)
+    >>> transformer = FunctionTransformer(func=cp.log1p)
     >>> X = cp.array([[0, 1], [2, 3]])
     >>> transformer.transform(X)
     array([[0.       , 0.6931...],

--- a/python/cuml/tests/dask/test_dask_serialization.py
+++ b/python/cuml/tests/dask/test_dask_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ def test_serialize_mnmg_model(client):
     X, y = make_regression(n_samples=1000, n_features=20, random_state=0)
     X, y = da.from_array(X), da.from_array(y)
 
-    model = LinearRegression(client)
+    model = LinearRegression(client=client)
     model.fit(X, y)
 
     pickled_model = pickle.dumps(model)


### PR DESCRIPTION
Split from https://github.com/rapidsai/cuml/pull/5799

Non-keyword args are deprecated from these signatures so fixing them where used