### PR TITLE
Make sure the proxied classes use the same `__name__`

### DIFF
--- a/python/cuml/cuml/experimental/accel/estimator_proxy.py
+++ b/python/cuml/cuml/experimental/accel/estimator_proxy.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -277,6 +277,7 @@ def intercept(
                 ),
             )
 
+    ProxyEstimator.__name__ = original_class_a.__name__
     logger.debug(
         f"Created proxy estimator: ({module_b}, {original_class_name}, {ProxyEstimator})"
     )

--- a/python/cuml/cuml/tests/experimental/accel/test_pipeline.py
+++ b/python/cuml/cuml/tests/experimental/accel/test_pipeline.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ from sklearn.neighbors import (
     KNeighborsClassifier,
     KNeighborsRegressor,
 )
-from sklearn.pipeline import Pipeline
+from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.datasets import make_classification, make_regression
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, mean_squared_error
@@ -145,3 +145,12 @@ def test_umap_with_logistic_regression(classification_data):
     # Fit and predict
     pipeline.fit(X_train, y_train)
     pipeline.predict(X_test)
+
+
+def test_automatic_step_naming():
+    # The automatically generated names of estimators should be the
+    # same with and without accelerator.
+    pipeline = make_pipeline(PCA(), LogisticRegression())
+
+    assert "pca" in pipeline.named_steps
+    assert "logisticregression" in pipeline.named_steps


### PR DESCRIPTION
The __name__ of a class is used to automatically derive names that need to match between accelerator and not accelerator. For example in a `Pipeline`:

```python
pipeline = make_pipeline(PCA(), LogisticRegression())

# Get the PCA instance
pipeline.named_steps["pca"]
```