### PR TITLE
Remove old deprecations

### DIFF
--- a/python/cuml/cuml/experimental/fil/fil.pyx
+++ b/python/cuml/cuml/experimental/fil/fil.pyx
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import functools
 import itertools
 import numpy as np
 import pathlib
 import treelite.sklearn
-import warnings
 from libcpp cimport bool
 from libc.stdint cimport uint32_t, uintptr_t
 
@@ -337,55 +335,6 @@ class _AutoIterations:
         return result
 
 
-def _handle_legacy_fil_args(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if kwargs.get('threshold', None) is not None:
-            raise FutureWarning(
-                'Parameter "threshold" has been deprecated.'
-                ' To use a threshold for binary classification, pass'
-                ' the "threshold" keyword directly to the predict method.'
-            )
-        if kwargs.get('algo', None) is not None:
-            warnings.warn(
-                'Parameter "algo" has been deprecated. Its use is no longer'
-                ' necessary to achieve optimal performance with FIL.',
-                FutureWarning
-            )
-        if kwargs.get('storage_type', None) is not None:
-            warnings.warn(
-                'Parameter "storage_type" has been deprecated. The correct'
-                ' storage type will be used automatically.',
-                FutureWarning
-            )
-        if kwargs.get('blocks_per_sm', None) is not None:
-            warnings.warn(
-                'Parameter "blocks_per_sm" has been deprecated. Its use is no'
-                ' longer necessary to achieve optimal performance with FIL.',
-                FutureWarning
-            )
-        if kwargs.get('threads_per_tree', None) is not None:
-            warnings.warn(
-                'Parameter "threads_per_tree" has been deprecated. Pass'
-                ' the "chunk_size" keyword argument to the predict method for'
-                ' equivalent functionality.',
-                FutureWarning
-            )
-        if kwargs.get('n_items', None) is not None:
-            warnings.warn(
-                'Parameter "n_items" has been deprecated. Its use is no'
-                ' longer necessary to achieve optimal performance with FIL.',
-                FutureWarning
-            )
-        if kwargs.get('compute_shape_str', None) is not None:
-            warnings.warn(
-                'Parameter "compute_shape_str" has been deprecated.',
-                FutureWarning
-            )
-        return func(*args, **kwargs)
-    return wrapper
-
-
 class ForestInference(UniversalBase, CMajorInputTagMixin):
     """
     ForestInference provides accelerated inference for forest models on both
@@ -560,27 +509,6 @@ class ForestInference(UniversalBase, CMajorInputTagMixin):
             self._reload_model()
 
     @property
-    def output_class(self):
-        warnings.warn(
-            '"output_class" has been renamed "is_classifier".'
-            ' Support for the old parameter name will be removed in an'
-            ' upcoming version.',
-            FutureWarning
-        )
-        return self.is_classifier
-
-    @output_class.setter
-    def output_class(self, value):
-        if value is not None:
-            warnings.warn(
-                '"output_class" has been renamed "is_classifier".'
-                ' Support for the old parameter name will be removed in an'
-                ' upcoming version.',
-                FutureWarning
-            )
-        self.is_classifier = value
-
-    @property
     def is_classifier(self):
         try:
             return self._is_classifier_
@@ -740,7 +668,6 @@ class ForestInference(UniversalBase, CMajorInputTagMixin):
         return self.forest.num_trees()
 
     @classmethod
-    @_handle_legacy_fil_args
     def load(
             cls,
             path,
@@ -878,7 +805,6 @@ class ForestInference(UniversalBase, CMajorInputTagMixin):
         )
 
     @classmethod
-    @_handle_legacy_fil_args
     def load_from_sklearn(
             cls,
             skl_model,

--- a/python/cuml/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/cuml/manifold/simpl_set.pyx
@@ -16,7 +16,6 @@
 
 # distutils: language = c++
 
-import warnings
 from cuml.internals.safe_imports import cpu_only_import
 np = cpu_only_import('numpy')
 from cuml.internals.safe_imports import gpu_only_import
@@ -229,7 +228,6 @@ def simplicial_set_embedding(
     metric_kwds=None,
     output_metric="euclidean",
     output_metric_kwds=None,
-    repulsion_strength=None,
     convert_dtype=True,
     verbose=False,
 ):
@@ -330,15 +328,6 @@ def simplicial_set_embedding(
     umap_params.learning_rate = <float> initial_alpha
     umap_params.a = <float> a
     umap_params.b = <float> b
-
-    if repulsion_strength:
-        gamma = repulsion_strength
-        warnings.simplefilter(action="always", category=FutureWarning)
-        warnings.warn('Parameter "repulsion_strength" has been'
-                      ' deprecated. It will be removed in version 24.12.'
-                      ' Please use the "gamma" parameter instead.',
-                      FutureWarning)
-
     umap_params.repulsion_strength = <float> gamma
     umap_params.negative_sample_rate = <int> negative_sample_rate
     umap_params.n_epochs = <int> n_epochs

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -359,9 +359,6 @@ class TSNE(UniversalBase,
             raise ValueError("post_momentum = {} should be more than "
                              "pre_momentum = {}".format(post_momentum,
                                                         pre_momentum))
-        if method == "fft":
-            warnings.warn("Starting from version 22.04, the default method "
-                          "of TSNE is 'fft'.")
 
         self.n_components = n_components
         self.perplexity = perplexity

--- a/python/cuml/cuml/metrics/regression.py
+++ b/python/cuml/cuml/metrics/regression.py
@@ -125,8 +125,8 @@ def r2_score(
     """
     if kwargs:
         warnings.warn(
-            "`convert_dtype` and `handle` were deprecated from `r2_score` and will "
-            "be removed in a future release.",
+            "`convert_dtype` and `handle` were deprecated from `r2_score` in version "
+            "25.02.01 and will be removed in 25.06.",
             FutureWarning,
         )
 

--- a/python/cuml/cuml/svm/svc.pyx
+++ b/python/cuml/cuml/svm/svc.pyx
@@ -591,10 +591,11 @@ class SVC(SVMBase,
         """
         if self.multiclass_strategy != "warn":
             self.decision_function_shape = self.multiclass_strategy
-            warnings.warn('Parameter "multiclass_strategy" has been'
-                          ' deprecated. Please use the'
-                          ' "decision_function_shape" parameter instead.',
-                          FutureWarning)
+            warnings.warn(
+                "`multiclass_strategy` was deprecated in 25.04 and will be "
+                "removed in 25.06. Please use `decision_function_shape` instead",
+                FutureWarning
+            )
 
         self.n_classes_ = self._get_num_classes(y)
 


### PR DESCRIPTION
This:
- Removes old deprecations, where the deprecation period has expired
- Cleans up a few active deprecation warnings to include the version at which the feature will be removed

After this PR (and #6423), all `FutureWarning`s raised by `cuml` include a version at which they will be removed, which makes grepping for things to remove pre-release easier.

Fixes #6410 (just noticed there was an active issue for this).