### PR TITLE
A few GPU<->CPU interop fixes

### DIFF
--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -658,41 +658,16 @@ class UniversalBase(Base):
     def gpu_to_cpu(self):
         # transfer attributes from GPU to CPU estimator
         for attr in self.get_attr_names():
-            # check presence of attribute
-            if hasattr(self, attr) or \
-               isinstance(getattr(type(self), attr, None), property):
-                # get the cuml attribute
-                if hasattr(self, attr):
-                    cu_attr = getattr(self, attr)
-                else:
-                    cu_attr = getattr(type(self), attr).fget(self)
-                # if the cuml attribute is a CumlArrayDescriptorMeta
-                if hasattr(cu_attr, 'get_input_value'):
-                    # extract the actual value from the
-                    # CumlArrayDescriptorMeta
-                    cu_attr_value = cu_attr.get_input_value()
-                    # check if descriptor is empty
-                    if cu_attr_value is not None:
-                        if cu_attr.input_type == 'cuml':
-                            # transform cumlArray to numpy and set it
-                            # as an attribute in the CPU estimator
-                            setattr(self._cpu_model, attr,
-                                    cu_attr_value.to_output('numpy'))
-                        else:
-                            # transfer all other types of attributes
-                            # directly
-                            setattr(self._cpu_model, attr,
-                                    cu_attr_value)
-                elif isinstance(cu_attr, CumlArray):
+            if hasattr(self, attr):
+                cu_attr = getattr(self, attr)
+                if isinstance(cu_attr, CumlArray):
                     # transform cumlArray to numpy and set it
                     # as an attribute in the CPU estimator
-                    setattr(self._cpu_model, attr,
-                            cu_attr.to_output('numpy'))
+                    setattr(self._cpu_model, attr, cu_attr.to_output('numpy'))
                 elif isinstance(cu_attr, cp_ndarray):
                     # transform cupy to numpy and set it
                     # as an attribute in the CPU estimator
-                    setattr(self._cpu_model, attr,
-                            cp.asnumpy(cu_attr))
+                    setattr(self._cpu_model, attr, cp.asnumpy(cu_attr))
                 else:
                     # transfer all other types of attributes directly
                     setattr(self._cpu_model, attr, cu_attr)
@@ -705,16 +680,8 @@ class UniversalBase(Base):
             ]
         ):
             for attr in self.get_attr_names():
-                # check presence of attribute
-                if hasattr(self._cpu_model, attr) or \
-                    isinstance(getattr(type(self._cpu_model),
-                                       attr, None), property):
-                    # get the cpu attribute
-                    if hasattr(self._cpu_model, attr):
-                        cpu_attr = getattr(self._cpu_model, attr)
-                    else:
-                        cpu_attr = getattr(type(self._cpu_model),
-                                           attr).fget(self._cpu_model)
+                if hasattr(self._cpu_model, attr):
+                    cpu_attr = getattr(self._cpu_model, attr)
                     # if the cpu attribute is an array
                     if isinstance(cpu_attr, np.ndarray):
                         # get data order wished for by


### PR DESCRIPTION
- Fixes `gpu_to_cpu` and `cpu_to_gpu` to no longer error when moving fields from properties that don't _yet_ have a value. The previous special casing of `property` fields was unnecessary and should never have been able to be hit by working code (pulling the property from the class then calling `fget` manually is the same as a simple `getattr(instance, attr)`).
- Fixes `accelerator_active` to always be reset to its original value, even if `build_cpu_model` or `gpu_to_cpu` error. Previously if these methods errored the accelerator would be silently disabled for the rest of the run, leading to tricky to diagnose bugs in our test suite.

Both of these issues showed up after some changes made in #6346. I'm not really sure how to test the bugs in isolation (or if a test for that is even warranted). I can confirm that with rebasing #6346 on top of this PR the remaining issues in the test suite go away.