### PR TITLE
Don't use private APIs in FIL notebook

### DIFF
--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -23,9 +23,6 @@
     "import cupy\n",
     "import os\n",
     "\n",
-    "from cuml.testing.utils import array_equal\n",
-    "from cuml.internals.import_utils import has_xgboost\n",
-    "\n",
     "from cuml.datasets import make_classification\n",
     "from cuml.metrics import accuracy_score\n",
     "from cuml.model_selection import train_test_split\n",
@@ -47,11 +44,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_xgboost():\n",
+    "try:\n",
     "    import xgboost as xgb\n",
-    "else:\n",
+    "except ImportError as exc:\n",
     "    raise ImportError(\"Please install xgboost using the conda package,\"\n",
-    "                      \"e.g.: conda install -c conda-forge xgboost\")"
+    "                      \"e.g.: conda install -c conda-forge xgboost\") from exc"
    ]
   },
   {
@@ -314,7 +311,7 @@
    "source": [
     "print(\"The shape of predictions obtained from xgboost : \", (trained_model_preds).shape)\n",
     "print(\"The shape of predictions obtained from FIL : \", (fil_preds).shape)\n",
-    "print(\"Are the predictions for xgboost and FIL the same : \",  array_equal(trained_model_preds, fil_preds))"
+    "print(\"Are the predictions for xgboost and FIL the same : \",  cupy.allclose(trained_model_preds, fil_preds))"
    ]
   },
   {
@@ -605,7 +602,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously this notebook used a couple internal `cuml` APIs. This PR switches them for public APIs instead.