### PR TITLE
Ensure CumlArray.to_output('cudf') does not convert NaN to NA

### DIFF
--- a/python/cuml/cuml/internals/array.py
+++ b/python/cuml/cuml/internals/array.py
@@ -707,8 +707,15 @@ class CumlArray:
                 out_index = cudf_to_pandas(self.index)
             else:
                 out_index = self.index
+            if output_mem_type.is_device_accessible:
+                # Do not convert NaNs to nulls in cuDF
+                df_kwargs = {"nan_as_null": False}
+            else:
+                df_kwargs = {}
             try:
-                result = output_mem_type.xdf.DataFrame(arr, index=out_index)
+                result = output_mem_type.xdf.DataFrame(
+                    arr, index=out_index, **df_kwargs
+                )
                 return result
             except TypeError:
                 raise ValueError("Unsupported dtype for DataFrame")

--- a/python/cuml/cuml/tests/test_array.py
+++ b/python/cuml/cuml/tests/test_array.py
@@ -803,5 +803,5 @@ def test_output_pandas(kind):
 def test_output_cudf_maintain_nan():
     expected = cp.array([[1.1, cp.nan], [cp.nan, 2.2]])
     # to_cupy would raise if NaN was converted to null
-    result = CumlArray.to_output("cudf").to_cupy()
+    result = CumlArray.from_input(expected).to_output("cudf").to_cupy()
     assert cp.array_equal(result, expected)

--- a/python/cuml/cuml/tests/test_array.py
+++ b/python/cuml/cuml/tests/test_array.py
@@ -798,3 +798,10 @@ def test_output_pandas(kind):
     arr = CumlArray.from_input(cp.ones(shape))
     out = arr.to_output("pandas")
     assert isinstance(out, exp_type)
+
+
+def test_output_cudf_maintain_nan():
+    expected = cp.array([[1.1, cp.nan], [cp.nan, 2.2]])
+    # to_cupy would raise if NaN was converted to null
+    result = CumlArray.to_output("cudf").to_cupy()
+    assert cp.array_equal(result, expected)


### PR DESCRIPTION
xref https://github.com/rapidsai/cuml/pull/6517#issuecomment-2786323769

After https://github.com/rapidsai/cudf/pull/18306, passing a cupy/numpy array with `nan` to `cudf.DataFrame` will respect the default `nan_as_null=True` default and be converted to `NA`. Before, `nan` for this type of input was always preserved as `nan`.

Therefore, this PR ensures that `CumlArray.to_output("cudf")` preserves `nan` matching the previous (buggy in cuDF) behavior.