### PR TITLE
simplify wheel CI scripts, other small packaging changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,8 +69,7 @@ repos:
                 CMakeLists[.]txt$|
                 CMakeLists_standalone[.]txt$|
                 [.]flake8[.]cython$|
-                meta[.]yaml$|
-                setup[.]cfg$
+                meta[.]yaml$
           exclude: |
             (?x)
                 cpp/src/tsne/cannylab/bh[.]cu$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
                 python/cuml/cuml/_thirdparty
         - id: verify-alpha-spec
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.16.0
+      rev: v1.17.0
       hooks:
           - id: rapids-dependency-file-generator
             args: ["--clean"]

--- a/BUILD.md
+++ b/BUILD.md
@@ -234,7 +234,6 @@ cuML's cmake has the following configurable flags available:
 | BUILD_PRIMS_TESTS | [ON, OFF]  | ON  | Enable/disable building cuML algorithm test executable `prims_test`.  |
 | BUILD_CUML_EXAMPLES | [ON, OFF]  | ON  | Enable/disable building cuML C++ API usage examples.  |
 | BUILD_CUML_BENCH | [ON, OFF] | ON | Enable/disable building of cuML C++ benchark.  |
-| BUILD_CUML_PRIMS_BENCH | [ON, OFF] | ON | Enable/disable building of ml-prims C++ benchark.  |
 | CMAKE_CXX11_ABI | [ON, OFF]  | ON  | Enable/disable the GLIBCXX11 ABI  |
 | DETECT_CONDA_ENV | [ON, OFF] | ON | Use detection of conda environment for dependencies. If set to ON, and no value for CMAKE_INSTALL_PREFIX is passed, then it'll assign it to $CONDA_PREFIX (to install in the active environment).  |
 | DISABLE_OPENMP | [ON, OFF]  | OFF  | Set to `ON` to disable OpenMP  |

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -10,10 +10,6 @@ source rapids-date-string
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-# This is the version of the suffix with a preceding hyphen. It's used
-# everywhere except in the final wheel name.
-PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
-
 rapids-generate-version > ./VERSION
 
 cd ${package_dir}

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,11 +7,6 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="cuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
-# On arm also need to install CMake because treelite needs to be compiled (no wheels available for arm).
-if [[ "$(arch)" == "aarch64" ]]; then
-    python -m pip install cmake
-fi
-
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/cuml*.whl)[test]
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -37,7 +37,6 @@ Current cmake offers the following configuration options:
 | BUILD_PRIMS_TESTS | [ON, OFF]  | ON  | Enable/disable building cuML algorithm test executable `prims_test`.  |
 | BUILD_CUML_EXAMPLES | [ON, OFF]  | ON  | Enable/disable building cuML C++ API usage examples.  |
 | BUILD_CUML_BENCH | [ON, OFF]  | ON  | Enable/disable building of cuML C++ benchark. |
-| BUILD_CUML_PRIMS_BENCH | [ON, OFF]  | ON  | Enable/disable building of ml-prims C++ benchark. |
 | BUILD_CUML_STD_COMMS | [ON, OFF] | ON | Enable/disable building cuML NCCL+UCX communicator for running multi-node multi-GPU algorithms. Note that UCX support can also be enabled/disabled (see below). The standard communicator and MPI communicator are not mutually exclusive and can both be installed at the same time. |
 | WITH_UCX | [ON, OFF] | OFF | Enable/disable UCX support in the standard cuML communicator. Algorithms requiring point-to-point messaging will not work when this is disabled. This flag is ignored if BUILD_CUML_STD_COMMS is set to OFF. |
 | BUILD_CUML_MPI_COMMS | [ON, OFF] | OFF | Enable/disable building cuML MPI+NCCL communicator for running multi-node multi-GPU C++ tests. MPI communicator and STD communicator may both be installed at the same time. If OFF, it overrides BUILD_CUML_MG_TESTS to be OFF as well. |

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -54,7 +54,6 @@ function(find_and_configure_raft)
         EXCLUDE_FROM_ALL       ${PKG_EXCLUDE_FROM_ALL}
         OPTIONS
           "BUILD_TESTS OFF"
