### PR TITLE
Ensure `output_type="pandas"` returns user-facing pandas

### DIFF
--- a/python/cuml/cuml/internals/input_utils.py
+++ b/python/cuml/cuml/internals/input_utils.py
@@ -15,7 +15,6 @@
 #
 
 from collections import namedtuple
-from typing import Literal
 
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
@@ -614,27 +613,3 @@ def sparse_scipy_to_cp(sp, dtype):
     v = cp.asarray(values, dtype=dtype)
 
     return cupyx.scipy.sparse.coo_matrix((v, (r, c)), sp.shape)
-
-
-def output_to_df_obj_like(
-    X_out: CumlArray, X_in, output_type: Literal["series", "dataframe"]
-):
-    """Cast CumlArray `X_out` to the dataframe / series type as `X_in`
-    `CumlArray` abstracts away the dataframe / series metadata, when API
-    methods needs to return a dataframe / series matching original input
-    metadata, this function can copy input metadata to output.
-    """
-
-    if output_type not in ["series", "dataframe"]:
-        raise ValueError(
-            f'output_type must be either "series" or "dataframe" : {output_type}'
-        )
-
-    out = None
-    if output_type == "series":
-        out = X_out.to_output("series")
-        out.name = X_in.name
-    elif output_type == "dataframe":
-        out = X_out.to_output("dataframe")
-        out.columns = X_in.columns
-    return out

--- a/python/cuml/cuml/internals/output_utils.py
+++ b/python/cuml/cuml/internals/output_utils.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def cudf_to_pandas(cudf_obj):
+    """Convert a ``cudf`` object to a ``pandas`` (or ``cudf.pandas``) object.
+
+    Unlike cudf's builtin ``to_pandas`` method, this function will return a
+    ``cudf.pandas`` object if ``cudf.pandas`` is active.
+    """
+    import cudf.pandas
+
+    if cudf.pandas.LOADED:
+        return cudf.pandas.as_proxy_object(cudf_obj)
+    else:
+        return cudf_obj.to_pandas()
+
+
+def output_to_df_obj_like(X_out, X_in, output_type):
+    """Cast CumlArray `X_out` to the dataframe / series type as `X_in`
+    `CumlArray` abstracts away the dataframe / series metadata, when API
+    methods needs to return a dataframe / series matching original input
+    metadata, this function can copy input metadata to output.
+    """
+
+    if output_type not in ["series", "dataframe"]:
+        raise ValueError(
+            f'output_type must be either "series" or "dataframe" : {output_type}'
+        )
+
+    out = None
+    if output_type == "series":
+        out = X_out.to_output("series")
+        out.name = X_in.name
+    elif output_type == "dataframe":
+        out = X_out.to_output("dataframe")
+        out.columns = X_in.columns
+    return out

--- a/python/cuml/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression.pyx
@@ -32,6 +32,7 @@ from cuml.internals.array import CumlArray
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals import logger
 from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.output_utils import cudf_to_pandas
 from cuml.common import using_output_type
 from cuml.internals.api_decorators import device_interop_preparation
 from cuml.internals.api_decorators import enable_device_interop
