### PR TITLE
Download build artifacts from Github for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,8 +83,8 @@ jobs:
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
+      package-name: libcuml
       package-type: cpp
-      wheel-name: libcuml
   wheel-publish-libcuml:
     needs: wheel-build-libcuml
     secrets: inherit
@@ -106,8 +106,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_cuml.sh
+      package-name: cuml
       package-type: python
-      wheel-name: cuml
   wheel-publish-cuml:
     needs: wheel-build-cuml
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -206,8 +206,8 @@ jobs:
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
+      package-name: libcuml
       package-type: cpp
-      wheel-name: libcuml
   wheel-build-cuml:
     needs: [checks, wheel-build-libcuml]
     secrets: inherit
@@ -215,8 +215,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_cuml.sh
+      package-name: cuml
       package-type: python
-      wheel-name: cuml
   wheel-tests-cuml:
     needs: [wheel-build-cuml, changed-files]
     secrets: inherit

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,7 +15,7 @@ rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION)
 export RAPIDS_PACKAGE_VERSION

--- a/ci/build_wheel_cuml.sh
+++ b/ci/build_wheel_cuml.sh
@@ -10,8 +10,8 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Download the libcuml wheel built in the previous step and make it
 # available for pip to find.
-RAPIDS_PY_WHEEL_NAME="libcuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp /tmp/libcuml_dist
-echo "libcuml-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo /tmp/libcuml_dist/libcuml_*.whl)" >> /tmp/constraints.txt
+LIBCUML_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+echo "libcuml-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUML_WHEELHOUSE}"/libcuml_*.whl)" >> /tmp/constraints.txt
 export PIP_CONSTRAINT="/tmp/constraints.txt"
 
 EXCLUDE_ARGS=(

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Generate Notebook testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -5,15 +5,15 @@ set -euo pipefail
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-RAPIDS_PY_WHEEL_NAME="cuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
-RAPIDS_PY_WHEEL_NAME="libcuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp ./dist
+CUML_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
+LIBCUML_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcuml_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 # Install just minimal dependencies first
 rapids-pip-retry install \
-  ./dist/libcuml*.whl \
-  ./dist/cuml*.whl
+  "${LIBCUML_WHEELHOUSE}"/libcuml*.whl \
+  "${CUML_WHEELHOUSE}"/cuml*.whl
 
 # Try to import cuml with just a minimal install"
 rapids-logger "Importing cuml with minimal dependencies"
@@ -21,8 +21,8 @@ python -c "import cuml"
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
-   ./dist/libcuml*.whl \
-  "$(echo ./dist/cuml*.whl)[test]"
+   "${LIBCUML_WHEELHOUSE}"/libcuml*.whl \
+  "$(echo "${CUML_WHEELHOUSE}"/cuml*.whl)[test]"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts, wherever applicable. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads in the same way as conda downloads.

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 