### PR TITLE
Handle "all default args" case in decorator

### DIFF
--- a/python/cuml/cuml/internals/api_decorators.py
+++ b/python/cuml/cuml/internals/api_decorators.py
@@ -55,16 +55,17 @@ def _find_arg(sig, arg_name, default_position):
 
     # Check for default name in input args
     if arg_name in sig.parameters:
-        return arg_name, params.index(arg_name)
+        param = sig.parameters[arg_name]
+        return arg_name, params.index(arg_name), param.default
     # Otherwise use argument in list by position
     elif arg_name is ...:
         index = int(_has_self(sig)) + default_position
-        return params[index], index
+        return params[index], index, None
     else:
         raise ValueError(f"Unable to find parameter '{arg_name}'.")
 
 
-def _get_value(args, kwargs, name, index):
+def _get_value(args, kwargs, name, index, default_value):
     """Determine value for a given set of args, kwargs, name and index."""
     try:
         return kwargs[name]
@@ -72,10 +73,13 @@ def _get_value(args, kwargs, name, index):
         try:
             return args[index]
         except IndexError:
-            raise IndexError(
-                f"Specified arg idx: {index}, and argument name: {name}, "
-                "were not found in args or kwargs."
-            )
+            if default_value is not inspect._empty:
+                return default_value
+            else:
+                raise IndexError(
+                    f"Specified arg idx: {index}, and argument name: {name}, "
+                    "were not found in args or kwargs."
+                )
 
 
 def _make_decorator_function(

--- a/python/cuml/cuml/internals/api_decorators.py
+++ b/python/cuml/cuml/internals/api_decorators.py
@@ -60,7 +60,7 @@ def _find_arg(sig, arg_name, default_position):
     # Otherwise use argument in list by position
     elif arg_name is ...:
         index = int(_has_self(sig)) + default_position
-        return params[index], index, None
+        return params[index], index, inspect._empty
     else:
         raise ValueError(f"Unable to find parameter '{arg_name}'.")
 

--- a/python/cuml/cuml/tests/experimental/accel/test_basic_estimators.py
+++ b/python/cuml/cuml/tests/experimental/accel/test_basic_estimators.py
@@ -169,3 +169,15 @@ def test_proxy_facade():
             proxy_value = getattr(PCA, attr)
 
             assert original_value == proxy_value
+
+
+def test_defaults_args_only_methods():
+    # Check that estimator methods that take no arguments work
+    # These are slightly weird because basically everything else takes
+    # a X as input.
+    X = np.random.rand(1000, 3)
+    y = X[:, 0] + np.sin(6 * np.pi * X[:, 1]) + 0.1 * np.random.randn(1000)
+
+    nn = NearestNeighbors(metric="chebyshev", n_neighbors=3)
+    nn.fit(X[:, 0].reshape((-1, 1)), y)
+    nn.kneighbors()


### PR DESCRIPTION
Fixes a problem when calling:
```python
import numpy as np
from cuml.neighbors import NearestNeighbors

X = np.random.rand(1000, 3)
y = X[:, 0] + np.sin(6 * np.pi * X[:, 1]) + 0.1 * np.random.randn(1000)

nn = NearestNeighbors(metric="chebyshev", n_neighbors=3)
nn.fit(X[:, 0].reshape((-1, 1)), y)
nn.kneighbors()
# fails with
# IndexError: Specified arg idx: 1, and argument name: X, were not found in args or kwargs.
```
That is, calling a method with no arguments and relying on the default values.

However, this is only part of the problem. Once we fix this, the next problem is that we can't determine the type that we want the output to have from the input (because it is `None`). We can also not look at the type of `X` used during fitting, or we'd have to specially record it.

For the 0cc accelerator we can probably just hardwire things to use Numpy as the output type. For the more general case, it is trickier

The PR title is a bit terrible, but I couldn't come up with a more useful one :-/

cc @dantegd 