### PR TITLE
Do not attempt to translate complex hyper-parameter values

### DIFF
--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -555,9 +555,15 @@ class Base(TagsMixin,
         # Allow the derived class to overwrite the base class
         translations.update(cls._hyperparam_interop_translator)
         for parameter_name, value in kwargs.items():
-
             if parameter_name in translations:
-                if value in translations[parameter_name]:
+                # If the value can't be hashed, it is probably a complicated value
+                # (like a NumPy array) that we can't translate.
+                try:
+                    translate_this = value in translations[parameter_name]
+                except TypeError:
+                    translate_this = False
+
+                if translate_this:
                     if translations[parameter_name][value] == "NotImplemented":
                         gpuaccel = False
                     else:


### PR DESCRIPTION
When the value passed in by the user is unhashable, it is probably a complicated/unique value that we should not translate. This change implements this, and fixes a problem observed in the 0cc example notebook where a Numpy array is passed in as parameter value.

Found this while looking at #6322. There is a CI error in that PR that will be fixed by this change. Specifically
```python
pca = PCA(n_components=n_digits).fit(data)
kmeans = KMeans(init=pca.components_, n_clusters=n_digits, n_init=1)
bench_k_means(kmeans=kmeans, name="PCA-based", data=data, labels=labels)
```
`pca.components_` isn't hashable, but luckily we don't want to translate this anyway :D

cc @wphicks 