### PR TITLE
resolve dependency-file-generator warning, other rapids-build-backend followup

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -7,7 +7,7 @@ rapids-logger "Create test conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key docs \
+  --file-key docs \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n docs

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 
-package_name="cuml"
 package_dir="python"
 
 source rapids-configure-sccache

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -8,7 +8,7 @@ rapids-logger "Create checks conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key checks \
+  --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n checks

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -38,10 +38,10 @@ function sed_runner() {
 echo "${NEXT_FULL_TAG}" > VERSION
 
 # pyproject.toml versions
-sed_runner "s/rmm==.*\",/rmm==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/pyproject.toml
-sed_runner "s/cudf==.*\",/cudf==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/pyproject.toml
-sed_runner "s/pylibraft==.*\",/pylibraft==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/pyproject.toml
-sed_runner "s/raft-dask==.*\",/raft-dask==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/pyproject.toml
+sed_runner "s/rmm==.*\",/rmm==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/pyproject.toml
+sed_runner "s/cudf==.*\",/cudf==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/pyproject.toml
+sed_runner "s/pylibraft==.*\",/pylibraft==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/pyproject.toml
+sed_runner "s/raft-dask==.*\",/raft-dask==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/pyproject.toml
 
 DEPENDENCIES=(
   cudf

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -8,7 +8,7 @@ rapids-logger "Create clang_tidy conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key clang_tidy \
+  --file-key clang_tidy \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n clang_tidy

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -14,9 +14,9 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_cpp \
+  --file-key test_cpp \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" \
-  --prepend-channels "${CPP_CHANNEL}" | tee env.yaml
+  --prepend-channel "${CPP_CHANNEL}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -13,7 +13,8 @@ rapids-dependency-file-generator \
   --output conda \
   --file-key test_notebooks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
-  --prepend-channel "${CPP_CHANNEL};${PYTHON_CHANNEL}" | tee env.yaml
+  --prepend-channel "${CPP_CHANNEL}" \
+  --prepend-channel "${PYTHON_CHANNEL}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -11,9 +11,9 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 rapids-logger "Generate Notebook testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_notebooks \
+  --file-key test_notebooks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
-  --prepend-channels "${CPP_CHANNEL};${PYTHON_CHANNEL}" | tee env.yaml
+  --prepend-channel "${CPP_CHANNEL};${PYTHON_CHANNEL}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -12,9 +12,9 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_python \
+  --file-key test_python \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
-  --prepend-channels "${CPP_CHANNEL};${PYTHON_CHANNEL}" | tee env.yaml
+  --prepend-channel "${CPP_CHANNEL};${PYTHON_CHANNEL}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -14,7 +14,8 @@ rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" \
-  --prepend-channel "${CPP_CHANNEL};${PYTHON_CHANNEL}" | tee env.yaml
+  --prepend-channel "${CPP_CHANNEL}" \
+  --prepend-channel "${PYTHON_CHANNEL}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

#5804 was one of the earlier `rapids-build-backend` PRs merged across RAPIDS. Since it was merged, we've made some small adjustments to the approach for `rapids-build-backend`. This catches `cuml` up with those changes:

* removes unused constants in `ci/build*` scripts
* uses `--file-key` instead of `--file_key` in `rapids-dependency-file-generator` calls
* uses `--prepend-channel` instead of `--prepend-channels` in `rapids-dependency-file-generator` calls
* ensures `ci/update-version.sh` preserves alpha specs