### PR TITLE
Fix dask logistic regression segfault/hang due to wrongly typed variable

### DIFF
--- a/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -387,7 +387,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
                         qnpams,
                         <bool> self.standardization,
                         <int> self._num_classes,
-                        <double*> &objective32,
+                        <double*> &objective64,
                         <int*> &num_iters)
                 else:
                     assert self.index_dtype == np.int64, f"unsupported index dtype: {self.index_dtype}"
@@ -403,7 +403,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
                         qnpams,
                         <bool> self.standardization,
                         <int> self._num_classes,
-                        <double*> &objective32,
+                        <double*> &objective64,
                         <int*> &num_iters)
 
             self.solver_model.objective = objective64

--- a/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
@@ -263,7 +263,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
         cdef float objective32
-        cdef float objective64
+        cdef double objective64
         cdef int num_iters
 
         cdef vector[float] c_classes_

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -34,13 +34,6 @@ cp = gpu_only_import("cupy")
 dask_cudf = gpu_only_import("dask_cudf")
 cudf = gpu_only_import("cudf")
 
-pytestmark = [
-    pytest.mark.mg,
-    pytest.mark.skip(
-        reason="pytest hang https://github.com/rapidsai/cuml/issues/6247"
-    ),
-]
-
 
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     workers = c.has_what().keys()


### PR DESCRIPTION
Closes #6247 

A wrongly typed variable was causing dask workers to crash due to a segfault, this PR fixes it. 