### PR TITLE
TST Add basic common test infrastructure

### DIFF
--- a/python/cuml/cuml/internals/mixins.py
+++ b/python/cuml/cuml/internals/mixins.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ _default_tags = {
     "X_types_gpu": ["2darray"],
     # Scikit-learn API standard tags
     "allow_nan": False,
+    "array_api_support": False,
     "binary_only": False,
     "multilabel": False,
     "multioutput": False,

--- a/python/cuml/cuml/tests/test_common.py
+++ b/python/cuml/cuml/tests/test_common.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from sklearn.utils import estimator_checks
+
+from cuml import LogisticRegression
+
+
+@estimator_checks.parametrize_with_checks([LogisticRegression()])
+def test_sklearn_compatible_estimator(estimator, check):
+    # Check that all estimators pass the "common estimator" checks
+    # provided by scikit-learn
+    check(estimator)


### PR DESCRIPTION
xref #6105

This adds a test that uses the test infrastructure that scikit-learn provides to find out if an estimator is compatible with scikit-learn. Short explanation https://scikit-learn.org/dev/developers/develop.html#rolling-your-own-estimator and we use https://scikit-learn.org/dev/modules/generated/sklearn.utils.estimator_checks.parametrize_with_checks.html#sklearn.utils.estimator_checks.parametrize_with_checks here to have a test that is parametrized by estimator and check. This makes it easy to see what is failing.

I've only added `LogisticRegression` for the moment, mostly because I wanted to see what other people think of this. I think it would be useful for issues like #6105 to find out which estimators are/aren't compatible, fix them and make sure they stay compatible. Fixing some of the failures would probably make it easier for users to swap scikit-learn and cuml without big effort. A downside is that right now a lot of the checks fail.

WDYT?