### PR TITLE
remove unused imports

### DIFF
--- a/python/cuml/.flake8
+++ b/python/cuml/.flake8
@@ -24,8 +24,6 @@ exclude =
 extend-ignore =
     # handled by black
     E501, W503, E203
-    # imported but unused
-    F401
     # redefinition of unused
     F811
 

--- a/python/cuml/cuml/benchmark/algorithms.py
+++ b/python/cuml/cuml/benchmark/algorithms.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,13 +54,13 @@ import cuml.metrics
 import cuml.decomposition
 import cuml.experimental
 import cuml.naive_bayes
-from cuml.dask import (
+from cuml.dask import (  # noqa: F401
     neighbors,
     cluster,
     manifold,
     decomposition,
     linear_model,
-)  # noqa: F401
+)
 from cuml.internals.import_utils import has_hdbscan, has_umap
 from cuml.internals.safe_imports import cpu_only_import
 

--- a/python/cuml/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/cuml/benchmark/bench_helper_funcs.py
@@ -125,7 +125,6 @@ def _training_data_to_numpy(X, y):
 
 def _build_fil_classifier(m, data, args, tmpdir):
     """Setup function for FIL classification benchmarking"""
-    from cuml.internals.import_utils import has_xgboost
 
     train_data, train_label = _training_data_to_numpy(data[0], data[1])
 
@@ -185,7 +184,6 @@ def _build_optimized_fil_classifier(m, data, args, tmpdir):
     """Setup function for FIL classification benchmarking with optimal
     parameters"""
     with using_device_type("gpu"):
-        from cuml.internals.import_utils import has_xgboost
 
         train_data, train_label = _training_data_to_numpy(data[0], data[1])
 
@@ -376,7 +374,6 @@ class GtilWrapper:
 
 def _build_gtil_classifier(m, data, args, tmpdir):
     """Setup function for treelite classification benchmarking"""
-    from cuml.internals.import_utils import has_xgboost
 
     max_depth = args["max_depth"]
     num_rounds = args["num_rounds"]

--- a/python/cuml/cuml/benchmark/datagen.py
+++ b/python/cuml/cuml/benchmark/datagen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ import cuml.datasets
 from cuml.internals.safe_imports import cpu_only_import
 import os
 import functools
-import gzip
 from cuml.internals.safe_imports import gpu_only_import
 
 cudf = gpu_only_import("cudf")

--- a/python/cuml/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/dask/linear_model/logistic_regression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,19 +13,13 @@
 # limitations under the License.
 #
 
-from cuml.dask.common.base import BaseEstimator
-from cuml.dask.common.base import DelayedPredictionMixin
 from cuml.dask.common.base import mnmg_import
-from cuml.dask.common.base import SyncFitMixinLinearModel
 from cuml.dask.linear_model import LinearRegression
 from raft_dask.common.comms import get_raft_comm_state
 from dask.distributed import get_worker
 
 from cuml.common.sparse_utils import is_sparse, has_scipy
-from cuml.dask.common import parts_to_ranks
-from cuml.dask.common.input_utils import DistributedDataHandler, concatenate
-from raft_dask.common.comms import Comms
-from cuml.dask.common.utils import wait_and_raise_from_futures
+from cuml.dask.common.input_utils import concatenate
 from cuml.internals.safe_imports import cpu_only_import
 from cuml.internals.safe_imports import gpu_only_import
 

--- a/python/cuml/cuml/internals/array.py
+++ b/python/cuml/cuml/internals/array.py
@@ -16,7 +16,6 @@
 
 import copy
 import operator
-import pickle
 from typing import Tuple
 
 from cuml.internals.global_settings import GlobalSettings

--- a/python/cuml/cuml/internals/available_devices.py
+++ b/python/cuml/cuml/internals/available_devices.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from cuml.internals.device_support import GPU_ENABLED
-from cuml.internals.safe_imports import gpu_only_import_from, UnavailableError
+from cuml.internals.safe_imports import UnavailableError
 
 
 from functools import cache
