### PR TITLE
Update README in experimental FIL

### DIFF
--- a/cpp/include/cuml/experimental/fil/README.md
+++ b/cpp/include/cuml/experimental/fil/README.md
@@ -39,7 +39,7 @@ similar load methods for each of the serialization formats it supports.
 
 ```cpp
 auto filename = "xgboost.json";
-auto tl_model = treelite::frontend::LoadXGBoostModel(filename);
+auto tl_model = treelite::model_loader::LoadXGBoostModelJSON(filename, "{}");
 ```
 
 We then import the Treelite model into FIL via the


### PR DESCRIPTION
`treelite::frontend::LoadXGBoostModel` is no longer present in the latest Treelite; use `treelite::model_loader::LoadXGBoostModelJSON` instead.