### PR TITLE
Mark one kmeans and one t_sne sklearn test as flaky 

### DIFF
--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -747,7 +747,6 @@
 - id: "sklearn.manifold.tests.test_t_sne::test_n_components_range"
 - id: "sklearn.manifold.tests.test_t_sne::test_n_iter_without_progress"
 - id: "sklearn.manifold.tests.test_t_sne::test_non_positive_computed_distances"
-- id: "sklearn.manifold.tests.test_t_sne::test_optimization_minimizes_kl_divergence"
 - id: "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_precomputed_kernel"
 - id: "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_sparse_input[csr_array]"
 - id: "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_sparse_input[csr_matrix]"

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -49,6 +49,8 @@
 - id: "sklearn.cluster.tests.test_k_means::test_relocating_with_duplicates[elkan-dense]"
 - id: "sklearn.cluster.tests.test_k_means::test_relocating_with_duplicates[lloyd-dense]"
 - id: "sklearn.cluster.tests.test_k_means::test_score_max_iter[42-KMeans]"
+  strict: false
+  reason: Test is flaky with cuml.accel
 - id: "sklearn.cluster.tests.test_k_means::test_transform[42-KMeans]"
 - id: "sklearn.cluster.tests.test_k_means::test_warning_elkan_1_cluster"
 - id: "sklearn.cluster.tests.test_k_means::test_warning_n_init_precomputed_centers[KMeans]"

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -747,6 +747,9 @@
 - id: "sklearn.manifold.tests.test_t_sne::test_n_components_range"
 - id: "sklearn.manifold.tests.test_t_sne::test_n_iter_without_progress"
 - id: "sklearn.manifold.tests.test_t_sne::test_non_positive_computed_distances"
+- id: "sklearn.manifold.tests.test_t_sne::test_optimization_minimizes_kl_divergence"
+  strict: false
+  reason: Test is flaky with cuml.accel
 - id: "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_precomputed_kernel"
 - id: "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_sparse_input[csr_array]"
 - id: "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_sparse_input[csr_matrix]"


### PR DESCRIPTION
Mark the following tests as flaky in cuml.accel test suite since they are showing flaky behavior:

- sklearn.cluster.tests.test_k_means::test_score_max_iter[42-KMeans]
- sklearn.manifold.tests.test_t_sne::test_optimization_minimizes_kl_divergence

Spun off from https://github.com/rapidsai/cuml/pull/6518 for immediate merge.