### PR TITLE
Stop exporting fill_k kernel as that causes ODR violations

### DIFF
--- a/cpp/src/fil/common.cuh
+++ b/cpp/src/fil/common.cuh
@@ -309,17 +309,12 @@ struct compute_smem_footprint : dispatch_functor<int> {
   int run(predict_params);
 };
 
-template <int NITEMS,
-          leaf_algo_t leaf_algo,
-          bool cols_in_shmem,
-          bool CATS_SUPPORTED,
-          class storage_type>
-__attribute__((visibility("hidden"))) __global__ void infer_k(storage_type forest,
-                                                              predict_params params);
-
 // infer() calls the inference kernel with the parameters on the stream
 template <typename storage_type>
 void infer(storage_type forest, predict_params params, cudaStream_t stream);
+
+template <typename storage_type>
+void infer_shared_mem_size(predict_params params, int max_shm);
 
 }  // namespace fil
 }  // namespace ML


### PR DESCRIPTION
Removes the usage of `fill_k` in `cpp/src/fil/fil.cu` as that breaks the ODR requirements of CUDA whole compilation. To allow setting the shared memory of the kernel we move the logic over to `cpp/src/fil/infer.cu` and provide a c++ interface.