-          "BUILD_BENCH OFF"
           "BUILD_PRIMS_BENCH OFF"
           "BUILD_CAGRA_HNSWLIB OFF"
           "RAFT_COMPILE_LIBRARY OFF"

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -55,6 +55,7 @@ function(find_and_configure_raft)
         OPTIONS
           "BUILD_TESTS OFF"
           "BUILD_BENCH OFF"
+          "BUILD_PRIMS_BENCH OFF"
           "BUILD_CAGRA_HNSWLIB OFF"
           "RAFT_COMPILE_LIBRARY OFF"
     )

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -551,7 +551,7 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - dsak-cudf-cu12==25.2.*,>=0.0.0a0
+              - dask-cudf-cu12==25.2.*,>=0.0.0a0
           - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,6 +13,7 @@ files:
       - depends_on_cupy
       - depends_on_cuvs
       - depends_on_dask_cudf
+      - depends_on_libcuvs
       - depends_on_librmm
       - depends_on_pylibraft
       - depends_on_raft_dask
@@ -32,6 +33,7 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_libcuvs
       - depends_on_librmm
   checks:
     output: none
@@ -48,6 +50,7 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_libcuvs
       - depends_on_librmm
   docs:
     output: none
@@ -59,20 +62,22 @@ files:
     output: none
     includes:
       - cuda_version
+      - depends_on_libcuml
       - test_libcuml
       - test_cpp
   test_python:
     output: none
     includes:
       - cuda_version
+      - depends_on_cuml
+      - depends_on_libcuml
       - py_version
-      - test_cuml
       - test_python
   test_notebooks:
     output: none
     includes:
       - cuda_version
-      - depends_on_cudf
+      - depends_on_cuml
       - depends_on_cupy
       - depends_on_cuvs
       - depends_on_dask_cudf
@@ -81,7 +86,6 @@ files:
       - depends_on_rmm
       - py_run
       - py_version
-      - test_cuml
       - test_notebooks
   py_build_cuml:
     output: pyproject
@@ -169,7 +173,6 @@ dependencies:
           - cxx-compiler
           - fmt>=11.0.2,<12
           - libcumlprims==25.2.*,>=0.0.0a0
-          - libcuvs==25.2.*,>=0.0.0a0
           - libraft-headers==25.2.*,>=0.0.0a0
           - spdlog>=1.14.1,<1.15
     specific:
@@ -420,14 +423,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &libcuml libcuml==25.2.*,>=0.0.0a0
           - libcuml-tests==25.2.*,>=0.0.0a0
-  test_cuml:
-    common:
-      - output_types: conda
-        packages:
-          - *libcuml
-          - cuml==25.2.*,>=0.0.0a0
   test_cpp:
     common:
       - output_types: conda
@@ -493,6 +489,11 @@ dependencies:
           - matrix:
             packages:
               - *cudf_unsuffixed
+  depends_on_cuml:
+    common:
+      - output_types: conda
+        packages:
+          - cuml==25.2.*,>=0.0.0a0
   depends_on_cupy:
     common:
       - output_types: conda
@@ -560,32 +561,21 @@ dependencies:
           - matrix:
             packages:
               - *dask_cudf_unsuffixed
+  depends_on_libcuml:
+    common:
+      - output_types: conda
+        packages:
+          - libcuml==25.2.*,>=0.0.0a0
+  depends_on_libcuvs:
+    common:
+      - output_types: conda
+        packages:
+          - libcuvs==25.2.*,>=0.0.0a0
   depends_on_librmm:
     common:
       - output_types: conda
         packages:
-          - &librmm_unsuffixed librmm==25.2.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - librmm-cu12==25.2.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "true"
-            packages:
-              - librmm-cu11==25.2.*,>=0.0.0a0
-          - matrix:
-            packages:
-              - *librmm_unsuffixed
+          - librmm==25.2.*,>=0.0.0a0
   depends_on_pylibraft:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -9,6 +9,14 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_cudf
+      - depends_on_cupy
+      - depends_on_cuvs
+      - depends_on_dask_cudf
+      - depends_on_librmm
+      - depends_on_pylibraft
+      - depends_on_raft_dask
+      - depends_on_rmm
       - docs
       - py_build
       - py_run
@@ -24,6 +32,7 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_librmm
   checks:
     output: none
     includes:
