### PR TITLE
Use `nogil` for `libcuml` calls

### DIFF
--- a/python/cuml/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cuml/cluster/agglomerative.pyx
@@ -35,7 +35,7 @@ from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 from cuml.metrics.distance_type cimport DistanceType
 
 
-cdef extern from "cuvs/cluster/agglomerative.hpp" namespace "cuvs::cluster::agglomerative":
+cdef extern from "cuvs/cluster/agglomerative.hpp" namespace "cuvs::cluster::agglomerative" nogil:
 
     cdef cppclass single_linkage_output[int]:
         int m
@@ -45,7 +45,7 @@ cdef extern from "cuvs/cluster/agglomerative.hpp" namespace "cuvs::cluster::aggl
         int *labels
         int *children
 
-cdef extern from "cuml/cluster/linkage.hpp" namespace "ML":
+cdef extern from "cuml/cluster/linkage.hpp" namespace "ML" nogil:
 
     cdef void single_linkage_pairwise(
         const handle_t &handle,

--- a/python/cuml/cuml/cluster/cpp/kmeans.pxd
+++ b/python/cuml/cuml/cluster/cpp/kmeans.pxd
@@ -30,7 +30,7 @@ from cuml.common.rng_state cimport RngState
 from cuml.metrics.distance_type cimport DistanceType
 
 
-cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans":
+cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans" nogil:
     cdef void fit_predict(handle_t& handle,
                           KMeansParams& params,
                           const float *X,

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -39,7 +39,7 @@ from cuml.metrics.distance_type cimport DistanceType
 from cuml.common import input_to_cuml_array, using_output_type
 
 
-cdef extern from "cuml/cluster/dbscan.hpp" namespace "ML::Dbscan":
+cdef extern from "cuml/cluster/dbscan.hpp" namespace "ML::Dbscan" nogil:
 
     ctypedef enum EpsNnMethod:
         BRUTE_FORCE "ML::Dbscan::EpsNnMethod::BRUTE_FORCE"

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -48,7 +48,7 @@ from pylibraft.common.handle import Handle
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common" nogil:
 
     ctypedef enum CLUSTER_SELECTION_METHOD:
         EOM "ML::HDBSCAN::Common::CLUSTER_SELECTION_METHOD::EOM"
@@ -118,7 +118,7 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
                                   int n_selected_clusters,
                                   PredictionData[int, float]& prediction_data)
 
-cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML" nogil:
 
     void hdbscan(const handle_t & handle,
                  const float * X,
@@ -145,7 +145,7 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
                            bool allow_single_cluster, int max_cluster_size,
                            float cluster_selection_epsilon)
 
-cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::HELPER":
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::HELPER" nogil:
 
     void compute_core_dists(const handle_t& handle,
                             const float* X,

--- a/python/cuml/cuml/cluster/hdbscan/prediction.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/prediction.pyx
@@ -32,7 +32,7 @@ from pylibraft.common.handle cimport handle_t
 from cuml.metrics.distance_type cimport DistanceType
 
 
-cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common" nogil:
 
     cdef cppclass CondensedHierarchy[value_idx, value_t]:
         CondensedHierarchy(
@@ -72,7 +72,7 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common":
         size_t n_rows
         size_t n_cols
 
-cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML":
+cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML" nogil:
 
     void compute_all_points_membership_vectors(
         const handle_t &handle,

--- a/python/cuml/cuml/cluster/kmeans_mg.pyx
+++ b/python/cuml/cuml/cluster/kmeans_mg.pyx
@@ -34,8 +34,7 @@ from cuml.cluster.kmeans_utils cimport params as KMeansParams
 from cuml.internals.utils import check_random_seed
 
 
-cdef extern from "cuml/cluster/kmeans_mg.hpp" \
-        namespace "ML::kmeans::opg" nogil:
+cdef extern from "cuml/cluster/kmeans_mg.hpp" namespace "ML::kmeans::opg" nogil:
 
     cdef void fit(handle_t& handle,
                   KMeansParams& params,

--- a/python/cuml/cuml/cluster/kmeans_utils.pxd
+++ b/python/cuml/cuml/cluster/kmeans_utils.pxd
@@ -23,13 +23,11 @@ from cuml.internals.logger cimport level_enum
 from cuml.metrics.distance_type cimport DistanceType
 
 
-cdef extern from "cuml/cluster/kmeans.hpp" namespace \
-        "cuvs::cluster::kmeans::params":
+cdef extern from "cuml/cluster/kmeans.hpp" namespace "cuvs::cluster::kmeans::params" nogil:
     enum InitMethod:
         KMeansPlusPlus, Random, Array
 
-cdef extern from "cuvs/cluster/kmeans.hpp" namespace \
-        "cuvs::cluster::kmeans":
+cdef extern from "cuvs/cluster/kmeans.hpp" namespace "cuvs::cluster::kmeans" nogil:
     cdef struct params:
         int n_clusters,
         InitMethod init

--- a/python/cuml/cuml/datasets/arima.pyx
+++ b/python/cuml/cuml/datasets/arima.pyx
@@ -30,7 +30,7 @@ from pylibraft.common.handle cimport handle_t
 from cuml.tsa.arima cimport ARIMAOrder
 
 
-cdef extern from "cuml/datasets/make_arima.hpp" namespace "ML":
+cdef extern from "cuml/datasets/make_arima.hpp" namespace "ML" nogil:
     void cpp_make_arima "ML::Datasets::make_arima" (
         const handle_t& handle,
         float* out,

--- a/python/cuml/cuml/datasets/regression.pyx
+++ b/python/cuml/cuml/datasets/regression.pyx
@@ -31,7 +31,7 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML":
+cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML" nogil:
     void cpp_make_regression "ML::Datasets::make_regression" (
         const handle_t& handle,
         float* out,

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -52,7 +52,7 @@ from pylibraft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 
 
-cdef extern from "cuml/decomposition/pca.hpp" namespace "ML":
+cdef extern from "cuml/decomposition/pca.hpp" namespace "ML" nogil:
 
     cdef void pcaFit(handle_t& handle,
                      float *input,

--- a/python/cuml/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/cuml/decomposition/pca_mg.pyx
@@ -35,7 +35,7 @@ from cuml.decomposition.utils cimport *
 from cuml.decomposition.utils_mg cimport *
 
 
-cdef extern from "cuml/decomposition/pca_mg.hpp" namespace "ML::PCA::opg":
+cdef extern from "cuml/decomposition/pca_mg.hpp" namespace "ML::PCA::opg" nogil:
 
     cdef void fit(handle_t& handle,
                   vector[floatData_t *] input_data,

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -39,7 +39,7 @@ from pylibraft.common.handle cimport handle_t
 from cuml.decomposition.utils cimport *
 
 
-cdef extern from "cuml/decomposition/tsvd.hpp" namespace "ML":
+cdef extern from "cuml/decomposition/tsvd.hpp" namespace "ML" nogil:
 
     cdef void tsvdFit(handle_t& handle,
                       float *input,

--- a/python/cuml/cuml/decomposition/tsvd_mg.pyx
+++ b/python/cuml/cuml/decomposition/tsvd_mg.pyx
@@ -32,7 +32,7 @@ from cuml.decomposition import TruncatedSVD
 from cuml.decomposition.base_mg import BaseDecompositionMG
 
 
-cdef extern from "cuml/decomposition/tsvd_mg.hpp" namespace "ML::TSVD::opg":
+cdef extern from "cuml/decomposition/tsvd_mg.hpp" namespace "ML::TSVD::opg" nogil:
 
     cdef void fit_transform(handle_t& handle,
                             vector[floatData_t *] input_data,

--- a/python/cuml/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/cuml/ensemble/randomforest_shared.pxd
@@ -39,7 +39,7 @@ cdef extern from "treelite/c_api.h":
     ctypedef void* TreeliteModelHandle
     cdef const char* TreeliteGetLastError()
 
-cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
+cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
     cdef enum CRITERION:
         GINI,
         ENTROPY,
@@ -50,7 +50,7 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
         INVERSE_GAUSSIAN,
         CRITERION_END
 
-cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
+cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
 
     cdef enum RF_type:
         CLASSIFICATION,

--- a/python/cuml/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.pyx
@@ -46,7 +46,7 @@ from cuml.ensemble.randomforest_shared cimport *
 from cuml.internals.logger cimport level_enum
 
 
-cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
+cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
 
     cdef void fit(handle_t& handle,
                   RandomForestMetaData[float, int]*,

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -47,7 +47,7 @@ from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 
-cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML":
+cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
 
     cdef void fit(handle_t& handle,
                   RandomForestMetaData[float, float]*,

--- a/python/cuml/cuml/experimental/fil/fil.pyx
+++ b/python/cuml/cuml/experimental/fil/fil.pyx
@@ -72,7 +72,7 @@ cdef raft_proto_device_t get_device_type(arr):
         dev = raft_proto_device_t.cpu
     return dev
 
-cdef extern from "cuml/experimental/fil/forest_model.hpp" namespace "ML::experimental::fil":
+cdef extern from "cuml/experimental/fil/forest_model.hpp" namespace "ML::experimental::fil" nogil:
     cdef cppclass forest_model:
         void predict[io_t](
             const raft_proto_handle_t&,
@@ -93,7 +93,7 @@ cdef extern from "cuml/experimental/fil/forest_model.hpp" namespace "ML::experim
         row_op row_postprocessing() except +
         element_op elem_postprocessing() except +
 
-cdef extern from "cuml/experimental/fil/treelite_importer.hpp" namespace "ML::experimental::fil":
+cdef extern from "cuml/experimental/fil/treelite_importer.hpp" namespace "ML::experimental::fil" nogil:
     forest_model import_from_treelite_handle(
         TreeliteModelHandle,
         fil_tree_layout,

--- a/python/cuml/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/cuml/experimental/linear_model/lars.pyx
@@ -41,7 +41,7 @@ from cuml.internals.mixins import RegressorMixin
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/solvers/lars.hpp" namespace "ML::Solver::Lars":
+cdef extern from "cuml/solvers/lars.hpp" namespace "ML::Solver::Lars" nogil:
 
     cdef void larsFit[math_t](
         const handle_t& handle, math_t* X, int n_rows, int n_cols,

--- a/python/cuml/cuml/explainer/base.pyx
+++ b/python/cuml/cuml/explainer/base.pyx
@@ -36,7 +36,7 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/explainer/permutation_shap.hpp" namespace "ML":
+cdef extern from "cuml/explainer/permutation_shap.hpp" namespace "ML" nogil:
 
     void shap_main_effect_dataset "ML::Explainer::shap_main_effect_dataset"(
         const handle_t& handle,

--- a/python/cuml/cuml/explainer/kernel_shap.pyx
+++ b/python/cuml/cuml/explainer/kernel_shap.pyx
@@ -32,7 +32,7 @@ from libc.stdint cimport uint64_t, uintptr_t
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/explainer/kernel_shap.hpp" namespace "ML":
+cdef extern from "cuml/explainer/kernel_shap.hpp" namespace "ML" nogil:
     void kernel_dataset "ML::Explainer::kernel_dataset"(
         handle_t& handle,
         float* X,

--- a/python/cuml/cuml/explainer/permutation_shap.pyx
+++ b/python/cuml/cuml/explainer/permutation_shap.pyx
@@ -25,7 +25,7 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/explainer/permutation_shap.hpp" namespace "ML":
+cdef extern from "cuml/explainer/permutation_shap.hpp" namespace "ML" nogil:
 
     void permutation_shap_dataset "ML::Explainer::permutation_shap_dataset"(
         const handle_t& handle,

--- a/python/cuml/cuml/explainer/tree_shap.pyx
+++ b/python/cuml/cuml/explainer/tree_shap.pyx
@@ -47,7 +47,7 @@ cdef extern from "treelite/c_api.h":
             TreeliteModelHandle model, const char * name, TreelitePyBufferFrame* out_frame) except +
     cdef const char * TreeliteGetLastError()
 
-cdef extern from "cuml/explainer/tree_shap.hpp" namespace "ML::Explainer":
+cdef extern from "cuml/explainer/tree_shap.hpp" namespace "ML::Explainer" nogil:
     cdef cppclass TreePathHandle:
         pass
 

--- a/python/cuml/cuml/internals/callbacks_implems.h
+++ b/python/cuml/cuml/internals/callbacks_implems.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,27 +41,33 @@ class DefaultGraphBasedDimRedCallback : public GraphBasedDimRedCallback {
 
   void on_preprocess_end(void* embeddings) override
   {
+    PyGILState_STATE gstate = PyGILState_Ensure();
     PyObject* numba_matrix = get_numba_matrix(embeddings);
     PyObject* res =
       PyObject_CallMethod(this->pyCallbackClass, "on_preprocess_end", "(O)", numba_matrix);
     Py_DECREF(numba_matrix);
     Py_DECREF(res);
+    PyGILState_Release(gstate);
   }
 
   void on_epoch_end(void* embeddings) override
   {
+    PyGILState_STATE gstate = PyGILState_Ensure();
     PyObject* numba_matrix = get_numba_matrix(embeddings);
     PyObject* res = PyObject_CallMethod(this->pyCallbackClass, "on_epoch_end", "(O)", numba_matrix);
     Py_DECREF(numba_matrix);
     Py_DECREF(res);
+    PyGILState_Release(gstate);
   }
 
   void on_train_end(void* embeddings) override
   {
+    PyGILState_STATE gstate = PyGILState_Ensure();
     PyObject* numba_matrix = get_numba_matrix(embeddings);
     PyObject* res = PyObject_CallMethod(this->pyCallbackClass, "on_train_end", "(O)", numba_matrix);
     Py_DECREF(numba_matrix);
     Py_DECREF(res);
+    PyGILState_Release(gstate);
   }
 
  public:

--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -30,7 +30,7 @@ from cuml.internals.input_utils import input_to_cuml_array
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
 
     cdef void gemmPredict(handle_t& handle,
                           const float *input,

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -40,7 +40,7 @@ from pylibraft.common.handle cimport handle_t
 from pylibraft.common.handle import Handle
 
 
-cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
 
     cdef void olsFit(handle_t& handle,
                      float *input,

--- a/python/cuml/cuml/linear_model/linear_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression_mg.pyx
@@ -32,7 +32,7 @@ from cuml.linear_model import LinearRegression
 from cuml.linear_model.base_mg import MGFitMixin
 
 
-cdef extern from "cuml/linear_model/ols_mg.hpp" namespace "ML::OLS::opg":
+cdef extern from "cuml/linear_model/ols_mg.hpp" namespace "ML::OLS::opg" nogil:
 
     cdef void fit(handle_t& handle,
                   vector[floatData_t *] input_data,

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -38,7 +38,7 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM":
+cdef extern from "cuml/linear_model/glm.hpp" namespace "ML::GLM" nogil:
 
     cdef void ridgeFit(handle_t& handle,
                        float *input,

--- a/python/cuml/cuml/linear_model/ridge_mg.pyx
+++ b/python/cuml/cuml/linear_model/ridge_mg.pyx
@@ -32,7 +32,7 @@ from cuml.linear_model import Ridge
 from cuml.linear_model.base_mg import MGFitMixin
 
 
-cdef extern from "cuml/linear_model/ridge_mg.hpp" namespace "ML::Ridge::opg":
+cdef extern from "cuml/linear_model/ridge_mg.hpp" namespace "ML::Ridge::opg" nogil:
 
     cdef void fit(handle_t& handle,
                   vector[floatData_t *] input_data,

--- a/python/cuml/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/cuml/manifold/simpl_set.pyx
@@ -35,7 +35,7 @@ from libc.stdlib cimport free
 from libcpp.memory cimport unique_ptr
 
 
-cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP":
+cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP" nogil:
 
     unique_ptr[COO] get_graph(handle_t &handle,
                               float* X,

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -55,7 +55,7 @@ cimport cuml.common.cuda
 from cuml.metrics.distance_type cimport DistanceType
 
 
-cdef extern from "cuml/manifold/tsne.h" namespace "ML":
+cdef extern from "cuml/manifold/tsne.h" namespace "ML" nogil:
 
     enum TSNE_ALGORITHM:
         EXACT = 0,
@@ -93,7 +93,7 @@ cdef extern from "cuml/manifold/tsne.h" namespace "ML":
         TSNE_ALGORITHM algorithm
 
 
-cdef extern from "cuml/manifold/tsne.h" namespace "ML":
+cdef extern from "cuml/manifold/tsne.h" namespace "ML" nogil:
 
     cdef void TSNE_fit(
         handle_t &handle,

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -53,7 +53,7 @@ from cuml.internals.logger cimport level_enum
 from cuml.manifold.umap_utils cimport *
 
 
-cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP":
+cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP" nogil:
 
     void fit(handle_t & handle,
              float * X,

--- a/python/cuml/cuml/manifold/umap_utils.pxd
+++ b/python/cuml/cuml/manifold/umap_utils.pxd
@@ -27,7 +27,7 @@ from cuml.metrics.distance_type cimport DistanceType
 from cuml.metrics.raft_distance_type cimport DistanceType as RaftDistanceType
 
 
-cdef extern from "cuml/manifold/umapparams.h" namespace "ML::UMAPParams":
+cdef extern from "cuml/manifold/umapparams.h" namespace "ML::UMAPParams" nogil:
 
     enum MetricType:
         EUCLIDEAN = 0,
@@ -41,7 +41,7 @@ cdef extern from "cuml/common/callback.hpp" namespace "ML::Internals":
     cdef cppclass GraphBasedDimRedCallback
 
 
-cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbors::experimental::nn_descent":
+cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbors::experimental::nn_descent" nogil:
     cdef struct index_params:
         uint64_t graph_degree,
         uint64_t intermediate_graph_degree,
@@ -52,7 +52,7 @@ cdef extern from "raft/neighbors/nn_descent_types.hpp" namespace "raft::neighbor
         RaftDistanceType metric,
         float metric_arg
 
-cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
+cdef extern from "cuml/manifold/umapparams.h" namespace "ML" nogil:
 
     cdef cppclass UMAPParams:
         int n_neighbors,
@@ -82,7 +82,7 @@ cdef extern from "cuml/manifold/umapparams.h" namespace "ML":
         GraphBasedDimRedCallback * callback,
         index_params nn_descent_params
 
-cdef extern from "raft/sparse/coo.hpp":
+cdef extern from "raft/sparse/coo.hpp" nogil:
     cdef cppclass COO "raft::sparse::COO<float, int>":
         COO(cuda_stream_view stream)
         void allocate(int nnz, int size, bool init, cuda_stream_view stream)

--- a/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -28,7 +28,7 @@ from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
 
     double adjusted_rand_index(handle_t &handle,
                                int *y,

--- a/python/cuml/cuml/metrics/cluster/completeness_score.pyx
+++ b/python/cuml/cuml/metrics/cluster/completeness_score.pyx
@@ -26,7 +26,7 @@ from pylibraft.common.handle import Handle
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double completeness_score(const handle_t & handle, const int *y,
                               const int *y_hat, const int n,
                               const int lower_class_range,

--- a/python/cuml/cuml/metrics/cluster/entropy.pyx
+++ b/python/cuml/cuml/metrics/cluster/entropy.pyx
@@ -32,7 +32,7 @@ from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double entropy(const handle_t &handle,
                    const int *y,
                    const int n,

--- a/python/cuml/cuml/metrics/cluster/homogeneity_score.pyx
+++ b/python/cuml/cuml/metrics/cluster/homogeneity_score.pyx
@@ -26,7 +26,7 @@ from pylibraft.common.handle import Handle
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double homogeneity_score(const handle_t & handle, const int *y,
                              const int *y_hat, const int n,
                              const int lower_class_range,

--- a/python/cuml/cuml/metrics/cluster/mutual_info_score.pyx
+++ b/python/cuml/cuml/metrics/cluster/mutual_info_score.pyx
@@ -26,7 +26,7 @@ from pylibraft.common.handle import Handle
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double mutual_info_score(const handle_t &handle,
                              const int *y,
                              const int *y_hat,

--- a/python/cuml/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/cuml/metrics/cluster/silhouette_score.pyx
@@ -31,7 +31,7 @@ from cuml.metrics.distance_type cimport DistanceType
 from cuml.prims.label.classlabels import check_labels, make_monotonic
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics::Batched":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics::Batched" nogil:
     float silhouette_score(
         const handle_t &handle,
         float *y,

--- a/python/cuml/cuml/metrics/cluster/v_measure.pyx
+++ b/python/cuml/cuml/metrics/cluster/v_measure.pyx
@@ -26,7 +26,7 @@ from pylibraft.common.handle import Handle
 from cuml.metrics.cluster.utils import prepare_cluster_metric_inputs
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double v_measure(const handle_t & handle,
                      const int * y,
                      const int * y_hat,

--- a/python/cuml/cuml/metrics/distance_type.pxd
+++ b/python/cuml/cuml/metrics/distance_type.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-cdef extern from "cuvs/distance/distance.hpp" namespace "cuvs::distance":
+cdef extern from "cuvs/distance/distance.hpp" namespace "cuvs::distance" nogil:
 
     ctypedef enum DistanceType:
         L2Expanded "cuvs::distance::DistanceType::L2Expanded"

--- a/python/cuml/cuml/metrics/kl_divergence.pyx
+++ b/python/cuml/cuml/metrics/kl_divergence.pyx
@@ -24,7 +24,7 @@ from libc.stdint cimport uintptr_t
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double c_kl_divergence "ML::Metrics::kl_divergence"(
         const handle_t &handle,
         const double *y,

--- a/python/cuml/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/cuml/metrics/pairwise_distances.pyx
@@ -40,7 +40,7 @@ from cuml.metrics.distance_type cimport DistanceType
 from cuml.thirdparty_adapters import _get_mask
 
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     void pairwise_distance(const handle_t &handle, const double *x,
                            const double *y, double *dist, int m, int n, int k,
                            DistanceType metric, bool isRowMajor,

--- a/python/cuml/cuml/metrics/raft_distance_type.pxd
+++ b/python/cuml/cuml/metrics/raft_distance_type.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-cdef extern from "raft/distance/distance_types.hpp" namespace "raft::distance":
+cdef extern from "raft/distance/distance_types.hpp" namespace "raft::distance" nogil:
 
     ctypedef enum DistanceType:
         L2Expanded "raft::distance::DistanceType::L2Expanded"

--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -26,12 +26,12 @@ from libc.stdint cimport uintptr_t
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuvs/distance/distance.hpp" namespace "cuvs::distance":
+cdef extern from "cuvs/distance/distance.hpp" namespace "cuvs::distance" nogil:
 
     ctypedef int DistanceType
     ctypedef DistanceType euclidean "(cuvs::distance::DistanceType)5"
 
-cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics":
+cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
 
     cdef double trustworthiness_score[T, DistanceType](const handle_t& h,
                                                        T* X,

--- a/python/cuml/cuml/neighbors/ann.pxd
+++ b/python/cuml/cuml/neighbors/ann.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@ from libc.stdint cimport uintptr_t
 from libcpp cimport bool
 
 
-cdef extern from "cuml/neighbors/knn.hpp" \
-        namespace "ML":
+cdef extern from "cuml/neighbors/knn.hpp" namespace "ML" nogil:
 
     cdef cppclass knnIndex:
         pass

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -38,7 +38,7 @@ from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 
-cdef extern from "cuml/neighbors/knn.hpp" namespace "ML":
+cdef extern from "cuml/neighbors/knn.hpp" namespace "ML" nogil:
 
     void knn_classify(
         handle_t &handle,

--- a/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -36,8 +36,7 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 
 
-cdef extern from "cuml/neighbors/knn_mg.hpp" namespace \
-        "ML::KNN::opg":
+cdef extern from "cuml/neighbors/knn_mg.hpp" namespace "ML::KNN::opg" nogil:
 
     cdef void knn_classify(
         handle_t &handle,

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -35,7 +35,7 @@ from pylibraft.common.handle cimport handle_t
 cimport cuml.common.cuda
 
 
-cdef extern from "cuml/neighbors/knn.hpp" namespace "ML":
+cdef extern from "cuml/neighbors/knn.hpp" namespace "ML" nogil:
 
     void knn_regress(
         handle_t &handle,

--- a/python/cuml/cuml/neighbors/kneighbors_regressor_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor_mg.pyx
@@ -33,8 +33,7 @@ from pylibraft.common.handle cimport handle_t
 from cuml.common.opg_data_utils_mg cimport *
 
 
-cdef extern from "cuml/neighbors/knn_mg.hpp" namespace \
-        "ML::KNN::opg":
+cdef extern from "cuml/neighbors/knn_mg.hpp" namespace "ML::KNN::opg" nogil:
 
     cdef void knn_regress(
         handle_t &handle,

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -51,7 +51,7 @@ from cuml.metrics.raft_distance_type cimport DistanceType as RaftDistanceType
 from cuml.neighbors.ann cimport *
 
 
-cdef extern from "raft/spatial/knn/ball_cover_types.hpp" namespace "raft::spatial::knn":
+cdef extern from "raft/spatial/knn/ball_cover_types.hpp" namespace "raft::spatial::knn" nogil:
     cdef cppclass BallCoverIndex[int64_t, float, uint32_t]:
         BallCoverIndex(const handle_t &handle,
                        float *X,
@@ -59,7 +59,7 @@ cdef extern from "raft/spatial/knn/ball_cover_types.hpp" namespace "raft::spatia
                        uint32_t n_cols,
                        RaftDistanceType metric) except +
 
-cdef extern from "cuml/neighbors/knn.hpp" namespace "ML":
+cdef extern from "cuml/neighbors/knn.hpp" namespace "ML" nogil:
     void brute_force_knn(
         const handle_t &handle,
         vector[float*] &inputs,
@@ -112,7 +112,7 @@ cdef extern from "cuml/neighbors/knn.hpp" namespace "ML":
         int n
     ) except +
 
-cdef extern from "cuml/neighbors/knn_sparse.hpp" namespace "ML::Sparse":
+cdef extern from "cuml/neighbors/knn_sparse.hpp" namespace "ML::Sparse" nogil:
     void brute_force_knn(handle_t &handle,
                          const int *idxIndptr,
                          const int *idxIndices,

--- a/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -37,8 +37,7 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 
 
-cdef extern from "cuml/neighbors/knn_mg.hpp" namespace \
-        "ML::KNN::opg":
+cdef extern from "cuml/neighbors/knn_mg.hpp" namespace "ML::KNN::opg" nogil:
 
     cdef void knn(
         handle_t &handle,

--- a/python/cuml/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/cuml/random_projection/random_projection.pyx
@@ -33,7 +33,7 @@ from cuml.internals.mixins import FMajorInputTagMixin
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 
 
-cdef extern from "cuml/random_projection/rproj_c.h" namespace "ML":
+cdef extern from "cuml/random_projection/rproj_c.h" namespace "ML" nogil:
 
     # Structure holding random projection hyperparameters
     cdef struct paramsRPROJ:

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -30,7 +30,7 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
+cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver" nogil:
 
     cdef void cdFit(handle_t& handle,
                     float *input,

--- a/python/cuml/cuml/solvers/cd_mg.pyx
+++ b/python/cuml/cuml/solvers/cd_mg.pyx
@@ -32,7 +32,7 @@ from cuml.linear_model.base_mg import MGFitMixin
 from cuml.solvers import CD
 
 
-cdef extern from "cuml/solvers/cd_mg.hpp" namespace "ML::CD::opg":
+cdef extern from "cuml/solvers/cd_mg.hpp" namespace "ML::CD::opg" nogil:
 
     cdef void fit(handle_t& handle,
                   vector[floatData_t *] input_data,

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -32,7 +32,7 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver":
+cdef extern from "cuml/solvers/solver.hpp" namespace "ML::Solver" nogil:
 
     cdef void sgdFit(handle_t& handle,
                      float *input,

--- a/python/cuml/cuml/svm/svc.pyx
+++ b/python/cuml/cuml/svm/svc.pyx
@@ -121,8 +121,7 @@ if has_sklearn():
                 return self.multi_class_model.predict_proba(X)
 
 
-cdef extern from "cuvs/distance/distance.hpp" \
-        namespace "cuvs::distance::kernels":
+cdef extern from "cuvs/distance/distance.hpp"  namespace "cuvs::distance::kernels" nogil:
     enum KernelType:
         LINEAR,
         POLYNOMIAL,
@@ -135,7 +134,7 @@ cdef extern from "cuvs/distance/distance.hpp" \
         double gamma
         double coef0
 
-cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM":
+cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM" nogil:
     enum SvmType:
         C_SVC,
         NU_SVC,
@@ -153,7 +152,7 @@ cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM":
         double epsilon
         SvmType svmType
 
-cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM":
+cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM" nogil:
 
     cdef cppclass SupportStorage[math_t]:
         int nnz

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -41,8 +41,7 @@ from cuml.internals.mixins import FMajorInputTagMixin, SparseInputTagMixin
 from libcpp cimport bool
 
 
-cdef extern from "cuvs/distance/distance.hpp" \
-        namespace "cuvs::distance::kernels":
+cdef extern from "cuvs/distance/distance.hpp" namespace "cuvs::distance::kernels" nogil:
     enum KernelType:
         LINEAR,
         POLYNOMIAL,
@@ -55,7 +54,7 @@ cdef extern from "cuvs/distance/distance.hpp" \
         double gamma
         double coef0
 
-cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM":
+cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM" nogil:
     enum SvmType:
         C_SVC,
         NU_SVC,
@@ -74,7 +73,7 @@ cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM":
         SvmType svmType
 
 
-cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM":
+cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM" nogil:
 
     cdef cppclass SupportStorage[math_t]:
         int nnz
@@ -93,7 +92,7 @@ cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM":
         int n_classes
         math_t *unique_labels
 
-cdef extern from "cuml/svm/svc.hpp" namespace "ML::SVM":
+cdef extern from "cuml/svm/svc.hpp" namespace "ML::SVM" nogil:
 
     cdef void svcPredict[math_t](
         const handle_t &handle, math_t* data, int n_rows, int n_cols,

--- a/python/cuml/cuml/svm/svr.pyx
+++ b/python/cuml/cuml/svm/svr.pyx
@@ -40,7 +40,7 @@ from cuml.svm.svm_base import SVMBase
 from cuml.internals.logger cimport level_enum
 
 
-cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":
+cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix" nogil:
     enum KernelType:
         LINEAR, POLYNOMIAL, RBF, TANH
 
@@ -50,7 +50,7 @@ cdef extern from "cuml/matrix/kernelparams.h" namespace "MLCommon::Matrix":
         double gamma
         double coef0
 
-cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM":
+cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM" nogil:
     enum SvmType:
         C_SVC, NU_SVC, EPSILON_SVR, NU_SVR
 
@@ -65,7 +65,7 @@ cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM":
         double epsilon
         SvmType svmType
 
-cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM":
+cdef extern from "cuml/svm/svm_model.h" namespace "ML::SVM" nogil:
 
     cdef cppclass SupportStorage[math_t]:
         int nnz

--- a/python/cuml/cuml/tsa/arima.pxd
+++ b/python/cuml/cuml/tsa/arima.pxd
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-cdef extern from "cuml/tsa/arima_common.h" namespace "ML":
+cdef extern from "cuml/tsa/arima_common.h" namespace "ML" nogil:
     ctypedef struct ARIMAOrder:
         int p       # Basic order
         int d

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -39,7 +39,7 @@ from cuml.internals.input_utils import input_to_cuml_array
 from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 
 
-cdef extern from "cuml/tsa/arima_common.h" namespace "ML":
+cdef extern from "cuml/tsa/arima_common.h" namespace "ML" nogil:
     cdef cppclass ARIMAParams[DataT]:
         DataT* mu
         DataT* beta
@@ -57,7 +57,7 @@ cdef extern from "cuml/tsa/arima_common.h" namespace "ML":
         size_t compute_size(const ARIMAOrder& order, int batch_size, int n_obs)
 
 
-cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML":
+cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML" nogil:
     ctypedef enum LoglikeMethod: CSS, MLE
 
     void cpp_pack "pack" (
@@ -113,7 +113,7 @@ cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML":
         const ARIMAOrder& order, bool missing)
 
 
-cdef extern from "cuml/tsa/batched_kalman.hpp" namespace "ML":
+cdef extern from "cuml/tsa/batched_kalman.hpp" namespace "ML" nogil:
 
     void batched_jones_transform(
         handle_t& handle, ARIMAMemory[double]& arima_mem,

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -46,7 +46,7 @@ from cuml.tsa.stationarity import kpss_test
 # - Would a "one-fits-all" method be useful?
 
 
-cdef extern from "cuml/tsa/auto_arima.h" namespace "ML":
+cdef extern from "cuml/tsa/auto_arima.h" namespace "ML" nogil:
     int divide_by_mask_build_index(const handle_t& handle, const bool* mask,
                                    int* index, int batch_size)
 
@@ -98,7 +98,7 @@ cdef extern from "cuml/tsa/auto_arima.h" namespace "ML":
         const int* d_id_to_pos, const int* d_id_to_sub, double* d_out,
         int batch_size, int n_sub, int n_obs)
 
-cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML":
+cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML" nogil:
     bool detect_missing(
         handle_t& handle, const double* d_y, int n_elem)
 

--- a/python/cuml/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/cuml/tsa/holtwinters.pyx
@@ -31,12 +31,12 @@ from cuml.internals.input_utils import input_to_cupy_array
 from pylibraft.common.handle cimport handle_t
 
 
-cdef extern from "cuml/tsa/holtwinters_params.h" namespace "ML":
+cdef extern from "cuml/tsa/holtwinters_params.h" namespace "ML" nogil:
     enum SeasonalType:
         ADDITIVE
         MULTIPLICATIVE
 
-cdef extern from "cuml/tsa/holtwinters.h" namespace "ML::HoltWinters":
+cdef extern from "cuml/tsa/holtwinters.h" namespace "ML::HoltWinters" nogil:
     cdef void buffer_size(
         int n, int batch_size, int frequency,
         int *start_leveltrend_len, int *start_season_len,

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -30,7 +30,7 @@ from pylibraft.common.handle import Handle
 from cuml.internals.input_utils import input_to_cuml_array
 
 
-cdef extern from "cuml/tsa/stationarity.h" namespace "ML":
+cdef extern from "cuml/tsa/stationarity.h" namespace "ML" nogil:
     int cpp_kpss "ML::Stationarity::kpss_test" (
         const handle_t& handle,
         const float* d_y,


### PR DESCRIPTION
This adds `nogil` to _most_ of our calls into `libcuml`. This was mostly a mechanical PR, with the exception of the callback associated with `umap` (where we had to reacquire the GIL in the callback).

Fixes #6271.