### PR TITLE
Do not run the scikit-learn test suite in parallel.

### DIFF
--- a/ci/test_python_scikit_learn_tests.sh
+++ b/ci/test_python_scikit_learn_tests.sh
@@ -16,8 +16,6 @@ rapids-logger "Running scikit-learn tests with cuML acceleration"
 
 # Run the tests
 timeout 1h ./python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh \
-    --numprocesses=8 \
-    --dist=worksteal \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-accel-scikit-learn.xml"
 
 # Analyze results and check pass rate threshold


### PR DESCRIPTION
As a mitigation for gh-6597.
Partial revert of gh-6553.