### PR TITLE
Fix the field ids in the pr/issue status automation

### DIFF
--- a/.github/workflows/pr_issue_status_automation.yml
+++ b/.github/workflows/pr_issue_status_automation.yml
@@ -24,7 +24,7 @@ jobs:
       needs: get-project-id
       with:
         PROJECT_ID: "PVT_kwDOAp2shc4AA8lR"
-        SINGLE_SELECT_FIELD_ID: "PVTSSF_lADOAp2shc4AiNzlzgaxNac"
+        SINGLE_SELECT_FIELD_ID: "PVTSSF_lADOAp2shc4AA8lRzgAftsM"
         SINGLE_SELECT_FIELD_NAME: "Status"
         SINGLE_SELECT_OPTION_VALUE: "In Progress"
         ITEM_PROJECT_ID: "${{ needs.get-project-id.outputs.ITEM_PROJECT_ID }}"
@@ -54,7 +54,7 @@ jobs:
       needs: [get-project-id, process-branch-name]
       with:
         PROJECT_ID: "PVT_kwDOAp2shc4AA8lR"
-        SINGLE_SELECT_FIELD_ID: "PVTSSF_lADOAp2shc4AiNzlzgg52UQ"
+        SINGLE_SELECT_FIELD_ID: "PVTSSF_lADOAp2shc4AA8lRzgFqH3Y"
         SINGLE_SELECT_FIELD_NAME: "Release"
         SINGLE_SELECT_OPTION_VALUE: "${{ needs.process-branch-name.outputs.branch-name }}"
         ITEM_PROJECT_ID: "${{ needs.get-project-id.outputs.ITEM_PROJECT_ID }}"


### PR DESCRIPTION
Update the field ids in the pr/issue status automation workflow to match the current project configuration.