### PR TITLE
Fix multi-target prediction in linear models

### DIFF
--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -127,7 +127,10 @@ class LinearPredictMixin:
 
         # If coef_ is 2D with shape (1, n_features), ensure predictions are also 2D
         if len(self.coef_.shape) == 2:
-            assert self.coef_.shape == (_n_rows, 1)
+            # coef_ is 2D with shape (1, n_features), but this function only
+            # handles single-target prediction. For multi-target prediction, use
+            # _predict_multi_target() instead.
+            assert self.coef_.shape == (1, _n_cols)
             preds = CumlArray.zeros((_n_rows, 1), dtype=dtype, index=X_m.index)
         else:
             preds = CumlArray.zeros(_n_rows, dtype=dtype, index=X_m.index)

--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -84,19 +84,22 @@ class LinearPredictMixin:
         Predict for multi-target case.
         """
         coef_arr = CumlArray.from_input(self.coef_).to_output('array')
-        X_arr = CumlArray.from_input(
+        X_m = CumlArray.from_input(
             X,
             check_dtype=self.dtype,
             convert_to_dtype=(self.dtype if convert_dtype else None),
             check_cols=self.n_features_in_
-        ).to_output('array')
+        )
+        X_arr = X_m.to_output('array')
         if isinstance(self.intercept_, (int, float, np.number)):
             intercept_ = self.intercept_
         else:
             intercept_ = CumlArray.from_input(self.intercept_).to_output('array')
 
         preds_arr = X_arr @ coef_arr.T + intercept_
-        return preds_arr
+
+        # Preserve the input's index in the prediction output
+        return CumlArray(preds_arr, index=X_m.index)
 
     def _predict_single_target(self, X, convert_dtype=True) -> CumlArray:
         """

--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -91,15 +91,6 @@ class LinearPredictMixin:
                     self.intercept_,
                     convert_to_dtype=self.dtype if isinstance(self.intercept_, float) else False
                 ).to_output('array')
-            # Ensure coefficient array has correct shape for matrix
-            # multiplication. This is a workaround specifically for the Ridge
-            # estimator where the cuml implementation of Ridge uses a 2D coef_
-            # array with shape (c, n) whereas the sklearn Ridge uses a coef_
-            # array with shape (n,c).
-            if len(coef_arr.shape) == 2:
-                n_rows, n_features = X_arr.shape[0], X_arr.shape[1]
-                if coef_arr.shape[0] != n_features and coef_arr.shape[1] == n_features:
-                    coef_arr = coef_arr.T  # transpose
 
             preds_arr = X_arr @ coef_arr + intercept_
             return preds_arr

--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -93,10 +93,7 @@ class LinearPredictMixin:
         if isinstance(self.intercept_, (int, float, np.number)):
             intercept_ = self.intercept_
         else:
-            intercept_ = CumlArray.from_input(
-                self.intercept_,
-                convert_to_dtype=self.dtype if isinstance(self.intercept_, float) else False
-            ).to_output('array')
+            intercept_ = CumlArray.from_input(self.intercept_).to_output('array')
 
         preds_arr = X_arr @ coef_arr.T + intercept_
         return preds_arr

