### PR TITLE
Constrain hypothesis test dependency to <6.131.1.

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - gcc_linux-aarch64=11.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
-- hypothesis>=6.0,<7
+- hypothesis>=6.0,<6.131.1
 - ipykernel
 - ipython
 - joblib>=0.11

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -24,7 +24,7 @@ dependencies:
 - gcc_linux-64=11.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
-- hypothesis>=6.0,<7
+- hypothesis>=6.0,<6.131.1
 - ipykernel
 - ipython
 - joblib>=0.11

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - gcc_linux-aarch64=13.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
-- hypothesis>=6.0,<7
+- hypothesis>=6.0,<6.131.1
 - ipykernel
 - ipython
 - joblib>=0.11

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - gcc_linux-64=13.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
-- hypothesis>=6.0,<7
+- hypothesis>=6.0,<6.131.1
 - ipykernel
 - ipython
 - joblib>=0.11

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -483,7 +483,9 @@ dependencies:
           - *cython
           - dask-ml
           - hdbscan>=0.8.39,<0.8.40
-          - hypothesis>=6.0,<7
+          # Constrained to <6.131.1 due to performance regression in example generation
+          # See: https://github.com/HypothesisWorks/hypothesis/issues/4365
+          - hypothesis>=6.0,<6.131.1
           - nltk
           - numpydoc
           - pytest==7.*

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -129,7 +129,7 @@ test = [
     "cython>=3.0.0",
     "dask-ml",
     "hdbscan>=0.8.39,<0.8.40",
-    "hypothesis>=6.0,<7",
+    "hypothesis>=6.0,<6.131.1",
     "nltk",
     "numpydoc",
     "pynndescent",


### PR DESCRIPTION
Due to performance regression in example generation in that version.

See https://github.com/HypothesisWorks/hypothesis/issues/4365 for context.