### PR TITLE
Support `weights="distance"` for `KNeighbors*` in `cuml.accel`

### DIFF
--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -629,6 +629,7 @@ class RandomForestRegressor(BaseRandomForestModel,
         domain="cuml_python")
     @insert_into_docstring(parameters=[('dense', '(n_samples, n_features)'),
                                        ('dense', '(n_samples, 1)')])
+    @enable_device_interop
     def score(self, X, y, algo='auto', convert_dtype=True,
               fil_sparse_format='auto', predict_model="GPU"):
         """

--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -795,10 +795,6 @@ class UniversalBase(Base):
         if not hasattr(self, "_gpuaccel"):
             return cuml.global_settings.device_type
 
-        # if using accelerator and doing inference, always use GPU
-        elif func_name not in ['fit', 'fit_transform', 'fit_predict']:
-            device_type = DeviceType.device
-
         # otherwise we select CPU when _gpuaccel is off
         elif not self._gpuaccel:
             device_type = DeviceType.host

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -164,17 +164,18 @@ class KNeighborsClassifier(ClassifierMixin,
         self.classes_ = None
         self.weights = weights
 
-        if weights != "uniform":
-            raise ValueError("Only uniform weighting strategy is "
-                             "supported currently.")
-
     @generate_docstring(convert_dtype_cast='np.float32')
     @cuml.internals.api_base_return_any(set_output_dtype=True)
+    @enable_device_interop
     def fit(self, X, y, convert_dtype=True) -> "KNeighborsClassifier":
         """
         Fit a GPU index for k-nearest neighbors classifier model.
 
         """
+        if self.weights != "uniform":
+            raise ValueError("Only uniform weighting strategy is "
+                             "supported currently.")
+
         super(KNeighborsClassifier, self).fit(X, convert_dtype)
         self.y, _, _, _ = \
             input_to_cuml_array(y, order='F', check_dtype=np.int32,
@@ -190,6 +191,7 @@ class KNeighborsClassifier(ClassifierMixin,
                                        'description': 'Labels predicted',
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_array(get_output_dtype=True)
+    @enable_device_interop
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Use the trained k-nearest neighbors classifier to

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -173,6 +173,7 @@ class KNeighborsRegressor(RegressorMixin,
         self.weights = weights
 
     @generate_docstring(convert_dtype_cast='np.float32')
+    @enable_device_interop
     def fit(self, X, y, convert_dtype=True) -> "KNeighborsRegressor":
         """
         Fit a GPU index for k-nearest neighbors regression model.

--- a/python/cuml/cuml_accel_tests/integration/test_kneighbors_classifier.py
+++ b/python/cuml/cuml_accel_tests/integration/test_kneighbors_classifier.py
@@ -50,7 +50,7 @@ def test_knn_classifier_n_neighbors(classification_data, n_neighbors):
     ), f"Accuracy should be reasonable with n_neighbors={n_neighbors}"
 
 
-@pytest.mark.parametrize("weights", ["uniform"])
+@pytest.mark.parametrize("weights", ["uniform", "distance"])
 def test_knn_classifier_weights(classification_data, weights):
     X, y = classification_data
     model = KNeighborsClassifier(weights=weights)

--- a/python/cuml/cuml_accel_tests/integration/test_kneighbors_regressor.py
+++ b/python/cuml/cuml_accel_tests/integration/test_kneighbors_regressor.py
@@ -45,7 +45,7 @@ def test_knn_regressor_n_neighbors(regression_data, n_neighbors):
     r2_score(y, y_pred)
 
 
-@pytest.mark.parametrize("weights", ["uniform"])
+@pytest.mark.parametrize("weights", ["uniform", "distance"])
 def test_knn_regressor_weights(regression_data, weights):
     X, y = regression_data
     model = KNeighborsRegressor(weights=weights)

--- a/python/cuml/cuml_accel_tests/integration/test_rf_regressor.py
+++ b/python/cuml/cuml_accel_tests/integration/test_rf_regressor.py
@@ -48,7 +48,10 @@ def test_rf_criterion_reg(regression_data, criterion):
         criterion=criterion, n_estimators=50, random_state=42
     )
     reg.fit(X, y)
-    _ = r2_score(y, reg.predict(X))
+    score1 = r2_score(y, reg.predict(X))
+    assert isinstance(score1, float)
+    score2 = reg.score(X, y)
+    assert isinstance(score2, float)
 
 
 @pytest.mark.parametrize("max_depth", [None, 5, 10])


### PR DESCRIPTION
Previously we would fail if the user specified `weights="distance"` to `KNeighborsClassifier`/`KNeighborsRegressor`. This fixes that and adds a test.

Part of fixing this required changing the logic in `dispatch_func` to not special-case inference methods. Previously we would always run inference on the GPU, even if `_gpuaccel` was False (meaning the hyperparameters specified weren't supported by cuml). I don't believe this to be the desired logic - if cuml doesn't support the specified hyperparameters, we cannot be sure that we do support them for `predict`. Further, the state is stored on the cpu estimator already, running inference on CPU makes more sense anyway IMO. It also makes understanding where something runs clearer:

- If the hyperparameters aren't supported by cuml, then everything runs on CPU
- If the arguments provided to a method aren't supported by cuml, then that method will dispatch to CPU
- Otherwise we run on GPU

Fixes #6545.