### PR TITLE
Update FIL Model Loading Parameter in FIL demo notebook

### DIFF
--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -233,7 +233,7 @@
     "\n",
     "The load function of the ForestInference class accepts the following parameters:\n",
     "\n",
-    "       filename : str\n",
+    "       path : str\n",
     "           Path to saved model file in a treelite-compatible format\n",
     "           (See https://treelite.readthedocs.io/en/latest/treelite-api.html\n",
     "        output_class : bool\n",
@@ -268,7 +268,7 @@
    "outputs": [],
    "source": [
     "fil_model = ForestInference.load(\n",
-    "    filename=model_path,\n",
+    "    model_path,\n",
     "    algo='BATCH_TREE_REORG',\n",
     "    output_class=True,\n",
     "    threshold=0.50,\n",
@@ -500,7 +500,7 @@
    "source": [
     "def worker_init(dask_worker, model_file='xgb.model'):\n",
     "   dask_worker.data[\"fil_model\"] = ForestInference.load(\n",
-    "       filename=model_file,\n",
+    "       model_file,\n",
     "       algo='BATCH_TREE_REORG',\n",
     "       output_class=True,\n",
     "       threshold=0.50,\n",


### PR DESCRIPTION
Updates `forest_inference_demo.ipynb` to use `path` instead of `filename` parameter in `ForestInference.load()` calls to match the new FIL implementation.

## Related Issues
- Fixes #749 (Docker issue with FIL model loading)
