### PR TITLE
capture sccache stats and build logs for telemetry

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -9,6 +9,8 @@ source rapids-configure-sccache
 
 source rapids-date-string
 
+source rapids-telemetry-setup
+
 export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
@@ -17,9 +19,9 @@ rapids-logger "Begin cpp build"
 
 sccache --zero-stats
 
-RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry build \
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-telemetry-record build.log rapids-conda-retry build \
   conda/recipes/libcuml
 
-sccache --show-adv-stats
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -9,6 +9,8 @@ source rapids-configure-sccache
 
 source rapids-date-string
 
+source rapids-telemetry-setup
+
 export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
@@ -23,12 +25,12 @@ sccache --zero-stats
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
+RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-telemetry-record build.log rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cuml
 
-sccache --show-adv-stats
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 # Build cuml-cpu only in CUDA 12 jobs since it only depends on python
 # version

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -8,6 +8,7 @@ package_dir=$2
 
 source rapids-configure-sccache
 source rapids-date-string
+source rapids-telemetry-setup
 
 rapids-generate-version > ./VERSION
 
@@ -16,11 +17,11 @@ cd "${package_dir}"
 sccache --zero-stats
 
 rapids-logger "Building '${package_name}' wheel"
-rapids-pip-retry wheel \
+rapids-telemetry-record build.log rapids-pip-retry wheel \
     -w dist \
     -v \
     --no-deps \
     --disable-pip-version-check \
     .
 
-sccache --show-adv-stats
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats

--- a/ci/build_wheel_cuml.sh
+++ b/ci/build_wheel_cuml.sh
@@ -29,8 +29,14 @@ EXCLUDE_ARGS=(
   --exclude "librapids_logger.so"
 )
 
+source rapids-telemetry-setup
+
+sccache --zero-stats
+
 export SKBUILD_CMAKE_ARGS="-DDISABLE_DEPRECATION_WARNINGS=ON;-DSINGLEGPU=OFF;-DUSE_LIBCUML_WHEEL=ON"
-./ci/build_wheel.sh "${package_name}" "${package_dir}"
+rapids-telemetry-record build.log ./ci/build_wheel.sh "${package_name}" "${package_dir}"
+
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 mkdir -p ${package_dir}/final_dist
 python -m auditwheel repair \

--- a/ci/build_wheel_libcuml.sh
+++ b/ci/build_wheel_libcuml.sh
@@ -43,8 +43,15 @@ EXCLUDE_ARGS=(
   --exclude "librapids_logger.so"
 )
 
+source rapids-telemetry-setup
+
+sccache --zero-stats
+
 export SKBUILD_CMAKE_ARGS="-DDISABLE_DEPRECATION_WARNINGS=ON;-DCPM_cumlprims_mg_SOURCE=${GITHUB_WORKSPACE}/cumlprims_mg/"
-./ci/build_wheel.sh "${package_name}" "${package_dir}"
+
+rapids-telemetry-record build.log ./ci/build_wheel.sh "${package_name}" "${package_dir}"
+
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 mkdir -p ${package_dir}/final_dist
 python -m auditwheel repair \


### PR DESCRIPTION
This pr uses new functionality added to shared-actions and shared-workflows to capture sccache hit rate information. To add this to other repos, we'll need to make the slight alteration here:

sccache --show-adv-stats | tee ../../telemetry-artifacts/sccache-stats.txt

That is, output the sccache stats to a file with a particular name in the telemetry-artifacts folder.

The captured sccache stats look like the screenshot below.

![image](https://github.com/user-attachments/assets/894b3021-c581-4831-958f-49207d482258)
