### PR TITLE
Define block size for sm_120

### DIFF
--- a/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
@@ -104,7 +104,7 @@ auto constexpr static const WARP_SIZE             = index_type{32};
 auto constexpr static const MAX_THREADS_PER_BLOCK = index_type{256};
 #ifdef __CUDACC__
 #if __CUDA_ARCH__ == 720 || __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860 || \
-  __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 890
+  __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200
 auto constexpr static const MAX_THREADS_PER_SM = index_type{1024};
 #else
 auto constexpr static const MAX_THREADS_PER_SM = index_type{2048};


### PR DESCRIPTION
CUDA 12.8 introduces sm_120 that requires a reduced number of threads per sm