### PR TITLE
Adjust scikit-learn test failure handling

### DIFF
--- a/ci/test_python_scikit_learn_tests.sh
+++ b/ci/test_python_scikit_learn_tests.sh
@@ -18,7 +18,7 @@ TEST_EXITCODE=$?
 # Analyze results and check pass rate threshold
 rapids-logger "Analyzing test results"
 ./python/cuml/cuml/accel/tests/scikit-learn/summarize-results.py \
-    --fail-below 80 \
+    --fail-below 85 \
     "${RAPIDS_TESTS_DIR}/junit-cuml-accel-scikit-learn.xml"
 THRESHOLD_EXITCODE=$?
 

--- a/ci/test_python_scikit_learn_tests.sh
+++ b/ci/test_python_scikit_learn_tests.sh
@@ -7,22 +7,29 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../ || exit 1
 # Common setup steps shared by Python test jobs
 source ./ci/test_python_common.sh
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
 # Run scikit-learn tests with acceleration enabled
 rapids-logger "Running scikit-learn tests with cuML acceleration"
 
-# Run the tests
+# Run the tests and capture the exit code
 timeout 1h ./python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-accel-scikit-learn.xml"
+TEST_EXITCODE=$?
 
 # Analyze results and check pass rate threshold
 rapids-logger "Analyzing test results"
 ./python/cuml/cuml/accel/tests/scikit-learn/summarize-results.py \
     --fail-below 80 \
     "${RAPIDS_TESTS_DIR}/junit-cuml-accel-scikit-learn.xml"
+THRESHOLD_EXITCODE=$?
+
+# Set final exit code based on conditions
+if [ "${RAPIDS_BUILD_TYPE}" == "nightly" ]; then
+    # For nightly runs, only fail if threshold is not met
+    EXITCODE=$THRESHOLD_EXITCODE
+else
+    # For regular runs, fail on any test failure
+    EXITCODE=$TEST_EXITCODE
+fi
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh
+++ b/python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh
@@ -14,14 +14,14 @@ set -eu
 # Get CUDA version
 CUDA_VERSION=$(nvcc --version | grep "release" | awk '{print $5}' | cut -d',' -f1)
 
-# Skip specific tests based on CUDA version
+# Base arguments
+PYTEST_ARGS="-p cuml.accel --pyargs sklearn -v --xfail-list=\"$(dirname "$0")/xfail-list.yaml\""
+
+# Skip sequential tests for CUDA 11.x until
+# https://github.com/rapidsai/cuml/issues/6622 is resolved
 if [[ "$CUDA_VERSION" == "11"* ]]; then
-    SKIP_TESTS="-k 'not test_sequential'"
-else
-    SKIP_TESTS=""
+    PYTEST_ARGS="$PYTEST_ARGS -k \"not test_sequential\""
 fi
 
-pytest -p cuml.accel --pyargs sklearn -v \
-    --xfail-list="$(dirname "$0")/xfail-list.yaml" \
-    $SKIP_TESTS \
-    "$@"
+# Run pytest with all arguments
+eval "pytest $PYTEST_ARGS" "$@"

--- a/python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh
+++ b/python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh
@@ -15,7 +15,7 @@ set -eu
 CUDA_VERSION=$(nvcc --version | grep "release" | awk '{print $5}' | cut -d',' -f1)
 
 # Base arguments
-PYTEST_ARGS="-p cuml.accel --pyargs sklearn -v --xfail-list=\"$(dirname "$0")/xfail-list.yaml\""
+PYTEST_ARGS="-p cuml.accel --pyargs sklearn --xfail-list=\"$(dirname "$0")/xfail-list.yaml\""
 
 # Skip sequential tests for CUDA 11.x until
 # https://github.com/rapidsai/cuml/issues/6622 is resolved


### PR DESCRIPTION
- Fix test_sequential skip for CUDA 11.x by properly handling the skip condition
- Modify test failure behavior to be more appropriate for different test scenarios:
  - Nightly tests: Only fail if pass rate threshold (80%) is not met
  - Regular test runs: Fail on any test failure to catch all regressions and improvements
- Reduce verbosity of scikit-learn cuml.accel tests for cleaner test output
- Increase scikit-learn test pass rate threshold from 80% to 85% to adjust for current pass rate.