### PR TITLE
Remove debug logging from nearest neighbors test

### DIFF
--- a/python/cuml/cuml/tests/test_nearest_neighbors.py
+++ b/python/cuml/cuml/tests/test_nearest_neighbors.py
@@ -617,14 +617,12 @@ def test_nearest_neighbors_sparse(
         a = a.astype("bool").astype("float32")
         b = b.astype("bool").astype("float32")
 
-    logger.set_level(logger.level_enum.debug)
     nn = cuKNN(
         metric=metric,
         p=2.0,
         n_neighbors=n_neighbors,
         algorithm="brute",
         output_type="numpy",
-        verbose=logger.level_enum.debug,
         algo_params={
             "batch_size_index": batch_size_index,
             "batch_size_query": batch_size_query,


### PR DESCRIPTION
Remove extraneous debug logging from nearest neighbors test. This is likely the root cause for sporadic test failures we observe as part of our test pipeline since it changes the logger level globally. Specifically, I suspect it leads to failures in the doc-tests of other estimators since it causes extraneous verbose output.