### PR TITLE
Revert "ci: pre-filter 11.4 jobs before they are enabled in shared workflows (#6447)"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -122,9 +122,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-cpp-checks:
     needs: conda-cpp-build
     secrets: inherit
@@ -146,18 +143,13 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_python_singlegpu.sh"
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   optional-job-conda-python-tests-cudf-pandas-integration:
     needs: [conda-python-build, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.04
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.ARCH == "amd64" and .CUDA_VER != "11.4.3"))
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: pull-request
       script: "ci/test_python_integration.sh"
   conda-python-tests-dask:
@@ -168,9 +160,6 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_python_dask.sh"
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-python-scikit-learn-accel-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -179,9 +168,6 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_python_scikit_learn_tests.sh"
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit


### PR DESCRIPTION
Now that nightlies are passing, we should be able to test these jobs in PRs.