### PR TITLE
Kernel PCA Algorithm C++

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -469,6 +469,12 @@ if(BUILD_CUML_CPP_LIBRARY)
         src/pca/pca.cu)
   endif()
 
+  if(all_algo OR kpca_algo)
+    target_sources(${CUML_CPP_TARGET}
+      PRIVATE
+        src/kpca/kpca.cu)
+  endif()
+
   if(all_algo OR randomforest_algo)
     target_sources(${CUML_CPP_TARGET}
       PRIVATE

--- a/cpp/cmake/modules/ConfigureAlgorithms.cmake
+++ b/cpp/cmake/modules/ConfigureAlgorithms.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ else()
     if(decomposition_algo)
       set(pca_algo ON)
       set(tsvd_algo ON)
+      set(kpca_algo ON)
     endif()
 
     if(ensemble_algo)

--- a/cpp/include/cuml/decomposition/kpca.hpp
+++ b/cpp/include/cuml/decomposition/kpca.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "params.hpp"
+
+namespace raft {
+class handle_t;
+}
+
+namespace ML {
+
+void kpcaFit(raft::handle_t& handle,
+             float* input,
+             float* eigenvectors,
+             float* eigenvalues,
+             int* n_components,
+             const paramsKPCA& prms);
+
+void kpcaFit(raft::handle_t& handle,
+             double* input,
+             double* eigenvectors,
+             double* eigenvalues,
+             int* n_components,
+             const paramsKPCA& prms);
+
+void kpcaTransformWithFitData(raft::handle_t& handle,
+                              float* eigenvectors,
+                              float* eigenvalues,
+                              float* trans_input,
+                              const paramsKPCA& prms);
+
+void kpcaTransformWithFitData(raft::handle_t& handle,
+                              double* eigenvectors,
+                              double* eigenvalues,
+                              double* trans_input,
+                              const paramsKPCA& prms);
+
+void kpcaTransform(const raft::handle_t& handle,
+                   float* fit_input,
+                   float* input,
+                   float* eigenvectors,
+                   float* eigenvalues,
+                   float* trans_input,
+                   const paramsKPCA& prms);
+
+void kpcaTransform(const raft::handle_t& handle,
+                   double* fit_input,
+                   double* input,
+                   double* eigenvectors,
+                   double* eigenvalues,
+                   double* trans_input,
+                   const paramsKPCA& prms);
+
+};  // end namespace ML

--- a/cpp/include/cuml/decomposition/params.hpp
+++ b/cpp/include/cuml/decomposition/params.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <cuml/matrix/kernelparams.h>
 
 #include <cstdint>
 
@@ -78,8 +79,19 @@ class paramsPCATemplate : public paramsTSVDTemplate<enum_solver> {
   bool whiten = false;
 };
 
+template <typename enum_solver = solver>
+class paramsKPCATemplate : public paramsTSVDTemplate<enum_solver> {
+ public:
+  MLCommon::Matrix::KernelParams kernel;
+  size_t n_training_samples  = 0;
+  bool copy                  = true;  // TODO unused
+  bool remove_zero_eig       = false;
+  bool fit_inverse_transform = false;  // TODO unused
+};
+
 typedef paramsTSVDTemplate<> paramsTSVD;
 typedef paramsPCATemplate<> paramsPCA;
+typedef paramsKPCATemplate<> paramsKPCA;
 
 enum class mg_solver { COV_EIG_DQ, COV_EIG_JACOBI, QR };
 

--- a/cpp/src/kpca/kpca.cu
+++ b/cpp/src/kpca/kpca.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kpca.cuh"
+
+#include <cuml/decomposition/kpca.hpp>
+namespace ML {
+
+void kpcaFit(raft::handle_t& handle,
+             float* input,
+             float* eigenvectors,
+             float* eigenvalues,
+             int* n_components,
+             const ML::paramsKPCA& prms)
+{
+  kpcaFit(handle, input, eigenvectors, eigenvalues, n_components, prms, handle.get_stream());
+}
+
+void kpcaFit(raft::handle_t& handle,
+             double* input,
+             double* eigenvectors,
+             double* eigenvalues,
+             int* n_components,
+             const ML::paramsKPCA& prms)
+{
+  kpcaFit(handle, input, eigenvectors, eigenvalues, n_components, prms, handle.get_stream());
+}
+
+void kpcaTransformWithFitData(raft::handle_t& handle,
+                              float* eigenvectors,
+                              float* eigenvalues,
+                              float* trans_input,
+                              const ML::paramsKPCA& prms)
+{
+  kpcaTransformWithFitData(
+    handle, eigenvectors, eigenvalues, trans_input, prms, handle.get_stream());
+}
+
+void kpcaTransformWithFitData(raft::handle_t& handle,
+                              double* eigenvectors,
+                              double* eigenvalues,
+                              double* trans_input,
+                              const paramsKPCA& prms)
+{
+  kpcaTransformWithFitData(
+    handle, eigenvectors, eigenvalues, trans_input, prms, handle.get_stream());
+}
+
+void kpcaTransform(const raft::handle_t& handle,
+                   float* fit_input,
+                   float* input,
+                   float* eigenvectors,
+                   float* eigenvalues,
+                   float* trans_input,
+                   const ML::paramsKPCA& prms)
+{
+  kpcaTransform(
+    handle, fit_input, input, eigenvectors, eigenvalues, trans_input, prms, handle.get_stream());
+}
+
+void kpcaTransform(const raft::handle_t& handle,
+                   double* fit_input,
+                   double* input,
+                   double* eigenvectors,
+                   double* eigenvalues,
+                   double* trans_input,
+                   const ML::paramsKPCA& prms)
+{
+  kpcaTransform(
+    handle, fit_input, input, eigenvectors, eigenvalues, trans_input, prms, handle.get_stream());
+}
+
+}  // namespace ML

--- a/cpp/src/kpca/kpca.cuh
+++ b/cpp/src/kpca/kpca.cuh
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <common/device_utils.cuh>
+
+#include <cuml/common/utils.hpp>
+#include <cuml/decomposition/params.hpp>
+#include <cuml/matrix/kernelparams.h>
+
+#include <raft/core/handle.hpp>
+#include <raft/distance/kernels.cuh>
+#include <raft/linalg/detail/cublas_wrappers.hpp>
+#include <raft/linalg/eig.cuh>
+#include <raft/linalg/gemm.cuh>
+#include <raft/linalg/subtract.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <raft/stats/mean.cuh>
+#include <raft/stats/mean_center.cuh>
+#include <raft/util/cuda_utils.cuh>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cuda_runtime.h>
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
+#include <thrust/find.h>
+#include <thrust/reduce.h>
+
+#include <tsvd/tsvd.cuh>
+
+#include <utility>
+
+namespace ML {
+
+// All the positive eigenvalues that are too small (with a value smaller than the maximum
+// eigenvalue multiplied by for double precision 1e-12 (2e-7 for float)) are set to zero.
+template <typename T>
+struct is_too_small;
+
+template <>
+struct is_too_small<double> {
+  double* eigenvectors;
+
+  __device__ is_too_small(double* eigenvectors) : eigenvectors(eigenvectors) {}
+
+  __device__ bool operator()(const double& x) const { return x < eigenvectors[0] * 1e-12; }
+};
+
+template <>
+struct is_too_small<float> {
+  float* eigenvectors;
+
+  __device__ is_too_small(float* eigenvectors) : eigenvectors(eigenvectors) {}
+
+  __device__ bool operator()(const float& x) const { return x < eigenvectors[0] * 2e-7; }
+};
+
+template <typename T>
+CUML_KERNEL void subtractMeanKernel(
+  T* mat, const T* row_means, const T* col_means, T overall_mean, int n_rows, int n_cols)
+{
+  const int row = blockIdx.x * blockDim.x + threadIdx.x;
+  const int col = blockIdx.y * blockDim.y + threadIdx.y;
+  if (row < n_rows && col < n_cols) {
+    const int index = col * n_rows + row;
+    mat[index]      = mat[index] - row_means[row] - col_means[col] + overall_mean;
+  }
+}
+
+template <typename value_t>
+CUML_KERNEL void divideBySqrtKernel(value_t* eigenvectors,
+                                    const value_t* sqrt_vals,
+                                    size_t n_training_samples,
+                                    size_t n_components)
+{
+  size_t col = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t row = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if (col < n_components && row < n_training_samples) {
+    size_t idx = col * n_training_samples + row;
+    eigenvectors[idx] /= sqrt_vals[col];
+  }
+}
+
+template <typename value_t>
+void evaluateKernelMatrix(const raft::handle_t& handle,
+                          value_t* input1,
+                          int n_rows1,
+                          value_t* input2,
+                          int n_rows2,
+                          int n_cols,
+                          const MLCommon::Matrix::KernelParams& kernel_params,
+                          rmm::device_uvector<value_t>& kernel_mat,
+                          cudaStream_t stream)
+{
+  auto thrust_policy = rmm::exec_policy(stream);
+  raft::distance::kernels::GramMatrixBase<value_t>* kernel =
+    raft::distance::kernels::KernelFactory<value_t>::create(kernel_params);
+  raft::device_matrix_view<const value_t, int, raft::layout_f_contiguous> input1_view =
+    raft::make_device_strided_matrix_view<const value_t, int, raft::layout_f_contiguous>(
+      input1, n_rows1, n_cols, 0);
+  raft::device_matrix_view<const value_t, int, raft::layout_f_contiguous> input2_view =
+    raft::make_device_strided_matrix_view<const value_t, int, raft::layout_f_contiguous>(
+      input2, n_rows2, n_cols, 0);
+
+  raft::device_matrix_view<value_t, int, raft::layout_f_contiguous> kernel_view =
+    raft::make_device_strided_matrix_view<value_t, int, raft::layout_f_contiguous>(
+      kernel_mat.data(), n_rows1, n_rows2, 0);
+
+  // Evaluate kernel matrix
+  kernel->evaluate(
+    handle, input1_view, input2_view, kernel_view, (value_t*)nullptr, (value_t*)nullptr);
+}
+
+/**
+ * @brief perform fit operation for kernel PCA. Generates eigenvalues and eigenvectors (unscaled)
+ * @param[in] handle: cuml handle object
+ * @param[in] input: data to fit using kernel PCA. Size n_rows x n_cols. The size of the data is
+ * indicated in prms.
+ * @param[out] eigenvectors: unscaled eigenvectors of the kernel matrix. Scaling occurs in the
+ * transform function. Size n_rows * n_rows.
+ * @param[out] eigenvalues: eigenvalues of the principal components. Size n_rows.
+ * @param[out] n_components: number of components to keep. If remove_zero_eig is set to true, this
+ * is the number of non-zero eigenvalues.
+ * @param[in] prms: data structure that includes all the parameters from input size to algorithm.
+ * @param[in] stream cuda stream
+ */
+template <typename value_t, typename enum_solver = ML::solver>
+void kpcaFit(const raft::handle_t& handle,
+             value_t* input,
+             value_t* eigenvectors,
+             value_t* eigenvalues,
+             int* n_components,
+             const ML::paramsKPCA& prms,
+             cudaStream_t stream)
+{
+  auto cublas_handle = handle.get_cublas_handle();
+  auto thrust_policy = rmm::exec_policy(stream);
+
+  // Evaluate and center the kernel matrix
+  rmm::device_uvector<value_t> kernel_mat(prms.n_rows * prms.n_rows, stream);
+  evaluateKernelMatrix(
+    handle, input, prms.n_rows, input, prms.n_rows, prms.n_cols, prms.kernel, kernel_mat, stream);
+  // Mean-center the kernel matrix
+  rmm::device_uvector<value_t> row_means(prms.n_rows, stream);
+
+  // Step 1: Compute row means
+  raft::stats::mean(
+    row_means.data(), kernel_mat.data(), prms.n_rows, prms.n_rows, false, true, stream);
+
+  // Step 2: Compute overall mean
+  value_t overall_mean;
+  thrust::device_ptr<value_t> d_kernel_mat_ptr(kernel_mat.data());
+  value_t sum  = thrust::reduce(thrust_policy,
+                               d_kernel_mat_ptr,
+                               d_kernel_mat_ptr + prms.n_rows * prms.n_rows,
+                               static_cast<value_t>(0));
+  overall_mean = sum / (prms.n_rows * prms.n_rows);
+
+  // Step 3: Mean-center the matrix
+  dim3 grid((prms.n_rows + 31) / 32, (prms.n_rows + 31) / 32);
+  dim3 block(32, 32);
+  subtractMeanKernel<value_t><<<grid, block, 0, stream>>>(
+    kernel_mat.data(), row_means.data(), row_means.data(), overall_mean, prms.n_rows, prms.n_rows);
+
+  // Either Jacobi (iterative power method) or DnC eigendecomp
+  if (prms.algorithm == enum_solver::COV_EIG_JACOBI) {
+    raft::linalg::eigJacobi(handle,
+                            kernel_mat.data(),
+                            prms.n_rows,
+                            prms.n_rows,
+                            eigenvectors,
+                            eigenvalues,
+                            stream,
+                            (value_t)prms.tol,
+                            prms.n_iterations);
+  } else {
+    raft::linalg::eigDC(
+      handle, kernel_mat.data(), prms.n_rows, prms.n_rows, eigenvectors, eigenvalues, stream);
+  }
+  // reverse since eigensolver returns in ascending order
+  raft::matrix::colReverse(eigenvectors, prms.n_rows, prms.n_rows, stream);
+  raft::matrix::rowReverse(eigenvalues, prms.n_rows, std::size_t(1), stream);
+  ML::signFlip(eigenvectors, prms.n_rows, prms.n_rows, eigenvalues, std::size_t(0), stream);
+  if (prms.remove_zero_eig) {
+    // Find the largest index of non-zero eigenvector
+    thrust::device_ptr<value_t> d_eigenvalues_ptr(eigenvalues);
+
+    auto it = thrust::find_if(thrust_policy,
+                              d_eigenvalues_ptr,
+                              d_eigenvalues_ptr + prms.n_rows,
+                              is_too_small<value_t>(eigenvalues));
+    int largest_nonzero_index =
+      (it == d_eigenvalues_ptr + prms.n_rows) ? prms.n_rows : (it - d_eigenvalues_ptr);
+    n_components[0] = min(largest_nonzero_index, (int)prms.n_components);
+  }
+}
+
+/**
+ * @brief performs transform operation for the pca. Transforms the data to kernel eigenspace. Used
+ * when fit and transform are on the same data.
+ * @param[in] handle: the internal cuml handle object
+ * @param[out] eigenvectors: principal components of the input data. Size n_rows * n_components.
+ * @param[out] eigenvalues: singular values of the data. Size n_components.
+ * @param[out] trans_input:  the transformed data. Size n_rows * n_components.
+ * @param[in] prms: data structure that includes all the parameters from input size to algorithm.
+ * @param[in] stream cuda stream
+ */
+template <typename value_t>
+void kpcaTransformWithFitData(const raft::handle_t& handle,
+                              value_t* eigenvectors,
+                              value_t* eigenvalues,
+                              value_t* trans_input,
+                              const ML::paramsKPCA& prms,
+                              cudaStream_t stream)
+{
+  rmm::device_uvector<value_t> sqrt_vals(prms.n_components, stream);
+  raft::matrix::seqRoot(eigenvalues, sqrt_vals.data(), prms.n_components, stream);
+  raft::update_device(trans_input, eigenvectors, prms.n_components * prms.n_rows, stream);
+  raft::matrix::matrixVectorBinaryMult(
+    trans_input, sqrt_vals.data(), prms.n_rows, prms.n_components, false, true, stream);
+}
+
+/**
+ * @brief performs transform operation for the pca. Transforms the data to kernel eigenspace.
+ * @param[in] handle: the internal cuml handle object
+ * @param[in] fit_input: data used. Size n_training_samples x n_cols.
+ * @param[in] input: data to transform. Size n_rows x n_cols.
+ * @param[in] eigenvectors: principal components of the input data. Size n_training_samples *
+ * n_components.
+ * @param[in] eigenvalues: singular values of the data. Size n_components.
+ * @param[out] trans_input:  the transformed data. Size n_rows * n_components.
+ * @param[in] prms: data structure that includes all the parameters from input size to algorithm.
+ * @param[in] stream cuda stream
+ */
+template <typename value_t>
+void kpcaTransform(const raft::handle_t& handle,
+                   value_t* fit_input,
+                   value_t* input,
+                   value_t* eigenvectors,
+                   value_t* eigenvalues,
+                   value_t* trans_input,
+                   const ML::paramsKPCA& prms,
+                   cudaStream_t stream)
+{
+  rmm::device_uvector<value_t> kernel_mat(prms.n_rows * prms.n_training_samples, stream);
+  rmm::device_uvector<value_t> fitted_kernel_mat(prms.n_training_samples * prms.n_training_samples,
+                                                 stream);
+  auto thrust_policy = rmm::exec_policy(stream);
+  thrust::fill(thrust_policy, kernel_mat.begin(), kernel_mat.end(), 0.0f);
+  evaluateKernelMatrix(handle,
+                       input,
+                       prms.n_rows,
+                       fit_input,
+                       prms.n_training_samples,
+                       prms.n_cols,
+                       prms.kernel,
+                       kernel_mat,
+                       stream);
+  evaluateKernelMatrix(handle,
+                       fit_input,
+                       prms.n_training_samples,
+                       fit_input,
+                       prms.n_training_samples,
+                       prms.n_cols,
+                       prms.kernel,
+                       fitted_kernel_mat,
+                       stream);
+
+  // Mean-center the kernel matrix
+  rmm::device_uvector<value_t> row_means(prms.n_training_samples, stream);
+  rmm::device_uvector<value_t> col_means(prms.n_rows, stream);
+
+  // Step 1: Compute row means
+  raft::stats::mean(row_means.data(),
+                    fitted_kernel_mat.data(),
+                    prms.n_training_samples,
+                    prms.n_training_samples,
+                    false,
+                    true,
+                    stream);
+
+  // Step 2: Compute column means
+  raft::stats::mean(
+    col_means.data(), kernel_mat.data(), prms.n_rows, prms.n_training_samples, false, true, stream);
+  // Step 3: Compute overall mean
+  value_t overall_mean;
+  thrust::device_ptr<value_t> d_kernel_mat_ptr(fitted_kernel_mat.data());
+  value_t sum  = thrust::reduce(thrust_policy,
+                               d_kernel_mat_ptr,
+                               d_kernel_mat_ptr + prms.n_rows * prms.n_rows,
+                               static_cast<value_t>(0));
+  overall_mean = sum / (prms.n_rows * prms.n_rows);
+  // Output the overall mean
+
+  // Step 4: Mean-center the matrix
+  dim3 grid((prms.n_rows + 31) / 32, (prms.n_training_samples + 31) / 32);
+  dim3 block(32, 32);
+  subtractMeanKernel<value_t><<<grid, block, 0, stream>>>(kernel_mat.data(),
+                                                          col_means.data(),
+                                                          row_means.data(),
+                                                          overall_mean,
+                                                          prms.n_rows,
+                                                          prms.n_training_samples);
+
+  rmm::device_uvector<value_t> sqrt_vals(prms.n_components, stream);
+  raft::matrix::seqRoot(eigenvalues, sqrt_vals.data(), prms.n_components, stream);
+  rmm::device_uvector<value_t> eigenvectors_div_by_sqrt(prms.n_training_samples * prms.n_components,
+                                                        stream);
+  raft::update_device(eigenvectors_div_by_sqrt.data(),
+                      eigenvectors,
+                      prms.n_components * prms.n_training_samples,
+                      stream);
+  // Launch kernel to divide each element in eigenvectors by the corresponding sqrt_val
+  dim3 gridDim((prms.n_components + 31) / 32, (prms.n_training_samples + 31) / 32);
+  dim3 blockDim(32, 32);
+  divideBySqrtKernel<<<gridDim, blockDim, 0, stream>>>(
+    eigenvectors_div_by_sqrt.data(), sqrt_vals.data(), prms.n_training_samples, prms.n_components);
+
+  raft::linalg::gemm(handle,
+                     trans_input,
+                     kernel_mat.data(),
+                     eigenvectors_div_by_sqrt.data(),
+                     prms.n_rows,
+                     prms.n_components,
+                     prms.n_training_samples,
+                     true,
+                     true,
+                     true,
+                     stream);
+}
+}  // namespace ML

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -169,6 +169,10 @@ if(all_algo OR pca_algo)
   ConfigureTest(PREFIX SG NAME PCA_TEST  sg/pca_test.cu ML_INCLUDE)
 endif()
 
+if(all_algo OR kpca_algo)
+  ConfigureTest(PREFIX SG NAME KPCA_TEST  sg/kpca_test.cu ML_INCLUDE)
+endif()
+
 if(all_algo OR randomforest_algo)
   ConfigureTest(PREFIX SG NAME RF_TEST  sg/rf_test.cu ML_INCLUDE)
 endif()

--- a/cpp/test/sg/kpca_test.cu
+++ b/cpp/test/sg/kpca_test.cu
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuml/decomposition/params.hpp>
+
+#include <raft/linalg/detail/cublas_wrappers.hpp>
+#include <raft/random/rng.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <kpca/kpca.cuh>
+#include <test_utils.h>
+
+#include <vector>
+
+namespace ML {
+
+using namespace MLCommon;
+
+template <typename T>
+struct KPcaInputs {
+  T tolerance;
+  int n_rows;
+  int n_cols;
+  int n_components;
+  int algo;
+  raft::distance::kernels::KernelParams kernel;
+  std::vector<T> data_h;
+  std::vector<T> eigenvectors_ref_h;
+  std::vector<T> eigenvalues_ref_h;
+  std::vector<T> trans_data_ref_h;
+  bool fit_transform_test;
+};
+
+template <typename T>
+class KPcaTest : public ::testing::TestWithParam<KPcaInputs<T>> {
+ public:
+  KPcaTest()
+    : params(::testing::TestWithParam<KPcaInputs<T>>::GetParam()),
+      stream(handle.get_stream()),
+      data(params.n_rows * params.n_cols, stream),
+      trans_data(params.n_rows * params.n_components, stream),
+      eigenvectors(params.n_rows * params.n_components, stream),
+      eigenvalues(params.n_components, stream),
+      alphas(params.n_rows * params.n_rows, stream),
+      lambdas(params.n_rows, stream),
+      trans_data_ref(params.n_rows * params.n_components, stream),
+      eigenvectors_ref(params.n_rows * params.n_components, stream),
+      eigenvalues_ref(params.n_components, stream)
+  {
+    if (!params.fit_transform_test)
+      fitThenTransform();
+    else
+      fitTransformTest();
+  }
+
+ protected:
+  void fitThenTransform()
+  {
+    raft::update_device(data.data(), params.data_h.data(), params.n_rows * params.n_cols, stream);
+    raft::update_device(trans_data_ref.data(),
+                        params.trans_data_ref_h.data(),
+                        params.n_rows * params.n_components,
+                        stream);
+    raft::update_device(
+      eigenvalues_ref.data(), params.eigenvalues_ref_h.data(), params.n_components, stream);
+    raft::update_device(eigenvectors_ref.data(),
+                        params.eigenvectors_ref_h.data(),
+                        params.n_rows * params.n_components,
+                        stream);
+
+    paramsKPCA prms;
+    prms.n_rows             = params.n_rows;
+    prms.n_training_samples = params.n_rows;
+    prms.n_cols             = params.n_cols;
+    prms.n_components       = params.n_components;
+    prms.kernel             = params.kernel;
+    prms.remove_zero_eig    = false;
+    if (params.algo == 0)
+      prms.algorithm = solver::COV_EIG_DQ;
+    else
+      prms.algorithm = solver::COV_EIG_JACOBI;
+    int* n_components = (int*)malloc(sizeof(int));
+    *n_components     = params.n_components;
+    kpcaFit(handle, data.data(), alphas.data(), lambdas.data(), n_components, prms, stream);
+
+    raft::update_device(
+      eigenvectors.data(), alphas.data(), prms.n_rows * prms.n_components, stream);
+    raft::update_device(eigenvalues.data(), lambdas.data(), prms.n_components, stream);
+    handle.sync_stream(stream);
+    kpcaTransform(handle,
+                  data.data(),
+                  data.data(),
+                  eigenvectors.data(),
+                  eigenvalues.data(),
+                  trans_data.data(),
+                  prms,
+                  stream);
+  }
+
+  void fitTransformTest()
+  {
+    raft::update_device(data.data(), params.data_h.data(), params.n_rows * params.n_cols, stream);
+    raft::update_device(trans_data_ref.data(),
+                        params.trans_data_ref_h.data(),
+                        params.n_rows * params.n_components,
+                        stream);
+    raft::update_device(
+      eigenvalues_ref.data(), params.eigenvalues_ref_h.data(), params.n_components, stream);
+    raft::update_device(eigenvectors_ref.data(),
+                        params.eigenvectors_ref_h.data(),
+                        params.n_rows * params.n_components,
+                        stream);
+
+    paramsKPCA prms;
+    prms.n_rows             = params.n_rows;
+    prms.n_training_samples = params.n_rows;
+    prms.n_cols             = params.n_cols;
+    prms.n_components       = params.n_components;
+    prms.kernel             = params.kernel;
+    prms.remove_zero_eig    = false;
+    if (params.algo == 0)
+      prms.algorithm = solver::COV_EIG_DQ;
+    else
+      prms.algorithm = solver::COV_EIG_JACOBI;
+
+    int* n_components = (int*)malloc(sizeof(int));
+    *n_components     = prms.n_components;
+    kpcaFit(handle, data.data(), alphas.data(), lambdas.data(), n_components, prms, stream);
+
+    raft::update_device(
+      eigenvectors.data(), alphas.data(), prms.n_rows * prms.n_components, stream);
+    raft::update_device(eigenvalues.data(), lambdas.data(), prms.n_components, stream);
+    handle.sync_stream(stream);
+    kpcaTransformWithFitData(
+      handle, eigenvectors.data(), eigenvalues.data(), trans_data.data(), prms, stream);
+  }
+
+ protected:
+  KPcaInputs<T> params;
+
+  rmm::device_uvector<T> data, trans_data, eigenvectors, eigenvalues, trans_data_ref,
+    eigenvectors_ref, eigenvalues_ref, lambdas, alphas;
+
+  raft::handle_t handle;
+  cudaStream_t stream;
+};
+
+float tolerance           = 0.01f;
+int n_rows                = 3;
+int n_cols                = 2;
+int n_components          = 2;
+int algo                  = 1;
+std::vector<float> data_h = {1.0, 2.0, 5.0, 4.0, 2.0, 1.0};
+
+raft::distance::kernels::KernelParams lin_kern = {raft::distance::kernels::LINEAR, 0, 0, 0};
+std::vector<float> lin_eigenvectors_ref_h = {-0.6525, -0.0987, 0.7513, -0.4907, 0.8105, -0.3197};
+std::vector<float> lin_eigenvalues_ref_h  = {12.6759, 0.6574};
+std::vector<float> lin_trans_data_ref_h   = {
+  -2.32318647, -0.35170213, 2.6748886, -0.39794495, 0.65716145, -0.25921649};
+KPcaInputs<float> linear_inputs                   = {tolerance,
+                                                     n_rows,
+                                                     n_cols,
+                                                     n_components,
+                                                     algo,
+                                                     lin_kern,
+                                                     data_h,
+                                                     lin_eigenvectors_ref_h,
+                                                     lin_eigenvalues_ref_h,
+                                                     lin_trans_data_ref_h,
+                                                     false};
+KPcaInputs<float> linear_inputs_for_fit_transform = {tolerance,
+                                                     n_rows,
+                                                     n_cols,
+                                                     n_components,
+                                                     algo,
+                                                     lin_kern,
+                                                     data_h,
+                                                     lin_eigenvectors_ref_h,
+                                                     lin_eigenvalues_ref_h,
+                                                     lin_trans_data_ref_h,
+                                                     true};
+
+raft::distance::kernels::KernelParams poly_kern = {
+  raft::distance::kernels::POLYNOMIAL, 3, 1.0 / 2.0f, 1};
+std::vector<float> poly_eigenvectors_ref_h = {-0.5430, -0.2565, 0.7995, -0.6097, 0.7751, -0.1653};
+std::vector<float> poly_eigenvalues_ref_h  = {1790.3207, 210.3639};
+std::vector<float> poly_trans_data_ref_h = {-22.9760, -10.8554, 33.8314, -8.8438, 11.2426, -2.3987};
+KPcaInputs<float> poly_inputs            = {tolerance,
+                                            n_rows,
+                                            n_cols,
+                                            n_components,
+                                            algo,
+                                            poly_kern,
+                                            data_h,
+                                            poly_eigenvectors_ref_h,
+                                            poly_eigenvalues_ref_h,
+                                            poly_trans_data_ref_h,
+                                            false};
+KPcaInputs<float> poly_inputs_for_fit_transform = {tolerance,
+                                                   n_rows,
+                                                   n_cols,
+                                                   n_components,
+                                                   algo,
+                                                   poly_kern,
+                                                   data_h,
+                                                   poly_eigenvectors_ref_h,
+                                                   poly_eigenvalues_ref_h,
+                                                   poly_trans_data_ref_h,
+                                                   true};
+
+raft::distance::kernels::KernelParams rbf_kern = {raft::distance::kernels::RBF, 0, 1.0 / 2.0f, 0};
+std::vector<float> rbf_eigenvectors_ref_h = {-0.4341, -0.3818, 0.8159, -0.6915, 0.7217, -0.0301};
+std::vector<float> rbf_eigenvalues_ref_h  = {1.0230, 0.9177};
+std::vector<float> rbf_trans_data_ref_h   = {-0.4391, -0.3862, 0.8253, -0.6624, 0.6914, -0.0289};
+KPcaInputs<float> rbf_inputs              = {tolerance,
+                                             n_rows,
+                                             n_cols,
+                                             n_components,
+                                             algo,
+                                             rbf_kern,
+                                             data_h,
+                                             rbf_eigenvectors_ref_h,
+                                             rbf_eigenvalues_ref_h,
+                                             rbf_trans_data_ref_h,
+                                             false};
+KPcaInputs<float> rbf_inputs_for_fit_transform = {tolerance,
+                                                  n_rows,
+                                                  n_cols,
+                                                  n_components,
+                                                  algo,
+                                                  rbf_kern,
+                                                  data_h,
+                                                  rbf_eigenvectors_ref_h,
+                                                  rbf_eigenvalues_ref_h,
+                                                  rbf_trans_data_ref_h,
+                                                  true};
+
+const std::vector<KPcaInputs<float>> inputs_f = {linear_inputs,
+                                                 poly_inputs,
+                                                 rbf_inputs,
+                                                 linear_inputs_for_fit_transform,
+                                                 poly_inputs_for_fit_transform,
+                                                 rbf_inputs_for_fit_transform};
+
+typedef KPcaTest<float> KPcaTestEigenvaluesF;
+TEST_P(KPcaTestEigenvaluesF, Result)
+{
+  ASSERT_TRUE(MLCommon::devArrMatch(eigenvalues.data(),
+                                    eigenvalues_ref.data(),
+                                    params.n_components,
+                                    MLCommon::CompareApproxAbs<float>(params.tolerance)));
+}
+
+typedef KPcaTest<float> KPcaTestEigenvectorsF;
+TEST_P(KPcaTestEigenvectorsF, Result)
+{
+  ASSERT_TRUE(MLCommon::devArrMatch(eigenvectors.data(),
+                                    eigenvectors_ref.data(),
+                                    (params.n_rows * params.n_components),
+                                    MLCommon::CompareApproxAbs<float>(params.tolerance)));
+}
+
+typedef KPcaTest<float> KPcaTestTransDataF;
+TEST_P(KPcaTestTransDataF, Result)
+{
+  ASSERT_TRUE(MLCommon::devArrMatch(trans_data.data(),
+                                    trans_data_ref.data(),
+                                    (params.n_rows * params.n_components),
+                                    MLCommon::CompareApproxAbs<float>(params.tolerance)));
+}
+
+INSTANTIATE_TEST_CASE_P(KPcaTests, KPcaTestEigenvaluesF, ::testing::ValuesIn(inputs_f));
+
+INSTANTIATE_TEST_CASE_P(KPcaTests, KPcaTestEigenvectorsF, ::testing::ValuesIn(inputs_f));
+
+INSTANTIATE_TEST_CASE_P(KPcaTests, KPcaTestTransDataF, ::testing::ValuesIn(inputs_f));
+
+// Adding double type test cases
+
+double tolerance_d          = 0.01;
+std::vector<double> data_hd = {1.0, 2.0, 5.0, 4.0, 2.0, 1.0};
+
+std::vector<double> lin_eigenvectors_ref_hd = {-0.6525, -0.0987, 0.7513, -0.4907, 0.8105, -0.3197};
+std::vector<double> lin_eigenvalues_ref_hd  = {12.6759, 0.6574};
+std::vector<double> lin_trans_data_ref_hd   = {
+  -2.32318647, -0.35170213, 2.6748886, -0.39794495, 0.65716145, -0.25921649};
+KPcaInputs<double> linear_inputs_d                   = {tolerance_d,
+                                                        n_rows,
+                                                        n_cols,
+                                                        n_components,
+                                                        algo,
+                                                        lin_kern,
+                                                        data_hd,
+                                                        lin_eigenvectors_ref_hd,
+                                                        lin_eigenvalues_ref_hd,
+                                                        lin_trans_data_ref_hd,
+                                                        false};
+KPcaInputs<double> linear_inputs_for_fit_transform_d = {tolerance_d,
+                                                        n_rows,
+                                                        n_cols,
+                                                        n_components,
+                                                        algo,
+                                                        lin_kern,
+                                                        data_hd,
+                                                        lin_eigenvectors_ref_hd,
+                                                        lin_eigenvalues_ref_hd,
+                                                        lin_trans_data_ref_hd,
+                                                        true};
+
+std::vector<double> poly_eigenvectors_ref_hd = {-0.5430, -0.2565, 0.7995, -0.6097, 0.7751, -0.1653};
+std::vector<double> poly_eigenvalues_ref_hd  = {1790.3207, 210.3639};
+std::vector<double> poly_trans_data_ref_hd   = {
+  -22.9760, -10.8554, 33.8314, -8.8438, 11.2426, -2.3987};
+KPcaInputs<double> poly_inputs_d                   = {tolerance_d,
+                                                      n_rows,
+                                                      n_cols,
+                                                      n_components,
+                                                      algo,
+                                                      poly_kern,
+                                                      data_hd,
+                                                      poly_eigenvectors_ref_hd,
+                                                      poly_eigenvalues_ref_hd,
+                                                      poly_trans_data_ref_hd,
+                                                      false};
+KPcaInputs<double> poly_inputs_for_fit_transform_d = {tolerance_d,
+                                                      n_rows,
+                                                      n_cols,
+                                                      n_components,
+                                                      algo,
+                                                      poly_kern,
+                                                      data_hd,
+                                                      poly_eigenvectors_ref_hd,
+                                                      poly_eigenvalues_ref_hd,
+                                                      poly_trans_data_ref_hd,
+                                                      true};
+
+std::vector<double> rbf_eigenvectors_ref_hd = {-0.4341, -0.3818, 0.8159, -0.6915, 0.7217, -0.0301};
+std::vector<double> rbf_eigenvalues_ref_hd  = {1.0230, 0.9177};
+std::vector<double> rbf_trans_data_ref_hd   = {-0.4391, -0.3862, 0.8253, -0.6624, 0.6914, -0.0289};
+KPcaInputs<double> rbf_inputs_d             = {tolerance_d,
+                                               n_rows,
+                                               n_cols,
+                                               n_components,
+                                               algo,
+                                               rbf_kern,
+                                               data_hd,
+                                               rbf_eigenvectors_ref_hd,
+                                               rbf_eigenvalues_ref_hd,
+                                               rbf_trans_data_ref_hd,
+                                               false};
+KPcaInputs<double> rbf_inputs_for_fit_transform_d = {tolerance_d,
+                                                     n_rows,
+                                                     n_cols,
+                                                     n_components,
+                                                     algo,
+                                                     rbf_kern,
+                                                     data_hd,
+                                                     rbf_eigenvectors_ref_hd,
+                                                     rbf_eigenvalues_ref_hd,
+                                                     rbf_trans_data_ref_hd,
+                                                     true};
+
+const std::vector<KPcaInputs<double>> inputs_d = {linear_inputs_d,
+                                                  poly_inputs_d,
+                                                  rbf_inputs_d,
+                                                  linear_inputs_for_fit_transform_d,
+                                                  poly_inputs_for_fit_transform_d,
+                                                  rbf_inputs_for_fit_transform_d};
+
+typedef KPcaTest<double> KPcaTestEigenvaluesD;
+TEST_P(KPcaTestEigenvaluesD, Result)
+{
+  ASSERT_TRUE(MLCommon::devArrMatch(eigenvalues.data(),
+                                    eigenvalues_ref.data(),
+                                    params.n_cols,
+                                    MLCommon::CompareApproxAbs<double>(params.tolerance)));
+}
+
+typedef KPcaTest<double> KPcaTestEigenvectorsD;
+TEST_P(KPcaTestEigenvectorsD, Result)
+{
+  ASSERT_TRUE(MLCommon::devArrMatch(eigenvectors.data(),
+                                    eigenvectors_ref.data(),
+                                    (params.n_rows * params.n_components),
+                                    MLCommon::CompareApproxAbs<double>(params.tolerance)));
+}
+
+typedef KPcaTest<double> KPcaTestTransDataD;
+TEST_P(KPcaTestTransDataD, Result)
+{
+  ASSERT_TRUE(MLCommon::devArrMatch(trans_data.data(),
+                                    trans_data_ref.data(),
+                                    (params.n_rows * params.n_components),
+                                    MLCommon::CompareApproxAbs<double>(params.tolerance)));
+}
+
+INSTANTIATE_TEST_CASE_P(KPcaTests, KPcaTestEigenvaluesD, ::testing::ValuesIn(inputs_d));
+
+INSTANTIATE_TEST_CASE_P(KPcaTests, KPcaTestEigenvectorsD, ::testing::ValuesIn(inputs_d));
+
+INSTANTIATE_TEST_CASE_P(KPcaTests, KPcaTestTransDataD, ::testing::ValuesIn(inputs_d));
+
+}  // end namespace ML


### PR DESCRIPTION
## Description
Adds C++ code for KernelPCA. This implementation of Kernel PCA supports three functions with float/double matrix input:

- kpcaFit()
  - Is used to fit model to input data in [fit(X)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html#sklearn.decomposition.KernelPCA.fit) and [fit_transform(X)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html#sklearn.decomposition.KernelPCA.fit_transform) in KernelPCA
- kpcaTransform()
  - Called after fit(X). Is used to support [transform(Y)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html#sklearn.decomposition.KernelPCA.transform). X and Y might be different, so we have to compute the centered gram matrix between training data X and test data Y. See [sklearn reference](https://github.com/scikit-learn/scikit-learn/blob/b72e81af473c079ae95314efbca86557a836defa/sklearn/decomposition/_kernel_pca.py#L502-L510).
- kpcaTransformWithFitData()
  - Used after kpcaFit() in [fit_transform(X)](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html#sklearn.decomposition.KernelPCA.fit_transform). We don't need to calculate the kernel matrix for X, since it's the same input data used in kpcaFit(). See [sklearn reference](https://github.com/scikit-learn/scikit-learn/blob/b72e81af473c079ae95314efbca86557a836defa/sklearn/decomposition/_kernel_pca.py#L478).

The PR builds on C++ code for kernelPCA that Garrison Hess and I started in 2021: https://github.com/rapidsai/cuml/pull/3842

Feature request: https://github.com/rapidsai/cuml/issues/1317

Tests were performed on an EC2 `g4dn.xlarge` instance with CUDA 12.2.
<details><summary>Click here to see environment details</summary><pre>

     **git***
     commit ade61faff6ac261028bc9b8bbca8b7e67be00d16 (HEAD -> fea-kernel-pca, fork/fea-kernel-pca)
     Author: Tomas Johannesson <tjohanne@alumni.cmu.edu>
     Date:   Tue Jul 23 22:01:19 2024 -0500

     syntax fix
     **git submodules***

     ***OS Information***
     DISTRIB_ID=Ubuntu
     DISTRIB_RELEASE=22.04
     DISTRIB_CODENAME=jammy
     DISTRIB_DESCRIPTION="Ubuntu 22.04.4 LTS"
     PRETTY_NAME="Ubuntu 22.04.4 LTS"
     NAME="Ubuntu"
     VERSION_ID="22.04"
     VERSION="22.04.4 LTS (Jammy Jellyfish)"
     VERSION_CODENAME=jammy
     ID=ubuntu
     ID_LIKE=debian
     HOME_URL="https://www.ubuntu.com/"
     SUPPORT_URL="https://help.ubuntu.com/"
     BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
     PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
     UBUNTU_CODENAME=jammy
     Linux ip-172-31-36-86 6.5.0-1020-aws #20~22.04.1-Ubuntu SMP Wed May  1 16:10:50 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux

     ***GPU Information***
     Thu Jul 25 01:28:58 2024
     +---------------------------------------------------------------------------------------+
     | NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.2     |
     |-----------------------------------------+----------------------+----------------------+
     | GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
     | Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
     |                                         |                      |               MIG M. |
     |=========================================+======================+======================|
     |   0  Tesla T4                       On  | 00000000:00:1E.0 Off |                    0 |
     | N/A   32C    P8              14W /  70W |      2MiB / 15360MiB |      0%      Default |
     |                                         |                      |                  N/A |
     +-----------------------------------------+----------------------+----------------------+

     +---------------------------------------------------------------------------------------+
     | Processes:                                                                            |
     |  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
     |        ID   ID                                                             Usage      |
     |=======================================================================================|
     |  No running processes found                                                           |
     +---------------------------------------------------------------------------------------+

     ***CPU***
     Architecture:                       x86_64
     CPU op-mode(s):                     32-bit, 64-bit
     Address sizes:                      46 bits physical, 48 bits virtual
     Byte Order:                         Little Endian
     CPU(s):                             4
     On-line CPU(s) list:                0-3
     Vendor ID:                          GenuineIntel
     Model name:                         Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
     CPU family:                         6
     Model:                              85
     Thread(s) per core:                 2
     Core(s) per socket:                 2
     Socket(s):                          1
     Stepping:                           7
     BogoMIPS:                           4999.99
     Flags:                              fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat pku ospke avx512_vnni
     Hypervisor vendor:                  KVM
     Virtualization type:                full
     L1d cache:                          64 KiB (2 instances)
     L1i cache:                          64 KiB (2 instances)
     L2 cache:                           2 MiB (2 instances)
     L3 cache:                           35.8 MiB (1 instance)
     NUMA node(s):                       1
     NUMA node0 CPU(s):                  0-3
     Vulnerability Gather data sampling: Unknown: Dependent on hypervisor status
     Vulnerability Itlb multihit:        KVM: Mitigation: VMX unsupported
     Vulnerability L1tf:                 Mitigation; PTE Inversion
     Vulnerability Mds:                  Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
     Vulnerability Meltdown:             Mitigation; PTI
     Vulnerability Mmio stale data:      Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
     Vulnerability Retbleed:             Vulnerable
     Vulnerability Spec rstack overflow: Not affected
     Vulnerability Spec store bypass:    Vulnerable
     Vulnerability Spectre v1:           Mitigation; usercopy/swapgs barriers and __user pointer sanitization
     Vulnerability Spectre v2:           Mitigation; Retpolines; STIBP disabled; RSB filling; PBRSB-eIBRS Not affected; BHI Retpoline
     Vulnerability Srbds:                Not affected
     Vulnerability Tsx async abort:      Not affected

     ***CMake***
     /home/ubuntu/miniconda3/envs/cuml_dev/bin/cmake
     cmake version 3.29.6

     CMake suite maintained and supported by Kitware (kitware.com/cmake).

     ***g++***
     /home/ubuntu/miniconda3/envs/cuml_dev/bin/g++
     g++ (conda-forge gcc 11.4.0-12) 11.4.0
     Copyright (C) 2021 Free Software Foundation, Inc.
     This is free software; see the source for copying conditions.  There is NO
     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


     ***nvcc***
     /home/ubuntu/miniconda3/envs/cuml_dev/bin/nvcc
     nvcc: NVIDIA (R) Cuda compiler driver
     Copyright (c) 2005-2023 NVIDIA Corporation
     Built on Tue_Aug_15_22:02:13_PDT_2023
     Cuda compilation tools, release 12.2, V12.2.140
     Build cuda_12.2.r12.2/compiler.33191640_0

     ***Python***
     /home/ubuntu/miniconda3/envs/cuml_dev/bin/python
     Python 3.11.9

     ***Environment Variables***
     PATH                            : /home/ubuntu/miniconda3/envs/cuml_dev/bin:/home/ubuntu/miniconda3/condabin:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/local/cuda-12.1/bin:/usr/local/cuda-12.1/include:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
     LD_LIBRARY_PATH                 : /opt/amazon/efa/lib:/opt/amazon/openmpi/lib:/opt/aws-ofi-nccl/lib:/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:/usr/local/cuda-12.1:/usr/local/cuda-12.1/targets/x86_64-linux/lib/:/usr/local/cuda-12.1/extras/CUPTI/lib64:/usr/local/lib:/usr/lib
     NUMBAPRO_NVVM                   :
     NUMBAPRO_LIBDEVICE              :
     CONDA_PREFIX                    : /home/ubuntu/miniconda3/envs/cuml_dev
     PYTHON_PATH                     :

     ***conda packages***
     /home/ubuntu/miniconda3/condabin/conda
     # packages in environment at /home/ubuntu/miniconda3/envs/cuml_dev:
     #
     # Name                    Version                   Build  Channel
     _libgcc_mutex             0.1                 conda_forge    conda-forge
     _openmp_mutex             4.5                       2_gnu    conda-forge
     _sysroot_linux-64_curr_repodata_hack 3                   h69a702a_14    conda-forge
     accessible-pygments       0.0.5              pyhd8ed1ab_0    conda-forge
     alabaster                 0.7.16             pyhd8ed1ab_0    conda-forge
     anyio                     4.4.0              pyhd8ed1ab_0    conda-forge
     argon2-cffi               23.1.0             pyhd8ed1ab_0    conda-forge
     argon2-cffi-bindings      21.2.0          py311h459d7ec_4    conda-forge
     arrow                     1.3.0              pyhd8ed1ab_0    conda-forge
     asttokens                 2.4.1              pyhd8ed1ab_0    conda-forge
     async-lru                 2.0.4              pyhd8ed1ab_0    conda-forge
     atk-1.0                   2.38.0               h04ea711_2    conda-forge
     attrs                     23.2.0             pyh71513ae_0    conda-forge
     aws-c-auth                0.7.22               h9137712_5    conda-forge
     aws-c-cal                 0.6.15               h88a6e22_0    conda-forge
     aws-c-common              0.9.19               h4ab18f5_0    conda-forge
     aws-c-compression         0.2.18               h83b837d_6    conda-forge
     aws-c-event-stream        0.4.2               h0cbf018_13    conda-forge
     aws-c-http                0.8.2                h360477d_2    conda-forge
     aws-c-io                  0.14.9               h2d549f9_2    conda-forge
     aws-c-mqtt                0.10.4               hf85b563_6    conda-forge
     aws-c-s3                  0.5.10               h679ed35_3    conda-forge
     aws-c-sdkutils            0.1.16               h83b837d_2    conda-forge
     aws-checksums             0.1.18               h83b837d_6    conda-forge
     aws-crt-cpp               0.26.12              h8bc9c4d_0    conda-forge
     aws-sdk-cpp               1.11.329             hf74b5d1_5    conda-forge
     azure-core-cpp            1.12.0               h830ed8b_0    conda-forge
     azure-identity-cpp        1.8.0                hdb0d106_1    conda-forge
     azure-storage-blobs-cpp   12.11.0              ha67cba7_1    conda-forge
     azure-storage-common-cpp  12.6.0               he3f277c_1    conda-forge
     azure-storage-files-datalake-cpp 12.10.0              h29b5301_1    conda-forge
     babel                     2.14.0             pyhd8ed1ab_0    conda-forge
     backports.zoneinfo        0.2.1           py311h38be061_8    conda-forge
     beautifulsoup4            4.12.3             pyha770c72_0    conda-forge
     binutils                  2.40                 h4852527_7    conda-forge
     binutils_impl_linux-64    2.40                 ha1999f0_7    conda-forge
     binutils_linux-64         2.40                 hb3c18ed_4    conda-forge
     bleach                    6.1.0              pyhd8ed1ab_0    conda-forge
     bokeh                     3.4.1              pyhd8ed1ab_0    conda-forge
     brotli                    1.1.0                hd590300_1    conda-forge
     brotli-bin                1.1.0                hd590300_1    conda-forge
     brotli-python             1.1.0           py311hb755f60_1    conda-forge
     bzip2                     1.0.8                h5eee18b_6
     c-ares                    1.28.1               hd590300_0    conda-forge
     c-compiler                1.5.2                h0b41bf4_0    conda-forge
     ca-certificates           2024.6.2             hbcca054_0    conda-forge
     cached-property           1.5.2                hd8ed1ab_1    conda-forge
     cached_property           1.5.2              pyha770c72_1    conda-forge
     cachetools                5.3.3              pyhd8ed1ab_0    conda-forge
     cairo                     1.18.0               hbb29018_2    conda-forge
     certifi                   2024.6.2           pyhd8ed1ab_0    conda-forge
     cffi                      1.16.0          py311hb3a22ac_0    conda-forge
     charset-normalizer        3.3.2              pyhd8ed1ab_0    conda-forge
     click                     8.1.7           unix_pyh707e725_0    conda-forge
     cloudpickle               3.0.0              pyhd8ed1ab_0    conda-forge
     cmake                     3.29.6               hcafd917_0    conda-forge
     colorama                  0.4.6              pyhd8ed1ab_0    conda-forge
     comm                      0.2.2              pyhd8ed1ab_0    conda-forge
     commonmark                0.9.1                      py_0    conda-forge
     contourpy                 1.2.1           py311h9547e67_0    conda-forge
     coverage                  7.5.4           py311h331c9d8_0    conda-forge
     cuda-cccl_linux-64        12.2.140             ha770c72_0    conda-forge
     cuda-crt-dev_linux-64     12.2.140             ha770c72_1    conda-forge
     cuda-crt-tools            12.2.140             ha770c72_1    conda-forge
     cuda-cudart               12.2.140             hd3aeb46_0    conda-forge
     cuda-cudart-dev           12.2.140             hd3aeb46_0    conda-forge
     cuda-cudart-dev_linux-64  12.2.140             h59595ed_0    conda-forge
     cuda-cudart-static        12.2.140             hd3aeb46_0    conda-forge
     cuda-cudart-static_linux-64 12.2.140             h59595ed_0    conda-forge
     cuda-cudart_linux-64      12.2.140             h59595ed_0    conda-forge
     cuda-driver-dev_linux-64  12.2.140             h59595ed_0    conda-forge
     cuda-nvcc                 12.2.140             hcdd1206_0    conda-forge
     cuda-nvcc-dev_linux-64    12.2.140             ha770c72_1    conda-forge
     cuda-nvcc-impl            12.2.140             hd3aeb46_1    conda-forge
     cuda-nvcc-tools           12.2.140             hd3aeb46_1    conda-forge
     cuda-nvcc_linux-64        12.2.140             h8a487aa_0    conda-forge
     cuda-nvrtc                12.2.140             hd3aeb46_0    conda-forge
     cuda-nvvm-dev_linux-64    12.2.140             ha770c72_1    conda-forge
     cuda-nvvm-impl            12.2.140             h59595ed_1    conda-forge
     cuda-nvvm-tools           12.2.140             h59595ed_1    conda-forge
     cuda-profiler-api         12.2.140             ha770c72_0    conda-forge
     cuda-python               12.5.0          py311h817de4b_0    conda-forge
     cuda-version              12.2                 he2b69de_3    conda-forge
     cudf                      24.08.00a189    cuda12_py311_240623_gf536e30172_189    rapidsai-nightly
     cuml                      24.8.0                   pypi_0    pypi
     cupy                      13.2.0          py311he5a987b_0    conda-forge
     cupy-core                 13.2.0          py311h3bdf873_0    conda-forge
     cxx-compiler              1.5.2                hf52228f_0    conda-forge
     cycler                    0.12.1             pyhd8ed1ab_0    conda-forge
     cython                    3.0.10          py311hb755f60_0    conda-forge
     cytoolz                   0.12.3          py311h459d7ec_0    conda-forge
     dask                      2024.5.1           pyhd8ed1ab_0    conda-forge
     dask-core                 2024.5.1           pyhd8ed1ab_0    conda-forge
     dask-cuda                 24.08.00a6      py311_240623_g098109a_6    rapidsai-nightly
     dask-cudf                 24.08.00a189    cuda12_py311_240623_gf536e30172_189    rapidsai-nightly
     dask-expr                 1.1.1              pyhd8ed1ab_1    conda-forge
     dask-glm                  0.3.0                    pypi_0    pypi
     dask-ml                   2024.4.4           pyhd8ed1ab_0    conda-forge
     debugpy                   1.8.1           py311hb755f60_0    conda-forge
     decopatch                 1.4.10             pyhd8ed1ab_0    conda-forge
     decorator                 5.1.1              pyhd8ed1ab_0    conda-forge
     defusedxml                0.7.1              pyhd8ed1ab_0    conda-forge
     distributed               2024.5.1           pyhd8ed1ab_0    conda-forge
     distributed-ucxx          0.39.00a        py3.11_240623_g1e6d80c_3    rapidsai-nightly
     dlpack                    0.8                  h59595ed_3    conda-forge
     docutils                  0.19            py311h38be061_1    conda-forge
     doxygen                   1.9.1                hb166930_1    conda-forge
     entrypoints               0.4                pyhd8ed1ab_0    conda-forge
     exceptiongroup            1.2.0              pyhd8ed1ab_2    conda-forge
     execnet                   2.1.1              pyhd8ed1ab_0    conda-forge
     executing                 2.0.1              pyhd8ed1ab_0    conda-forge
     expat                     2.6.2                h59595ed_0    conda-forge
     fastrlock                 0.8.2           py311hb755f60_2    conda-forge
     fmt                       10.2.1               h00ab1b0_0    conda-forge
     font-ttf-dejavu-sans-mono 2.37                 hab24e00_0    conda-forge
     font-ttf-inconsolata      3.000                h77eed37_0    conda-forge
     font-ttf-source-code-pro  2.038                h77eed37_0    conda-forge
     font-ttf-ubuntu           0.83                 h77eed37_2    conda-forge
     fontconfig                2.14.2               h14ed4e7_0    conda-forge
     fonts-conda-ecosystem     1                             0    conda-forge
     fonts-conda-forge         1                             0    conda-forge
     fonttools                 4.53.0          py311h331c9d8_0    conda-forge
     fqdn                      1.5.1              pyhd8ed1ab_0    conda-forge
     freetype                  2.12.1               h267a509_2    conda-forge
     fribidi                   1.0.10               h36c2ea0_0    conda-forge
     fsspec                    2024.6.0           pyhff2d567_0    conda-forge
     future                    1.0.0              pyhd8ed1ab_0    conda-forge
     gcc                       11.4.0              h602e360_12    conda-forge
     gcc_impl_linux-64         11.4.0              h00c12a0_12    conda-forge
     gcc_linux-64              11.4.0               ha077dfb_4    conda-forge
     gdk-pixbuf                2.42.12              hb9ae30d_0    conda-forge
     gflags                    2.2.2             he1b5a44_1004    conda-forge
     giflib                    5.2.2                hd590300_0    conda-forge
     glog                      0.7.1                hbabe93e_0    conda-forge
     graphite2                 1.3.13            h59595ed_1003    conda-forge
     graphviz                  11.0.0               hc68bbd7_0    conda-forge
     gtk2                      2.24.33              h280cfa0_4    conda-forge
     gts                       0.7.6                h977cf35_4    conda-forge
     gxx                       11.4.0              h602e360_12    conda-forge
     gxx_impl_linux-64         11.4.0              h634f3ee_12    conda-forge
     gxx_linux-64              11.4.0               h35bfe5d_4    conda-forge
     h11                       0.14.0             pyhd8ed1ab_0    conda-forge
     h2                        4.1.0              pyhd8ed1ab_0    conda-forge
     harfbuzz                  8.5.0                hfac3d4d_0    conda-forge
     hdbscan                   0.8.30          py311h1f0f07a_0    conda-forge
     hpack                     4.0.0              pyh9f0ad1d_0    conda-forge
     httpcore                  1.0.5              pyhd8ed1ab_0    conda-forge
     httpx                     0.27.0             pyhd8ed1ab_0    conda-forge
     hyperframe                6.0.1              pyhd8ed1ab_0    conda-forge
     hypothesis                6.103.2            pyha770c72_0    conda-forge
     icu                       73.2                 h59595ed_0    conda-forge
     idna                      3.7                pyhd8ed1ab_0    conda-forge
     imagesize                 1.4.1              pyhd8ed1ab_0    conda-forge
     importlib-metadata        7.2.0              pyha770c72_0    conda-forge
     importlib-resources       6.4.0              pyhd8ed1ab_0    conda-forge
     importlib_metadata        7.2.0                hd8ed1ab_0    conda-forge
     importlib_resources       6.4.0              pyhd8ed1ab_0    conda-forge
     iniconfig                 2.0.0              pyhd8ed1ab_0    conda-forge
     ipykernel                 6.29.4             pyh3099207_0    conda-forge
     ipython                   8.25.0             pyh707e725_0    conda-forge
     isoduration               20.11.0            pyhd8ed1ab_0    conda-forge
     jedi                      0.19.1             pyhd8ed1ab_0    conda-forge
     jinja2                    3.1.4              pyhd8ed1ab_0    conda-forge
     joblib                    1.4.2              pyhd8ed1ab_0    conda-forge
     json5                     0.9.25             pyhd8ed1ab_0    conda-forge
     jsonpointer               3.0.0           py311h38be061_0    conda-forge
     jsonschema                4.22.0             pyhd8ed1ab_0    conda-forge
     jsonschema-specifications 2023.12.1          pyhd8ed1ab_0    conda-forge
     jsonschema-with-format-nongpl 4.22.0             pyhd8ed1ab_0    conda-forge
     jupyter-lsp               2.2.5              pyhd8ed1ab_0    conda-forge
     jupyter_client            8.6.2              pyhd8ed1ab_0    conda-forge
     jupyter_core              5.7.2           py311h38be061_0    conda-forge
     jupyter_events            0.10.0             pyhd8ed1ab_0    conda-forge
     jupyter_server            2.14.1             pyhd8ed1ab_0    conda-forge
     jupyter_server_terminals  0.5.3              pyhd8ed1ab_0    conda-forge
     jupyterlab                4.2.3              pyhd8ed1ab_0    conda-forge
     jupyterlab_pygments       0.3.0              pyhd8ed1ab_1    conda-forge
     jupyterlab_server         2.27.2             pyhd8ed1ab_0    conda-forge
     kernel-headers_linux-64   3.10.0              h4a8ded7_14    conda-forge
     keyutils                  1.6.1                h166bdaf_0    conda-forge
     kiwisolver                1.4.5           py311h9547e67_1    conda-forge
     krb5                      1.21.2               h659d440_0    conda-forge
     lcms2                     2.16                 hb7c19ff_0    conda-forge
     ld_impl_linux-64          2.40                 hf3520f5_7    conda-forge
     lerc                      4.0.0                h27087fc_0    conda-forge
     libabseil                 20240116.2      cxx17_h59595ed_0    conda-forge
     libarrow                  16.1.0          h4a673ee_10_cpu    conda-forge
     libarrow-acero            16.1.0          hac33072_10_cpu    conda-forge
     libarrow-dataset          16.1.0          hac33072_10_cpu    conda-forge
     libarrow-substrait        16.1.0          h7e0c224_10_cpu    conda-forge
     libblas                   3.9.0           22_linux64_openblas    conda-forge
     libbrotlicommon           1.1.0                hd590300_1    conda-forge
     libbrotlidec              1.1.0                hd590300_1    conda-forge
     libbrotlienc              1.1.0                hd590300_1    conda-forge
     libcblas                  3.9.0           22_linux64_openblas    conda-forge
     libcrc32c                 1.1.2                h9c3ff4c_0    conda-forge
     libcublas                 12.2.5.6             hd3aeb46_0    conda-forge
     libcublas-dev             12.2.5.6             hd3aeb46_0    conda-forge
     libcudf                   24.08.00a189    cuda12_240623_gf536e30172_189    rapidsai-nightly
     libcufft                  11.0.8.103           hd3aeb46_0    conda-forge
     libcufft-dev              11.0.8.103           hd3aeb46_0    conda-forge
     libcufile                 1.7.2.10             hd3aeb46_0    conda-forge
     libcufile-dev             1.7.2.10             hd3aeb46_0    conda-forge
     libcumlprims              24.08.00a       cuda12_240623_g10e088a_1    rapidsai-nightly
     libcurand                 10.3.3.141           hd3aeb46_0    conda-forge
     libcurand-dev             10.3.3.141           hd3aeb46_0    conda-forge
     libcurl                   8.8.0                hca28451_0    conda-forge
     libcusolver               11.5.2.141           hd3aeb46_0    conda-forge
     libcusolver-dev           11.5.2.141           hd3aeb46_0    conda-forge
     libcusparse               12.1.2.141           hd3aeb46_0    conda-forge
     libcusparse-dev           12.1.2.141           hd3aeb46_0    conda-forge
     libdeflate                1.20                 hd590300_0    conda-forge
     libedit                   3.1.20191231         he28a2e2_2    conda-forge
     libev                     4.33                 hd590300_2    conda-forge
     libevent                  2.1.12               hf998b51_1    conda-forge
     libexpat                  2.6.2                h59595ed_0    conda-forge
     libffi                    3.4.4                h6a678d5_1
     libgcc-devel_linux-64     11.4.0             h8f596e0_112    conda-forge
     libgcc-ng                 13.2.0              h77fa898_12    conda-forge
     libgd                     2.3.3                h119a65a_9    conda-forge
     libgfortran-ng            13.2.0              h69a702a_12    conda-forge
     libgfortran5              13.2.0              h3d2ce59_12    conda-forge
     libglib                   2.80.2               h8a4344b_1    conda-forge
     libgomp                   13.2.0              h77fa898_12    conda-forge
     libgoogle-cloud           2.25.0               h2736e30_0    conda-forge
     libgoogle-cloud-storage   2.25.0               h3d9a0c8_0    conda-forge
     libgrpc                   1.62.2               h15f2491_0    conda-forge
     libhwloc                  2.10.0          default_h5622ce7_1001    conda-forge
     libiconv                  1.17                 hd590300_2    conda-forge
     libjpeg-turbo             3.0.0                hd590300_1    conda-forge
     libkvikio                 24.08.00a       cuda12_240623_g3cc6678_10    rapidsai-nightly
     liblapack                 3.9.0           22_linux64_openblas    conda-forge
     libllvm14                 14.0.6               hcd5def8_4    conda-forge
     libnghttp2                1.58.0               h47da74e_1    conda-forge
     libnl                     3.9.0                hd590300_0    conda-forge
     libnsl                    2.0.1                hd590300_0    conda-forge
     libnvjitlink              12.2.140             hd3aeb46_0    conda-forge
     libopenblas               0.3.27          pthreads_h413a1c8_0    conda-forge
     libparquet                16.1.0          h6a7eafb_10_cpu    conda-forge
     libpng                    1.6.43               h2797004_0    conda-forge
     libprotobuf               4.25.3               h08a7969_0    conda-forge
     libraft                   24.08.00a33     cuda12_240623_gb86a5f90_33    rapidsai-nightly
     libraft-headers           24.08.00a33     cuda12_240623_gb86a5f90_33    rapidsai-nightly
     libraft-headers-only      24.08.00a33     cuda12_240623_gb86a5f90_33    rapidsai-nightly
     libre2-11                 2023.09.01           h5a48ba9_2    conda-forge
     librmm                    24.08.00a17     cuda12_240623_gf2d07976_17    rapidsai-nightly
     librsvg                   2.58.1               hadf69e7_0    conda-forge
     libsanitizer              11.4.0              h5763a12_12    conda-forge
     libsodium                 1.0.18               h36c2ea0_1    conda-forge
     libsqlite                 3.46.0               hde9e2c9_0    conda-forge
     libssh2                   1.11.0               h0841786_0    conda-forge
     libstdcxx-devel_linux-64  11.4.0             h8f596e0_112    conda-forge
     libstdcxx-ng              13.2.0              hc0a3c3a_12    conda-forge
     libthrift                 0.19.0               hb90f79a_1    conda-forge
     libtiff                   4.6.0                h1dd3fc0_3    conda-forge
     libucxx                   0.39.00a        cuda12_240623_g1e6d80c_3    rapidsai-nightly
     libutf8proc               2.8.0                h166bdaf_0    conda-forge
     libuuid                   2.38.1               h0b41bf4_0    conda-forge
     libuv                     1.48.0               hd590300_0    conda-forge
     libwebp                   1.4.0                h2c329e2_0    conda-forge
     libwebp-base              1.4.0                hd590300_0    conda-forge
     libxcb                    1.16                 hd590300_0    conda-forge
     libxcrypt                 4.4.36               hd590300_1    conda-forge
     libxml2                   2.12.7               hc051c1a_1    conda-forge
     libzlib                   1.3.1                h4ab18f5_1    conda-forge
     llvmlite                  0.43.0          py311hbde99c3_0    conda-forge
     locket                    1.0.0              pyhd8ed1ab_0    conda-forge
     lz4                       4.3.3           py311h38e4bf4_0    conda-forge
     lz4-c                     1.9.4                hcb278e6_0    conda-forge
     makefun                   1.15.2             pyhd8ed1ab_0    conda-forge
     markdown                  3.6                pyhd8ed1ab_0    conda-forge
     markdown-it-py            3.0.0              pyhd8ed1ab_0    conda-forge
     markupsafe                2.1.5           py311h459d7ec_0    conda-forge
     matplotlib-base           3.8.4           py311ha4ca890_2    conda-forge
     matplotlib-inline         0.1.7              pyhd8ed1ab_0    conda-forge
     mdurl                     0.1.2              pyhd8ed1ab_0    conda-forge
     mistune                   3.0.2              pyhd8ed1ab_0    conda-forge
     msgpack-python            1.0.8           py311h52f7536_0    conda-forge
     multipledispatch          0.6.0                      py_0    conda-forge
     munkres                   1.1.4              pyh9f0ad1d_0    conda-forge
     nbclient                  0.10.0             pyhd8ed1ab_0    conda-forge
     nbconvert                 7.16.4               hd8ed1ab_1    conda-forge
     nbconvert-core            7.16.4             pyhd8ed1ab_1    conda-forge
     nbconvert-pandoc          7.16.4               hd8ed1ab_1    conda-forge
     nbformat                  5.10.4             pyhd8ed1ab_0    conda-forge
     nbsphinx                  0.9.4              pyhd8ed1ab_0    conda-forge
     nccl                      2.22.3.1             hbc370b7_0    conda-forge
     ncurses                   6.5                  h59595ed_0    conda-forge
     nest-asyncio              1.6.0              pyhd8ed1ab_0    conda-forge
     ninja                     1.12.1               h297d8ca_0    conda-forge
     nltk                      3.8.1              pyhd8ed1ab_0    conda-forge
     notebook                  7.2.1              pyhd8ed1ab_0    conda-forge
     notebook-shim             0.2.4              pyhd8ed1ab_0    conda-forge
     numba                     0.60.0          py311h4bc866e_0    conda-forge
     numpy                     1.26.4          py311h64a7726_0    conda-forge
     numpydoc                  1.6.0              pyhd8ed1ab_0    conda-forge
     nvcomp                    3.0.6                h10b603f_0    conda-forge
     nvtx                      0.2.10          py311h459d7ec_0    conda-forge
     openjpeg                  2.5.2                h488ebb8_0    conda-forge
     openssl                   3.3.1                h4ab18f5_1    conda-forge
     orc                       2.0.1                h17fec99_1    conda-forge
     overrides                 7.7.0              pyhd8ed1ab_0    conda-forge
     packaging                 24.1               pyhd8ed1ab_0    conda-forge
     pandas                    2.2.2           py311h14de704_1    conda-forge
     pandoc                    3.2                  ha770c72_0    conda-forge
     pandocfilters             1.5.0              pyhd8ed1ab_0    conda-forge
     pango                     1.54.0               h84a9a3c_0    conda-forge
     parso                     0.8.4              pyhd8ed1ab_0    conda-forge
     partd                     1.4.2              pyhd8ed1ab_0    conda-forge
     pathspec                  0.12.1             pyhd8ed1ab_0    conda-forge
     patsy                     0.5.6              pyhd8ed1ab_0    conda-forge
     pcre2                     10.44                h0f59acf_0    conda-forge
     pexpect                   4.9.0              pyhd8ed1ab_0    conda-forge
     pickleshare               0.7.5                   py_1003    conda-forge
     pillow                    10.3.0          py311h82a398c_1    conda-forge
     pip                       24.0               pyhd8ed1ab_0    conda-forge
     pixman                    0.43.2               h59595ed_0    conda-forge
     pkgutil-resolve-name      1.3.10             pyhd8ed1ab_1    conda-forge
     platformdirs              4.2.2              pyhd8ed1ab_0    conda-forge
     pluggy                    1.5.0              pyhd8ed1ab_0    conda-forge
     prometheus_client         0.20.0             pyhd8ed1ab_0    conda-forge
     prompt-toolkit            3.0.47             pyha770c72_0    conda-forge
     psutil                    5.9.8           py311h459d7ec_0    conda-forge
     pthread-stubs             0.4               h36c2ea0_1001    conda-forge
     ptyprocess                0.7.0              pyhd3deb0d_0    conda-forge
     pure_eval                 0.2.2              pyhd8ed1ab_0    conda-forge
     py-cpuinfo                9.0.0              pyhd8ed1ab_0    conda-forge
     pyarrow                   16.1.0          py311hbd00459_3    conda-forge
     pyarrow-core              16.1.0          py311h8c3dac4_3_cpu    conda-forge
     pyarrow-hotfix            0.6                pyhd8ed1ab_0    conda-forge
     pycparser                 2.22               pyhd8ed1ab_0    conda-forge
     pydata-sphinx-theme       0.15.3             pyhd8ed1ab_0    conda-forge
     pygments                  2.18.0             pyhd8ed1ab_0    conda-forge
     pylibraft                 24.08.00a33     cuda12_py311_240623_gb86a5f90_33    rapidsai-nightly
     pynndescent               0.5.8              pyh1a96a4e_0    conda-forge
     pynvjitlink               0.2.4           py311hd269673_0    rapidsai
     pynvml                    11.4.1             pyhd8ed1ab_0    conda-forge
     pyparsing                 3.1.2              pyhd8ed1ab_0    conda-forge
     pysocks                   1.7.1              pyha2e5f31_6    conda-forge
     pytest                    7.4.4              pyhd8ed1ab_0    conda-forge
     pytest-benchmark          4.0.0              pyhd8ed1ab_0    conda-forge
     pytest-cases              3.8.5              pyhd8ed1ab_0    conda-forge
     pytest-cov                5.0.0              pyhd8ed1ab_0    conda-forge
     pytest-xdist              3.6.1              pyhd8ed1ab_0    conda-forge
     python                    3.11.9          hb806964_0_cpython    conda-forge
     python-dateutil           2.9.0              pyhd8ed1ab_0    conda-forge
     python-fastjsonschema     2.20.0             pyhd8ed1ab_0    conda-forge
     python-json-logger        2.0.7              pyhd8ed1ab_0    conda-forge
     python-tzdata             2024.1             pyhd8ed1ab_0    conda-forge
     python_abi                3.11                    4_cp311    conda-forge
     pytz                      2024.1             pyhd8ed1ab_0    conda-forge
     pyyaml                    6.0.1           py311h459d7ec_1    conda-forge
     pyzmq                     26.0.3          py311h08a0b41_0    conda-forge
     raft-dask                 24.08.00a33     cuda12_py311_240623_gb86a5f90_33    rapidsai-nightly
     rapids-build-backend      0.3.1                      py_0    rapidsai-nightly
     rapids-dask-dependency    24.08.00a4                 py_0    rapidsai-nightly
     rapids-dependency-file-generator 1.13.11                    py_0    rapidsai
     rdma-core                 51.1                 he02047a_0    conda-forge
     re2                       2023.09.01           h7f4b329_2    conda-forge
     readline                  8.2                  h5eee18b_0
     recommonmark              0.7.1              pyhd8ed1ab_0    conda-forge
     referencing               0.35.1             pyhd8ed1ab_0    conda-forge
     regex                     2024.5.15       py311h331c9d8_0    conda-forge
     requests                  2.32.3             pyhd8ed1ab_0    conda-forge
     rfc3339-validator         0.1.4              pyhd8ed1ab_0    conda-forge
     rfc3986-validator         0.1.1              pyh9f0ad1d_0    conda-forge
     rhash                     1.4.4                hd590300_0    conda-forge
     rich                      13.7.1             pyhd8ed1ab_0    conda-forge
     rmm                       24.08.00a17     cuda12_py311_240623_gf2d07976_17    rapidsai-nightly
     rpds-py                   0.18.1          py311h5ecf98a_0    conda-forge
     s2n                       1.4.16               he19d79f_0    conda-forge
     scikit-build-core         0.9.6              pyh4af843d_0    conda-forge
     scikit-learn              1.5.0           py311he08f58d_1    conda-forge
     scipy                     1.13.1          py311h517d4fd_0    conda-forge
     seaborn                   0.13.2               hd8ed1ab_2    conda-forge
     seaborn-base              0.13.2             pyhd8ed1ab_2    conda-forge
     send2trash                1.8.3              pyh0d859eb_0    conda-forge
     setuptools                69.5.1          py311h06a4308_0
     six                       1.16.0             pyh6c4a22f_0    conda-forge
     snappy                    1.2.0                hdb0a2a9_1    conda-forge
     sniffio                   1.3.1              pyhd8ed1ab_0    conda-forge
     snowballstemmer           2.2.0              pyhd8ed1ab_0    conda-forge
     sortedcontainers          2.4.0              pyhd8ed1ab_0    conda-forge
     soupsieve                 2.5                pyhd8ed1ab_1    conda-forge
     sparse                    0.15.4             pyhd8ed1ab_0    conda-forge
     spdlog                    1.12.0               hd2e6256_2    conda-forge
     sphinx                    5.3.0              pyhd8ed1ab_0    conda-forge
     sphinx-copybutton         0.5.2              pyhd8ed1ab_0    conda-forge
     sphinx-markdown-tables    0.0.17             pyh6c4a22f_0    conda-forge
     sphinxcontrib-applehelp   1.0.8              pyhd8ed1ab_0    conda-forge
     sphinxcontrib-devhelp     1.0.6              pyhd8ed1ab_0    conda-forge
     sphinxcontrib-htmlhelp    2.0.5              pyhd8ed1ab_0    conda-forge
     sphinxcontrib-jsmath      1.0.1              pyhd8ed1ab_0    conda-forge
     sphinxcontrib-qthelp      1.0.7              pyhd8ed1ab_0    conda-forge
     sphinxcontrib-serializinghtml 1.1.10             pyhd8ed1ab_0    conda-forge
     sqlite                    3.46.0               h6d4b2fc_0    conda-forge
     stack_data                0.6.2              pyhd8ed1ab_0    conda-forge
     statsmodels               0.14.2          py311h18e1886_0    conda-forge
     sysroot_linux-64          2.17                h4a8ded7_14    conda-forge
     tabulate                  0.9.0              pyhd8ed1ab_1    conda-forge
     tbb                       2021.12.0            h297d8ca_1    conda-forge
     tblib                     3.0.0              pyhd8ed1ab_0    conda-forge
     terminado                 0.18.1             pyh0d859eb_0    conda-forge
     threadpoolctl             3.5.0              pyhc1e730c_0    conda-forge
     tinycss2                  1.3.0              pyhd8ed1ab_0    conda-forge
     tk                        8.6.13          noxft_h4845f30_101    conda-forge
     toml                      0.10.2             pyhd8ed1ab_0    conda-forge
     tomli                     2.0.1              pyhd8ed1ab_0    conda-forge
     tomlkit                   0.12.5             pyha770c72_0    conda-forge
     toolz                     0.12.1             pyhd8ed1ab_0    conda-forge
     tornado                   6.4.1           py311h331c9d8_0    conda-forge
     tqdm                      4.66.4             pyhd8ed1ab_0    conda-forge
     traitlets                 5.14.3             pyhd8ed1ab_0    conda-forge
     treelite                  4.2.1           py311he8f9275_0    conda-forge
     types-python-dateutil     2.9.0.20240316     pyhd8ed1ab_0    conda-forge
     typing-extensions         4.12.2               hd8ed1ab_0    conda-forge
     typing_extensions         4.12.2             pyha770c72_0    conda-forge
     typing_utils              0.1.0              pyhd8ed1ab_0    conda-forge
     tzdata                    2024a                h04d1e81_0
     ucx                       1.15.0               hda83522_8    conda-forge
     ucx-py                    0.39.00a3       py311_240623_g42c03ef_3    rapidsai-nightly
     ucxx                      0.39.00a        cuda12_py3.11_240623_g1e6d80c_3    rapidsai-nightly
     umap-learn                0.5.3           py311h38be061_1    conda-forge
     uri-template              1.3.0              pyhd8ed1ab_0    conda-forge
     urllib3                   2.2.2              pyhd8ed1ab_0    conda-forge
     wcwidth                   0.2.13             pyhd8ed1ab_0    conda-forge
     webcolors                 24.6.0             pyhd8ed1ab_0    conda-forge
     webencodings              0.5.1              pyhd8ed1ab_2    conda-forge
     websocket-client          1.8.0              pyhd8ed1ab_0    conda-forge
     wheel                     0.43.0          py311h06a4308_0
     xorg-kbproto              1.0.7             h7f98852_1002    conda-forge
     xorg-libice               1.1.1                hd590300_0    conda-forge
     xorg-libsm                1.2.4                h7391055_0    conda-forge
     xorg-libx11               1.8.9                hb711507_1    conda-forge
     xorg-libxau               1.0.11               hd590300_0    conda-forge
     xorg-libxdmcp             1.1.3                h7f98852_0    conda-forge
     xorg-libxext              1.3.4                h0b41bf4_2    conda-forge
     xorg-libxrender           0.9.11               hd590300_0    conda-forge
     xorg-renderproto          0.11.1            h7f98852_1002    conda-forge
     xorg-xextproto            7.3.0             h0b41bf4_1003    conda-forge
     xorg-xproto               7.0.31            h7f98852_1007    conda-forge
     xyzservices               2024.6.0           pyhd8ed1ab_0    conda-forge
     xz                        5.4.6                h5eee18b_1
     yaml                      0.2.5                h7f98852_2    conda-forge
     zeromq                    4.3.5                h75354e8_4    conda-forge
     zict                      3.0.0              pyhd8ed1ab_0    conda-forge
     zipp                      3.19.2             pyhd8ed1ab_0    conda-forge
     zlib                      1.3.1                h4ab18f5_1    conda-forge
     zstd                      1.5.6                ha6fb4c9_0    conda-forge

</pre></details>

## Notes for Reviewers


## C++ unit test reference
<details>
  <summary>Sklearn script to generate C++ test reference data</summary><pre>
import numpy as np
from sklearn.decomposition import KernelPCA, PCA

# Input data
n_rows = 3
n_cols = 2
n_components = 2
data = np.array([
    [1.0, 4.0],
    [2.0, 2.0],
    [5.0, 1.0]
])

# Kernel Parameters
class KernelParams:
    def __init__(self, kernel, degree=3, gamma=1.0, coef0=1):
        self.kernel = kernel
        self.degree = degree
        self.gamma = gamma
        self.coef0 = coef0

# Define kernel parameters
lin_kern = KernelParams(kernel='linear', degree=0, gamma=0, coef0=0)
poly_kern = KernelParams(kernel='poly', degree=3, gamma=1.0/2.0, coef0=1)
rbf_kern = KernelParams(kernel='rbf', degree=0, gamma=1.0/2.0, coef0=0)

# Function to compute and print kernel matrices
def compute_and_print_kernel_matrices(data, kernel_params, n_components):
    kpca = KernelPCA(n_components=n_components,
                     kernel=kernel_params.kernel,
                     degree=kernel_params.degree,
                     gamma=kernel_params.gamma,
                     coef0=kernel_params.coef0)
    
    # Fit and transform data
    transformed_data = kpca.fit_transform(data)

    # Print results
    print(f"transformed_data for {kernel_params.kernel} kernel:\n{transformed_data}")
    print(f"eigenvalues_ for {kernel_params.kernel} kernel:\n{kpca.eigenvalues_}")
    print(f"eigenvectors_ for {kernel_params.kernel} kernel:\n{kpca.eigenvectors_}")

# Compute and print kernel matrices for linear, polynomial, and RBF kernels
kernels = [lin_kern, poly_kern, rbf_kern]
for kernel_params in kernels:
    compute_and_print_kernel_matrices(data, kernel_params, n_components)
</pre></details>

Output from script and C++ expected values are below. Note that C++ matrices are in column order while Python w. numpy uses row order.
Sklearn linear kernel:
```
transformed_data for linear kernel:
[[-2.32318647 -0.39794495]
 [-0.35170213  0.65716145]
 [ 2.6748886  -0.25921649]]
eigenvalues_ for linear kernel:
[12.67591879  0.65741454]
eigenvectors_ for linear kernel:
[[-0.65252078 -0.49079864]
 [-0.0987837   0.81049889]
 [ 0.75130448 -0.31970025]]
```
C++ test reference:
```
std::vector<float> lin_trans_data_ref_h = {-2.32318647,-0.35170213, 2.6748886, -0.39794495, 0.65716145,-0.25921649};
std::vector<float> lin_eigenvalues_ref_h = {12.6759, 0.6574};
std::vector<float> lin_eigenvectors_ref_h = {-0.6525, -0.0987, 0.7513, -0.4907, 0.8105, -0.3197};
```

Sklearn poly kernel:
```
transformed_data for poly kernel:
[[-22.97601835  -8.84385051]
 [-10.85540799  11.24260772]
 [ 33.83142634  -2.39875721]]
eigenvalues_ for poly kernel:
[1790.30271016  210.36395651]
eigenvectors_ for poly kernel:
[[-0.54301464 -0.6097555 ]
 [-0.25655644  0.77514222]
 [ 0.79957107 -0.16538672]]
```
C++ test reference:
```
std::vector<float> poly_trans_data_ref_h = {-22.9760, -10.8554, 33.8314, -8.8438, 11.2426, -2.3987};
std::vector<float> poly_eigenvalues_ref_h = {1790.3207, 210.3639};
std::vector<float> poly_eigenvectors_ref_h = {-0.5430, -0.2565, 0.7995, -0.6097, 0.7751, -0.1653};
```
Sklearn rbf kernel:
```
transformed_data for rbf kernel:
[[-0.43907684 -0.66248897]
 [-0.38619599  0.69140675]
 [ 0.82527283 -0.02891778]]
eigenvalues_ for rbf kernel:
[1.02301105 0.91777117]
eigenvectors_ for rbf kernel:
[[-0.43411058 -0.69153067]
 [-0.38182784  0.72171613]
 [ 0.81593842 -0.03018545]]
```
C++ test reference:
```
std::vector<float> rbf_trans_data_ref_h = {-0.4391, -0.3862, 0.8253, -0.6624, 0.6914, -0.0289};
std::vector<float> rbf_eigenvalues_ref_h = {1.0230, 0.9177};
std::vector<float> rbf_eigenvectors_ref_h = {-0.4341, -0.3818, 0.8159, -0.6915, 0.7217, -0.0301};
```

## [Definition of Done Criteria Checklist](https://github.com/rapidsai/cuml/blob/branch-24.08/wiki/DEFINITION_OF_DONE_CRITERIA.md)
### C++ Checklist

#### Design
- [x] Existing prims are used wherever possible
- [x] Array inputs and outputs to algorithms are accepted on device
- [x] New prims created wherever there is potential for reuse across different algorithms or prims
- [x] User-facing API is [stateless](cpp/DEVELOPER_GUIDE.md#public-cuml-interface) and follows the [plain-old data (POD)](https://en.wikipedia.org/wiki/Passive_data_structure) design paradigm
- [x] Public API contains a C-Wrapper around the stateless API
- [ ] (optional) Public API contains an Scikit-learn-like stateful wrapper around the stateless API

#### Testing
- [ ] Prims: GTests with different inputs
- [x] Algorithms: End-to-end GTests with different inputs and different datasets

#### Documentation
- [x] Complete and comprehensive [Doxygen](http://www.doxygen.nl/manual/docblocks.html) strings explaining the public API, restrictions, and gotchas. Any array parameters should also note whether the underlying memory is host or device.
- [x] Array inputs/outputs should also mention their expected size/dimension.
- [x] If there are references to the underlying algorithm, they must be cited too.

## Unit test results
<details>
  <summary>C++ Test Results</summary><pre>
(cuml_dev) ubuntu@ip-172-31-36-86:~/cuml$ ./cpp/build/test/SG_KPCA_TEST
Running main() from /home/ubuntu/cuml/cpp/build/_deps/gtest-src/googletest/src/gtest_main.cc
[==========] Running 36 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from KPcaTests/KPcaTestEigenvaluesF
[ RUN      ] KPcaTests/KPcaTestEigenvaluesF.Result/0
[       OK ] KPcaTests/KPcaTestEigenvaluesF.Result/0 (430 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesF.Result/1
[       OK ] KPcaTests/KPcaTestEigenvaluesF.Result/1 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesF.Result/2
[       OK ] KPcaTests/KPcaTestEigenvaluesF.Result/2 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesF.Result/3
[       OK ] KPcaTests/KPcaTestEigenvaluesF.Result/3 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesF.Result/4
[       OK ] KPcaTests/KPcaTestEigenvaluesF.Result/4 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesF.Result/5
[       OK ] KPcaTests/KPcaTestEigenvaluesF.Result/5 (2 ms)
[----------] 6 tests from KPcaTests/KPcaTestEigenvaluesF (442 ms total)

[----------] 6 tests from KPcaTests/KPcaTestEigenvectorsF
[ RUN      ] KPcaTests/KPcaTestEigenvectorsF.Result/0
[       OK ] KPcaTests/KPcaTestEigenvectorsF.Result/0 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsF.Result/1
[       OK ] KPcaTests/KPcaTestEigenvectorsF.Result/1 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsF.Result/2
[       OK ] KPcaTests/KPcaTestEigenvectorsF.Result/2 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsF.Result/3
[       OK ] KPcaTests/KPcaTestEigenvectorsF.Result/3 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsF.Result/4
[       OK ] KPcaTests/KPcaTestEigenvectorsF.Result/4 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsF.Result/5
[       OK ] KPcaTests/KPcaTestEigenvectorsF.Result/5 (2 ms)
[----------] 6 tests from KPcaTests/KPcaTestEigenvectorsF (13 ms total)

[----------] 6 tests from KPcaTests/KPcaTestTransDataF
[ RUN      ] KPcaTests/KPcaTestTransDataF.Result/0
[       OK ] KPcaTests/KPcaTestTransDataF.Result/0 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataF.Result/1
[       OK ] KPcaTests/KPcaTestTransDataF.Result/1 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataF.Result/2
[       OK ] KPcaTests/KPcaTestTransDataF.Result/2 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataF.Result/3
[       OK ] KPcaTests/KPcaTestTransDataF.Result/3 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataF.Result/4
[       OK ] KPcaTests/KPcaTestTransDataF.Result/4 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataF.Result/5
[       OK ] KPcaTests/KPcaTestTransDataF.Result/5 (2 ms)
[----------] 6 tests from KPcaTests/KPcaTestTransDataF (13 ms total)

[----------] 6 tests from KPcaTests/KPcaTestEigenvaluesD
[ RUN      ] KPcaTests/KPcaTestEigenvaluesD.Result/0
[       OK ] KPcaTests/KPcaTestEigenvaluesD.Result/0 (9 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesD.Result/1
[       OK ] KPcaTests/KPcaTestEigenvaluesD.Result/1 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesD.Result/2
[       OK ] KPcaTests/KPcaTestEigenvaluesD.Result/2 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesD.Result/3
[       OK ] KPcaTests/KPcaTestEigenvaluesD.Result/3 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesD.Result/4
[       OK ] KPcaTests/KPcaTestEigenvaluesD.Result/4 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvaluesD.Result/5
[       OK ] KPcaTests/KPcaTestEigenvaluesD.Result/5 (2 ms)
[----------] 6 tests from KPcaTests/KPcaTestEigenvaluesD (23 ms total)

[----------] 6 tests from KPcaTests/KPcaTestEigenvectorsD
[ RUN      ] KPcaTests/KPcaTestEigenvectorsD.Result/0
[       OK ] KPcaTests/KPcaTestEigenvectorsD.Result/0 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsD.Result/1
[       OK ] KPcaTests/KPcaTestEigenvectorsD.Result/1 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsD.Result/2
[       OK ] KPcaTests/KPcaTestEigenvectorsD.Result/2 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsD.Result/3
[       OK ] KPcaTests/KPcaTestEigenvectorsD.Result/3 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsD.Result/4
[       OK ] KPcaTests/KPcaTestEigenvectorsD.Result/4 (2 ms)
[ RUN      ] KPcaTests/KPcaTestEigenvectorsD.Result/5
[       OK ] KPcaTests/KPcaTestEigenvectorsD.Result/5 (2 ms)
[----------] 6 tests from KPcaTests/KPcaTestEigenvectorsD (16 ms total)

[----------] 6 tests from KPcaTests/KPcaTestTransDataD
[ RUN      ] KPcaTests/KPcaTestTransDataD.Result/0
[       OK ] KPcaTests/KPcaTestTransDataD.Result/0 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataD.Result/1
[       OK ] KPcaTests/KPcaTestTransDataD.Result/1 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataD.Result/2
[       OK ] KPcaTests/KPcaTestTransDataD.Result/2 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataD.Result/3
[       OK ] KPcaTests/KPcaTestTransDataD.Result/3 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataD.Result/4
[       OK ] KPcaTests/KPcaTestTransDataD.Result/4 (2 ms)
[ RUN      ] KPcaTests/KPcaTestTransDataD.Result/5
[       OK ] KPcaTests/KPcaTestTransDataD.Result/5 (2 ms)
[----------] 6 tests from KPcaTests/KPcaTestTransDataD (16 ms total)

[----------] Global test environment tear-down
[==========] 36 tests from 6 test suites ran. (525 ms total)
[  PASSED  ] 36 tests.
</pre></details>

