### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,7 @@ coverage:
   status:
     project: off
     patch: off
-comment:
-  behavior: new
+comment: false
 
 # Suggested workaround to fix "missing base report" issue when using Squash and
 # Merge Strategy in GitHub. See this comment from CodeCov support about this


### PR DESCRIPTION
The comments aren't that useful or actionable, and the prior behavior would clutter up my email inbox. Better to just disable them, we're mostly using codecov as an aggregator and UI for viewing coverage reports anyway.