### PR TITLE
[DO NOT MERGE] Check that full CI tests are NumPy 2 ready

### DIFF
--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -24,6 +24,9 @@ set +u
 conda activate test
 set -u
 
+# Force update NumPy, to run full tests with NumPy 2 on CI
+python -m pip install -U numpy
+
 # dask and other tests sporadically run into this issue in ARM tests
 # exception=ImportError('/opt/conda/envs/test/lib/python3.10/site-packages/cuml/internals/../../../.././libgomp.so.1: cannot allocate memory in static TLS block')>)
 # this should avoid that/opt/conda/lib

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -25,7 +25,7 @@ conda activate test
 set -u
 
 # Force update NumPy, to run full tests with NumPy 2 on CI
-python -m pip install -U numpy
+python -m pip install -U "numpy<2.1"
 
 # dask and other tests sporadically run into this issue in ARM tests
 # exception=ImportError('/opt/conda/envs/test/lib/python3.10/site-packages/cuml/internals/../../../.././libgomp.so.1: cannot allocate memory in static TLS block')>)

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -23,7 +23,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 # Force update NumPy, to run full tests with NumPy 2 on CI
-python -m pip install -U numpy
+python -m pip install -U "numpy<2.1"
 
 rapids-logger "pytest cuml single GPU"
 ./ci/run_cuml_singlegpu_pytests.sh \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -22,6 +22,8 @@ EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
+# Force update NumPy, to run full tests with NumPy 2 on CI
+python -m pip install -U numpy
 
 rapids-logger "pytest cuml single GPU"
 ./ci/run_cuml_singlegpu_pytests.sh \

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -51,7 +51,7 @@ dependencies:
 - pip
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==24.10.*,>=0.0.0a0
-- pynndescent==0.5.8
+- pynndescent
 - pytest-benchmark
 - pytest-cases
 - pytest-cov

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -47,7 +47,7 @@ dependencies:
 - pip
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==24.10.*,>=0.0.0a0
-- pynndescent==0.5.8
+- pynndescent
 - pytest-benchmark
 - pytest-cases
 - pytest-cov

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -501,7 +501,7 @@ dependencies:
           - *scikit_learn
           - statsmodels
           - umap-learn==0.5.3
-          - pynndescent==0.5.8
+          - pynndescent
       - output_types: conda
         packages:
           - pip

--- a/python/cuml/cuml/__init__.py
+++ b/python/cuml/cuml/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from . import patch_cupy_312
 
 from cuml.internals.base import Base, UniversalBase
 from cuml.internals.available_devices import is_cuda_available