@@ -39,6 +48,7 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_librmm
   docs:
     output: none
     includes:
@@ -62,6 +72,13 @@ files:
     output: none
     includes:
       - cuda_version
+      - depends_on_cudf
+      - depends_on_cupy
+      - depends_on_cuvs
+      - depends_on_dask_cudf
+      - depends_on_pylibraft
+      - depends_on_raft_dask
+      - depends_on_rmm
       - py_run
       - py_version
       - test_cuml
@@ -81,16 +98,26 @@ files:
       key: requires
     includes:
       - common_build
+      - depends_on_cuvs
+      - depends_on_pylibraft
+      - depends_on_rmm
       - py_build
-  py_run:
+  py_run_cuml:
     output: pyproject
     pyproject_dir: python/cuml
     extras:
       table: project
     includes:
       - cuda_wheels
+      - depends_on_cudf
+      - depends_on_cupy
+      - depends_on_cuvs
+      - depends_on_dask_cudf
+      - depends_on_pylibraft
+      - depends_on_raft_dask
+      - depends_on_rmm
       - py_run
-  py_test:
+  py_test_cuml:
     output: pyproject
     pyproject_dir: python/cuml
     extras:
@@ -144,7 +171,6 @@ dependencies:
           - libcumlprims==25.2.*,>=0.0.0a0
           - libcuvs==25.2.*,>=0.0.0a0
           - libraft-headers==25.2.*,>=0.0.0a0
-          - librmm==25.2.*,>=0.0.0a0
           - spdlog>=1.14.1,<1.15
     specific:
       - output_types: conda
@@ -181,17 +207,6 @@ dependencies:
         packages:
           - &cython cython>=3.0.0
           - &treelite treelite==4.3.0
-      - output_types: conda
-        packages:
-          - &cuvs_unsuffixed cuvs==25.2.*,>=0.0.0a0
-          - &pylibraft_unsuffixed pylibraft==25.2.*,>=0.0.0a0
-          - &rmm_unsuffixed rmm==25.2.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          # This index is needed for cudf and rmm.
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [conda, requirements, pyproject]
         matrices:
@@ -206,27 +221,6 @@ dependencies:
           - matrix:
             packages:
               - cuda-python
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - cuvs-cu12==25.2.*,>=0.0.0a0
-              - pylibraft-cu12==25.2.*,>=0.0.0a0
-              - rmm-cu12==25.2.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "true"
-            packages:
-              - cuvs-cu11==25.2.*,>=0.0.0a0
-              - pylibraft-cu11==25.2.*,>=0.0.0a0
-              - rmm-cu11==25.2.*,>=0.0.0a0
-          - matrix:
-            packages:
-              - *cuvs_unsuffixed
-              - *pylibraft_unsuffixed
-              - *rmm_unsuffixed
 
   py_run:
     common:
@@ -243,78 +237,11 @@ dependencies:
           - packaging
           - rapids-dask-dependency==25.2.*,>=0.0.0a0
           - *treelite
-      - output_types: conda
-        packages:
-          - &cudf_unsuffixed cudf==25.2.*,>=0.0.0a0
-          - &cupy_unsuffixed cupy>=12.0.0
-          - &dask_cudf_unsuffixed dask-cudf==25.2.*,>=0.0.0a0
-          - &raft_dask_unsuffixed raft-dask==25.2.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          # This index is needed for cudf and rmm.
           - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - cudf-cu12==25.2.*,>=0.0.0a0
