### PR TITLE
Fix nightly CI: remove deprecated creation of columns by using explicit dtype

### DIFF
--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/tests/test_array.py
+++ b/python/cuml/tests/test_array.py
@@ -251,8 +251,8 @@ def test_get_set_item(inp, indices, mem_type):
         _assert_equal(inp_view, ary[indices])
 
         # Check equality after assigning to array slice.
-        ary[indices] = 1.0
-        inp[indices] = 1.0
+        ary[indices] = inp.dtype.type(1.0)
+        inp[indices] = inp.dtype.type(1.0)
 
         # We need to assume that inp is not a cudf.Series here, otherwise
         # ary.to_output("cupy") called by equal() will trigger a


### PR DESCRIPTION
After turning warnings as errors in pytests, the following error is blocking nightly (and I presume PR) CI: 

```python
================================================================================================================================================= short test summary info ==================================================================================================================================================
FAILED cuml/tests/test_array.py::test_get_set_item - FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '1.0' has dtype incompatible with int8, please explicitly cast to a compatible dtype first.
```

This PR fixes that by explicitly assigning columns with the correct type scalars. 