### PR TITLE
Fix bug in pytest_plugin

### DIFF
--- a/python/cuml/cuml/accel/pytest_plugin.py
+++ b/python/cuml/cuml/accel/pytest_plugin.py
@@ -129,9 +129,9 @@ def pytest_collection_modifyitems(config, items):
                 # Add the xfail marker
                 item.add_marker(
                     pytest.mark.xfail(
+                        config["condition"],
                         reason=config["reason"],
                         strict=config["strict"],
-                        condition=config["condition"],
                     )
                 )
                 # If there's a marker, add it as a proper pytest marker


### PR DESCRIPTION
Fix bug in pytest_plugin where condition was passed as a keyword argument to pytest.mark.xfail instead of as the first argument.