### PR TITLE
Speedup dask `LogisticRegression` tests

### DIFF
--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -14,7 +14,6 @@
 #
 
 import random
-from functools import partial
 
 import cudf
 import cupy as cp
@@ -476,13 +475,10 @@ def test_l1(fit_intercept, delayed, n_classes, C, client):
 
 @pytest.mark.mg
 @pytest.mark.parametrize("fit_intercept", [False, True])
-@pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize("delayed", [True])
 @pytest.mark.parametrize("n_classes", [2, 6])
 @pytest.mark.parametrize("l1_ratio", [0.2, 0.8])
-def test_elasticnet(
-    fit_intercept, datatype, delayed, n_classes, l1_ratio, client
-):
+def test_elasticnet(fit_intercept, delayed, n_classes, l1_ratio, client):
     datatype = np.float32 if fit_intercept else np.float64
 
     nrows = int(1e5) if n_classes < 5 else int(2e5)
@@ -524,8 +520,7 @@ def test_sparse_from_dense(reg_dtype, client):
 
     _convert_index = np.int32 if random.choice([True, False]) else np.int64
 
-    run_test = partial(
-        _test_lbfgs,
+    lr = _test_lbfgs(
         nrows=int(1e5),
         ncols=20,
         n_parts=2,
@@ -540,8 +535,6 @@ def test_sparse_from_dense(reg_dtype, client):
         convert_to_sparse=True,
         _convert_index=_convert_index,
     )
-
-    lr = run_test()
     assert lr.dtype == datatype
     assert lr.index_dtype == _convert_index
 

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -521,18 +521,15 @@ def test_elasticnet(
         (("elasticnet", 2.0, 0.2), np.float64),
     ],
 )
-@pytest.mark.parametrize("n_classes", [2, 6])
-def test_sparse_from_dense(fit_intercept, reg_dtype, n_classes, client):
+def test_sparse_from_dense(fit_intercept, reg_dtype, client):
     penalty, C, l1_ratio = reg_dtype[0]
     datatype = reg_dtype[1]
-
-    nrows = int(1e5) if n_classes < 5 else int(2e5)
 
     _convert_index = np.int32 if random.choice([True, False]) else np.int64
 
     run_test = partial(
         _test_lbfgs,
-        nrows=nrows,
+        nrows=int(1e5),
         ncols=20,
         n_parts=2,
         fit_intercept=fit_intercept,
@@ -540,7 +537,7 @@ def test_sparse_from_dense(fit_intercept, reg_dtype, n_classes, client):
         delayed=True,
         client=client,
         penalty=penalty,
-        n_classes=n_classes,
+        n_classes=2,
         C=C,
         l1_ratio=l1_ratio,
         convert_to_sparse=True,
@@ -628,9 +625,8 @@ def test_exception_one_label(fit_intercept, client):
     ],
 )
 @pytest.mark.parametrize("delayed", [False])
-@pytest.mark.parametrize("n_classes", [2, 6])
 def test_standardization_on_normal_dataset(
-    fit_intercept, reg_dtype, delayed, n_classes, client
+    fit_intercept, reg_dtype, delayed, client
 ):
 
     regularization = reg_dtype[0]
