### PR TITLE
Skip the test_svc_methods tests on CUDA 11.8

### DIFF
--- a/python/cuml/cuml/tests/test_device_selection.py
+++ b/python/cuml/cuml/tests/test_device_selection.py
@@ -72,6 +72,7 @@ import cuml
 from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import("numpy")
+cp = gpu_only_import("cupy")
 pd = cpu_only_import("pandas")
 cudf = gpu_only_import("cudf")
 
@@ -1121,6 +1122,14 @@ def test_svc_methods(
     class_type,
     probability,
 ):
+    # Skip on CUDA 11.8 due to segfaults in decision_function
+    # See: https://github.com/rapidsai/cuml/issues/6480
+    if 11080 <= cp.cuda.runtime.runtimeGetVersion() < 11090:
+        pytest.skip(
+            "Skipping test_svc_methods on CUDA 11.8 due to segfaults in "
+            "decision_function (#6480)"
+        )
+
     if class_type == "single_class":
         X_train = X_train_class
         y_train = y_train_class


### PR DESCRIPTION
As mitigation for https://github.com/rapidsai/cuml/issues/6480 .