### PR TITLE
Add sklearn as run_constrained dep in cuml conda recipe

### DIFF
--- a/conda/recipes/cuml/meta.yaml
+++ b/conda/recipes/cuml/meta.yaml
@@ -95,6 +95,8 @@ requirements:
     - rapids-dask-dependency ={{ minor_version }}
     - treelite {{ treelite_version }}
     - rapids-logger =0.1
+  run_constrained:
+    - scikit-learn >=1.5.0,<2.0a0
 
 test:
   requirements:


### PR DESCRIPTION
Currently `cuml` doesn't require scikit-learn is installed, but if it is installed we recommend (and really require) it be a compatible version.

Short of making scikit-learn a hard dependency at this time, we instead add `scikit-learn` as a `run_constrained` dependency with a lower bound of 1.5.0 (released in May 2024). This is our recommended lowest supported version of scikit-learn. If a user installs `cuml` with conda, this will not necessarily pull in `scikit-learn` as well, but if they also require `scikit-learn` this sets a constraint on the valid versions the solver can install.