### PR TITLE
Add `cuml.accel.is_proxy`

### DIFF
--- a/python/cuml/cuml/accel/__init__.py
+++ b/python/cuml/cuml/accel/__init__.py
@@ -15,12 +15,14 @@
 #
 
 from cuml.accel.core import enabled, install
+from cuml.accel.estimator_proxy import is_proxy
 from cuml.accel.magics import load_ipython_extension
 from cuml.accel.pytest_plugin import pytest_load_initial_conftests
 
 __all__ = (
-    "install",
     "enabled",
+    "install",
+    "is_proxy",
     "load_ipython_extension",
     "pytest_load_initial_conftests",
 )

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -18,6 +18,16 @@ import importlib
 import inspect
 
 
+def is_proxy(instance_or_class) -> bool:
+    """Check if an instance or class is a proxy object created by the accelerator."""
+
+    if isinstance(instance_or_class, type):
+        cls = instance_or_class
+    else:
+        cls = type(instance_or_class)
+    return issubclass(cls, ProxyMixin)
+
+
 def reconstruct_proxy(proxy_module, proxy_name, state):
     module = importlib.import_module(proxy_module)
     cls = getattr(module, proxy_name)

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -22,6 +22,18 @@ from sklearn import clone
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.neighbors import NearestNeighbors
 
+from cuml.accel import is_proxy
+
+
+def test_is_proxy():
+    class Foo:
+        pass
+
+    assert is_proxy(PCA)
+    assert is_proxy(PCA())
+    assert not is_proxy(Foo)
+    assert not is_proxy(Foo())
+
 
 def test_meta_attributes():
     # Check that the proxy estimator pretends to look like the


### PR DESCRIPTION
This adds a new utility for checking if a class or instance is an accelerated proxy object. Useful for easing introspection when working with and debugging `cuml.accel`.