### PR TITLE
Fix race condition in `_block_gemv` kernel

### DIFF
--- a/cpp/src_prims/linalg/block.cuh
+++ b/cpp/src_prims/linalg/block.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -404,6 +404,10 @@ DI void _block_gemv(int m,
         y[i] = alpha * acc;
       }
     }
+    // Ensure that thread 0 has finished reading from shared memory
+    // before other threads move onto the next iteration in the loop
+    // and overwrite the shared memory with new values
+    __syncthreads();
   }
 }
 


### PR DESCRIPTION
The kernel, in order:
1. Starts a loop for every thread
2. Writes to shared memory using all threads, then syncs
3. Uses thread 0 to reduce in shared memory
4. Continues forward with the loop

A sync was necessary between step 3 and 4 to ensure other threads don't continue and overwrite in shared memory while thread 0 is still reading and doing reductions.