### PR TITLE
Use verify-alpha-spec hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,13 +59,8 @@ repos:
                 - cpp/test
             pass_filenames: false
             language: python
-    - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.13.11
-      hooks:
-          - id: rapids-dependency-file-generator
-            args: ["--clean"]
     - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v0.0.3
+      rev: v0.2.0
       hooks:
         - id: verify-copyright
           files: |
@@ -79,6 +74,12 @@ repos:
           exclude: |
             (?x)
                 cpp/src/tsne/cannylab/bh[.]cu$
+        - id: verify-alpha-spec
+    - repo: https://github.com/rapidsai/dependency-file-generator
+      rev: v1.13.11
+      hooks:
+          - id: rapids-dependency-file-generator
+            args: ["--clean"]
 
 default_language_version:
     python: python3


### PR DESCRIPTION
With the deployment of rapids-build-backend, we need to make sure our dependencies have alpha specs.

Contributes to https://github.com/rapidsai/build-planning/issues/31