### PR TITLE
Make UMAP callback pickleable

### DIFF
--- a/python/cuml/cuml/internals/internals.pyx
+++ b/python/cuml/cuml/internals/internals.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,12 +78,20 @@ IF GPUBUILD == 1:
 
         cdef DefaultGraphBasedDimRedCallback native_callback
 
-        def __init__(self):
+        def __cinit__(self):
             self.native_callback.pyCallbackClass = <PyObject *><void*>self
 
+        def __reduce__(self):
+            return (type(self), ())
+
         def get_native_callback(self):
-            if self.native_callback.pyCallbackClass == NULL:
-                raise ValueError(
-                    "You need to call `super().__init__` in your callback."
-                )
             return <uintptr_t>&(self.native_callback)
+
+        def on_preprocess_end(self, embeddings):
+            pass
+
+        def on_epoch_end(self, embeddings):
+            pass
+
+        def on_train_end(self, embeddings):
+            pass

--- a/python/cuml/cuml/tests/test_internals_api.py
+++ b/python/cuml/cuml/tests/test_internals_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,46 +13,17 @@
 # limitations under the License.
 
 import pytest
-from cuml.manifold import UMAP
-from cuml.internals import GraphBasedDimRedCallback
-from sklearn.datasets import load_digits
+import pickle
 
-digits = load_digits()
-data, target = digits.data, digits.target
+from cuml.internals import GraphBasedDimRedCallback
 
 
 class CustomCallback(GraphBasedDimRedCallback):
-    preprocess_event, epoch_event, train_event = False, 0, False
-
-    def __init__(self, skip_init=False):
-        if not skip_init:
-            super().__init__()
-
-    def check(self):
-        assert self.preprocess_event
-        assert self.epoch_event > 10
-        assert self.train_event
-
-    def on_preprocess_end(self, embeddings):
-        self.preprocess_event = True
-
-    def on_epoch_end(self, embeddings):
-        self.epoch_event += 1
-
-    def on_train_end(self, embeddings):
-        self.train_event = True
+    pass
 
 
-@pytest.mark.parametrize("n_components", [2, 4, 8])
-def test_internals_api(n_components):
-    callback = CustomCallback()
-    reducer = UMAP(n_components=n_components, callback=callback)
-    reducer.fit(data)
-    callback.check()
-
-    # Make sure super().__init__ is called
-    callback = CustomCallback(skip_init=True)
-    model = UMAP(n_epochs=10, callback=callback)
-
-    with pytest.raises(ValueError):
-        model.fit_transform(data)
+def test_callback_pickleable():
+    obj = CustomCallback()
+    buf = pickle.dumps(obj)
+    obj2 = pickle.loads(buf)
+    assert isinstance(obj2, CustomCallback)


### PR DESCRIPTION
The structure of this callback object should really be cleaned up (by moving the callback to the stack before the call to UMAP we can avoid having an object with pointers to itself _and_ better manage the lifetime of the callback instance). This would also let us avoid implementing this callback in cython, which mucks up the default pickling implementation. As is though this is the easiest way to get things pickleable. Users will still need to define `__reduce__` themselves if they add any state to an instance, but given that this code was added for an internal use case and hasn't seen any changes or expansion in 6 years I don't suspect there are many external users of this API. Can always clean this up later if a user asks about it.

Fixes #5282.