### PR TITLE
Cleanup UMAP nn-descent parameter handling

### DIFF
--- a/cpp/include/cuml/manifold/umapparams.h
+++ b/cpp/include/cuml/manifold/umapparams.h
@@ -25,7 +25,35 @@
 
 namespace ML {
 
-using nn_index_params = raft::neighbors::experimental::nn_descent::index_params;
+struct nn_index_params {
+  /**
+   * Internally, nn-descent builds an all-neighbors knn graph of
+   * dimensions (N, intermediate_graph_degree) before selecting the final
+   * `n_neighbors` neighbors. It's recommended that
+   * `intermediate_graph_degree` >= 1.5 * n_neighbors. If 0, defaults
+   * to `1.5 * n_neighbors`.
+   */
+  size_t intermediate_graph_degree = 0;
+
+  /**
+   * The number of iterations that nn-descent will refine the graph for. More
+   * iterations produce a better quality graph at cost of performance.
+   */
+  size_t max_iterations = 20;
+
+  /**
+   * The delta at which nn-descent will terminate its iterations.
+   */
+  float termination_threshold = 0.0001;
+
+  /**
+   * The `nn-descent algorithm supports batching a dataset to reduce GPU memory usage.
+   * The default (1) means no batching. Increasing the number will split the data into
+   * `n_clusters` batches. Increasing `n_clusters` too high can result in excess overhead,
+   * as well as decrease recall.
+   */
+  size_t n_clusters = 1;
+};
 
 class UMAPParams {
  public:

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -27,6 +27,7 @@
 #include <raft/core/host_mdspan.hpp>
 #include <raft/core/mdspan.hpp>
 #include <raft/core/mdspan_types.hpp>
+#include <raft/distance/distance_types.hpp>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/matrix/slice.cuh>
 #include <raft/neighbors/nn_descent.cuh>
@@ -68,6 +69,20 @@ auto get_graph_nnd(const raft::handle_t& handle,
                    const ML::manifold_dense_inputs_t<float>& inputs,
                    const ML::UMAPParams* params)
 {
+  NNDescent::index_params nnd_params;
+  nnd_params.n_clusters            = params->nn_descent_params.n_clusters;
+  nnd_params.termination_threshold = params->nn_descent_params.termination_threshold;
+  nnd_params.max_iterations        = params->nn_descent_params.max_iterations;
+  nnd_params.graph_degree          = params->n_neighbors;
+  if (params->nn_descent_params.intermediate_graph_degree == 0) {
+    nnd_params.intermediate_graph_degree = 1.5 * params->n_neighbors;
+  } else {
+    nnd_params.intermediate_graph_degree = params->nn_descent_params.intermediate_graph_degree;
+  }
+  nnd_params.return_distances = true;
+  nnd_params.metric           = raft::distance::DistanceType{params->metric};
+  nnd_params.metric_arg       = params->p;
+
   auto epilogue = DistancePostProcessSqrt<int64_t, float>{};
   cudaPointerAttributes attr;
   RAFT_CUDA_TRY(cudaPointerGetAttributes(&attr, inputs.X));
@@ -75,10 +90,10 @@ auto get_graph_nnd(const raft::handle_t& handle,
   if (ptr != nullptr) {
     auto dataset =
       raft::make_device_matrix_view<const float, int64_t>(inputs.X, inputs.n, inputs.d);
-    return NNDescent::build<float, int64_t>(handle, params->nn_descent_params, dataset, epilogue);
+    return NNDescent::build<float, int64_t>(handle, nnd_params, dataset, epilogue);
   } else {
     auto dataset = raft::make_host_matrix_view<const float, int64_t>(inputs.X, inputs.n, inputs.d);
-    return NNDescent::build<float, int64_t>(handle, params->nn_descent_params, dataset, epilogue);
+    return NNDescent::build<float, int64_t>(handle, nnd_params, dataset, epilogue);
   }
 }
 
@@ -117,44 +132,19 @@ inline void launcher(const raft::handle_t& handle,
       raft::make_device_matrix_view<float, int64_t>(out.knn_dists, inputsB.n, n_neighbors));
   } else {  // nn_descent
     // TODO:  use nndescent from cuvs
-    RAFT_EXPECTS(static_cast<size_t>(n_neighbors) <= params->nn_descent_params.graph_degree,
-                 "n_neighbors should be smaller than the graph degree computed by nn descent");
-    RAFT_EXPECTS(params->nn_descent_params.return_distances,
-                 "return_distances for nn descent should be set to true to be used for UMAP");
-
     auto graph = get_graph_nnd(handle, inputsA, params);
 
     // `graph.graph()` is a host array (n x graph_degree).
-    // Slice and copy to a temporary host array (n x n_neighbors), then copy
-    // that to the output device array `out.knn_indices` (n x n_neighbors).
-    // TODO: force graph_degree = n_neighbors so the temporary host array and
-    // slice isn't necessary.
-    auto temp_indices_h = raft::make_host_matrix<int64_t, int64_t>(inputsA.n, n_neighbors);
-    size_t graph_degree = params->nn_descent_params.graph_degree;
-#pragma omp parallel for
-    for (size_t i = 0; i < static_cast<size_t>(inputsA.n); i++) {
-      for (int j = 0; j < n_neighbors; j++) {
-        auto target                 = temp_indices_h.data_handle();
-        auto source                 = graph.graph().data_handle();
-        target[i * n_neighbors + j] = source[i * graph_degree + j];
-      }
-    }
+    // Copy to output device array of same shape.
     raft::copy(handle,
                raft::make_device_matrix_view(out.knn_indices, inputsA.n, n_neighbors),
-               temp_indices_h.view());
+               graph.graph());
 
     // `graph.distances()` is a device array (n x graph_degree).
-    // Slice and copy to the output device array `out.knn_dists` (n x n_neighbors).
-    // TODO: force graph_degree = n_neighbors so this slice isn't necessary.
-    raft::matrix::slice_coordinates coords{static_cast<int64_t>(0),
-                                           static_cast<int64_t>(0),
-                                           static_cast<int64_t>(inputsA.n),
-                                           static_cast<int64_t>(n_neighbors)};
-    raft::matrix::slice<float, int64_t, raft::row_major>(
-      handle,
-      raft::make_const_mdspan(graph.distances().value()),
-      raft::make_device_matrix_view(out.knn_dists, inputsA.n, n_neighbors),
-      coords);
+    // Copy to output device array of same shape.
+    raft::copy(handle,
+               raft::make_device_matrix_view(out.knn_dists, inputsA.n, n_neighbors),
+               graph.distances().value());
   }
 }
 

