### PR TITLE
[HOTFIX] Add compatibility of imports with multiple Scikit-learn versions

### DIFF
--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -45,7 +45,6 @@ from ..utils.validation import (check_is_fitted, FLOAT_DTYPES,
 from ..utils.extmath import _incremental_mean_and_var
 from ..utils.extmath import row_norms
 from ....thirdparty_adapters import check_array
-from sklearn.utils._indexing import resample
 from cuml.internals.mixins import AllowNaNTagMixin, SparseInputTagMixin, \
     StatelessTagMixin
 from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
@@ -62,6 +61,7 @@ from itertools import combinations_with_replacement as combinations_w_r
 from cuml.internals.safe_imports import cpu_only_import
 cpu_np = cpu_only_import('numpy')
 np = gpu_only_import('cupy')
+resample = cpu_only_import_from('sklearn.utils._indexing', 'resample')
 sparse = gpu_only_import_from('cupyx.scipy', 'sparse')
 stats = cpu_only_import_from('scipy', 'stats')
 

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -61,7 +61,6 @@ from itertools import combinations_with_replacement as combinations_w_r
 from cuml.internals.safe_imports import cpu_only_import
 cpu_np = cpu_only_import('numpy')
 np = gpu_only_import('cupy')
-resample = cpu_only_import_from('sklearn.utils._indexing', 'resample')
 sparse = gpu_only_import_from('cupyx.scipy', 'sparse')
 stats = cpu_only_import_from('scipy', 'stats')
 
@@ -2301,6 +2300,8 @@ class QuantileTransformer(TransformerMixin,
         X = np.asnumpy(X)
         if self.subsample is not None and self.subsample < n_samples:
             # Take a subsample of `X`
+            resample = \
+                cpu_only_import_from('sklearn.utils._indexing', 'resample')
             X = resample(
                 X, replace=False, n_samples=self.subsample, random_state=random_state
             )

--- a/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -2301,8 +2301,6 @@ class QuantileTransformer(TransformerMixin,
         X = np.asnumpy(X)
         if self.subsample is not None and self.subsample < n_samples:
             # Take a subsample of `X`
-            resample = \
-                cpu_only_import_from('sklearn.utils._indexing', 'resample')
             X = resample(
                 X, replace=False, n_samples=self.subsample, random_state=random_state
             )

--- a/python/cuml/internals/device_support.pyx
+++ b/python/cuml/internals/device_support.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/internals/device_support.pyx
+++ b/python/cuml/internals/device_support.pyx
@@ -26,7 +26,7 @@ try:
 
     CPU_ENABLED = True
 
-    if(Version(dask.__version__) >= MIN_SKLEARN_VERSION):
+    if(Version(sklearn.__version__) >= MIN_SKLEARN_VERSION):
         MIN_SKLEARN_PRESENT = True
     else:
         MIN_SKLEARN_PRESENT = False

--- a/python/cuml/internals/device_support.pyx
+++ b/python/cuml/internals/device_support.pyx
@@ -17,7 +17,7 @@
 
 from packaging.version import Version
 
-MIN_SKLEARN_VERSION = Version(1.5)
+MIN_SKLEARN_VERSION = Version('1.5')
 
 
 try:
@@ -26,13 +26,13 @@ try:
     CPU_ENABLED = True
 
     if(Version(sklearn.__version__) >= MIN_SKLEARN_VERSION):
-        MIN_SKLEARN_PRESENT = True
+        MIN_SKLEARN_PRESENT = (True, None, None)
     else:
-        MIN_SKLEARN_PRESENT = False
+        MIN_SKLEARN_PRESENT = (False, sklearn.__version__, MIN_SKLEARN_VERSION)
 
 except ImportError:
     CPU_ENABLED = False
-    MIN_SKLEARN_PRESENT = False
+    MIN_SKLEARN_PRESENT = (False, None, None)
 
 IF GPUBUILD == 1:
     GPU_ENABLED = True

--- a/python/cuml/internals/device_support.pyx
+++ b/python/cuml/internals/device_support.pyx
@@ -20,7 +20,6 @@ from packaging.version import Version
 MIN_SKLEARN_VERSION = Version(1.5)
 
 
-
 try:
     import sklearn  # noqa: F401  # no-cython-lint
 

--- a/python/cuml/internals/device_support.pyx
+++ b/python/cuml/internals/device_support.pyx
@@ -15,11 +15,25 @@
 #
 
 
+from packaging.version import Version
+
+MIN_SKLEARN_VERSION = Version(1.5)
+
+
+
 try:
     import sklearn  # noqa: F401  # no-cython-lint
+
     CPU_ENABLED = True
+
+    if(Version(dask.__version__) >= MIN_SKLEARN_VERSION):
+        MIN_SKLEARN_PRESENT = True
+    else:
+        MIN_SKLEARN_PRESENT = False
+
 except ImportError:
     CPU_ENABLED = False
+    MIN_SKLEARN_PRESENT = False
 
 IF GPUBUILD == 1:
     GPU_ENABLED = True

--- a/python/cuml/internals/safe_imports.py
+++ b/python/cuml/internals/safe_imports.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/internals/safe_imports.py
+++ b/python/cuml/internals/safe_imports.py
@@ -440,13 +440,15 @@ def cpu_only_import(module, *, alt=None):
 
     else:
         if CPU_ENABLED:
-            err_msg = "Installed version of Scikit-learn {} "
-                      "is lower than the latest tested and supported "
-                      "version {}. This can affect the functionality "
-                      "of some CPU components of cuML, GPU estimators "
-                      "are unaffected.".format(
-                          MIN_SKLEARN_PRESENT[1], MIN_SKLEARN_PRESENT[2]
-                      )
+            err_msg = (
+                "Installed version of Scikit-learn {} "
+                "is lower than the latest tested and supported "
+                "version {}. This can affect the functionality "
+                "of some CPU components of cuML, GPU estimators "
+                "are unaffected.".format(
+                    MIN_SKLEARN_PRESENT[1], MIN_SKLEARN_PRESENT[2]
+                )
+            )
         else:
             err_msg = f"{module} is not installed in GPU-only installations"
         return safe_import(
@@ -489,16 +491,20 @@ def cpu_only_import_from(module, symbol, *, alt=None):
         return getattr(imported_module, symbol)
     else:
         if CPU_ENABLED:
-            err_msg = "Installed version of Scikit-learn {} "
-                      "is lower than the latest tested and supported "
-                      "version {}. This can affect the functionality "
-                      "of some CPU components of cuML, GPU estimators "
-                      "are unaffected.".format(
-                          MIN_SKLEARN_PRESENT[1], MIN_SKLEARN_PRESENT[2]
-                      )
+            err_msg = (
+                "Installed version of Scikit-learn {} "
+                "is lower than the latest tested and supported "
+                "version {}. This can affect the functionality "
+                "of some CPU components of cuML, GPU estimators "
+                "are unaffected.".format(
+                    MIN_SKLEARN_PRESENT[1], MIN_SKLEARN_PRESENT[2]
+                )
+            )
         else:
-            err_msg = f"{module}.{symbol} is not installed in GPU-only "
-                      "installations"
+            err_msg = (
+                f"{module}.{symbol} is not installed in GPU-only "
+                "installations"
+            )
 
         return safe_import_from(
             module,

--- a/python/cuml/internals/safe_imports.py
+++ b/python/cuml/internals/safe_imports.py
@@ -17,11 +17,13 @@
 
 import importlib
 import traceback
+import warnings
 
 from contextlib import contextmanager
 from cuml.internals.device_support import (
     CPU_ENABLED,
     GPU_ENABLED,
+    MIN_SKLEARN_VERSION,
     MIN_SKLEARN_PRESENT,
 )
 from cuml.internals import logger
@@ -433,18 +435,23 @@ def cpu_only_import(module, *, alt=None):
         The imported module, the given alternate, or a class derived from
         UnavailableMeta.
     """
-    if CPU_ENABLED:
-        if "sklearn" not in module or MIN_SKLEARN_PRESENT:
-            return importlib.import_module(module)
-        else:
-            try:
-                return importlib.import_module(module)
-            except (ModuleNotFoundError, ImportError):
-                return alt
+    if CPU_ENABLED and MIN_SKLEARN_PRESENT[0]:
+        return importlib.import_module(module)
+
     else:
+        if CPU_ENABLED:
+            err_msg = "Installed version of Scikit-learn {} "
+                      "is lower than the latest tested and supported "
+                      "version {}. This can affect the functionality "
+                      "of some CPU components of cuML, GPU estimators "
+                      "are unaffected.".format(
+                          MIN_SKLEARN_PRESENT[1], MIN_SKLEARN_PRESENT[2]
+                      )
+        else:
+            err_msg = f"{module} is not installed in GPU-only installations"
         return safe_import(
             module,
-            msg=f"{module} is not installed in GPU-only installations",
+            msg=err_msg,
             alt=alt,
         )
 
@@ -477,14 +484,25 @@ def cpu_only_import_from(module, symbol, *, alt=None):
         The imported symbol, the given alternate, or a class derived from
         UnavailableMeta.
     """
-    if CPU_ENABLED:
+    if CPU_ENABLED and MIN_SKLEARN_PRESENT[0]:
         imported_module = importlib.import_module(module)
         return getattr(imported_module, symbol)
     else:
+        if CPU_ENABLED:
+            err_msg = "Installed version of Scikit-learn {} "
+                      "is lower than the latest tested and supported "
+                      "version {}. This can affect the functionality "
+                      "of some CPU components of cuML, GPU estimators "
+                      "are unaffected.".format(
+                          MIN_SKLEARN_PRESENT[1], MIN_SKLEARN_PRESENT[2]
+                      )
+        else:
+            err_msg = f"{module}.{symbol} is not installed in GPU-only "
+                      "installations"
+
         return safe_import_from(
             module,
             symbol,
-            msg=f"{module}.{symbol} is not available in GPU-only"
-            " installations",
+            msg=err_msg,
             alt=alt,
         )

--- a/python/cuml/internals/safe_imports.py
+++ b/python/cuml/internals/safe_imports.py
@@ -19,7 +19,11 @@ import importlib
 import traceback
 
 from contextlib import contextmanager
-from cuml.internals.device_support import CPU_ENABLED, GPU_ENABLED
+from cuml.internals.device_support import (
+    CPU_ENABLED,
+    GPU_ENABLED,
+    MIN_SKLEARN_PRESENT,
+)
 from cuml.internals import logger
 
 
@@ -430,7 +434,13 @@ def cpu_only_import(module, *, alt=None):
         UnavailableMeta.
     """
     if CPU_ENABLED:
-        return importlib.import_module(module)
+        if "sklearn" not in module or MIN_SKLEARN_PRESENT:
+            return importlib.import_module(module)
+        else:
+            try:
+                return importlib.import_module(module)
+            except (ModuleNotFoundError, ImportError):
+                return alt
     else:
         return safe_import(
             module,


### PR DESCRIPTION
closes #5920 

PR adds the capability to import cuML with a broader ranged of Scikit-learn versions (tested with 1.2) as opposed to only with the currently tested/supported version (1.5) 