### PR TITLE
Avoid dask_cudf.core imports

### DIFF
--- a/python/cuml/internals/array.py
+++ b/python/cuml/internals/array.py
@@ -48,8 +48,8 @@ CudfBuffer = gpu_only_import_from("cudf.core.buffer", "Buffer")
 CudfDataFrame = gpu_only_import_from("cudf", "DataFrame")
 CudfIndex = gpu_only_import_from("cudf", "Index")
 CudfSeries = gpu_only_import_from("cudf", "Series")
-DaskCudfDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
-DaskCudfSeries = gpu_only_import_from("dask_cudf.core", "Series")
+DaskCudfDataFrame = gpu_only_import_from("dask_cudf", "DataFrame")
+DaskCudfSeries = gpu_only_import_from("dask_cudf", "Series")
 DaskDataFrame = gpu_only_import_from("dask.dataframe", "DataFrame")
 DaskSeries = gpu_only_import_from("dask.dataframe", "Series")
 DeviceBuffer = gpu_only_import_from("rmm", "DeviceBuffer")
@@ -793,7 +793,7 @@ class CumlArray:
 
         if header["desc"]["shape"] != ary._array_interface["shape"]:
             raise ValueError(
-                f"Received a `Buffer` with the wrong size."
+                "Received a `Buffer` with the wrong size."
                 f" Expected {header['desc']['shape']}, "
                 f"but got {ary._array_interface['shape']}"
             )

--- a/python/cuml/internals/input_utils.py
+++ b/python/cuml/internals/input_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,8 +46,8 @@ scipy_sparse = safe_import(
 cp_ndarray = gpu_only_import_from("cupy", "ndarray")
 CudfSeries = gpu_only_import_from("cudf", "Series")
 CudfDataFrame = gpu_only_import_from("cudf", "DataFrame")
-DaskCudfSeries = gpu_only_import_from("dask_cudf.core", "Series")
-DaskCudfDataFrame = gpu_only_import_from("dask_cudf.core", "DataFrame")
+DaskCudfSeries = gpu_only_import_from("dask_cudf", "Series")
+DaskCudfDataFrame = gpu_only_import_from("dask_cudf", "DataFrame")
 np_ndarray = cpu_only_import_from("numpy", "ndarray")
 numba_devicearray = gpu_only_import_from("numba.cuda", "devicearray")
 try:


### PR DESCRIPTION
Fixes some leftover `dask_cudf.core` imports missed in https://github.com/rapidsai/cuml/pull/5835.
