### PR TITLE
[DO NOT MERGE] Test CCCL version bump

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,6 +16,8 @@
 
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
+set(rapids-cmake-url "https://github.com/sleeepyjack/rapids-cmake/archive/refs/heads/bugfix/cccl-span.zip")
+
 include(../rapids_config.cmake)
 
 include(rapids-cmake)


### PR DESCRIPTION
This PR tests an upcoming CCCL version bump (https://github.com/rapidsai/rapids-cmake/pull/631) and should not be merged.