### PR TITLE
Stop excluding cutlass from symbol exclusion check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,7 +113,6 @@ jobs:
     with:
       build_type: pull-request
       enable_check_symbols: true
-      symbol_exclusions: raft_cutlass
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit


### PR DESCRIPTION
Depends on https://github.com/rapidsai/raft/pull/2503, which includes the kernel visibility fixes needed from cutlass.