-              - &cupy_pyproject_cu12 cupy-cuda12x>=12.0.0
-              - cuvs-cu12==25.2.*,>=0.0.0a0
-              - dask-cudf-cu12==25.2.*,>=0.0.0a0
-              - pylibraft-cu12==25.2.*,>=0.0.0a0
-              - raft-dask-cu12==25.2.*,>=0.0.0a0
-              - rmm-cu12==25.2.*,>=0.0.0a0
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_unsuffixed
-              # NOTE: cupy still has a "-cuda12x" suffix here, because it's suffixed
-              #       in DLFW builds
-              - *cupy_pyproject_cu12
-              - *cuvs_unsuffixed
-              - *dask_cudf_unsuffixed
-              - *pylibraft_unsuffixed
-              - *raft_dask_unsuffixed
-              - *rmm_unsuffixed
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "true"
-            packages: &py_run_packages_cu11
-              - cudf-cu11==25.2.*,>=0.0.0a0
-              - &cupy_pyproject_cu11 cupy-cuda11x>=12.0.0
-              - cuvs-cu11==25.2.*,>=0.0.0a0
-              - dask-cudf-cu11==25.2.*,>=0.0.0a0
-              - pylibraft-cu11==25.2.*,>=0.0.0a0
-              - raft-dask-cu11==25.2.*,>=0.0.0a0
-              - rmm-cu11==25.2.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_unsuffixed
-              # NOTE: cupy still has a "-cuda11x" suffix here, because it's suffixed
-              #       in DLFW builds
-              - *cupy_pyproject_cu11
-              - *cuvs_unsuffixed
-              - *dask_cudf_unsuffixed
-              - *pylibraft_unsuffixed
-              - *raft_dask_unsuffixed
-              - *rmm_unsuffixed
-          - matrix:
-            packages:
-              - *cudf_unsuffixed
-              - *cupy_pyproject_cu11
-              - *cuvs_unsuffixed
-              - *dask_cudf_unsuffixed
-              - *pylibraft_unsuffixed
-              - *raft_dask_unsuffixed
-              - *rmm_unsuffixed
   cuda_version:
     specific:
       - output_types: conda
@@ -493,13 +420,13 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - libcuml==25.2.*,>=0.0.0a0
+          - &libcuml libcuml==25.2.*,>=0.0.0a0
           - libcuml-tests==25.2.*,>=0.0.0a0
   test_cuml:
     common:
       - output_types: conda
         packages:
-          - libcuml==25.2.*,>=0.0.0a0
+          - *libcuml
           - cuml==25.2.*,>=0.0.0a0
   test_cpp:
     common:
@@ -540,3 +467,200 @@ dependencies:
           - *scikit_learn
           - seaborn
           - *xgboost
+  depends_on_cudf:
+    common:
+      - output_types: conda
+        packages:
+          - &cudf_unsuffixed cudf==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - cudf-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - cudf-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *cudf_unsuffixed
+  depends_on_cupy:
+    common:
+      - output_types: conda
+        packages:
+          - cupy>=12.0.0
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages:
+              - cupy-cuda12x>=12.0.0
+          - matrix: {cuda: "11.*"}
+            packages: &cupy_packages_cu11
+              - cupy-cuda11x>=12.0.0
+          - {matrix: null, packages: *cupy_packages_cu11}
+  depends_on_cuvs:
+    common:
+      - output_types: conda
+        packages:
+          - &cuvs_unsuffixed cuvs==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - cuvs-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - cuvs-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *cuvs_unsuffixed
+  depends_on_dask_cudf:
+    common:
+      - output_types: conda
+        packages:
+          - &dask_cudf_unsuffixed dask-cudf==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - dsak-cudf-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - dask-cudf-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *dask_cudf_unsuffixed
+  depends_on_librmm:
+    common:
+      - output_types: conda
+        packages:
+          - &librmm_unsuffixed librmm==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - librmm-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - librmm-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *librmm_unsuffixed
+  depends_on_pylibraft:
+    common:
+      - output_types: conda
+        packages:
+          - &pylibraft_unsuffixed pylibraft==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - pylibraft-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - pylibraft-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *pylibraft_unsuffixed
+  depends_on_raft_dask:
+    common:
+      - output_types: conda
+        packages:
+          - &raft_dask_unsuffixed raft-dask==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - raft-dask-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - raft-dask-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *raft_dask_unsuffixed
+  depends_on_rmm:
+    common:
+      - output_types: conda
+        packages:
+          - &rmm_unsuffixed rmm==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - rmm-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - rmm-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *rmm_unsuffixed

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,7 +13,9 @@ files:
       - depends_on_cupy
       - depends_on_cuvs
       - depends_on_dask_cudf
+      - depends_on_libcumlprims
       - depends_on_libcuvs
+      - depends_on_libraft_headers
       - depends_on_librmm
       - depends_on_pylibraft
       - depends_on_raft_dask
