### PR TITLE
Fix forwarding of `initial_alpha` and `learning_rate` in UMAP

### DIFF
--- a/python/cuml/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/cuml/manifold/simpl_set.pyx
@@ -329,7 +329,8 @@ def simplicial_set_embedding(
 
     cdef UMAPParams* umap_params = new UMAPParams()
     umap_params.n_components = <int> n_components
-    umap_params.initial_alpha = <int> initial_alpha
+    umap_params.initial_alpha = <float> initial_alpha
+    umap_params.learning_rate = <float> initial_alpha
     umap_params.a = <float> a
     umap_params.b = <float> b
 

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -473,6 +473,7 @@ class UMAP(UniversalBase,
             umap_params.n_components = <int> self.n_components
             umap_params.n_epochs = <int> self.n_epochs if self.n_epochs else 0
             umap_params.learning_rate = <float> self.learning_rate
+            umap_params.initial_alpha = <float> self.learning_rate
             umap_params.min_dist = <float> self.min_dist
             umap_params.spread = <float> self.spread
             umap_params.set_op_mix_ratio = <float> self.set_op_mix_ratio


### PR DESCRIPTION
Previously these parameters weren't fully forwarded properly to `libcuml`.

Split out from #6316 (thanks Victor!)