### PR TITLE
Make sure specifying default value or nothing behaves the same in `KMeans

### DIFF
--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -196,6 +196,18 @@ class KMeans(UniversalBase,
     <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html>`_.
     """
 
+    _hyperparam_interop_translator = {
+        "init": {
+            # k-means++ would work, but setting it explicitly changes the configuration
+            # of the estimator compared to not specifying it. So we explicitly translate
+            # it to the default value.
+            "k-means++": "scalable-k-means++",
+        },
+        "algorithm": {
+            "elkan": "NotImplemented",
+        },
+    }
+
     _cpu_estimator_import_path = 'sklearn.cluster.KMeans'
     labels_ = CumlArrayDescriptor(order='C')
     cluster_centers_ = CumlArrayDescriptor(order='C')

--- a/python/cuml/cuml/tests/experimental/accel/estimators_hyperparams/test_accel_kmeans.py
+++ b/python/cuml/cuml/tests/experimental/accel/estimators_hyperparams/test_accel_kmeans.py
@@ -100,3 +100,20 @@ def test_kmeans_random_state(clustering_data):
     kmeans2 = KMeans(n_clusters=3, random_state=42).fit(X)
     # With the same random_state, results should be the same
     assert np.allclose(kmeans1.cluster_centers_, kmeans2.cluster_centers_)
+
+
+def test_kmeans_init_parameter():
+    # Check that not passing a value for a constructor argument and passing the
+    # scikit-learn default value leads to the same behavior.
+    X, y = make_blobs(
+        n_samples=300, centers=3, cluster_std=1.0, random_state=42
+    )
+    km1 = KMeans(init="k-means++")
+    km1.fit(X, y)
+    # Check that the translation of "k-means++" worked.
+    assert km1.init == "scalable-k-means++"
+
+    km2 = KMeans()
+    km2.fit(X, y)
+    # No init parameter should lead to the cuml default being used.
+    assert km2.init == "scalable-k-means++"


### PR DESCRIPTION
Specifying the default value of a constructor argument or not specifying it at all should behave the same when the accelerator is turned on.

This only fixes up `KMeans(init=...)`, there might be more cases where this is needed.

Also adds a "not implemented" for the elkan algorithm.