### PR TITLE
Adjust deprecated cupy.sparse usage

### DIFF
--- a/python/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/manifold/simpl_set.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ from cuml.internals.safe_imports import cpu_only_import
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
 cp = gpu_only_import('cupy')
+cupyx = gpu_only_import('cupyx')
 
 from cuml.manifold.umap_utils cimport *
 from cuml.manifold.umap_utils import GraphHolder, find_ab_params, \
@@ -350,8 +351,8 @@ def simplicial_set_embedding(
 
     graph = graph.tocoo()
     graph.sum_duplicates()
-    if not isinstance(graph, cp.sparse.coo_matrix):
-        graph = cp.sparse.coo_matrix(graph)
+    if not isinstance(graph, cupyx.scipy.sparse.coo_matrix):
+        graph = cupyx.scipy.sparse.coo_matrix(graph)
 
     handle = Handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()

--- a/python/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/manifold/umap_utils.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ from cuml.internals.safe_imports import cpu_only_import
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
 cp = gpu_only_import('cupy')
+cupyx = gpu_only_import('cupyx')
 
 
 cdef class GraphHolder:
@@ -102,7 +103,7 @@ cdef class GraphHolder:
         rows = create_nonowning_cp_array(self.rows(), np.int32)
         cols = create_nonowning_cp_array(self.cols(), np.int32)
 
-        return cp.sparse.coo_matrix(((vals, (rows, cols))))
+        return cupyx.scipy.sparse.coo_matrix(((vals, (rows, cols))))
 
     def __dealloc__(self):
         self.c_graph.reset(NULL)

--- a/python/cuml/tests/test_simpl_set.py
+++ b/python/cuml/tests/test_simpl_set.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
+cupyx = gpu_only_import("cupyx")
 
 
 IS_ARM = platform.processor() == "aarch64"
@@ -111,7 +112,7 @@ def test_fuzzy_simplicial_set(
         )[0].tocoo()
 
     cu_fss_graph = cu_fss_graph.todense()
-    ref_fss_graph = cp.sparse.coo_matrix(ref_fss_graph).todense()
+    ref_fss_graph = cupyx.scipy.sparse.coo_matrix(ref_fss_graph).todense()
     assert correctness_sparse(
         ref_fss_graph, cu_fss_graph, atol=0.1, rtol=0.2, threshold=0.95
     )

--- a/python/cuml/tests/test_umap.py
+++ b/python/cuml/tests/test_umap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -667,7 +667,7 @@ def test_fuzzy_simplicial_set(n_rows, n_features, n_neighbors):
     ref_fss_graph = model.graph_
 
     cu_fss_graph = cu_fss_graph.todense()
-    ref_fss_graph = cp.sparse.coo_matrix(ref_fss_graph).todense()
+    ref_fss_graph = cupyx.scipy.sparse.coo_matrix(ref_fss_graph).todense()
     assert correctness_sparse(
         ref_fss_graph, cu_fss_graph, atol=0.1, rtol=0.2, threshold=0.95
     )


### PR DESCRIPTION
Split from https://github.com/rapidsai/cuml/pull/5799

`cupy.sparse` is deprecated in favor of `cupyx.scipy.sparse`