### PR TITLE
Expose using_device_type in base cuml namespace

### DIFF
--- a/python/cuml/cuml/__init__.py
+++ b/python/cuml/cuml/__init__.py
@@ -101,6 +101,7 @@ from cuml.internals.global_settings import (
     _global_settings_data,
 )
 
+from cuml.common.device_selection import using_device_type
 from cuml.internals.memory_utils import (
     set_global_output_type,
     using_output_type,
@@ -197,4 +198,5 @@ __all__ = [
     "make_classification",
     "make_regression",
     "stationarity",
+    "using_device_type",
 ]


### PR DESCRIPTION
Since we have generally exposed our public API directly under `cuml.some_function_or_class` rather than nesting it more deeply and `using_device_type` is a key piece of the public API, this PR ensures that `using_device_type` can be imported directly via `from cuml import using_device_type`.