### PR TITLE
Log UMAP arrays at trace verbosity level.

### DIFF
--- a/cpp/src/umap/fuzzy_simpl_set/naive.cuh
+++ b/cpp/src/umap/fuzzy_simpl_set/naive.cuh
@@ -314,12 +314,12 @@ void launcher(int n,
   raft::sparse::COO<value_t> in(stream, n * n_neighbors, n, n);
 
   // check for logging in order to avoid the potentially costly `arr2Str` call!
-  if (ML::default_logger().should_log(ML::level_enum::debug)) {
-    CUML_LOG_DEBUG("Smooth kNN Distances");
+  if (ML::default_logger().should_log(ML::level_enum::trace)) {
+    CUML_LOG_TRACE("Smooth kNN Distances");
     auto str = raft::arr2Str(sigmas.data(), 25, "sigmas", stream);
-    CUML_LOG_DEBUG("%s", str.c_str());
+    CUML_LOG_TRACE("%s", str.c_str());
     str = raft::arr2Str(rhos.data(), 25, "rhos", stream);
-    CUML_LOG_DEBUG("%s", str.c_str());
+    CUML_LOG_TRACE("%s", str.c_str());
   }
 
   RAFT_CUDA_TRY(cudaPeekAtLastError());
@@ -342,11 +342,11 @@ void launcher(int n,
                                                                               n_neighbors);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
-  if (ML::default_logger().should_log(ML::level_enum::debug)) {
-    CUML_LOG_DEBUG("Compute Membership Strength");
+  if (ML::default_logger().should_log(ML::level_enum::trace)) {
+    CUML_LOG_TRACE("Compute Membership Strength");
     std::stringstream ss;
     ss << in;
-    CUML_LOG_DEBUG(ss.str().c_str());
+    CUML_LOG_TRACE(ss.str().c_str());
   }
 
   /**

--- a/cpp/src/umap/fuzzy_simpl_set/naive.cuh
+++ b/cpp/src/umap/fuzzy_simpl_set/naive.cuh
@@ -313,9 +313,9 @@ void launcher(int n,
 
   raft::sparse::COO<value_t> in(stream, n * n_neighbors, n, n);
 
+  CUML_LOG_DEBUG("Smooth kNN Distances");
   // check for logging in order to avoid the potentially costly `arr2Str` call!
   if (ML::default_logger().should_log(ML::level_enum::trace)) {
-    CUML_LOG_TRACE("Smooth kNN Distances");
     auto str = raft::arr2Str(sigmas.data(), 25, "sigmas", stream);
     CUML_LOG_TRACE("%s", str.c_str());
     str = raft::arr2Str(rhos.data(), 25, "rhos", stream);
@@ -342,8 +342,8 @@ void launcher(int n,
                                                                               n_neighbors);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
+  CUML_LOG_DEBUG("Compute Membership Strength");
   if (ML::default_logger().should_log(ML::level_enum::trace)) {
-    CUML_LOG_TRACE("Compute Membership Strength");
     std::stringstream ss;
     ss << in;
     CUML_LOG_TRACE(ss.str().c_str());

--- a/cpp/src/umap/simpl_set_embed/algo.cuh
+++ b/cpp/src/umap/simpl_set_embed/algo.cuh
@@ -341,10 +341,10 @@ void launcher(
 
   make_epochs_per_sample(out.vals(), out.nnz, n_epochs, epochs_per_sample.data(), stream);
 
-  if (ML::default_logger().should_log(ML::level_enum::debug)) {
+  if (ML::default_logger().should_log(ML::level_enum::trace)) {
     std::stringstream ss;
     ss << raft::arr2Str(epochs_per_sample.data(), out.nnz, "epochs_per_sample", stream);
-    CUML_LOG_DEBUG(ss.str().c_str());
+    CUML_LOG_TRACE(ss.str().c_str());
   }
 
   optimize_layout<TPB_X, T>(embedding,

--- a/cpp/src/umap/supervised.cuh
+++ b/cpp/src/umap/supervised.cuh
@@ -301,15 +301,15 @@ void perform_general_intersection(const raft::handle_t& handle,
     handle, y_inputs, y_inputs, knn_graph, params->target_n_neighbors, params, stream);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
-  if (ML::default_logger().should_log(ML::level_enum::debug)) {
-    CUML_LOG_DEBUG("Target kNN Graph");
+  if (ML::default_logger().should_log(ML::level_enum::trace)) {
+    CUML_LOG_TRACE("Target kNN Graph");
     std::stringstream ss1, ss2;
     ss1 << raft::arr2Str(
       y_knn_indices.data(), rgraph_coo->n_rows * params->target_n_neighbors, "knn_indices", stream);
-    CUML_LOG_DEBUG("%s", ss1.str().c_str());
+    CUML_LOG_TRACE("%s", ss1.str().c_str());
     ss2 << raft::arr2Str(
       y_knn_dists.data(), rgraph_coo->n_rows * params->target_n_neighbors, "knn_dists", stream);
-    CUML_LOG_DEBUG("%s", ss2.str().c_str());
+    CUML_LOG_TRACE("%s", ss2.str().c_str());
   }
 
   /**

--- a/cpp/src/umap/supervised.cuh
+++ b/cpp/src/umap/supervised.cuh
@@ -301,8 +301,8 @@ void perform_general_intersection(const raft::handle_t& handle,
     handle, y_inputs, y_inputs, knn_graph, params->target_n_neighbors, params, stream);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
+  CUML_LOG_DEBUG("Target kNN Graph");
   if (ML::default_logger().should_log(ML::level_enum::trace)) {
-    CUML_LOG_TRACE("Target kNN Graph");
     std::stringstream ss1, ss2;
     ss1 << raft::arr2Str(
       y_knn_indices.data(), rgraph_coo->n_rows * params->target_n_neighbors, "knn_indices", stream);


### PR DESCRIPTION
Reduce the UMAP logging verbosity. Avoids printing potentially large arrays.