### PR TITLE
Revert "CI: Increase nightly CI check window to 14 days. (#6628)"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,7 +58,6 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
-          max_days_without_success: 14
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
This reverts commit 4ea180ab263ec7e2dd76681586ae90a2424d3035.