### PR TITLE
Fallback to CPU for sparse inputs for KMeans

### DIFF
--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -49,6 +49,7 @@ from cuml.common.doc_utils import generate_docstring
 from cuml.internals.mixins import ClusterMixin
 from cuml.internals.mixins import CMajorInputTagMixin
 from cuml.common import input_to_cuml_array
+from cuml.common.sparse_utils import is_sparse
 from cuml.internals.api_decorators import device_interop_preparation
 from cuml.internals.api_decorators import enable_device_interop
 from cuml.internals.global_settings import GlobalSettings
@@ -746,3 +747,12 @@ class KMeans(UniversalBase,
         return ['cluster_centers_', 'labels_', 'inertia_',
                 'n_iter_', 'n_features_in_', '_n_threads',
                 "feature_names_in_", "_n_features_out"]
+
+    def _should_dispatch_cpu(self, func_name, *args, **kwargs):
+        """
+        Dispatch to CPU implementation when sparse arrays are detected in the input
+        """
+        if func_name == "fit" and len(args) > 0:
+            X = args[0]
+            return is_sparse(X)
+        return False

--- a/python/cuml/cuml/common/sparse_utils.py
+++ b/python/cuml/cuml/common/sparse_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ def is_sparse(X):
     is_sparse : boolean
         is the input sparse?
     """
-    is_scipy_sparse = has_scipy() and scipy.sparse.isspmatrix(X)
-    return cupyx.scipy.sparse.isspmatrix(X) or is_scipy_sparse
+    is_scipy_sparse = has_scipy() and scipy.sparse.issparse(X)
+    return cupyx.scipy.sparse.issparse(X) or is_scipy_sparse
 
 
 def is_dense(X):

--- a/python/cuml/cuml/internals/input_utils.py
+++ b/python/cuml/cuml/internals/input_utils.py
@@ -532,7 +532,7 @@ def input_to_host_array_with_sparse_support(X):
     if X is None:
         return None
     try:
-        if scipy_sparse.isspmatrix(X):
+        if scipy_sparse.issparse(X):
             return X
     except UnavailableError:
         pass


### PR DESCRIPTION
This PR adds support for handling sparse input arrays in the KMeans algorithm by dispatching to CPU implementation when sparse arrays are detected during fitting. It also updates the sparse array detection utilities to be more robust and consistent across the codebase.

Fixes scikit-learn test `test_kmeans_results[float64-lloyd-sparse_array]` in combination with #6442 .

## Changes
- Added `_should_dispatch_cpu` method to KMeans to handle sparse input arrays
- Updated `is_sparse` utility function to use `issparse` instead of `isspmatrix` for better compatibility
- Updated sparse array detection in `input_utils.py` to use the new `issparse` method

## Testing
- Verified that KMeans correctly dispatches to CPU implementation when sparse arrays are detected