### PR TITLE
Remove conditional compilation blocks leftover from `cuml-cpu`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd "$(dirname $0)"; pwd)
 
-VALIDTARGETS="clean libcuml cuml cuml-cpu cpp-mgtests prims bench prims-bench cppdocs pydocs"
+VALIDTARGETS="clean libcuml cuml cpp-mgtests prims bench prims-bench cppdocs pydocs"
 VALIDFLAGS="-v -g -n --allgpuarch --singlegpu --nolibcumltest --nvtx --show_depr_warn --codecov --ccache --configure-only -h --help "
 VALIDARGS="${VALIDTARGETS} ${VALIDFLAGS}"
 HELP="$0 [<target> ...] [<flag> ...]
@@ -27,7 +27,6 @@ HELP="$0 [<target> ...] [<flag> ...]
    libcuml           - build the cuml C++ code only. Also builds the C-wrapper library
                        around the C++ code.
    cuml              - build the cuml Python package
-   cuml-cpu          - build the cuml CPU Python package
    cpp-mgtests       - build libcuml mnmg tests. Builds MPI communicator, adding MPI as dependency.
    prims             - build the ml-prims tests
    bench             - build the libcuml C++ benchmark
@@ -305,9 +304,4 @@ if (! hasArg --configure-only) && (completeBuild || hasArg cuml || hasArg pydocs
         cd ${REPODIR}/docs
         make html
     fi
-fi
-
-if hasArg cuml-cpu; then
-    SKBUILD_CMAKE_ARGS="-DCUML_CPU=ON;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE" \
-        python -m pip install --no-build-isolation --no-deps --config-settings rapidsai.disable-cuda=true ${REPODIR}/python/cuml
 fi

--- a/python/cuml/CMakeLists.txt
+++ b/python/cuml/CMakeLists.txt
@@ -18,8 +18,6 @@ include(../../cmake/rapids_config.cmake)
 
 set(language_list "CXX")
 
-# We always need CUDA for cuML GPU because the raft dependency brings in a
-# header-only cuco dependency that enables CUDA unconditionally.
 include(rapids-cuda)
 rapids_cuda_init_architectures(cuml-python)
 list(APPEND language_list "CUDA")

--- a/python/cuml/CMakeLists.txt
+++ b/python/cuml/CMakeLists.txt
@@ -16,16 +16,13 @@ cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
 include(../../cmake/rapids_config.cmake)
 
-option(CUML_CPU "Build only cuML CPU Python components." OFF)
 set(language_list "CXX")
 
-if(NOT CUML_CPU)
-  # We always need CUDA for cuML GPU because the raft dependency brings in a
-  # header-only cuco dependency that enables CUDA unconditionally.
-  include(rapids-cuda)
-  rapids_cuda_init_architectures(cuml-python)
-  list(APPEND language_list "CUDA")
-endif()
+# We always need CUDA for cuML GPU because the raft dependency brings in a
+# header-only cuco dependency that enables CUDA unconditionally.
+include(rapids-cuda)
+rapids_cuda_init_architectures(cuml-python)
+list(APPEND language_list "CUDA")
 
 project(
   cuml-python
@@ -41,7 +38,6 @@ option(USE_LIBCUML_WHEEL "Use libcuml wheel to provide some dependencies" OFF)
 
 # todo: use CMAKE_MESSAGE_CONTEXT for prefix for logging.
 # https://github.com/rapidsai/cuml/issues/4843
-message(VERBOSE "CUML_PY: Build only cuML CPU Python components.: ${CUML_CPU}")
 message(VERBOSE "CUML_PY: Disabling all mnmg components and comms libraries: ${SINGLEGPU}")
 
 set(CUML_ALGORITHMS "ALL" CACHE STRING "Choose which algorithms are built cuML. Can specify individual algorithms or groups in a semicolon-separated list.")
@@ -52,70 +48,39 @@ set(CUML_CPP_SRC "../../cpp")
 ################################################################################
 # - Process User Options  ------------------------------------------------------
 
-if(CUML_CPU)
-  set(CUML_UNIVERSAL OFF)
-  set(SINGLEGPU ON)
+include(rapids-cpm)
+include(rapids-export)
+rapids_cpm_init()
 
-  # only a subset of algorithms are supported in CPU-only cuML
-  set(CUML_ALGORITHMS "linearregression")
-  list(APPEND CUML_ALGORITHMS "pca")
-  list(APPEND CUML_ALGORITHMS "tsvd")
-  list(APPEND CUML_ALGORITHMS "elasticnet")
-  list(APPEND CUML_ALGORITHMS "logisticregression")
-  list(APPEND CUML_ALGORITHMS "ridge")
-  list(APPEND CUML_ALGORITHMS "lasso")
-  list(APPEND CUML_ALGORITHMS "umap")
-  list(APPEND CUML_ALGORITHMS "knn")
-  list(APPEND CUML_ALGORITHMS "hdbscan")
-  list(APPEND CUML_ALGORITHMS "dbscan")
-  list(APPEND CUML_ALGORITHMS "kmeans")
+# --- treelite --- #
+# Need to call get_treelite explicitly because we need the correct
+# ${TREELITE_LIBS} definition for RF.
+#
+# And because cuml Cython code needs the headers to satisfy calls like
+# 'cdef extern from "treelite/c_api.h"'
 
-  # this won't be needed when we add CPU libcuml++ (FIL)
-  set(cuml_sg_libraries "")
-
-  list(APPEND CYTHON_FLAGS
-  "--compile-time-env GPUBUILD=0")
-
-# cuml-cpu does not need libcuml++.so
+# wheel builds use a static treelite, because the 'libtreelite.so' in 'treelite' wheels
+# isn't intended for dynamic linking by third-party projects (e.g. hides its symbols)
+if(USE_LIBCUML_WHEEL)
+set(CUML_PYTHON_TREELITE_TARGET treelite::treelite_static)
+set(CUML_USE_TREELITE_STATIC ON)
 else()
+set(CUML_PYTHON_TREELITE_TARGET treelite::treelite)
+set(CUML_USE_TREELITE_STATIC OFF)
+endif()
 
-  include(rapids-cpm)
-  include(rapids-export)
-  rapids_cpm_init()
+set(CUML_EXCLUDE_TREELITE_FROM_ALL ON)
 
-  # --- treelite --- #
-  # Need to call get_treelite explicitly because we need the correct
-  # ${TREELITE_LIBS} definition for RF.
-  #
-  # And because cuml Cython code needs the headers to satisfy calls like
-  # 'cdef extern from "treelite/c_api.h"'
+include(${CUML_CPP_SRC}/cmake/thirdparty/get_treelite.cmake)
 
-  # wheel builds use a static treelite, because the 'libtreelite.so' in 'treelite' wheels
-  # isn't intended for dynamic linking by third-party projects (e.g. hides its symbols)
-  if(USE_LIBCUML_WHEEL)
-    set(CUML_PYTHON_TREELITE_TARGET treelite::treelite_static)
-    set(CUML_USE_TREELITE_STATIC ON)
-  else()
-    set(CUML_PYTHON_TREELITE_TARGET treelite::treelite)
-    set(CUML_USE_TREELITE_STATIC OFF)
-  endif()
+# --- libcuml --- #
+find_package(cuml "${RAPIDS_VERSION}" REQUIRED)
 
-  set(CUML_EXCLUDE_TREELITE_FROM_ALL ON)
+set(cuml_sg_libraries cuml::${CUML_CPP_TARGET})
+set(cuml_mg_libraries cuml::${CUML_CPP_TARGET})
 
-  include(${CUML_CPP_SRC}/cmake/thirdparty/get_treelite.cmake)
-
-  # --- libcuml --- #
-  find_package(cuml "${RAPIDS_VERSION}" REQUIRED)
-
-  set(cuml_sg_libraries cuml::${CUML_CPP_TARGET})
-  set(cuml_mg_libraries cuml::${CUML_CPP_TARGET})
-
-  if(NOT SINGLEGPU)
-    list(APPEND cuml_mg_libraries cumlprims_mg::cumlprims_mg)
-  endif()
-
-  list(APPEND CYTHON_FLAGS
-  "--compile-time-env GPUBUILD=1")
+if(NOT SINGLEGPU)
+list(APPEND cuml_mg_libraries cumlprims_mg::cumlprims_mg)
 endif()
 
  ################################################################################
@@ -123,12 +88,6 @@ endif()
 
 include("${CUML_CPP_SRC}/cmake/modules/ConfigureAlgorithms.cmake")
 include(cmake/ConfigureCythonAlgorithms.cmake)
-
-if(CUML_CPU)
-  # libcuml requires metrics built if HDSCAN is built, which is not the case
-  # for cuml-cpu
-  unset(metrics_algo)
-endif()
 
 message(VERBOSE "CUML_PY: Building cuML with algorithms: '${CUML_ALGORITHMS}'.")
 

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -413,26 +413,26 @@ class DBSCAN(UniversalBase,
                     <level_enum> self.verbose,
                     <bool> opg)
 
-            # make sure that the `fit` is complete before the following
-            # delete call happens
-            self.handle.sync()
-            del X_m
+        # make sure that the `fit` is complete before the following
+        # delete call happens
+        self.handle.sync()
+        del X_m
 
-            # Finally, resize the core_sample_indices array if necessary
-            if self.calc_core_sample_indices:
-                # Temp convert to cupy array (better than using `cupy.asarray`)
-                with using_output_type("cupy"):
-                    # First get the min index. These have to monotonically
-                    # increasing, so the min index should be the first returned -1
-                    min_index = cp.argmin(self.core_sample_indices_).item()
-                    # Check for the case where there are no -1's
-                    if ((min_index == 0 and
-                         self.core_sample_indices_[min_index].item() != -1)):
-                        # Nothing to delete. The array has no -1's
-                        pass
-                    else:
-                        self.core_sample_indices_ = \
-                            self.core_sample_indices_[:min_index]
+        # Finally, resize the core_sample_indices array if necessary
+        if self.calc_core_sample_indices:
+            # Temp convert to cupy array (better than using `cupy.asarray`)
+            with using_output_type("cupy"):
+                # First get the min index. These have to monotonically
+                # increasing, so the min index should be the first returned -1
+                min_index = cp.argmin(self.core_sample_indices_).item()
+                # Check for the case where there are no -1's
+                if ((min_index == 0 and
+                        self.core_sample_indices_[min_index].item() != -1)):
+                    # Nothing to delete. The array has no -1's
+                    pass
+                else:
+                    self.core_sample_indices_ = \
+                        self.core_sample_indices_[:min_index]
 
         return self
 

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -25,7 +25,6 @@ cp = gpu_only_import('cupy')
 
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals import logger
 from cuml.internals.api_decorators import (
     device_interop_preparation,
     enable_device_interop,
@@ -34,81 +33,81 @@ from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
+from libc.stdint cimport int64_t, uintptr_t
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
+
 from cuml.internals.logger cimport level_enum
+from cuml.metrics.distance_type cimport DistanceType
 
-IF GPUBUILD == 1:
-    from libc.stdint cimport int64_t, uintptr_t
-    from libcpp cimport bool
-    from pylibraft.common.handle cimport handle_t
+from cuml.common import input_to_cuml_array, using_output_type
 
-    from cuml.metrics.distance_type cimport DistanceType
-    from cuml.common import input_to_cuml_array, using_output_type
-    cdef extern from "cuml/cluster/dbscan.hpp" \
-            namespace "ML::Dbscan":
 
-        ctypedef enum EpsNnMethod:
-            BRUTE_FORCE "ML::Dbscan::EpsNnMethod::BRUTE_FORCE"
-            RBC "ML::Dbscan::EpsNnMethod::RBC"
+cdef extern from "cuml/cluster/dbscan.hpp" namespace "ML::Dbscan":
 
-        cdef void fit(handle_t& handle,
-                      float *input,
-                      int n_rows,
-                      int n_cols,
-                      float eps,
-                      int min_pts,
-                      DistanceType metric,
-                      int *labels,
-                      int *core_sample_indices,
-                      float* sample_weight,
-                      size_t max_mbytes_per_batch,
-                      EpsNnMethod eps_nn_method,
-                      level_enum verbosity,
-                      bool opg) except +
+    ctypedef enum EpsNnMethod:
+        BRUTE_FORCE "ML::Dbscan::EpsNnMethod::BRUTE_FORCE"
+        RBC "ML::Dbscan::EpsNnMethod::RBC"
 
-        cdef void fit(handle_t& handle,
-                      double *input,
-                      int n_rows,
-                      int n_cols,
-                      double eps,
-                      int min_pts,
-                      DistanceType metric,
-                      int *labels,
-                      int *core_sample_indices,
-                      double* sample_weight,
-                      size_t max_mbytes_per_batch,
-                      EpsNnMethod eps_nn_method,
-                      level_enum verbosity,
-                      bool opg) except +
+    cdef void fit(handle_t& handle,
+                  float *input,
+                  int n_rows,
+                  int n_cols,
+                  float eps,
+                  int min_pts,
+                  DistanceType metric,
+                  int *labels,
+                  int *core_sample_indices,
+                  float* sample_weight,
+                  size_t max_mbytes_per_batch,
+                  EpsNnMethod eps_nn_method,
+                  level_enum verbosity,
+                  bool opg) except +
 
-        cdef void fit(handle_t& handle,
-                      float *input,
-                      int64_t n_rows,
-                      int64_t n_cols,
-                      double eps,
-                      int min_pts,
-                      DistanceType metric,
-                      int64_t *labels,
-                      int64_t *core_sample_indices,
-                      float* sample_weight,
-                      size_t max_mbytes_per_batch,
-                      EpsNnMethod eps_nn_method,
-                      level_enum verbosity,
-                      bool opg) except +
+    cdef void fit(handle_t& handle,
+                  double *input,
+                  int n_rows,
+                  int n_cols,
+                  double eps,
+                  int min_pts,
+                  DistanceType metric,
+                  int *labels,
+                  int *core_sample_indices,
+                  double* sample_weight,
+                  size_t max_mbytes_per_batch,
+                  EpsNnMethod eps_nn_method,
+                  level_enum verbosity,
+                  bool opg) except +
 
-        cdef void fit(handle_t& handle,
-                      double *input,
-                      int64_t n_rows,
-                      int64_t n_cols,
-                      double eps,
-                      int min_pts,
-                      DistanceType metric,
-                      int64_t *labels,
-                      int64_t *core_sample_indices,
-                      double* sample_weight,
-                      size_t max_mbytes_per_batch,
-                      EpsNnMethod eps_nn_method,
-                      level_enum verbosity,
-                      bool opg) except +
+    cdef void fit(handle_t& handle,
+                  float *input,
+                  int64_t n_rows,
+                  int64_t n_cols,
+                  double eps,
+                  int min_pts,
+                  DistanceType metric,
+                  int64_t *labels,
+                  int64_t *core_sample_indices,
+                  float* sample_weight,
+                  size_t max_mbytes_per_batch,
+                  EpsNnMethod eps_nn_method,
+                  level_enum verbosity,
+                  bool opg) except +
+
+    cdef void fit(handle_t& handle,
+                  double *input,
+                  int64_t n_rows,
+                  int64_t n_cols,
+                  double eps,
+                  int min_pts,
+                  DistanceType metric,
+                  int64_t *labels,
+                  int64_t *core_sample_indices,
+                  double* sample_weight,
+                  size_t max_mbytes_per_batch,
+                  EpsNnMethod eps_nn_method,
+                  level_enum verbosity,
+                  bool opg) except +
 
 
 class DBSCAN(UniversalBase,
@@ -285,135 +284,134 @@ class DBSCAN(UniversalBase,
                              "Valid values are {'int32', 'int64', "
                              "np.int32, np.int64}")
 
-        IF GPUBUILD == 1:
-            X_m, n_rows, self.n_features_in_, self.dtype = \
+        X_m, n_rows, self.n_features_in_, self.dtype = \
+            input_to_cuml_array(
+                X,
+                order='C',
+                convert_to_dtype=(np.float32 if convert_dtype
+                                  else None),
+                check_dtype=[np.float32, np.float64]
+            )
+
+        if n_rows == 0:
+            raise ValueError("No rows in the input array. DBScan cannot be "
+                             "fitted!")
+
+        cdef uintptr_t input_ptr = X_m.ptr
+
+        cdef uintptr_t sample_weight_ptr = <uintptr_t> NULL
+        if sample_weight is not None:
+            sample_weight_m, _, _, _ = \
                 input_to_cuml_array(
-                    X,
-                    order='C',
-                    convert_to_dtype=(np.float32 if convert_dtype
+                    sample_weight,
+                    convert_to_dtype=(self.dtype if convert_dtype
                                       else None),
-                    check_dtype=[np.float32, np.float64]
-                )
+                    check_dtype=self.dtype,
+                    check_rows=n_rows,
+                    check_cols=1)
+            sample_weight_ptr = sample_weight_m.ptr
 
-            if n_rows == 0:
-                raise ValueError("No rows in the input array. DBScan cannot be "
-                                 "fitted!")
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            cdef uintptr_t input_ptr = X_m.ptr
+        self.labels_ = CumlArray.empty(n_rows, dtype=out_dtype,
+                                       index=X_m.index)
+        cdef uintptr_t labels_ptr = self.labels_.ptr
 
-            cdef uintptr_t sample_weight_ptr = <uintptr_t> NULL
-            if sample_weight is not None:
-                sample_weight_m, _, _, _ = \
-                    input_to_cuml_array(
-                        sample_weight,
-                        convert_to_dtype=(self.dtype if convert_dtype
-                                          else None),
-                        check_dtype=self.dtype,
-                        check_rows=n_rows,
-                        check_cols=1)
-                sample_weight_ptr = sample_weight_m.ptr
+        cdef uintptr_t core_sample_indices_ptr = <uintptr_t> NULL
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        # metric
+        metric_parsing = {
+            "L2": DistanceType.L2SqrtExpanded,
+            "euclidean": DistanceType.L2SqrtExpanded,
+            "cosine": DistanceType.CosineExpanded,
+            "precomputed": DistanceType.Precomputed
+        }
+        if self.metric in metric_parsing:
+            metric = metric_parsing[self.metric.lower()]
+        else:
+            raise ValueError("Invalid value for metric: {}"
+                             .format(self.metric))
 
-            self.labels_ = CumlArray.empty(n_rows, dtype=out_dtype,
-                                           index=X_m.index)
-            cdef uintptr_t labels_ptr = self.labels_.ptr
+        # algo
+        algo_parsing = {
+            "brute": EpsNnMethod.BRUTE_FORCE,
+            "rbc": EpsNnMethod.RBC
+        }
+        if self.algorithm in algo_parsing:
+            algorithm = algo_parsing[self.algorithm.lower()]
+        else:
+            raise ValueError("Invalid value for algorithm: {}"
+                             .format(self.algorithm))
 
-            cdef uintptr_t core_sample_indices_ptr = <uintptr_t> NULL
+        # Create the output core_sample_indices only if needed
+        if self.calc_core_sample_indices:
+            self.core_sample_indices_ = \
+                CumlArray.empty(n_rows, dtype=out_dtype)
+            core_sample_indices_ptr = self.core_sample_indices_.ptr
 
-            # metric
-            metric_parsing = {
-                "L2": DistanceType.L2SqrtExpanded,
-                "euclidean": DistanceType.L2SqrtExpanded,
-                "cosine": DistanceType.CosineExpanded,
-                "precomputed": DistanceType.Precomputed
-            }
-            if self.metric in metric_parsing:
-                metric = metric_parsing[self.metric.lower()]
+        if self.dtype == np.float32:
+            if out_dtype == "int32" or out_dtype is np.int32:
+                fit(handle_[0],
+                    <float*>input_ptr,
+                    <int> n_rows,
+                    <int> self.n_features_in_,
+                    <float> self.eps,
+                    <int> self.min_samples,
+                    <DistanceType> metric,
+                    <int*> labels_ptr,
+                    <int*> core_sample_indices_ptr,
+                    <float*> sample_weight_ptr,
+                    <size_t>self.max_mbytes_per_batch,
+                    <EpsNnMethod> algorithm,
+                    <level_enum> self.verbose,
+                    <bool> opg)
             else:
-                raise ValueError("Invalid value for metric: {}"
-                                 .format(self.metric))
+                fit(handle_[0],
+                    <float*>input_ptr,
+                    <int64_t> n_rows,
+                    <int64_t> self.n_features_in_,
+                    <float> self.eps,
+                    <int> self.min_samples,
+                    <DistanceType> metric,
+                    <int64_t*> labels_ptr,
+                    <int64_t*> core_sample_indices_ptr,
+                    <float*> sample_weight_ptr,
+                    <size_t>self.max_mbytes_per_batch,
+                    <EpsNnMethod> algorithm,
+                    <level_enum> self.verbose,
+                    <bool> opg)
 
-            # algo
-            algo_parsing = {
-                "brute": EpsNnMethod.BRUTE_FORCE,
-                "rbc": EpsNnMethod.RBC
-            }
-            if self.algorithm in algo_parsing:
-                algorithm = algo_parsing[self.algorithm.lower()]
+        else:
+            if out_dtype == "int32" or out_dtype is np.int32:
+                fit(handle_[0],
+                    <double*>input_ptr,
+                    <int> n_rows,
+                    <int> self.n_features_in_,
+                    <double> self.eps,
+                    <int> self.min_samples,
+                    <DistanceType> metric,
+                    <int*> labels_ptr,
+                    <int*> core_sample_indices_ptr,
+                    <double*> sample_weight_ptr,
+                    <size_t> self.max_mbytes_per_batch,
+                    <EpsNnMethod> algorithm,
+                    <level_enum> self.verbose,
+                    <bool> opg)
             else:
-                raise ValueError("Invalid value for algorithm: {}"
-                                 .format(self.algorithm))
-
-            # Create the output core_sample_indices only if needed
-            if self.calc_core_sample_indices:
-                self.core_sample_indices_ = \
-                    CumlArray.empty(n_rows, dtype=out_dtype)
-                core_sample_indices_ptr = self.core_sample_indices_.ptr
-
-            if self.dtype == np.float32:
-                if out_dtype == "int32" or out_dtype is np.int32:
-                    fit(handle_[0],
-                        <float*>input_ptr,
-                        <int> n_rows,
-                        <int> self.n_features_in_,
-                        <float> self.eps,
-                        <int> self.min_samples,
-                        <DistanceType> metric,
-                        <int*> labels_ptr,
-                        <int*> core_sample_indices_ptr,
-                        <float*> sample_weight_ptr,
-                        <size_t>self.max_mbytes_per_batch,
-                        <EpsNnMethod> algorithm,
-                        <level_enum> self.verbose,
-                        <bool> opg)
-                else:
-                    fit(handle_[0],
-                        <float*>input_ptr,
-                        <int64_t> n_rows,
-                        <int64_t> self.n_features_in_,
-                        <float> self.eps,
-                        <int> self.min_samples,
-                        <DistanceType> metric,
-                        <int64_t*> labels_ptr,
-                        <int64_t*> core_sample_indices_ptr,
-                        <float*> sample_weight_ptr,
-                        <size_t>self.max_mbytes_per_batch,
-                        <EpsNnMethod> algorithm,
-                        <level_enum> self.verbose,
-                        <bool> opg)
-
-            else:
-                if out_dtype == "int32" or out_dtype is np.int32:
-                    fit(handle_[0],
-                        <double*>input_ptr,
-                        <int> n_rows,
-                        <int> self.n_features_in_,
-                        <double> self.eps,
-                        <int> self.min_samples,
-                        <DistanceType> metric,
-                        <int*> labels_ptr,
-                        <int*> core_sample_indices_ptr,
-                        <double*> sample_weight_ptr,
-                        <size_t> self.max_mbytes_per_batch,
-                        <EpsNnMethod> algorithm,
-                        <level_enum> self.verbose,
-                        <bool> opg)
-                else:
-                    fit(handle_[0],
-                        <double*>input_ptr,
-                        <int64_t> n_rows,
-                        <int64_t> self.n_features_in_,
-                        <double> self.eps,
-                        <int> self.min_samples,
-                        <DistanceType> metric,
-                        <int64_t*> labels_ptr,
-                        <int64_t*> core_sample_indices_ptr,
-                        <double*> sample_weight_ptr,
-                        <size_t> self.max_mbytes_per_batch,
-                        <EpsNnMethod> algorithm,
-                        <level_enum> self.verbose,
-                        <bool> opg)
+                fit(handle_[0],
+                    <double*>input_ptr,
+                    <int64_t> n_rows,
+                    <int64_t> self.n_features_in_,
+                    <double> self.eps,
+                    <int> self.min_samples,
+                    <DistanceType> metric,
+                    <int64_t*> labels_ptr,
+                    <int64_t*> core_sample_indices_ptr,
+                    <double*> sample_weight_ptr,
+                    <size_t> self.max_mbytes_per_batch,
+                    <EpsNnMethod> algorithm,
+                    <level_enum> self.verbose,
+                    <bool> opg)
 
             # make sure that the `fit` is complete before the following
             # delete call happens

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -36,142 +36,143 @@ from cuml.internals.api_decorators import (
 )
 from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
-from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.import_utils import has_hdbscan
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
-IF GPUBUILD == 1:
-    from cython.operator cimport dereference as deref
-    from libc.stdlib cimport free
-    from libcpp cimport bool
-    from rmm.librmm.device_uvector cimport device_uvector
+from cython.operator cimport dereference as deref
+from libc.stdlib cimport free
+from libcpp cimport bool
+from rmm.librmm.device_uvector cimport device_uvector
 
-    from cuml.metrics.distance_type cimport DistanceType
-    from pylibraft.common.handle import Handle
-    from pylibraft.common.handle cimport handle_t
+from cuml.metrics.distance_type cimport DistanceType
 
-    cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
+from pylibraft.common.handle import Handle
 
-        ctypedef enum CLUSTER_SELECTION_METHOD:
-            EOM "ML::HDBSCAN::Common::CLUSTER_SELECTION_METHOD::EOM"
-            LEAF "ML::HDBSCAN::Common::CLUSTER_SELECTION_METHOD::LEAF"
+from pylibraft.common.handle cimport handle_t
 
-        cdef cppclass CondensedHierarchy[value_idx, value_t]:
-            CondensedHierarchy(
-                const handle_t &handle, size_t n_leaves)
 
-            CondensedHierarchy(const handle_t& handle_,
-                               size_t n_leaves_,
-                               int _n_edges_,
-                               value_idx* parents_,
-                               value_idx* children_,
-                               value_t* lambdas_,
-                               value_idx* sizes_)
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
 
-            value_idx *get_parents()
-            value_idx *get_children()
-            value_t *get_lambdas()
-            value_idx *get_sizes()
-            value_idx get_n_edges()
+    ctypedef enum CLUSTER_SELECTION_METHOD:
+        EOM "ML::HDBSCAN::Common::CLUSTER_SELECTION_METHOD::EOM"
+        LEAF "ML::HDBSCAN::Common::CLUSTER_SELECTION_METHOD::LEAF"
 
-        cdef cppclass hdbscan_output[int, float]:
-            hdbscan_output(const handle_t &handle,
-                           int n_leaves,
-                           int *labels,
+    cdef cppclass CondensedHierarchy[value_idx, value_t]:
+        CondensedHierarchy(
+            const handle_t &handle, size_t n_leaves)
+
+        CondensedHierarchy(const handle_t& handle_,
+                           size_t n_leaves_,
+                           int _n_edges_,
+                           value_idx* parents_,
+                           value_idx* children_,
+                           value_t* lambdas_,
+                           value_idx* sizes_)
+
+        value_idx *get_parents()
+        value_idx *get_children()
+        value_t *get_lambdas()
+        value_idx *get_sizes()
+        value_idx get_n_edges()
+
+    cdef cppclass hdbscan_output[int, float]:
+        hdbscan_output(const handle_t &handle,
+                       int n_leaves,
+                       int *labels,
+                       float *probabilities,
+                       int *children,
+                       int *sizes,
+                       float *deltas,
+                       int *mst_src,
+                       int *mst_dst,
+                       float *mst_weights)
+        int get_n_leaves()
+        int get_n_clusters()
+        float *get_stabilities()
+        int *get_labels()
+        int *get_inverse_label_map()
+        float *get_core_dists()
+        CondensedHierarchy[int, float] &get_condensed_tree()
+
+    cdef cppclass HDBSCANParams:
+        int min_samples
+        int min_cluster_size
+        int max_cluster_size,
+
+        float cluster_selection_epsilon,
+
+        bool allow_single_cluster,
+        CLUSTER_SELECTION_METHOD cluster_selection_method,
+
+    cdef cppclass PredictionData[int, float]:
+        PredictionData(const handle_t &handle,
+                       int m,
+                       int n,
+                       float *core_dists)
+
+        size_t n_rows
+        size_t n_cols
+
+    void generate_prediction_data(const handle_t& handle,
+                                  CondensedHierarchy[int, float]&
+                                  condensed_tree,
+                                  int* labels,
+                                  int* inverse_label_map,
+                                  int n_selected_clusters,
+                                  PredictionData[int, float]& prediction_data)
+
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
+
+    void hdbscan(const handle_t & handle,
+                 const float * X,
+                 size_t m, size_t n,
+                 DistanceType metric,
+                 HDBSCANParams & params,
+                 hdbscan_output & output,
+                 float * core_dists)
+
+    void build_condensed_hierarchy(
+      const handle_t &handle,
+      const int *children,
+      const float *delta,
+      const int *sizes,
+      int min_cluster_size,
+      int n_leaves,
+      CondensedHierarchy[int, float] &condensed_tree)
+
+    void _extract_clusters(const handle_t &handle, size_t n_leaves,
+                           int _n_edges, int *parents, int *children,
+                           float *lambdas, int *sizes, int *labels,
                            float *probabilities,
-                           int *children,
-                           int *sizes,
-                           float *deltas,
-                           int *mst_src,
-                           int *mst_dst,
-                           float *mst_weights)
-            int get_n_leaves()
-            int get_n_clusters()
-            float *get_stabilities()
-            int *get_labels()
-            int *get_inverse_label_map()
-            float *get_core_dists()
-            CondensedHierarchy[int, float] &get_condensed_tree()
+                           CLUSTER_SELECTION_METHOD cluster_selection_method,
+                           bool allow_single_cluster, int max_cluster_size,
+                           float cluster_selection_epsilon)
 
-        cdef cppclass HDBSCANParams:
-            int min_samples
-            int min_cluster_size
-            int max_cluster_size,
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::HELPER":
 
-            float cluster_selection_epsilon,
+    void compute_core_dists(const handle_t& handle,
+                            const float* X,
+                            float* core_dists,
+                            size_t m,
+                            size_t n,
+                            DistanceType metric,
+                            int min_samples)
 
-            bool allow_single_cluster,
-            CLUSTER_SELECTION_METHOD cluster_selection_method,
+    void compute_inverse_label_map(const handle_t& handle,
+                                   CondensedHierarchy[int, float]&
+                                   condensed_tree,
+                                   size_t n_leaves,
+                                   CLUSTER_SELECTION_METHOD
+                                   cluster_selection_method,
+                                   device_uvector[int]& inverse_label_map,
+                                   bool allow_single_cluster,
+                                   int max_cluster_size,
+                                   float cluster_selection_epsilon)
 
-        cdef cppclass PredictionData[int, float]:
-            PredictionData(const handle_t &handle,
-                           int m,
-                           int n,
-                           float *core_dists)
-
-            size_t n_rows
-            size_t n_cols
-
-        void generate_prediction_data(const handle_t& handle,
-                                      CondensedHierarchy[int, float]&
-                                      condensed_tree,
-                                      int* labels,
-                                      int* inverse_label_map,
-                                      int n_selected_clusters,
-                                      PredictionData[int, float]& prediction_data)
-
-    cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
-
-        void hdbscan(const handle_t & handle,
-                     const float * X,
-                     size_t m, size_t n,
-                     DistanceType metric,
-                     HDBSCANParams & params,
-                     hdbscan_output & output,
-                     float * core_dists)
-
-        void build_condensed_hierarchy(
-          const handle_t &handle,
-          const int *children,
-          const float *delta,
-          const int *sizes,
-          int min_cluster_size,
-          int n_leaves,
-          CondensedHierarchy[int, float] &condensed_tree)
-
-        void _extract_clusters(const handle_t &handle, size_t n_leaves,
-                               int _n_edges, int *parents, int *children,
-                               float *lambdas, int *sizes, int *labels,
-                               float *probabilities,
-                               CLUSTER_SELECTION_METHOD cluster_selection_method,
-                               bool allow_single_cluster, int max_cluster_size,
-                               float cluster_selection_epsilon)
-
-    cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::HELPER":
-
-        void compute_core_dists(const handle_t& handle,
-                                const float* X,
-                                float* core_dists,
-                                size_t m,
-                                size_t n,
-                                DistanceType metric,
-                                int min_samples)
-
-        void compute_inverse_label_map(const handle_t& handle,
-                                       CondensedHierarchy[int, float]&
-                                       condensed_tree,
-                                       size_t n_leaves,
-                                       CLUSTER_SELECTION_METHOD
-                                       cluster_selection_method,
-                                       device_uvector[int]& inverse_label_map,
-                                       bool allow_single_cluster,
-                                       int max_cluster_size,
-                                       float cluster_selection_epsilon)
-
-    _metrics_mapping = {
-        'l2': DistanceType.L2SqrtExpanded,
-        'euclidean': DistanceType.L2SqrtExpanded,
-    }
+_metrics_mapping = {
+    'l2': DistanceType.L2SqrtExpanded,
+    'euclidean': DistanceType.L2SqrtExpanded,
+}
 
 
 def _cuml_array_from_ptr(ptr, buf_size, shape, dtype, owner):
@@ -263,64 +264,61 @@ def condense_hierarchy(dendrogram,
                             check_dtype=[np.int32],
                             convert_to_dtype=(np.int32))
 
-    IF GPUBUILD == 1:
+    handle = Handle()
+    cdef handle_t *handle_ = <handle_t*> <size_t> handle.getHandle()
+    n_leaves = dendrogram.shape[0]+1
+    cdef CondensedHierarchy[int, float] *condensed_tree =\
+        new CondensedHierarchy[int, float](
+            handle_[0], <size_t>n_leaves)
 
-        handle = Handle()
-        cdef handle_t *handle_ = <handle_t*> <size_t> handle.getHandle()
-        n_leaves = dendrogram.shape[0]+1
-        cdef CondensedHierarchy[int, float] *condensed_tree =\
-            new CondensedHierarchy[int, float](
-                handle_[0], <size_t>n_leaves)
+    cdef uintptr_t _children_ptr = _children.ptr
+    cdef uintptr_t _lambdas_ptr = _lambdas.ptr
+    cdef uintptr_t _sizes_ptr = _sizes.ptr
 
-        cdef uintptr_t _children_ptr = _children.ptr
-        cdef uintptr_t _lambdas_ptr = _lambdas.ptr
-        cdef uintptr_t _sizes_ptr = _sizes.ptr
+    build_condensed_hierarchy(handle_[0],
+                              <int*> _children_ptr,
+                              <float*> _lambdas_ptr,
+                              <int*> _sizes_ptr,
+                              <int>min_cluster_size,
+                              n_leaves,
+                              deref(condensed_tree))
 
-        build_condensed_hierarchy(handle_[0],
-                                  <int*> _children_ptr,
-                                  <float*> _lambdas_ptr,
-                                  <int*> _sizes_ptr,
-                                  <int>min_cluster_size,
-                                  n_leaves,
-                                  deref(condensed_tree))
+    n_condensed_tree_edges = \
+        condensed_tree.get_n_edges()
 
-        n_condensed_tree_edges = \
-            condensed_tree.get_n_edges()
+    condensed_parent_ = _construct_condensed_tree_attribute(
+        <size_t>condensed_tree.get_parents(), n_condensed_tree_edges)
 
-        condensed_parent_ = _construct_condensed_tree_attribute(
-            <size_t>condensed_tree.get_parents(), n_condensed_tree_edges)
+    condensed_child_ = _construct_condensed_tree_attribute(
+        <size_t>condensed_tree.get_children(), n_condensed_tree_edges)
 
-        condensed_child_ = _construct_condensed_tree_attribute(
-            <size_t>condensed_tree.get_children(), n_condensed_tree_edges)
+    condensed_lambdas_ = \
+        _construct_condensed_tree_attribute(
+            <size_t>condensed_tree.get_lambdas(), n_condensed_tree_edges,
+            "float32")
 
-        condensed_lambdas_ = \
-            _construct_condensed_tree_attribute(
-                <size_t>condensed_tree.get_lambdas(), n_condensed_tree_edges,
-                "float32")
+    condensed_sizes_ = _construct_condensed_tree_attribute(
+        <size_t>condensed_tree.get_sizes(), n_condensed_tree_edges)
 
-        condensed_sizes_ = _construct_condensed_tree_attribute(
-            <size_t>condensed_tree.get_sizes(), n_condensed_tree_edges)
+    condensed_tree_host = _build_condensed_tree_plot_host(
+        condensed_parent_.to_output('numpy'),
+        condensed_child_.to_output("numpy"),
+        condensed_lambdas_.to_output("numpy"),
+        condensed_sizes_.to_output("numpy"), cluster_selection_epsilon,
+        allow_single_cluster)
 
-        condensed_tree_host = _build_condensed_tree_plot_host(
-            condensed_parent_.to_output('numpy'),
-            condensed_child_.to_output("numpy"),
-            condensed_lambdas_.to_output("numpy"),
-            condensed_sizes_.to_output("numpy"), cluster_selection_epsilon,
-            allow_single_cluster)
+    del condensed_tree
 
-        del condensed_tree
-
-        return condensed_tree_host
+    return condensed_tree_host
 
 
 def delete_hdbscan_output(obj):
-    IF GPUBUILD == 1:
-        cdef hdbscan_output *output
-        if hasattr(obj, "hdbscan_output_"):
-            output = <hdbscan_output*>\
-                      <uintptr_t> obj.hdbscan_output_
-            del output
-            del obj.hdbscan_output_
+    cdef hdbscan_output *output
+    if hasattr(obj, "hdbscan_output_"):
+        output = <hdbscan_output*>\
+                  <uintptr_t> obj.hdbscan_output_
+        del output
+        del obj.hdbscan_output_
 
 
 class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
@@ -669,30 +667,29 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
             raise ValueError(
                 'The model is not trained yet (call fit() first).')
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            cdef uintptr_t core_dists = self.core_dists.ptr
-            cdef PredictionData[int, float] *prediction_data = new PredictionData(
-                handle_[0], <int> self.n_rows, <int> self.n_cols,
-                <float*> core_dists)
-            self.prediction_data_ptr = <size_t>prediction_data
+        cdef uintptr_t core_dists = self.core_dists.ptr
+        cdef PredictionData[int, float] *prediction_data = new PredictionData(
+            handle_[0], <int> self.n_rows, <int> self.n_cols,
+            <float*> core_dists)
+        self.prediction_data_ptr = <size_t>prediction_data
 
-            cdef uintptr_t condensed_tree_ptr = self.condensed_tree_ptr
-            cdef CondensedHierarchy[int, float] *condensed_tree = \
-                <CondensedHierarchy[int, float] *> condensed_tree_ptr
-            labels, _, _, _ = input_to_cuml_array(self.labels_,
-                                                  order='C',
-                                                  convert_to_dtype=np.int32)
-            cdef uintptr_t _labels_ptr = labels.ptr
-            cdef uintptr_t inverse_label_map_ptr = self.inverse_label_map.ptr
+        cdef uintptr_t condensed_tree_ptr = self.condensed_tree_ptr
+        cdef CondensedHierarchy[int, float] *condensed_tree = \
+            <CondensedHierarchy[int, float] *> condensed_tree_ptr
+        labels, _, _, _ = input_to_cuml_array(self.labels_,
+                                              order='C',
+                                              convert_to_dtype=np.int32)
+        cdef uintptr_t _labels_ptr = labels.ptr
+        cdef uintptr_t inverse_label_map_ptr = self.inverse_label_map.ptr
 
-            generate_prediction_data(handle_[0],
-                                     deref(condensed_tree),
-                                     <int*> _labels_ptr,
-                                     <int*> inverse_label_map_ptr,
-                                     <int> self.n_clusters_,
-                                     deref(prediction_data))
+        generate_prediction_data(handle_[0],
+                                 deref(condensed_tree),
+                                 <int*> _labels_ptr,
+                                 <int*> inverse_label_map_ptr,
+                                 <int> self.n_clusters_,
+                                 deref(prediction_data))
 
         self.handle.sync()
 
@@ -700,69 +697,67 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
 
     def __dealloc__(self):
         delete_hdbscan_output(self)
-        IF GPUBUILD == 1:
-            cdef CondensedHierarchy[int, float]* condensed_tree_ptr
-            if hasattr(self, "condensed_tree_ptr"):
-                condensed_tree_ptr = <CondensedHierarchy[int, float]*> \
-                                         <uintptr_t> self.condensed_tree_ptr
-                free(condensed_tree_ptr)
-                del self.condensed_tree_ptr
-            cdef PredictionData* prediction_data_ptr
-            if hasattr(self, "prediction_data_ptr"):
-                prediction_data_ptr = \
-                    <PredictionData*> <uintptr_t> self.prediction_data_ptr
-                free(prediction_data_ptr)
-                del self.prediction_data_ptr
-            # this is only constructed when trying to gpu predict
-            # with a cpu model
-            if hasattr(self, "inverse_label_map_ptr"):
-                inverse_label_map_ptr = \
-                    <device_uvector[int]*> <uintptr_t> self.inverse_label_map_ptr
-                free(inverse_label_map_ptr)
-                del self.inverse_label_map_ptr
+        cdef CondensedHierarchy[int, float]* condensed_tree_ptr
+        if hasattr(self, "condensed_tree_ptr"):
+            condensed_tree_ptr = <CondensedHierarchy[int, float]*> \
+                                     <uintptr_t> self.condensed_tree_ptr
+            free(condensed_tree_ptr)
+            del self.condensed_tree_ptr
+        cdef PredictionData* prediction_data_ptr
+        if hasattr(self, "prediction_data_ptr"):
+            prediction_data_ptr = \
+                <PredictionData*> <uintptr_t> self.prediction_data_ptr
+            free(prediction_data_ptr)
+            del self.prediction_data_ptr
+        # this is only constructed when trying to gpu predict
+        # with a cpu model
+        if hasattr(self, "inverse_label_map_ptr"):
+            inverse_label_map_ptr = \
+                <device_uvector[int]*> <uintptr_t> self.inverse_label_map_ptr
+            free(inverse_label_map_ptr)
+            del self.inverse_label_map_ptr
 
     def _construct_output_attributes(self):
-        IF GPUBUILD == 1:
-            cdef hdbscan_output *hdbscan_output_ = \
-                    <hdbscan_output*><size_t>self.hdbscan_output_
+        cdef hdbscan_output *hdbscan_output_ = \
+                <hdbscan_output*><size_t>self.hdbscan_output_
 
-            self.n_clusters_ = hdbscan_output_.get_n_clusters()
+        self.n_clusters_ = hdbscan_output_.get_n_clusters()
 
-            if self.n_clusters_ > 0:
-                self.cluster_persistence_ = _cuml_array_from_ptr(
-                    <size_t>hdbscan_output_.get_stabilities(),
-                    hdbscan_output_.get_n_clusters() * sizeof(float),
-                    (1, hdbscan_output_.get_n_clusters()), "float32", self)
-            else:
-                self.cluster_persistence_ = CumlArray.empty((0,), dtype="float32")
+        if self.n_clusters_ > 0:
+            self.cluster_persistence_ = _cuml_array_from_ptr(
+                <size_t>hdbscan_output_.get_stabilities(),
+                hdbscan_output_.get_n_clusters() * sizeof(float),
+                (1, hdbscan_output_.get_n_clusters()), "float32", self)
+        else:
+            self.cluster_persistence_ = CumlArray.empty((0,), dtype="float32")
 
-            n_condensed_tree_edges = \
-                hdbscan_output_.get_condensed_tree().get_n_edges()
+        n_condensed_tree_edges = \
+            hdbscan_output_.get_condensed_tree().get_n_edges()
 
-            self.condensed_parent_ = _construct_condensed_tree_attribute(
-                <size_t>hdbscan_output_.get_condensed_tree().get_parents(),
-                n_condensed_tree_edges)
+        self.condensed_parent_ = _construct_condensed_tree_attribute(
+            <size_t>hdbscan_output_.get_condensed_tree().get_parents(),
+            n_condensed_tree_edges)
 
-            self.condensed_child_ = _construct_condensed_tree_attribute(
-                <size_t>hdbscan_output_.get_condensed_tree().get_children(),
-                n_condensed_tree_edges)
+        self.condensed_child_ = _construct_condensed_tree_attribute(
+            <size_t>hdbscan_output_.get_condensed_tree().get_children(),
+            n_condensed_tree_edges)
 
-            self.condensed_lambdas_ = \
-                _construct_condensed_tree_attribute(
-                    <size_t>hdbscan_output_.get_condensed_tree().get_lambdas(),
-                    n_condensed_tree_edges, "float32")
+        self.condensed_lambdas_ = \
+            _construct_condensed_tree_attribute(
+                <size_t>hdbscan_output_.get_condensed_tree().get_lambdas(),
+                n_condensed_tree_edges, "float32")
 
-            self.condensed_sizes_ = _construct_condensed_tree_attribute(
-                <size_t>hdbscan_output_.get_condensed_tree().get_sizes(),
-                n_condensed_tree_edges)
+        self.condensed_sizes_ = _construct_condensed_tree_attribute(
+            <size_t>hdbscan_output_.get_condensed_tree().get_sizes(),
+            n_condensed_tree_edges)
 
-            if self.n_clusters_ > 0:
-                self.inverse_label_map = _cuml_array_from_ptr(
-                    <size_t>hdbscan_output_.get_inverse_label_map(),
-                    self.n_clusters_ * sizeof(int),
-                    (self.n_clusters_, ), "int32", self)
-            else:
-                self.inverse_label_map = CumlArray.empty((0,), dtype="int32")
+        if self.n_clusters_ > 0:
+            self.inverse_label_map = _cuml_array_from_ptr(
+                <size_t>hdbscan_output_.get_inverse_label_map(),
+                self.n_clusters_ * sizeof(int),
+                (self.n_clusters_, ), "int32", self)
+        else:
+            self.inverse_label_map = CumlArray.empty((0,), dtype="int32")
 
     @generate_docstring()
     @enable_device_interop
@@ -787,93 +782,92 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
 
         cdef uintptr_t _input_ptr = X_m.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            # Hardcode n_components_ to 1 for single linkage. This will
-            # not be the case for other linkage types.
-            self.n_connected_components_ = 1
-            self.n_leaves_ = n_rows
+        # Hardcode n_components_ to 1 for single linkage. This will
+        # not be the case for other linkage types.
+        self.n_connected_components_ = 1
+        self.n_leaves_ = n_rows
 
-            self.labels_ = CumlArray.empty(n_rows, dtype="int32", index=X_m.index)
-            self.children_ = CumlArray.empty((2, n_rows), dtype="int32")
-            self.probabilities_ = CumlArray.empty(n_rows, dtype="float32")
-            self.sizes_ = CumlArray.empty(n_rows, dtype="int32")
-            self.lambdas_ = CumlArray.empty(n_rows, dtype="float32")
-            self.mst_src_ = CumlArray.empty(n_rows-1, dtype="int32")
-            self.mst_dst_ = CumlArray.empty(n_rows-1, dtype="int32")
-            self.mst_weights_ = CumlArray.empty(n_rows-1, dtype="float32")
-            self.core_dists = CumlArray.empty(n_rows, dtype="float32")
+        self.labels_ = CumlArray.empty(n_rows, dtype="int32", index=X_m.index)
+        self.children_ = CumlArray.empty((2, n_rows), dtype="int32")
+        self.probabilities_ = CumlArray.empty(n_rows, dtype="float32")
+        self.sizes_ = CumlArray.empty(n_rows, dtype="int32")
+        self.lambdas_ = CumlArray.empty(n_rows, dtype="float32")
+        self.mst_src_ = CumlArray.empty(n_rows-1, dtype="int32")
+        self.mst_dst_ = CumlArray.empty(n_rows-1, dtype="int32")
+        self.mst_weights_ = CumlArray.empty(n_rows-1, dtype="float32")
+        self.core_dists = CumlArray.empty(n_rows, dtype="float32")
 
-            cdef uintptr_t _labels_ptr = self.labels_.ptr
-            cdef uintptr_t _children_ptr = self.children_.ptr
-            cdef uintptr_t _sizes_ptr = self.sizes_.ptr
-            cdef uintptr_t _lambdas_ptr = self.lambdas_.ptr
-            cdef uintptr_t _probabilities_ptr = self.probabilities_.ptr
-            cdef uintptr_t mst_src_ptr = self.mst_src_.ptr
-            cdef uintptr_t mst_dst_ptr = self.mst_dst_.ptr
-            cdef uintptr_t mst_weights_ptr = self.mst_weights_.ptr
+        cdef uintptr_t _labels_ptr = self.labels_.ptr
+        cdef uintptr_t _children_ptr = self.children_.ptr
+        cdef uintptr_t _sizes_ptr = self.sizes_.ptr
+        cdef uintptr_t _lambdas_ptr = self.lambdas_.ptr
+        cdef uintptr_t _probabilities_ptr = self.probabilities_.ptr
+        cdef uintptr_t mst_src_ptr = self.mst_src_.ptr
+        cdef uintptr_t mst_dst_ptr = self.mst_dst_.ptr
+        cdef uintptr_t mst_weights_ptr = self.mst_weights_.ptr
 
-            # If calling fit a second time, release
-            # any memory owned from previous trainings
-            delete_hdbscan_output(self)
+        # If calling fit a second time, release
+        # any memory owned from previous trainings
+        delete_hdbscan_output(self)
 
-            cdef hdbscan_output *linkage_output = new hdbscan_output(
-                handle_[0], n_rows,
-                <int*>_labels_ptr,
-                <float*>_probabilities_ptr,
-                <int*>_children_ptr,
-                <int*>_sizes_ptr,
-                <float*>_lambdas_ptr,
-                <int*>mst_src_ptr,
-                <int*>mst_dst_ptr,
-                <float*>mst_weights_ptr)
+        cdef hdbscan_output *linkage_output = new hdbscan_output(
+            handle_[0], n_rows,
+            <int*>_labels_ptr,
+            <float*>_probabilities_ptr,
+            <int*>_children_ptr,
+            <int*>_sizes_ptr,
+            <float*>_lambdas_ptr,
+            <int*>mst_src_ptr,
+            <int*>mst_dst_ptr,
+            <float*>mst_weights_ptr)
 
-            self.hdbscan_output_ = <size_t>linkage_output
+        self.hdbscan_output_ = <size_t>linkage_output
 
-            cdef HDBSCANParams params
-            params.min_samples = self.min_samples
-            # params.alpha = self.alpha
-            params.min_cluster_size = self.min_cluster_size
-            params.max_cluster_size = self.max_cluster_size
-            params.cluster_selection_epsilon = self.cluster_selection_epsilon
-            params.allow_single_cluster = self.allow_single_cluster
+        cdef HDBSCANParams params
+        params.min_samples = self.min_samples
+        # params.alpha = self.alpha
+        params.min_cluster_size = self.min_cluster_size
+        params.max_cluster_size = self.max_cluster_size
+        params.cluster_selection_epsilon = self.cluster_selection_epsilon
+        params.allow_single_cluster = self.allow_single_cluster
 
-            if self.cluster_selection_method == 'eom':
-                params.cluster_selection_method = CLUSTER_SELECTION_METHOD.EOM
-            elif self.cluster_selection_method == 'leaf':
-                params.cluster_selection_method = CLUSTER_SELECTION_METHOD.LEAF
-            else:
-                raise ValueError("Cluster selection method not supported. "
-                                 "Must one of {'eom', 'leaf'}")
+        if self.cluster_selection_method == 'eom':
+            params.cluster_selection_method = CLUSTER_SELECTION_METHOD.EOM
+        elif self.cluster_selection_method == 'leaf':
+            params.cluster_selection_method = CLUSTER_SELECTION_METHOD.LEAF
+        else:
+            raise ValueError("Cluster selection method not supported. "
+                             "Must one of {'eom', 'leaf'}")
 
-            cdef DistanceType metric
-            if self.metric in _metrics_mapping:
-                metric = _metrics_mapping[self.metric]
-            else:
-                raise ValueError(f"metric '{self.metric}' not supported, only "
-                                 "'l2' and 'euclidean' are currently "
-                                 "supported.")
+        cdef DistanceType metric
+        if self.metric in _metrics_mapping:
+            metric = _metrics_mapping[self.metric]
+        else:
+            raise ValueError(f"metric '{self.metric}' not supported, only "
+                             "'l2' and 'euclidean' are currently "
+                             "supported.")
 
-            cdef uintptr_t core_dists_ptr = self.core_dists.ptr
+        cdef uintptr_t core_dists_ptr = self.core_dists.ptr
 
-            if self.connectivity == 'knn' or self.connectivity == 'pairwise':
-                hdbscan(handle_[0],
-                        <float*>_input_ptr,
-                        <int> n_rows,
-                        <int> n_cols,
-                        <DistanceType> metric,
-                        params,
-                        deref(linkage_output),
-                        <float*> core_dists_ptr)
-            else:
-                raise ValueError("'connectivity' can only be one of "
-                                 "{'knn', 'pairwise'}")
+        if self.connectivity == 'knn' or self.connectivity == 'pairwise':
+            hdbscan(handle_[0],
+                    <float*>_input_ptr,
+                    <int> n_rows,
+                    <int> n_cols,
+                    <DistanceType> metric,
+                    params,
+                    deref(linkage_output),
+                    <float*> core_dists_ptr)
+        else:
+            raise ValueError("'connectivity' can only be one of "
+                             "{'knn', 'pairwise'}")
 
-            self.fit_called_ = True
+        self.fit_called_ = True
 
-            self.condensed_tree_ptr = \
-                <size_t> &linkage_output[0].get_condensed_tree()
+        self.condensed_tree_ptr = \
+            <size_t> &linkage_output[0].get_condensed_tree()
 
         self._construct_output_attributes()
 
@@ -931,26 +925,25 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
         cdef uintptr_t _lambdas_ptr = lambdas.ptr
         cdef uintptr_t _probabilities_ptr = self.probabilities_test.ptr
 
-        IF GPUBUILD == 1:
-            if self.cluster_selection_method == 'eom':
-                cluster_selection_method = CLUSTER_SELECTION_METHOD.EOM
-            elif self.cluster_selection_method == 'leaf':
-                cluster_selection_method = CLUSTER_SELECTION_METHOD.LEAF
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if self.cluster_selection_method == 'eom':
+            cluster_selection_method = CLUSTER_SELECTION_METHOD.EOM
+        elif self.cluster_selection_method == 'leaf':
+            cluster_selection_method = CLUSTER_SELECTION_METHOD.LEAF
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            _extract_clusters(handle_[0],
-                              <size_t> n_leaves,
-                              <int> _n_edges,
-                              <int*> _parents_ptr,
-                              <int*> _children_ptr,
-                              <float*> _lambdas_ptr,
-                              <int*> _sizes_ptr,
-                              <int*> _labels_ptr,
-                              <float*> _probabilities_ptr,
-                              <CLUSTER_SELECTION_METHOD> cluster_selection_method,
-                              <bool> self.allow_single_cluster,
-                              <int> self.max_cluster_size,
-                              <float> self.cluster_selection_epsilon)
+        _extract_clusters(handle_[0],
+                          <size_t> n_leaves,
+                          <int> _n_edges,
+                          <int*> _parents_ptr,
+                          <int*> _children_ptr,
+                          <float*> _lambdas_ptr,
+                          <int*> _sizes_ptr,
+                          <int*> _labels_ptr,
+                          <float*> _probabilities_ptr,
+                          <CLUSTER_SELECTION_METHOD> cluster_selection_method,
+                          <bool> self.allow_single_cluster,
+                          <int> self.max_cluster_size,
+                          <float> self.cluster_selection_epsilon)
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -988,41 +981,40 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
         self.inverse_label_map = state["inverse_label_map"]
         self.n_clusters_ = state["n_clusters_"]
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            cdef uintptr_t _parent_ptr = self.condensed_parent_.ptr
-            cdef uintptr_t _child_ptr = self.condensed_child_.ptr
-            cdef uintptr_t _lambdas_ptr = self.condensed_lambdas_.ptr
-            cdef uintptr_t _sizes_ptr = self.condensed_sizes_.ptr
+        cdef uintptr_t _parent_ptr = self.condensed_parent_.ptr
+        cdef uintptr_t _child_ptr = self.condensed_child_.ptr
+        cdef uintptr_t _lambdas_ptr = self.condensed_lambdas_.ptr
+        cdef uintptr_t _sizes_ptr = self.condensed_sizes_.ptr
 
-            cdef CondensedHierarchy[int, float] *condensed_tree = \
-                new CondensedHierarchy[int, float](
-                    handle_[0], <size_t>self.n_rows,
-                    <int>self.condensed_parent_.shape[0],
-                    <int*> _parent_ptr, <int*> _child_ptr,
-                    <float*> _lambdas_ptr, <int*> _sizes_ptr)
+        cdef CondensedHierarchy[int, float] *condensed_tree = \
+            new CondensedHierarchy[int, float](
+                handle_[0], <size_t>self.n_rows,
+                <int>self.condensed_parent_.shape[0],
+                <int*> _parent_ptr, <int*> _child_ptr,
+                <float*> _lambdas_ptr, <int*> _sizes_ptr)
 
-            self.condensed_tree_ptr = <size_t> condensed_tree
+        self.condensed_tree_ptr = <size_t> condensed_tree
 
-            cdef uintptr_t core_dists_ptr = self.core_dists.ptr
-            cdef PredictionData[int, float] *prediction_data = new PredictionData(
-                handle_[0], <int> self.n_rows, <int> self.n_cols,
-                <float*> core_dists_ptr)
-            self.prediction_data_ptr = <size_t>prediction_data
+        cdef uintptr_t core_dists_ptr = self.core_dists.ptr
+        cdef PredictionData[int, float] *prediction_data = new PredictionData(
+            handle_[0], <int> self.n_rows, <int> self.n_cols,
+            <float*> core_dists_ptr)
+        self.prediction_data_ptr = <size_t>prediction_data
 
-            self.labels, _, _, _ = input_to_cuml_array(self.labels_.values['cuml'],
-                                                       order='C',
-                                                       convert_to_dtype=np.int32)
-            cdef uintptr_t _labels_ptr = self.labels.ptr
-            cdef uintptr_t inverse_label_map_ptr = self.inverse_label_map.ptr
+        self.labels, _, _, _ = input_to_cuml_array(self.labels_.values['cuml'],
+                                                   order='C',
+                                                   convert_to_dtype=np.int32)
+        cdef uintptr_t _labels_ptr = self.labels.ptr
+        cdef uintptr_t inverse_label_map_ptr = self.inverse_label_map.ptr
 
-            generate_prediction_data(handle_[0],
-                                     deref(condensed_tree),
-                                     <int*> _labels_ptr,
-                                     <int*> inverse_label_map_ptr,
-                                     <int> self.n_clusters_,
-                                     deref(prediction_data))
+        generate_prediction_data(handle_[0],
+                                 deref(condensed_tree),
+                                 <int*> _labels_ptr,
+                                 <int*> inverse_label_map_ptr,
+                                 <int> self.n_clusters_,
+                                 deref(prediction_data))
 
         self.handle.sync()
 
@@ -1074,62 +1066,61 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
         cdef uintptr_t _lambdas_ptr = self.condensed_lambdas_.ptr
         cdef uintptr_t _sizes_ptr = self.condensed_sizes_.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            cdef CondensedHierarchy[int, float] *condensed_tree = \
-                new CondensedHierarchy[int, float](
-                    handle_[0], <size_t>self.n_rows, <int>_n_edges,
-                    <int*> _parent_ptr, <int*> _child_ptr,
-                    <float*> _lambdas_ptr, <int*> _sizes_ptr)
-            self.condensed_tree_ptr = <size_t> condensed_tree
+        cdef CondensedHierarchy[int, float] *condensed_tree = \
+            new CondensedHierarchy[int, float](
+                handle_[0], <size_t>self.n_rows, <int>_n_edges,
+                <int*> _parent_ptr, <int*> _child_ptr,
+                <float*> _lambdas_ptr, <int*> _sizes_ptr)
+        self.condensed_tree_ptr = <size_t> condensed_tree
 
-            self.core_dists = CumlArray.empty(self.n_rows, dtype="float32")
-            metric = _metrics_mapping[self.metric]
+        self.core_dists = CumlArray.empty(self.n_rows, dtype="float32")
+        metric = _metrics_mapping[self.metric]
 
-            cdef uintptr_t X_ptr = self.X_m.ptr
-            cdef uintptr_t core_dists_ptr = self.core_dists.ptr
+        cdef uintptr_t X_ptr = self.X_m.ptr
+        cdef uintptr_t core_dists_ptr = self.core_dists.ptr
 
-            compute_core_dists(handle_[0],
-                               <float*> X_ptr,
-                               <float*> core_dists_ptr,
-                               <size_t> self.n_rows,
-                               <size_t> self.n_cols,
-                               <DistanceType> metric,
-                               <int> self.min_samples)
+        compute_core_dists(handle_[0],
+                           <float*> X_ptr,
+                           <float*> core_dists_ptr,
+                           <size_t> self.n_rows,
+                           <size_t> self.n_cols,
+                           <DistanceType> metric,
+                           <int> self.min_samples)
 
-            cdef device_uvector[int] *inverse_label_map = \
-                new device_uvector[int](0, handle_[0].get_stream())
+        cdef device_uvector[int] *inverse_label_map = \
+            new device_uvector[int](0, handle_[0].get_stream())
 
-            cdef CLUSTER_SELECTION_METHOD cluster_selection_method
-            if self.cluster_selection_method == 'eom':
-                cluster_selection_method = CLUSTER_SELECTION_METHOD.EOM
-            elif self.cluster_selection_method == 'leaf':
-                cluster_selection_method = CLUSTER_SELECTION_METHOD.LEAF
+        cdef CLUSTER_SELECTION_METHOD cluster_selection_method
+        if self.cluster_selection_method == 'eom':
+            cluster_selection_method = CLUSTER_SELECTION_METHOD.EOM
+        elif self.cluster_selection_method == 'leaf':
+            cluster_selection_method = CLUSTER_SELECTION_METHOD.LEAF
 
-            compute_inverse_label_map(handle_[0],
-                                      deref(condensed_tree),
-                                      <size_t> self.n_rows,
-                                      <CLUSTER_SELECTION_METHOD>
-                                      cluster_selection_method,
-                                      deref(inverse_label_map),
-                                      <bool> self.allow_single_cluster,
-                                      <int> self.max_cluster_size,
-                                      <float> self.cluster_selection_epsilon)
+        compute_inverse_label_map(handle_[0],
+                                  deref(condensed_tree),
+                                  <size_t> self.n_rows,
+                                  <CLUSTER_SELECTION_METHOD>
+                                  cluster_selection_method,
+                                  deref(inverse_label_map),
+                                  <bool> self.allow_single_cluster,
+                                  <int> self.max_cluster_size,
+                                  <float> self.cluster_selection_epsilon)
 
-            self.n_clusters_ = <int> inverse_label_map[0].size()
-            self.inverse_label_map_ptr = <size_t> inverse_label_map[0].data()
-            self.inverse_label_map = \
-                _cuml_array_from_ptr(self.inverse_label_map_ptr,
-                                     self.n_clusters_ * sizeof(int),
-                                     (self.n_clusters_, ), "int32", self)
+        self.n_clusters_ = <int> inverse_label_map[0].size()
+        self.inverse_label_map_ptr = <size_t> inverse_label_map[0].data()
+        self.inverse_label_map = \
+            _cuml_array_from_ptr(self.inverse_label_map_ptr,
+                                 self.n_clusters_ * sizeof(int),
+                                 (self.n_clusters_, ), "int32", self)
 
-            self.fit_called_ = True
-            self.generate_prediction_data()
+        self.fit_called_ = True
+        self.generate_prediction_data()
 
-            self.handle.sync()
+        self.handle.sync()
 
-            self._cpu_to_gpu_interop_prepped = True
+        self._cpu_to_gpu_interop_prepped = True
 
     def gpu_to_cpu(self):
         super().gpu_to_cpu()

--- a/python/cuml/cuml/cluster/hdbscan/prediction.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/prediction.pyx
@@ -31,96 +31,95 @@ from cuml.internals.array import CumlArray
 from cuml.internals.device_type import DeviceType
 from cuml.internals.import_utils import has_hdbscan
 
-IF GPUBUILD == 1:
-    from cython.operator cimport dereference as deref
-    from pylibraft.common.handle cimport handle_t
+from cython.operator cimport dereference as deref
+from pylibraft.common.handle cimport handle_t
 
-    from cuml.metrics.distance_type cimport DistanceType
-    from pylibraft.common.handle import Handle
+from cuml.metrics.distance_type cimport DistanceType
 
-    cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
 
-        cdef cppclass CondensedHierarchy[value_idx, value_t]:
-            CondensedHierarchy(
-                const handle_t &handle, size_t n_leaves)
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
 
-            value_idx *get_parents()
-            value_idx *get_children()
-            value_t *get_lambdas()
-            value_idx get_n_edges()
+    cdef cppclass CondensedHierarchy[value_idx, value_t]:
+        CondensedHierarchy(
+            const handle_t &handle, size_t n_leaves)
 
-        cdef cppclass hdbscan_output[int, float]:
-            hdbscan_output(const handle_t &handle,
-                           int n_leaves,
-                           int *labels,
-                           float *probabilities,
-                           int *children,
-                           int *sizes,
-                           float *deltas,
-                           int *mst_src,
-                           int *mst_dst,
-                           float *mst_weights)
+        value_idx *get_parents()
+        value_idx *get_children()
+        value_t *get_lambdas()
+        value_idx get_n_edges()
 
-            int get_n_leaves()
-            int get_n_clusters()
-            float *get_stabilities()
-            int *get_labels()
-            int *get_inverse_label_map()
-            float *get_core_dists()
-            CondensedHierarchy[int, float] &get_condensed_tree()
+    cdef cppclass hdbscan_output[int, float]:
+        hdbscan_output(const handle_t &handle,
+                       int n_leaves,
+                       int *labels,
+                       float *probabilities,
+                       int *children,
+                       int *sizes,
+                       float *deltas,
+                       int *mst_src,
+                       int *mst_dst,
+                       float *mst_weights)
 
-        cdef cppclass PredictionData[int, float]:
-            PredictionData(const handle_t &handle,
-                           int m,
-                           int n,
-                           float *core_dists)
+        int get_n_leaves()
+        int get_n_clusters()
+        float *get_stabilities()
+        int *get_labels()
+        int *get_inverse_label_map()
+        float *get_core_dists()
+        CondensedHierarchy[int, float] &get_condensed_tree()
 
-            size_t n_rows
-            size_t n_cols
+    cdef cppclass PredictionData[int, float]:
+        PredictionData(const handle_t &handle,
+                       int m,
+                       int n,
+                       float *core_dists)
 
-    cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
+        size_t n_rows
+        size_t n_cols
 
-        void compute_all_points_membership_vectors(
-            const handle_t &handle,
-            CondensedHierarchy[int, float] &condensed_tree,
-            PredictionData[int, float] &prediction_data_,
-            float* X,
-            DistanceType metric,
-            float* membership_vec,
-            size_t batch_size)
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
 
-        void compute_membership_vector(
-            const handle_t& handle,
-            CondensedHierarchy[int, float] &condensed_tree,
-            PredictionData[int, float] &prediction_data,
-            float* X,
-            float* points_to_predict,
-            size_t n_prediction_points,
-            int min_samples,
-            DistanceType metric,
-            float* membership_vec,
-            size_t batch_size)
+    void compute_all_points_membership_vectors(
+        const handle_t &handle,
+        CondensedHierarchy[int, float] &condensed_tree,
+        PredictionData[int, float] &prediction_data_,
+        float* X,
+        DistanceType metric,
+        float* membership_vec,
+        size_t batch_size)
 
-        void out_of_sample_predict(const handle_t &handle,
-                                   CondensedHierarchy[int, float] &condensed_tree,
-                                   PredictionData[int, float] &prediction_data,
-                                   float* X,
-                                   int* labels,
-                                   float* points_to_predict,
-                                   size_t n_prediction_points,
-                                   DistanceType metric,
-                                   int min_samples,
-                                   int* out_labels,
-                                   float* out_probabilities)
+    void compute_membership_vector(
+        const handle_t& handle,
+        CondensedHierarchy[int, float] &condensed_tree,
+        PredictionData[int, float] &prediction_data,
+        float* X,
+        float* points_to_predict,
+        size_t n_prediction_points,
+        int min_samples,
+        DistanceType metric,
+        float* membership_vec,
+        size_t batch_size)
 
-    _metrics_mapping = {
-        'l1': DistanceType.L1,
-        'cityblock': DistanceType.L1,
-        'manhattan': DistanceType.L1,
-        'l2': DistanceType.L2SqrtExpanded,
-        'euclidean': DistanceType.L2SqrtExpanded,
-        'cosine': DistanceType.CosineExpanded
-    }
+    void out_of_sample_predict(const handle_t &handle,
+                               CondensedHierarchy[int, float] &condensed_tree,
+                               PredictionData[int, float] &prediction_data,
+                               float* X,
+                               int* labels,
+                               float* points_to_predict,
+                               size_t n_prediction_points,
+                               DistanceType metric,
+                               int min_samples,
+                               int* out_labels,
+                               float* out_probabilities)
+
+_metrics_mapping = {
+    'l1': DistanceType.L1,
+    'cityblock': DistanceType.L1,
+    'manhattan': DistanceType.L1,
+    'l2': DistanceType.L2SqrtExpanded,
+    'euclidean': DistanceType.L2SqrtExpanded,
+    'cosine': DistanceType.CosineExpanded
+}
 
 
 def all_points_membership_vectors(clusterer, batch_size=4096):
@@ -209,20 +208,19 @@ def all_points_membership_vectors(clusterer, batch_size=4096):
 
     cdef uintptr_t _membership_vec_ptr = membership_vec.ptr
 
-    IF GPUBUILD == 1:
-        cdef PredictionData *prediction_data_ = \
-            <PredictionData*><size_t>clusterer.prediction_data_ptr
+    cdef PredictionData *prediction_data_ = \
+        <PredictionData*><size_t>clusterer.prediction_data_ptr
 
-        cdef CondensedHierarchy[int, float] *condensed_tree = \
-            <CondensedHierarchy[int, float]*><size_t> clusterer.condensed_tree_ptr
-        cdef handle_t* handle_ = <handle_t*><size_t>clusterer.handle.getHandle()
-        compute_all_points_membership_vectors(handle_[0],
-                                              deref(condensed_tree),
-                                              deref(prediction_data_),
-                                              <float*> _input_ptr,
-                                              _metrics_mapping[clusterer.metric],
-                                              <float*> _membership_vec_ptr,
-                                              batch_size)
+    cdef CondensedHierarchy[int, float] *condensed_tree = \
+        <CondensedHierarchy[int, float]*><size_t> clusterer.condensed_tree_ptr
+    cdef handle_t* handle_ = <handle_t*><size_t>clusterer.handle.getHandle()
+    compute_all_points_membership_vectors(handle_[0],
+                                          deref(condensed_tree),
+                                          deref(prediction_data_),
+                                          <float*> _input_ptr,
+                                          _metrics_mapping[clusterer.metric],
+                                          <float*> _membership_vec_ptr,
+                                          batch_size)
 
     clusterer.handle.sync()
     return membership_vec.to_output(
@@ -315,40 +313,39 @@ def membership_vector(clusterer, points_to_predict, batch_size=4096, convert_dty
     if n_cols != clusterer.n_cols:
         raise ValueError('New points dimension does not match fit data!')
 
-    IF GPUBUILD == 1:
-        cdef uintptr_t _prediction_ptr = _points_to_predict_m.ptr
-        cdef uintptr_t _input_ptr = clusterer.X_m.ptr
+    cdef uintptr_t _prediction_ptr = _points_to_predict_m.ptr
+    cdef uintptr_t _input_ptr = clusterer.X_m.ptr
 
-        membership_vec = CumlArray.empty(
-            (n_prediction_points * clusterer.n_clusters_,),
-            dtype="float32")
+    membership_vec = CumlArray.empty(
+        (n_prediction_points * clusterer.n_clusters_,),
+        dtype="float32")
 
-        cdef uintptr_t _membership_vec_ptr = membership_vec.ptr
+    cdef uintptr_t _membership_vec_ptr = membership_vec.ptr
 
-        cdef CondensedHierarchy[int, float] *condensed_tree = \
-            <CondensedHierarchy[int, float]*><size_t> clusterer.condensed_tree_ptr
+    cdef CondensedHierarchy[int, float] *condensed_tree = \
+        <CondensedHierarchy[int, float]*><size_t> clusterer.condensed_tree_ptr
 
-        cdef PredictionData *prediction_data_ = \
-            <PredictionData*><size_t>clusterer.prediction_data_ptr
+    cdef PredictionData *prediction_data_ = \
+        <PredictionData*><size_t>clusterer.prediction_data_ptr
 
-        cdef handle_t* handle_ = <handle_t*><size_t>clusterer.handle.getHandle()
+    cdef handle_t* handle_ = <handle_t*><size_t>clusterer.handle.getHandle()
 
-        compute_membership_vector(handle_[0],
-                                  deref(condensed_tree),
-                                  deref(prediction_data_),
-                                  <float*> _input_ptr,
-                                  <float*> _prediction_ptr,
-                                  n_prediction_points,
-                                  clusterer.min_samples,
-                                  _metrics_mapping[clusterer.metric],
-                                  <float*> _membership_vec_ptr,
-                                  batch_size)
+    compute_membership_vector(handle_[0],
+                              deref(condensed_tree),
+                              deref(prediction_data_),
+                              <float*> _input_ptr,
+                              <float*> _prediction_ptr,
+                              n_prediction_points,
+                              clusterer.min_samples,
+                              _metrics_mapping[clusterer.metric],
+                              <float*> _membership_vec_ptr,
+                              batch_size)
 
-        clusterer.handle.sync()
-        return membership_vec.to_output(
-            output_type="numpy",
-            output_dtype="float32").reshape((n_prediction_points,
-                                             clusterer.n_clusters_))
+    clusterer.handle.sync()
+    return membership_vec.to_output(
+        output_type="numpy",
+        output_dtype="float32").reshape((n_prediction_points,
+                                         clusterer.n_clusters_))
 
 
 def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
@@ -457,26 +454,25 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
 
     cdef uintptr_t _labels_ptr = labels.ptr
 
-    IF GPUBUILD == 1:
-        cdef CondensedHierarchy[int, float] *condensed_tree = \
-            <CondensedHierarchy[int, float]*><size_t> clusterer.condensed_tree_ptr
+    cdef CondensedHierarchy[int, float] *condensed_tree = \
+        <CondensedHierarchy[int, float]*><size_t> clusterer.condensed_tree_ptr
 
-        cdef PredictionData *prediction_data_ = \
-            <PredictionData*><size_t>clusterer.prediction_data_ptr
+    cdef PredictionData *prediction_data_ = \
+        <PredictionData*><size_t>clusterer.prediction_data_ptr
 
-        cdef handle_t* handle_ = <handle_t*><size_t>clusterer.handle.getHandle()
+    cdef handle_t* handle_ = <handle_t*><size_t>clusterer.handle.getHandle()
 
-        out_of_sample_predict(handle_[0],
-                              deref(condensed_tree),
-                              deref(prediction_data_),
-                              <float*> _input_ptr,
-                              <int*> _labels_ptr,
-                              <float*> _prediction_ptr,
-                              n_prediction_points,
-                              _metrics_mapping[clusterer.metric],
-                              clusterer.min_samples,
-                              <int*> _prediction_labels_ptr,
-                              <float*> _prediction_probs_ptr)
+    out_of_sample_predict(handle_[0],
+                          deref(condensed_tree),
+                          deref(prediction_data_),
+                          <float*> _input_ptr,
+                          <int*> _labels_ptr,
+                          <float*> _prediction_ptr,
+                          n_prediction_points,
+                          _metrics_mapping[clusterer.metric],
+                          clusterer.min_samples,
+                          <int*> _prediction_labels_ptr,
+                          <float*> _prediction_probs_ptr)
 
     clusterer.handle.sync()
     return prediction_labels.to_output(output_type="numpy"), \

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -29,6 +29,8 @@ rmm = gpu_only_import('rmm')
 
 from libc.stdint cimport uintptr_t
 
+from enum import IntEnum
+
 import cuml.internals
 import cuml.internals.logger as logger
 from cuml.common import using_output_type
@@ -50,70 +52,70 @@ from cuml.internals.input_utils import (
 from cuml.internals.mixins import FMajorInputTagMixin, SparseInputTagMixin
 from cuml.prims.stats import cov
 
-IF GPUBUILD == 1:
-    from enum import IntEnum
-    from cython.operator cimport dereference as deref
-    from pylibraft.common.handle cimport handle_t
+from cython.operator cimport dereference as deref
+from pylibraft.common.handle cimport handle_t
 
-    from cuml.decomposition.utils cimport *
+from cuml.decomposition.utils cimport *
 
-    cdef extern from "cuml/decomposition/pca.hpp" namespace "ML":
 
-        cdef void pcaFit(handle_t& handle,
-                         float *input,
-                         float *components,
-                         float *explained_var,
-                         float *explained_var_ratio,
-                         float *singular_vals,
-                         float *mu,
-                         float *noise_vars,
-                         const paramsPCA &prms) except +
+cdef extern from "cuml/decomposition/pca.hpp" namespace "ML":
 
-        cdef void pcaFit(handle_t& handle,
-                         double *input,
-                         double *components,
-                         double *explained_var,
-                         double *explained_var_ratio,
-                         double *singular_vals,
-                         double *mu,
-                         double *noise_vars,
-                         const paramsPCA &prms) except +
+    cdef void pcaFit(handle_t& handle,
+                     float *input,
+                     float *components,
+                     float *explained_var,
+                     float *explained_var_ratio,
+                     float *singular_vals,
+                     float *mu,
+                     float *noise_vars,
+                     const paramsPCA &prms) except +
 
-        cdef void pcaInverseTransform(handle_t& handle,
-                                      float *trans_input,
-                                      float *components,
-                                      float *singular_vals,
-                                      float *mu,
-                                      float *input,
-                                      const paramsPCA &prms) except +
+    cdef void pcaFit(handle_t& handle,
+                     double *input,
+                     double *components,
+                     double *explained_var,
+                     double *explained_var_ratio,
+                     double *singular_vals,
+                     double *mu,
+                     double *noise_vars,
+                     const paramsPCA &prms) except +
 
-        cdef void pcaInverseTransform(handle_t& handle,
-                                      double *trans_input,
-                                      double *components,
-                                      double *singular_vals,
-                                      double *mu,
-                                      double *input,
-                                      const paramsPCA &prms) except +
+    cdef void pcaInverseTransform(handle_t& handle,
+                                  float *trans_input,
+                                  float *components,
+                                  float *singular_vals,
+                                  float *mu,
+                                  float *input,
+                                  const paramsPCA &prms) except +
 
-        cdef void pcaTransform(handle_t& handle,
-                               float *input,
-                               float *components,
-                               float *trans_input,
-                               float *singular_vals,
-                               float *mu,
-                               const paramsPCA &prms) except +
+    cdef void pcaInverseTransform(handle_t& handle,
+                                  double *trans_input,
+                                  double *components,
+                                  double *singular_vals,
+                                  double *mu,
+                                  double *input,
+                                  const paramsPCA &prms) except +
 
-        cdef void pcaTransform(handle_t& handle,
-                               double *input,
-                               double *components,
-                               double *trans_input,
-                               double *singular_vals,
-                               double *mu,
-                               const paramsPCA &prms) except +
+    cdef void pcaTransform(handle_t& handle,
+                           float *input,
+                           float *components,
+                           float *trans_input,
+                           float *singular_vals,
+                           float *mu,
+                           const paramsPCA &prms) except +
 
-    class Solver(IntEnum):
-        COV_EIG_DQ = <underlying_type_t_solver> solver.COV_EIG_DQ
-        COV_EIG_JACOBI = <underlying_type_t_solver> solver.COV_EIG_JACOBI
+    cdef void pcaTransform(handle_t& handle,
+                           double *input,
+                           double *components,
+                           double *trans_input,
+                           double *singular_vals,
+                           double *mu,
+                           const paramsPCA &prms) except +
+
+
+class Solver(IntEnum):
+    COV_EIG_DQ = <underlying_type_t_solver> solver.COV_EIG_DQ
+    COV_EIG_JACOBI = <underlying_type_t_solver> solver.COV_EIG_JACOBI
 
 
 class PCA(UniversalBase,
@@ -335,33 +337,31 @@ class PCA(UniversalBase,
         self._sparse_model = None
 
     def _get_algorithm_c_name(self, algorithm):
-        IF GPUBUILD == 1:
-            algo_map = {
-                'full': Solver.COV_EIG_DQ,
-                'auto': Solver.COV_EIG_DQ,
-                # 'arpack': NOT_SUPPORTED,
-                # 'randomized': NOT_SUPPORTED,
-                'jacobi': Solver.COV_EIG_JACOBI
-            }
-            if algorithm not in algo_map:
-                msg = "algorithm {!r} is not supported"
-                raise TypeError(msg.format(algorithm))
+        algo_map = {
+            'full': Solver.COV_EIG_DQ,
+            'auto': Solver.COV_EIG_DQ,
+            # 'arpack': NOT_SUPPORTED,
+            # 'randomized': NOT_SUPPORTED,
+            'jacobi': Solver.COV_EIG_JACOBI
+        }
+        if algorithm not in algo_map:
+            msg = "algorithm {!r} is not supported"
+            raise TypeError(msg.format(algorithm))
 
-            return algo_map[algorithm]
+        return algo_map[algorithm]
 
     def _build_params(self, n_rows, n_cols):
-        IF GPUBUILD == 1:
-            cdef paramsPCA *params = new paramsPCA()
-            params.n_components = self.n_components_
-            params.n_rows = n_rows
-            params.n_cols = n_cols
-            params.whiten = self.whiten
-            params.n_iterations = self.iterated_power
-            params.tol = self.tol
-            params.algorithm = <solver> (<underlying_type_t_solver> (
-                self.c_algorithm))
+        cdef paramsPCA *params = new paramsPCA()
+        params.n_components = self.n_components_
+        params.n_rows = n_rows
+        params.n_cols = n_cols
+        params.whiten = self.whiten
+        params.n_iterations = self.iterated_power
+        params.tol = self.tol
+        params.algorithm = <solver> (<underlying_type_t_solver> (
+            self.c_algorithm))
 
-            return <size_t>params
+        return <size_t>params
 
     def _initialize_arrays(self, n_components, n_rows, n_cols):
 
@@ -463,55 +463,54 @@ class PCA(UniversalBase,
         cdef uintptr_t _input_ptr = X_m.ptr
         self.feature_names_in_ = X_m.index
 
-        IF GPUBUILD == 1:
-            cdef paramsPCA *params = <paramsPCA*><size_t> \
-                self._build_params(self.n_samples_, self.n_features_in_)
+        cdef paramsPCA *params = <paramsPCA*><size_t> \
+            self._build_params(self.n_samples_, self.n_features_in_)
 
-            if params.n_components > self.n_features_in_:
-                raise ValueError('Number of components should not be greater than'
-                                 'the number of columns in the data')
+        if params.n_components > self.n_features_in_:
+            raise ValueError('Number of components should not be greater than'
+                             'the number of columns in the data')
 
-            # Calling _initialize_arrays, guarantees everything is CumlArray
-            self._initialize_arrays(params.n_components,
-                                    params.n_rows, params.n_cols)
+        # Calling _initialize_arrays, guarantees everything is CumlArray
+        self._initialize_arrays(params.n_components,
+                                params.n_rows, params.n_cols)
 
-            cdef uintptr_t comp_ptr = self.components_.ptr
+        cdef uintptr_t comp_ptr = self.components_.ptr
 
-            cdef uintptr_t explained_var_ptr = \
-                self.explained_variance_.ptr
+        cdef uintptr_t explained_var_ptr = \
+            self.explained_variance_.ptr
 
-            cdef uintptr_t explained_var_ratio_ptr = \
-                self.explained_variance_ratio_.ptr
+        cdef uintptr_t explained_var_ratio_ptr = \
+            self.explained_variance_ratio_.ptr
 
-            cdef uintptr_t singular_vals_ptr = \
-                self.singular_values_.ptr
+        cdef uintptr_t singular_vals_ptr = \
+            self.singular_values_.ptr
 
-            cdef uintptr_t _mean_ptr = self.mean_.ptr
+        cdef uintptr_t _mean_ptr = self.mean_.ptr
 
-            cdef uintptr_t noise_vars_ptr = \
-                self.noise_variance_.ptr
+        cdef uintptr_t noise_vars_ptr = \
+            self.noise_variance_.ptr
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if self.dtype == np.float32:
-                pcaFit(handle_[0],
-                       <float*> _input_ptr,
-                       <float*> comp_ptr,
-                       <float*> explained_var_ptr,
-                       <float*> explained_var_ratio_ptr,
-                       <float*> singular_vals_ptr,
-                       <float*> _mean_ptr,
-                       <float*> noise_vars_ptr,
-                       deref(params))
-            else:
-                pcaFit(handle_[0],
-                       <double*> _input_ptr,
-                       <double*> comp_ptr,
-                       <double*> explained_var_ptr,
-                       <double*> explained_var_ratio_ptr,
-                       <double*> singular_vals_ptr,
-                       <double*> _mean_ptr,
-                       <double*> noise_vars_ptr,
-                       deref(params))
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if self.dtype == np.float32:
+            pcaFit(handle_[0],
+                   <float*> _input_ptr,
+                   <float*> comp_ptr,
+                   <float*> explained_var_ptr,
+                   <float*> explained_var_ratio_ptr,
+                   <float*> singular_vals_ptr,
+                   <float*> _mean_ptr,
+                   <float*> noise_vars_ptr,
+                   deref(params))
+        else:
+            pcaFit(handle_[0],
+                   <double*> _input_ptr,
+                   <double*> comp_ptr,
+                   <double*> explained_var_ptr,
+                   <double*> explained_var_ratio_ptr,
+                   <double*> singular_vals_ptr,
+                   <double*> _mean_ptr,
+                   <double*> noise_vars_ptr,
+                   deref(params))
 
         # make sure the previously scheduled gpu tasks are complete before the
         # following transfers start
@@ -608,45 +607,44 @@ class PCA(UniversalBase,
 
         cdef uintptr_t _trans_input_ptr = X_m.ptr
 
-        IF GPUBUILD == 1:
-            # todo: check n_cols and dtype
-            cdef paramsPCA params
-            params.n_components = self.n_components_
-            params.n_rows = _n_rows
-            params.n_cols = self.n_features_in_
-            params.whiten = self.whiten
+        # todo: check n_cols and dtype
+        cdef paramsPCA params
+        params.n_components = self.n_components_
+        params.n_rows = _n_rows
+        params.n_cols = self.n_features_in_
+        params.whiten = self.whiten
 
-            input_data = CumlArray.zeros((params.n_rows, params.n_cols),
-                                         dtype=dtype.type)
+        input_data = CumlArray.zeros((params.n_rows, params.n_cols),
+                                     dtype=dtype.type)
 
-            cdef uintptr_t input_ptr = input_data.ptr
-            cdef uintptr_t components_ptr = self.components_.ptr
-            cdef uintptr_t singular_vals_ptr = self.singular_values_.ptr
-            cdef uintptr_t _mean_ptr = self.mean_.ptr
+        cdef uintptr_t input_ptr = input_data.ptr
+        cdef uintptr_t components_ptr = self.components_.ptr
+        cdef uintptr_t singular_vals_ptr = self.singular_values_.ptr
+        cdef uintptr_t _mean_ptr = self.mean_.ptr
 
-            cdef handle_t* h_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype.type == np.float32:
-                pcaInverseTransform(h_[0],
-                                    <float*> _trans_input_ptr,
-                                    <float*> components_ptr,
-                                    <float*> singular_vals_ptr,
-                                    <float*> _mean_ptr,
-                                    <float*> input_ptr,
-                                    params)
-            else:
-                pcaInverseTransform(h_[0],
-                                    <double*> _trans_input_ptr,
-                                    <double*> components_ptr,
-                                    <double*> singular_vals_ptr,
-                                    <double*> _mean_ptr,
-                                    <double*> input_ptr,
-                                    params)
+        cdef handle_t* h_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype.type == np.float32:
+            pcaInverseTransform(h_[0],
+                                <float*> _trans_input_ptr,
+                                <float*> components_ptr,
+                                <float*> singular_vals_ptr,
+                                <float*> _mean_ptr,
+                                <float*> input_ptr,
+                                params)
+        else:
+            pcaInverseTransform(h_[0],
+                                <double*> _trans_input_ptr,
+                                <double*> components_ptr,
+                                <double*> singular_vals_ptr,
+                                <double*> _mean_ptr,
+                                <double*> input_ptr,
+                                params)
 
-            # make sure the previously scheduled gpu tasks are complete before the
-            # following transfers start
-            self.handle.sync()
+        # make sure the previously scheduled gpu tasks are complete before the
+        # following transfers start
+        self.handle.sync()
 
-            return input_data
+        return input_data
 
     @cuml.internals.api_base_return_array_skipall
     def _sparse_transform(self, X) -> CumlArray:
@@ -708,47 +706,46 @@ class PCA(UniversalBase,
 
         cdef uintptr_t _input_ptr = X_m.ptr
 
-        IF GPUBUILD == 1:
-            # todo: check dtype
-            cdef paramsPCA params
-            params.n_components = self.n_components_
-            params.n_rows = _n_rows
-            params.n_cols = _n_cols
-            params.whiten = self.whiten
+        # todo: check dtype
+        cdef paramsPCA params
+        params.n_components = self.n_components_
+        params.n_rows = _n_rows
+        params.n_cols = _n_cols
+        params.whiten = self.whiten
 
-            t_input_data = \
-                CumlArray.zeros((params.n_rows, params.n_components),
-                                dtype=dtype.type, index=X_m.index)
+        t_input_data = \
+            CumlArray.zeros((params.n_rows, params.n_components),
+                            dtype=dtype.type, index=X_m.index)
 
-            cdef uintptr_t _trans_input_ptr = t_input_data.ptr
-            cdef uintptr_t components_ptr = self.components_.ptr
-            cdef uintptr_t singular_vals_ptr = \
-                self.singular_values_.ptr
-            cdef uintptr_t _mean_ptr = self.mean_.ptr
+        cdef uintptr_t _trans_input_ptr = t_input_data.ptr
+        cdef uintptr_t components_ptr = self.components_.ptr
+        cdef uintptr_t singular_vals_ptr = \
+            self.singular_values_.ptr
+        cdef uintptr_t _mean_ptr = self.mean_.ptr
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype.type == np.float32:
-                pcaTransform(handle_[0],
-                             <float*> _input_ptr,
-                             <float*> components_ptr,
-                             <float*> _trans_input_ptr,
-                             <float*> singular_vals_ptr,
-                             <float*> _mean_ptr,
-                             params)
-            else:
-                pcaTransform(handle_[0],
-                             <double*> _input_ptr,
-                             <double*> components_ptr,
-                             <double*> _trans_input_ptr,
-                             <double*> singular_vals_ptr,
-                             <double*> _mean_ptr,
-                             params)
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype.type == np.float32:
+            pcaTransform(handle_[0],
+                         <float*> _input_ptr,
+                         <float*> components_ptr,
+                         <float*> _trans_input_ptr,
+                         <float*> singular_vals_ptr,
+                         <float*> _mean_ptr,
+                         params)
+        else:
+            pcaTransform(handle_[0],
+                         <double*> _input_ptr,
+                         <double*> components_ptr,
+                         <double*> _trans_input_ptr,
+                         <double*> singular_vals_ptr,
+                         <double*> _mean_ptr,
+                         params)
 
-            # make sure the previously scheduled gpu tasks are complete before the
-            # following transfers start
-            self.handle.sync()
+        # make sure the previously scheduled gpu tasks are complete before the
+        # following transfers start
+        self.handle.sync()
 
-            return t_input_data
+        return t_input_data
 
     @classmethod
     def _get_param_names(cls):

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -25,6 +25,8 @@ from cuml.internals.safe_imports import gpu_only_import
 rmm = gpu_only_import('rmm')
 from libc.stdint cimport uintptr_t
 
+from enum import IntEnum
+
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
@@ -36,71 +38,72 @@ from cuml.internals.array import CumlArray
 from cuml.internals.base import UniversalBase
 from cuml.internals.mixins import FMajorInputTagMixin
 
-IF GPUBUILD == 1:
-    from enum import IntEnum
-    from cython.operator cimport dereference as deref
-    from pylibraft.common.handle cimport handle_t
+from cython.operator cimport dereference as deref
+from pylibraft.common.handle cimport handle_t
 
-    from cuml.decomposition.utils cimport *
-    cdef extern from "cuml/decomposition/tsvd.hpp" namespace "ML":
+from cuml.decomposition.utils cimport *
 
-        cdef void tsvdFit(handle_t& handle,
-                          float *input,
-                          float *components,
-                          float *singular_vals,
-                          const paramsTSVD &prms) except +
 
-        cdef void tsvdFit(handle_t& handle,
-                          double *input,
-                          double *components,
-                          double *singular_vals,
-                          const paramsTSVD &prms) except +
+cdef extern from "cuml/decomposition/tsvd.hpp" namespace "ML":
 
-        cdef void tsvdFitTransform(handle_t& handle,
-                                   float *input,
+    cdef void tsvdFit(handle_t& handle,
+                      float *input,
+                      float *components,
+                      float *singular_vals,
+                      const paramsTSVD &prms) except +
+
+    cdef void tsvdFit(handle_t& handle,
+                      double *input,
+                      double *components,
+                      double *singular_vals,
+                      const paramsTSVD &prms) except +
+
+    cdef void tsvdFitTransform(handle_t& handle,
+                               float *input,
+                               float *trans_input,
+                               float *components,
+                               float *explained_var,
+                               float *explained_var_ratio,
+                               float *singular_vals,
+                               const paramsTSVD &prms) except +
+
+    cdef void tsvdFitTransform(handle_t& handle,
+                               double *input,
+                               double *trans_input,
+                               double *components,
+                               double *explained_var,
+                               double *explained_var_ratio,
+                               double *singular_vals,
+                               const paramsTSVD &prms) except +
+
+    cdef void tsvdInverseTransform(handle_t& handle,
                                    float *trans_input,
                                    float *components,
-                                   float *explained_var,
-                                   float *explained_var_ratio,
-                                   float *singular_vals,
+                                   float *input,
                                    const paramsTSVD &prms) except +
 
-        cdef void tsvdFitTransform(handle_t& handle,
-                                   double *input,
+    cdef void tsvdInverseTransform(handle_t& handle,
                                    double *trans_input,
                                    double *components,
-                                   double *explained_var,
-                                   double *explained_var_ratio,
-                                   double *singular_vals,
+                                   double *input,
                                    const paramsTSVD &prms) except +
 
-        cdef void tsvdInverseTransform(handle_t& handle,
-                                       float *trans_input,
-                                       float *components,
-                                       float *input,
-                                       const paramsTSVD &prms) except +
+    cdef void tsvdTransform(handle_t& handle,
+                            float *input,
+                            float *components,
+                            float *trans_input,
+                            const paramsTSVD &prms) except +
 
-        cdef void tsvdInverseTransform(handle_t& handle,
-                                       double *trans_input,
-                                       double *components,
-                                       double *input,
-                                       const paramsTSVD &prms) except +
+    cdef void tsvdTransform(handle_t& handle,
+                            double *input,
+                            double *components,
+                            double *trans_input,
+                            const paramsTSVD &prms) except +
 
-        cdef void tsvdTransform(handle_t& handle,
-                                float *input,
-                                float *components,
-                                float *trans_input,
-                                const paramsTSVD &prms) except +
 
-        cdef void tsvdTransform(handle_t& handle,
-                                double *input,
-                                double *components,
-                                double *trans_input,
-                                const paramsTSVD &prms) except +
-
-    class Solver(IntEnum):
-        COV_EIG_DQ = <underlying_type_t_solver> solver.COV_EIG_DQ
-        COV_EIG_JACOBI = <underlying_type_t_solver> solver.COV_EIG_JACOBI
+class Solver(IntEnum):
+    COV_EIG_DQ = <underlying_type_t_solver> solver.COV_EIG_DQ
+    COV_EIG_JACOBI = <underlying_type_t_solver> solver.COV_EIG_JACOBI
 
 
 class TruncatedSVD(UniversalBase,
@@ -286,29 +289,27 @@ class TruncatedSVD(UniversalBase,
         self.singular_values_ = None
 
     def _get_algorithm_c_name(self, algorithm):
-        IF GPUBUILD == 1:
-            algo_map = {
-                'full': Solver.COV_EIG_DQ,
-                'auto': Solver.COV_EIG_DQ,
-                'jacobi': Solver.COV_EIG_JACOBI
-            }
-            if algorithm not in algo_map:
-                msg = "algorithm {!r} is not supported"
-                raise TypeError(msg.format(algorithm))
-            return algo_map[algorithm]
+        algo_map = {
+            'full': Solver.COV_EIG_DQ,
+            'auto': Solver.COV_EIG_DQ,
+            'jacobi': Solver.COV_EIG_JACOBI
+        }
+        if algorithm not in algo_map:
+            msg = "algorithm {!r} is not supported"
+            raise TypeError(msg.format(algorithm))
+        return algo_map[algorithm]
 
     def _build_params(self, n_rows, n_cols):
-        IF GPUBUILD == 1:
-            cdef paramsTSVD *params = new paramsTSVD()
-            params.n_components = self.n_components
-            params.n_rows = n_rows
-            params.n_cols = n_cols
-            params.n_iterations = self.n_iter
-            params.tol = self.tol
-            params.algorithm = <solver> (<underlying_type_t_solver> (
-                self.c_algorithm))
+        cdef paramsTSVD *params = new paramsTSVD()
+        params.n_components = self.n_components
+        params.n_rows = n_rows
+        params.n_cols = n_cols
+        params.n_iterations = self.n_iter
+        params.tol = self.tol
+        params.algorithm = <solver> (<underlying_type_t_solver> (
+            self.c_algorithm))
 
-            return <size_t>params
+        return <size_t>params
 
     def _initialize_arrays(self, n_components, n_rows, n_cols):
 
@@ -368,38 +369,37 @@ class TruncatedSVD(UniversalBase,
         if self.n_components> self.n_features_in_:
             raise ValueError(' n_components must be < n_features')
 
-        IF GPUBUILD == 1:
-            cdef paramsTSVD *params = <paramsTSVD*><size_t> \
-                self._build_params(self.n_rows, self.n_features_in_)
-            _trans_input_ = CumlArray.zeros((params.n_rows, params.n_components),
-                                            dtype=self.dtype, index=X_m.index)
-            cdef uintptr_t t_input_ptr = _trans_input_.ptr
+        cdef paramsTSVD *params = <paramsTSVD*><size_t> \
+            self._build_params(self.n_rows, self.n_features_in_)
+        _trans_input_ = CumlArray.zeros((params.n_rows, params.n_components),
+                                        dtype=self.dtype, index=X_m.index)
+        cdef uintptr_t t_input_ptr = _trans_input_.ptr
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if self.dtype == np.float32:
-                tsvdFitTransform(handle_[0],
-                                 <float*> _input_ptr,
-                                 <float*> t_input_ptr,
-                                 <float*> _comp_ptr,
-                                 <float*> _explained_var_ptr,
-                                 <float*> _explained_var_ratio_ptr,
-                                 <float*> _singular_vals_ptr,
-                                 deref(params))
-            else:
-                tsvdFitTransform(handle_[0],
-                                 <double*> _input_ptr,
-                                 <double*> t_input_ptr,
-                                 <double*> _comp_ptr,
-                                 <double*> _explained_var_ptr,
-                                 <double*> _explained_var_ratio_ptr,
-                                 <double*> _singular_vals_ptr,
-                                 deref(params))
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if self.dtype == np.float32:
+            tsvdFitTransform(handle_[0],
+                             <float*> _input_ptr,
+                             <float*> t_input_ptr,
+                             <float*> _comp_ptr,
+                             <float*> _explained_var_ptr,
+                             <float*> _explained_var_ratio_ptr,
+                             <float*> _singular_vals_ptr,
+                             deref(params))
+        else:
+            tsvdFitTransform(handle_[0],
+                             <double*> _input_ptr,
+                             <double*> t_input_ptr,
+                             <double*> _comp_ptr,
+                             <double*> _explained_var_ptr,
+                             <double*> _explained_var_ratio_ptr,
+                             <double*> _singular_vals_ptr,
+                             deref(params))
 
-            # make sure the previously scheduled gpu tasks are complete before the
-            # following transfers start
-            self.handle.sync()
+        # make sure the previously scheduled gpu tasks are complete before the
+        # following transfers start
+        self.handle.sync()
 
-            return _trans_input_
+        return _trans_input_
 
     @generate_docstring(return_values={'name': 'X_original',
                                        'type': 'dense',
@@ -418,38 +418,37 @@ class TruncatedSVD(UniversalBase,
                                 convert_to_dtype=(dtype if convert_dtype
                                                   else None))
 
-        IF GPUBUILD == 1:
-            cdef paramsTSVD params
-            params.n_components = self.n_components
-            params.n_rows = _n_rows
-            params.n_cols = self.n_features_in_
+        cdef paramsTSVD params
+        params.n_components = self.n_components
+        params.n_rows = _n_rows
+        params.n_cols = self.n_features_in_
 
-            input_data = CumlArray.zeros((params.n_rows, params.n_cols),
-                                         dtype=dtype, index=_X_m.index)
+        input_data = CumlArray.zeros((params.n_rows, params.n_cols),
+                                     dtype=dtype, index=_X_m.index)
 
-            cdef uintptr_t trans_input_ptr = _X_m.ptr
-            cdef uintptr_t input_ptr = input_data.ptr
-            cdef uintptr_t components_ptr = self.components_.ptr
+        cdef uintptr_t trans_input_ptr = _X_m.ptr
+        cdef uintptr_t input_ptr = input_data.ptr
+        cdef uintptr_t components_ptr = self.components_.ptr
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype.type == np.float32:
-                tsvdInverseTransform(handle_[0],
-                                     <float*> trans_input_ptr,
-                                     <float*> components_ptr,
-                                     <float*> input_ptr,
-                                     params)
-            else:
-                tsvdInverseTransform(handle_[0],
-                                     <double*> trans_input_ptr,
-                                     <double*> components_ptr,
-                                     <double*> input_ptr,
-                                     params)
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype.type == np.float32:
+            tsvdInverseTransform(handle_[0],
+                                 <float*> trans_input_ptr,
+                                 <float*> components_ptr,
+                                 <float*> input_ptr,
+                                 params)
+        else:
+            tsvdInverseTransform(handle_[0],
+                                 <double*> trans_input_ptr,
+                                 <double*> components_ptr,
+                                 <double*> input_ptr,
+                                 params)
 
-            # make sure the previously scheduled gpu tasks are complete before the
-            # following transfers start
-            self.handle.sync()
+        # make sure the previously scheduled gpu tasks are complete before the
+        # following transfers start
+        self.handle.sync()
 
-            return input_data
+        return input_data
 
     @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
@@ -470,39 +469,38 @@ class TruncatedSVD(UniversalBase,
                                                   else None),
                                 check_cols=self.n_features_in_)
 
-        IF GPUBUILD == 1:
-            cdef paramsTSVD params
-            params.n_components = self.n_components
-            params.n_rows = _n_rows
-            params.n_cols = self.n_features_in_
+        cdef paramsTSVD params
+        params.n_components = self.n_components
+        params.n_rows = _n_rows
+        params.n_cols = self.n_features_in_
 
-            t_input_data = \
-                CumlArray.zeros((params.n_rows, params.n_components),
-                                dtype=dtype, index=_X_m.index)
+        t_input_data = \
+            CumlArray.zeros((params.n_rows, params.n_components),
+                            dtype=dtype, index=_X_m.index)
 
-            cdef uintptr_t input_ptr = _X_m.ptr
-            cdef uintptr_t trans_input_ptr = t_input_data.ptr
-            cdef uintptr_t components_ptr = self.components_.ptr
+        cdef uintptr_t input_ptr = _X_m.ptr
+        cdef uintptr_t trans_input_ptr = t_input_data.ptr
+        cdef uintptr_t components_ptr = self.components_.ptr
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype.type == np.float32:
-                tsvdTransform(handle_[0],
-                              <float*> input_ptr,
-                              <float*> components_ptr,
-                              <float*> trans_input_ptr,
-                              params)
-            else:
-                tsvdTransform(handle_[0],
-                              <double*> input_ptr,
-                              <double*> components_ptr,
-                              <double*> trans_input_ptr,
-                              params)
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype.type == np.float32:
+            tsvdTransform(handle_[0],
+                          <float*> input_ptr,
+                          <float*> components_ptr,
+                          <float*> trans_input_ptr,
+                          params)
+        else:
+            tsvdTransform(handle_[0],
+                          <double*> input_ptr,
+                          <double*> components_ptr,
+                          <double*> trans_input_ptr,
+                          params)
 
-            # make sure the previously scheduled gpu tasks are complete before the
-            # following transfers start
-            self.handle.sync()
+        # make sure the previously scheduled gpu tasks are complete before the
+        # following transfers start
+        self.handle.sync()
 
-            return t_input_data
+        return t_input_data
 
     @classmethod
     def _get_param_names(cls):

--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -22,7 +22,6 @@ import numbers
 import os
 from importlib import import_module
 
-from cuml.internals.device_support import GPU_ENABLED
 from cuml.internals.safe_imports import (
     cpu_only_import,
     gpu_only_import_from,
@@ -54,7 +53,6 @@ from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.input_utils import (
     determine_array_type,
     input_to_cuml_array,
-    input_to_host_array,
     input_to_host_array_with_sparse_support,
     is_array_like,
 )
@@ -74,10 +72,9 @@ cp_ndarray = gpu_only_import_from('cupy', 'ndarray')
 cp = gpu_only_import('cupy')
 
 
-IF GPUBUILD == 1:
-    import pylibraft.common.handle
+import pylibraft.common.handle
 
-    import cuml.common.cuda
+import cuml.common.cuda
 
 
 class VerbosityDescriptor:
@@ -256,11 +253,7 @@ class Base(TagsMixin,
         Constructor. All children must call init method of this base class.
 
         """
-        IF GPUBUILD == 1:
-            self.handle = pylibraft.common.handle.Handle() if handle is None \
-                else handle
-        ELSE:
-            self.handle = None
+        self.handle = pylibraft.common.handle.Handle() if handle is None else handle
 
         # The following manipulation of the root_cm ensures that the verbose
         # descriptor sees any set or get of the verbose attribute as happening
@@ -889,7 +882,7 @@ class UniversalBase(Base):
         estimator = cls()
         estimator.import_cpu_model()
         estimator._cpu_model = model
-        params, gpuaccel = cls._hyperparam_translator(**model.get_params())
+        params, _ = cls._hyperparam_translator(**model.get_params())
         params = {key: params[key] for key in cls._get_param_names() if key in params}
         estimator.set_params(**params)
         estimator.cpu_to_gpu()

--- a/python/cuml/cuml/internals/device_support.pyx
+++ b/python/cuml/cuml/internals/device_support.pyx
@@ -25,7 +25,7 @@ try:
 
     CPU_ENABLED = True
 
-    if(Version(sklearn.__version__) >= MIN_SKLEARN_VERSION):
+    if (Version(sklearn.__version__) >= MIN_SKLEARN_VERSION):
         MIN_SKLEARN_PRESENT = (True, None, None)
     else:
         MIN_SKLEARN_PRESENT = (False, sklearn.__version__, MIN_SKLEARN_VERSION)
@@ -34,17 +34,4 @@ except ImportError:
     CPU_ENABLED = False
     MIN_SKLEARN_PRESENT = (False, None, None)
 
-IF GPUBUILD == 1:
-    GPU_ENABLED = True
-
-ELSE:
-    GPU_ENABLED = False
-
-    import warnings
-    warnings.warn(
-        "`cuml-cpu` is deprecated in favor of `cuml.accel`, cuML's new Zero Code "
-        "Change Acceleration layer. The final release of `cuml-cpu` is version 25.04. "
-        "To learn more about `cuml.accel` please see "
-        "https://docs.rapids.ai/api/cuml/stable/zero-code-change/",
-        FutureWarning
-    )
+GPU_ENABLED = True

--- a/python/cuml/cuml/internals/internals.pyx
+++ b/python/cuml/cuml/internals/internals.pyx
@@ -29,69 +29,70 @@ cdef extern from "Python.h":
     cdef cppclass PyObject
 
 
-IF GPUBUILD == 1:
-    from libc.stdint cimport uintptr_t
-    cdef extern from "callbacks_implems.h" namespace "ML::Internals":
-        cdef cppclass Callback:
-            pass
+from libc.stdint cimport uintptr_t
 
-        cdef cppclass DefaultGraphBasedDimRedCallback(Callback):
-            void setup(int n, int d) except +
-            void on_preprocess_end(void* embeddings) except +
-            void on_epoch_end(void* embeddings) except +
-            void on_train_end(void* embeddings) except +
-            PyObject* pyCallbackClass
 
-    cdef class PyCallback:
+cdef extern from "callbacks_implems.h" namespace "ML::Internals":
+    cdef cppclass Callback:
+        pass
 
-        def get_numba_matrix(self, embeddings, shape, typestr):
+    cdef cppclass DefaultGraphBasedDimRedCallback(Callback):
+        void setup(int n, int d) except +
+        void on_preprocess_end(void* embeddings) except +
+        void on_epoch_end(void* embeddings) except +
+        void on_train_end(void* embeddings) except +
+        PyObject* pyCallbackClass
 
-            sizeofType = 4 if typestr == "float32" else 8
-            desc = {
-                'shape': shape,
-                'strides': (shape[1]*sizeofType, sizeofType),
-                'typestr': typestr,
-                'data': [embeddings],
-                'order': 'C',
-                'version': 1
-            }
+cdef class PyCallback:
 
-            return from_cuda_array_interface(desc)
+    def get_numba_matrix(self, embeddings, shape, typestr):
 
-    cdef class GraphBasedDimRedCallback(PyCallback):
-        """
-        Usage
-        -----
+        sizeofType = 4 if typestr == "float32" else 8
+        desc = {
+            'shape': shape,
+            'strides': (shape[1]*sizeofType, sizeofType),
+            'typestr': typestr,
+            'data': [embeddings],
+            'order': 'C',
+            'version': 1
+        }
 
-        class CustomCallback(GraphBasedDimRedCallback):
-            def on_preprocess_end(self, embeddings):
-                print(embeddings.copy_to_host())
+        return from_cuda_array_interface(desc)
 
-            def on_epoch_end(self, embeddings):
-                print(embeddings.copy_to_host())
+cdef class GraphBasedDimRedCallback(PyCallback):
+    """
+    Usage
+    -----
 
-            def on_train_end(self, embeddings):
-                print(embeddings.copy_to_host())
-
-        reducer = UMAP(n_components=2, callback=CustomCallback())
-        """
-
-        cdef DefaultGraphBasedDimRedCallback native_callback
-
-        def __cinit__(self):
-            self.native_callback.pyCallbackClass = <PyObject *><void*>self
-
-        def __reduce__(self):
-            return (type(self), ())
-
-        def get_native_callback(self):
-            return <uintptr_t>&(self.native_callback)
-
+    class CustomCallback(GraphBasedDimRedCallback):
         def on_preprocess_end(self, embeddings):
-            pass
+            print(embeddings.copy_to_host())
 
         def on_epoch_end(self, embeddings):
-            pass
+            print(embeddings.copy_to_host())
 
         def on_train_end(self, embeddings):
-            pass
+            print(embeddings.copy_to_host())
+
+    reducer = UMAP(n_components=2, callback=CustomCallback())
+    """
+
+    cdef DefaultGraphBasedDimRedCallback native_callback
+
+    def __cinit__(self):
+        self.native_callback.pyCallbackClass = <PyObject *><void*>self
+
+    def __reduce__(self):
+        return (type(self), ())
+
+    def get_native_callback(self):
+        return <uintptr_t>&(self.native_callback)
+
+    def on_preprocess_end(self, embeddings):
+        pass
+
+    def on_epoch_end(self, embeddings):
+        pass
+
+    def on_train_end(self, embeddings):
+        pass

--- a/python/cuml/cuml/internals/logger.pxd
+++ b/python/cuml/cuml/internals/logger.pxd
@@ -19,72 +19,62 @@
 
 from libcpp.string cimport string
 
-IF GPUBUILD == 1:
-    import sys
-    from libcpp cimport bool
-    from libcpp.memory cimport make_shared, shared_ptr
+import sys
 
-    cdef extern from "rapids_logger/logger.hpp" namespace "rapids_logger" nogil:
+from libcpp cimport bool
+from libcpp.memory cimport make_shared, shared_ptr
 
-        cpdef enum class level_enum:
-            trace
-            debug
-            info
-            warn
-            error
-            critical
-            off
-            n_levels
 
-        cdef cppclass sink:
-            pass
+cdef extern from "rapids_logger/logger.hpp" namespace "rapids_logger" nogil:
 
-        ctypedef shared_ptr[sink] sink_ptr
-
-    # Spoof the logger as a namespace to get the sink_vector generated correctly.
-    cdef extern from "rapids_logger/logger.hpp" namespace "rapids_logger::logger" nogil:
-
-        cdef cppclass sink_vector:
-            void push_back(const sink_ptr& sink) except +
-            void pop_back() except +
-            void clear()
-
-    cdef extern from "rapids_logger/logger.hpp" namespace "rapids_logger" nogil:
-        cdef cppclass logger:
-            logger(string name, string filename) except +
-            void set_level(level_enum log_level) except +
-            void set_pattern(const string& pattern)
-            level_enum level() except +
-            void flush() except +
-            void flush_on(level_enum level) except +
-            level_enum flush_level() except +
-            bool should_log(level_enum msg_level) except +
-            void log(level_enum lvl, const string& fmt, ...)
-            const sink_vector& sinks() const
-
-        ctypedef void(*log_callback_t)(int, const char*) except * with gil
-        ctypedef void(*flush_callback_t)() except * with gil
-
-        cdef cppclass callback_sink_mt:
-            callback_sink_mt(log_callback_t callback, flush_callback_t flush) except +
-
-    cdef extern from "cuml/common/logger.hpp" namespace "ML" nogil:
-        cdef logger& default_logger() except +
-        cdef string default_pattern() except +
-
-    cdef void _log_callback(int lvl, const char * msg) with gil
-    cdef void _log_flush() with gil
-
-ELSE:
     cpdef enum class level_enum:
-        trace = 0
-        debug = 1
-        info = 2
-        warn = 3
-        error = 4
-        critical = 5
-        off = 6
-        n_levels = 7
+        trace
+        debug
+        info
+        warn
+        error
+        critical
+        off
+        n_levels
+
+    cdef cppclass sink:
+        pass
+
+    ctypedef shared_ptr[sink] sink_ptr
+
+# Spoof the logger as a namespace to get the sink_vector generated correctly.
+cdef extern from "rapids_logger/logger.hpp" namespace "rapids_logger::logger" nogil:
+
+    cdef cppclass sink_vector:
+        void push_back(const sink_ptr& sink) except +
+        void pop_back() except +
+        void clear()
+
+cdef extern from "rapids_logger/logger.hpp" namespace "rapids_logger" nogil:
+    cdef cppclass logger:
+        logger(string name, string filename) except +
+        void set_level(level_enum log_level) except +
+        void set_pattern(const string& pattern)
+        level_enum level() except +
+        void flush() except +
+        void flush_on(level_enum level) except +
+        level_enum flush_level() except +
+        bool should_log(level_enum msg_level) except +
+        void log(level_enum lvl, const string& fmt, ...)
+        const sink_vector& sinks() const
+
+    ctypedef void(*log_callback_t)(int, const char*) except * with gil
+    ctypedef void(*flush_callback_t)() except * with gil
+
+    cdef cppclass callback_sink_mt:
+        callback_sink_mt(log_callback_t callback, flush_callback_t flush) except +
+
+cdef extern from "cuml/common/logger.hpp" namespace "ML" nogil:
+    cdef logger& default_logger() except +
+    cdef string default_pattern() except +
+
+cdef void _log_callback(int lvl, const char * msg) with gil
+cdef void _log_flush() with gil
 
 
 cdef class LogLevelSetter:

--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -35,25 +35,26 @@ from cuml.internals.api_decorators import enable_device_interop
 from cuml.internals.array import CumlArray
 from cuml.internals.input_utils import input_to_cuml_array
 
-IF GPUBUILD == 1:
-    from pylibraft.common.handle cimport handle_t
-    cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+from pylibraft.common.handle cimport handle_t
 
-        cdef void gemmPredict(handle_t& handle,
-                              const float *input,
-                              size_t _n_rows,
-                              size_t _n_cols,
-                              const float *coef,
-                              float intercept,
-                              float *preds) except +
 
-        cdef void gemmPredict(handle_t& handle,
-                              const double *input,
-                              size_t _n_rows,
-                              size_t _n_cols,
-                              const double *coef,
-                              double intercept,
-                              double *preds) except +
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+
+    cdef void gemmPredict(handle_t& handle,
+                          const float *input,
+                          size_t _n_rows,
+                          size_t _n_cols,
+                          const float *coef,
+                          float intercept,
+                          float *preds) except +
+
+    cdef void gemmPredict(handle_t& handle,
+                          const double *input,
+                          size_t _n_rows,
+                          size_t _n_cols,
+                          const double *coef,
+                          double intercept,
+                          double *preds) except +
 
 
 class LinearPredictMixin:
@@ -138,24 +139,23 @@ class LinearPredictMixin:
             preds = CumlArray.zeros(_n_rows, dtype=dtype, index=X_m.index)
         cdef uintptr_t _preds_ptr = preds.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype.type == np.float32:
-                gemmPredict(handle_[0],
-                            <float*>_X_ptr,
-                            <size_t>_n_rows,
-                            <size_t>_n_cols,
-                            <float*>_coef_ptr,
-                            <float>intercept,
-                            <float*>_preds_ptr)
-            else:
-                gemmPredict(handle_[0],
-                            <double*>_X_ptr,
-                            <size_t>_n_rows,
-                            <size_t>_n_cols,
-                            <double*>_coef_ptr,
-                            <double>intercept,
-                            <double*>_preds_ptr)
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype.type == np.float32:
+            gemmPredict(handle_[0],
+                        <float*>_X_ptr,
+                        <size_t>_n_rows,
+                        <size_t>_n_cols,
+                        <float*>_coef_ptr,
+                        <float>intercept,
+                        <float*>_preds_ptr)
+        else:
+            gemmPredict(handle_[0],
+                        <double*>_X_ptr,
+                        <size_t>_n_rows,
+                        <size_t>_n_cols,
+                        <double*>_coef_ptr,
+                        <double>intercept,
+                        <double*>_preds_ptr)
 
         self.handle.sync()
 

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -42,36 +42,37 @@ from cuml.internals.base import UniversalBase
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.linear_model.base import LinearPredictMixin
 
-IF GPUBUILD == 1:
-    from libcpp cimport bool
-    from pylibraft.common.handle cimport handle_t
-    from pylibraft.common.handle import Handle
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
 
-    cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+from pylibraft.common.handle import Handle
 
-        cdef void olsFit(handle_t& handle,
-                         float *input,
-                         size_t n_rows,
-                         size_t n_cols,
-                         float *labels,
-                         float *coef,
-                         float *intercept,
-                         bool fit_intercept,
-                         bool normalize,
-                         int algo,
-                         float *sample_weight) except +
 
-        cdef void olsFit(handle_t& handle,
-                         double *input,
-                         size_t n_rows,
-                         size_t n_cols,
-                         double *labels,
-                         double *coef,
-                         double *intercept,
-                         bool fit_intercept,
-                         bool normalize,
-                         int algo,
-                         double *sample_weight) except +
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+
+    cdef void olsFit(handle_t& handle,
+                     float *input,
+                     size_t n_rows,
+                     size_t n_cols,
+                     float *labels,
+                     float *coef,
+                     float *intercept,
+                     bool fit_intercept,
+                     bool normalize,
+                     int algo,
+                     float *sample_weight) except +
+
+    cdef void olsFit(handle_t& handle,
+                     double *input,
+                     size_t n_rows,
+                     size_t n_cols,
+                     double *labels,
+                     double *coef,
+                     double *intercept,
+                     bool fit_intercept,
+                     bool normalize,
+                     int algo,
+                     double *sample_weight) except +
 
 
 def divide_non_zero(x1, x2):
@@ -284,11 +285,10 @@ class LinearRegression(LinearPredictMixin,
     def __init__(self, *, algorithm='eig', fit_intercept=True,
                  copy_X=True, normalize=False,
                  handle=None, verbose=False, output_type=None):
-        IF GPUBUILD == 1:
-            if handle is None and algorithm == 'eig':
-                # if possible, create two streams, so that eigenvalue decomposition
-                # can benefit from running independent operations concurrently.
-                handle = Handle(n_streams=2)
+        if handle is None and algorithm == 'eig':
+            # if possible, create two streams, so that eigenvalue decomposition
+            # can benefit from running independent operations concurrently.
+            handle = Handle(n_streams=2)
         super().__init__(handle=handle,
                          verbose=verbose,
                          output_type=output_type)
@@ -385,38 +385,37 @@ class LinearRegression(LinearPredictMixin,
         cdef float _c_intercept_f32
         cdef double _c_intercept_f64
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if self.dtype == np.float32:
+        if self.dtype == np.float32:
 
-                olsFit(handle_[0],
-                       <float*>_X_ptr,
-                       <size_t>n_rows,
-                       <size_t>self.n_features_in_,
-                       <float*>_y_ptr,
-                       <float*>_coef_ptr,
-                       <float*>&_c_intercept_f32,
-                       <bool>self.fit_intercept,
-                       <bool>self.normalize,
-                       <int>self.algo,
-                       <float*>sample_weight_ptr)
+            olsFit(handle_[0],
+                   <float*>_X_ptr,
+                   <size_t>n_rows,
+                   <size_t>self.n_features_in_,
+                   <float*>_y_ptr,
+                   <float*>_coef_ptr,
+                   <float*>&_c_intercept_f32,
+                   <bool>self.fit_intercept,
+                   <bool>self.normalize,
+                   <int>self.algo,
+                   <float*>sample_weight_ptr)
 
-                self.intercept_ = _c_intercept_f32
-            else:
-                olsFit(handle_[0],
-                       <double*>_X_ptr,
-                       <size_t>n_rows,
-                       <size_t>self.n_features_in_,
-                       <double*>_y_ptr,
-                       <double*>_coef_ptr,
-                       <double*>&_c_intercept_f64,
-                       <bool>self.fit_intercept,
-                       <bool>self.normalize,
-                       <int>self.algo,
-                       <double*>sample_weight_ptr)
+            self.intercept_ = _c_intercept_f32
+        else:
+            olsFit(handle_[0],
+                   <double*>_X_ptr,
+                   <size_t>n_rows,
+                   <size_t>self.n_features_in_,
+                   <double*>_y_ptr,
+                   <double*>_coef_ptr,
+                   <double*>&_c_intercept_f64,
+                   <bool>self.fit_intercept,
+                   <bool>self.normalize,
+                   <int>self.algo,
+                   <double*>sample_weight_ptr)
 
-                self.intercept_ = _c_intercept_f64
+            self.intercept_ = _c_intercept_f64
 
         self.handle.sync()
 

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -16,7 +16,6 @@
 
 # distutils: language = c++
 
-from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.safe_imports import cpu_only_import
 
 np = cpu_only_import('numpy')
@@ -31,7 +30,6 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.api_decorators import (
-    api_base_return_array_skipall,
     device_interop_preparation,
     enable_device_interop,
 )
@@ -40,38 +38,39 @@ from cuml.internals.base import UniversalBase
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.linear_model.base import LinearPredictMixin
 
-IF GPUBUILD == 1:
-    from libcpp cimport bool
-    from pylibraft.common.handle cimport handle_t
-    cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
 
-        cdef void ridgeFit(handle_t& handle,
-                           float *input,
-                           size_t n_rows,
-                           size_t n_cols,
-                           float *labels,
-                           float *alpha,
-                           int n_alpha,
-                           float *coef,
-                           float *intercept,
-                           bool fit_intercept,
-                           bool normalize,
-                           int algo,
-                           float *sample_weight) except +
 
-        cdef void ridgeFit(handle_t& handle,
-                           double *input,
-                           size_t n_rows,
-                           size_t n_cols,
-                           double *labels,
-                           double *alpha,
-                           int n_alpha,
-                           double *coef,
-                           double *intercept,
-                           bool fit_intercept,
-                           bool normalize,
-                           int algo,
-                           double *sample_weight) except +
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+
+    cdef void ridgeFit(handle_t& handle,
+                       float *input,
+                       size_t n_rows,
+                       size_t n_cols,
+                       float *labels,
+                       float *alpha,
+                       int n_alpha,
+                       float *coef,
+                       float *intercept,
+                       bool fit_intercept,
+                       bool normalize,
+                       int algo,
+                       float *sample_weight) except +
+
+    cdef void ridgeFit(handle_t& handle,
+                       double *input,
+                       size_t n_rows,
+                       size_t n_cols,
+                       double *labels,
+                       double *alpha,
+                       int n_alpha,
+                       double *coef,
+                       double *intercept,
+                       bool fit_intercept,
+                       bool normalize,
+                       int algo,
+                       double *sample_weight) except +
 
 
 class Ridge(UniversalBase,
@@ -327,43 +326,42 @@ class Ridge(UniversalBase,
         cdef float _c_alpha_f32
         cdef double _c_alpha_f64
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if self.dtype == np.float32:
-                _c_alpha_f32 = self.alpha
-                ridgeFit(handle_[0],
-                         <float*>_X_ptr,
-                         <size_t>n_rows,
-                         <size_t>self.n_features_in_,
-                         <float*>_y_ptr,
-                         <float*>&_c_alpha_f32,
-                         <int>self.n_alpha,
-                         <float*>_coef_ptr,
-                         <float*>&_c_intercept_f32,
-                         <bool>self.fit_intercept,
-                         <bool>self.normalize,
-                         <int>self.algo,
-                         <float*>_sample_weight_ptr)
+        if self.dtype == np.float32:
+            _c_alpha_f32 = self.alpha
+            ridgeFit(handle_[0],
+                     <float*>_X_ptr,
+                     <size_t>n_rows,
+                     <size_t>self.n_features_in_,
+                     <float*>_y_ptr,
+                     <float*>&_c_alpha_f32,
+                     <int>self.n_alpha,
+                     <float*>_coef_ptr,
+                     <float*>&_c_intercept_f32,
+                     <bool>self.fit_intercept,
+                     <bool>self.normalize,
+                     <int>self.algo,
+                     <float*>_sample_weight_ptr)
 
-                self.intercept_ = _c_intercept_f32
-            else:
-                _c_alpha_f64 = self.alpha
-                ridgeFit(handle_[0],
-                         <double*>_X_ptr,
-                         <size_t>n_rows,
-                         <size_t>self.n_features_in_,
-                         <double*>_y_ptr,
-                         <double*>&_c_alpha_f64,
-                         <int>self.n_alpha,
-                         <double*>_coef_ptr,
-                         <double*>&_c_intercept_f64,
-                         <bool>self.fit_intercept,
-                         <bool>self.normalize,
-                         <int>self.algo,
-                         <double*>_sample_weight_ptr)
+            self.intercept_ = _c_intercept_f32
+        else:
+            _c_alpha_f64 = self.alpha
+            ridgeFit(handle_[0],
+                     <double*>_X_ptr,
+                     <size_t>n_rows,
+                     <size_t>self.n_features_in_,
+                     <double*>_y_ptr,
+                     <double*>&_c_alpha_f64,
+                     <int>self.n_alpha,
+                     <double*>_coef_ptr,
+                     <double*>&_c_intercept_f64,
+                     <bool>self.fit_intercept,
+                     <bool>self.normalize,
+                     <int>self.algo,
+                     <double*>_sample_weight_ptr)
 
-                self.intercept_ = _c_intercept_f64
+            self.intercept_ = _c_intercept_f64
 
         self.handle.sync()
 

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -53,8 +53,6 @@ from cuml.internals.api_decorators import (
 )
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.available_devices import is_cuda_available
-from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.mixins import CMajorInputTagMixin, SparseInputTagMixin
@@ -63,92 +61,70 @@ from cuml.internals.utils import check_random_seed
 rmm = gpu_only_import('rmm')
 
 from libc.stdint cimport uintptr_t
+from libc.stdlib cimport free
+from pylibraft.common.handle cimport handle_t
 
-if is_cuda_available():
-    from cuml.manifold.simpl_set import fuzzy_simplicial_set  # no-cython-lint
-    from cuml.manifold.simpl_set import (
-        simplicial_set_embedding,  # no-cython-lint
-    )
+from cuml.manifold.umap_utils cimport *
 
-    # TODO: These two symbols are considered part of the public API of this module
-    # which is why imports should not be removed. The no-cython-lint markers can be
-    # replaced with an explicit __all__ specifications once
-    # https://github.com/MarcoGorelli/cython-lint/issues/80 is resolved.
-else:
-    # if no GPU is present, we import the UMAP equivalents
-    from umap.umap_ import fuzzy_simplicial_set  # no-cython-lint
-    from umap.umap_ import simplicial_set_embedding  # no-cython-lint
+from cuml.manifold.simpl_set import fuzzy_simplicial_set  # no-cython-lint
+from cuml.manifold.simpl_set import simplicial_set_embedding  # no-cython-lint
+from cuml.manifold.umap_utils import GraphHolder, coerce_metric, find_ab_params
 
 
-IF GPUBUILD == 1:
-    from libc.stdlib cimport free
-    from pylibraft.common.handle cimport handle_t
+cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP":
 
-    from cuml.manifold.umap_utils cimport *
-    from cuml.manifold.simpl_set import (
-        fuzzy_simplicial_set,
-        simplicial_set_embedding,
-    )
-    from cuml.manifold.umap_utils import (
-        GraphHolder,
-        coerce_metric,
-        find_ab_params,
-    )
+    void fit(handle_t & handle,
+             float * X,
+             float * y,
+             int n,
+             int d,
+             int64_t * knn_indices,
+             float * knn_dists,
+             UMAPParams * params,
+             float * embeddings,
+             COO * graph) except +
 
-    cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP":
+    void fit_sparse(handle_t &handle,
+                    int *indptr,
+                    int *indices,
+                    float *data,
+                    size_t nnz,
+                    float *y,
+                    int n,
+                    int d,
+                    int * knn_indices,
+                    float * knn_dists,
+                    UMAPParams *params,
+                    float *embeddings,
+                    COO * graph) except +
 
-        void fit(handle_t & handle,
-                 float * X,
-                 float * y,
-                 int n,
-                 int d,
-                 int64_t * knn_indices,
-                 float * knn_dists,
-                 UMAPParams * params,
-                 float * embeddings,
-                 COO * graph) except +
+    void transform(handle_t & handle,
+                   float * X,
+                   int n,
+                   int d,
+                   float * orig_X,
+                   int orig_n,
+                   float * embedding,
+                   int embedding_n,
+                   UMAPParams * params,
+                   float * out) except +
 
-        void fit_sparse(handle_t &handle,
-                        int *indptr,
-                        int *indices,
-                        float *data,
-                        size_t nnz,
-                        float *y,
-                        int n,
-                        int d,
-                        int * knn_indices,
-                        float * knn_dists,
-                        UMAPParams *params,
-                        float *embeddings,
-                        COO * graph) except +
-
-        void transform(handle_t & handle,
-                       float * X,
-                       int n,
-                       int d,
-                       float * orig_X,
-                       int orig_n,
-                       float * embedding,
-                       int embedding_n,
-                       UMAPParams * params,
-                       float * out) except +
-
-        void transform_sparse(handle_t &handle,
-                              int *indptr,
-                              int *indices,
-                              float *data,
-                              size_t nnz,
-                              int n,
-                              int d,
-                              int *orig_x_indptr,
-                              int *orig_x_indices,
-                              float *orig_x_data,
-                              size_t orig_nnz,
-                              int orig_n,
-                              float *embedding,
-                              int embedding_n,
-                              UMAPParams *params,
-                              float *transformed) except +
+    void transform_sparse(handle_t &handle,
+                          int *indptr,
+                          int *indices,
+                          float *data,
+                          size_t nnz,
+                          int n,
+                          int d,
+                          int *orig_x_indptr,
+                          int *orig_x_indices,
+                          float *orig_x_data,
+                          size_t orig_nnz,
+                          int orig_n,
+                          float *embedding,
+                          int embedding_n,
+                          UMAPParams *params,
+                          float *transformed) except +
 
 
 class UMAP(UniversalBase,
@@ -478,79 +454,76 @@ class UMAP(UniversalBase,
             raise ValueError("min_dist should be <= spread")
 
     def _build_umap_params(self, sparse):
-        IF GPUBUILD == 1:
-            cdef UMAPParams* umap_params = new UMAPParams()
-            umap_params.n_neighbors = <int> self.n_neighbors
-            umap_params.n_components = <int> self.n_components
-            umap_params.n_epochs = <int> self.n_epochs if self.n_epochs else 0
-            umap_params.learning_rate = <float> self.learning_rate
-            umap_params.initial_alpha = <float> self.learning_rate
-            umap_params.min_dist = <float> self.min_dist
-            umap_params.spread = <float> self.spread
-            umap_params.set_op_mix_ratio = <float> self.set_op_mix_ratio
-            umap_params.local_connectivity = <float> self.local_connectivity
-            umap_params.repulsion_strength = <float> self.repulsion_strength
-            umap_params.negative_sample_rate = <int> self.negative_sample_rate
-            umap_params.transform_queue_size = <int> self.transform_queue_size
-            umap_params.verbosity = <level_enum> self.verbose
-            umap_params.a = <float> self.a
-            umap_params.b = <float> self.b
-            umap_params.target_n_neighbors = <int> self.target_n_neighbors
-            umap_params.target_weight = <float> self.target_weight
-            umap_params.random_state = <uint64_t> check_random_seed(self.random_state)
-            umap_params.deterministic = <bool> self.deterministic
+        cdef UMAPParams* umap_params = new UMAPParams()
+        umap_params.n_neighbors = <int> self.n_neighbors
+        umap_params.n_components = <int> self.n_components
+        umap_params.n_epochs = <int> self.n_epochs if self.n_epochs else 0
+        umap_params.learning_rate = <float> self.learning_rate
+        umap_params.initial_alpha = <float> self.learning_rate
+        umap_params.min_dist = <float> self.min_dist
+        umap_params.spread = <float> self.spread
+        umap_params.set_op_mix_ratio = <float> self.set_op_mix_ratio
+        umap_params.local_connectivity = <float> self.local_connectivity
+        umap_params.repulsion_strength = <float> self.repulsion_strength
+        umap_params.negative_sample_rate = <int> self.negative_sample_rate
+        umap_params.transform_queue_size = <int> self.transform_queue_size
+        umap_params.verbosity = <level_enum> self.verbose
+        umap_params.a = <float> self.a
+        umap_params.b = <float> self.b
+        umap_params.target_n_neighbors = <int> self.target_n_neighbors
+        umap_params.target_weight = <float> self.target_weight
+        umap_params.random_state = <uint64_t> check_random_seed(self.random_state)
+        umap_params.deterministic = <bool> self.deterministic
 
-            if self.init == "spectral":
-                umap_params.init = <int> 1
-            else:  # self.init == "random"
-                umap_params.init = <int> 0
+        if self.init == "spectral":
+            umap_params.init = <int> 1
+        else:  # self.init == "random"
+            umap_params.init = <int> 0
 
-            if self.target_metric == "euclidean":
-                umap_params.target_metric = MetricType.EUCLIDEAN
-            else:  # self.target_metric == "categorical"
-                umap_params.target_metric = MetricType.CATEGORICAL
+        if self.target_metric == "euclidean":
+            umap_params.target_metric = MetricType.EUCLIDEAN
+        else:  # self.target_metric == "categorical"
+            umap_params.target_metric = MetricType.CATEGORICAL
 
-            umap_params.metric = coerce_metric(
-                self.metric, sparse=sparse, build_algo=self.build_algo
-            )
+        umap_params.metric = coerce_metric(
+            self.metric, sparse=sparse, build_algo=self.build_algo
+        )
 
-            if self.metric_kwds is None:
-                umap_params.p = <float> 2.0
-            else:
-                umap_params.p = <float>self.metric_kwds.get('p')
+        if self.metric_kwds is None:
+            umap_params.p = <float> 2.0
+        else:
+            umap_params.p = <float>self.metric_kwds.get('p')
 
-            if self.build_algo == "brute_force_knn":
-                umap_params.build_algo = graph_build_algo.BRUTE_FORCE_KNN
-            else:
-                umap_params.build_algo = graph_build_algo.NN_DESCENT
-                build_kwds = self.build_kwds or {}
-                umap_params.nn_descent_params.graph_degree = <uint64_t> build_kwds.get("nnd_graph_degree", 64)
-                umap_params.nn_descent_params.intermediate_graph_degree = <uint64_t> build_kwds.get("nnd_intermediate_graph_degree", 128)
-                umap_params.nn_descent_params.max_iterations = <uint64_t> build_kwds.get("nnd_max_iterations", 20)
-                umap_params.nn_descent_params.termination_threshold = <float> build_kwds.get("nnd_termination_threshold", 0.0001)
-                umap_params.nn_descent_params.return_distances = <bool> build_kwds.get("nnd_return_distances", True)
-                umap_params.nn_descent_params.n_clusters = <uint64_t> build_kwds.get("nnd_n_clusters", 1)
-                # Forward metric & metric_kwds to nn_descent
-                umap_params.nn_descent_params.metric = <RaftDistanceType> umap_params.metric
-                umap_params.nn_descent_params.metric_arg = umap_params.p
+        if self.build_algo == "brute_force_knn":
+            umap_params.build_algo = graph_build_algo.BRUTE_FORCE_KNN
+        else:
+            umap_params.build_algo = graph_build_algo.NN_DESCENT
+            build_kwds = self.build_kwds or {}
+            umap_params.nn_descent_params.graph_degree = <uint64_t> build_kwds.get("nnd_graph_degree", 64)
+            umap_params.nn_descent_params.intermediate_graph_degree = <uint64_t> build_kwds.get("nnd_intermediate_graph_degree", 128)
+            umap_params.nn_descent_params.max_iterations = <uint64_t> build_kwds.get("nnd_max_iterations", 20)
+            umap_params.nn_descent_params.termination_threshold = <float> build_kwds.get("nnd_termination_threshold", 0.0001)
+            umap_params.nn_descent_params.return_distances = <bool> build_kwds.get("nnd_return_distances", True)
+            umap_params.nn_descent_params.n_clusters = <uint64_t> build_kwds.get("nnd_n_clusters", 1)
+            # Forward metric & metric_kwds to nn_descent
+            umap_params.nn_descent_params.metric = <RaftDistanceType> umap_params.metric
+            umap_params.nn_descent_params.metric_arg = umap_params.p
 
-            cdef uintptr_t callback_ptr = 0
-            if self.callback:
-                callback_ptr = self.callback.get_native_callback()
-                umap_params.callback = <GraphBasedDimRedCallback*>callback_ptr
+        cdef uintptr_t callback_ptr = 0
+        if self.callback:
+            callback_ptr = self.callback.get_native_callback()
+            umap_params.callback = <GraphBasedDimRedCallback*>callback_ptr
 
-            return <size_t>umap_params
+        return <size_t>umap_params
 
     @staticmethod
     def _destroy_umap_params(ptr):
-        IF GPUBUILD == 1:
-            cdef UMAPParams* umap_params = <UMAPParams*> <size_t> ptr
-            free(umap_params)
+        cdef UMAPParams* umap_params = <UMAPParams*> <size_t> ptr
+        free(umap_params)
 
     @staticmethod
     def find_ab_params(spread, min_dist):
-        IF GPUBUILD == 1:
-            return find_ab_params(spread, min_dist)
+        return find_ab_params(spread, min_dist)
 
     @generate_docstring(convert_dtype_cast='np.float32',
                         X='dense_sparse',
@@ -666,45 +639,44 @@ class UMAP(UniversalBase,
                                                       else None))
             _y_raw_ptr = y_m.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t * handle_ = \
-                <handle_t*> <size_t> self.handle.getHandle()
-            fss_graph = GraphHolder.new_graph(handle_.get_stream())
-            cdef UMAPParams* umap_params = \
-                <UMAPParams*> <size_t> self._build_umap_params(
-                                                               self.sparse_fit)
-            if self.sparse_fit:
-                fit_sparse(handle_[0],
-                           <int*><uintptr_t> self._raw_data.indptr.ptr,
-                           <int*><uintptr_t> self._raw_data.indices.ptr,
-                           <float*><uintptr_t> self._raw_data.data.ptr,
-                           <size_t> self._raw_data.nnz,
-                           <float*> _y_raw_ptr,
-                           <int> self.n_rows,
-                           <int> self.n_dims,
-                           <int*> _knn_indices_ptr,
-                           <float*> _knn_dists_ptr,
-                           <UMAPParams*> umap_params,
-                           <float*> _embed_raw_ptr,
-                           <COO*> fss_graph.get())
+        cdef handle_t * handle_ = \
+            <handle_t*> <size_t> self.handle.getHandle()
+        fss_graph = GraphHolder.new_graph(handle_.get_stream())
+        cdef UMAPParams* umap_params = \
+            <UMAPParams*> <size_t> self._build_umap_params(
+                                                           self.sparse_fit)
+        if self.sparse_fit:
+            fit_sparse(handle_[0],
+                       <int*><uintptr_t> self._raw_data.indptr.ptr,
+                       <int*><uintptr_t> self._raw_data.indices.ptr,
+                       <float*><uintptr_t> self._raw_data.data.ptr,
+                       <size_t> self._raw_data.nnz,
+                       <float*> _y_raw_ptr,
+                       <int> self.n_rows,
+                       <int> self.n_dims,
+                       <int*> _knn_indices_ptr,
+                       <float*> _knn_dists_ptr,
+                       <UMAPParams*> umap_params,
+                       <float*> _embed_raw_ptr,
+                       <COO*> fss_graph.get())
 
-            else:
-                fit(handle_[0],
-                    <float*><uintptr_t> self._raw_data.ptr,
-                    <float*> _y_raw_ptr,
-                    <int> self.n_rows,
-                    <int> self.n_dims,
-                    <int64_t*> _knn_indices_ptr,
-                    <float*> _knn_dists_ptr,
-                    <UMAPParams*>umap_params,
-                    <float*>_embed_raw_ptr,
-                    <COO*> fss_graph.get())
+        else:
+            fit(handle_[0],
+                <float*><uintptr_t> self._raw_data.ptr,
+                <float*> _y_raw_ptr,
+                <int> self.n_rows,
+                <int> self.n_dims,
+                <int64_t*> _knn_indices_ptr,
+                <float*> _knn_dists_ptr,
+                <UMAPParams*>umap_params,
+                <float*>_embed_raw_ptr,
+                <COO*> fss_graph.get())
 
-            self.graph_ = fss_graph.get_cupy_coo()
+        self.graph_ = fss_graph.get_cupy_coo()
 
-            self.handle.sync()
+        self.handle.sync()
 
-            UMAP._destroy_umap_params(<size_t>umap_params)
+        UMAP._destroy_umap_params(<size_t>umap_params)
 
         return self
 
@@ -828,43 +800,39 @@ class UMAP(UniversalBase,
             self.build_algo = "brute_force_knn"
             logger.info("Transform can only be run with brute force. Using brute force.")
 
-        IF GPUBUILD == 1:
-            cdef UMAPParams* umap_params = \
-                <UMAPParams*> <size_t> self._build_umap_params(
-                                                               self.sparse_fit)
-            cdef handle_t * handle_ = \
-                <handle_t*> <size_t> self.handle.getHandle()
-            if self.sparse_fit:
-                transform_sparse(handle_[0],
-                                 <int*><uintptr_t> X_m.indptr.ptr,
-                                 <int*><uintptr_t> X_m.indices.ptr,
-                                 <float*><uintptr_t> X_m.data.ptr,
-                                 <size_t> X_m.nnz,
-                                 <int> X_m.shape[0],
-                                 <int> X_m.shape[1],
-                                 <int*><uintptr_t> self._raw_data.indptr.ptr,
-                                 <int*><uintptr_t> self._raw_data.indices.ptr,
-                                 <float*><uintptr_t> self._raw_data.data.ptr,
-                                 <size_t> self._raw_data.nnz,
-                                 <int> self._raw_data.shape[0],
-                                 <float*> _embed_ptr,
-                                 <int> self._raw_data.shape[0],
-                                 <UMAPParams*> umap_params,
-                                 <float*> _xformed_ptr)
-            else:
-                transform(handle_[0],
-                          <float*><uintptr_t> X_m.ptr,
-                          <int> n_rows,
-                          <int> n_cols,
-                          <float*><uintptr_t>self._raw_data.ptr,
-                          <int> self._raw_data.shape[0],
-                          <float*> _embed_ptr,
-                          <int> n_rows,
-                          <UMAPParams*> umap_params,
-                          <float*> _xformed_ptr)
-            self.handle.sync()
+        cdef UMAPParams* umap_params = <UMAPParams*> <size_t> self._build_umap_params(self.sparse_fit)
+        cdef handle_t * handle_ = <handle_t*> <size_t> self.handle.getHandle()
+        if self.sparse_fit:
+            transform_sparse(handle_[0],
+                             <int*><uintptr_t> X_m.indptr.ptr,
+                             <int*><uintptr_t> X_m.indices.ptr,
+                             <float*><uintptr_t> X_m.data.ptr,
+                             <size_t> X_m.nnz,
+                             <int> X_m.shape[0],
+                             <int> X_m.shape[1],
+                             <int*><uintptr_t> self._raw_data.indptr.ptr,
+                             <int*><uintptr_t> self._raw_data.indices.ptr,
+                             <float*><uintptr_t> self._raw_data.data.ptr,
+                             <size_t> self._raw_data.nnz,
+                             <int> self._raw_data.shape[0],
+                             <float*> _embed_ptr,
+                             <int> self._raw_data.shape[0],
+                             <UMAPParams*> umap_params,
+                             <float*> _xformed_ptr)
+        else:
+            transform(handle_[0],
+                      <float*><uintptr_t> X_m.ptr,
+                      <int> n_rows,
+                      <int> n_cols,
+                      <float*><uintptr_t>self._raw_data.ptr,
+                      <int> self._raw_data.shape[0],
+                      <float*> _embed_ptr,
+                      <int> n_rows,
+                      <UMAPParams*> umap_params,
+                      <float*> _xformed_ptr)
+        self.handle.sync()
 
-            UMAP._destroy_umap_params(<size_t>umap_params)
+        UMAP._destroy_umap_params(<size_t>umap_params)
 
         del X_m
         return embedding

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -32,7 +32,6 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring, insert_into_docstring
 from cuml.common.sparse_utils import is_dense, is_sparse
-from cuml.internals import api_base_return_generic
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.base import UniversalBase
@@ -56,97 +55,97 @@ rmm = gpu_only_import('rmm')
 
 cimport cuml.common.cuda
 
-IF GPUBUILD == 1:
-    import warnings
-    from cython.operator cimport dereference as deref
-    from libc.stdint cimport int64_t, uint32_t, uintptr_t
-    from libcpp cimport bool
-    from libcpp.vector cimport vector
-    from pylibraft.common.handle cimport handle_t
+import warnings
 
-    cdef extern from "raft/spatial/knn/ball_cover_types.hpp" \
-            namespace "raft::spatial::knn":
-        cdef cppclass BallCoverIndex[int64_t, float, uint32_t]:
-            BallCoverIndex(const handle_t &handle,
-                           float *X,
-                           uint32_t n_rows,
-                           uint32_t n_cols,
-                           RaftDistanceType metric) except +
+from cython.operator cimport dereference as deref
+from libc.stdint cimport int64_t, uint32_t, uintptr_t
+from libcpp cimport bool
+from libcpp.vector cimport vector
+from pylibraft.common.handle cimport handle_t
 
-    cdef extern from "cuml/neighbors/knn.hpp" namespace "ML":
-        void brute_force_knn(
-            const handle_t &handle,
-            vector[float*] &inputs,
-            vector[int] &sizes,
-            int D,
-            float *search_items,
-            int n,
-            int64_t *res_I,
-            float *res_D,
-            int k,
-            bool rowMajorIndex,
-            bool rowMajorQuery,
-            DistanceType metric,
-            float metric_arg
-        ) except +
 
-        void rbc_build_index(
-            const handle_t &handle,
-            BallCoverIndex[int64_t, float, uint32_t] &index,
-        ) except +
+cdef extern from "raft/spatial/knn/ball_cover_types.hpp" namespace "raft::spatial::knn":
+    cdef cppclass BallCoverIndex[int64_t, float, uint32_t]:
+        BallCoverIndex(const handle_t &handle,
+                       float *X,
+                       uint32_t n_rows,
+                       uint32_t n_cols,
+                       RaftDistanceType metric) except +
 
-        void rbc_knn_query(
-            const handle_t &handle,
-            BallCoverIndex[int64_t, float, uint32_t] &index,
-            uint32_t k,
-            float *search_items,
-            uint32_t n_search_items,
-            int64_t *out_inds,
-            float *out_dists
-        ) except +
+cdef extern from "cuml/neighbors/knn.hpp" namespace "ML":
+    void brute_force_knn(
+        const handle_t &handle,
+        vector[float*] &inputs,
+        vector[int] &sizes,
+        int D,
+        float *search_items,
+        int n,
+        int64_t *res_I,
+        float *res_D,
+        int k,
+        bool rowMajorIndex,
+        bool rowMajorQuery,
+        DistanceType metric,
+        float metric_arg
+    ) except +
 
-        void approx_knn_build_index(
-            handle_t &handle,
-            knnIndex* index,
-            knnIndexParam* params,
-            DistanceType metric,
-            float metricArg,
-            float *index_array,
-            int n,
-            int D
-        ) except +
+    void rbc_build_index(
+        const handle_t &handle,
+        BallCoverIndex[int64_t, float, uint32_t] &index,
+    ) except +
 
-        void approx_knn_search(
-            handle_t &handle,
-            float *distances,
-            int64_t* indices,
-            knnIndex* index,
-            int k,
-            const float *query_array,
-            int n
-        ) except +
+    void rbc_knn_query(
+        const handle_t &handle,
+        BallCoverIndex[int64_t, float, uint32_t] &index,
+        uint32_t k,
+        float *search_items,
+        uint32_t n_search_items,
+        int64_t *out_inds,
+        float *out_dists
+    ) except +
 
-    cdef extern from "cuml/neighbors/knn_sparse.hpp" namespace "ML::Sparse":
-        void brute_force_knn(handle_t &handle,
-                             const int *idxIndptr,
-                             const int *idxIndices,
-                             const float *idxData,
-                             size_t idxNNZ,
-                             int n_idx_rows,
-                             int n_idx_cols,
-                             const int *queryIndptr,
-                             const int *queryIndices,
-                             const float *queryData,
-                             size_t queryNNZ,
-                             int n_query_rows,
-                             int n_query_cols,
-                             int *output_indices,
-                             float *output_dists,
-                             int k,
-                             size_t batch_size_index,
-                             size_t batch_size_query,
-                             DistanceType metric,
-                             float metricArg) except +
+    void approx_knn_build_index(
+        handle_t &handle,
+        knnIndex* index,
+        knnIndexParam* params,
+        DistanceType metric,
+        float metricArg,
+        float *index_array,
+        int n,
+        int D
+    ) except +
+
+    void approx_knn_search(
+        handle_t &handle,
+        float *distances,
+        int64_t* indices,
+        knnIndex* index,
+        int k,
+        const float *query_array,
+        int n
+    ) except +
+
+cdef extern from "cuml/neighbors/knn_sparse.hpp" namespace "ML::Sparse":
+    void brute_force_knn(handle_t &handle,
+                         const int *idxIndptr,
+                         const int *idxIndices,
+                         const float *idxData,
+                         size_t idxNNZ,
+                         int n_idx_rows,
+                         int n_idx_cols,
+                         const int *queryIndptr,
+                         const int *queryIndices,
+                         const float *queryData,
+                         size_t queryNNZ,
+                         int n_query_rows,
+                         int n_query_cols,
+                         int *output_indices,
+                         float *output_dists,
+                         int k,
+                         size_t batch_size_index,
+                         size_t batch_size_query,
+                         DistanceType metric,
+                         float metricArg) except +
 
 
 class NearestNeighbors(UniversalBase,
@@ -392,54 +391,53 @@ class NearestNeighbors(UniversalBase,
                               self.effective_metric_,
                               self._fit_method))
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><uintptr_t> self.handle.getHandle()
-            cdef knnIndexParam* algo_params = <knnIndexParam*> 0
-            if self._fit_method in ['ivfflat', 'ivfpq']:
-                warnings.warn("\nWarning: Approximate Nearest Neighbor methods "
-                              "might be unstable in this version of cuML. "
-                              "This is due to a known issue in the FAISS "
-                              "release that this cuML version is linked to. "
-                              "(see cuML issue #4020)")
+        cdef handle_t* handle_ = <handle_t*><uintptr_t> self.handle.getHandle()
+        cdef knnIndexParam* algo_params = <knnIndexParam*> 0
+        if self._fit_method in ['ivfflat', 'ivfpq']:
+            warnings.warn("\nWarning: Approximate Nearest Neighbor methods "
+                          "might be unstable in this version of cuML. "
+                          "This is due to a known issue in the FAISS "
+                          "release that this cuML version is linked to. "
+                          "(see cuML issue #4020)")
 
-                if not is_dense(X):
-                    raise ValueError("Approximate Nearest Neighbors methods "
-                                     "require dense data")
+            if not is_dense(X):
+                raise ValueError("Approximate Nearest Neighbors methods "
+                                 "require dense data")
 
-                additional_info = {'n_samples': self.n_samples_fit_,
-                                   'n_features': self.n_features_in_}
-                knn_index = new knnIndex()
-                self.knn_index = <uintptr_t> knn_index
-                algo_params = <knnIndexParam*><uintptr_t> \
-                    build_algo_params(self._fit_method, self.algo_params,
-                                      additional_info)
-                metric = self._build_metric_type(self.effective_metric_)
+            additional_info = {'n_samples': self.n_samples_fit_,
+                               'n_features': self.n_features_in_}
+            knn_index = new knnIndex()
+            self.knn_index = <uintptr_t> knn_index
+            algo_params = <knnIndexParam*><uintptr_t> \
+                build_algo_params(self._fit_method, self.algo_params,
+                                  additional_info)
+            metric = self._build_metric_type(self.effective_metric_)
 
-                approx_knn_build_index(handle_[0],
-                                       <knnIndex*>knn_index,
-                                       <knnIndexParam*>algo_params,
-                                       <DistanceType>metric,
-                                       <float>self.p,
-                                       <float*><uintptr_t>self._fit_X.ptr,
-                                       <int>self.n_samples_fit_,
-                                       <int>self.n_features_in_)
-                self.handle.sync()
+            approx_knn_build_index(handle_[0],
+                                   <knnIndex*>knn_index,
+                                   <knnIndexParam*>algo_params,
+                                   <DistanceType>metric,
+                                   <float>self.p,
+                                   <float*><uintptr_t>self._fit_X.ptr,
+                                   <int>self.n_samples_fit_,
+                                   <int>self.n_features_in_)
+            self.handle.sync()
 
-                destroy_algo_params(<uintptr_t>algo_params)
+            destroy_algo_params(<uintptr_t>algo_params)
 
-                del self._fit_X
-            elif self._fit_method == "rbc":
-                metric = self._build_metric_type(self.effective_metric_)
+            del self._fit_X
+        elif self._fit_method == "rbc":
+            metric = self._build_metric_type(self.effective_metric_)
 
-                rbc_index = new BallCoverIndex[int64_t, float, uint32_t](
-                    handle_[0], <float*><uintptr_t>self._fit_X.ptr,
-                    <uint32_t>self.n_samples_fit_, <uint32_t>self.n_features_in_,
-                    <RaftDistanceType>metric)
-                rbc_build_index(handle_[0],
-                                deref(rbc_index))
-                self.knn_index = <uintptr_t>rbc_index
+            rbc_index = new BallCoverIndex[int64_t, float, uint32_t](
+                handle_[0], <float*><uintptr_t>self._fit_X.ptr,
+                <uint32_t>self.n_samples_fit_, <uint32_t>self.n_features_in_,
+                <RaftDistanceType>metric)
+            rbc_build_index(handle_[0],
+                            deref(rbc_index))
+            self.knn_index = <uintptr_t>rbc_index
 
-            self.n_indices = 1
+        self.n_indices = 1
         return self
 
     @classmethod
@@ -729,64 +727,63 @@ class NearestNeighbors(UniversalBase,
 
         cdef uintptr_t _I_ptr = I_ndarr.ptr
         cdef uintptr_t _D_ptr = D_ndarr.ptr
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            cdef vector[float*] *inputs = new vector[float*]()
-            cdef vector[int] *sizes = new vector[int]()
-            cdef knnIndex* knn_index = <knnIndex*> 0
-            cdef BallCoverIndex[int64_t, float, uint32_t]* rbc_index = \
-                <BallCoverIndex[int64_t, float, uint32_t]*> 0
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef vector[float*] *inputs = new vector[float*]()
+        cdef vector[int] *sizes = new vector[int]()
+        cdef knnIndex* knn_index = <knnIndex*> 0
+        cdef BallCoverIndex[int64_t, float, uint32_t]* rbc_index = \
+            <BallCoverIndex[int64_t, float, uint32_t]*> 0
 
-            fallback_to_brute = self._fit_method == "rbc" and \
-                n_neighbors > math.sqrt(self.n_samples_fit_)
+        fallback_to_brute = self._fit_method == "rbc" and \
+            n_neighbors > math.sqrt(self.n_samples_fit_)
 
-            if fallback_to_brute:
-                warnings.warn("algorithm='rbc' requires sqrt(%s) be "
-                              "> n_neighbors (%s). falling back to "
-                              "brute force search" %
-                              (self.n_samples_fit_, n_neighbors))
+        if fallback_to_brute:
+            warnings.warn("algorithm='rbc' requires sqrt(%s) be "
+                          "> n_neighbors (%s). falling back to "
+                          "brute force search" %
+                          (self.n_samples_fit_, n_neighbors))
 
-            if self._fit_method == 'brute' or fallback_to_brute:
-                inputs.push_back(<float*><uintptr_t>self._fit_X.ptr)
-                sizes.push_back(<int>self.n_samples_fit_)
+        if self._fit_method == 'brute' or fallback_to_brute:
+            inputs.push_back(<float*><uintptr_t>self._fit_X.ptr)
+            sizes.push_back(<int>self.n_samples_fit_)
 
-                brute_force_knn(
-                    handle_[0],
-                    deref(inputs),
-                    deref(sizes),
-                    <int>self.n_features_in_,
-                    <float*><uintptr_t>X_m.ptr,
-                    <int>N,
-                    <int64_t*>_I_ptr,
-                    <float*>_D_ptr,
-                    <int>n_neighbors,
-                    True,
-                    True,
-                    <DistanceType>_metric,
-                    # minkowski order is currently the only metric argument.
-                    <float>self.p
-                )
-            elif self._fit_method == "rbc":
-                rbc_index = <BallCoverIndex[int64_t, float, uint32_t]*>\
-                    <uintptr_t>self.knn_index
-                rbc_knn_query(handle_[0],
-                              deref(rbc_index),
-                              <uint32_t> n_neighbors,
-                              <float*><uintptr_t>X_m.ptr,
-                              <uint32_t> N,
-                              <int64_t*>_I_ptr,
-                              <float*>_D_ptr)
-            else:
-                knn_index = <knnIndex*><uintptr_t> self.knn_index
-                approx_knn_search(
-                    handle_[0],
-                    <float*>_D_ptr,
-                    <int64_t*>_I_ptr,
-                    <knnIndex*>knn_index,
-                    <int>n_neighbors,
-                    <float*><uintptr_t>X_m.ptr,
-                    <int>N
-                )
+            brute_force_knn(
+                handle_[0],
+                deref(inputs),
+                deref(sizes),
+                <int>self.n_features_in_,
+                <float*><uintptr_t>X_m.ptr,
+                <int>N,
+                <int64_t*>_I_ptr,
+                <float*>_D_ptr,
+                <int>n_neighbors,
+                True,
+                True,
+                <DistanceType>_metric,
+                # minkowski order is currently the only metric argument.
+                <float>self.p
+            )
+        elif self._fit_method == "rbc":
+            rbc_index = <BallCoverIndex[int64_t, float, uint32_t]*>\
+                <uintptr_t>self.knn_index
+            rbc_knn_query(handle_[0],
+                          deref(rbc_index),
+                          <uint32_t> n_neighbors,
+                          <float*><uintptr_t>X_m.ptr,
+                          <uint32_t> N,
+                          <int64_t*>_I_ptr,
+                          <float*>_D_ptr)
+        else:
+            knn_index = <knnIndex*><uintptr_t> self.knn_index
+            approx_knn_search(
+                handle_[0],
+                <float*>_D_ptr,
+                <int64_t*>_I_ptr,
+                <knnIndex*>knn_index,
+                <int>n_neighbors,
+                <float*><uintptr_t>X_m.ptr,
+                <int>N
+            )
 
         return D_ndarr, I_ndarr
 
@@ -828,30 +825,28 @@ class NearestNeighbors(UniversalBase,
         cdef uintptr_t _I_ptr = I_ndarr.ptr
         cdef uintptr_t _D_ptr = D_ndarr.ptr
 
-        IF GPUBUILD == 1:
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-
-            brute_force_knn(handle_[0],
-                            <int*> _idx_indptr,
-                            <int*> _idx_indices,
-                            <float*> _idx_data,
-                            self._fit_X.nnz,
-                            self.n_samples_fit_,
-                            self.n_features_in_,
-                            <int*> _search_indptr,
-                            <int*> _search_indices,
-                            <float*> _search_data,
-                            X_m.nnz,
-                            X_m.shape[0],
-                            X_m.shape[1],
-                            <int*>_I_ptr,
-                            <float*>_D_ptr,
-                            n_neighbors,
-                            <size_t>batch_size_index,
-                            <size_t>batch_size_query,
-                            <DistanceType> _metric,
-                            <float>self.p)
+        brute_force_knn(handle_[0],
+                        <int*> _idx_indptr,
+                        <int*> _idx_indices,
+                        <float*> _idx_data,
+                        self._fit_X.nnz,
+                        self.n_samples_fit_,
+                        self.n_features_in_,
+                        <int*> _search_indptr,
+                        <int*> _search_indices,
+                        <float*> _search_data,
+                        X_m.nnz,
+                        X_m.shape[0],
+                        X_m.shape[1],
+                        <int*>_I_ptr,
+                        <float*>_D_ptr,
+                        n_neighbors,
+                        <size_t>batch_size_index,
+                        <size_t>batch_size_query,
+                        <DistanceType> _metric,
+                        <float>self.p)
 
         return D_ndarr, I_ndarr
 

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -32,62 +32,63 @@ from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.mixins import FMajorInputTagMixin
 
-IF GPUBUILD == 1:
-    from libcpp cimport bool
-    from pylibraft.common.handle cimport handle_t
-    cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
 
-        cdef void cdFit(handle_t& handle,
-                        float *input,
+
+cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
+
+    cdef void cdFit(handle_t& handle,
+                    float *input,
+                    int n_rows,
+                    int n_cols,
+                    float *labels,
+                    float *coef,
+                    float *intercept,
+                    bool fit_intercept,
+                    bool normalize,
+                    int epochs,
+                    int loss,
+                    float alpha,
+                    float l1_ratio,
+                    bool shuffle,
+                    float tol,
+                    float *sample_weight) except +
+
+    cdef void cdFit(handle_t& handle,
+                    double *input,
+                    int n_rows,
+                    int n_cols,
+                    double *labels,
+                    double *coef,
+                    double *intercept,
+                    bool fit_intercept,
+                    bool normalize,
+                    int epochs,
+                    int loss,
+                    double alpha,
+                    double l1_ratio,
+                    bool shuffle,
+                    double tol,
+                    double *sample_weight) except +
+
+    cdef void cdPredict(handle_t& handle,
+                        const float *input,
                         int n_rows,
                         int n_cols,
-                        float *labels,
-                        float *coef,
-                        float *intercept,
-                        bool fit_intercept,
-                        bool normalize,
-                        int epochs,
-                        int loss,
-                        float alpha,
-                        float l1_ratio,
-                        bool shuffle,
-                        float tol,
-                        float *sample_weight) except +
+                        const float *coef,
+                        float intercept,
+                        float *preds,
+                        int loss) except +
 
-        cdef void cdFit(handle_t& handle,
-                        double *input,
+    cdef void cdPredict(handle_t& handle,
+                        const double *input,
                         int n_rows,
                         int n_cols,
-                        double *labels,
-                        double *coef,
-                        double *intercept,
-                        bool fit_intercept,
-                        bool normalize,
-                        int epochs,
-                        int loss,
-                        double alpha,
-                        double l1_ratio,
-                        bool shuffle,
-                        double tol,
-                        double *sample_weight) except +
-
-        cdef void cdPredict(handle_t& handle,
-                            const float *input,
-                            int n_rows,
-                            int n_cols,
-                            const float *coef,
-                            float intercept,
-                            float *preds,
-                            int loss) except +
-
-        cdef void cdPredict(handle_t& handle,
-                            const double *input,
-                            int n_rows,
-                            int n_cols,
-                            const double *coef,
-                            double intercept,
-                            double *preds,
-                            int loss) except +
+                        const double *coef,
+                        double intercept,
+                        double *preds,
+                        int loss) except +
 
 
 class CD(Base,
@@ -260,47 +261,46 @@ class CD(Base,
         cdef float _c_intercept_f32
         cdef double _c_intercept2_f64
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if self.dtype == np.float32:
-                cdFit(handle_[0],
-                      <float*>_X_ptr,
-                      <int>n_rows,
-                      <int>self.n_cols,
-                      <float*>_y_ptr,
-                      <float*>_coef_ptr,
-                      <float*>&_c_intercept_f32,
-                      <bool>self.fit_intercept,
-                      <bool>self.normalize,
-                      <int>self.max_iter,
-                      <int>self._get_loss_int(),
-                      <float>self.alpha,
-                      <float>self.l1_ratio,
-                      <bool>self.shuffle,
-                      <float>self.tol,
-                      <float*>sample_weight_ptr)
+        if self.dtype == np.float32:
+            cdFit(handle_[0],
+                  <float*>_X_ptr,
+                  <int>n_rows,
+                  <int>self.n_cols,
+                  <float*>_y_ptr,
+                  <float*>_coef_ptr,
+                  <float*>&_c_intercept_f32,
+                  <bool>self.fit_intercept,
+                  <bool>self.normalize,
+                  <int>self.max_iter,
+                  <int>self._get_loss_int(),
+                  <float>self.alpha,
+                  <float>self.l1_ratio,
+                  <bool>self.shuffle,
+                  <float>self.tol,
+                  <float*>sample_weight_ptr)
 
-                self.intercept_ = _c_intercept_f32
-            else:
-                cdFit(handle_[0],
-                      <double*>_X_ptr,
-                      <int>n_rows,
-                      <int>self.n_cols,
-                      <double*>_y_ptr,
-                      <double*>_coef_ptr,
-                      <double*>&_c_intercept2_f64,
-                      <bool>self.fit_intercept,
-                      <bool>self.normalize,
-                      <int>self.max_iter,
-                      <int>self._get_loss_int(),
-                      <double>self.alpha,
-                      <double>self.l1_ratio,
-                      <bool>self.shuffle,
-                      <double>self.tol,
-                      <double*>sample_weight_ptr)
+            self.intercept_ = _c_intercept_f32
+        else:
+            cdFit(handle_[0],
+                  <double*>_X_ptr,
+                  <int>n_rows,
+                  <int>self.n_cols,
+                  <double*>_y_ptr,
+                  <double*>_coef_ptr,
+                  <double*>&_c_intercept2_f64,
+                  <bool>self.fit_intercept,
+                  <bool>self.normalize,
+                  <int>self.max_iter,
+                  <int>self._get_loss_int(),
+                  <double>self.alpha,
+                  <double>self.l1_ratio,
+                  <bool>self.shuffle,
+                  <double>self.tol,
+                  <double*>sample_weight_ptr)
 
-                self.intercept_ = _c_intercept2_f64
+            self.intercept_ = _c_intercept2_f64
 
         self.handle.sync()
         del X_m
@@ -332,27 +332,26 @@ class CD(Base,
                                 index=X_m.index)
         cdef uintptr_t _preds_ptr = preds.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if self.dtype == np.float32:
-                cdPredict(handle_[0],
-                          <float*>_X_ptr,
-                          <int>n_rows,
-                          <int>_n_cols,
-                          <float*>_coef_ptr,
-                          <float>self.intercept_,
-                          <float*>_preds_ptr,
-                          <int>self._get_loss_int())
-            else:
-                cdPredict(handle_[0],
-                          <double*>_X_ptr,
-                          <int>n_rows,
-                          <int>_n_cols,
-                          <double*>_coef_ptr,
-                          <double>self.intercept_,
-                          <double*>_preds_ptr,
-                          <int>self._get_loss_int())
+        if self.dtype == np.float32:
+            cdPredict(handle_[0],
+                      <float*>_X_ptr,
+                      <int>n_rows,
+                      <int>_n_cols,
+                      <float*>_coef_ptr,
+                      <float>self.intercept_,
+                      <float*>_preds_ptr,
+                      <int>self._get_loss_int())
+        else:
+            cdPredict(handle_[0],
+                      <double*>_X_ptr,
+                      <int>n_rows,
+                      <int>_n_cols,
+                      <double*>_coef_ptr,
+                      <double>self.intercept_,
+                      <double*>_preds_ptr,
+                      <int>self._get_loss_int())
 
         self.handle.sync()
 

--- a/python/cuml/cuml/solvers/qn.pyx
+++ b/python/cuml/cuml/solvers/qn.pyx
@@ -35,212 +35,216 @@ from cuml.internals.base import Base
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.mixins import FMajorInputTagMixin
 
-IF GPUBUILD == 1:
-    from libcpp cimport bool
-    from cuml.metrics import accuracy_score
-    from pylibraft.common.handle cimport handle_t
-    cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
+from libcpp cimport bool
 
-        cdef enum qn_loss_type "ML::GLM::qn_loss_type":
-            QN_LOSS_LOGISTIC "ML::GLM::QN_LOSS_LOGISTIC"
-            QN_LOSS_SQUARED  "ML::GLM::QN_LOSS_SQUARED"
-            QN_LOSS_SOFTMAX  "ML::GLM::QN_LOSS_SOFTMAX"
-            QN_LOSS_SVC_L1   "ML::GLM::QN_LOSS_SVC_L1"
-            QN_LOSS_SVC_L2   "ML::GLM::QN_LOSS_SVC_L2"
-            QN_LOSS_SVR_L1   "ML::GLM::QN_LOSS_SVR_L1"
-            QN_LOSS_SVR_L2   "ML::GLM::QN_LOSS_SVR_L2"
-            QN_LOSS_ABS      "ML::GLM::QN_LOSS_ABS"
-            QN_LOSS_UNKNOWN  "ML::GLM::QN_LOSS_UNKNOWN"
+from cuml.metrics import accuracy_score
 
-        cdef struct qn_params:
-            qn_loss_type loss
-            double penalty_l1
-            double penalty_l2
-            double grad_tol
-            double change_tol
-            int max_iter
-            int linesearch_max_iter
-            int lbfgs_memory
-            int verbose
-            bool fit_intercept
-            bool penalty_normalized
+from pylibraft.common.handle cimport handle_t
 
-        void qnFit[T, I](
-            const handle_t& cuml_handle,
-            const qn_params& pams,
-            T *X,
-            bool X_col_major,
-            T *y,
-            I N,
-            I D,
-            I C,
-            T *w0,
-            T *f,
-            int *num_iters,
-            T *sample_weight) except +
 
-        void qnFitSparse[T, I](
-            const handle_t& cuml_handle,
-            const qn_params& pams,
-            T *X_values,
-            I *X_cols,
-            I *X_row_ids,
-            I X_nnz,
-            T *y,
-            I N,
-            I D,
-            I C,
-            T *w0,
-            T *f,
-            int *num_iters,
-            T *sample_weight) except +
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
 
-        void qnDecisionFunction[T, I](
-            const handle_t& cuml_handle,
-            const qn_params& pams,
-            T *X,
-            bool X_col_major,
-            I N,
-            I D,
-            I C,
-            T *params,
-            T *scores) except +
+    cdef enum qn_loss_type "ML::GLM::qn_loss_type":
+        QN_LOSS_LOGISTIC "ML::GLM::QN_LOSS_LOGISTIC"
+        QN_LOSS_SQUARED  "ML::GLM::QN_LOSS_SQUARED"
+        QN_LOSS_SOFTMAX  "ML::GLM::QN_LOSS_SOFTMAX"
+        QN_LOSS_SVC_L1   "ML::GLM::QN_LOSS_SVC_L1"
+        QN_LOSS_SVC_L2   "ML::GLM::QN_LOSS_SVC_L2"
+        QN_LOSS_SVR_L1   "ML::GLM::QN_LOSS_SVR_L1"
+        QN_LOSS_SVR_L2   "ML::GLM::QN_LOSS_SVR_L2"
+        QN_LOSS_ABS      "ML::GLM::QN_LOSS_ABS"
+        QN_LOSS_UNKNOWN  "ML::GLM::QN_LOSS_UNKNOWN"
 
-        void qnDecisionFunctionSparse[T, I](
-            const handle_t& cuml_handle,
-            const qn_params& pams,
-            T *X_values,
-            I *X_cols,
-            I *X_row_ids,
-            I X_nnz,
-            I N,
-            I D,
-            I C,
-            T *params,
-            T *scores) except +
+    cdef struct qn_params:
+        qn_loss_type loss
+        double penalty_l1
+        double penalty_l2
+        double grad_tol
+        double change_tol
+        int max_iter
+        int linesearch_max_iter
+        int lbfgs_memory
+        int verbose
+        bool fit_intercept
+        bool penalty_normalized
 
-        void qnPredict[T, I](
-            const handle_t& cuml_handle,
-            const qn_params& pams,
-            T *X,
-            bool X_col_major,
-            I N,
-            I D,
-            I C,
-            T *params,
-            T *preds) except +
+    void qnFit[T, I](
+        const handle_t& cuml_handle,
+        const qn_params& pams,
+        T *X,
+        bool X_col_major,
+        T *y,
+        I N,
+        I D,
+        I C,
+        T *w0,
+        T *f,
+        int *num_iters,
+        T *sample_weight) except +
 
-        void qnPredictSparse[T, I](
-            const handle_t& cuml_handle,
-            const qn_params& pams,
-            T *X_values,
-            I *X_cols,
-            I *X_row_ids,
-            I X_nnz,
-            I N,
-            I D,
-            I C,
-            T *params,
-            T *preds) except +
+    void qnFitSparse[T, I](
+        const handle_t& cuml_handle,
+        const qn_params& pams,
+        T *X_values,
+        I *X_cols,
+        I *X_row_ids,
+        I X_nnz,
+        T *y,
+        I N,
+        I D,
+        I C,
+        T *w0,
+        T *f,
+        int *num_iters,
+        T *sample_weight) except +
 
-    class StructWrapper(type):
-        '''Define a property for each key in `get_param_defaults`,
-           for which there is no explicit property defined in the class.
-        '''
-        def __new__(cls, name, bases, attrs):
-            def add_prop(prop_name):
-                setattr(x, prop_name, property(
-                    lambda self: self._getparam(prop_name),
-                    lambda self, value: self._setparam(prop_name, value)
-                ))
+    void qnDecisionFunction[T, I](
+        const handle_t& cuml_handle,
+        const qn_params& pams,
+        T *X,
+        bool X_col_major,
+        I N,
+        I D,
+        I C,
+        T *params,
+        T *scores) except +
 
-            x = super().__new__(cls, name, bases, attrs)
+    void qnDecisionFunctionSparse[T, I](
+        const handle_t& cuml_handle,
+        const qn_params& pams,
+        T *X_values,
+        I *X_cols,
+        I *X_row_ids,
+        I X_nnz,
+        I N,
+        I D,
+        I C,
+        T *params,
+        T *scores) except +
 
-            for prop_name in getattr(x, 'get_param_defaults', lambda: {})():
-                if not hasattr(x, prop_name):
-                    add_prop(prop_name)
-            del add_prop
+    void qnPredict[T, I](
+        const handle_t& cuml_handle,
+        const qn_params& pams,
+        T *X,
+        bool X_col_major,
+        I N,
+        I D,
+        I C,
+        T *params,
+        T *preds) except +
 
-            return x
+    void qnPredictSparse[T, I](
+        const handle_t& cuml_handle,
+        const qn_params& pams,
+        T *X_values,
+        I *X_cols,
+        I *X_row_ids,
+        I X_nnz,
+        I N,
+        I D,
+        I C,
+        T *params,
+        T *preds) except +
 
-    class StructParams(metaclass=StructWrapper):
-        params: dict
 
-        def __new__(cls, *args, **kwargs):
-            x = object.__new__(cls)
-            x.params = cls.get_param_defaults().copy()
-            return x
+class StructWrapper(type):
+    '''Define a property for each key in `get_param_defaults`,
+        for which there is no explicit property defined in the class.
+    '''
+    def __new__(cls, name, bases, attrs):
+        def add_prop(prop_name):
+            setattr(x, prop_name, property(
+                lambda self: self._getparam(prop_name),
+                lambda self, value: self._setparam(prop_name, value)
+            ))
 
-        def __init__(self, **kwargs):
-            allowed_keys = set(self._get_param_names())
-            for key, val in kwargs.items():
-                if key in allowed_keys:
-                    setattr(self, key, val)
+        x = super().__new__(cls, name, bases, attrs)
 
-        def _getparam(self, key):
-            return self.params[key]
+        for prop_name in getattr(x, 'get_param_defaults', lambda: {})():
+            if not hasattr(x, prop_name):
+                add_prop(prop_name)
+        del add_prop
 
-        def _setparam(self, key, val):
-            self.params[key] = val
+        return x
 
-        @classmethod
-        def _get_param_names(cls):
-            return cls.get_param_defaults().keys()
 
-        def __str__(self):
-            return type(self).__name__ + str(self.params)
+class StructParams(metaclass=StructWrapper):
+    params: dict
 
-    class QNParams(StructParams):
+    def __new__(cls, *args, **kwargs):
+        x = object.__new__(cls)
+        x.params = cls.get_param_defaults().copy()
+        return x
 
-        @staticmethod
-        def get_param_defaults():
-            IF GPUBUILD == 1:
-                cdef qn_params ps
-                return ps
+    def __init__(self, **kwargs):
+        allowed_keys = set(self._get_param_names())
+        for key, val in kwargs.items():
+            if key in allowed_keys:
+                setattr(self, key, val)
 
-        @property
-        def loss(self) -> str:
-            loss = self._getparam('loss')
-            IF GPUBUILD == 1:
-                if loss == qn_loss_type.QN_LOSS_LOGISTIC:
-                    return "sigmoid"
-                if loss == qn_loss_type.QN_LOSS_SQUARED:
-                    return "l2"
-                if loss == qn_loss_type.QN_LOSS_SOFTMAX:
-                    return "softmax"
-                if loss == qn_loss_type.QN_LOSS_SVC_L1:
-                    return "svc_l1"
-                if loss == qn_loss_type.QN_LOSS_SVC_L2:
-                    return "svc_l2"
-                if loss == qn_loss_type.QN_LOSS_SVR_L1:
-                    return "svr_l1"
-                if loss == qn_loss_type.QN_LOSS_SVR_L2:
-                    return "svr_l2"
-                if loss == qn_loss_type.QN_LOSS_ABS:
-                    return "l1"
+    def _getparam(self, key):
+        return self.params[key]
+
+    def _setparam(self, key, val):
+        self.params[key] = val
+
+    @classmethod
+    def _get_param_names(cls):
+        return cls.get_param_defaults().keys()
+
+    def __str__(self):
+        return type(self).__name__ + str(self.params)
+
+
+class QNParams(StructParams):
+
+    @staticmethod
+    def get_param_defaults():
+        cdef qn_params ps
+        return ps
+
+    @property
+    def loss(self) -> str:
+        loss = self._getparam('loss')
+        if loss == qn_loss_type.QN_LOSS_LOGISTIC:
+            return "sigmoid"
+        if loss == qn_loss_type.QN_LOSS_SQUARED:
+            return "l2"
+        if loss == qn_loss_type.QN_LOSS_SOFTMAX:
+            return "softmax"
+        if loss == qn_loss_type.QN_LOSS_SVC_L1:
+            return "svc_l1"
+        if loss == qn_loss_type.QN_LOSS_SVC_L2:
+            return "svc_l2"
+        if loss == qn_loss_type.QN_LOSS_SVR_L1:
+            return "svr_l1"
+        if loss == qn_loss_type.QN_LOSS_SVR_L2:
+            return "svr_l2"
+        if loss == qn_loss_type.QN_LOSS_ABS:
+            return "l1"
+        else:
             raise ValueError(f"Unknown loss enum value: {loss}")
 
-        @loss.setter
-        def loss(self, loss: str):
-            IF GPUBUILD == 1:
-                if loss in {"sigmoid", "logistic"}:
-                    self._setparam('loss', qn_loss_type.QN_LOSS_LOGISTIC)
-                elif loss == "softmax":
-                    self._setparam('loss', qn_loss_type.QN_LOSS_SOFTMAX)
-                elif loss in {"normal", "l2"}:
-                    self._setparam('loss', qn_loss_type.QN_LOSS_SQUARED)
-                elif loss == "l1":
-                    self._setparam('loss', qn_loss_type.QN_LOSS_ABS)
-                elif loss == "svc_l1":
-                    self._setparam('loss', qn_loss_type.QN_LOSS_SVC_L1)
-                elif loss == "svc_l2":
-                    self._setparam('loss', qn_loss_type.QN_LOSS_SVC_L2)
-                elif loss == "svr_l1":
-                    self._setparam('loss', qn_loss_type.QN_LOSS_SVR_L1)
-                elif loss == "svr_l2":
-                    self._setparam('loss', qn_loss_type.QN_LOSS_SVR_L2)
-                else:
-                    raise ValueError(f"Unknown loss string value: {loss}")
+    @loss.setter
+    def loss(self, loss: str):
+        if loss in {"sigmoid", "logistic"}:
+            self._setparam('loss', qn_loss_type.QN_LOSS_LOGISTIC)
+        elif loss == "softmax":
+            self._setparam('loss', qn_loss_type.QN_LOSS_SOFTMAX)
+        elif loss in {"normal", "l2"}:
+            self._setparam('loss', qn_loss_type.QN_LOSS_SQUARED)
+        elif loss == "l1":
+            self._setparam('loss', qn_loss_type.QN_LOSS_ABS)
+        elif loss == "svc_l1":
+            self._setparam('loss', qn_loss_type.QN_LOSS_SVC_L1)
+        elif loss == "svc_l2":
+            self._setparam('loss', qn_loss_type.QN_LOSS_SVC_L2)
+        elif loss == "svr_l1":
+            self._setparam('loss', qn_loss_type.QN_LOSS_SVR_L1)
+        elif loss == "svr_l2":
+            self._setparam('loss', qn_loss_type.QN_LOSS_SVR_L2)
+        else:
+            raise ValueError(f"Unknown loss string value: {loss}")
 
 
 class QN(Base,
@@ -497,142 +501,139 @@ class QN(Base,
                                                       else None))
             _sample_weight_ptr = sample_weight.ptr
 
-        IF GPUBUILD == 1:
-            self.qnparams = QNParams(
-                loss=self.loss,
-                penalty_l1=self.l1_strength,
-                penalty_l2=self.l2_strength,
-                grad_tol=self.tol,
-                change_tol=self.delta
-                if self.delta is not None else (self.tol * 0.01),
-                max_iter=self.max_iter,
-                linesearch_max_iter=self.linesearch_max_iter,
-                lbfgs_memory=self.lbfgs_memory,
-                verbose=self.verbose,
-                fit_intercept=self.fit_intercept,
-                penalty_normalized=self.penalty_normalized
-            )
+        self.qnparams = QNParams(
+            loss=self.loss,
+            penalty_l1=self.l1_strength,
+            penalty_l2=self.l2_strength,
+            grad_tol=self.tol,
+            change_tol=self.delta
+            if self.delta is not None else (self.tol * 0.01),
+            max_iter=self.max_iter,
+            linesearch_max_iter=self.linesearch_max_iter,
+            lbfgs_memory=self.lbfgs_memory,
+            verbose=self.verbose,
+            fit_intercept=self.fit_intercept,
+            penalty_normalized=self.penalty_normalized
+        )
 
-            cdef qn_params qnpams = self.qnparams.params
+        cdef qn_params qnpams = self.qnparams.params
 
-            solves_classification = qnpams.loss in {
-                qn_loss_type.QN_LOSS_LOGISTIC,
-                qn_loss_type.QN_LOSS_SOFTMAX,
-                qn_loss_type.QN_LOSS_SVC_L1,
-                qn_loss_type.QN_LOSS_SVC_L2
-            }
-            solves_multiclass = qnpams.loss in {
-                qn_loss_type.QN_LOSS_SOFTMAX
-            }
+        solves_classification = qnpams.loss in {
+            qn_loss_type.QN_LOSS_LOGISTIC,
+            qn_loss_type.QN_LOSS_SOFTMAX,
+            qn_loss_type.QN_LOSS_SVC_L1,
+            qn_loss_type.QN_LOSS_SVC_L2
+        }
+        solves_multiclass = qnpams.loss in {
+            qn_loss_type.QN_LOSS_SOFTMAX
+        }
 
-            if solves_classification:
-                self._num_classes = len(cp.unique(y_m))
-            else:
-                self._num_classes = 1
+        if solves_classification:
+            self._num_classes = len(cp.unique(y_m))
+        else:
+            self._num_classes = 1
 
-            if not solves_multiclass and self._num_classes > 2:
-                raise ValueError(
-                    f"The selected solver ({self.loss}) does not support"
-                    f" more than 2 classes ({self._num_classes} discovered).")
+        if not solves_multiclass and self._num_classes > 2:
+            raise ValueError(
+                f"The selected solver ({self.loss}) does not support"
+                f" more than 2 classes ({self._num_classes} discovered).")
 
-            if qnpams.loss == qn_loss_type.QN_LOSS_SOFTMAX \
-               and self._num_classes <= 2:
-                raise ValueError("Two classes or less cannot be trained"
-                                 "with softmax (multinomial).")
+        if qnpams.loss == qn_loss_type.QN_LOSS_SOFTMAX and self._num_classes <= 2:
+            raise ValueError("Two classes or less cannot be trained with softmax (multinomial).")
 
-            if solves_classification and not solves_multiclass:
-                self._num_classes_dim = self._num_classes - 1
-            else:
-                self._num_classes_dim = self._num_classes
+        if solves_classification and not solves_multiclass:
+            self._num_classes_dim = self._num_classes - 1
+        else:
+            self._num_classes_dim = self._num_classes
 
-            if self.fit_intercept:
-                coef_size = (self.n_cols + 1, self._num_classes_dim)
-            else:
-                coef_size = (self.n_cols, self._num_classes_dim)
+        if self.fit_intercept:
+            coef_size = (self.n_cols + 1, self._num_classes_dim)
+        else:
+            coef_size = (self.n_cols, self._num_classes_dim)
 
-            if self._coef_ is None or not self.warm_start:
-                self._coef_ = CumlArray.zeros(
-                    coef_size, dtype=self.dtype, order='C')
+        if self._coef_ is None or not self.warm_start:
+            self._coef_ = CumlArray.zeros(
+                coef_size, dtype=self.dtype, order='C')
 
-            cdef uintptr_t _coef_ptr = self._coef_.ptr
+        cdef uintptr_t _coef_ptr = self._coef_.ptr
 
-            cdef float objective32
-            cdef double objective64
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef float objective32
+        cdef double objective64
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            cdef int num_iters
+        cdef int num_iters
 
-            if self.dtype == np.float32:
-                if sparse_input:
-                    qnFitSparse[float, int](
-                        handle_[0],
-                        qnpams,
-                        <float*><uintptr_t> X_m.data.ptr,
-                        <int*><uintptr_t> X_m.indices.ptr,
-                        <int*><uintptr_t> X_m.indptr.ptr,
-                        <int> X_m.nnz,
-                        <float*> _y_ptr,
-                        <int> n_rows,
-                        <int> self.n_cols,
-                        <int> self._num_classes,
-                        <float*> _coef_ptr,
-                        <float*> &objective32,
-                        <int*> &num_iters,
-                        <float*> _sample_weight_ptr)
-
-                else:
-                    qnFit[float, int](
-                        handle_[0],
-                        qnpams,
-                        <float*><uintptr_t> X_m.ptr,
-                        <bool> _is_col_major(X_m),
-                        <float*> _y_ptr,
-                        <int> n_rows,
-                        <int> self.n_cols,
-                        <int> self._num_classes,
-                        <float*> _coef_ptr,
-                        <float*> &objective32,
-                        <int*> &num_iters,
-                        <float*> _sample_weight_ptr)
-
-                self.objective = objective32
+        if self.dtype == np.float32:
+            if sparse_input:
+                qnFitSparse[float, int](
+                    handle_[0],
+                    qnpams,
+                    <float*><uintptr_t> X_m.data.ptr,
+                    <int*><uintptr_t> X_m.indices.ptr,
+                    <int*><uintptr_t> X_m.indptr.ptr,
+                    <int> X_m.nnz,
+                    <float*> _y_ptr,
+                    <int> n_rows,
+                    <int> self.n_cols,
+                    <int> self._num_classes,
+                    <float*> _coef_ptr,
+                    <float*> &objective32,
+                    <int*> &num_iters,
+                    <float*> _sample_weight_ptr)
 
             else:
-                if sparse_input:
-                    qnFitSparse[double, int](
-                        handle_[0],
-                        qnpams,
-                        <double*><uintptr_t> X_m.data.ptr,
-                        <int*><uintptr_t> X_m.indices.ptr,
-                        <int*><uintptr_t> X_m.indptr.ptr,
-                        <int> X_m.nnz,
-                        <double*> _y_ptr,
-                        <int> n_rows,
-                        <int> self.n_cols,
-                        <int> self._num_classes,
-                        <double*> _coef_ptr,
-                        <double*> &objective64,
-                        <int*> &num_iters,
-                        <double*> _sample_weight_ptr)
+                qnFit[float, int](
+                    handle_[0],
+                    qnpams,
+                    <float*><uintptr_t> X_m.ptr,
+                    <bool> _is_col_major(X_m),
+                    <float*> _y_ptr,
+                    <int> n_rows,
+                    <int> self.n_cols,
+                    <int> self._num_classes,
+                    <float*> _coef_ptr,
+                    <float*> &objective32,
+                    <int*> &num_iters,
+                    <float*> _sample_weight_ptr)
 
-                else:
-                    qnFit[double, int](
-                        handle_[0],
-                        qnpams,
-                        <double*><uintptr_t> X_m.ptr,
-                        <bool> _is_col_major(X_m),
-                        <double*> _y_ptr,
-                        <int> n_rows,
-                        <int> self.n_cols,
-                        <int> self._num_classes,
-                        <double*> _coef_ptr,
-                        <double*> &objective64,
-                        <int*> &num_iters,
-                        <double*> _sample_weight_ptr)
+            self.objective = objective32
 
-                self.objective = objective64
+        else:
+            if sparse_input:
+                qnFitSparse[double, int](
+                    handle_[0],
+                    qnpams,
+                    <double*><uintptr_t> X_m.data.ptr,
+                    <int*><uintptr_t> X_m.indices.ptr,
+                    <int*><uintptr_t> X_m.indptr.ptr,
+                    <int> X_m.nnz,
+                    <double*> _y_ptr,
+                    <int> n_rows,
+                    <int> self.n_cols,
+                    <int> self._num_classes,
+                    <double*> _coef_ptr,
+                    <double*> &objective64,
+                    <int*> &num_iters,
+                    <double*> _sample_weight_ptr)
 
-            self.num_iters = num_iters
+            else:
+                qnFit[double, int](
+                    handle_[0],
+                    qnpams,
+                    <double*><uintptr_t> X_m.ptr,
+                    <bool> _is_col_major(X_m),
+                    <double*> _y_ptr,
+                    <int> n_rows,
+                    <int> self.n_cols,
+                    <int> self._num_classes,
+                    <double*> _coef_ptr,
+                    <double*> &objective64,
+                    <int*> &num_iters,
+                    <double*> _sample_weight_ptr)
+
+            self.objective = objective64
+
+        self.num_iters = num_iters
 
         self._calc_intercept()
 
@@ -700,78 +701,77 @@ class QN(Base,
         cdef uintptr_t _coef_ptr = self._coef_.ptr
         cdef uintptr_t _scores_ptr = scores.ptr
 
-        IF GPUBUILD == 1:
-            if not hasattr(self, 'qnparams'):
-                self.qnparams = QNParams(
-                    loss=self.loss,
-                    penalty_l1=self.l1_strength,
-                    penalty_l2=self.l2_strength,
-                    grad_tol=self.tol,
-                    change_tol=self.delta
-                    if self.delta is not None else (self.tol * 0.01),
-                    max_iter=self.max_iter,
-                    linesearch_max_iter=self.linesearch_max_iter,
-                    lbfgs_memory=self.lbfgs_memory,
-                    verbose=self.verbose,
-                    fit_intercept=self.fit_intercept,
-                    penalty_normalized=self.penalty_normalized
-                )
+        if not hasattr(self, 'qnparams'):
+            self.qnparams = QNParams(
+                loss=self.loss,
+                penalty_l1=self.l1_strength,
+                penalty_l2=self.l2_strength,
+                grad_tol=self.tol,
+                change_tol=self.delta
+                if self.delta is not None else (self.tol * 0.01),
+                max_iter=self.max_iter,
+                linesearch_max_iter=self.linesearch_max_iter,
+                lbfgs_memory=self.lbfgs_memory,
+                verbose=self.verbose,
+                fit_intercept=self.fit_intercept,
+                penalty_normalized=self.penalty_normalized
+            )
 
-            _num_classes = self.get_num_classes(_num_classes_dim)
+        _num_classes = self.get_num_classes(_num_classes_dim)
 
-            cdef qn_params qnpams = self.qnparams.params
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype == np.float32:
-                if sparse_input:
-                    qnDecisionFunctionSparse[float, int](
-                        handle_[0],
-                        qnpams,
-                        <float*><uintptr_t> X_m.data.ptr,
-                        <int*><uintptr_t> X_m.indices.ptr,
-                        <int*><uintptr_t> X_m.indptr.ptr,
-                        <int> X_m.nnz,
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <float*> _coef_ptr,
-                        <float*> _scores_ptr)
-                else:
-                    qnDecisionFunction[float, int](
-                        handle_[0],
-                        qnpams,
-                        <float*><uintptr_t> X_m.ptr,
-                        <bool> _is_col_major(X_m),
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <float*> _coef_ptr,
-                        <float*> _scores_ptr)
-
+        cdef qn_params qnpams = self.qnparams.params
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype == np.float32:
+            if sparse_input:
+                qnDecisionFunctionSparse[float, int](
+                    handle_[0],
+                    qnpams,
+                    <float*><uintptr_t> X_m.data.ptr,
+                    <int*><uintptr_t> X_m.indices.ptr,
+                    <int*><uintptr_t> X_m.indptr.ptr,
+                    <int> X_m.nnz,
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <float*> _coef_ptr,
+                    <float*> _scores_ptr)
             else:
-                if sparse_input:
-                    qnDecisionFunctionSparse[double, int](
-                        handle_[0],
-                        qnpams,
-                        <double*><uintptr_t> X_m.data.ptr,
-                        <int*><uintptr_t> X_m.indices.ptr,
-                        <int*><uintptr_t> X_m.indptr.ptr,
-                        <int> X_m.nnz,
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <double*> _coef_ptr,
-                        <double*> _scores_ptr)
-                else:
-                    qnDecisionFunction[double, int](
-                        handle_[0],
-                        qnpams,
-                        <double*><uintptr_t> X_m.ptr,
-                        <bool> _is_col_major(X_m),
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <double*> _coef_ptr,
-                        <double*> _scores_ptr)
+                qnDecisionFunction[float, int](
+                    handle_[0],
+                    qnpams,
+                    <float*><uintptr_t> X_m.ptr,
+                    <bool> _is_col_major(X_m),
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <float*> _coef_ptr,
+                    <float*> _scores_ptr)
+
+        else:
+            if sparse_input:
+                qnDecisionFunctionSparse[double, int](
+                    handle_[0],
+                    qnpams,
+                    <double*><uintptr_t> X_m.data.ptr,
+                    <int*><uintptr_t> X_m.indices.ptr,
+                    <int*><uintptr_t> X_m.indptr.ptr,
+                    <int> X_m.nnz,
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <double*> _coef_ptr,
+                    <double*> _scores_ptr)
+            else:
+                qnDecisionFunction[double, int](
+                    handle_[0],
+                    qnpams,
+                    <double*><uintptr_t> X_m.ptr,
+                    <bool> _is_col_major(X_m),
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <double*> _coef_ptr,
+                    <double*> _scores_ptr)
 
         self._calc_intercept()
 
@@ -828,77 +828,76 @@ class QN(Base,
         if(n_rows == 0):
             return preds
 
-        IF GPUBUILD == 1:
-            if not hasattr(self, 'qnparams'):
-                self.qnparams = QNParams(
-                    loss=self.loss,
-                    penalty_l1=self.l1_strength,
-                    penalty_l2=self.l2_strength,
-                    grad_tol=self.tol,
-                    change_tol=self.delta
-                    if self.delta is not None else (self.tol * 0.01),
-                    max_iter=self.max_iter,
-                    linesearch_max_iter=self.linesearch_max_iter,
-                    lbfgs_memory=self.lbfgs_memory,
-                    verbose=self.verbose,
-                    fit_intercept=self.fit_intercept,
-                    penalty_normalized=self.penalty_normalized
-                )
+        if not hasattr(self, 'qnparams'):
+            self.qnparams = QNParams(
+                loss=self.loss,
+                penalty_l1=self.l1_strength,
+                penalty_l2=self.l2_strength,
+                grad_tol=self.tol,
+                change_tol=self.delta
+                if self.delta is not None else (self.tol * 0.01),
+                max_iter=self.max_iter,
+                linesearch_max_iter=self.linesearch_max_iter,
+                lbfgs_memory=self.lbfgs_memory,
+                verbose=self.verbose,
+                fit_intercept=self.fit_intercept,
+                penalty_normalized=self.penalty_normalized
+            )
 
-            _num_classes = self.get_num_classes(_num_classes_dim)
-            cdef qn_params qnpams = self.qnparams.params
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
-            if dtype == np.float32:
-                if sparse_input:
-                    qnPredictSparse[float, int](
-                        handle_[0],
-                        qnpams,
-                        <float*><uintptr_t> X_m.data.ptr,
-                        <int*><uintptr_t> X_m.indices.ptr,
-                        <int*><uintptr_t> X_m.indptr.ptr,
-                        <int> X_m.nnz,
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <float*> _coef_ptr,
-                        <float*> _pred_ptr)
-                else:
-                    qnPredict[float, int](
-                        handle_[0],
-                        qnpams,
-                        <float*><uintptr_t> X_m.ptr,
-                        <bool> _is_col_major(X_m),
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <float*> _coef_ptr,
-                        <float*> _pred_ptr)
-
+        _num_classes = self.get_num_classes(_num_classes_dim)
+        cdef qn_params qnpams = self.qnparams.params
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        if dtype == np.float32:
+            if sparse_input:
+                qnPredictSparse[float, int](
+                    handle_[0],
+                    qnpams,
+                    <float*><uintptr_t> X_m.data.ptr,
+                    <int*><uintptr_t> X_m.indices.ptr,
+                    <int*><uintptr_t> X_m.indptr.ptr,
+                    <int> X_m.nnz,
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <float*> _coef_ptr,
+                    <float*> _pred_ptr)
             else:
-                if sparse_input:
-                    qnPredictSparse[double, int](
-                        handle_[0],
-                        qnpams,
-                        <double*><uintptr_t> X_m.data.ptr,
-                        <int*><uintptr_t> X_m.indices.ptr,
-                        <int*><uintptr_t> X_m.indptr.ptr,
-                        <int> X_m.nnz,
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <double*> _coef_ptr,
-                        <double*> _pred_ptr)
-                else:
-                    qnPredict[double, int](
-                        handle_[0],
-                        qnpams,
-                        <double*><uintptr_t> X_m.ptr,
-                        <bool> _is_col_major(X_m),
-                        <int> n_rows,
-                        <int> n_cols,
-                        <int> _num_classes,
-                        <double*> _coef_ptr,
-                        <double*> _pred_ptr)
+                qnPredict[float, int](
+                    handle_[0],
+                    qnpams,
+                    <float*><uintptr_t> X_m.ptr,
+                    <bool> _is_col_major(X_m),
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <float*> _coef_ptr,
+                    <float*> _pred_ptr)
+
+        else:
+            if sparse_input:
+                qnPredictSparse[double, int](
+                    handle_[0],
+                    qnpams,
+                    <double*><uintptr_t> X_m.data.ptr,
+                    <int*><uintptr_t> X_m.indices.ptr,
+                    <int*><uintptr_t> X_m.indptr.ptr,
+                    <int> X_m.nnz,
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <double*> _coef_ptr,
+                    <double*> _pred_ptr)
+            else:
+                qnPredict[double, int](
+                    handle_[0],
+                    qnpams,
+                    <double*><uintptr_t> X_m.ptr,
+                    <bool> _is_col_major(X_m),
+                    <int> n_rows,
+                    <int> n_cols,
+                    <int> _num_classes,
+                    <double*> _coef_ptr,
+                    <double*> _pred_ptr)
 
         self._calc_intercept()
 
@@ -909,30 +908,28 @@ class QN(Base,
         return preds
 
     def score(self, X, y):
-        if GPUBUILD == 1:
-            return accuracy_score(y, self.predict(X))
+        return accuracy_score(y, self.predict(X))
 
     def get_num_classes(self, _num_classes_dim):
         """
         Retrieves the number of classes from the classes dimension
         in the coefficients.
         """
-        IF GPUBUILD == 1:
-            cdef qn_params qnpams = self.qnparams.params
-            solves_classification = qnpams.loss in {
-                qn_loss_type.QN_LOSS_LOGISTIC,
-                qn_loss_type.QN_LOSS_SOFTMAX,
-                qn_loss_type.QN_LOSS_SVC_L1,
-                qn_loss_type.QN_LOSS_SVC_L2
-            }
-            solves_multiclass = qnpams.loss in {
-                qn_loss_type.QN_LOSS_SOFTMAX
-            }
-            if solves_classification and not solves_multiclass:
-                _num_classes = _num_classes_dim + 1
-            else:
-                _num_classes = _num_classes_dim
-            return _num_classes
+        cdef qn_params qnpams = self.qnparams.params
+        solves_classification = qnpams.loss in {
+            qn_loss_type.QN_LOSS_LOGISTIC,
+            qn_loss_type.QN_LOSS_SOFTMAX,
+            qn_loss_type.QN_LOSS_SVC_L1,
+            qn_loss_type.QN_LOSS_SVC_L2
+        }
+        solves_multiclass = qnpams.loss in {
+            qn_loss_type.QN_LOSS_SOFTMAX
+        }
+        if solves_classification and not solves_multiclass:
+            _num_classes = _num_classes_dim + 1
+        else:
+            _num_classes = _num_classes_dim
+        return _num_classes
 
     def _calc_intercept(self):
         """

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -37,88 +37,89 @@ from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.mixins import FMajorInputTagMixin
 
-IF GPUBUILD == 1:
-    from libcpp cimport bool
-    from pylibraft.common.handle cimport handle_t
-    cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
+from libcpp cimport bool
+from pylibraft.common.handle cimport handle_t
 
-        cdef void sgdFit(handle_t& handle,
-                         float *input,
+
+cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
+
+    cdef void sgdFit(handle_t& handle,
+                     float *input,
+                     int n_rows,
+                     int n_cols,
+                     float *labels,
+                     float *coef,
+                     float *intercept,
+                     bool fit_intercept,
+                     int batch_size,
+                     int epochs,
+                     int lr_type,
+                     float eta0,
+                     float power_t,
+                     int loss,
+                     int penalty,
+                     float alpha,
+                     float l1_ratio,
+                     bool shuffle,
+                     float tol,
+                     int n_iter_no_change) except +
+
+    cdef void sgdFit(handle_t& handle,
+                     double *input,
+                     int n_rows,
+                     int n_cols,
+                     double *labels,
+                     double *coef,
+                     double *intercept,
+                     bool fit_intercept,
+                     int batch_size,
+                     int epochs,
+                     int lr_type,
+                     double eta0,
+                     double power_t,
+                     int loss,
+                     int penalty,
+                     double alpha,
+                     double l1_ratio,
+                     bool shuffle,
+                     double tol,
+                     int n_iter_no_change) except +
+
+    cdef void sgdPredict(handle_t& handle,
+                         const float *input,
                          int n_rows,
                          int n_cols,
-                         float *labels,
-                         float *coef,
-                         float *intercept,
-                         bool fit_intercept,
-                         int batch_size,
-                         int epochs,
-                         int lr_type,
-                         float eta0,
-                         float power_t,
-                         int loss,
-                         int penalty,
-                         float alpha,
-                         float l1_ratio,
-                         bool shuffle,
-                         float tol,
-                         int n_iter_no_change) except +
+                         const float *coef,
+                         float intercept,
+                         float *preds,
+                         int loss) except +
 
-        cdef void sgdFit(handle_t& handle,
-                         double *input,
+    cdef void sgdPredict(handle_t& handle,
+                         const double *input,
                          int n_rows,
                          int n_cols,
-                         double *labels,
-                         double *coef,
-                         double *intercept,
-                         bool fit_intercept,
-                         int batch_size,
-                         int epochs,
-                         int lr_type,
-                         double eta0,
-                         double power_t,
-                         int loss,
-                         int penalty,
-                         double alpha,
-                         double l1_ratio,
-                         bool shuffle,
-                         double tol,
-                         int n_iter_no_change) except +
+                         const double *coef,
+                         double intercept,
+                         double *preds,
+                         int loss) except +
 
-        cdef void sgdPredict(handle_t& handle,
-                             const float *input,
-                             int n_rows,
-                             int n_cols,
-                             const float *coef,
-                             float intercept,
-                             float *preds,
-                             int loss) except +
+    cdef void sgdPredictBinaryClass(handle_t& handle,
+                                    const float *input,
+                                    int n_rows,
+                                    int n_cols,
+                                    const float *coef,
+                                    float intercept,
+                                    float *preds,
+                                    int loss) except +
 
-        cdef void sgdPredict(handle_t& handle,
-                             const double *input,
-                             int n_rows,
-                             int n_cols,
-                             const double *coef,
-                             double intercept,
-                             double *preds,
-                             int loss) except +
-
-        cdef void sgdPredictBinaryClass(handle_t& handle,
-                                        const float *input,
-                                        int n_rows,
-                                        int n_cols,
-                                        const float *coef,
-                                        float intercept,
-                                        float *preds,
-                                        int loss) except +
-
-        cdef void sgdPredictBinaryClass(handle_t& handle,
-                                        const double *input,
-                                        int n_rows,
-                                        int n_cols,
-                                        const double *coef,
-                                        double intercept,
-                                        double *preds,
-                                        int loss) except +
+    cdef void sgdPredictBinaryClass(handle_t& handle,
+                                    const double *input,
+                                    int n_rows,
+                                    int n_cols,
+                                    const double *coef,
+                                    double intercept,
+                                    double *preds,
+                                    int loss) except +
 
 
 class SGD(Base,
@@ -350,55 +351,54 @@ class SGD(Base,
         cdef float _c_intercept_f32
         cdef double _c_intercept_f64
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if self.dtype == np.float32:
-                sgdFit(handle_[0],
-                       <float*>_X_ptr,
-                       <int>n_rows,
-                       <int>self.n_cols,
-                       <float*>_y_ptr,
-                       <float*>_coef_ptr,
-                       <float*>&_c_intercept_f32,
-                       <bool>self.fit_intercept,
-                       <int>self.batch_size,
-                       <int>self.epochs,
-                       <int>self.lr_type,
-                       <float>self.eta0,
-                       <float>self.power_t,
-                       <int>self._get_loss_int(),
-                       <int>self._get_penalty_int(),
-                       <float>self.alpha,
-                       <float>self.l1_ratio,
-                       <bool>self.shuffle,
-                       <float>self.tol,
-                       <int>self.n_iter_no_change)
+        if self.dtype == np.float32:
+            sgdFit(handle_[0],
+                   <float*>_X_ptr,
+                   <int>n_rows,
+                   <int>self.n_cols,
+                   <float*>_y_ptr,
+                   <float*>_coef_ptr,
+                   <float*>&_c_intercept_f32,
+                   <bool>self.fit_intercept,
+                   <int>self.batch_size,
+                   <int>self.epochs,
+                   <int>self.lr_type,
+                   <float>self.eta0,
+                   <float>self.power_t,
+                   <int>self._get_loss_int(),
+                   <int>self._get_penalty_int(),
+                   <float>self.alpha,
+                   <float>self.l1_ratio,
+                   <bool>self.shuffle,
+                   <float>self.tol,
+                   <int>self.n_iter_no_change)
 
-                self.intercept_ = _c_intercept_f32
-            else:
-                sgdFit(handle_[0],
-                       <double*>_X_ptr,
-                       <int>n_rows,
-                       <int>self.n_cols,
-                       <double*>_y_ptr,
-                       <double*>_coef_ptr,
-                       <double*>&_c_intercept_f64,
-                       <bool>self.fit_intercept,
-                       <int>self.batch_size,
-                       <int>self.epochs,
-                       <int>self.lr_type,
-                       <double>self.eta0,
-                       <double>self.power_t,
-                       <int>self._get_loss_int(),
-                       <int>self._get_penalty_int(),
-                       <double>self.alpha,
-                       <double>self.l1_ratio,
-                       <bool>self.shuffle,
-                       <double>self.tol,
-                       <int>self.n_iter_no_change)
+            self.intercept_ = _c_intercept_f32
+        else:
+            sgdFit(handle_[0],
+                   <double*>_X_ptr,
+                   <int>n_rows,
+                   <int>self.n_cols,
+                   <double*>_y_ptr,
+                   <double*>_coef_ptr,
+                   <double*>&_c_intercept_f64,
+                   <bool>self.fit_intercept,
+                   <int>self.batch_size,
+                   <int>self.epochs,
+                   <int>self.lr_type,
+                   <double>self.eta0,
+                   <double>self.power_t,
+                   <int>self._get_loss_int(),
+                   <int>self._get_penalty_int(),
+                   <double>self.alpha,
+                   <double>self.l1_ratio,
+                   <bool>self.shuffle,
+                   <double>self.tol,
+                   <int>self.n_iter_no_change)
 
-                self.intercept_ = _c_intercept_f64
+            self.intercept_ = _c_intercept_f64
 
         self.handle.sync()
 
@@ -428,27 +428,26 @@ class SGD(Base,
         preds = CumlArray.zeros(_n_rows, dtype=self.dtype, index=X_m.index)
         cdef uintptr_t _preds_ptr = preds.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if self.dtype == np.float32:
-                sgdPredict(handle_[0],
-                           <float*>_X_ptr,
-                           <int>_n_rows,
-                           <int>_n_cols,
-                           <float*>_coef_ptr,
-                           <float>self.intercept_,
-                           <float*>_preds_ptr,
-                           <int>self._get_loss_int())
-            else:
-                sgdPredict(handle_[0],
-                           <double*>_X_ptr,
-                           <int>_n_rows,
-                           <int>_n_cols,
-                           <double*>_coef_ptr,
-                           <double>self.intercept_,
-                           <double*>_preds_ptr,
-                           <int>self._get_loss_int())
+        if self.dtype == np.float32:
+            sgdPredict(handle_[0],
+                       <float*>_X_ptr,
+                       <int>_n_rows,
+                       <int>_n_cols,
+                       <float*>_coef_ptr,
+                       <float>self.intercept_,
+                       <float*>_preds_ptr,
+                       <int>self._get_loss_int())
+        else:
+            sgdPredict(handle_[0],
+                       <double*>_X_ptr,
+                       <int>_n_rows,
+                       <int>_n_cols,
+                       <double*>_coef_ptr,
+                       <double>self.intercept_,
+                       <double*>_preds_ptr,
+                       <int>self._get_loss_int())
 
         self.handle.sync()
 
@@ -477,27 +476,26 @@ class SGD(Base,
         preds = CumlArray.zeros(_n_rows, dtype=dtype, index=X_m.index)
         cdef uintptr_t _preds_ptr = preds.ptr
 
-        IF GPUBUILD == 1:
-            cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
+        cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
-            if dtype.type == np.float32:
-                sgdPredictBinaryClass(handle_[0],
-                                      <float*>_X_ptr,
-                                      <int>_n_rows,
-                                      <int>_n_cols,
-                                      <float*>_coef_ptr,
-                                      <float>self.intercept_,
-                                      <float*>_preds_ptr,
-                                      <int>self._get_loss_int())
-            else:
-                sgdPredictBinaryClass(handle_[0],
-                                      <double*>_X_ptr,
-                                      <int>_n_rows,
-                                      <int>_n_cols,
-                                      <double*>_coef_ptr,
-                                      <double>self.intercept_,
-                                      <double*>_preds_ptr,
-                                      <int>self._get_loss_int())
+        if dtype.type == np.float32:
+            sgdPredictBinaryClass(handle_[0],
+                                  <float*>_X_ptr,
+                                  <int>_n_rows,
+                                  <int>_n_cols,
+                                  <float*>_coef_ptr,
+                                  <float>self.intercept_,
+                                  <float*>_preds_ptr,
+                                  <int>self._get_loss_int())
+        else:
+            sgdPredictBinaryClass(handle_[0],
+                                  <double*>_X_ptr,
+                                  <int>_n_rows,
+                                  <int>_n_cols,
+                                  <double*>_coef_ptr,
+                                  <double>self.intercept_,
+                                  <double*>_preds_ptr,
+                                  <int>self._get_loss_int())
 
         self.handle.sync()
 


### PR DESCRIPTION
We're no longer releasing builds of `cuml-cpu`. This PR:

- Removes the previous `IF GPUBUILD` blocks used to conditionally guard compilation for `cuml-cpu` builds. I didn't remove or simplify the usage of `gpu_only_import`/`cpu_only_import`, this PR is only tackling removal of the conditional compilation.
- Removes setting `GPUBUILD` in the cmake file
- Since the latter effectively breaks `cuml-cpu` builds, I went ahead and fully removed `cuml-cpu` from our cmake setup.

Fixes #6231. Part of #6523.