### PR TITLE
Fix label binarize for binary class

### DIFF
--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -64,7 +64,7 @@ def label_binarize(
 
     cp.cuda.Stream.null.synchronize()
 
-    is_binary = True if classes.shape[0] == 2 else False
+    is_binary = classes.shape[0] == 2
     
     if sparse_output:
         sp = sp.tocsr()

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -64,14 +64,19 @@ def label_binarize(
 
     cp.cuda.Stream.null.synchronize()
 
+    is_binary = True if classes.shape[0] == 2 else False
+    
     if sparse_output:
         sp = sp.tocsr()
+        if is_binary:
+            sp = sp.getcol(1)   # getcol does not support -1 indexing
         return sp
     else:
 
         arr = sp.toarray().astype(y.dtype)
         arr[arr == 0] = neg_label
-
+        if is_binary:
+            arr = arr[:, -1].reshape((-1, 1))
         return arr
 
 

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023=4, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023=4, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/preprocessing/label.py
+++ b/python/cuml/preprocessing/label.py
@@ -65,11 +65,11 @@ def label_binarize(
     cp.cuda.Stream.null.synchronize()
 
     is_binary = classes.shape[0] == 2
-    
+
     if sparse_output:
         sp = sp.tocsr()
         if is_binary:
-            sp = sp.getcol(1)   # getcol does not support -1 indexing
+            sp = sp.getcol(1)  # getcol does not support -1 indexing
         return sp
     else:
 

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -1142,16 +1142,26 @@ def test_label_binarize():
     sk_bin = sk_label_binarize([1, 0, 1, 1], classes=[0, 1])
     assert_allclose(cu_bin, sk_bin)
 
-    cu_bin_sparse = cu_label_binarize(cp.array([1, 0, 1, 1]), classes=cp.array([0, 1]), sparse_output=True)
-    sk_bin_sparse = sk_label_binarize([1, 0, 1, 1], classes=[0, 1], sparse_output=True)
+    cu_bin_sparse = cu_label_binarize(
+        cp.array([1, 0, 1, 1]), classes=cp.array([0, 1]), sparse_output=True
+    )
+    sk_bin_sparse = sk_label_binarize(
+        [1, 0, 1, 1], classes=[0, 1], sparse_output=True
+    )
     assert_allclose(cu_bin_sparse, sk_bin_sparse)
     
-    cu_multi = cu_label_binarize(cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6]))
+    cu_multi = cu_label_binarize(
+        cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6])
+    )
     sk_multi = sk_label_binarize([1, 6, 3], classes=[1, 3, 4, 6])
     assert_allclose(cu_multi, sk_multi)
     
-    cu_multi_sparse = cu_label_binarize(cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6]), sparse_output=True)
-    sk_multi_sparse = sk_label_binarize([1, 6, 3], classes=[1, 3, 4, 6], sparse_output=True)
+    cu_multi_sparse = cu_label_binarize(
+        cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6]), sparse_output=True
+    )
+    sk_multi_sparse = sk_label_binarize(
+        [1, 6, 3], classes=[1, 3, 4, 6], sparse_output=True
+    )
     assert_allclose(cu_multi_sparse, sk_multi_sparse)
 
 def test__repr__():

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -43,6 +43,7 @@ from cuml.preprocessing import (
     quantile_transform as cu_quantile_transform,
     robust_scale as cu_robust_scale,
     scale as cu_scale,
+    label_binarize as cu_label_binarize,
 )
 from sklearn.preprocessing import (
     Binarizer as skBinarizer,
@@ -68,6 +69,7 @@ from sklearn.preprocessing import (
     quantile_transform as sk_quantile_transform,
     robust_scale as sk_robust_scale,
     scale as sk_scale,
+    label_binarize as sk_label_binarize,
 )
 from sklearn.impute import (
     MissingIndicator as skMissingIndicator,
@@ -1134,6 +1136,23 @@ def test_kernel_centerer():
 
     assert_allclose(sk_t_X, t_X)
 
+
+def test_label_binarize():
+    cu_bin = cu_label_binarize(cp.array([1, 0, 1, 1]), classes=cp.array([0, 1]))
+    sk_bin = sk_label_binarize([1, 0, 1, 1], classes=[0, 1])
+    assert_allclose(cu_bin, sk_bin)
+
+    cu_bin_sparse = cu_label_binarize(cp.array([1, 0, 1, 1]), classes=cp.array([0, 1]), sparse_output=True)
+    sk_bin_sparse = sk_label_binarize([1, 0, 1, 1], classes=[0, 1], sparse_output=True)
+    assert_allclose(cu_bin_sparse, sk_bin_sparse)
+    
+    cu_multi = cu_label_binarize(cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6]))
+    sk_multi = sk_label_binarize([1, 6, 3], classes=[1, 3, 4, 6])
+    assert_allclose(cu_multi, sk_multi)
+    
+    cu_multi_sparse = cu_label_binarize(cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6]), sparse_output=True)
+    sk_multi_sparse = sk_label_binarize([1, 6, 3], classes=[1, 3, 4, 6], sparse_output=True)
+    assert_allclose(cu_multi_sparse, sk_multi_sparse)
 
 def test__repr__():
     assert cuBinarizer().__repr__() == "Binarizer()"

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -1138,7 +1138,9 @@ def test_kernel_centerer():
 
 
 def test_label_binarize():
-    cu_bin = cu_label_binarize(cp.array([1, 0, 1, 1]), classes=cp.array([0, 1]))
+    cu_bin = cu_label_binarize(
+        cp.array([1, 0, 1, 1]), classes=cp.array([0, 1])
+    )
     sk_bin = sk_label_binarize([1, 0, 1, 1], classes=[0, 1])
     assert_allclose(cu_bin, sk_bin)
 
@@ -1149,13 +1151,13 @@ def test_label_binarize():
         [1, 0, 1, 1], classes=[0, 1], sparse_output=True
     )
     assert_allclose(cu_bin_sparse, sk_bin_sparse)
-    
+
     cu_multi = cu_label_binarize(
         cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6])
     )
     sk_multi = sk_label_binarize([1, 6, 3], classes=[1, 3, 4, 6])
     assert_allclose(cu_multi, sk_multi)
-    
+
     cu_multi_sparse = cu_label_binarize(
         cp.array([1, 6, 3]), classes=cp.array([1, 3, 4, 6]), sparse_output=True
     )
@@ -1163,6 +1165,7 @@ def test_label_binarize():
         [1, 6, 3], classes=[1, 3, 4, 6], sparse_output=True
     )
     assert_allclose(cu_multi_sparse, sk_multi_sparse)
+
 
 def test__repr__():
     assert cuBinarizer().__repr__() == "Binarizer()"


### PR DESCRIPTION
Closes #5740 

Fix for cuml's `label_binarize` to have the same output as scikit-learn's `label_binarize` for binary classes.

Note: Unlike scikit-learn's [`scipy.sparse._csr.csr_matrix.getcol()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.getcol.html), cuml's `cupyx.scipy.sparse.csr_matrix.getcol()` does not support -1 indexing.



