### PR TITLE
Fix RandomForestClassifier return type

### DIFF
--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -1,6 +1,6 @@
 
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/ensemble/randomforestclassifier.pyx
@@ -550,6 +550,7 @@ class RandomForestClassifier(BaseRandomForestModel,
         domain="cuml_python")
     @insert_into_docstring(parameters=[('dense', '(n_samples, n_features)')],
                            return_values=[('dense', '(n_samples, 1)')])
+    @cuml.internals.api_base_return_array(get_output_dtype=True)
     def predict(self, X, predict_model="GPU", threshold=0.5,
                 algo='auto', convert_dtype=True,
                 fil_sparse_format='auto') -> CumlArray:

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -1382,3 +1382,11 @@ def test_rf_min_samples_split_with_small_float(estimator, make_data):
 
     # Does not error
     clf.fit(X, y)
+
+
+def test_rf_predict_returns_int():
+
+    X, y = make_classification()
+    clf = cuml.ensemble.RandomForestClassifier().fit(X,y)
+    pred = clf.predict(X)
+    assert pred.dtype == np.int64

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -1387,6 +1387,6 @@ def test_rf_min_samples_split_with_small_float(estimator, make_data):
 def test_rf_predict_returns_int():
 
     X, y = make_classification()
-    clf = cuml.ensemble.RandomForestClassifier().fit(X,y)
+    clf = cuml.ensemble.RandomForestClassifier().fit(X, y)
     pred = clf.predict(X)
     assert pred.dtype == np.int64


### PR DESCRIPTION
Closes #5637 

```
import cuml
from cuml.datasets import make_classification

X, y = make_classification()

clf = cuml.ensemble.RandomForestClassifier().fit(X,y)
print(clf.predict(X[:5]).dtype)
```

Result is

```
int64
```