### PR TITLE
declare runtime dependency on 'packaging', update scikit-learn and hdbscan for cuml-cpu to match cuml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
             pass_filenames: false
             language: python
     - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v0.5.0
+      rev: v0.6.0
       hooks:
         - id: verify-copyright
           files: |
@@ -83,7 +83,7 @@ repos:
         - id: verify-codeowners
           args: [--fix, --project-prefix=cuml]
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.17.0
+      rev: v1.17.1
       hooks:
           - id: rapids-dependency-file-generator
             args: ["--clean"]

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -30,10 +30,10 @@ RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
 
 sccache --show-adv-stats
 
-# Build cuml-cpu only in CUDA 11 jobs since it only depends on python
+# Build cuml-cpu only in CUDA 12 jobs since it only depends on python
 # version
 RAPIDS_CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
-if [[ ${RAPIDS_CUDA_MAJOR} == "11" ]]; then
+if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
   sccache --zero-stats
 
   RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \

--- a/conda/recipes/cuml-cpu/meta.yaml
+++ b/conda/recipes/cuml-cpu/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v')  + environ.get('VERSION_SUFFIX', '') %}
 {% set py_version = environ['CONDA_PY'] %}
@@ -33,8 +33,9 @@ requirements:
     - python x.x
     - numpy>=1.23,<3.0a0
     - pandas
-    - scikit-learn=1.2
-    - hdbscan>=0.8.38,<0.8.39
+    - packaging
+    - scikit-learn=1.5.*
+    - hdbscan>=0.8.39,<0.8.40
     - umap-learn=0.5.6
     - nvtx
 

--- a/conda/recipes/cuml-cpu/meta.yaml
+++ b/conda/recipes/cuml-cpu/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - numpy>=1.23,<3.0a0
     - pandas
     - packaging
-    - scikit-learn=1.5.*
+    - scikit-learn==1.5.*
     - hdbscan>=0.8.39,<0.8.40
     - umap-learn=0.5.6
     - nvtx

--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -88,6 +88,7 @@ requirements:
     - libcuml ={{ version }}
     - libcumlprims ={{ minor_version }}
     - numpy >=1.23,<3.0a0
+    - packaging
     - pylibraft ={{ minor_version }}
     - python x.x
     - raft-dask ={{ minor_version }}
@@ -95,7 +96,7 @@ requirements:
     - treelite {{ treelite_version }}
     - rapids-logger =0.1
 
-tests:
+test:
   requirements:
     - cuda-version ={{ cuda_version }}
   imports:


### PR DESCRIPTION
Contributes to #6403

#6400 is held up on some difficult issues and might take a while. This pulls out some other fixes / improvements from it which are non-controversial and which we should try to get into 25.04.

* adds missing runtime dependency on `packaging`
* updates `scikit-learn` and `hdbscan` dependencies for `cuml-cpu` to match `cuml`
* minor updates to build scripts (new versions of RAPIDS pre-commit hooks, building `cuml-cpu` only on CUDA 12 CI jobs)