--- a/python/cuml/cuml/patch_cupy_312.py
+++ b/python/cuml/cuml/patch_cupy_312.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import itertools
+import binascii
+import os
+import hashlib
+import time
+
+import numpy
+
+import cupy
+from cupy import _core
+from cupy._core import _fusion_interface
+from cupy._core import fusion
+from cupy._sorting import search
+from cupy_backends.cuda.api import runtime
+
+
+_UINT64_MAX = 0xFFFFFFFFFFFFFFFF
+
+
+def copyto(dst, src, casting="same_kind", where=None):
+    src_is_scalar = False
+    src_type = type(src)
+
+    if src_type in (bool, int, float, complex):
+        dst_arr = numpy.empty((), dtype=dst.dtype)
+        # NumPy 1.x and 2.0 make implementing copyto cast safety hard, so
+        # test whether NumPy copy allows the copy operation:
+        numpy.copyto(dst_arr, src, casting=casting)
+        can_cast = True
+        src_is_scalar = True
+    elif src_type in (fusion._FusionVarScalar, _fusion_interface._ScalarProxy):
+        src_dtype = src.dtype
+        can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
+        src_is_scalar = True
+    elif isinstance(src, numpy.ndarray) or numpy.isscalar(src):
+        if src.size != 1:
+            raise ValueError(
+                "non-scalar numpy.ndarray cannot be used for copyto"
+            )
+        src_dtype = src.dtype
+        can_cast = numpy.can_cast(src, dst.dtype, casting)
+        src = src.item()
+        src_is_scalar = True
+    else:
+        src_dtype = src.dtype
+        can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
+
+    if not can_cast:
+        raise TypeError(
+            "Cannot cast %s to %s in %s casting mode"
+            % (src_dtype, dst.dtype, casting)
+        )
+
+    if fusion._is_fusing():
+        # TODO(kataoka): NumPy allows stripping leading unit dimensions.
+        # But fusion array proxy does not currently support
+        # `shape` and `squeeze`.
+
+        if where is None:
+            _core.elementwise_copy(src, dst)
+        else:
+            fusion._call_ufunc(search._where_ufunc, where, src, dst, dst)
+        return
+
+    if not src_is_scalar:
+        # Check broadcast condition
+        # - for fast-paths and
+        # - for a better error message (than ufunc's).
+        # NumPy allows stripping leading unit dimensions.
+        if not all(
+            [
+                s in (d, 1)
+                for s, d in itertools.zip_longest(
+                    reversed(src.shape), reversed(dst.shape), fillvalue=1
+                )
+            ]
+        ):
+            raise ValueError(
+                "could not broadcast input array "
+                f"from shape {src.shape} into shape {dst.shape}"
+            )
+        squeeze_ndim = src.ndim - dst.ndim
+        if squeeze_ndim > 0:
+            # always succeeds because broadcast conition is checked.
+            src = src.squeeze(tuple(range(squeeze_ndim)))
+
+    if where is not None:
+        _core.elementwise_copy(src, dst, _where=where)
+        return
+
+    if dst.size == 0:
+        return
+
+    if src_is_scalar:
+        _core.elementwise_copy(src, dst)
+        return
+
+    if _can_memcpy(dst, src):
+        dst.data.copy_from_async(src.data, src.nbytes)
+        return
+
+    device = dst.device
+    prev_device = runtime.getDevice()
+    try:
+        runtime.setDevice(device.id)
+        if src.device != device:
+            src = src.copy()
+        _core.elementwise_copy(src, dst)
+    finally:
+        runtime.setDevice(prev_device)
+
+
+def _can_memcpy(dst, src):
+    c_contiguous = dst.flags.c_contiguous and src.flags.c_contiguous
+    f_contiguous = dst.flags.f_contiguous and src.flags.f_contiguous
+    return (
+        (c_contiguous or f_contiguous)
+        and dst.dtype == src.dtype
+        and dst.size == src.size
+    )
+
+
+# Replace the main cupy functions:
+cupy.copyto = copyto
+cupy._manipulation.basic.copyto = copyto
+
+# FFTshifts used now invalid symbol in NuMpy (could also patch `NumPy instead...)
+
+
+def fftshift(x, axes=None):
+    x = cupy.asarray(x)
+    if axes is None:
+        axes = list(range(x.ndim))
+    elif isinstance(axes, int):
+        axes = (axes,)
+    return cupy.roll(x, [x.shape[axis] // 2 for axis in axes], axes)
+
+
+def ifftshift(x, axes=None):
+    x = cupy.asarray(x)
+    if axes is None:
+        axes = list(range(x.ndim))
+    elif isinstance(axes, int):
+        axes = (axes,)
+    return cupy.roll(x, [-(x.shape[axis] // 2) for axis in axes], axes)
+
+
+cupy.fft.fftshift = fftshift
+cupy.fft.ifftshift = ifftshift
+
+
+def seed(self, seed=None):
+    from cupy_backends.cuda.libs import curand
+
+    if seed is None:
+        try:
+            seed_str = binascii.hexlify(os.urandom(8))
+            seed = int(seed_str, 16)
+        except NotImplementedError:
+            seed = (time.time() * 1000000) % _UINT64_MAX
+    else:
+        if isinstance(seed, numpy.ndarray):
+            seed = int(hashlib.md5(seed).hexdigest()[:16], 16)
+        else:
+            seed_arr = numpy.asarray(seed)
+            if seed_arr.dtype.kind not in "biu":
+                raise TypeError("Seed must be an integer.")
+            seed = int(seed_arr)
+            # Check that no integer overflow occurred during the cast
+            if seed < 0 or seed >= 2**64:
+                raise ValueError(
+                    "Seed must be an integer between 0 and 2**64 - 1"
+                )
+
+    curand.setPseudoRandomGeneratorSeed(self._generator, seed)
+    if self.method not in (
+        curand.CURAND_RNG_PSEUDO_MT19937,
+        curand.CURAND_RNG_PSEUDO_MTGP32,
+    ):
+        curand.setGeneratorOffset(self._generator, 0)
+
+    self._rk_seed = seed
+
+
+cupy.random.RandomState.seed = seed

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -682,7 +682,7 @@ def test_exception_one_label(fit_intercept, client):
     y = np.array([1.0, 1.0, 1.0, 1.0], datatype)
     X_df, y_df = _prep_training_data(client, X, y, n_parts)
 
-    err_msg = "This solver needs samples of at least 2 classes in the data, but the data contains only one class: 1.0"
+    err_msg = "This solver needs samples of at least 2 classes in the data, but the data contains only one class:.*1.0"
 
     from cuml.dask.linear_model import LogisticRegression as cumlLBFGS_dask
 

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -43,6 +43,8 @@ filterwarnings = [
   "error::FutureWarning",
   "error::DeprecationWarning",
   "error:::cudf",
+  # TODO: Temporary fix for CI, silence warning originating from cudf.pandas.
+  "ignore:(.*)numpy.core.multiarray is deprecated(.*):DeprecationWarning",
   "ignore:[^.]*ABCs[^.]*:DeprecationWarning:patsy[.*]",
   "ignore:(.*)alias(.*):DeprecationWarning:hdbscan[.*]",
   # TODO: https://github.com/rapidsai/cuml/issues/5878

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -116,7 +116,7 @@ test = [
     "hypothesis>=6.0,<7",
     "nltk",
     "numpydoc",
-    "pynndescent==0.5.8",
+    "pynndescent",
     "pytest-benchmark",
     "pytest-cases",
     "pytest-cov",


### PR DESCRIPTION
CuPy 13.3 is coming soon, and that should mean we can simply remove the `numpy<2.0` pin.  However, while we tested quite extensively locally, I have never made sure that the full CI should be passing just fine.

This tests CI, with CuPy 13.2.0, but applying the important patches (via monkeypatching).  It also unpins `pynndescent` since it has (trivial) issues with NumPy 2.

**Not meant to be merged, simply a double check, to see if there might be any need for fix-ups.**