@@ -33,7 +35,9 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_libcumlprims
       - depends_on_libcuvs
+      - depends_on_libraft_headers
       - depends_on_librmm
   checks:
     output: none
@@ -50,7 +54,9 @@ files:
       - common_build
       - cuda
       - cuda_version
+      - depends_on_libcumlprims
       - depends_on_libcuvs
+      - depends_on_libraft_headers
       - depends_on_librmm
   docs:
     output: none
@@ -103,6 +109,8 @@ files:
     includes:
       - common_build
       - depends_on_cuvs
+      - depends_on_libcumlprims
+      - depends_on_libraft_headers
       - depends_on_pylibraft
       - depends_on_rmm
       - py_build
@@ -172,8 +180,6 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - fmt>=11.0.2,<12
-          - libcumlprims==25.2.*,>=0.0.0a0
-          - libraft-headers==25.2.*,>=0.0.0a0
           - spdlog>=1.14.1,<1.15
     specific:
       - output_types: conda
@@ -566,11 +572,21 @@ dependencies:
       - output_types: conda
         packages:
           - libcuml==25.2.*,>=0.0.0a0
+  depends_on_libcumlprims:
+    common:
+      - output_types: conda
+        packages:
+          - libcumlprims==25.2.*,>=0.0.0a0
   depends_on_libcuvs:
     common:
       - output_types: conda
         packages:
           - libcuvs==25.2.*,>=0.0.0a0
+  depends_on_libraft_headers:
+    common:
+      - output_types: conda
+        packages:
+          - libraft-headers==25.2.*,>=0.0.0a0
   depends_on_librmm:
     common:
       - output_types: conda

--- a/python/cuml/CMakeLists.txt
+++ b/python/cuml/CMakeLists.txt
@@ -83,14 +83,12 @@ if(NOT CUML_CPU)
     set(BUILD_CUML_C_LIBRARY OFF)
     set(BUILD_CUML_EXAMPLES OFF)
     set(BUILD_CUML_BENCH OFF)
-    set(BUILD_CUML_PRIMS_BENCH OFF)
     set(CUML_EXPORT_TREELITE_LINKAGE ON)
     set(CUML_PYTHON_TREELITE_TARGET treelite::treelite_static)
 
     # Statically link dependencies if building wheels
     set(CUDA_STATIC_RUNTIME ON)
     set(CUML_USE_CUVS_STATIC ON)
-    set(CUML_USE_FAISS_STATIC ON)
     set(CUML_USE_TREELITE_STATIC ON)
     set(CUML_USE_CUMLPRIMS_MG_STATIC ON)
     # Link to the CUDA wheels with shared libraries for CUDA 12+


### PR DESCRIPTION
Fixes #6023

Proposes some miscellaneous packaging cleanup:

* updates `rapids-dependency-file-generator` to its latest version (1.17.0) in pre-commit config
* removes unused `PACKAGE_CUDA_SUFFIX` in `build_wheel.sh`
* removes unnecessary `pip install cmake` in `test_wheel.sh`
   - *there are aarch64 `treelite` wheels now: https://pypi.org/project/treelite/#files*
* CMake option cleanup:
   - adds `BUILD_PRIMS_BENCH OFF`, removes `BUILD_BENCH OFF` in `get_raft.cmake` (matching changes to RAFT from 23.04: https://github.com/rapidsai/raft/pull/1304)
  - removes unnecessary `BUILD_CUML_PRIMS_BENCH` ([nothing uses this](https://github.com/search?q=org%3Arapidsai+%22BUILD_CUML_PRIMS_BENCH%22+AND+NOT+is%3Aarchived&type=code))
  - removes unnecessary `CUML_USE_FAISS_STATIC` ([nothing uses this](https://github.com/search?q=org%3Arapidsai+%22CUML_USE_FAISS_STATIC%22+AND+NOT+is%3Aarchived&type=code))
* `dependencies.yaml` changes:
  - breaks some dependencies out into `depends_on_*` groups to reduce duplication, and for consistency with other RAPIDS projects ([docs explaining this](https://github.com/rapidsai/build-planning/blob/d9e3c606d95c835ee384ac6480a4af0ac6cb024a/docs/docs/packaging.md#L181))
  - alphabetizes dependency lists