@@ -26,7 +26,7 @@ def gpu_available_no_context_creation():
     creating a CUDA context. We check for CuPy presence as a proxy of that.
     """
     try:
-        import cupy
+        import cupy  # noqa: F401
 
         return True
     except ImportError:

--- a/python/cuml/cuml/internals/base_helpers.py
+++ b/python/cuml/cuml/internals/base_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 #
 
 from inspect import Parameter, signature
-import typing
 
 from cuml.internals.api_decorators import (
     api_base_return_generic,
@@ -25,8 +24,6 @@ from cuml.internals.api_decorators import (
     api_return_any,
     _deprecate_pos_args,
 )
-from cuml.internals.array import CumlArray
-from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.base_return_types import _get_base_return_type
 from cuml.internals.constants import CUML_WRAPPED_FLAG
 

--- a/python/cuml/cuml/internals/safe_imports.py
+++ b/python/cuml/cuml/internals/safe_imports.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,13 +17,11 @@
 
 import importlib
 import traceback
-import warnings
 
 from contextlib import contextmanager
 from cuml.internals.device_support import (
     CPU_ENABLED,
     GPU_ENABLED,
-    MIN_SKLEARN_VERSION,
     MIN_SKLEARN_PRESENT,
 )
 from cuml.internals import logger

--- a/python/cuml/cuml/model_selection/_split.py
+++ b/python/cuml/cuml/model_selection/_split.py
@@ -21,7 +21,6 @@ from cuml.internals.input_utils import (
     determine_df_obj_type,
 )
 from cuml.internals.output_utils import output_to_df_obj_like
-from cuml.internals.mem_type import MemoryType
 from cuml.internals.array import array_to_memory_order, CumlArray
 from cuml.internals.safe_imports import (
     cpu_only_import,

--- a/python/cuml/cuml/multiclass/multiclass.py
+++ b/python/cuml/cuml/multiclass/multiclass.py
@@ -24,11 +24,6 @@ from cuml.common import (
     input_to_host_array,
     input_to_host_array_with_sparse_support,
 )
-from cuml.internals.input_utils import (
-    input_to_cupy_array,
-    determine_array_type_full,
-)
-from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals import _deprecate_pos_args
 
 

--- a/python/cuml/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/cuml/preprocessing/LabelEncoder.py
@@ -18,10 +18,8 @@ from typing import TYPE_CHECKING
 
 from cuml import Base
 from cuml._thirdparty.sklearn.utils.validation import check_is_fitted
-from cuml.common.exceptions import NotFittedError
 from cuml.internals.safe_imports import (
     cpu_only_import,
-    cpu_only_import_from,
     gpu_only_import,
 )
 

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import warnings
-from typing import List, Optional, TypeVar
+from typing import Optional
 
 import cuml.internals.logger as logger
 from cudf import DataFrame, Series

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_elastic_net.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_elastic_net.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 from sklearn.datasets import make_regression
 from sklearn.linear_model import ElasticNet
-from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.metrics import r2_score
 from sklearn.preprocessing import StandardScaler
 
 

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_hdbscan_extended.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_hdbscan_extended.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 import pytest
 import numpy as np
-from sklearn.datasets import make_blobs, make_moons
+from sklearn.datasets import make_blobs
 from sklearn.preprocessing import StandardScaler
 import hdbscan
 from hdbscan import validity

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_linear_regression.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_linear_regression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ import pytest
 import numpy as np
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
-from sklearn.metrics import r2_score
 
 
 @pytest.fixture(scope="module")

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_logistic_regression.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_logistic_regression.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 #
 
 import pytest
-import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_rf_regressor.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_rf_regressor.py
@@ -15,7 +15,6 @@
 #
 
 import pytest
-import numpy as np
 from sklearn.datasets import make_regression
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import r2_score

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_ridge.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_ridge.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import pytest
 import numpy as np
 from sklearn.datasets import make_regression
 from sklearn.linear_model import Ridge
-from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.metrics import r2_score
 from sklearn.preprocessing import StandardScaler
 
 

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_tsvd.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_tsvd.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import pytest
 import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.decomposition import TruncatedSVD
-from sklearn.preprocessing import StandardScaler
 from scipy.sparse import csr_matrix
 
 

--- a/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_umap.py
+++ b/python/cuml/cuml/tests/accel/estimators_hyperparams/test_accel_umap.py
@@ -15,7 +15,6 @@
 #
 
 import pytest
-import numpy as np
 from sklearn.datasets import make_swiss_roll
 from umap import UMAP
 from sklearn.manifold import trustworthiness

--- a/python/cuml/cuml/tests/accel/test_basic_estimators.py
+++ b/python/cuml/cuml/tests/accel/test_basic_estimators.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import numpy as np
-from sklearn import clone, cluster
-import cuml
-from cuml.internals.global_settings import GlobalSettings
+from sklearn import clone
+import cuml  # noqa: F401
+from cuml.internals.global_settings import GlobalSettings  # noqa: F401
 from cuml.internals.safe_imports import gpu_only_import
 from sklearn.datasets import make_classification, make_regression, make_blobs
 from sklearn.linear_model import (
@@ -34,13 +33,6 @@ from sklearn.neighbors import (
     KNeighborsClassifier,
     KNeighborsRegressor,
 )
-from sklearn.metrics import (
-    mean_squared_error,
-    r2_score,
-    adjusted_rand_score,
-    accuracy_score,
-)
-from scipy.sparse import random as sparse_random
 
 cp = gpu_only_import("cupy")
 

--- a/python/cuml/cuml/tests/accel/test_pipeline.py
+++ b/python/cuml/cuml/tests/accel/test_pipeline.py
@@ -24,20 +24,15 @@ from sklearn.linear_model import (
     Ridge,
     Lasso,
 )
-from sklearn.manifold import TSNE
 from sklearn.neighbors import (
     NearestNeighbors,
     KNeighborsClassifier,
     KNeighborsRegressor,
 )
-from sklearn.preprocessing import Normalizer
 from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.datasets import make_classification, make_regression
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, mean_squared_error
 from umap import UMAP
-import hdbscan
-import numpy as np
 import scipy as sp
 
 

--- a/python/cuml/cuml/tests/accel/test_sparse_dispatch.py
+++ b/python/cuml/cuml/tests/accel/test_sparse_dispatch.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,8 +30,6 @@ from sklearn.linear_model import (
 )
 from sklearn.neighbors import (
     NearestNeighbors,
-    KNeighborsClassifier,
-    KNeighborsRegressor,
 )
 from sklearn.base import is_classifier, is_regressor
 from hdbscan import HDBSCAN

--- a/python/cuml/cuml/tests/dask/conftest.py
+++ b/python/cuml/cuml/tests/dask/conftest.py
@@ -1,11 +1,10 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 import certifi
 import pytest
 from ssl import create_default_context
 from urllib.request import build_opener, HTTPSHandler, install_opener
 
-from dask_cuda import initialize
 from dask_cuda import LocalCUDACluster
 from dask_cuda.utils_test import IncreasedCloseTimeoutNanny
 from dask.distributed import Client

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -17,13 +17,13 @@ from cuml.internals.safe_imports import gpu_only_import
 import pytest
 from cuml.dask.common import utils as dask_utils
 from functools import partial
-from sklearn.metrics import accuracy_score, mean_squared_error
+from sklearn.metrics import accuracy_score
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression as skLR
 from cuml.internals.safe_imports import cpu_only_import
 from cuml.internals import logger
 from cuml.testing.utils import array_equal
-from scipy.sparse import csr_matrix, load_npz, save_npz
+from scipy.sparse import csr_matrix
 import random
 
 random.seed(0)

--- a/python/cuml/cuml/tests/test_compose.py
+++ b/python/cuml/cuml/tests/test_compose.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,10 +44,10 @@ import pytest
 
 from cuml.internals.safe_imports import gpu_only_import
 
-from cuml.testing.test_preproc_utils import (
+from cuml.testing.test_preproc_utils import (  # noqa: F401
     clf_dataset,
     sparse_clf_dataset,
-)  # noqa: F401
+)
 
 cudf = gpu_only_import("cudf")
 np = cpu_only_import("numpy")

--- a/python/cuml/cuml/tests/test_exceptions.py
+++ b/python/cuml/cuml/tests/test_exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@ import numpy as np
 from scipy.sparse import csr_matrix
 from cuml.cluster import KMeans, DBSCAN
 from cuml.decomposition import TruncatedSVD
-from cuml.kernel_ridge import KernelRidge
-from cuml.linear_model import (
+from cuml.kernel_ridge import KernelRidge  # noqa: F401
+from cuml.linear_model import (  # noqa: F401
     LinearRegression,
     LogisticRegression,
     ElasticNet,
     Ridge,
     Lasso,
 )
-from cuml.neighbors import (
+from cuml.neighbors import (  # noqa: F401
     NearestNeighbors,
     KNeighborsClassifier,
     KNeighborsRegressor,

--- a/python/cuml/cuml/tests/test_input_estimators.py
+++ b/python/cuml/cuml/tests/test_input_estimators.py
@@ -22,7 +22,6 @@ from cuml.datasets import make_regression
 from cuml.model_selection import train_test_split
 from cuml.testing.utils import (
     ClassEnumerator,
-    get_classes_from_package,
 )
 from functools import lru_cache
 

--- a/python/cuml/cuml/tests/test_internals_api.py
+++ b/python/cuml/cuml/tests/test_internals_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import pickle
 
 from cuml.internals import GraphBasedDimRedCallback

--- a/python/cuml/cuml/tests/test_linear_model.py
+++ b/python/cuml/cuml/tests/test_linear_model.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from contextlib import nullcontext
 from functools import lru_cache
 
 from packaging.version import Version

--- a/python/cuml/cuml/tests/test_nearest_neighbors.py
+++ b/python/cuml/cuml/tests/test_nearest_neighbors.py
@@ -38,7 +38,7 @@ from cuml.datasets import make_blobs
 from sklearn.metrics import pairwise_distances
 from cuml.metrics import pairwise_distances as cuPW
 
-from cuml.internals import logger
+from cuml.internals import logger  # noqa: F401
 
 from cuml.internals.safe_imports import gpu_only_import
 

--- a/python/cuml/cuml/tests/test_preprocessing.py
+++ b/python/cuml/cuml/tests/test_preprocessing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ from sklearn.impute import (
     SimpleImputer as skSimpleImputer,
 )
 
-from cuml.testing.test_preproc_utils import (
+from cuml.testing.test_preproc_utils import (  # noqa: F401
     clf_dataset,
     int_dataset,
     blobs_dataset,
@@ -87,7 +87,7 @@ from cuml.testing.test_preproc_utils import (
     sparse_int_dataset,
     sparse_imputer_dataset,
     sparse_dataset_with_coo,
-)  # noqa: F401
+)
 from cuml.testing.test_preproc_utils import assert_allclose
 from cuml.metrics import pairwise_kernels
 

--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -34,7 +34,7 @@ from numpy.testing import assert_allclose
 
 from sklearn.datasets import make_blobs, make_classification, make_regression
 from sklearn.utils.validation import check_is_fitted
-from sklearn.cluster import KMeans as SkKMeans, DBSCAN as SkDBSCAN
+from sklearn.cluster import KMeans as SkKMeans
 from sklearn.decomposition import PCA as SkPCA, TruncatedSVD as SkTruncatedSVD
 from sklearn.linear_model import (
     LinearRegression as SkLinearRegression,
@@ -43,8 +43,6 @@ from sklearn.linear_model import (
     Ridge as SkRidge,
     Lasso as SkLasso,
 )
-from sklearn.manifold import TSNE as SkTSNE
-from sklearn.neighbors import NearestNeighbors as SkNearestNeighbors
 
 ###############################################################################
 #                              Helper functions                               #
@@ -82,8 +80,6 @@ def assert_estimator_roundtrip(
 
     # Convert back
     roundtrip_model = type(cuml_model).from_sklearn(sklearn_model)
-
-    from pprint import pprint
 
     rm_params = roundtrip_model.get_params()
 


### PR DESCRIPTION
Contributes to #6403

While working on that, my IDE highlighted a few unused imports. Looked into that a bit and saw that this project is currently configured to ignore `flake8`'s warnings about unused imports:

https://github.com/rapidsai/cuml/blob/c5c0656694d01d654e06c5a3d898004a81c4eeb6/python/cuml/.flake8#L27-L28

I went back to the PR that introduced that (#4983) and didn't see any discussion that made me think that was the intended long-term state.

This proposes:

* enforcing `flake8`'s unused imports check
* removing unused imports

## Notes for Reviewers

### Benefits of these changes

* faster imports
* reduced exposure to changes in dependencies
* reduced effort required to identify and remove dead code
* reduced risk of import issue in alternative builds of the package (like #6403)

### Approach I took

Removed `F401` exclusion from `.flake8`, then ran

```shell
pre-commit run --all-files
```

Manually went through the suggestions and looked at the usage.

For library code:

* added `# noqa: F401` for imports that looked like they were intentional (e.g. for their side effects)
* removed anything that looked unused

For test code:

* preserved any unused imports from `cuml` itself, via `#noqa` comments
  - *just importing from a model gives you some minimal test coverage of it, I didn't want to accidentally remove any of that*
* removed anything else that looked unused
