### PR TITLE
Remove usage of `cudf.core.buffer`

### DIFF
--- a/python/cuml/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
+++ b/python/cuml/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
@@ -78,33 +78,13 @@ def replace_suffix(word_str_ser, suffix, replacement, can_replace_mask):
         return stem_ser + replacement_ser
 
 
-@cuda.jit()
-def subtract_valid(input_array, valid_bool_array, sub_val):
-    pos = cuda.grid(1)
-    if pos < input_array.size:
-        if valid_bool_array[pos]:
-            input_array[pos] = input_array[pos] - sub_val
-
-
 def get_stem_series(word_str_ser, suffix_len, can_replace_mask):
     """
     word_str_ser: input string column
     suffix_len: length of suffix to replace
     can_repalce_mask: bool array marking strings where to replace
     """
-    with cudf.core.buffer.acquire_spill_lock():
-        NTHRD = 1024
-        NBLCK = int(np.ceil(float(len(word_str_ser)) / float(NTHRD)))
-
-        start_series = cudf.Series(cp.zeros(len(word_str_ser), dtype=cp.int32))
-        end_ser = word_str_ser.str.len()
-
-        end_ar = end_ser._column.data_array_view(mode="read")
-        can_replace_mask_ar = can_replace_mask._column.data_array_view(
-            mode="read"
-        )
-
-        subtract_valid[NBLCK, NTHRD](end_ar, can_replace_mask_ar, suffix_len)
-        return word_str_ser.str.slice_from(
-            starts=start_series, stops=end_ser.fillna(0)
-        )
+    starts = cudf.Series(cp.zeros(len(word_str_ser), dtype=cp.int32))
+    stops = (word_str_ser.str.len() - suffix_len).fillna(0)
+    sliced = word_str_ser.str.slice_from(starts, stops)
+    return sliced.where(can_replace_mask, word_str_ser)

--- a/python/cuml/cuml/tests/test_input_utils.py
+++ b/python/cuml/cuml/tests/test_input_utils.py
@@ -371,11 +371,12 @@ def check_numpy_order(ary, order):
 
 def check_ptr(a, b, input_type):
     if input_type == "cudf":
-        for (_, col_a), (_, col_b) in zip(a._data.items(), b._data.items()):
-            with cudf.core.buffer.acquire_spill_lock():
-                assert col_a.base_data.get_ptr(
-                    mode="read"
-                ) == col_b.base_data.get_ptr(mode="read")
+        for col_a, col_b in zip(a._columns, b._columns, strict=True):
+            # get_ptr could spill the buffer data, but possibly OK
+            # if this is only used for testing
+            assert col_a.base_data.get_ptr(
+                mode="read"
+            ) == col_b.base_data.get_ptr(mode="read")
     else:
 
         def get_ptr(x):


### PR DESCRIPTION
APIs in this module are private and and should not be used.

* The use in `test_input_utils.py` appeared not strictly needed as potentially spilling buffers for this assertion doesn't not have any material consequence later on
* The use in `suffix_utils.py` is unneeded if `get_stem_series` is implemented just using public cuDF APIs. There's a minor performance hit which I hope is reasonable

```python
import cudf
from cuml.preprocessing.text.stem.porter_stemmer_utils.suffix_utils import get_stem_series

word_str_ser = cudf.Series(["true", "false"] * 500_000)
can_replace_mask = cudf.Series([True, False, False, True] * 250_000)
%timeit get_stem_series(word_str_ser, suffix_len=2, can_replace_mask=can_replace_mask)

9.81 ms ± 481 μs per loop (mean ± std. dev. of 7 runs, 100 loops each) # branch-25.06
15.9 ms ± 479 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # PR
```