### PR TITLE
Replace deprecated disutils.version with packaging.version

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -47,6 +47,7 @@ dependencies:
 - numba>=0.57
 - numpydoc
 - nvcc_linux-64=11.8
+- packaging
 - pip
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==24.6.*

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -43,6 +43,7 @@ dependencies:
 - nltk
 - numba>=0.57
 - numpydoc
+- packaging
 - pip
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==24.6.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -202,6 +202,7 @@ dependencies:
             # we make it optional (i.e. an extra for pip
             # installation/run_constrained for conda)?
           - scipy>=1.8.0
+          - packaging
           - rapids-dask-dependency==24.6.*
           - *treelite
       - output_types: conda

--- a/python/cuml/internals/import_utils.py
+++ b/python/cuml/internals/import_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 import platform
 
+from packaging.version import Version
+
 from cuml.internals.safe_imports import gpu_only_import, UnavailableError
-from distutils.version import LooseVersion
 
 
 numba = gpu_only_import("numba")
@@ -123,14 +124,14 @@ def check_min_dask_version(version):
     try:
         import dask
 
-        return LooseVersion(dask.__version__) >= LooseVersion(version)
+        return Version(dask.__version__) >= Version(version)
     except ImportError:
         return False
 
 
 def check_min_numba_version(version):
     try:
-        return LooseVersion(str(numba.__version__)) >= LooseVersion(version)
+        return Version(str(numba.__version__)) >= Version(version)
     except UnavailableError:
         return False
 
@@ -139,7 +140,7 @@ def check_min_cupy_version(version):
     if has_cupy():
         import cupy
 
-        return LooseVersion(str(cupy.__version__)) >= LooseVersion(version)
+        return Version(str(cupy.__version__)) >= Version(version)
     else:
         return False
 
@@ -186,9 +187,7 @@ def has_shap(min_version="0.37"):
         if min_version is None:
             return True
         else:
-            return LooseVersion(str(shap.__version__)) >= LooseVersion(
-                min_version
-            )
+            return Version(str(shap.__version__)) >= Version(min_version)
     except ImportError:
         return False
 
@@ -200,9 +199,7 @@ def has_daskglm(min_version=None):
         if min_version is None:
             return True
         else:
-            return LooseVersion(str(dask_glm.__version__)) >= LooseVersion(
-                min_version
-            )
+            return Version(str(dask_glm.__version__)) >= Version(min_version)
     except ImportError:
         return False
 

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 from contextlib import nullcontext
-from distutils.version import LooseVersion
 from functools import lru_cache
 
+from packaging.version import Version
 import pytest
 import sklearn
 from cuml.internals.array import elements_in_representable_range
@@ -488,7 +488,7 @@ def test_logistic_regression(
 ):
     ncols, n_info = column_info
     # Checking sklearn >= 0.21 for testing elasticnet
-    sk_check = LooseVersion(str(sklearn.__version__)) >= LooseVersion("0.21.0")
+    sk_check = Version(str(sklearn.__version__)) >= Version("0.21.0")
     if not sk_check and penalty == "elasticnet":
         pytest.skip(
             "Need sklearn > 0.21 for testing logistic with" "elastic net."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "dask-cudf==24.6.*",
     "joblib>=0.11",
     "numba>=0.57",
+    "packaging",
     "pylibraft==24.6.*",
     "raft-dask==24.6.*",
     "rapids-dask-dependency==24.6.*",


### PR DESCRIPTION
Split from https://github.com/rapidsai/cuml/pull/5799

`distutils` will be removed in Python 3.12. For version parsing, other RAPIDS libraries use `packaging` so added as a dependency as well