### PR TITLE
WIP: remove unnecessary 'setuptools' dependency

### DIFF
--- a/conda/recipes/cuml-cpu/meta.yaml
+++ b/conda/recipes/cuml-cpu/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - ninja
   host:
     - python x.x
-    - setuptools
     - scikit-build-core >=0.7.0
     - cython>=3.0.0
   run:

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -70,7 +70,6 @@ requirements:
     - python x.x
     - raft-dask ={{ minor_version }}
     - scikit-build-core >=0.7.0
-    - setuptools
     - treelite {{ treelite_version }}
   run:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}

--- a/python/README.md
+++ b/python/README.md
@@ -55,7 +55,6 @@ cuML's convenience [development yaml files](https://github.com/rapidsai/cuml/tre
 To build cuML's Python package, the following dependencies are required:
 
 - cudatoolkit version corresponding to system CUDA toolkit
-- setuptools
 - cython >= 0.29, < 0.30
 - numpy
 - cmake >= 3.14


### PR DESCRIPTION
Similar to https://github.com/rapidsai/cudf/pull/15736, it looks like this project has an unnecessary dependency on `setuptools`. I suspect that's left over from before the project was cut over to `scikit-build-core`.

## Notes for Reviewers

There are no uses of `setuptools` here:

```shell
git grep setuptools
```

Also note that I'm intentionally **targeting `branch-24.08`**, to avoid making this change on `branch-24.06` so close to a release.