### PR TITLE
fix(ci): quote array expansion in new accel ci test

### DIFF
--- a/ci/accel/scikit-learn-tests/run-tests.sh
+++ b/ci/accel/scikit-learn-tests/run-tests.sh
@@ -11,4 +11,4 @@
 
 set -eu
 
-pytest -p cuml.accel --pyargs sklearn -v $@
+pytest -p cuml.accel --pyargs sklearn -v "$@"


### PR DESCRIPTION
Quick followup to #6246 since there was one shellcheck warning that was merged to the main branch that wasn't in my shellcheck PR.
