### PR TITLE
Remove type from pickle header for CumlArray

### DIFF
--- a/python/cuml/cuml/internals/array.py
+++ b/python/cuml/cuml/internals/array.py
@@ -728,9 +728,8 @@ class CumlArray:
 
     @classmethod
     def host_deserialize(cls, header, frames):
-        typ = pickle.loads(header["type-serialized"])
         assert all(not is_cuda for is_cuda in header["is-cuda"])
-        obj = typ.deserialize(header, frames)
+        obj = cls.deserialize(header, frames)
         return obj
 
     @nvtx_annotate(
@@ -748,9 +747,8 @@ class CumlArray:
 
     @classmethod
     def device_deserialize(cls, header, frames):
-        typ = pickle.loads(header["type-serialized"])
         assert all(is_cuda for is_cuda in header["is-cuda"])
-        obj = typ.deserialize(header, frames)
+        obj = cls.deserialize(header, frames)
         return obj
 
     @nvtx_annotate(
@@ -761,7 +759,6 @@ class CumlArray:
     def serialize(self, mem_type=None) -> Tuple[dict, list]:
         mem_type = self.mem_type if mem_type is None else mem_type
         header = {
-            "type-serialized": pickle.dumps(type(self)),
             "constructor-kwargs": {
                 "dtype": self.dtype.str,
                 "shape": self.shape,

--- a/python/cuml/cuml/tests/test_array.py
+++ b/python/cuml/cuml/tests/test_array.py
@@ -535,8 +535,6 @@ def test_serialize(inp, to_serialize_mem_type, from_serialize_mem_type):
     with using_memory_type(from_serialize_mem_type):
         ary2 = CumlArray.deserialize(header, frames)
 
-        assert pickle.loads(header["type-serialized"]) is CumlArray
-
         _assert_equal(inp, ary2)
 
         assert ary._array_interface["shape"] == ary2._array_interface["shape"]


### PR DESCRIPTION
Including the type in the header is unnecessary for (de)serialization