### PR TITLE
Plumb `metric` and `metric_kwds` through to UMAP with `nn_descent`

### DIFF
--- a/python/cuml/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/cuml/manifold/simpl_set.pyx
@@ -25,7 +25,7 @@ cupyx = gpu_only_import('cupyx')
 
 from cuml.manifold.umap_utils cimport *
 from cuml.manifold.umap_utils import GraphHolder, find_ab_params, \
-    metric_parsing
+    coerce_metric
 
 from cuml.internals.input_utils import input_to_cuml_array, is_array_like
 from cuml.internals.array import CumlArray
@@ -158,10 +158,7 @@ def fuzzy_simplicial_set(X,
     umap_params.deterministic = <bool> deterministic
     umap_params.set_op_mix_ratio = <float> set_op_mix_ratio
     umap_params.local_connectivity = <float> local_connectivity
-    try:
-        umap_params.metric = metric_parsing[metric.lower()]
-    except KeyError:
-        raise ValueError(f"Invalid value for metric: {metric}")
+    umap_params.metric = coerce_metric(metric)
     if metric_kwds is None:
         umap_params.p = <float> 2.0
     else:
@@ -353,10 +350,8 @@ def simplicial_set_embedding(
             umap_params.init = <int> 1
         else:
             raise ValueError("Invalid initialization strategy")
-    try:
-        umap_params.metric = metric_parsing[metric.lower()]
-    except KeyError:
-        raise ValueError(f"Invalid value for metric: {metric}")
+
+    umap_params.metric = coerce_metric(metric)
     if metric_kwds is None:
         umap_params.p = <float> 2.0
     else:

--- a/python/cuml/cuml/manifold/umap_utils.pxd
+++ b/python/cuml/cuml/manifold/umap_utils.pxd
@@ -24,6 +24,7 @@ from libc.stdint cimport uint64_t, uintptr_t, int64_t
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
 from cuml.metrics.distance_type cimport DistanceType
+from cuml.metrics.raft_distance_type cimport DistanceType as RaftDistanceType
 from cuml.internals.logger cimport level_enum
 
 cdef extern from "cuml/manifold/umapparams.h" namespace "ML::UMAPParams":
@@ -39,6 +40,7 @@ cdef extern from "cuml/common/callback.hpp" namespace "ML::Internals":
 
     cdef cppclass GraphBasedDimRedCallback
 
+
 cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbors::experimental::nn_descent":
     cdef struct index_params:
         uint64_t graph_degree,
@@ -47,6 +49,8 @@ cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbor
         float termination_threshold,
         bool return_distances,
         uint64_t n_clusters,
+        RaftDistanceType metric,
+        float metric_arg
 
 cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
 

--- a/python/cuml/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/cuml/manifold/umap_utils.pyx
@@ -16,6 +16,8 @@
 
 # distutils: language = c++
 
+from typing import Literal
+
 from rmm.pylibrmm.memory_resource cimport get_current_device_resource
 from pylibraft.common.handle cimport handle_t
 from cuml.manifold.umap_utils cimport *
@@ -134,7 +136,7 @@ def find_ab_params(spread, min_dist):
     return params[0], params[1]
 
 
-metric_parsing = {
+_METRICS = {
     "l2": DistanceType.L2SqrtExpanded,
     "euclidean": DistanceType.L2SqrtExpanded,
     "sqeuclidean": DistanceType.L2Expanded,
@@ -153,32 +155,59 @@ metric_parsing = {
     "canberra": DistanceType.Canberra
 }
 
+_SUPPORTED_METRICS = {
+    "nn_descent": {
+        "sparse": frozenset(),
+        "dense": frozenset((DistanceType.L2SqrtExpanded,))
+    },
+    "brute_force_knn": {
+        "sparse": frozenset((
+            DistanceType.Canberra,
+            DistanceType.CorrelationExpanded,
+            DistanceType.CosineExpanded,
+            DistanceType.HammingUnexpanded,
+            DistanceType.HellingerExpanded,
+            DistanceType.JaccardExpanded,
+            DistanceType.L1,
+            DistanceType.L2SqrtExpanded,
+            DistanceType.L2Expanded,
+            DistanceType.Linf,
+            DistanceType.LpUnexpanded,
+        )),
+        "dense": frozenset((
+            DistanceType.Canberra,
+            DistanceType.CorrelationExpanded,
+            DistanceType.CosineExpanded,
+            DistanceType.HammingUnexpanded,
+            DistanceType.HellingerExpanded,
+            # DistanceType.JaccardExpanded,  # not supported
+            DistanceType.L1,
+            DistanceType.L2SqrtExpanded,
+            DistanceType.L2Expanded,
+            DistanceType.Linf,
+            DistanceType.LpUnexpanded,
+        ))
+    }
+}
 
-DENSE_SUPPORTED_METRICS = [
-    DistanceType.Canberra,
-    DistanceType.CorrelationExpanded,
-    DistanceType.CosineExpanded,
-    DistanceType.HammingUnexpanded,
-    DistanceType.HellingerExpanded,
-    # DistanceType.JaccardExpanded,  # not supported
-    DistanceType.L1,
-    DistanceType.L2SqrtExpanded,
-    DistanceType.L2Expanded,
-    DistanceType.Linf,
-    DistanceType.LpUnexpanded,
-]
 
+def coerce_metric(
+    metric: str,
+    sparse: bool = False,
+    build_algo: Literal["brute_force_knn", "nn_descent"] = "brute_force_knn",
+) -> DistanceType:
+    """Coerce a metric string to a `DistanceType`.
 
-SPARSE_SUPPORTED_METRICS = [
-    DistanceType.Canberra,
-    DistanceType.CorrelationExpanded,
-    DistanceType.CosineExpanded,
-    DistanceType.HammingUnexpanded,
-    DistanceType.HellingerExpanded,
-    DistanceType.JaccardExpanded,
-    DistanceType.L1,
-    DistanceType.L2SqrtExpanded,
-    DistanceType.L2Expanded,
-    DistanceType.Linf,
-    DistanceType.LpUnexpanded,
-]
+    Also checks that the metric is valid and supported.
+    """
+    try:
+        out = _METRICS[metric.lower()]
+    except KeyError:
+        raise ValueError(f"Invalid value for metric: {metric!r}")
+
+    kind = "sparse" if sparse else "dense"
+    supported = _SUPPORTED_METRICS[build_algo][kind]
+    if out not in supported:
+        raise NotImplementedError(f"Metric {metric!r} not supported for {kind} inputs.")
+
+    return out

--- a/python/cuml/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/cuml/manifold/umap_utils.pyx
@@ -208,6 +208,8 @@ def coerce_metric(
     kind = "sparse" if sparse else "dense"
     supported = _SUPPORTED_METRICS[build_algo][kind]
     if out not in supported:
-        raise NotImplementedError(f"Metric {metric!r} not supported for {kind} inputs.")
+        raise NotImplementedError(
+            f"Metric {metric!r} not supported for {kind} inputs with {build_algo=}"
+        )
 
     return out

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -715,9 +715,12 @@ def test_fuzzy_simplicial_set(n_rows, n_features, n_neighbors):
         ("canberra", True),
     ],
 )
-def test_umap_distance_metrics_fit_transform_trust(metric, supported):
+@pytest.mark.parametrize("build_algo", ["brute_force_knn", "nn_descent"])
+def test_umap_distance_metrics_fit_transform_trust(
+    metric, supported, build_algo
+):
     data, labels = make_blobs(
-        n_samples=1000, n_features=64, centers=5, random_state=42
+        n_samples=500, n_features=64, centers=5, random_state=42
     )
 
     if metric == "jaccard":
@@ -727,7 +730,11 @@ def test_umap_distance_metrics_fit_transform_trust(metric, supported):
         n_neighbors=10, min_dist=0.01, metric=metric, init="random"
     )
     cuml_model = cuUMAP(
-        n_neighbors=10, min_dist=0.01, metric=metric, init="random"
+        n_neighbors=10,
+        min_dist=0.01,
+        metric=metric,
+        init="random",
+        build_algo=build_algo,
     )
     if not supported:
         with pytest.raises(NotImplementedError):

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -17,10 +17,10 @@
 # Please install UMAP before running the code
 # use 'conda install -c conda-forge umap-learn' command to install it
 
-import platform
 import pytest
 import copy
 import joblib
+import umap
 from sklearn.metrics import adjusted_rand_score
 from sklearn.manifold import trustworthiness
 from sklearn.datasets import make_blobs
@@ -44,12 +44,6 @@ np = cpu_only_import("numpy")
 cp = gpu_only_import("cupy")
 cupyx = gpu_only_import("cupyx")
 scipy_sparse = cpu_only_import("scipy.sparse")
-
-
-IS_ARM = platform.processor() == "aarch64"
-
-if not IS_ARM:
-    import umap
 
 
 dataset_names = ["iris", "digits", "wine", "blobs"]
@@ -81,9 +75,6 @@ def test_blobs_cluster(nrows, n_feats, build_algo):
 )
 @pytest.mark.parametrize(
     "n_feats", [unit_param(10), quality_param(100), stress_param(1000)]
-)
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
 )
 @pytest.mark.parametrize("build_algo", ["brute_force_knn", "nn_descent"])
 def test_umap_fit_transform_score(nrows, n_feats, build_algo):
