### PR TITLE
split up CUDA-suffixed dependencies in dependencies.yaml

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -53,8 +53,8 @@ DEPENDENCIES=(
   rapids-dask-dependency
   rmm
 )
-for FILE in dependencies.yaml conda/environments/*.yaml; do
-  for DEP in "${DEPENDENCIES[@]}"; do
+for DEP in "${DEPENDENCIES[@]}"; do
+  for FILE in dependencies.yaml conda/environments/*.yaml; do
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
   done
   for FILE in python/*/pyproject.toml; do

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -37,12 +37,6 @@ function sed_runner() {
 # Centralized version file update
 echo "${NEXT_FULL_TAG}" > VERSION
 
-# pyproject.toml versions
-sed_runner "s/rmm==.*\",/rmm==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/cuml/pyproject.toml
-sed_runner "s/cudf==.*\",/cudf==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/cuml/pyproject.toml
-sed_runner "s/pylibraft==.*\",/pylibraft==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/cuml/pyproject.toml
-sed_runner "s/raft-dask==.*\",/raft-dask==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\",/g" python/cuml/pyproject.toml
-
 DEPENDENCIES=(
   cudf
   cuml
@@ -62,6 +56,9 @@ DEPENDENCIES=(
 for FILE in dependencies.yaml conda/environments/*.yaml; do
   for DEP in "${DEPENDENCIES[@]}"; do
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
+  done
+  for FILE in python/*/pyproject.toml; do
+    sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" ${FILE}
   done
 done
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -180,8 +180,8 @@ dependencies:
           - &treelite treelite==4.2.1
       - output_types: conda
         packages:
-          - &pylibraft_conda pylibraft==24.8.*,>=0.0.0a0
-          - &rmm_conda rmm==24.8.*,>=0.0.0a0
+          - &pylibraft_unsuffixed pylibraft==24.8.*,>=0.0.0a0
+          - &rmm_unsuffixed rmm==24.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -211,27 +211,15 @@ dependencies:
               - pylibraft-cu12==24.8.*,>=0.0.0a0
               - rmm-cu12==24.8.*,>=0.0.0a0
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *pylibraft_conda
-              - *rmm_conda
-          - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
               - pylibraft-cu11==24.8.*,>=0.0.0a0
               - rmm-cu11==24.8.*,>=0.0.0a0
           - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
             packages:
-              - *pylibraft_conda
-              - *rmm_conda
-          - matrix:
-            packages:
-              - *pylibraft_conda
-              - *rmm_conda
+              - *pylibraft_unsuffixed
+              - *rmm_unsuffixed
 
   py_run:
     common:
@@ -249,10 +237,10 @@ dependencies:
           - *treelite
       - output_types: conda
         packages:
-          - &cudf_conda cudf==24.8.*,>=0.0.0a0
-          - &cupy_conda cupy>=12.0.0
-          - &dask_cudf_conda dask-cudf==24.8.*,>=0.0.0a0
-          - &raft_dask_conda raft-dask==24.8.*,>=0.0.0a0
+          - &cudf_unsuffixed cudf==24.8.*,>=0.0.0a0
+          - &cupy_unsuffixed cupy>=12.0.0
+          - &dask_cudf_unsuffixed dask-cudf==24.8.*,>=0.0.0a0
+          - &raft_dask_unsuffixed raft-dask==24.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -276,14 +264,14 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "false"
             packages:
-              - *cudf_conda
+              - *cudf_unsuffixed
               # NOTE: cupy still has a "-cuda12x" suffix here, because it's suffixed
               #       in DLFW builds
               - *cupy_pyproject_cu12
-              - *dask_cudf_conda
-              - *pylibraft_conda
-              - *raft_dask_conda
-              - *rmm_conda
+              - *dask_cudf_unsuffixed
+              - *pylibraft_unsuffixed
+              - *raft_dask_unsuffixed
+              - *rmm_unsuffixed
           - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
@@ -298,22 +286,22 @@ dependencies:
               cuda: "11.*"
               cuda_suffixed: "false"
             packages:
-              - *cudf_conda
+              - *cudf_unsuffixed
               # NOTE: cupy still has a "-cuda11x" suffix here, because it's suffixed
               #       in DLFW builds
               - *cupy_pyproject_cu11
-              - *dask_cudf_conda
-              - *pylibraft_conda
-              - *raft_dask_conda
-              - *rmm_conda
+              - *dask_cudf_unsuffixed
+              - *pylibraft_unsuffixed
+              - *raft_dask_unsuffixed
+              - *rmm_unsuffixed
           - matrix:
             packages:
-              - *cudf_conda
+              - *cudf_unsuffixed
               - *cupy_pyproject_cu11
-              - *dask_cudf_conda
-              - *pylibraft_conda
-              - *raft_dask_conda
-              - *rmm_conda
+              - *dask_cudf_unsuffixed
+              - *pylibraft_unsuffixed
+              - *raft_dask_unsuffixed
+              - *rmm_unsuffixed
   cuda_version:
     specific:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -204,18 +204,34 @@ dependencies:
               - cuda-python
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - pylibraft-cu12==24.8.*,>=0.0.0a0
               - rmm-cu12==24.8.*,>=0.0.0a0
-          - matrix: {cuda: "11.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "false"
             packages:
-              - &pylibraft_cu11 pylibraft-cu11==24.8.*,>=0.0.0a0
-              - &rmm_cu11 rmm-cu11==24.8.*,>=0.0.0a0
+              - *pylibraft_conda
+              - *rmm_conda
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - pylibraft-cu11==24.8.*,>=0.0.0a0
+              - rmm-cu11==24.8.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "false"
+            packages:
+              - *pylibraft_conda
+              - *rmm_conda
           - matrix:
             packages:
-              - pylibraft==24.8.*,>=0.0.0a0
-              - rmm==24.8.*,>=0.0.0a0
+              - *pylibraft_conda
+              - *rmm_conda
 
   py_run:
     common:
@@ -246,22 +262,50 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - cudf-cu12==24.8.*,>=0.0.0a0
-              - cupy-cuda12x>=12.0.0
+              - &cupy_pyproject_cu12 cupy-cuda12x>=12.0.0
               - dask-cudf-cu12==24.8.*,>=0.0.0a0
               - pylibraft-cu12==24.8.*,>=0.0.0a0
               - raft-dask-cu12==24.8.*,>=0.0.0a0
               - rmm-cu12==24.8.*,>=0.0.0a0
-          - matrix: {cuda: "11.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "false"
+            packages:
+              - *cudf_conda
+              # NOTE: cupy still has a "-cuda12x" suffix here, because it's suffixed
+              #       in DLFW builds
+              - *cupy_pyproject_cu12
+              - *dask_cudf_conda
+              - *pylibraft_conda
+              - *raft_dask_conda
+              - *rmm_conda
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
             packages: &py_run_packages_cu11
               - cudf-cu11==24.8.*,>=0.0.0a0
               - &cupy_pyproject_cu11 cupy-cuda11x>=12.0.0
               - dask-cudf-cu11==24.8.*,>=0.0.0a0
-              - *pylibraft_cu11
+              - pylibraft-cu11==24.8.*,>=0.0.0a0
               - raft-dask-cu11==24.8.*,>=0.0.0a0
-              - *rmm_cu11
+              - rmm-cu11==24.8.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "false"
+            packages:
+              - *cudf_conda
+              # NOTE: cupy still has a "-cuda11x" suffix here, because it's suffixed
+              #       in DLFW builds
+              - *cupy_pyproject_cu11
+              - *dask_cudf_conda
+              - *pylibraft_conda
+              - *raft_dask_conda
+              - *rmm_conda
           - matrix:
             packages:
               - *cudf_conda

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -153,6 +153,7 @@ versioneer\.py |
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
+matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cuda-python",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31

In short, RAPIDS DLFW builds want to produce wheels with unsuffixed dependencies, e.g. `cudf` depending on `rmm`, not `rmm-cu12`.

This PR is part of a series across all of RAPIDS to try to support that type of build by setting up CUDA-suffixed and CUDA-unsuffixed dependency lists in `dependencies.yaml`.

For more details, see:
* https://github.com/rapidsai/build-planning/issues/31#issuecomment-2245815818
* https://github.com/rapidsai/cudf/pull/16183

## Notes for Reviewers

### Why target 24.08?

This is targeting 24.08 because:

1. it should be very low-risk
2. getting these changes into 24.08 prevents the need to carry around patches for every library in DLFW builds using RAPIDS 24.08