### PR TITLE
fix version in Doxygen docs

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,6 +6,7 @@ rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"
+export RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
 
 rapids-dependency-file-generator \
   --output conda \
@@ -44,4 +45,4 @@ mkdir -p "${RAPIDS_DOCS_DIR}/cuml/html"
 mv _html/* "${RAPIDS_DOCS_DIR}/cuml/html"
 popd
 
-RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)" rapids-upload-docs
+RAPIDS_VERSION_NUMBER="${RAPIDS_VERSION_MAJOR_MINOR}" rapids-upload-docs


### PR DESCRIPTION
Follow-up to #6103.

In that PR, I'd removed the `export RAPIDS_MAJOR_MINOR_VERSION`. I realized that this project's Doxygen setup actually expects that to be set in the environment.

https://github.com/rapidsai/cuml/blob/22342aad0ecd327e3140471c479d01d83b932c23/ci/build_docs.sh#L35

https://github.com/rapidsai/cuml/blob/22342aad0ecd327e3140471c479d01d83b932c23/cpp/Doxyfile.in#L41

This fixes that, sorry 😬 