### PR TITLE
Require sphinx<8.2.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -72,7 +72,7 @@ dependencies:
 - seaborn
 - sphinx-copybutton
 - sphinx-markdown-tables
-- sphinx==8.1.*
+- sphinx<8.2.0
 - statsmodels
 - sysroot_linux-64==2.28
 - treelite==4.4.1

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -70,9 +70,9 @@ dependencies:
 - scikit-learn==1.5.*
 - scipy>=1.8.0
 - seaborn
-- sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables
+- sphinx==8.1.*
 - statsmodels
 - sysroot_linux-64==2.28
 - treelite==4.4.1

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -66,9 +66,9 @@ dependencies:
 - scikit-learn==1.5.*
 - scipy>=1.8.0
 - seaborn
-- sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables
+- sphinx==8.1.*
 - statsmodels
 - sysroot_linux-64==2.28
 - treelite==4.4.1

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -68,7 +68,7 @@ dependencies:
 - seaborn
 - sphinx-copybutton
 - sphinx-markdown-tables
-- sphinx==8.1.*
+- sphinx<8.2.0
 - statsmodels
 - sysroot_linux-64==2.28
 - treelite==4.4.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -439,7 +439,7 @@ dependencies:
           - pydata-sphinx-theme!=0.14.2
           - recommonmark
           - &scikit_learn scikit-learn==1.5.*
-          - sphinx
+          - sphinx==8.1.*
           - sphinx-copybutton
           - sphinx-markdown-tables
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -439,7 +439,7 @@ dependencies:
           - pydata-sphinx-theme!=0.14.2
           - recommonmark
           - &scikit_learn scikit-learn==1.5.*
-          - sphinx==8.1.*
+          - sphinx<8.2.0
           - sphinx-copybutton
           - sphinx-markdown-tables
       - output_types: conda


### PR DESCRIPTION
The most recent release of sphinx version 8.2.0 is breaking nbsphinx, see: https://github.com/spatialaudio/nbsphinx/issues/825

This PR pins sphinx to version 8.1.*.