### PR TITLE
Support positional args in `cuml.accel` estimators

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -14,7 +14,6 @@ from ....thirdparty_adapters import check_array
 from ..utils.validation import check_is_fitted
 from ..utils.skl_dependencies import TransformerMixin, BaseComposition, \
     BaseEstimator
-from cuml.internals import _deprecate_pos_args
 from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.global_settings import _global_settings_data
 import cuml
@@ -554,9 +553,9 @@ class ColumnTransformer(TransformerMixin, BaseComposition, BaseEstimator):
     """
     _required_parameters = ['transformers']
 
-    @_deprecate_pos_args(version="0.20")
     def __init__(self,
                  transformers=None,
+                 *,
                  remainder='drop',
                  sparse_threshold=0.3,
                  n_jobs=None,

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -29,7 +29,6 @@
 # limitations under the License.
 
 from ....internals.memory_utils import using_output_type
-from ....internals import _deprecate_pos_args
 from ....internals import api_return_generic
 from ....common.array_descriptor import CumlArrayDescriptor
 from ....internals.array_sparse import SparseCumlArray
@@ -103,7 +102,6 @@ def _handle_zeros_in_scale(scale, copy=True):
         return scale
 
 
-@_deprecate_pos_args(version="21.06")
 @api_return_generic(get_output_type=True)
 def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
     """Standardize a dataset along any axis
@@ -305,7 +303,6 @@ class MinMaxScaler(TransformerMixin,
     data_max_ = CumlArrayDescriptor()
     data_range_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, feature_range=(0, 1), *, copy=True):
         self.feature_range = feature_range
         self.copy = copy
