### PR TITLE
Avoid cudf column APIs after cudf.Series disallows column inputs

### DIFF
--- a/python/cuml/cuml/dask/preprocessing/LabelEncoder.py
+++ b/python/cuml/cuml/dask/preprocessing/LabelEncoder.py
@@ -114,8 +114,8 @@ class LabelEncoder(
         0    a
         1    a
         2    b
-        0    c
-        1    b
+        3    c
+        4    b
         dtype: object
         >>> client.close()
         >>> cluster.close()


### PR DESCRIPTION
closes https://github.com/rapidsai/cuml/issues/6017

With https://github.com/rapidsai/cudf/pull/16454, `cudf.Series` no longer accepts cudf `ColumnBase` objects. The usage of this pattern in cuml was mostly not needed as there existed public APIs to avoid this behavior

