### PR TITLE
Support non-trivial `classes_` in `LogisticRegression`

### DIFF
--- a/python/cuml/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression.pyx
@@ -24,13 +24,14 @@ import pprint
 
 import cuml.internals
 from cuml.solvers import QN
+from cuml.preprocessing import LabelEncoder
 from cuml.internals.base import UniversalBase
 from cuml.internals.mixins import ClassifierMixin, FMajorInputTagMixin, SparseInputTagMixin
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.array import CumlArray
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals import logger
-from cuml.common import input_to_cuml_array
+from cuml.internals.input_utils import input_to_cuml_array
 from cuml.common import using_output_type
 from cuml.internals.api_decorators import device_interop_preparation
 from cuml.internals.api_decorators import enable_device_interop
@@ -186,7 +187,6 @@ class LogisticRegression(UniversalBase,
     """
 
     _cpu_estimator_import_path = 'sklearn.linear_model.LogisticRegression'
-    classes_ = CumlArrayDescriptor(order='F')
     class_weight = CumlArrayDescriptor(order='F')
     expl_spec_weights_ = CumlArrayDescriptor(order='F')
 
@@ -286,7 +286,7 @@ class LogisticRegression(UniversalBase,
             self.verb_prefix = ""
 
     @generate_docstring(X='dense_sparse')
-    @cuml.internals.api_base_return_any(set_output_dtype=True)
+    @cuml.internals.api_base_return_any()
     @enable_device_interop
     def fit(self, X, y, sample_weight=None,
             convert_dtype=True) -> "LogisticRegression":
@@ -298,17 +298,15 @@ class LogisticRegression(UniversalBase,
         if hasattr(X, 'index'):
             self.feature_names_in_ = X.index
 
-        # Converting y to device array here to use `unique` function
-        # since calling input_to_cuml_array again in QN has no cost
-        # Not needed to check dtype since qn class checks it already
-        y_m, n_rows, _, _ = input_to_cuml_array(y)
-        self.classes_ = cp.unique(y_m)
+        # LabelEncoder currently always returns cudf (ignoring output_type),
+        # but we need to explicitly set `output_type` or we'll get an error
+        # on init since `output_type` would default to `mirror`.
+        enc = LabelEncoder(output_type="cudf")
+        y_orig_dtype = getattr(y, "dtype", None)
+        y = enc.fit_transform(y).to_cupy()
+        n_rows = len(y)
+        self.classes_ = enc.classes_.to_numpy(dtype=y_orig_dtype)
         self._num_classes = len(self.classes_)
-
-        if self._num_classes == 2:
-            if self.classes_[0] != 0 or self.classes_[1] != 1:
-                raise ValueError("Only values of 0 and 1 are"
-                                 " supported for binary classification.")
 
         if sample_weight is not None or self.class_weight is not None:
             if sample_weight is None:
@@ -331,9 +329,7 @@ class LogisticRegression(UniversalBase,
 
             if self.class_weight is not None:
                 if self.class_weight == 'balanced':
-                    class_weight = n_rows / \
-                                   (self._num_classes *
-                                    cp.bincount(y_m.to_output('cupy')))
+                    class_weight = n_rows / (self._num_classes * cp.bincount(y))
                     class_weight = CumlArray(class_weight)
                 else:
                     check_expl_spec_weights()
@@ -345,8 +341,7 @@ class LogisticRegression(UniversalBase,
                         self.class_weight = class_weight
                     else:
                         class_weight = self.class_weight
-                out = y_m.to_output('cupy')
-                sample_weight *= class_weight[out].to_output('cupy')
+                sample_weight *= class_weight[y].to_output('cupy')
                 sample_weight = CumlArray(sample_weight)
 
         if self._num_classes > 2:
@@ -362,7 +357,7 @@ class LogisticRegression(UniversalBase,
         if logger.should_log_for(logger.level_enum.debug):
             logger.debug(self.verb_prefix + "Calling QN fit " + str(loss))
 
-        self.solver_model.fit(X, y_m, sample_weight=sample_weight,
+        self.solver_model.fit(X, y, sample_weight=sample_weight,
                               convert_dtype=convert_dtype)
 
         # coefficients and intercept are contained in the same array
@@ -405,14 +400,64 @@ class LogisticRegression(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
-    @cuml.internals.api_base_return_array(get_output_dtype=True)
+    @cuml.internals.api_base_return_any()
     @enable_device_interop
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the y for X.
 
         """
-        return self.solver_model.predict(X, convert_dtype=convert_dtype)
+        indices = self.solver_model.predict(X, convert_dtype=convert_dtype)
+
+        # TODO: Scikit-Learn's `LogisticRegression.predict` returns the same
+        # dtype as the input classes, _and_ natively supports non-numeric
+        # dtypes. CumlArray doesn't currently support wrapping containers with
+        # non-numeric dtypes. As such, we cannot rely on the normal decorators
+        # to handle output conversion, and need to handle output coercion
+        # internally. This is a hack.
+        output_type = self._get_output_type(X)
+
+        is_numeric = self.classes_.dtype.kind in 'ifu'
+        nclasses = len(self.classes_)
+
+        # Choose a smaller index type when possible
+        ind_dtype = np.int32 if nclasses <= np.iinfo(np.int32).max else np.int64
+
+        if is_numeric:
+            if (self.classes_ == np.arange(nclasses)).all():
+                # Fast path for common case of monotonically increasing numeric classes
+                out = indices.to_output("cupy", output_dtype=self.classes_.dtype)
+            else:
+                # Classes are not monotonically increasing from 0, we need to
+                # do a transform.
+                out = cp.asarray(self.classes_).take(
+                    indices.to_output("cupy", output_dtype=ind_dtype)
+                )
+
+            # Numeric types can always rely on CumlArray's output_type handling
+            return CumlArray(out).to_output(output_type)
+        else:
+            # Non-numeric classes. We use cudf since it supports all types, and will
+            # error appropriately later on when converting to outputs like `cupy`
+            # that don't support strings.
+            import cudf
+            out = (
+                cudf.Series(self.classes_).take(
+                    indices.to_output("cupy", output_dtype=ind_dtype)
+                ).reset_index(drop=True)
+            )
+            if output_type in ("cudf", "df_obj", "series"):
+                return out
+            elif output_type == "dataframe":
+                return out.to_frame()
+            elif output_type == "pandas":
+                return out.to_pandas()
+            elif output_type in ("numpy", "array"):
+                return out.to_numpy(dtype=self.classes_.dtype)
+            else:
+                raise TypeError(
+                    f"{output_type=} doesn't support objects of dtype {self.classes_.dtype!r}"
+                )
 
     @generate_docstring(X='dense_sparse',
                         return_values={'name': 'preds',
@@ -525,6 +570,19 @@ class LogisticRegression(UniversalBase,
         # Update solver
         self.solver_model.set_params(**params)
         return self
+
+    @property
+    def classes_(self):
+        return self._classes
+
+    @classes_.setter
+    def classes_(self, value):
+        if isinstance(value, CumlArray):
+            # XXX: The default cpu_to_gpu converts all numpy arrays on CPU
+            # to CumlArrays, which we don't want. For now we hack around this
+            # by explicitly converting classes_ back to numpy.
+            value = value.to_output("numpy")
+        self._classes = value
 
     @property
     @cuml.internals.api_base_return_array_skipall

--- a/python/cuml/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/cuml/preprocessing/LabelEncoder.py
@@ -44,6 +44,9 @@ def _to_cudf_series(y, **kwargs):
     elif isinstance(y, (np.ndarray, cp.ndarray)):
         if y.ndim == 2 and y.shape[-1] == 1:
             y = y.flatten()
+    if getattr(y, "dtype", None) == "float16":
+        # Upcast float16 since cudf cannot handle them yet
+        y = y.astype("float32")
     return cudf.Series(y, **kwargs)
 
 

--- a/python/cuml/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/cuml/preprocessing/LabelEncoder.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,12 +29,22 @@ if TYPE_CHECKING:
     import cudf
     import cupy as cp
     import numpy as np
-    from pandas import Series as pdSeries
 else:
     cudf = gpu_only_import("cudf")
     cp = gpu_only_import("cupy")
     np = cpu_only_import("numpy")
-    pdSeries = cpu_only_import_from("pandas", "Series")
+    pd = cpu_only_import("pandas")
+
+
+def _to_cudf_series(y, **kwargs):
+    if isinstance(y, (pd.DataFrame, cudf.DataFrame)):
+        if len(y.columns) != 1:
+            raise ValueError(f"`y` must be 1 dimensional, got {y.shape}")
+        y = y.iloc[:, 0]
+    elif isinstance(y, (np.ndarray, cp.ndarray)):
+        if y.ndim == 2 and y.shape[-1] == 1:
+            y = y.flatten()
+    return cudf.Series(y, **kwargs)
 
 
 class LabelEncoder(Base):
@@ -181,7 +191,11 @@ class LabelEncoder(Base):
 
         if _classes is None:
             # dedupe and sort
-            y = cudf.Series(y).drop_duplicates().sort_values(ignore_index=True)
+            y = (
+                _to_cudf_series(y)
+                .drop_duplicates()
+                .sort_values(ignore_index=True)
+            )
             self.classes_ = y
         else:
             self.classes_ = _classes
@@ -215,7 +229,7 @@ class LabelEncoder(Base):
         """
         check_is_fitted(self)
 
-        y = cudf.Series(y, dtype="category")
+        y = _to_cudf_series(y, dtype="category")
 
         encoded = y.cat.set_categories(self.classes_).cat.codes
 
@@ -232,7 +246,7 @@ class LabelEncoder(Base):
         `LabelEncoder().fit(y).transform(y)`
         """
 
-        y = cudf.Series(y)
+        y = _to_cudf_series(y)
         self.dtype = y.dtype if y.dtype != cp.dtype("O") else str
 
         y = y.astype("category")
@@ -257,8 +271,8 @@ class LabelEncoder(Base):
         """
         # check LabelEncoder is fitted
         check_is_fitted(self)
-        # check input type is cudf.Series
-        y = cudf.Series(y)
+
+        y = _to_cudf_series(y)
 
         # check if ord_label out of bound
         ord_label = y.unique()

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -409,29 +409,23 @@ def test_n_classes_small(client):
     X = np.array([(1, 2), (1, 3)], np.float32)
     y = np.array([1.0, 0.0], np.float32)
     lr = assert_small(X=X, y=y, n_classes=2)
-    assert np.array_equal(
-        lr.classes_.to_numpy(), np.array([0.0, 1.0], np.float32)
-    )
+    assert np.array_equal(lr.classes_, np.array([0.0, 1.0], np.float32))
 
     X = np.array([(1, 2), (1, 3), (1, 2.5)], np.float32)
     y = np.array([1.0, 0.0, 1.0], np.float32)
     lr = assert_small(X=X, y=y, n_classes=2)
-    assert np.array_equal(
-        lr.classes_.to_numpy(), np.array([0.0, 1.0], np.float32)
-    )
+    assert np.array_equal(lr.classes_, np.array([0.0, 1.0], np.float32))
 
     X = np.array([(1, 2), (1, 2.5), (1, 3)], np.float32)
     y = np.array([1.0, 1.0, 0.0], np.float32)
     lr = assert_small(X=X, y=y, n_classes=2)
-    assert np.array_equal(
-        lr.classes_.to_numpy(), np.array([0.0, 1.0], np.float32)
-    )
+    assert np.array_equal(lr.classes_, np.array([0.0, 1.0], np.float32))
 
     X = np.array([(1, 2), (1, 3), (1, 2.5)], np.float32)
     y = np.array([10.0, 50.0, 20.0], np.float32)
     lr = assert_small(X=X, y=y, n_classes=3)
     assert np.array_equal(
-        lr.classes_.to_numpy(), np.array([10.0, 20.0, 50.0], np.float32)
+        lr.classes_, np.array([10.0, 20.0, 50.0], np.float32)
     )
 
 

--- a/python/cuml/cuml/tests/test_label_encoder.py
+++ b/python/cuml/cuml/tests/test_label_encoder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -189,30 +189,41 @@ def _array_to_similarity_mat(x):
 
 @pytest.mark.parametrize("length", [10, 1000])
 @pytest.mark.parametrize("cardinality", [5, 10, 50])
-@pytest.mark.parametrize("dtype", ["cupy", "numpy", "pd"])
-def test_labelencoder_fit_transform_cupy_numpy_pd(length, cardinality, dtype):
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "cupy",
+        "numpy",
+        "cupy-2D",
+        "numpy-2D",
+        "pd.Series",
+        "pd.DataFrame",
+        "cudf.Series",
+        "cudf.DataFrame",
+    ],
+)
+def test_labelencoder_fit_transform_input_types(length, cardinality, kind):
     """Try encoding with various types"""
-    x = cp.random.choice(cardinality, (length,))
-    # to series
-    if dtype == "numpy":
-        x = x.get()
-    elif dtype == "pd":
-        x = pd.Series(x.get())
-    encoded = LabelEncoder().fit_transform(x)
+    raw = np.random.choice(cardinality, (length,))
+    if kind.startswith("numpy"):
+        x = raw if kind == "numpy" else raw[:, None]
+    elif kind.startswith("cupy"):
+        x = cp.asarray(raw if kind == "cupy" else raw[:, None])
+    elif kind.startswith("pd."):
+        x = pd.Series(raw)
+        if kind == "pd.DataFrame":
+            x = x.to_frame()
+    elif kind.startswith("cudf."):
+        x = cudf.Series(raw)
+        if kind == "cudf.DataFrame":
+            x = x.to_frame()
 
-    if dtype == "pd":
-        x_arr = _df_to_similarity_mat(x)
-    else:
-        x_arr = _array_to_similarity_mat(x)
+    encoder = LabelEncoder()
+    res = encoder.fit_transform(x)
+    sol = cudf.Series(raw).astype("category")
 
-    encoded_arr = _array_to_similarity_mat(encoded.values)
-
-    # to array
-    if dtype == "numpy" or dtype == "pd":
-        encoded_arr = encoded_arr.get()
-    if dtype == "pd":
-        x = x.to_numpy()
-    assert ((encoded_arr == encoded_arr.T) == (x == x_arr.T)).all()
+    cudf.testing.assert_series_equal(res, sol.cat.codes)
+    cudf.testing.assert_index_equal(encoder.classes_, sol.cat.categories)
 
 
 @pytest.mark.parametrize("use_fit_transform", [False, True])

--- a/python/cuml/cuml/tests/test_linear_model.py
+++ b/python/cuml/cuml/tests/test_linear_model.py
@@ -865,6 +865,28 @@ def test_logistic_regression_complex_classes(y_kind, output_type):
         assert isinstance(res, cudf.Series)
 
 
+@pytest.mark.parametrize("y_kind", ["pandas", "cudf"])
+def test_logistic_regression_categorical_y(y_kind):
+    X, y_inds = make_classification(
+        n_samples=100,
+        n_features=20,
+        n_informative=10,
+        n_classes=3,
+        random_state=0,
+    )
+    categories = np.array(["apple", "banana", "carrot"], dtype="object")
+    y = pd.Series(pd.Categorical.from_codes(y_inds, categories))
+    if y_kind == "cudf":
+        y = cudf.Series(y)
+
+    model = cuLog(output_type="numpy")
+    model.fit(X, y)
+    np.testing.assert_array_equal(model.classes_, categories, strict=True)
+    res = model.predict(X)
+    assert isinstance(res, np.ndarray)
+    assert res.dtype == "object"
+
+
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("test_dtype", [np.float64, np.float32])
 def test_linreg_predict_convert_dtype(train_dtype, test_dtype):

--- a/python/cuml/cuml/tests/test_linear_model.py
+++ b/python/cuml/cuml/tests/test_linear_model.py
@@ -811,7 +811,7 @@ def test_logistic_regression_input_type_consistency(constructor, dtype):
 
 
 @pytest.mark.parametrize(
-    "y_kind", ["object", "fixed-string", "int32", "float32"]
+    "y_kind", ["object", "fixed-string", "int32", "float32", "float16"]
 )
 @pytest.mark.parametrize("output_type", ["numpy", "cupy", "cudf", "pandas"])
 def test_logistic_regression_complex_classes(y_kind, output_type):
@@ -819,6 +819,8 @@ def test_logistic_regression_complex_classes(y_kind, output_type):
     increasing classes properly in both `fit` and `predict`"""
     if output_type == "cupy" and y_kind in ("object", "fixed-string"):
         pytest.skip("cupy doesn't support strings!")
+    elif output_type in ("cudf", "pandas") and y_kind == "float16":
+        pytest.skip("float16 dtype not supported")
 
     X, y_inds = make_classification(
         n_samples=100,

--- a/python/cuml/cuml/tests/test_linear_model.py
+++ b/python/cuml/cuml/tests/test_linear_model.py
@@ -861,7 +861,12 @@ def test_logistic_regression_complex_classes(y_kind, output_type):
         assert isinstance(res, cp.ndarray)
     elif output_type == "pandas":
         assert res.dtype == df_dtype
-        assert isinstance(res, pd.Series)
+        # TODO: this check works around a bug in cuml's output handling
+        # currently where isinstance(res, pd.Series) would fail
+        # if `cudf.pandas` is active. Writing the check odd for now
+        # to get this fix in, can switch back to `isinstance(res, pd.Series)`
+        # once that's fixed.
+        assert type(res).__module__.startswith("pandas")
     elif output_type == "cudf":
         assert res.dtype == df_dtype
         assert isinstance(res, cudf.Series)


### PR DESCRIPTION
Scikit-Learn's `LogisticRegression` is a bit unique in that it natively supports complex labels (e.g. raw strings/categories/non-monotonically increasing ints), rather than requiring that the labels are pre-encoded. It does this by internally using a `LabelEncoder` during `fit`, then converting the predicted labels back to the original label dtype in `predict`.

This PR adds support for this in `cuml`, improving compatibility with sklearn. This required:

- A small improvement to `LabelEncoder` to support all the input types that `cuml` natively supports.
- Addition of a `LabelEncoder` in `LogisticRegression.fit`
- Changing how we store `classes_`. Previously this used the descriptor functionality to support different container types. However, `CumlArray`/`cupy`/`numba` don't support non-numeric types, so we can't use that to store the classes anymore. We now always store `classes_` as a numpy array. I think this is fine - the size of classes is small - and also makes us a bit more compatible with sklearn since we can better ensure our dtypes match theirs.
- Changing `predict` to convert the numeric output back into the original classes. This was complicated since `CumlArray`/`cupy`/`numba` don't support non-numeric types, which means that most of our existing `output_type` machinery fails for these cases. I hacked something in that I think is sufficient, but it's definitely a hack.
- Addition of a new test to check things work properly across dtypes and container types.

This is an alternative to #6328. The fix here doesn't add any additional state, and I believe the test cases added here provide better coverage of the behavior we're trying to ensure.