### PR TITLE
Fix nightly jobs by updating hypothesis strategies to account for sklearn change

### DIFF
--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -33,6 +33,6 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 # Enable hypothesis testing for nightly test runs.
-if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
-  export HYPOTHESIS_ENABLED="true"
-fi
+# if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
+export HYPOTHESIS_ENABLED="true"
+# fi

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -33,6 +33,6 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 # Enable hypothesis testing for nightly test runs.
-# if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
-export HYPOTHESIS_ENABLED="true"
-# fi
+if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
+  export HYPOTHESIS_ENABLED="true"
+fi

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cuml/testing/strategies.py
+++ b/python/cuml/testing/strategies.py
@@ -396,8 +396,8 @@ def combined_datasets_strategy(*datasets, name=None, doc=None):
     def strategy(
         draw,
         dtypes=floating_dtypes(),
-        n_samples=integers(min_value=0, max_value=200),
-        n_features=integers(min_value=0, max_value=200),
+        n_samples=integers(min_value=1, max_value=200),
+        n_features=integers(min_value=1, max_value=200),
     ):
         """Datasets strategy composed of multiple datasets strategies."""
         datasets_strategies = (


### PR DESCRIPTION
Nightly jobs are showing a failure from hypothesis having a strategy that calls sklearn make_regression with n_samples being zero, which is no longer supported. This PR fixes that. 