### PR TITLE
Adjust test_kmeans to avoid false positive failures

### DIFF
--- a/python/cuml/cuml/tests/test_kmeans.py
+++ b/python/cuml/cuml/tests/test_kmeans.py
@@ -171,7 +171,7 @@ def test_weighted_kmeans(nrows, ncols, nclusters, max_weight, random_state):
     sk_kmeans.fit(cp.asnumpy(X), sample_weight=wt)
     sk_score = sk_kmeans.score(cp.asnumpy(X))
 
-    assert abs(cu_score - sk_score) <= cluster_std * 1.5
+    assert cu_score - sk_score <= cluster_std * 1.5
 
 
 @pytest.mark.parametrize("nrows", [1000, 10000])

--- a/python/cuml/cuml/tests/test_kmeans.py
+++ b/python/cuml/cuml/tests/test_kmeans.py
@@ -418,5 +418,6 @@ def test_fit_transform_weighted_kmeans(
     sk_transf = sk_kmeans.fit_transform(cp.asnumpy(X), sample_weight=wt)
     sk_score = sk_kmeans.score(cp.asnumpy(X))
 
-    assert abs(cu_score - sk_score) <= cluster_std * 1.5
+    # we fail if cuML's score is significantly worse than sklearn's
+    assert cu_score - sk_score <= cluster_std * 1.5
     assert sk_transf.shape == cuml_transf.shape


### PR DESCRIPTION
Before this, we would fail when cuML KMeans achieved a better score than scikit-learn by the margin. 