### PR TITLE
Fix np.NAN to np.nan.

### DIFF
--- a/python/cuml/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/cuml/tests/test_kernel_ridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ def gradient_norm(model, X, y, K, sw=None):
     ).reshape(y.shape)
 
     # initialise to NaN in case below loop has 0 iterations
-    grads = cp.full_like(y, np.NAN)
+    grads = cp.full_like(y, np.nan)
     for i, (beta, target, current_alpha) in enumerate(
         zip(betas.T, y.T, model.alpha)
     ):


### PR DESCRIPTION
NumPy 2 requires `np.nan` instead of `np.NAN`. This appeared as a nightly test failure:

```
FAILED test_kernel_ridge.py::test_estimator - AttributeError: module 'numpy' has no attribute 'NAN'
```

Referencing the NumPy 2 changelog: https://numpy.org/devdocs/release/2.0.0-notes.html

> Alias np.NaN has been removed. Use np.nan instead.
