### PR TITLE
Don't log coverage output to terminal in CI

### DIFF
--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 # Support invoking test_python_dask.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
@@ -16,7 +16,6 @@ test_args=(
   --cov-config=../../../.coveragerc
   --cov=cuml_dask
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-dask-coverage.xml"
-  --cov-report=term
 )
 
 # Run tests

--- a/ci/test_python_integration.sh
+++ b/ci/test_python_integration.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 # Support invoking test_python_singlegpu.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
@@ -18,8 +18,7 @@ rapids-logger "pytest cuml integration"
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \
   --cov-config=../../.coveragerc \
   --cov=cuml \
-  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml" \
-  --cov-report=term
+  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml"
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -18,8 +18,7 @@ rapids-logger "pytest cuml single GPU"
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \
   --cov-config=../../.coveragerc \
   --cov=cuml \
-  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml" \
-  --cov-report=term
+  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml"
 
   rapids-logger "pytest cuml accelerator"
 ./ci/run_cuml_singlegpu_accel_pytests.sh \
@@ -28,8 +27,7 @@ rapids-logger "pytest cuml single GPU"
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-accel.xml" \
   --cov-config=../../../../.coveragerc \
   --cov=cuml \
-  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-accel-coverage.xml" \
-  --cov-report=term
+  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-accel-coverage.xml"
 
 
 if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
@@ -41,7 +39,6 @@ if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
     --cov-config=../../.coveragerc \
     --cov=cuml \
     --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-memleak-coverage.xml" \
-    --cov-report=term \
     -m "memleak"
 fi
 


### PR DESCRIPTION
Outputting coverage to terminal adds sometimes 100s of lines you need to scroll past before you can find the actual failure.

We already upload coverage to codecov where it can be consumed a lot easier (and more correctly - coverage from a single pytest run will differ from total coverage from all runs).

Fixes #6357.