### PR TITLE
Only run one `cudf.pandas` enabled build per PR

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -149,7 +149,8 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
-      matrix_filter: map(select(.ARCH == "amd64"))
+      # Select the amd64 entry with the highest CUDA and Python version
+      matrix_filter: map(select(.ARCH=="amd64")) | [max_by([.CUDA_VER,.PY_VER]|map(split(".")|map(tonumber)))]
       build_type: pull-request
       script: "ci/test_python_integration.sh"
   conda-python-tests-dask:


### PR DESCRIPTION
Previously we'd run several of these across different CUDA architectures & python versions. Since we're already doing the same for cuml's main tests, we shouldn't need the full breadth for `cudf.pandas`. Any issues here should happen at the python level only and shouldn't be python version specific. We still run the full test matrix as part of nightlies (so any rare issues will still be caught). Doing this here helps reduce CI usage bit.

Part of #6582.