### PR TITLE
Fix cudf.DataFrame construction with dict like inputs and ensure CumlArray.to_output('cudf') does not convert NaN to NA

### DIFF
--- a/python/cuml/cuml/internals/array.py
+++ b/python/cuml/cuml/internals/array.py
@@ -707,9 +707,15 @@ class CumlArray:
                 out_index = cudf_to_pandas(self.index)
             else:
                 out_index = self.index
+            if output_mem_type.is_device_accessible:
+                # Do not convert NaNs to nulls in cuDF
+                df_kwargs = {"nan_as_null": False}
+            else:
+                df_kwargs = {}
             try:
-                result = output_mem_type.xdf.DataFrame(arr, index=out_index)
-                return result
+                return output_mem_type.xdf.DataFrame(
+                    arr, index=out_index, **df_kwargs
+                )
             except TypeError:
                 raise ValueError("Unsupported dtype for DataFrame")
 

--- a/python/cuml/cuml/tests/dask/test_dask_one_hot_encoder.py
+++ b/python/cuml/cuml/tests/dask/test_dask_one_hot_encoder.py
@@ -204,7 +204,7 @@ def test_onehot_drop_one_of_each(client):
             "Some categories [a-zA-Z, ]* were not found",
         ],
         [
-            DataFrame({"chars": "b", "int": 3}),
+            DataFrame({"chars": ["b"], "int": [3]}),
             "Wrong input for parameter `drop`.",
         ],
     ],

--- a/python/cuml/cuml/tests/test_array.py
+++ b/python/cuml/cuml/tests/test_array.py
@@ -798,3 +798,10 @@ def test_output_pandas(kind):
     arr = CumlArray.from_input(cp.ones(shape))
     out = arr.to_output("pandas")
     assert isinstance(out, exp_type)
+
+
+def test_output_cudf_maintain_nan():
+    expected = cp.array([[1.1, cp.nan], [cp.nan, 2.2]])
+    # to_cupy would raise if NaN was converted to null
+    result = CumlArray.from_input(expected).to_output("cudf").to_cupy()
+    assert cp.array_equal(result, expected, equal_nan=True)

--- a/python/cuml/cuml/tests/test_one_hot_encoder.py
+++ b/python/cuml/cuml/tests/test_one_hot_encoder.py
@@ -231,7 +231,7 @@ def test_onehot_drop_one_of_each(as_array):
             "Some categories [0-9a-zA-Z, ]* were not found",
         ],
         [
-            DataFrame({"chars": "b", "int": 3}),
+            DataFrame({"chars": ["b"], "int": [3]}),
             "Wrong input for parameter `drop`.",
         ],
     ],


### PR DESCRIPTION
After https://github.com/rapidsai/cudf/pull/18306, constructing a `cudf.DataFrame` from a dict with scalar values would require the `index` and `column` parameters to be passed, matching pandas.

For these tests, it appears that a DataFrame with a single row would be sufficient for these tests.

Additionally, passing a cupy/numpy array with nan to cudf.DataFrame will respect the default nan_as_null=True default and be converted to NA. Before, nan for this type of input was always preserved as nan.

Therefore, this PR ensures that CumlArray.to_output("cudf") preserves nan matching the previous (buggy in cuDF) behavior.