### PR TITLE
Revise LabelEncoder to use CumlArray.from_input() for input digestion

### DIFF
--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -41,6 +41,4 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 # Enable hypothesis testing for nightly test runs.
-if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
-  export HYPOTHESIS_ENABLED="true"
-fi
+export HYPOTHESIS_ENABLED="true"


### PR DESCRIPTION
Fixes failures we observe in combination with hypothesis on [nightlies](https://github.com/rapidsai/cuml/actions/runs/13584390361/job/37976114110):


Affected tests:
```
FAILED cuml/tests/test_linear_model.py::test_logistic_regression_unscaled - pyarrow.lib.ArrowNotImplementedError: Byte-swapped arrays not supported
FAILED cuml/tests/test_linear_model.py::test_logistic_regression_decision_function - pyarrow.lib.ArrowNotImplementedError: Byte-swapped arrays not supported
FAILED cuml/tests/test_linear_model.py::test_logistic_regression_predict_proba - pyarrow.lib.ArrowNotImplementedError: Byte-swapped arrays not supported
FAILED cuml/tests/test_linear_model.py::test_logistic_predict_convert_dtype - pyarrow.lib.ArrowNotImplementedError: Byte-swapped arrays not supported
```

MRE
```python
y = np.array([1, 2, 3, 4, 5], dtype=">f4")
CumlArray(y).to_output("pandas")  # passes
CumlArray(y).to_output("cudf")  # fails
```

This is a partial revert of https://github.com/rapidsai/cuml/pull/6346. Note that this change no longer supports float16 inputs, but that was already not the case previously and I would consider that currently globally not supported.