### PR TITLE
Set default values for conftest options.

### DIFF
--- a/python/cuml/cuml/tests/dask/conftest.py
+++ b/python/cuml/cuml/tests/dask/conftest.py
@@ -72,11 +72,17 @@ def pytest_addoption(parser):
     group = parser.getgroup("Dask cuML Custom Options")
 
     group.addoption(
-        "--run_ucx", action="store_true", help="run _only_ UCX-Py tests"
+        "--run_ucx",
+        action="store_true",
+        default=False,
+        help="run _only_ UCX-Py tests",
     )
 
     group.addoption(
-        "--run_ucxx", action="store_true", help="run _only_ UCXX tests"
+        "--run_ucxx",
+        action="store_true",
+        default=False,
+        help="run _only_ UCXX tests",
     )
 
 


### PR DESCRIPTION
There is no default being set for `run_ucx` or `run_ucxx`. This results in an error on Python 3.12 (maybe other versions too):

```
AttributeError: 'Namespace' object has no attribute 'run_ucx'. Did you mean: 'run_unit'?
```

This PR adds a default value for those conftest options.
