### PR TITLE
Clean up after removing KMeans deprecation warning

### DIFF
--- a/python/cuml/cuml/tests/test_common.py
+++ b/python/cuml/cuml/tests/test_common.py
@@ -19,10 +19,6 @@ import numpy as np
 import cuml
 from cuml.datasets import make_blobs
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of `n_init` will change from 1 to 'auto' in 25.04"
-)
-
 
 @pytest.mark.parametrize(
     "Estimator",

--- a/python/cuml/cuml/tests/test_public_methods_attributes.py
+++ b/python/cuml/cuml/tests/test_public_methods_attributes.py
@@ -26,9 +26,6 @@ pytestmark = [
     pytest.mark.filterwarnings(
         "ignore:Starting from version 22.04, the default method of TSNE is 'fft'."
     ),
-    pytest.mark.filterwarnings(
-        "ignore:The default value of `n_init` will change from 1 to 'auto' in 25.04"
-    ),
 ]
 
 

--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -103,12 +103,6 @@ def assert_estimator_roundtrip(
         _ = original_params.pop("init", None)
         _ = rm_params.pop("init", None)
 
-        # This failure will be fixed by
-        # https://github.com/rapidsai/cuml/pull/6142
-        # otherwise the predict with default n_init like this
-        # roundtrip will fail later.
-        pytest.xfail(reason="auto is not supported by cuML n_init yet")
-
     def dict_diff(a, b):
         # Get all keys from both dictionaries
         all_keys = set(a.keys()) | set(b.keys())
@@ -158,9 +152,6 @@ def test_basic_roundtrip():
     assert ckm.n_clusters == 13
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The default value of `n_init` will change from 1 to 'auto' in 25.04"
-)
 def test_kmeans(random_state):
     # Using sklearn directly for demonstration
     X, _ = make_blobs(


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/cuml/pull/6142#issuecomment-2722654707

This cleans up some leftovers from the deprecation cycle for `KMeans`'s `init="auto"`