--- a/python/cuml/cuml/manifold/umap_utils.pxd
+++ b/python/cuml/cuml/manifold/umap_utils.pxd
@@ -41,18 +41,12 @@ cdef extern from "cuml/common/callback.hpp" namespace "ML::Internals":
     cdef cppclass GraphBasedDimRedCallback
 
 
-cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbors::experimental::nn_descent":
-    cdef struct index_params:
-        uint64_t graph_degree,
+cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
+    cdef struct nn_index_params:
         uint64_t intermediate_graph_degree,
         uint64_t max_iterations,
         float termination_threshold,
-        bool return_distances,
         uint64_t n_clusters,
-        RaftDistanceType metric,
-        float metric_arg
-
-cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
 
     cdef cppclass UMAPParams:
         int n_neighbors,
@@ -80,7 +74,7 @@ cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
         DistanceType metric,
         float p,
         GraphBasedDimRedCallback * callback,
-        index_params nn_descent_params
+        nn_index_params nn_descent_params
 
 cdef extern from "raft/sparse/coo.hpp":
     cdef cppclass COO "raft::sparse::COO<float, int>":


### PR DESCRIPTION
Previously we embedded and exposed `raft::neighbors::experimental::nn_descent::index_params` in `UMAPParams`. Since that struct included duplicate items that also existed in the parent class (like e.g. `metric`), we had to do some plumbing on the python side to ensure both locations were aligned. Likewise, some of the options in `index_params` had strict requirements for UMAP (`return_distances = True`, `graph_degree >= n_neighbors`, ...).

With a recent bugfix on the RAFT side, there's now never a reason to set `graph_degree` to anything except `n_neighbors`.  Taking this as motivation, this PR:

- Creates a new struct `nn_index_params` to expose _only_ the options for nn-descent that make sense to expose in UMAP. This is a breaking change in the C++ API, but afaik we have no external users of the C++ API. There is no breaking change on the Python side.
- Removes `graph_degree` from public options. `graph_degree` now always defaults to `n_neighbors`.
- Changes the default for `intermediate_graph_degree` to be `1.5 * n_neighbors`. This can still be overridden by users, but from what I understand should be a good default regardless of problem size.
- Removes now unnecessary slicing (and an intermediate host allocation) when processing the output of nn-descent. We still have to do a copy (for now) since the caller allocates the memory for the graph.
- Improves the documentation for the `nnd_*` parameters on the python side to better inform the user of their meaning.

Fixes #6091.