--- a/python/cuml/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/cuml/linear_model/elastic_net.pyx
@@ -262,17 +262,18 @@ class ElasticNet(UniversalBase,
 
         """
         X_m, _, self.n_features_in_, self.dtype = input_to_cuml_array(X)
+        y_m, _, _, _ = input_to_cuml_array(y)
         if hasattr(X_m, 'index'):
             self.feature_names_in_ = X_m.index
 
         # Check for multi-target regression
-        if (self.solver in ['cd', 'qn']) and y.ndim > 1 and y.shape[1] > 1:
+        if (self.solver in ['cd', 'qn']) and y_m.ndim > 1 and y_m.shape[1] > 1:
             raise ValueError(
                 f"The {self.solver} solver does not support "
                 "multi-target regression."
             )
 
-        self.solver_model.fit(X_m, y, convert_dtype=convert_dtype,
+        self.solver_model.fit(X_m, y_m, convert_dtype=convert_dtype,
                               sample_weight=sample_weight)
         if isinstance(self.solver_model, QN):
             coefs = self.solver_model.coef_

--- a/python/cuml/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/cuml/linear_model/elastic_net.pyx
@@ -264,6 +264,13 @@ class ElasticNet(UniversalBase,
         if hasattr(X, 'index'):
             self.feature_names_in_ = X.index
 
+        # Check for multi-target regression
+        if (self.solver in ['cd', 'qn']) and y.ndim > 1 and y.shape[1] > 1:
+            raise ValueError(
+                f"The {self.solver} solver does not support "
+                "multi-target regression."
+            )
+
         self.solver_model.fit(X, y, convert_dtype=convert_dtype,
                               sample_weight=sample_weight)
         if isinstance(self.solver_model, QN):

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -122,6 +122,8 @@ def fit_multi_target(X, y, fit_intercept=True, sample_weight=None):
     params = vh.T @ divide_non_zero(u.T @ y_arr, s[:, None])
 
     coef = params[:-1] if fit_intercept else params
+    # Transpose coef to match scikit-learn's shape (n_targets, n_features)
+    coef = coef.T
     intercept = params[-1] if fit_intercept else None
 
     return (
@@ -464,8 +466,8 @@ class LinearRegression(LinearPredictMixin,
         self.coef_ = CumlArray.from_input(
             coef,
             check_dtype=self.dtype,
-            check_rows=self.n_features_in_,
-            check_cols=y_cols
+            check_rows=y_cols,
+            check_cols=self.n_features_in_
         )
         if self.fit_intercept:
             self.intercept_ = CumlArray.from_input(

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -388,9 +388,3 @@ class Ridge(UniversalBase,
             # Check if we have multiple targets or 2D array
             return len(y_m.shape) > 1
         return False
-
-    def cpu_to_gpu(self):
-        super().cpu_to_gpu()
-        intercept_ = getattr(self._cpu_model, 'intercept_', None)
-        if intercept_ is not None and isinstance(self.intercept_, float):
-            setattr(self, 'intercept_', intercept_)

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -378,6 +378,13 @@ class Ridge(UniversalBase,
     def get_attr_names(self):
         return ['intercept_', 'coef_', 'n_features_in_', 'feature_names_in_']
 
+    def cpu_to_gpu(self):
+        """Transfer attributes from CPU estimator to GPU estimator."""
+        super().cpu_to_gpu()
+        # Special handling for coef_ to match cuML's shape (c, n) vs sklearn's (n, c)
+        if hasattr(self, 'coef_') and len(self.coef_.shape) == 2:
+            self.coef_ = self.coef_.T
+
     def _should_dispatch_cpu(self, func_name, *args, **kwargs):
         """
         Dispatch fit() function to CPU implementation for multi-target regression.

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -379,51 +379,32 @@ class Ridge(UniversalBase,
     def get_attr_names(self):
         return ['intercept_', 'coef_', 'n_features_in_', 'feature_names_in_']
 
-    @generate_docstring(return_values={'name': 'preds',
-                                       'type': 'dense',
-                                       'description': 'Predicted values',
-                                       'shape': '(n_samples, 1)'})
-    @api_base_return_array_skipall
-    @enable_device_interop
-    def predict(self, X, convert_dtype=True) -> CumlArray:
-        """
-        Predicts `y` values for `X`.
-        """
-        if self.coef_ is None:
-            raise ValueError(
-                "LinearModel.predict() cannot be called before fit(). "
-                "Please fit the model first."
-            )
+    def _predict_multi_target(self, X, convert_dtype=True) -> CumlArray:
 
-        # Set dtype from coef_ as done in base class
-        self.dtype = self.coef_.dtype
-
-        # Only handle multi-target case here, let super() handle single-target
-        if len(self.coef_.shape) == 2 and self.coef_.shape[0] > 1:
-            coef_arr = CumlArray.from_input(self.coef_).to_output('array')
-            X_arr = CumlArray.from_input(
-                X,
-                check_dtype=self.dtype,
-                convert_to_dtype=(self.dtype if convert_dtype else None),
-                check_cols=self.n_features_in_
+        """
+        Predict for multi-target case.
+        """
+        coef_arr = CumlArray.from_input(self.coef_).to_output('array')
+        X_arr = CumlArray.from_input(
+            X,
+            check_dtype=self.dtype,
+            convert_to_dtype=(self.dtype if convert_dtype else None),
+            check_cols=self.n_features_in_
+        ).to_output('array')
+        if isinstance(self.intercept_, (int, float, np.number)):
+            intercept_ = self.intercept_
+        else:
+            intercept_ = CumlArray.from_input(
+                self.intercept_,
+                convert_to_dtype=self.dtype if isinstance(self.intercept_, float) else False
             ).to_output('array')
-            if isinstance(self.intercept_, (int, float, np.number)):
-                intercept_ = self.intercept_
-            else:
-                intercept_ = CumlArray.from_input(
-                    self.intercept_,
-                    convert_to_dtype=self.dtype if isinstance(self.intercept_, float) else False
-                ).to_output('array')
 
-            # For multi-target, we need to transpose coef_ for matrix multiplication
-            # X: (n_samples, n_features)
-            # coef_: (n_targets, n_features)
-            # We want: (n_samples, n_targets)
-            preds_arr = X_arr @ coef_arr.T + intercept_
-            return preds_arr
-
-        # Let super() handle single-target case
-        return super().predict(X, convert_dtype)
+        # For multi-target, we need to transpose coef_ for matrix multiplication
+        # X: (n_samples, n_features)
+        # coef_: (n_targets, n_features)
+        # We want: (n_samples, n_targets)
+        preds_arr = X_arr @ coef_arr.T + intercept_
+        return preds_arr
 
     def _should_dispatch_cpu(self, func_name, *args, **kwargs):
         """

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -385,7 +385,7 @@ class Ridge(UniversalBase,
         2. For fit-related functions only (fit, fit_transform, fit_predict)
         """
         if func_name == "fit" and len(args) > 1:
-            y_m, _, _, _ = input_to_cuml_array(args[1])
+            y_m, _, _, _ = input_to_cuml_array(args[1], convert_to_mem_type=False)
 
             # Check if we have multiple targets or 2D array
             return len(y_m.shape) > 1

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -380,9 +380,7 @@ class Ridge(UniversalBase,
 
     def _should_dispatch_cpu(self, func_name, *args, **kwargs):
         """
-        Dispatch to CPU implementation when:
-        1. Multi-target regression is detected (y has more than 1 column or is 2D)
-        2. For fit-related functions only (fit, fit_transform, fit_predict)
+        Dispatch fit() function to CPU implementation for multi-target regression.
         """
         if func_name == "fit" and len(args) > 1:
             y_m, _, _, _ = input_to_cuml_array(args[1], convert_to_mem_type=False)


### PR DESCRIPTION
- Update base linear model prediction to handle multi-target scenarios
- Improve handling of intercept for multi-target predictions
- Add CPU dispatch method for Ridge regression with multi-target support

---

21b2894e270e800a1cf486c06ed098a6afa8586a..86afee12556df12d12bdb7ffd6760b598d1be89d

## Test Summaries

|Metric|Baseline|Current|
|------|--------|--------|
|total|1845|1845|
|failures|318|278|
|errors|0|0|
|skipped|140|140|
|time|56.615|52.674|

<details>
<summary> Tests that failed in baseline but passed in current </summary>

```
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-8-asarray-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-8-asarray-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-8-csr_array-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-8-csr_matrix-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-20-csr_matrix-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-8-csr_matrix-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-20-csr_array-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-8-csr_matrix-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-8-asarray-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-20-csr_array-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-20-asarray-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-8-csr_matrix-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-8-csr_matrix-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-8-csr_array-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-20-csr_matrix-eigen]
linear_model.tests.test_ridge.test_ridge_intercept
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-20-asarray-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-20-csr_array-eigen]
tests.test_kernel_ridge.test_kernel_ridge_multi_output
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-8-csr_array-svd]
linear_model.tests.test_ridge.test_dense_sparse[csr_matrix-_test_multi_ridge_diabetes]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-20-csr_array-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-8-csr_matrix-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-20-csr_array-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-8-csr_array-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-20-csr_matrix-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-20-csr_matrix-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-20-asarray-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-20-csr_matrix-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-8-asarray-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-20-csr_matrix-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-8-asarray-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-20-asarray-svd]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-20-csr_array-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-20-asarray-svd]
linear_model.tests.test_ridge.test_dense_sparse[csr_array-_test_multi_ridge_diabetes]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-20-asarray-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape1-True-20.0-8-csr_array-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape3-False-30.0-8-asarray-eigen]
linear_model.tests.test_ridge.test_ridge_gcv_sample_weights[y_shape2-True-150.0-8-csr_array-eigen]
```
</details>

## Summary
|Category|Count|
|--------|-----|
|Regressions|0|
|Fixes|40|
|Skip Changes|0|
|Added Tests|0|
|Removed Tests|0|
