### PR TITLE
Temporarily increase `max_days_without_success`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,6 +56,9 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
+          # TODO: remove this once upstream issues in RAFT are resolved on 11.4.
+          # The limit was temporarily increased to unblock work.
+          max_days_without_success: 30
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
Nightly CI is currently failing on CUDA 11.4 due to what appears to be an upstream issue in RAFT. Temporarily bumping the limit here to unblock team members (while we continue attempting to resolve the issue).