### PR TITLE
Ignore cudf's __dataframe__ deprecation.

### DIFF
--- a/python/cuml/cuml/tests/test_input_utils.py
+++ b/python/cuml/cuml/tests/test_input_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ cp = gpu_only_import("cupy")
 np = cpu_only_import("numpy")
 
 nbcuda = gpu_only_import_from("numba", "cuda")
+cudf_pandas_active = gpu_only_import_from("cudf.pandas", "LOADED")
 pdDF = cpu_only_import_from("pandas", "DataFrame")
 
 
@@ -446,11 +447,14 @@ def test_tocupy_missing_values_handling():
     assert str(array.dtype) == "float64"
     assert cp.isnan(array[1])
 
-    with pytest.raises(ValueError):
-        df = cudf.Series(data=[7, None, 3])
-        array, n_rows, n_cols, dtype = input_to_cupy_array(
-            df, fail_on_null=True
-        )
+    # cudf.pandas now mimics pandas better for handling None, so we don't
+    # need to fail and raise this error when cudf.pandas is active.
+    if not cudf_pandas_active:
+        with pytest.raises(ValueError):
+            df = cudf.Series(data=[7, None, 3])
+            array, n_rows, n_cols, dtype = input_to_cupy_array(
+                df, fail_on_null=True
+            )
 
 
 @pytest.mark.cudf_pandas

--- a/python/cuml/cuml/tests/test_kneighbors_classifier.py
+++ b/python/cuml/cuml/tests/test_kneighbors_classifier.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -218,6 +218,8 @@ def test_predict_large_n_classes(datatype):
     assert array_equal(y_hat.astype(np.int32), y_test.astype(np.int32))
 
 
+# Ignore FutureWarning: Using `__dataframe__` is deprecated
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("n_samples", [100])
 @pytest.mark.parametrize("n_features", [40])
 @pytest.mark.parametrize("n_neighbors", [4])

--- a/python/cuml/cuml/tests/test_metrics.py
+++ b/python/cuml/cuml/tests/test_metrics.py
@@ -163,6 +163,8 @@ def test_r2_score(datatype, use_handle):
     np.testing.assert_almost_equal(score, 0.98, decimal=7)
 
 
+# Ignore FutureWarning: Using `__dataframe__` is deprecated
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_sklearn_search():
     """Test ensures scoring function works with sklearn machinery"""
     import numpy as np


### PR DESCRIPTION
Currently CI is failing due to https://github.com/rapidsai/cudf/pull/17736.

The `__dataframe__` protocol appears to be used internally by scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/311bf6badd74bb69081eb90e2643f15706d3473c/sklearn/utils/validation.py#L389

Errors look like:
```
FAILED test_metrics.py::test_sklearn_search - FutureWarning: Using `__dataframe__` is deprecated
```

This PR ignores the `FutureWarning` to allow CI to pass.