### PR TITLE
Remove guarded imports of `scipy`

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -269,9 +269,6 @@ dependencies:
           - joblib>=0.11
           - numba>=0.59.1,<0.61.0a0
           - numpy>=1.23,<3.0a0
-            # TODO: Is scipy really a hard dependency, or should
-            # we make it optional (i.e. an extra for pip
-            # installation/run_constrained for conda)?
           - scipy>=1.8.0
           - packaging
           - rapids-dask-dependency==25.6.*,>=0.0.0a0

--- a/python/cuml/cuml/benchmark/datagen.py
+++ b/python/cuml/cuml/benchmark/datagen.py
@@ -42,13 +42,13 @@ import cudf
 import cupy as cp
 import numpy as np
 import pandas as pd
+import scipy.sparse
 import sklearn.model_selection
 from numba import cuda
 from sklearn.datasets import fetch_covtype, load_svmlight_file
 
 import cuml.datasets
 from cuml.internals import input_utils
-from cuml.internals.import_utils import has_scipy
 
 
 def _gen_data_regression(
@@ -429,10 +429,6 @@ def _convert_to_gpuarray_c(data):
 
 def _sparsify_and_convert(data, input_type, sparsity_ratio=0.3):
     """Randomly set values to 0 and produce a sparse array."""
-    if not has_scipy():
-        raise RuntimeError("Scipy is required")
-    import scipy
-
     random_loc = np.random.choice(
         data.size, int(data.size * sparsity_ratio), replace=False
     )

--- a/python/cuml/cuml/common/__init__.py
+++ b/python/cuml/cuml/common/__init__.py
@@ -28,7 +28,6 @@ from cuml.internals.import_utils import (
     check_min_numba_version,
     has_cupy,
     has_dask,
-    has_scipy,
 )
 from cuml.internals.input_utils import (
     input_to_cuml_array,
@@ -58,7 +57,6 @@ __all__ = [
     "has_dask",
     "check_min_numba_version",
     "check_min_cupy_version",
-    "has_scipy",
     "input_to_cuml_array",
     "input_to_host_array",
     "input_to_host_array_with_sparse_support",

--- a/python/cuml/cuml/common/sparse_utils.py
+++ b/python/cuml/cuml/common/sparse_utils.py
@@ -15,11 +15,7 @@
 #
 
 import cupyx
-
-from cuml.internals.import_utils import has_scipy
-
-if has_scipy():
-    import scipy.sparse
+import scipy.sparse
 
 
 def is_sparse(X):
@@ -35,8 +31,7 @@ def is_sparse(X):
     is_sparse : boolean
         is the input sparse?
     """
-    is_scipy_sparse = has_scipy() and scipy.sparse.issparse(X)
-    return cupyx.scipy.sparse.issparse(X) or is_scipy_sparse
+    return scipy.sparse.issparse(X) or cupyx.scipy.sparse.issparse(X)
 
 
 def is_dense(X):

--- a/python/cuml/cuml/common/sparsefuncs.py
+++ b/python/cuml/cuml/common/sparsefuncs.py
@@ -22,21 +22,12 @@ import numpy as np
 from cupyx.scipy.sparse import coo_matrix as cp_coo_matrix
 from cupyx.scipy.sparse import csc_matrix as cp_csc_matrix
 from cupyx.scipy.sparse import csr_matrix as cp_csr_matrix
+from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
 
 import cuml
 from cuml.common.kernel_utils import cuda_kernel_factory
-from cuml.internals.import_utils import has_scipy
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.internals.memory_utils import with_cupy_rmm
-
-if has_scipy():
-    from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
-else:
-    from cuml.common.import_utils import DummyClass
-
-    csr_matrix = DummyClass
-    coo_matrix = DummyClass
-    csc_matrix = DummyClass
 
 
 def _map_l1_norm_kernel(dtype):

--- a/python/cuml/cuml/dask/common/dask_arr_utils.py
+++ b/python/cuml/cuml/dask/common/dask_arr_utils.py
@@ -20,9 +20,10 @@ import cupyx
 import dask
 import dask.dataframe as dd
 import numpy as np
+import scipy.sparse
 from dask.distributed import default_client
 
-from cuml.common import has_scipy, rmm_cupy_ary
+from cuml.common import rmm_cupy_ary
 from cuml.internals.memory_utils import with_cupy_rmm
 
 
@@ -46,13 +47,7 @@ def _conv_array_to_sparse(arr):
                 dense numpy or cupy array
     :return: cupy sparse CSR matrix
     """
-    if has_scipy():
-        from scipy.sparse import isspmatrix as scipy_sparse_isspmatrix
-    else:
-        from cuml.internals.import_utils import (
-            dummy_function_always_false as scipy_sparse_isspmatrix,
-        )
-    if scipy_sparse_isspmatrix(arr):
+    if scipy.sparse.isspmatrix(arr):
         ret = cupyx.scipy.sparse.csr_matrix(arr.tocsr())
     elif cupyx.scipy.sparse.isspmatrix(arr):
         ret = arr

--- a/python/cuml/cuml/dask/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/dask/linear_model/logistic_regression.py
@@ -19,7 +19,7 @@ import scipy
 from dask.distributed import get_worker
 from raft_dask.common.comms import get_raft_comm_state
 
-from cuml.common.sparse_utils import has_scipy, is_sparse
+from cuml.common.sparse_utils import is_sparse
 from cuml.dask.common.base import mnmg_import
 from cuml.dask.common.input_utils import concatenate
 from cuml.dask.linear_model import LinearRegression
@@ -169,7 +169,7 @@ class LogisticRegression(LinearRegression):
         if is_sparse(data[0][0]) is False:
             inp_X = concatenate([X for X, _ in data])
 
-        elif has_scipy() and scipy.sparse.isspmatrix(data[0][0]):
+        elif scipy.sparse.isspmatrix(data[0][0]):
             inp_X = scipy.sparse.vstack([X for X, _ in data])
 
         elif cupyx.scipy.sparse.isspmatrix(data[0][0]):

--- a/python/cuml/cuml/internals/import_utils.py
+++ b/python/cuml/cuml/internals/import_utils.py
@@ -137,22 +137,6 @@ def check_min_cupy_version(version):
         return False
 
 
-def has_scipy(raise_if_unavailable=False, min_version=None):
-    try:
-        import scipy  # NOQA
-
-        if min_version is None:
-            return True
-        else:
-            return Version(str(scipy.__version__)) >= Version(min_version)
-
-    except ImportError:
-        if not raise_if_unavailable:
-            return False
-        else:
-            raise ImportError("Scipy is not available.")
-
-
 def has_sklearn():
     try:
         import sklearn  # NOQA
@@ -198,11 +182,3 @@ def has_daskglm(min_version=None):
             return Version(str(dask_glm.__version__)) >= Version(min_version)
     except ImportError:
         return False
-
-
-def dummy_function_always_false(*args, **kwargs):
-    return False
-
-
-class DummyClass(object):
-    pass

--- a/python/cuml/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/cuml/manifold/umap_utils.pyx
@@ -118,15 +118,10 @@ def find_ab_params(spread, min_dist):
     smooth curve (from a pre-defined family with simple gradient) that
     best matches an offset exponential decay.
     """
+    from scipy.optimize import curve_fit
 
     def curve(x, a, b):
         return 1.0 / (1.0 + a * x ** (2 * b))
-
-    from cuml.internals.import_utils import has_scipy
-    if has_scipy():
-        from scipy.optimize import curve_fit
-    else:
-        raise RuntimeError('Scipy is needed to run find_ab_params')
 
     xv = np.linspace(0, spread * 3, 300)
     yv = np.zeros(xv.shape)

--- a/python/cuml/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/cuml/naive_bayes/naive_bayes.py
@@ -18,6 +18,7 @@ import warnings
 
 import cupy as cp
 import cupyx
+import scipy.sparse
 
 import cuml.internals.nvtx as nvtx
 from cuml.common import CumlArray
@@ -25,7 +26,6 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.kernel_utils import cuda_kernel_factory
 from cuml.internals.base import Base
-from cuml.internals.import_utils import has_scipy
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.internals.mixins import ClassifierMixin
 from cuml.prims.array import binarize
@@ -176,16 +176,10 @@ class _BaseNB(Base, ClassifierMixin):
         Perform classification on an array of test vectors X.
 
         """
-        if has_scipy():
-            from scipy.sparse import isspmatrix as scipy_sparse_isspmatrix
-        else:
-            from cuml.internals.import_utils import (
-                dummy_function_always_false as scipy_sparse_isspmatrix,
-            )
 
         # todo: use a sparse CumlArray style approach when ready
         # https://github.com/rapidsai/cuml/issues/2216
-        if scipy_sparse_isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
+        if scipy.sparse.isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
             X = _convert_x_sparse(X)
             index = None
         else:
@@ -225,16 +219,9 @@ class _BaseNB(Base, ClassifierMixin):
         Return log-probability estimates for the test vector X.
 
         """
-        if has_scipy():
-            from scipy.sparse import isspmatrix as scipy_sparse_isspmatrix
-        else:
-            from cuml.internals.import_utils import (
-                dummy_function_always_false as scipy_sparse_isspmatrix,
-            )
-
         # todo: use a sparse CumlArray style approach when ready
         # https://github.com/rapidsai/cuml/issues/2216
-        if scipy_sparse_isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
+        if scipy.sparse.isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
             X = _convert_x_sparse(X)
             index = None
         else:
@@ -401,19 +388,12 @@ class GaussianNB(_BaseNB):
         sample_weight=None,
         convert_dtype=True,
     ) -> "GaussianNB":
-        if has_scipy():
-            from scipy.sparse import isspmatrix as scipy_sparse_isspmatrix
-        else:
-            from cuml.internals.import_utils import (
-                dummy_function_always_false as scipy_sparse_isspmatrix,
-            )
-
         if getattr(self, "classes_") is None and _classes is None:
             raise ValueError(
                 "classes must be passed on the first call " "to partial_fit."
             )
 
-        if scipy_sparse_isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
+        if scipy.sparse.isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
             X = _convert_x_sparse(X)
         else:
             X = input_to_cupy_array(
@@ -827,15 +807,8 @@ class _BaseDiscreteNB(_BaseNB):
     def _partial_fit(
         self, X, y, sample_weight=None, _classes=None, convert_dtype=True
     ) -> "_BaseDiscreteNB":
-        if has_scipy():
-            from scipy.sparse import isspmatrix as scipy_sparse_isspmatrix
-        else:
-            from cuml.internals.import_utils import (
-                dummy_function_always_false as scipy_sparse_isspmatrix,
-            )
-
         # TODO: use SparseCumlArray
-        if scipy_sparse_isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
+        if scipy.sparse.isspmatrix(X) or cupyx.scipy.sparse.isspmatrix(X):
             X = _convert_x_sparse(X)
         else:
             X = input_to_cupy_array(

--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -19,16 +19,12 @@ import math
 import cupy as cp
 import numpy as np
 from numba import cuda
+from scipy.special import gammainc
 
 from cuml.common.exceptions import NotFittedError
 from cuml.internals.base import Base
-from cuml.internals.import_utils import has_scipy
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.metrics import pairwise_distances
-
-if has_scipy():
-    from scipy.special import gammainc
-
 
 VALID_KERNELS = [
     "gaussian",
@@ -428,7 +424,6 @@ class KernelDensity(Base):
             # we first draw points from a d-dimensional normal distribution,
             # then use an incomplete gamma function to map them to a uniform
             # d-dimensional tophat distribution.
-            has_scipy(raise_if_unavailable=True)
             dim = self.X_.shape[1]
             X = rng.normal(size=(n_samples, dim))
             s_sq = cp.einsum("ij,ij->i", X, X).get()

--- a/python/cuml/cuml/preprocessing/label.py
+++ b/python/cuml/cuml/preprocessing/label.py
@@ -15,9 +15,10 @@
 
 import cupy as cp
 import cupyx
+import scipy.sparse
 
 import cuml.internals
-from cuml.common import CumlArray, has_scipy
+from cuml.common import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.base import Base
@@ -265,18 +266,10 @@ class LabelBinarizer(Base):
 
         arr : array with original labels
         """
-
-        if has_scipy():
-            from scipy.sparse import isspmatrix as scipy_sparse_isspmatrix
-        else:
-            from cuml.internals.import_utils import (
-                dummy_function_always_false as scipy_sparse_isspmatrix,
-            )
-
         # If we are already given multi-class, just return it.
         if cupyx.scipy.sparse.isspmatrix(y):
             y_mapped = y.tocsr().indices.astype(self.classes_.dtype)
-        elif scipy_sparse_isspmatrix(y):
+        elif scipy.sparse.isspmatrix(y):
             y = y.tocsr()
             y_mapped = cp.array(y.indices, dtype=y.indices.dtype)
         else:

--- a/python/cuml/cuml/tests/dask/test_dask_nearest_neighbors.py
+++ b/python/cuml/cuml/tests/dask/test_dask_nearest_neighbors.py
@@ -21,9 +21,9 @@ import dask_cudf
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.stats
 from sklearn.neighbors import KNeighborsClassifier
 
-from cuml.common import has_scipy
 from cuml.dask.common import utils as dask_utils
 from cuml.testing.utils import (
     array_equal,
@@ -43,14 +43,9 @@ if IS_ARM and cp.cuda.runtime.runtimeGetVersion() < 11080:
 
 
 def predict(neigh_ind, _y, n_neighbors):
-    if has_scipy():
-        import scipy.stats as stats
-    else:
-        raise RuntimeError("Scipy is needed to run predict()")
-
     neigh_ind = neigh_ind.astype(np.int64)
 
-    ypred, count = stats.mode(_y[neigh_ind], axis=1)
+    ypred, count = scipy.stats.mode(_y[neigh_ind], axis=1)
     return ypred.ravel(), count.ravel() * 1.0 / n_neighbors
 
 

--- a/python/cuml/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -19,6 +19,7 @@ import math
 import cupy as cp
 import numpy as np
 import pytest
+import scipy.special
 import sklearn.neighbors
 from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
@@ -26,7 +27,7 @@ from sklearn.model_selection import train_test_split
 import cuml
 from cuml import KernelExplainer, Lasso
 from cuml.datasets import make_regression
-from cuml.internals.import_utils import has_scipy, has_shap
+from cuml.internals.import_utils import has_shap
 from cuml.testing.datasets import with_dtype
 from cuml.testing.utils import ClassEnumerator, get_shap_values
 
@@ -243,10 +244,7 @@ def test_kernel_housing_dataset(housing_dataset):
 def test_binom_coef():
     for i in range(1, 101):
         val = cuml.explainer.kernel_shap._binomCoef(100, i)
-        if has_scipy():
-            from scipy.special import binom
-
-            assert math.isclose(val, binom(100, i), rel_tol=1e-15)
+        assert math.isclose(val, scipy.special.binom(100, i), rel_tol=1e-15)
 
 
 def test_shapley_kernel():

--- a/python/cuml/cuml/tests/test_batched_lbfgs.py
+++ b/python/cuml/cuml/tests/test_batched_lbfgs.py
@@ -16,8 +16,9 @@
 
 import numpy as np
 import pytest
+import scipy
+from packaging.version import Version
 
-from cuml.common import has_scipy
 from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 
 
@@ -66,7 +67,7 @@ def g_batched_rosenbrock(
 
 
 @pytest.mark.xfail(
-    condition=has_scipy(min_version="1.15"),
+    condition=Version(scipy.__version__) >= Version("1.15"),
     reason="https://github.com/rapidsai/cuml/issues/6210",
 )
 def test_batched_lbfgs_rosenbrock():

--- a/python/cuml/cuml/tests/test_label_binarizer.py
+++ b/python/cuml/cuml/tests/test_label_binarizer.py
@@ -15,9 +15,9 @@
 import cupy as cp
 import numpy as np
 import pytest
+import scipy.sparse
 from sklearn.preprocessing import LabelBinarizer as skLB
 
-from cuml.common import has_scipy
 from cuml.preprocessing import LabelBinarizer
 from cuml.testing.utils import array_equal
 
@@ -50,14 +50,6 @@ def test_basic_functions(labels, dtype, sparse_output):
 
     if sparse_output:
         skl_bin_xformed = skl_bin.transform(xform_labels.get())
-
-        if has_scipy():
-            import scipy.sparse
-        else:
-            pytest.skip(
-                "Skipping test_basic_functions(sparse_output=True) "
-                + "because Scipy is missing"
-            )
 
         skl_csr = scipy.sparse.coo_matrix(skl_bin_xformed).tocsr()
         cuml_csr = xformed

--- a/python/cuml/cuml/tests/test_nearest_neighbors.py
+++ b/python/cuml/cuml/tests/test_nearest_neighbors.py
@@ -30,7 +30,6 @@ from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import NearestNeighbors as skKNN
 
 import cuml
-from cuml.common import has_scipy
 from cuml.datasets import make_blobs
 from cuml.internals import logger  # noqa: F401
 from cuml.metrics import pairwise_distances as cuPW
@@ -99,10 +98,6 @@ def metric_p_combinations():
 @pytest.mark.parametrize("datatype", ["dataframe", "numpy"])
 @pytest.mark.parametrize("metric_p", metric_p_combinations())
 @pytest.mark.parametrize("nrows", [1000, stress_param(10000)])
-@pytest.mark.skipif(
-    not has_scipy(),
-    reason="Skipping test_self_neighboring" " because Scipy is missing",
-)
 def test_self_neighboring(datatype, metric_p, nrows):
     """Test that searches using an indexed vector itself return sensible
     results for that vector
@@ -116,11 +111,6 @@ def test_self_neighboring(datatype, metric_p, nrows):
     n_neighbors = 3
 
     metric, p = metric_p
-
-    if not has_scipy():
-        pytest.skip(
-            "Skipping test_self_neighboring because " + "Scipy is missing"
-        )
 
     X, y = make_blobs(
         n_samples=nrows, centers=n_clusters, n_features=ncols, random_state=0
@@ -178,12 +168,6 @@ def test_self_neighboring(datatype, metric_p, nrows):
 def test_neighborhood_predictions(
     nrows, ncols, n_neighbors, n_clusters, datatype, algo
 ):
-    if not has_scipy():
-        pytest.skip(
-            "Skipping test_neighborhood_predictions because "
-            + "Scipy is missing"
-        )
-
     X, y = make_blobs(
         n_samples=nrows, centers=n_clusters, n_features=ncols, random_state=0
     )

--- a/python/cuml/cuml/tests/test_random_projection.py
+++ b/python/cuml/cuml/tests/test_random_projection.py
@@ -15,12 +15,12 @@
 
 import numpy as np
 import pytest
+from scipy.spatial.distance import pdist
 from sklearn.datasets import make_blobs
 from sklearn.random_projection import (
     johnson_lindenstrauss_min_dim as sklearn_johnson_lindenstrauss_min_dim,
 )
 
-from cuml.common import has_scipy
 from cuml.random_projection import (
     GaussianRandomProjection,
     SparseRandomProjection,
@@ -55,14 +55,6 @@ def test_random_projection_fit(datatype, method):
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize("method", ["gaussian", "sparse"])
 def test_random_projection_fit_transform(datatype, method):
-    if has_scipy():
-        from scipy.spatial.distance import pdist
-    else:
-        pytest.skip(
-            "Skipping test_random_projection_fit_transform because "
-            + "Scipy is missing"
-        )
-
     eps = 0.2
 
     # dataset generation
@@ -109,14 +101,6 @@ def test_johnson_lindenstrauss_min_dim():
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize("method", ["sparse"])
 def test_random_projection_fit_transform_default(datatype, method):
-    if has_scipy():
-        from scipy.spatial.distance import pdist
-    else:
-        pytest.skip(
-            "Skipping test_random_projection_fit_transform_default "
-            + "because Scipy is missing"
-        )
-
     eps = 0.8
     # dataset generation
     data, target = make_blobs(n_samples=30, centers=4, n_features=5000)

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -34,7 +34,6 @@ from cuml.internals.base import Base
 from pylibraft.common.handle cimport handle_t
 
 import cuml.internals.logger as logger
-from cuml.common import has_scipy
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 
@@ -317,11 +316,6 @@ class ARIMA(Base):
                  verbose=False,
                  output_type=None,
                  convert_dtype=True):
-
-        if not has_scipy():
-            raise RuntimeError("Scipy is needed to run cuML's ARIMA estimator."
-                               " Please install it to enable ARIMA "
-                               "estimation.")
 
         # Initialize base class
         super().__init__(handle=handle,

--- a/python/cuml/cuml/tsa/batched_lbfgs.py
+++ b/python/cuml/cuml/tsa/batched_lbfgs.py
@@ -15,10 +15,14 @@
 #
 
 import numpy as np
+import scipy
+from packaging.version import Version
+from scipy.optimize import _lbfgsb
 
 import cuml.internals.logger as logger
 import cuml.internals.nvtx as nvtx
-from cuml.common import has_scipy
+
+_SCIPY_ATLEAST_115 = Version(scipy.__version__) >= Version("1.15")
 
 
 def _fd_fprime(x, f, h):
@@ -94,13 +98,6 @@ def batched_fmin_lbfgs_b(
 
     """
 
-    if has_scipy():
-        from scipy.optimize import _lbfgsb
-
-        scipy_greater_115 = has_scipy(min_version="1.15")
-    else:
-        raise RuntimeError("Scipy is needed to run batched_fmin_lbfgs_b")
-
     n = len(x0) // num_batches
 
     if fprime is None:
@@ -142,7 +139,7 @@ def batched_fmin_lbfgs_b(
     iwa = [np.copy(np.zeros(3 * n, np.int32)) for ib in range(num_batches)]
 
     # we need different inputs after Scipy 1.15 using a C-based lbfgs
-    if scipy_greater_115:
+    if _SCIPY_ATLEAST_115:
         task = [np.copy(np.zeros(1, np.int32)) for ib in range(num_batches)]
         ln_task = [np.copy(np.zeros(1, np.int32)) for ib in range(num_batches)]
     else:
@@ -152,7 +149,7 @@ def batched_fmin_lbfgs_b(
     lsave = [np.copy(np.zeros(4, np.int32)) for ib in range(num_batches)]
     isave = [np.copy(np.zeros(44, np.int32)) for ib in range(num_batches)]
     dsave = [np.copy(np.zeros(29, np.float64)) for ib in range(num_batches)]
-    if not scipy_greater_115:
+    if not _SCIPY_ATLEAST_115:
         for ib in range(num_batches):
             task[ib][:] = "START"
 
@@ -167,7 +164,7 @@ def batched_fmin_lbfgs_b(
             for ib in range(num_batches):
                 if converged[ib]:
                     continue
-                if scipy_greater_115:
+                if _SCIPY_ATLEAST_115:
                     _lbfgsb.setulb(
                         m,
                         x[ib],
@@ -228,7 +225,7 @@ def batched_fmin_lbfgs_b(
                 #     7 : "ERROR",
                 #     8 : "ABNORMAL"
                 # }
-                if scipy_greater_115:
+                if _SCIPY_ATLEAST_115:
                     cond1 = task[0] == 3
                     cond2 = task[0] == 1
                     cond3 = task[0] == 4
@@ -246,7 +243,7 @@ def batched_fmin_lbfgs_b(
                 elif cond2:
                     n_iterations[ib] += 1
                     if n_iterations[ib] >= maxiter:
-                        if scipy_greater_115:
+                        if _SCIPY_ATLEAST_115:
                             task[ib][0] = 5
                             task[ib][1] = 504
                         else:


### PR DESCRIPTION
SciPy is currently a required dependency of cuml (and has been for a while). With the intent to make sklearn a required dependency (which also requires scipy), it seems unlikely we'll ever step back from this requirement.

This PR removes all the remaining guarded imports of scipy, along with the `has_scipy` function. There were plenty of places where we didn't guard the import, so doing this improves consistency and deletes some unneeded branching. In the 2 places where we were using `has_scipy` to also check the version I've inlined the checks which is also more readable IMO.