### PR TITLE
Split wheel tests into two jobs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,7 @@ jobs:
       - wheel-build-libcuml
       - wheel-build-cuml
       - wheel-tests-cuml
+      - wheel-tests-cuml-dask
       - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.06
@@ -225,6 +226,14 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
+  wheel-tests-cuml-dask:
+    needs: [wheel-build-cuml, changed-files]
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
+    with:
+      build_type: pull-request
+      script: ci/test_wheel_dask.sh
   devcontainer:
     needs: telemetry-setup
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,3 +73,12 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel.sh
+  wheel-tests-cuml-dask:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: ci/test_wheel_dask.sh

--- a/ci/test_wheel_dask.sh
+++ b/ci/test_wheel_dask.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -10,15 +10,6 @@ LIBCUML_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcuml_${RAPIDS_PY_CUDA_SUFFIX}" rap
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
-# Install just minimal dependencies first
-rapids-pip-retry install \
-  "${LIBCUML_WHEELHOUSE}"/libcuml*.whl \
-  "${CUML_WHEELHOUSE}"/cuml*.whl
-
-# Try to import cuml with just a minimal install"
-rapids-logger "Importing cuml with minimal dependencies"
-python -c "import cuml"
-
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
    "${LIBCUML_WHEELHOUSE}"/libcuml*.whl \
@@ -28,17 +19,8 @@ EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
-rapids-logger "pytest cuml single GPU"
-./ci/run_cuml_singlegpu_pytests.sh \
-  --numprocesses=8 \
-  --dist=worksteal \
-  -k 'not test_sparse_pca_inputs' \
-  --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml"
-
-# Run test_sparse_pca_inputs separately
-./ci/run_cuml_singlegpu_pytests.sh \
-  -k 'test_sparse_pca_inputs' \
-  --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-sparse-pca.xml"
+rapids-logger "pytest cuml dask"
+timeout 2h ./ci/run_cuml_dask_pytests.sh --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml"
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
The wheel tests in CI previousl ran both the single-gpu and multi-gpu tests. This made them take up to 90 minutes a run, which was getting long.

We now split them into two separate runs (one for single-gpu, one for multi-gpu), which should help speed things up.

Fixes #6582.