@@ -451,7 +448,6 @@ class MinMaxScaler(TransformerMixin,
         return X
 
 
-@_deprecate_pos_args(version="21.06")
 @api_return_generic(get_output_type=True)
 def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     """Transform features by scaling each feature to a given range.
@@ -632,7 +628,6 @@ class StandardScaler(TransformerMixin,
     mean_ = CumlArrayDescriptor()
     var_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, copy=True, with_mean=True, with_std=True):
         self.with_mean = with_mean
         self.with_std = with_std
@@ -940,7 +935,6 @@ class MaxAbsScaler(TransformerMixin,
     n_samples_seen_ = CumlArrayDescriptor()
     max_abs_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, copy=True):
         self.copy = copy
 
@@ -1063,7 +1057,6 @@ class MaxAbsScaler(TransformerMixin,
         return X
 
 
-@_deprecate_pos_args(version="21.06")
 @api_return_generic(get_output_type=True)
 def maxabs_scale(X, *, axis=0, copy=True):
     """Scale each feature to the [-1, 1] range without breaking the sparsity.
@@ -1200,7 +1193,6 @@ class RobustScaler(TransformerMixin,
     center_ = CumlArrayDescriptor()
     scale_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, with_centering=True, with_scaling=True,
                  quantile_range=(25.0, 75.0), copy=True):
         self.with_centering = with_centering
@@ -1327,7 +1319,6 @@ class RobustScaler(TransformerMixin,
         return X
 
 
-@_deprecate_pos_args(version="21.06")
 @api_return_generic(get_output_type=True)
 def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
                  quantile_range=(25.0, 75.0), copy=True):
@@ -1474,7 +1465,6 @@ class PolynomialFeatures(TransformerMixin,
     exponentially in the degree. High degrees can cause overfitting.
     """
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, degree=2, *, interaction_only=False, include_bias=True,
                  order='C'):
         self.degree = degree
@@ -1689,7 +1679,6 @@ class PolynomialFeatures(TransformerMixin,
         return XP  # TODO keep order
 
 
-@_deprecate_pos_args(version="21.06")
 @api_return_generic(get_output_type=True)
 def normalize(X, norm='l2', *, axis=1, copy=True, return_norm=False):
     """Scale input vectors individually to unit norm (vector length).
@@ -1837,7 +1826,6 @@ class Normalizer(TransformerMixin,
     normalize: Equivalent function without the estimator API.
     """
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, norm='l2', *, copy=True):
         self.norm = norm
         self.copy = copy
@@ -1871,7 +1859,6 @@ class Normalizer(TransformerMixin,
         return normalize(X, norm=self.norm, axis=1, copy=copy)
 
 
-@_deprecate_pos_args(version="21.06")
 @api_return_generic(get_output_type=True)
 def binarize(X, *, threshold=0.0, copy=True):
     """Boolean thresholding of array-like or sparse matrix
@@ -1968,7 +1955,6 @@ class Binarizer(TransformerMixin,
     binarize: Equivalent function without the estimator API.
     """
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, threshold=0.0, copy=True):
         self.threshold = threshold
         self.copy = copy
@@ -2267,7 +2253,6 @@ class QuantileTransformer(TransformerMixin,
     quantiles_ = CumlArrayDescriptor()
     references_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, n_quantiles=1000, output_distribution='uniform',
                  ignore_implicit_zeros=False, subsample=int(1e5),
                  random_state=None, copy=True):
@@ -2606,7 +2591,6 @@ class QuantileTransformer(TransformerMixin,
         return self._transform(X, inverse=True)
 
 
-@_deprecate_pos_args(version="21.06")
 def quantile_transform(X, *, axis=0, n_quantiles=1000,
                        output_distribution='uniform',
                        ignore_implicit_zeros=False,
@@ -2797,7 +2781,6 @@ class PowerTransformer(TransformerMixin,
            of the Royal Statistical Society B, 26, 211-252 (1964).
 
     """
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, method='yeo-johnson', *, standardize=True, copy=True):
         self.method = method
         self.standardize = standardize
@@ -3080,7 +3063,6 @@ class PowerTransformer(TransformerMixin,
         return X
 
 
-@_deprecate_pos_args(version="21.06")
 def power_transform(X, method='yeo-johnson', *, standardize=True, copy=True):
     """
     Power transforms are a family of parametric, monotonic transformations

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -25,7 +25,6 @@
 # limitations under the License.
 #
 
-from ....internals import _deprecate_pos_args
 from ....internals.memory_utils import using_output_type
 from ....common.array_descriptor import CumlArrayDescriptor
 from ....internals.array_sparse import SparseCumlArray
@@ -152,7 +151,6 @@ class KBinsDiscretizer(TransformerMixin,
     bin_edges_internal_ = CumlArrayDescriptor()
     n_bins_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, n_bins=5, *, encode='onehot', strategy='quantile'):
         self.n_bins = n_bins
         self.encode = encode

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -12,7 +12,6 @@ import cuml
 from ....internals.array_sparse import SparseCumlArray
 from ..utils.skl_dependencies import TransformerMixin, BaseEstimator
 from ..utils.validation import _allclose_dense_sparse
-from ....internals import _deprecate_pos_args
 
 
 def _identity(X):
@@ -72,7 +71,6 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
            [1.0986..., 1.3862...]])
     """
 
-    @_deprecate_pos_args(version="0.20")
     def __init__(self, *, func=None, inverse_func=None, accept_sparse=False,
                  check_inverse=True, kw_args=None, inv_kw_args=None):
         self.func = func

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -10,7 +10,6 @@
 # Authors mentioned above do not endorse or promote this production.
 
 
-from ....internals import _deprecate_pos_args
 from ....common.array_descriptor import CumlArrayDescriptor
 from ....internals.array_sparse import SparseCumlArray
 from ..utils.validation import FLOAT_DTYPES
@@ -232,7 +231,6 @@ class SimpleImputer(_BaseImputer, BaseEstimator,
 
     statistics_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, missing_values=np.nan, strategy="mean",
                  fill_value=None, copy=True, add_indicator=False):
         super().__init__(
@@ -537,7 +535,6 @@ class MissingIndicator(TransformerMixin,
     """
     features_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, *, missing_values=np.nan, features="missing-only",
                  sparse="auto", error_on_new=True):
         self.missing_values = missing_values

--- a/python/cuml/cuml/internals/__init__.py
+++ b/python/cuml/cuml/internals/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 from cuml.internals.available_devices import is_cuda_available
 from cuml.internals.base_helpers import BaseMetaClass, _tags_class_and_instance
 from cuml.internals.api_decorators import (
-    _deprecate_pos_args,
     api_base_fit_transform,
     api_base_return_any_skipall,
     api_base_return_any,

--- a/python/cuml/cuml/multiclass/multiclass.py
+++ b/python/cuml/cuml/multiclass/multiclass.py
@@ -24,7 +24,6 @@ from cuml.common import (
     input_to_host_array,
     input_to_host_array_with_sparse_support,
 )
-from cuml.internals import _deprecate_pos_args
 
 
 class MulticlassClassifier(Base, ClassifierMixin):
@@ -55,8 +54,8 @@ class MulticlassClassifier(Base, ClassifierMixin):
         ...                            random_state=137)
 
         >>> cls = MulticlassClassifier(LogisticRegression(), strategy='ovo')
-        >>> cls.fit(X,y)
-        MulticlassClassifier()
+        >>> cls.fit(X, y)
+        MulticlassClassifier(estimator=LogisticRegression())
         >>> cls.predict(X)
         array([1, 1, 1, 1, 1, 1, 2, 1, 1, 2])
 
@@ -92,7 +91,6 @@ class MulticlassClassifier(Base, ClassifierMixin):
 
     """
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(
         self,
         estimator,
@@ -216,8 +214,8 @@ class OneVsRestClassifier(MulticlassClassifier):
         ...                            random_state=137)
 
         >>> cls = OneVsRestClassifier(LogisticRegression())
-        >>> cls.fit(X,y)
-        OneVsRestClassifier()
+        >>> cls.fit(X, y)
+        OneVsRestClassifier(estimator=LogisticRegression())
         >>> cls.predict(X)
         array([1, 1, 1, 1, 1, 1, 2, 1, 1, 2])
 
@@ -243,7 +241,6 @@ class OneVsRestClassifier(MulticlassClassifier):
         :ref:`output-data-type-configuration` for more info.
     """
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(
         self, estimator, *args, handle=None, verbose=False, output_type=None
     ):
@@ -292,8 +289,8 @@ class OneVsOneClassifier(MulticlassClassifier):
         ...                            random_state=137)
 
         >>> cls = OneVsOneClassifier(LogisticRegression())
-        >>> cls.fit(X,y)
-        OneVsOneClassifier()
+        >>> cls.fit(X, y)
+        OneVsOneClassifier(estimator=LogisticRegression())
         >>> cls.predict(X)
         array([1, 1, 1, 1, 1, 1, 2, 1, 1, 2])
 
@@ -318,7 +315,6 @@ class OneVsOneClassifier(MulticlassClassifier):
         :ref:`output-data-type-configuration` for more info.
     """
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(
         self, estimator, *args, handle=None, verbose=False, output_type=None
     ):

--- a/python/cuml/cuml/tests/accel/test_basic_estimators.py
+++ b/python/cuml/cuml/tests/accel/test_basic_estimators.py
@@ -221,3 +221,13 @@ def test_defaults_args_only_methods():
     nn = NearestNeighbors(metric="chebyshev", n_neighbors=3)
     nn.fit(X[:, 0].reshape((-1, 1)), y)
     nn.kneighbors()
+
+
+def test_positional_arg_estimators_work():
+    """Some sklearn estimators take positional args, check that these
+    are handled properly"""
+    pca = PCA(42)
+    assert pca.n_components == 42
+
+    svd = TruncatedSVD(42)
+    assert svd.n_components == 42

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 import cuml.internals.logger as logger
 from cuml.common import has_scipy
 from cuml.internals.input_utils import input_to_cuml_array
-from cuml.internals import _deprecate_pos_args
 
 
 cdef extern from "cuml/tsa/arima_common.h" namespace "ML":
@@ -307,7 +306,6 @@ class ARIMA(Base):
     sma_ = CumlArrayDescriptor()
     sigma2_ = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self,
                  endog,
                  *,

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ from cuml.internals import logger
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals import _deprecate_pos_args
 from pylibraft.common.handle cimport handle_t
 from pylibraft.common.handle import Handle
 from cuml.common import input_to_cuml_array
@@ -184,7 +183,6 @@ class AutoARIMA(Base):
 
     d_y = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self,
                  endog,
                  *,

--- a/python/cuml/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/cuml/tsa/holtwinters.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ from libc.stdint cimport uintptr_t
 
 import cuml.internals
 from cuml.internals.input_utils import input_to_cupy_array
-from cuml.internals import _deprecate_pos_args
 from cuml.common import using_output_type
 from cuml.internals.base import Base
 from cuml.internals.array import CumlArray
@@ -122,9 +121,7 @@ class ExponentialSmoothing(Base):
         ...                     3, 4, 5, 6, 7, 8, 9,
         ...                     10, 11, 12, 13, 14],
         ...                     dtype=cp.float64)
-        >>> cu_hw = ExponentialSmoothing(data, seasonal_periods=12)
-        >>> cu_hw.fit()
-        ExponentialSmoothing()
+        >>> cu_hw = ExponentialSmoothing(data, seasonal_periods=12).fit()
         >>> cu_pred = cu_hw.forecast(4)
         >>> print('Forecasted points:', cu_pred) # doctest: +SKIP
         Forecasted points :
@@ -183,7 +180,6 @@ class ExponentialSmoothing(Base):
     season = CumlArrayDescriptor()
     SSE = CumlArrayDescriptor()
 
-    @_deprecate_pos_args(version="21.06")
     def __init__(self, endog, *, seasonal="additive",
                  seasonal_periods=2, start_periods=2,
                  ts_num=1, eps=2.24e-3, handle=None,


### PR DESCRIPTION
Some `sklearn` estimators support _some_ positional arguments. Previously we weren't handling positional arguments at all in the proxy estimators, leading to incorrect translations or outright errors upon instantiation. This fixes that and adds a relevant test.

This issue was compounded by bugs in the previously added code for deprecating positional args in `cuml` estimators. Since this deprecation was added in 21.04 (almost 4 years ago), I've removed the deprecation warning and all related code. 4 years should be ample time for users to have upgraded :).