### PR TITLE
Avoid private attributes on cuDF objects

### DIFF
--- a/python/cuml/cuml/feature_extraction/_vectorizers.py
+++ b/python/cuml/cuml/feature_extraction/_vectorizers.py
@@ -468,7 +468,7 @@ class CountVectorizer(_VectorizerMixin):
         tokenized_df["token"] = (
             tokenized_df["token"]
             .cat.set_categories(self.vocabulary_)
-            ._column.codes
+            .cat.codes
         )
 
         # Count of each token in each document
@@ -491,7 +491,7 @@ class CountVectorizer(_VectorizerMixin):
             df[column]
             .astype("category")
             .cat.set_categories(keep_values)
-            ._column.codes
+            .cat.codes
         )
         df = df.dropna(subset=column)
         return df

--- a/python/cuml/cuml/preprocessing/LabelEncoder.py
+++ b/python/cuml/cuml/preprocessing/LabelEncoder.py
@@ -292,12 +292,7 @@ class LabelEncoder(Base):
 
         y = y.astype(self.dtype)
 
-        # TODO: Remove ._column once .replace correctly accepts cudf.Index
-        ran_idx = (
-            cudf.Index(cp.arange(len(self.classes_)))
-            .astype(self.dtype)
-            ._column
-        )
+        ran_idx = cudf.Index(cp.arange(len(self.classes_))).astype(self.dtype)
         res = y.replace(ran_idx, self.classes_)
 
         return res


### PR DESCRIPTION
It appears the usage of `._column` can be replace with public APIs or avoided it entirely.