### PR TITLE
Update KMeans test to improve stability by setting n_init to 2 (#6553)

### DIFF
--- a/python/cuml/cuml/tests/test_kmeans.py
+++ b/python/cuml/cuml/tests/test_kmeans.py
@@ -199,12 +199,14 @@ def test_kmeans_clusters_blobs(
         random_state=0,
     )
 
+    # Set n_init to 2 to improve stability of k-means|| initialization
+    # See https://github.com/rapidsai/cuml/issues/5530 for details
     cuml_kmeans = cuml.KMeans(
         init="k-means||",
         n_clusters=nclusters,
         random_state=random_state,
         output_type="numpy",
-        n_init=1,
+        n_init=2,
     )
 
     preds = cuml_kmeans.fit_predict(X)


### PR DESCRIPTION
This change modifies the KMeans test to set n_init to 2, enhancing the stability of the k-means|| initialization process. Additional context can be found in issue #5530.

Closes #5530.