### PR TITLE
Add caching and object size metrics to `conda` CI builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -231,9 +231,6 @@ while true; do
     shift
 done
 
-echo "BUILD_REPORT_METRICS: $BUILD_REPORT_METRICS"
-echo "BUILD_REPORT_INCL_CACHE_STATS: $BUILD_REPORT_INCL_CACHE_STATS"
-
 # If clean given, run it prior to any other steps
 if (( ${CLEAN} == 1 )); then
     # If the dirs to clean are mounted dirs in a container, the

--- a/build.sh
+++ b/build.sh
@@ -330,9 +330,9 @@ if (! hasArg --configure-only) && (completeBuild || hasArg libcuml || hasArg pri
         fi
         MSG="${MSG}<br/>parallel setting: $PARALLEL_LEVEL"
         MSG="${MSG}<br/>parallel build time: $compile_total seconds"
-        if [[ -f "${LIBCUML_BUILD_DIR}/libcuml.so" ]]; then
-            LIBCUML_FS=$(ls -lh ${LIBCUML_BUILD_DIR}/libcuml.so | awk '{print $5}')
-            MSG="${MSG}<br/>libcuml.so size: $LIBCUML_FS"
+        if [[ -f "${LIBCUML_BUILD_DIR}/libcuml++.so" ]]; then
+            LIBCUML_FS=$(ls -lh ${LIBCUML_BUILD_DIR}/libcuml++.so | awk '{print $5}')
+            MSG="${MSG}<br/>libcuml++.so size: $LIBCUML_FS"
         fi
         BMR_DIR=${RAPIDS_ARTIFACTS_DIR:-"${LIBCUML_BUILD_DIR}"}
         echo "The HTML report can be found at [${BMR_DIR}/ninja_log.html]. In CI, this report"

--- a/build.sh
+++ b/build.sh
@@ -231,6 +231,8 @@ while true; do
     shift
 done
 
+echo "BUILD_REPORT_METRICS: $BUILD_REPORT_METRICS"
+echo "BUILD_REPORT_INCL_CACHE_STATS: $BUILD_REPORT_INCL_CACHE_STATS"
 
 # If clean given, run it prior to any other steps
 if (( ${CLEAN} == 1 )); then
@@ -329,6 +331,7 @@ if completeBuild || hasArg libcuml || hasArg prims || hasArg bench || hasArg pri
         echo "The HTML report can be found at [${BMR_DIR}/ninja_log.html]. In CI, this report"
         echo "will also be uploaded to the appropriate subdirectory of https://downloads.rapids.ai/ci/cuml/, and"
         echo "the entire URL can be found in \"conda-cpp-build\" runs under the task \"Upload additional artifacts\""
+        echo "Metrics output dir: [$BMR_DIR]"
         mkdir -p ${BMR_DIR}
         MSG_OUTFILE="$(mktemp)"
         echo "$MSG" > "${MSG_OUTFILE}"

--- a/conda/recipes/libcuml/recipe.yaml
+++ b/conda/recipes/libcuml/recipe.yaml
@@ -27,7 +27,7 @@ cache:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
-        ./build.sh -n libcuml prims -v --allgpuarch
+        ./build.sh -n libcuml prims -v --allgpuarch --build-metrics=compile_lib --incl-cache-stats
       secrets:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY

--- a/conda/recipes/libcuml/recipe.yaml
+++ b/conda/recipes/libcuml/recipe.yaml
@@ -27,7 +27,7 @@ cache:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
-        ./build.sh -n libcuml prims -v --allgpuarch --build-metrics=compile_lib --incl-cache-stats
+        ./build.sh -n libcuml prims -v --allgpuarch --build-metrics --incl-cache-stats
       secrets:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This PR generates a build metrics report that is uploaded as an additional artifact in CI conda builds. The original idea and implementation comes from the `libcudf` team.