### PR TITLE
CI: Increase nightly CI check window to 14 days.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,6 +58,7 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
+          max_days_without_success: 14
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
Increase nightly CI check window to 14 days to account for current test issues in the scikit-learn test suite.