### PR TITLE
Avoid importing `umap` with `import cuml`

### DIFF
--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -16,11 +16,9 @@
 
 # distutils: language = c++
 
-from cuml.internals.safe_imports import cpu_only_import, safe_import_from
+from cuml.internals.safe_imports import cpu_only_import
 np = cpu_only_import('numpy')
 pd = cpu_only_import('pandas')
-nearest_neighbors = safe_import_from('umap.umap_', 'nearest_neighbors')
-DISCONNECTION_DISTANCES = safe_import_from('umap.umap_', 'DISCONNECTION_DISTANCES')
 
 import joblib
 import warnings
@@ -905,6 +903,7 @@ class UMAP(UniversalBase,
 
     @property
     def _disconnection_distance(self):
+        from umap.umap_ import DISCONNECTION_DISTANCES
         self.disconnection_distance = DISCONNECTION_DISTANCES.get(self.metric, np.inf)
         return self.disconnection_distance
 
@@ -913,6 +912,7 @@ class UMAP(UniversalBase,
         self.disconnection_distance = value
 
     def gpu_to_cpu(self):
+        from umap.umap_ import nearest_neighbors
         if hasattr(self, 'knn_dists') and hasattr(self, 'knn_indices'):
             self._knn_dists = self.knn_dists
             self._knn_indices = self.knn_indices


### PR DESCRIPTION
Previously we were importing `umap` (if installed) on every import of `cuml`, which added considerable import time (3.5 seconds on my machine!).

The utilities imported from `umap` were only used when converting a `cuml.UMAP` model to its CPU `umap.UMAP` equivalent. We now delay these imports until/if they're needed, reducing `cuml` import time.