### PR TITLE
skip CMake 3.30.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-python>=11.7.1,<12.0a0
 - cuda-version=11.8
 - cudatoolkit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api

--- a/conda/environments/clang_tidy_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-118_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - clang-tools==15.0.7
 - clang==15.0.7
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-version=11.8
 - cudatoolkit
 - cxx-compiler

--- a/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-118_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-version=11.8
 - cudatoolkit
 - cxx-compiler

--- a/conda/environments/cpp_all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-122_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api

--- a/conda/recipes/cuml-cpu/conda_build_config.yaml
+++ b/conda/recipes/cuml-cpu/conda_build_config.yaml
@@ -5,7 +5,7 @@ cxx_compiler_version:
   - 11
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -11,7 +11,7 @@ cuda11_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -17,7 +17,7 @@ c_stdlib_version:
   - "=2.17"
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 treelite_version:
   - "=4.2.1"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -129,7 +129,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - ninja
       - output_types: conda
         packages:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -153,7 +153,7 @@ versioneer\.py |
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "cuda-python",
     "cython>=3.0.0",
     "ninja",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.
