### PR TITLE
Fix SSL error.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -8,6 +8,7 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
+- certifi
 - cmake>=3.26.4,!=3.30.0
 - cuda-python>=11.7.1,<12.0a0,<=11.8.3
 - cuda-version=11.8

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -8,6 +8,7 @@ channels:
 - nvidia
 dependencies:
 - c-compiler
+- certifi
 - cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -510,6 +510,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
+          - certifi
           - *cython
           - dask-ml
           - hdbscan>=0.8.39,<0.8.40

--- a/python/cuml/cuml/tests/conftest.py
+++ b/python/cuml/cuml/tests/conftest.py
@@ -24,6 +24,9 @@ from sklearn.datasets import fetch_20newsgroups
 from sklearn.utils import Bunch
 from datetime import timedelta
 from math import ceil
+from ssl import create_default_context
+from urllib.request import build_opener, HTTPSHandler, install_opener
+import certifi
 import hypothesis
 from cuml.internals.safe_imports import gpu_only_import
 import pytest
@@ -40,6 +43,14 @@ cp = gpu_only_import("cupy")
 
 # Add the import here for any plugins that should be loaded EVERY TIME
 pytest_plugins = "cuml.testing.plugins.quick_run_plugin"
+
+
+# Install SSL certificates
+def pytest_sessionstart(session):
+    ssl_context = create_default_context(cafile=certifi.where())
+    https_handler = HTTPSHandler(context=ssl_context)
+    install_opener(build_opener(https_handler))
+
 
 CI = os.environ.get("CI") in ("true", "1")
 HYPOTHESIS_ENABLED = os.environ.get("HYPOTHESIS_ENABLED") in (

--- a/python/cuml/cuml/tests/dask/conftest.py
+++ b/python/cuml/cuml/tests/dask/conftest.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
+import certifi
 import pytest
+from ssl import create_default_context
+from urllib.request import build_opener, HTTPSHandler, install_opener
 
 from dask_cuda import initialize
 from dask_cuda import LocalCUDACluster
@@ -10,6 +13,13 @@ from dask.distributed import Client
 enable_tcp_over_ucx = True
 enable_nvlink = False
 enable_infiniband = False
+
+
+# Install SSL certificates
+def pytest_sessionstart(session):
+    ssl_context = create_default_context(cafile=certifi.where())
+    https_handler = HTTPSHandler(context=ssl_context)
+    install_opener(build_opener(https_handler))
 
 
 @pytest.fixture(scope="module")

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -121,6 +121,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
+    "certifi",
     "cython>=3.0.0",
     "dask-ml",
     "hdbscan>=0.8.39,<0.8.40",


### PR DESCRIPTION
Last night, [wheel-tests-cuml / 11.8.0, 3.10, arm64, rockylinux8, a100, latest-driver, oldest-deps](https://github.com/rapidsai/cuml/actions/runs/12273029767/job/34243006376#logs) failed.

The failure occurred in `testing/dask/utils.py`'s `load_text_corpus`:

https://github.com/rapidsai/cuml/blob/052cddef9648c3266974a0b43970afb347ba9d01/python/cuml/cuml/testing/dask/utils.py#L12

The errors looked like:

```
FAILED test_dask_naive_bayes.py::test_basic_fit_predict - urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>
FAILED test_dask_naive_bayes.py::test_single_distributed_exact_results - urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>
FAILED test_dask_naive_bayes.py::test_score - urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)>
```

This adopts some fixes from https://github.com/rapidsai/cugraph/pull/4825 that will hopefully help with SSL certificate failures.
