### PR TITLE
Adjust accel verbosity

### DIFF
--- a/python/cuml/cuml/experimental/accel/__init__.py
+++ b/python/cuml/cuml/experimental/accel/__init__.py
@@ -33,13 +33,15 @@ def _install_for_library(library_name):
 
 def install():
     """Enable cuML Accelerator Mode."""
-    logger.info("cuML: Installing accelerator...")
+    logger.debug("cuML: Installing accelerator...")
     libraries_to_accelerate = ["sklearn", "umap", "hdbscan"]
     accelerated_libraries = []
     failed_to_accelerate = []
     for library_name in libraries_to_accelerate:
-        logger.debug(f"cuML: Installing accelerator for {library_name}...")
         try:
+            logger.debug(
+                f"cuML: Attempt to install accelerator for {library_name}..."
+            )
             _install_for_library(library_name)
         except (
             ModuleNotFoundError,
@@ -61,15 +63,16 @@ def install():
     GlobalSettings().accelerator_loaded = any(accelerated_libraries)
     GlobalSettings().accelerator_active = any(accelerated_libraries)
 
-    if GlobalSettings().accelerator_loaded:
-        if any(failed_to_accelerate):
-            logger.warn(
-                f"cuML: Accelerator initialized, some installations failed: {', '.join(failed_to_accelerate)}"
-            )
-        else:
-            logger.info("cuML: Accelerator successfully initialized.")
-    else:
-        logger.warn("cuML: Accelerator failed to initialize.")
+    if any(accelerated_libraries) and not any(failed_to_accelerate):
+        logger.info("cuML: Successfully initialized accelerator.")
+    elif any(accelerated_libraries) and any(failed_to_accelerate):
+        logger.warn(
+            "cuML: Accelerator initialized, but failed to initialize for some libraries."
+        )
+    elif not any(accelerated_libraries) and not any(failed_to_accelerate):
+        logger.warn(
+            "cuML: Accelerator failed to initialize, because none of the underlying libraries are installed."
+        )
 
     set_global_output_type("numpy")
 

--- a/python/cuml/cuml/experimental/accel/__init__.py
+++ b/python/cuml/cuml/experimental/accel/__init__.py
@@ -33,9 +33,6 @@ def _install_for_library(library_name):
 
 def install():
     """Enable cuML Accelerator Mode."""
-    logger.set_level(logger.level_enum.info)
-    logger.set_pattern("%v")
-
     logger.info("cuML: Installing accelerator...")
     libraries_to_accelerate = ["sklearn", "umap", "hdbscan"]
     accelerated_libraries = []

--- a/python/cuml/cuml/experimental/accel/__main__.py
+++ b/python/cuml/cuml/experimental/accel/__main__.py
@@ -48,7 +48,12 @@ from . import install
     default="converted_sklearn_model.pkl",
     help="Output path for the converted sklearn estimator file.",
 )
-@click.option("-v", "--verbose", count=True)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Increase output verbosity (can be used multiple times, e.g. -vv). Default shows warnings only.",
+)
 @click.argument("args", nargs=-1)
 def main(module, convert_to_sklearn, format, output, verbose, args):
     default_logger_level_index = list(logger.level_enum).index(

--- a/python/cuml/cuml/experimental/accel/__main__.py
+++ b/python/cuml/cuml/experimental/accel/__main__.py
@@ -22,6 +22,8 @@ import os
 import runpy
 import sys
 
+from cuml.internals import logger
+
 from . import install
 
 
@@ -46,8 +48,16 @@ from . import install
     default="converted_sklearn_model.pkl",
     help="Output path for the converted sklearn estimator file.",
 )
+@click.option("-v", "--verbose", count=True)
 @click.argument("args", nargs=-1)
-def main(module, convert_to_sklearn, format, output, args):
+def main(module, convert_to_sklearn, format, output, verbose, args):
+    default_logger_level_index = list(logger.level_enum).index(
+        logger.level_enum.warn
+    )
+    logger_level_index = max(0, default_logger_level_index - verbose)
+    logger_level = list(logger.level_enum)[logger_level_index]
+    logger.set_level(logger_level)
+    logger.set_pattern("%v")
 
     # Enable acceleration
     install()

--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -758,7 +758,7 @@ class UniversalBase(Base):
         if device_type == DeviceType.device:
             # call the function from the GPU estimator
             if GlobalSettings().accelerator_active:
-                logger.info(f"cuML: Performing {func_name} in GPU")
+                logger.debug(f"cuML: Performing {func_name} in GPU")
             return gpu_func(self, *args, **kwargs)
 
         # CPU case
@@ -781,7 +781,7 @@ class UniversalBase(Base):
             # get the function from the CPU estimator
             cpu_func = getattr(self._cpu_model, func_name)
             # call the function from the CPU estimator
-            logger.info(f"cuML: Performing {func_name} in CPU")
+            logger.debug(f"cuML: Performing {func_name} in CPU")
             res = cpu_func(*args, **kwargs)
 
             # CPU training

--- a/python/cuml/cuml/tests/experimental/accel/estimators_hyperparams/test_accel_tsne.py
+++ b/python/cuml/cuml/tests/experimental/accel/estimators_hyperparams/test_accel_tsne.py
@@ -155,13 +155,10 @@ def test_tsne_random_state(synthetic_data):
     )
 
 
-def test_tsne_verbose(synthetic_data, capsys):
+def test_tsne_verbose(synthetic_data):
     X, _ = synthetic_data
     model = TSNE(verbose=1, random_state=42)
     model.fit_transform(X)
-    captured = capsys.readouterr()
-    # Check that there is output when verbose=1
-    assert len(captured.out) > 0, "There should be output when verbose=1"
 
 
 def test_tsne_structure_preservation(synthetic_data):


### PR DESCRIPTION
Adds a `-v/--verbose` option to the accel entrypoint and adjusts log verbosity and messages during accel installation.

Follow-up for #6348 