### PR TITLE
refactor(rattler): enable strict channel priority for builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -18,16 +18,14 @@ sccache --zero-stats
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version)
 export RAPIDS_PACKAGE_VERSION
 
+# populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
 
 # --no-build-id allows for caching with `sccache`
 # more info is available at
 # https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
 rattler-build build --recipe conda/recipes/libcuml \
-                    --experimental \
-                    --no-build-id \
-                    --channel-priority disabled \
-                    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+                    "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
 
 sccache --show-adv-stats

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -20,7 +20,7 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION)
 export RAPIDS_PACKAGE_VERSION
 
-# populates `RATTLER_CHANNELS` array
+# populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
 
 rapids-logger "Prepending channel ${CPP_CHANNEL} to RATTLER_CHANNELS"
@@ -35,10 +35,7 @@ rapids-logger "Building cuml"
 # more info is available at
 # https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
 rattler-build build --recipe conda/recipes/cuml \
-                    --experimental \
-                    --no-build-id \
-                    --channel-priority disabled \
-                    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+                    "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
 
 sccache --show-adv-stats
@@ -52,10 +49,7 @@ if [[ ${RAPIDS_CUDA_MAJOR} == "12" ]]; then
   sccache --zero-stats
 
   rattler-build build --recipe conda/recipes/cuml-cpu \
-                      --experimental \
-                      --no-build-id \
-                      --channel-priority disabled \
-                      --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+                      "${RATTLER_ARGS[@]}" \
                       "${RATTLER_CHANNELS[@]}"
 
   sccache --show-adv-stats


### PR DESCRIPTION
This PR enables strict channel priority for building conda packages with `rattler-build`.

xref rapidsai/build-planning#84
