### PR TITLE
fix(rattler): add librmm to host for libcuml to fix overlinking error

### DIFF
--- a/conda/recipes/libcuml/recipe.yaml
+++ b/conda/recipes/libcuml/recipe.yaml
@@ -108,6 +108,7 @@ outputs:
         - rapids-logger =0.1
         - libcumlprims =${{ minor_version }}
         - libcuvs =${{ minor_version }}
+        - librmm =${{ minor_version }}
         - treelite ${{ treelite_version }}
         - if: cuda_major == "11"
           then:


### PR DESCRIPTION
## Description

We need `librmm` for _building_ `libcudf` and `librmm` is available in the cache build stage.  However the overlinking checks happen on a per-output basis and now that `librmm` isn't header-only, `rattler` is detecting a missing link.
This adds the `librmm` entry to the `host` section of the appropriate outputs.

xref https://github.com/rapidsai/build-planning/issues/175