@@ -257,9 +248,6 @@ def test_umap_transform_on_digits(target_metric):
 
 @pytest.mark.parametrize("target_metric", ["categorical", "euclidean"])
 @pytest.mark.parametrize("name", dataset_names)
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
-)
 def test_umap_fit_transform_trust(name, target_metric):
 
     if name == "iris":
@@ -303,9 +291,6 @@ def test_umap_fit_transform_trust(name, target_metric):
 @pytest.mark.parametrize("should_downcast", [True])
 @pytest.mark.parametrize("input_type", ["dataframe", "ndarray"])
 @pytest.mark.parametrize("build_algo", ["brute_force_knn", "nn_descent"])
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
-)
 def test_umap_data_formats(
     input_type,
     should_downcast,
@@ -344,9 +329,6 @@ def test_umap_data_formats(
 @pytest.mark.parametrize("target_metric", ["categorical", "euclidean"])
 @pytest.mark.filterwarnings("ignore:(.*)connected(.*):UserWarning:sklearn[.*]")
 @pytest.mark.parametrize("build_algo", ["brute_force_knn", "nn_descent"])
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
-)
 def test_umap_fit_transform_score_default(target_metric, build_algo):
 
     n_samples = 500
@@ -546,9 +528,6 @@ def test_umap_transform_trustworthiness_with_consistency_enabled():
 
 
 @pytest.mark.filterwarnings("ignore:(.*)zero(.*)::scipy[.*]|umap[.*]")
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
-)
 @pytest.mark.parametrize("build_algo", ["brute_force_knn", "nn_descent"])
 def test_exp_decay_params(build_algo):
     def compare_exp_decay_params(a=None, b=None, min_dist=0.1, spread=1.0):
