### PR TITLE
Fix `scikit-learn` version specifier

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -66,7 +66,7 @@ dependencies:
 - recommonmark
 - rmm==24.12.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
-- scikit-learn==1.5
+- scikit-learn==1.5.*
 - scipy>=1.8.0
 - seaborn
 - spdlog>=1.14.1,<1.15

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -62,7 +62,7 @@ dependencies:
 - recommonmark
 - rmm==24.12.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
-- scikit-learn==1.5
+- scikit-learn==1.5.*
 - scipy>=1.8.0
 - seaborn
 - spdlog>=1.14.1,<1.15

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -463,7 +463,7 @@ dependencies:
           # https://github.com/pydata/pydata-sphinx-theme/issues/1539
           - pydata-sphinx-theme!=0.14.2
           - recommonmark
-          - &scikit_learn scikit-learn==1.5
+          - &scikit_learn scikit-learn==1.5.*
           - sphinx<6
           - sphinx-copybutton
           - sphinx-markdown-tables

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -133,7 +133,7 @@ test = [
     "pytest-cov",
     "pytest-xdist",
     "pytest==7.*",
-    "scikit-learn==1.5",
+    "scikit-learn==1.5.*",
     "seaborn",
     "statsmodels",
     "umap-learn==0.5.6",


### PR DESCRIPTION
This version should be `1.5.*`, otherwise this causes pip solves to fail with the following error when included with a wheel downloaded via `pip download`:

```
ERROR: Cannot install scikit-learn, scikit-learn 1.5.2 (from scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl) and scikit-learn==1.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested scikit-learn 1.5.2 (from scikit_learn-1.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl)
    The user requested scikit-learn
    The user requested scikit-learn==1.5

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```