### PR TITLE
Add new `cuml.accel` module

### DIFF
--- a/ci/run_cuml_singlegpu_accel_pytests.sh
+++ b/ci/run_cuml_singlegpu_accel_pytests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 # Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/cuml/tests/experimental/accel
 
-python -m pytest -p cuml.experimental.accel --cache-clear "$@" .
+python -m pytest -p cuml.accel --cache-clear "$@" .

--- a/python/cuml/cuml/accel/__init__.py
+++ b/python/cuml/cuml/accel/__init__.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from cuml.experimental.accel import (
+    install,
+    load_ipython_extension,
+    pytest_load_initial_conftests,
+)

--- a/python/cuml/cuml/accel/__main__.py
+++ b/python/cuml/cuml/accel/__main__.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from cuml.experimental.accel.__main__ import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is just an alias shim around the old `cuml.experimental.accel` module, to help avoid merge conflicts or usage of the previous experimental module. In the future we should move the code out of experimental and over to `accel` instead.