### PR TITLE
Ensure FIL CPU can be run without an available GPU

### DIFF
--- a/python/cuml/cuml/experimental/fil/fil.pyx
+++ b/python/cuml/cuml/experimental/fil/fil.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -297,7 +297,8 @@ cdef class ForestInference_impl():
                 chunk_specification
             )
 
-        self.raft_proto_handle.synchronize()
+        if GlobalSettings().device_type == DeviceType.device:
+            self.raft_proto_handle.synchronize()
 
         return preds
 


### PR DESCRIPTION
Due to an upstream change, CPU FIL was touching the CUDA context in a way that required a GPU to be present in order for it to be used. Until CPU FIL is actually included in the cuML CPU build (which will avoid this problem for anyone using the cuML CPU package), this change ensures that CPU FIL can still be run even if no GPU is available.