### PR TITLE
Clarify support in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ Welcome to cuML's documentation!
 =================================
 
 cuML is a suite of fast, GPU-accelerated machine learning algorithms
-designed for data science and analytical tasks. Our API mirrors Sklearn's,
+designed for data science and analytical tasks. Our API mirrors scikit-learn,
 and we provide practitioners with the easy fit-predict-transform paradigm
 without ever having to program on a GPU.
 
@@ -13,9 +13,7 @@ in the GPU, and compute tasks can be performed on it directly.
 cuML is fully open source, and the RAPIDS team welcomes new and seasoned
 contributors, users and hobbyists! Thank you for your wonderful support!
 
-An installation requirement for cuML is that your system must be Linux-like.
-Support for Windows is possible in the near future.
-
+cuML is only supported on Linux operating systems.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Clarifies supported platforms on cuML docs homepage.