@@ -462,7 +463,7 @@ class LogisticRegression(UniversalBase,
             elif output_type == "dataframe":
                 return out.to_frame()
             elif output_type == "pandas":
-                return out.to_pandas()
+                return cudf_to_pandas(out)
             elif output_type in ("numpy", "array"):
                 return out.to_numpy(dtype=self.classes_.dtype)
             else:

--- a/python/cuml/cuml/model_selection/_split.py
+++ b/python/cuml/cuml/model_selection/_split.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ from cuml.common import input_to_cuml_array
 from cuml.internals.input_utils import (
     determine_array_type,
     determine_df_obj_type,
-    output_to_df_obj_like,
 )
+from cuml.internals.output_utils import output_to_df_obj_like
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.array import array_to_memory_order, CumlArray
 from cuml.internals.safe_imports import (

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ from cuml.internals.safe_imports import (
     gpu_only_import,
     gpu_only_import_from,
 )
+from cuml.internals.output_utils import cudf_to_pandas
 from cuml.preprocessing import LabelEncoder
 
 np = cpu_only_import("numpy")
@@ -642,7 +643,7 @@ def _get_output(
     elif output_type == "numpy":
         return cp.asnumpy(out.to_cupy(na_value=np.nan, dtype=dtype))
     elif output_type == "pandas":
-        return out.to_pandas()
+        return cudf_to_pandas(out)
     else:
         raise ValueError("Unsupported output type.")
 

--- a/python/cuml/cuml/tests/test_array.py
+++ b/python/cuml/cuml/tests/test_array.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -728,3 +728,20 @@ def test_order_to_strides(input_type, dtype, shape, order):
         np.array(_order_to_strides(order, shape, dtype))
         == np.array(input_array.strides)
     )
+
+
+@pytest.mark.parametrize("kind", ["dataframe", "series"])
+def test_output_pandas(kind):
+    """Check that `output_type=pandas` matches the user-facing pandas.
+
+    If `cudf.pandas` is enabled we want to output a `cudf.pandas` proxy, not
+    the original raw `pandas` object (like `cudf_obj.to_pandas()` does)."""
+    if kind == "series":
+        shape = 10
+        exp_type = pd.Series
+    else:
+        shape = (10, 3)
+        exp_type = pd.DataFrame
+    arr = CumlArray.from_input(cp.ones(shape))
+    out = arr.to_output("pandas")
+    assert isinstance(out, exp_type)

--- a/python/cuml/cuml/tests/test_linear_model.py
+++ b/python/cuml/cuml/tests/test_linear_model.py
@@ -861,12 +861,7 @@ def test_logistic_regression_complex_classes(y_kind, output_type):
         assert isinstance(res, cp.ndarray)
     elif output_type == "pandas":
         assert res.dtype == df_dtype
-        # TODO: this check works around a bug in cuml's output handling
-        # currently where isinstance(res, pd.Series) would fail
-        # if `cudf.pandas` is active. Writing the check odd for now
-        # to get this fix in, can switch back to `isinstance(res, pd.Series)`
-        # once that's fixed.
-        assert type(res).__module__.startswith("pandas")
+        assert isinstance(res, pd.Series)
     elif output_type == "cudf":
         assert res.dtype == df_dtype
         assert isinstance(res, cudf.Series)

--- a/python/cuml/cuml/tests/test_ordinal_encoder.py
+++ b/python/cuml/cuml/tests/test_ordinal_encoder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ from sklearn.preprocessing import OrdinalEncoder as skOrdinalEncoder
 from cuml.internals.safe_imports import gpu_only_import_from
 from cuml.preprocessing import OrdinalEncoder
 
-cudf_pandas_active = gpu_only_import_from("cudf.pandas", "LOADED")
 DataFrame = gpu_only_import_from("cudf", "DataFrame")
 
 
@@ -98,8 +97,7 @@ def test_output_type(test_sample) -> None:
     enc = OrdinalEncoder(output_type="cudf").fit(X)
     assert isinstance(enc.transform(X), DataFrame)
     enc = OrdinalEncoder(output_type="pandas").fit(X)
-    if not cudf_pandas_active:
-        assert isinstance(enc.transform(X), pd.DataFrame)
+    assert isinstance(enc.transform(X), pd.DataFrame)
     enc = OrdinalEncoder(output_type="numpy").fit(X)
     assert isinstance(enc.transform(X), np.ndarray)
     # output_type == "input"


### PR DESCRIPTION
Previously if `cudf.pandas` was active, we'd _sometimes_ still return a true `pandas` object rather than a `cudf.pandas` proxy object. This PR fixes that, so we always return objects from whatever the active user-facing "pandas" module is.

Fixes #6351.