### PR TITLE
WIP: install 'hdbscan' from PyPI

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -447,11 +447,10 @@ dependencies:
           # TODO: remove pin once a release that includes fixes for the error
           # is released: https://github.com/rapidsai/cuml/issues/5514
           - hdbscan<=0.8.30
-      - output_types: pyproject
+      - output_types: [requirements, pyproject]
         packages:
           - dask-glm==0.3.0
-            # TODO: Can we stop pulling from the master branch now that there was a release in October?
-          - hdbscan @ git+https://github.com/scikit-learn-contrib/hdbscan.git@master
+          - hdbscan>=0.8.36
   test_notebooks:
     common:
       - output_types: [conda, requirements]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -106,7 +106,7 @@ classifiers = [
 test = [
     "dask-glm==0.3.0",
     "dask-ml",
-    "hdbscan @ git+https://github.com/scikit-learn-contrib/hdbscan.git@master",
+    "hdbscan>=0.8.36",
     "hypothesis>=6.0,<7",
     "nltk",
     "numpydoc",


### PR DESCRIPTION
## Description

Proposes:

* getting test dependency `hdbscan` from PyPI instead of GitHub
   - *(there was a release 3 weeks ago: https://pypi.org/project/hdbscan/)*
* ensuring `rapids-dependency-file-generator --output requirements` generates a full set of test dependencies

## Benefits of these changes

* ensures devcontainers environment includes all of `cuml`'s test dependencies
* removes a dependency on building from the tip of a remote git repo, and all the potential for instability and security issues that comes with that

## Notes for Reviewers

I tried testing a `devcontainers` change today (https://github.com/rapidsai/devcontainers/pull/325), like this:

```shell
# clean previous build outputs
uninstall-all -j
clean-all -j

# work on latest branches of everything
rapids-checkout-same-branch --omit ucxx
git -C ./ucxx checkout branch-0.39
rapids-pull-repositories

# install all the other dependencies
rapids-make-pip-env --force

# build all the packages
build-all -j

# run the cuml unit tests
cd ./cuml
./ci/run_cuml_singlegpu_pytests.sh
```

Found that the `cuml` unit tests failed immediately with an error complaining about `hdbscan` not being available. Looks like that's because it's used unconditionally here:

https://github.com/rapidsai/cuml/blob/6342914f3ad8460da70c2b53cdedd84657531a0b/python/cuml/tests/test_hdbscan.py#L20

This hasn't shown up in CI because in CI, the `cuml` wheel's `[test]` extra is used to figure out what dependencies to install:

https://github.com/rapidsai/cuml/blob/6342914f3ad8460da70c2b53cdedd84657531a0b/ci/test_wheel.sh#L16

But RAPIDS devcontainers use `rapids-dependency-file-generator --output requirements`:

https://github.com/rapidsai/devcontainers/blob/0ec3cbd47af5ffdc1399af2cb9e33e34617230c3/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh#L90-L96