### PR TITLE
FIX Pass instances to the constructor of the meta-estimator in `SVC`

### DIFF
--- a/python/cuml/cuml/svm/svc.pyx
+++ b/python/cuml/cuml/svm/svc.pyx
@@ -902,11 +902,11 @@ class SVC(SVMBase,
                         gpu_est = turn_cpu_into_gpu(cpu_est, params)
                     else:
                         if self.decision_function_shape == 'ovr':
-                            gpu_est = OneVsRestClassifier(SVC)
+                            gpu_est = OneVsRestClassifier(SVC(output_type=self.output_type))
                             gpu_est.label_binarizer_ = LabelBinarizer(sparse_output=True)
                             gpu_est.label_binarizer_.fit(classes)
                         elif self.decision_function_shape == 'ovo':
-                            gpu_est = OneVsOneClassifier(SVC)
+                            gpu_est = OneVsOneClassifier(SVC(output_type=self.output_type))
                             gpu_est.pairwise_indices_ = None
                         else:
                             raise ValueError
@@ -981,11 +981,11 @@ class SVC(SVMBase,
                     else:
                         classes = self.classes_.to_output('numpy').astype(np.int32)
                         if self.decision_function_shape == 'ovr':
-                            cpu_est = OneVsRestClassifier(skSVC)
+                            cpu_est = OneVsRestClassifier(skSVC())
                             cpu_est.label_binarizer_ = LabelBinarizer(sparse_output=True)
                             cpu_est.label_binarizer_.fit(classes)
                         elif self.decision_function_shape == 'ovo':
-                            cpu_est = OneVsOneClassifier(skSVC)
+                            cpu_est = OneVsOneClassifier(skSVC())
                             cpu_est.pairwise_indices_ = None
                         else:
                             raise ValueError
@@ -1012,11 +1012,11 @@ class SVC(SVMBase,
             classes = self.classes_.to_output('numpy').astype(np.int32)
 
             if self.decision_function_shape == 'ovr':
-                self._cpu_model.multi_class_model = OneVsRestClassifier(skSVC)
+                self._cpu_model.multi_class_model = OneVsRestClassifier(skSVC())
                 self._cpu_model.multi_class_model.label_binarizer_ = LabelBinarizer(sparse_output=True)
                 self._cpu_model.multi_class_model.label_binarizer_.fit(classes)
             elif self.decision_function_shape == 'ovo':
-                self._cpu_model.multi_class_model = OneVsOneClassifier(skSVC)
+                self._cpu_model.multi_class_model = OneVsOneClassifier(skSVC())
                 self._cpu_model.multi_class_model.pairwise_indices_ = None
             else:
                 raise ValueError


### PR DESCRIPTION
The `estimator` attribute is used in the scikit-learn tags machinery to figure out what tags the meta estimator has. We pass a default constructed instance as it isn't actually used.

This was found as part of #6438 but can be fixed standalone. The problem isn't with the new scikit-learn version, but we discovered it with it.

cc @viclafargue 