@@ -693,9 +672,6 @@ def correctness_sparse(a, b, atol=0.1, rtol=0.2, threshold=0.95):
 @pytest.mark.parametrize("n_rows", [200, 800])
 @pytest.mark.parametrize("n_features", [8, 32])
 @pytest.mark.parametrize("n_neighbors", [8, 16])
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
-)
 def test_fuzzy_simplicial_set(n_rows, n_features, n_neighbors):
     n_clusters = 30
     random_state = 42
@@ -738,9 +714,6 @@ def test_fuzzy_simplicial_set(n_rows, n_features, n_neighbors):
         ("hamming", True),
         ("canberra", True),
     ],
-)
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
 )
 def test_umap_distance_metrics_fit_transform_trust(metric, supported):
     data, labels = make_blobs(
@@ -791,9 +764,6 @@ def test_umap_distance_metrics_fit_transform_trust(metric, supported):
         ("hamming", True, True),
         ("canberra", True, True),
     ],
-)
-@pytest.mark.skipif(
-    IS_ARM, reason="https://github.com/rapidsai/cuml/issues/5441"
 )
 def test_umap_distance_metrics_fit_transform_trust_on_sparse_input(
     metric, supported, umap_learn_supported

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -699,25 +699,36 @@ def test_fuzzy_simplicial_set(n_rows, n_features, n_neighbors):
 
 
 @pytest.mark.parametrize(
-    "metric,supported",
+    "metric,build_algo,supported",
     [
-        ("l2", True),
-        ("euclidean", True),
-        ("sqeuclidean", True),
-        ("l1", True),
-        ("manhattan", True),
-        ("minkowski", True),
-        ("chebyshev", True),
-        ("cosine", True),
-        ("correlation", True),
-        ("jaccard", False),
-        ("hamming", True),
-        ("canberra", True),
+        ("l2", "brute_force_knn", True),
+        ("euclidean", "brute_force_knn", True),
+        ("sqeuclidean", "brute_force_knn", True),
+        ("l1", "brute_force_knn", True),
+        ("manhattan", "brute_force_knn", True),
+        ("minkowski", "brute_force_knn", True),
+        ("chebyshev", "brute_force_knn", True),
+        ("cosine", "brute_force_knn", True),
+        ("correlation", "brute_force_knn", True),
+        ("jaccard", "brute_force_knn", False),
+        ("hamming", "brute_force_knn", True),
+        ("canberra", "brute_force_knn", True),
+        ("l2", "nn_descent", True),
+        ("euclidean", "nn_descent", True),
+        ("sqeuclidean", "nn_descent", False),
+        ("l1", "nn_descent", False),
+        ("manhattan", "nn_descent", False),
+        ("minkowski", "nn_descent", False),
+        ("chebyshev", "nn_descent", False),
+        ("cosine", "nn_descent", False),
+        ("correlation", "nn_descent", False),
+        ("jaccard", "nn_descent", False),
+        ("hamming", "nn_descent", False),
+        ("canberra", "nn_descent", False),
     ],
 )
-@pytest.mark.parametrize("build_algo", ["brute_force_knn", "nn_descent"])
 def test_umap_distance_metrics_fit_transform_trust(
-    metric, supported, build_algo
+    metric, build_algo, supported
 ):
     data, labels = make_blobs(
         n_samples=500, n_features=64, centers=5, random_state=42


### PR DESCRIPTION
Previously we were erroneously missing this plumbing, leaving the `metric` and `metric_arg` as the defaults when `nn_descent` is used. In the long run we should redo how the parameters are passed when `nn_descent` is enabled to avoid this duplication (there's a few other uselessly exposed params like `return_distances`), but for now fixing the plumbing to be more correct seems fine.

On top of #6303, leaving as draft for now until that's merged.

Also re-enables tests on ARM, fixes #5441.