### PR TITLE
Reduce CI test combinations for scikit-learn acceleration tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -168,6 +168,8 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_python_scikit_learn_tests.sh"
+      # Select the amd64 entry with the highest CUDA and Python version
+      matrix_filter: map(select(.ARCH=="amd64")) | [max_by([.CUDA_VER,.PY_VER]|map(split(".")|map(tonumber)))]
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
       script: "ci/test_python_dask.sh"
   conda-python-scikit-learn-accel-tests:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,8 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: "ci/test_python_scikit_learn_tests.sh"
+      # Select amd64 and one job per major CUDA version with the latest CUDA and Python versions
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([.CUDA_VER,.PY_VER]|map(split(".")|map(tonumber))))
   wheel-tests-cuml:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06


### PR DESCRIPTION
This PR optimizes the CI test matrix by reducing test combinations for scikit-learn acceleration tests, focusing on the most relevant configurations while maintaining test coverage.

Changes:

- PR workflows (`pr.yaml`):
  - Added `matrix_filter` to select amd64 + latest Python/CUDA
- Nightly tests (`test.yaml`):
  - Added `matrix_filter` to select amd64 + latest Python, one job per major CUDA version
  - Fixed likely oversight: Updated shared workflow from `branch-25.04` to `branch-25.06`

Follow-up to https://github.com/rapidsai/cuml/pull/6457