### PR TITLE
Add use_cuda_wheels matrix entry

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -420,6 +420,7 @@ dependencies:
               - nvidia-curand-cu12
               - nvidia-cusparse-cu12
               - nvidia-cusolver-cu12
+          # CUDA 11 does not provide wheels, so use the system libraries instead
           - matrix:
               cuda: "11.*"
               use_cuda_wheels: "true"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,7 +88,7 @@ files:
     extras:
       table: project
     includes:
-      - cuda
+      - cuda_wheels
       - py_run
   py_test:
     output: pyproject
@@ -407,10 +407,13 @@ dependencies:
               - *libcusolver114
               - *libcusparse_dev114
               - *libcusparse114
+  cuda_wheels:
+    specific:
       - output_types: pyproject
         matrices:
           - matrix:
               cuda: "12.*"
+              use_cuda_wheels: "true"
             packages:
               - nvidia-cublas-cu12
               - nvidia-cufft-cu12
@@ -419,7 +422,15 @@ dependencies:
               - nvidia-cusolver-cu12
           - matrix:
               cuda: "11.*"
+              use_cuda_wheels: "true"
             packages:
+          # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
+          # (e.g. for DLFW and pip devcontainers)
+          - matrix:
+              use_cuda_wheels: "false"
+            packages:
+          # if no matching matrix selectors passed, list the unsuffixed packages
+          # (just as a source of documentation, as this populates pyproject.toml in source control)
           - matrix:
             packages:
               - nvidia-cublas

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -159,7 +159,7 @@ versioneer\.py |
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true"
+matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cuda-python",


### PR DESCRIPTION
We want to be able to control whether or not the wheel uses the CUDA wheels. Add a `use_cuda_wheels` matrix entry to control this.

Contributes to https://github.com/rapidsai/build-planning/issues/35