### PR TITLE
Fix compiler dependency on ARM

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -22,7 +22,7 @@ dependencies:
 - dask-cudf==25.4.*,>=0.0.0a0
 - dask-ml
 - doxygen=1.9.1
-- gcc_linux-64=11.*
+- gcc_linux-aarch64=11.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
 - hypothesis>=6.0,<7

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -241,7 +241,7 @@ dependencies:
               arch: aarch64
               cuda: "11.8"
             packages:
-              - gcc_linux-64=11.*
+              - gcc_linux-aarch64=11.*
               - nvcc_linux-aarch64=11.8
           - matrix:
               arch: x86_64


### PR DESCRIPTION
I noticed that `dependencies.yaml` had a dependency on an `x86_64` compiler on `aarch64`. This was a typo, not an attempt at cross-compilation.
