### PR TITLE
Improve model round-tripping

### DIFF
--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -705,6 +705,11 @@ class UniversalBase(Base):
             ]
         ):
             for attr in self.get_attr_names():
+                cuml_param_names = self._get_param_names()
+                for param, value in self._cpu_model.get_params().items():
+                    if param in cuml_param_names:
+                        self.set_params(**{param: value})
+
                 # check presence of attribute
                 if hasattr(self._cpu_model, attr) or \
                     isinstance(getattr(type(self._cpu_model),

--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -72,6 +72,7 @@ def assert_estimator_roundtrip(
     else:
         cuml_model.fit(X)
 
+    original_params = cuml_model.get_params()
     # Convert to sklearn model
     sklearn_model = cuml_model.as_sklearn()
     check_is_fitted(sklearn_model)
@@ -80,6 +81,8 @@ def assert_estimator_roundtrip(
 
     # Convert back
     roundtrip_model = type(cuml_model).from_sklearn(sklearn_model)
+
+    assert original_params == roundtrip_model.get_params()
 
     # Ensure roundtrip model is fitted
     check_is_fitted(roundtrip_model)
@@ -115,7 +118,7 @@ def test_kmeans(random_state):
     X, _ = make_blobs(
         n_samples=50, n_features=2, centers=3, random_state=random_state
     )
-    original = KMeans(n_clusters=3, random_state=random_state)
+    original = KMeans(n_clusters=13, random_state=random_state)
     assert_estimator_roundtrip(original, SkKMeans, X)
 
 


### PR DESCRIPTION
This PR is the result of investigating #6142 

A short version of the story is that this roundtrip doesn't work:
```python
import cuml
from sklearn import cluster

km = cluster.KMeans(n_clusters=13)
ckm = cuml.KMeans.from_sklearn(km)

print(ckm.n_clusters)  # -> 8, should be 13
```

This PR kinda fixes things, but really we need the hyper-parameter translator from the 0cc accelerator.

cc @dantegd 