### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -89,7 +89,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cuda-python",

--- a/python/libcuml/pyproject.toml
+++ b/python/libcuml/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
