### PR TITLE
Switch debug build to RelWithDebInfo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -168,7 +168,7 @@ while true; do
             CMAKE_LOG_LEVEL=VERBOSE
             ;;
         -g | --debug )
-            BUILD_TYPE=Debug
+            BUILD_TYPE=RelWithDebInfo
             ;;
         -n | --no-install )
             INSTALL_TARGET=""


### PR DESCRIPTION
It seems cuML doesn't actually build with the `Debug` build type using the `-g` option. Switching to `RelWithDebInfo` seems to work, and gives us line number information, although some code is optimized out. Seems like a reasonable comprise to help with debugging until we can get the `Debug` working properly.