### PR TITLE
Don't run memleak tests in CI

### DIFF
--- a/ci/run_cuml_integration_pytests.sh
+++ b/ci/run_cuml_integration_pytests.sh
@@ -4,4 +4,4 @@
 # Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/cuml/tests || exit 1
 
-python -m pytest -p cudf.pandas --cache-clear --ignore=dask -m "not memleak" "$@" --quick_run .
+python -m pytest -p cudf.pandas --cache-clear --ignore=dask "$@" --quick_run .

--- a/ci/run_cuml_singlegpu_memleak_pytests.sh
+++ b/ci/run_cuml_singlegpu_memleak_pytests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Copyright (c) 2024-2025, NVIDIA CORPORATION.
-
-# Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
-cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/cuml/tests || exit 1
-
-python -m pytest --cache-clear --ignore=dask -m "memleak" "$@" .

--- a/ci/run_cuml_singlegpu_pytests.sh
+++ b/ci/run_cuml_singlegpu_pytests.sh
@@ -4,4 +4,4 @@
 # Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/cuml/tests || exit 1
 
-python -m pytest --cache-clear --ignore=dask -m "not memleak" "$@" .
+python -m pytest --cache-clear --ignore=dask "$@" .

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -29,18 +29,5 @@ rapids-logger "pytest cuml single GPU"
   --cov=cuml \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-accel-coverage.xml"
 
-
-if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
-  rapids-logger "memory leak pytests"
-
-  ./ci/run_cuml_singlegpu_memleak_pytests.sh \
-    --numprocesses=1 \
-    --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-memleak.xml" \
-    --cov-config=../../.coveragerc \
-    --cov=cuml \
-    --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-memleak-coverage.xml" \
-    -m "memleak"
-fi
-
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/python/cuml/cuml/tests/conftest.py
+++ b/python/cuml/cuml/tests/conftest.py
@@ -124,6 +124,7 @@ def pytest_addoption(parser):
     - --run_stress: Run stress tests
     - --run_quality: Run quality tests
     - --run_unit: Run unit tests
+    - --run_memleak: Run memleak tests
     """
     group = parser.getgroup("cuML Custom Options")
 
@@ -158,6 +159,13 @@ def pytest_addoption(parser):
         ),
     )
 
+    group.addoption(
+        "--run_memleak",
+        action="store_true",
+        default=False,
+        help="Runs tests marked with 'memleak'. These test for memory leaks.",
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     """Modify test collection based on command line options.
@@ -190,6 +198,7 @@ def pytest_collection_modifyitems(config, items):
     # Handle test categories (unit/quality/stress)
     should_run_quality = config.getoption("--run_quality")
     should_run_stress = config.getoption("--run_stress")
+    should_run_memleak = config.getoption("--run_memleak")
 
     # Run unit is implied if no --run_XXX is set
     should_run_unit = config.getoption("--run_unit") or not (
@@ -220,6 +229,14 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "stress" in item.keywords:
                 item.add_marker(skip_stress)
+
+    if not should_run_memleak:
+        skip_memleak = pytest.mark.skip(
+            reason="Memory leak tests run with --run_memleak flag."
+        )
+        for item in items:
+            if "memleak" in item.keywords:
+                item.add_marker(skip_memleak)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
`cuml` has a few `memleak` tests. These are currently all xfailed due to flakiness in CI (or poor measurement of "is this a memleak"). Currently we skip them manually with `-m "not memleak"` in _most_ (but not all) test runs, and have a dedicated run for them in the nightlies. However, since all memleak tests are xfailed, the nightly run (which takes 18 mins per build) provides no signal. These just aren't currently good tests.

I was encouraged offline to keep the test code around. Rather than fully delete them, I've:

- Made the `memleak` marker skip by default. You need to invoke pytest with `--run_memleak` to run the memleak tests. This means these tests no longer run on any build.
- Removed the run of them memleak tests from nightly CI.
- Removed some vestiges of trying to skip them in certain runs. We skip them by default now, no need to manually specify skipping.

Fixes #6475.