### PR TITLE
[FEA] UMAP API for building with batched NN Descent

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -82,8 +82,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-      FORK             jinsolp
-      PINNED_TAG       batch-nnd
+      FORK             rapidsai
+      PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
       EXCLUDE_FROM_ALL ${CUML_EXCLUDE_RAFT_FROM_ALL}
       # When PINNED_TAG above doesn't match cuml,
       # force local raft clone in build directory

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -82,8 +82,8 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION          ${CUML_MIN_VERSION_raft}
-      FORK             rapidsai
-      PINNED_TAG       branch-${CUML_BRANCH_VERSION_raft}
+      FORK             jinsolp
+      PINNED_TAG       batch-nnd
       EXCLUDE_FROM_ALL ${CUML_EXCLUDE_RAFT_FROM_ALL}
       # When PINNED_TAG above doesn't match cuml,
       # force local raft clone in build directory

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -59,7 +59,7 @@ void launcher(const raft::handle_t& handle,
 
 //  Functor to post-process distances as L2Sqrt*
 template <typename value_idx, typename value_t = float>
-struct DistancePostProcessSqrt {
+struct DistancePostProcessSqrt : NNDescent::DistEpilogue<value_idx, value_t> {
   DI value_t operator()(value_t value, value_idx row, value_idx col) const { return sqrtf(value); }
 };
 

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -298,8 +298,8 @@ class UMAP(UniversalBase,
     build_kwds: dict (optional, default=None)
         Build algorithm argument {'nnd_graph_degree': 64, 'nnd_intermediate_graph_degree': 128,
         'nnd_max_iterations': 20, 'nnd_termination_threshold': 0.0001, 'nnd_return_distances': True,
-        'nnd_do_batch': False, 'nnd_n_clusters': 2}
-        Note that nnd_n_clusters only becomes effective when nnd_do_batch is True.
+        'nnd_n_clusters': 1}
+        Note that nnd_n_clusters > 1 will result in batch-building with NN Descent.
 
     Notes
     -----
@@ -491,19 +491,16 @@ class UMAP(UniversalBase,
                     umap_params.nn_descent_params.max_iterations = <uint64_t> 20
                     umap_params.nn_descent_params.termination_threshold = <float> 0.0001
                     umap_params.nn_descent_params.return_distances = <bool> True
-                    umap_params.nn_descent_params.n_clusters = <uint64_t> 2
-                    umap_params.nn_descent_params.do_batch = <bool> False
+                    umap_params.nn_descent_params.n_clusters = <uint64_t> 1
                 else:
                     umap_params.nn_descent_params.graph_degree = <uint64_t> cls.build_kwds.get("nnd_graph_degree", 64)
                     umap_params.nn_descent_params.intermediate_graph_degree = <uint64_t> cls.build_kwds.get("nnd_intermediate_graph_degree", 128)
                     umap_params.nn_descent_params.max_iterations = <uint64_t> cls.build_kwds.get("nnd_max_iterations", 20)
                     umap_params.nn_descent_params.termination_threshold = <float> cls.build_kwds.get("nnd_termination_threshold", 0.0001)
                     umap_params.nn_descent_params.return_distances = <bool> cls.build_kwds.get("nnd_return_distances", True)
-                    umap_params.nn_descent_params.n_clusters = <uint64_t> cls.build_kwds.get("nnd_n_clusters", 2)
-                    umap_params.nn_descent_params.do_batch = <bool> cls.build_kwds.get("nnd_do_batch", False)
-
-                    if cls.build_kwds.get("nnd_do_batch", False) and cls.build_kwds.get("nnd_n_clusters", 2) < 2:
-                        logger.info("Changing nnd_n_clusters to 2 to do batching. Set nnd_do_batch to False to run without batching")
+                    if cls.build_kwds.get("nnd_n_clusters", 1) < 1:
+                        logger.info("Negative number of nnd_n_clusters not allowed. Changing nnd_n_clusters to 1")
+                    umap_params.nn_descent_params.n_clusters = <uint64_t> cls.build_kwds.get("nnd_n_clusters", 1)
 
             umap_params.target_weight = <float> cls.target_weight
             umap_params.random_state = <uint64_t> cls.random_state

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -488,12 +488,16 @@ class UMAP(UniversalBase,
                     umap_params.nn_descent_params.max_iterations = <uint64_t> 20
                     umap_params.nn_descent_params.termination_threshold = <float> 0.0001
                     umap_params.nn_descent_params.return_distances = <bool> True
+                    umap_params.nn_descent_params.n_clusters = <uint64_t> 2
+                    umap_params.nn_descent_params.do_batch = <bool> False
                 else:
                     umap_params.nn_descent_params.graph_degree = <uint64_t> cls.build_kwds.get("nnd_graph_degree", 64)
                     umap_params.nn_descent_params.intermediate_graph_degree = <uint64_t> cls.build_kwds.get("nnd_intermediate_graph_degree", 128)
                     umap_params.nn_descent_params.max_iterations = <uint64_t> cls.build_kwds.get("nnd_max_iterations", 20)
                     umap_params.nn_descent_params.termination_threshold = <float> cls.build_kwds.get("nnd_termination_threshold", 0.0001)
                     umap_params.nn_descent_params.return_distances = <bool> cls.build_kwds.get("nnd_return_distances", True)
+                    umap_params.nn_descent_params.n_clusters = <uint64_t> cls.build_kwds.get("nnd_n_clusters", 2)
+                    umap_params.nn_descent_params.do_batch = <bool> cls.build_kwds.get("nnd_do_batch", False)
             umap_params.target_weight = <float> cls.target_weight
             umap_params.random_state = <uint64_t> cls.random_state
             umap_params.deterministic = <bool> cls.deterministic

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -442,7 +442,8 @@ class UMAP(UniversalBase,
                 # https://github.com/rapidsai/cuml/issues/5985
                 logger.info("build_algo set to brute_force_knn because random_state is given")
                 self.build_algo ="brute_force_knn"
-            self.build_algo = build_algo
+            else:
+                self.build_algo = build_algo
         else:
             raise Exception("Invalid build algo: {}. Only support auto, brute_force_knn and nn_descent" % build_algo)
 
@@ -500,6 +501,10 @@ class UMAP(UniversalBase,
                     umap_params.nn_descent_params.return_distances = <bool> cls.build_kwds.get("nnd_return_distances", True)
                     umap_params.nn_descent_params.n_clusters = <uint64_t> cls.build_kwds.get("nnd_n_clusters", 2)
                     umap_params.nn_descent_params.do_batch = <bool> cls.build_kwds.get("nnd_do_batch", False)
+
+                    if cls.build_kwds.get("nnd_do_batch", False) and cls.build_kwds.get("nnd_n_clusters", 2) < 2:
+                        logger.info("Changing nnd_n_clusters to 2 to do batching. Set nnd_do_batch to False to run without batching")
+
             umap_params.target_weight = <float> cls.target_weight
             umap_params.random_state = <uint64_t> cls.random_state
             umap_params.deterministic = <bool> cls.deterministic

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -297,7 +297,9 @@ class UMAP(UniversalBase,
         smaller than or equal to 50K. Otherwise, runs with nn descent.
     build_kwds: dict (optional, default=None)
         Build algorithm argument {'nnd_graph_degree': 64, 'nnd_intermediate_graph_degree': 128,
-        'nnd_max_iterations': 20, 'nnd_termination_threshold': 0.0001, 'nnd_return_distances': True}
+        'nnd_max_iterations': 20, 'nnd_termination_threshold': 0.0001, 'nnd_return_distances': True,
+        'nnd_do_batch': False, 'nnd_n_clusters': 2}
+        Note that nnd_n_clusters only becomes effective when nnd_do_batch is True.
 
     Notes
     -----

--- a/python/cuml/cuml/manifold/umap_utils.pxd
+++ b/python/cuml/cuml/manifold/umap_utils.pxd
@@ -46,7 +46,6 @@ cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbor
         float termination_threshold,
         bool return_distances,
         uint64_t n_clusters,
-        bool do_batch
 
 cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
 

--- a/python/cuml/cuml/manifold/umap_utils.pxd
+++ b/python/cuml/cuml/manifold/umap_utils.pxd
@@ -40,11 +40,13 @@ cdef extern from "cuml/common/callback.hpp" namespace "ML::Internals":
 
 cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbors::experimental::nn_descent":
     cdef struct index_params:
-        int64_t graph_degree,
-        int64_t intermediate_graph_degree,
-        int64_t max_iterations,
+        uint64_t graph_degree,
+        uint64_t intermediate_graph_degree,
+        uint64_t max_iterations,
         float termination_threshold,
-        bool return_distances
+        bool return_distances,
+        uint64_t n_clusters,
+        bool do_batch
 
 cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
 

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -838,3 +838,31 @@ def test_umap_distance_metrics_fit_transform_trust_on_sparse_input(
 
     if umap_learn_supported:
         assert array_equal(umap_trust, cuml_trust, 0.05, with_sign=True)
+
+
+@pytest.mark.parametrize("n_rows", [3000])
+@pytest.mark.parametrize("n_features", [200, 500])
+@pytest.mark.parametrize("data_on_host", [True, False])
+@pytest.mark.parametrize("num_clusters", [3, 5])
+def test_umap_trustworthiness_on_batch_nnd(
+    n_rows, n_features, data_on_host, num_clusters
+):
+
+    data, labels = make_blobs(
+        n_samples=n_rows, n_features=n_features, centers=5, random_state=42
+    )
+
+    cuml_model = cuUMAP(
+        n_neighbors=10,
+        min_dist=0.01,
+        build_algo="nn_descent",
+        build_kwds={"nnd_do_batch": True, "nnd_n_clusters": num_clusters},
+    )
+
+    cuml_embedding = cuml_model.fit_transform(
+        data, convert_dtype=True, data_on_host=data_on_host
+    )
+
+    cuml_trust = trustworthiness(data, cuml_embedding, n_neighbors=10)
+
+    assert cuml_trust > 0.9

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -840,13 +840,9 @@ def test_umap_distance_metrics_fit_transform_trust_on_sparse_input(
         assert array_equal(umap_trust, cuml_trust, 0.05, with_sign=True)
 
 
-@pytest.mark.parametrize("n_rows", [3000])
-@pytest.mark.parametrize("n_features", [200, 500])
 @pytest.mark.parametrize("data_on_host", [True, False])
-@pytest.mark.parametrize("num_clusters", [3, 5])
-def test_umap_trustworthiness_on_batch_nnd(
-    n_rows, n_features, data_on_host, num_clusters
-):
+@pytest.mark.parametrize("num_clusters", [0, 3, 5])
+def test_umap_trustworthiness_on_batch_nnd(data_on_host, num_clusters):
 
     digits = datasets.load_digits()
 

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -848,9 +848,7 @@ def test_umap_trustworthiness_on_batch_nnd(
     n_rows, n_features, data_on_host, num_clusters
 ):
 
-    data, labels = make_blobs(
-        n_samples=n_rows, n_features=n_features, centers=5, random_state=42
-    )
+    digits = datasets.load_digits()
 
     cuml_model = cuUMAP(
         n_neighbors=10,
@@ -860,9 +858,9 @@ def test_umap_trustworthiness_on_batch_nnd(
     )
 
     cuml_embedding = cuml_model.fit_transform(
-        data, convert_dtype=True, data_on_host=data_on_host
+        digits.data, convert_dtype=True, data_on_host=data_on_host
     )
 
-    cuml_trust = trustworthiness(data, cuml_embedding, n_neighbors=10)
+    cuml_trust = trustworthiness(digits.data, cuml_embedding, n_neighbors=10)
 
     assert cuml_trust > 0.9

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -850,7 +850,7 @@ def test_umap_trustworthiness_on_batch_nnd(data_on_host, num_clusters):
         n_neighbors=10,
         min_dist=0.01,
         build_algo="nn_descent",
-        build_kwds={"nnd_do_batch": True, "nnd_n_clusters": num_clusters},
+        build_kwds={"nnd_n_clusters": num_clusters},
     )
 
     cuml_embedding = cuml_model.fit_transform(


### PR DESCRIPTION
### Description
adds the following parameters as part of the `build_kwds`
- `n_clusters`: number of clusters to use when batching. Larger number of clusters reduce GPU memory usage. Defaults to 1 (no batch)

Results showing consistent trustworthiness scores for doing/not doing batching.

Also note below that now UMAP can run with datasets that don't fit on the GPU. Putting the dataset on host and enabling the batching method allows UMAP to run with a dataset that is 50M x 768 (153GB).

<img width="709" alt="Screenshot 2024-08-13 at 5 55 27 PM" src="https://github.com/user-attachments/assets/39263583-4ffc-4b0b-886f-f1b0f21a99be">


### Notes
[This PR in raft](https://github.com/rapidsai/raft/pull/2403) needs to be merged before this PR