### PR TITLE
Dask 2025.4.0 compatibility

### DIFF
--- a/python/cuml/cuml/dask/common/input_utils.py
+++ b/python/cuml/cuml/dask/common/input_utils.py
@@ -154,7 +154,14 @@ class DistributedDataHandler:
             for idx, wf in enumerate(self.worker_to_parts.items())
         ]
 
-        sizes = self.client.compute(parts, sync=True)
+        worker_addresses, futures = zip(*parts)
+        results = self.client.gather(futures)
+        sizes = [
+            (worker_address, result)
+            for worker_address, result in zip(
+                worker_addresses, results, strict=True
+            )
+        ]
 
         for w, sizes_parts in sizes:
             sizes, total = sizes_parts

--- a/python/cuml/cuml/dask/datasets/utils.py
+++ b/python/cuml/cuml/dask/datasets/utils.py
@@ -16,6 +16,8 @@
 
 import dask.array as da
 import dask.delayed
+from dask.delayed import Delayed
+from distributed import Future
 
 from cuml.internals.safe_imports import gpu_only_import
 
@@ -36,8 +38,10 @@ def _dask_array_from_delayed(part, dtype, nrows, ncols=None):
     # and make an array of shape (nrows, 1)
 
     shape = (nrows, ncols) if ncols else (nrows,)
+    if not isinstance(part, (Delayed, Future)):
+        part = dask.delayed(part)
     return da.from_delayed(
-        dask.delayed(part), shape=shape, meta=cp.zeros((1)), dtype=dtype
+        part, shape=shape, meta=cp.zeros((0,) * len(shape), dtype=dtype)
     )
 
 


### PR DESCRIPTION
This fixes several failures with newer versions in Dask observed at https://github.com/rapidsai/dask-upstream-testing/issues/44. Most came down to unnecessarily wrapping `Future` objects in `Delayed`.