@@ -639,11 +635,9 @@ def test_standardization_on_normal_dataset(
     C = regularization[1]
     l1_ratio = regularization[2]
 
-    nrows = int(1e5) if n_classes < 5 else int(2e5)
-
     # test correctness compared with scikit-learn
     lr = _test_lbfgs(
-        nrows=nrows,
+        nrows=int(1e5),
         ncols=20,
         n_parts=2,
         fit_intercept=fit_intercept,
@@ -651,7 +645,7 @@ def test_standardization_on_normal_dataset(
         delayed=delayed,
         client=client,
         penalty=penalty,
-        n_classes=n_classes,
+        n_classes=2,
         C=C,
         l1_ratio=l1_ratio,
         standardization=True,

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -451,7 +451,7 @@ def test_n_classes(n_parts, fit_intercept, n_classes, client):
 @pytest.mark.mg
 @pytest.mark.parametrize("fit_intercept", [False, True])
 @pytest.mark.parametrize("delayed", [True])
-@pytest.mark.parametrize("n_classes", [2, 8])
+@pytest.mark.parametrize("n_classes", [2, 6])
 @pytest.mark.parametrize("C", [1.0, 10.0])
 def test_l1(fit_intercept, delayed, n_classes, C, client):
     datatype = np.float64 if fit_intercept else np.float32
@@ -480,7 +480,7 @@ def test_l1(fit_intercept, delayed, n_classes, C, client):
 @pytest.mark.parametrize("fit_intercept", [False, True])
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize("delayed", [True])
-@pytest.mark.parametrize("n_classes", [2, 8])
+@pytest.mark.parametrize("n_classes", [2, 6])
 @pytest.mark.parametrize("l1_ratio", [0.2, 0.8])
 def test_elasticnet(
     fit_intercept, datatype, delayed, n_classes, l1_ratio, client
@@ -521,7 +521,7 @@ def test_elasticnet(
         (("elasticnet", 2.0, 0.2), np.float64),
     ],
 )
-@pytest.mark.parametrize("n_classes", [2, 8])
+@pytest.mark.parametrize("n_classes", [2, 6])
 def test_sparse_from_dense(fit_intercept, reg_dtype, n_classes, client):
     penalty, C, l1_ratio = reg_dtype[0]
     datatype = reg_dtype[1]
@@ -628,7 +628,7 @@ def test_exception_one_label(fit_intercept, client):
     ],
 )
 @pytest.mark.parametrize("delayed", [False])
-@pytest.mark.parametrize("n_classes", [2, 8])
+@pytest.mark.parametrize("n_classes", [2, 6])
 def test_standardization_on_normal_dataset(
     fit_intercept, reg_dtype, delayed, n_classes, client
 ):

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -585,7 +585,7 @@ def test_sparse_nlp20news(dtype, nlp_20news, client):
 
     from sklearn.linear_model import LogisticRegression as CPULR
 
-    cpu = CPULR(C=20.0)
+    cpu = CPULR(C=20.0, solver="saga")
     cpu.fit(X_train, y_train)
     cpu_preds = cpu.predict(X_test)
     cpu_score = accuracy_score(y_test, cpu_preds.tolist())

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -428,7 +428,7 @@ def test_n_classes_small(client):
 
 @pytest.mark.parametrize("n_parts", [2, 23])
 @pytest.mark.parametrize("fit_intercept", [False, True])
-@pytest.mark.parametrize("n_classes", [8])
+@pytest.mark.parametrize("n_classes", [2, 6])
 def test_n_classes(n_parts, fit_intercept, n_classes, client):
     datatype = np.float32 if fit_intercept else np.float64
     nrows = int(1e5) if n_classes < 5 else int(2e5)

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -712,20 +712,18 @@ def adjust_standardization_model_for_comparison(
     ],
 )
 @pytest.mark.parametrize("delayed", [False])
-@pytest.mark.parametrize("ncol_and_nclasses", [(2, 2), (6, 4), (100, 10)])
 def test_standardization_on_scaled_dataset(
-    fit_intercept, reg_dtype, delayed, ncol_and_nclasses, client
+    fit_intercept, reg_dtype, delayed, client
 ):
-
     regularization = reg_dtype[0]
     datatype = reg_dtype[1]
 
     penalty = regularization[0]
     C = regularization[1]
     l1_ratio = regularization[2]
-    n_classes = ncol_and_nclasses[1]
-    nrows = int(1e5) if n_classes < 5 else int(2e5)
-    ncols = ncol_and_nclasses[0]
+    nrows = int(2e5)
+    ncols = 20
+    n_classes = 6
     n_info = ncols
     n_redundant = 0
     n_parts = 2


### PR DESCRIPTION
This PR applies a few changes (see the commit messages for details) to speedup the dask `LogisticRegression` tests. Most of the changes fall into one of a few categories:

- Removing useless parametrization (either unnecessary for testing the specific feature targeted by the test, or actually ignored and was just doubling the number of tests run)
- Reducing the scale tested by a bit
- Coupling certain parameter combinations to reduce the number of tests without reducing coverage
- Using a faster solver for the CPU versions

All together this reduces the time taken from 28 minutes to 7 minutes on my machine, a 4x speedup.

For I assume historical reasons, most of the dask test suite doesn't run in PRs since it's gated behind `quality_param`/`stress_param` annotations. This file is one of the exceptions, and thus takes ~1/2 the time used for a single PR test run. Rather than add those annotations here (I'm mostly against them and hope we can remove them, as discussed in #6580), I've opted to making the tests here more targeted and faster without skipping certain tests in PRs.