### PR TITLE
Port `sklearn.decomposition` to new proxy estimator structure

### DIFF
--- a/python/cuml/cuml/accel/_wrappers/sklearn/decomposition.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/decomposition.py
@@ -16,7 +16,6 @@
 
 import cuml.decomposition
 from cuml.accel.estimator_proxy import ProxyBase
-from cuml.accel.estimator_proxy_mixin import ProxyMixin
 
 __all__ = ("PCA", "TruncatedSVD")
 
@@ -25,5 +24,5 @@ class PCA(ProxyBase):
     _gpu_class = cuml.decomposition.PCA
 
 
-class TruncatedSVD(ProxyMixin, cuml.decomposition.TruncatedSVD):
-    pass
+class TruncatedSVD(ProxyBase):
+    _gpu_class = cuml.decomposition.TruncatedSVD

--- a/python/cuml/cuml/accel/_wrappers/sklearn/decomposition.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/decomposition.py
@@ -15,13 +15,14 @@
 #
 
 import cuml.decomposition
+from cuml.accel.estimator_proxy import ProxyBase
 from cuml.accel.estimator_proxy_mixin import ProxyMixin
 
 __all__ = ("PCA", "TruncatedSVD")
 
 
-class PCA(ProxyMixin, cuml.decomposition.PCA):
-    pass
+class PCA(ProxyBase):
+    _gpu_class = cuml.decomposition.PCA
 
 
 class TruncatedSVD(ProxyMixin, cuml.decomposition.TruncatedSVD):

--- a/python/cuml/cuml/accel/_wrappers/sklearn/linear_model.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/linear_model.py
@@ -16,7 +16,6 @@
 
 import cuml.linear_model
 from cuml.accel.estimator_proxy import ProxyBase
-from cuml.common.sparse_utils import is_sparse
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.interop import UnsupportedOnGPU
 
@@ -32,11 +31,6 @@ __all__ = (
 class LinearRegression(ProxyBase):
     _gpu_class = cuml.linear_model.LinearRegression
 
-    def _gpu_fit(self, X, y, sample_weight=None):
-        if is_sparse(X):
-            raise UnsupportedOnGPU
-        return self._gpu.fit(X, y, sample_weight=sample_weight)
-
 
 class LogisticRegression(ProxyBase):
     _gpu_class = cuml.linear_model.LogisticRegression
@@ -44,11 +38,6 @@ class LogisticRegression(ProxyBase):
 
 class ElasticNet(ProxyBase):
     _gpu_class = cuml.linear_model.ElasticNet
-
-    def _gpu_fit(self, X, y, sample_weight=None):
-        if is_sparse(X):
-            raise UnsupportedOnGPU
-        return self._gpu.fit(X, y, sample_weight=sample_weight)
 
 
 class Ridge(ProxyBase):
@@ -58,15 +47,8 @@ class Ridge(ProxyBase):
         y = input_to_cuml_array(y, convert_to_mem_type=False)[0]
         if len(y.shape) > 1:
             raise UnsupportedOnGPU
-        if is_sparse(X):
-            raise UnsupportedOnGPU
         return self._gpu.fit(X, y, sample_weight=sample_weight)
 
 
 class Lasso(ProxyBase):
     _gpu_class = cuml.linear_model.Lasso
-
-    def _gpu_fit(self, X, y, sample_weight=None):
-        if is_sparse(X):
-            raise UnsupportedOnGPU
-        return self._gpu.fit(X, y, sample_weight=sample_weight)

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -79,6 +79,8 @@
   - "sklearn.semi_supervised.tests.test_self_training::test_zero_iterations[y1-estimator0]"
   - "sklearn.tests.test_common::test_estimators[ElasticNet()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[Lasso()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[LinearRegression()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_estimator_sparse_tag]"
   - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_n_features_in_after_fitting]"

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -97,7 +97,6 @@
   - "sklearn.decomposition.tests.test_pca::test_infer_dim_by_explained_variance[X0-0.95-2]"
   - "sklearn.decomposition.tests.test_pca::test_infer_dim_by_explained_variance[X1-0.01-1]"
   - "sklearn.decomposition.tests.test_pca::test_infer_dim_by_explained_variance[X2-0.5-2]"
-  - "sklearn.decomposition.tests.test_pca::test_mle_simple_case"
   - "sklearn.decomposition.tests.test_pca::test_n_components_none[data0-arpack-3]"
   - "sklearn.decomposition.tests.test_pca::test_n_components_none[data1-arpack-3]"
   - "sklearn.decomposition.tests.test_pca::test_pca_dtype_preservation[42-arpack]"
@@ -1416,6 +1415,24 @@
   - "sklearn.tests.test_common::test_estimators[Ridge()-check_fit1d]"
   - "sklearn.tests.test_common::test_estimators[Ridge()-check_fit2d_predict1d]"
   - "sklearn.tests.test_common::test_estimators[Ridge()-check_requires_y_none]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_complex_data]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_dtype_object]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_estimators_empty_data_messages]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_estimators_nan_inf]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_transformer_data_not_an_array]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_fit2d_1sample]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_fit2d_1feature]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_fit1d]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_fit2d_predict1d]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_complex_data]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_dtype_object]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_estimators_empty_data_messages]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_estimators_nan_inf]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_transformer_data_not_an_array]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_fit2d_1sample]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_fit2d_1feature]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_fit1d]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_fit2d_predict1d]"
 - reason: "cuml doesn't set `feature_names_in_` properly"
   marker: cuml_accel_feature_names_in
   tests:
@@ -1424,6 +1441,8 @@
   - "sklearn.tests.test_common::test_pandas_column_name_consistency[LinearRegression()]"
   - "sklearn.tests.test_common::test_pandas_column_name_consistency[LogisticRegression()]"
   - "sklearn.tests.test_common::test_pandas_column_name_consistency[Ridge()]"
+  - "sklearn.tests.test_common::test_pandas_column_name_consistency[PCA()]"
+  - "sklearn.tests.test_common::test_pandas_column_name_consistency[TruncatedSVD()]"
 - reason: "cuml raises a different error if X doesn't have expected n features"
   marker: cuml_accel_check_n_features_in
   tests:
@@ -1432,6 +1451,8 @@
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[LinearRegression()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[LogisticRegression()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[Ridge()]"
+  - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[PCA()]"
+  - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[TruncatedSVD()]"
 - reason: "cuml missing certain fit attributes"
   marker: cuml_accel_missing_fit_attributes
   tests:

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -32,16 +32,19 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.exceptions import NotFittedError
 from cuml.common.sparse_utils import is_sparse
-from cuml.internals.api_decorators import (
-    device_interop_preparation,
-    enable_device_interop,
-)
 from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import Base
 from cuml.internals.input_utils import (
     input_to_cuml_array,
     input_to_cupy_array,
     sparse_scipy_to_cp,
+)
+from cuml.internals.interop import (
+    InteropMixin,
+    UnsupportedOnGPU,
+    to_cpu,
+    to_gpu,
+    warn_legacy_device_interop,
 )
 from cuml.internals.mixins import FMajorInputTagMixin, SparseInputTagMixin
 from cuml.prims.stats import cov
@@ -112,7 +115,8 @@ class Solver(IntEnum):
     COV_EIG_JACOBI = <underlying_type_t_solver> solver.COV_EIG_JACOBI
 
 
-class PCA(UniversalBase,
+class PCA(Base,
+          InteropMixin,
           FMajorInputTagMixin,
           SparseInputTagMixin):
 
@@ -267,7 +271,6 @@ class PCA(UniversalBase,
     <http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html>`_.
     """
 
-    _cpu_estimator_import_path = 'sklearn.decomposition.PCA'
     components_ = CumlArrayDescriptor(order='F')
     explained_variance_ = CumlArrayDescriptor(order='F')
     explained_variance_ratio_ = CumlArrayDescriptor(order='F')
@@ -275,27 +278,82 @@ class PCA(UniversalBase,
     mean_ = CumlArrayDescriptor(order='F')
     trans_input_ = CumlArrayDescriptor(order='F')
 
-    _hyperparam_interop_translator = {
-        "svd_solver": {
-            "arpack": "full",
-            "randomized": "full",
-            "covariance_eigh": "full"
-        },
-        "iterated_power": {
-            "auto": 15,
-        },
-        "n_components": {
-            "mle": "NotImplemented"
-        },
-        "tol": {
-            # tolerance controls tolerance of different solvers
-            # between sklearn and cuML, so at least the default
-            # value needs to be translated.
-            0.0: 1e-7
-        }
-    }
+    _cpu_class_path = "sklearn.decomposition.PCA"
 
-    @device_interop_preparation
+    @classmethod
+    def _get_param_names(cls):
+        return super()._get_param_names() + \
+            ["copy", "iterated_power", "n_components", "svd_solver", "tol", "whiten"]
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        if model.n_components == "mle":
+            raise UnsupportedOnGPU
+
+        svd_solver = "auto" if model.svd_solver == "auto" else "full"
+
+        # Since the solvers are different, we want to adjust the tolerances used.
+        # TODO: here we only adjust the default tolerance, there's likely a better
+        # conversion equation we should apply.
+        if (tol := model.tol) == 0.0:
+            tol = 1e-7
+
+        if (iterated_power := model.iterated_power) == "auto":
+            iterated_power = 15
+
+        return {
+            "n_components": model.n_components,
+            "copy": model.copy,
+            "whiten": model.whiten,
+            "svd_solver": svd_solver,
+            "tol": tol,
+            "iterated_power": iterated_power,
+        }
+
+    def _params_to_cpu(self):
+        # Since the solvers are different, we want to adjust the tolerances used.
+        # TODO: here we only adjust the default tolerance, there's likely a better
+        # conversion equation we should apply.
+        if (tol := self.tol) == 1e-7:
+            tol = 0.0
+
+        svd_solver = "auto" if self.svd_solver == "jacobi" else self.svd_solver
+
+        return {
+            "n_components": self.n_components,
+            "copy": self.copy,
+            "whiten": self.whiten,
+            "svd_solver": svd_solver,
+            "tol": tol,
+            "iterated_power": self.iterated_power,
+        }
+
+    def _attrs_from_cpu(self, model):
+        return {
+            "components_": to_gpu(model.components_, order="F"),
+            "explained_variance_": to_gpu(model.explained_variance_, order="F"),
+            "explained_variance_ratio_": to_gpu(model.explained_variance_ratio_, order="F"),
+            "singular_values_": to_gpu(model.singular_values_, order="F"),
+            "mean_": to_gpu(model.mean_, order="F"),
+            "n_components_": model.n_components_,
+            "n_samples_": model.n_samples_,
+            "noise_variance_": model.noise_variance_,
+            **super()._attrs_from_cpu(model),
+        }
+
+    def _attrs_to_cpu(self, model):
+        return {
+            "components_": to_cpu(self.components_),
+            "explained_variance_": to_cpu(self.explained_variance_),
+            "explained_variance_ratio_": to_cpu(self.explained_variance_ratio_),
+            "singular_values_": to_cpu(self.singular_values_),
+            "mean_": to_cpu(self.mean_),
+            "n_components_": self.n_components_,
+            "n_samples_": self.n_samples_,
+            "noise_variance_": self.noise_variance_,
+            **super()._attrs_to_cpu(model),
+        }
+
     def __init__(self, *, copy=True, handle=None, iterated_power=15,
                  n_components=None, svd_solver='auto',
                  tol=1e-7, verbose=False, whiten=False,
@@ -418,7 +476,7 @@ class PCA(UniversalBase,
         return self
 
     @generate_docstring(X='dense_sparse')
-    @enable_device_interop
+    @warn_legacy_device_interop
     def fit(self, X, y=None, convert_dtype=True) -> "PCA":
         """
         Fit the model with X. y is currently ignored.
@@ -517,7 +575,7 @@ class PCA(UniversalBase,
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.api_base_return_array_skipall
-    @enable_device_interop
+    @warn_legacy_device_interop
     def fit_transform(self, X, y=None) -> CumlArray:
         """
         Fit the model with X and apply the dimensionality reduction on X.
@@ -563,7 +621,7 @@ class PCA(UniversalBase,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_features)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     def inverse_transform(self, X, convert_dtype=False,
                           return_sparse=False, sparse_tol=1e-10) -> CumlArray:
         """
@@ -666,7 +724,7 @@ class PCA(UniversalBase,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     def transform(self, X, convert_dtype=True) -> CumlArray:
         """
         Apply dimensionality reduction to X.
@@ -740,20 +798,8 @@ class PCA(UniversalBase,
 
         return t_input_data
 
-    @classmethod
-    def _get_param_names(cls):
-        return super()._get_param_names() + \
-            ["copy", "iterated_power", "n_components", "svd_solver", "tol",
-                "whiten"]
-
     def _check_is_fitted(self, attr):
         if not hasattr(self, attr) or (getattr(self, attr) is None):
             msg = ("This instance is not fitted yet. Call 'fit' "
                    "with appropriate arguments before using this estimator.")
             raise NotFittedError(msg)
-
-    def get_attr_names(self):
-        return ['components_', 'explained_variance_',
-                'explained_variance_ratio_', 'singular_values_',
-                'mean_', 'n_components_', 'noise_variance_',
-                'n_samples_', 'n_features_in_', 'feature_names_in_']

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -25,12 +25,14 @@ from enum import IntEnum
 from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.api_decorators import (
-    device_interop_preparation,
-    enable_device_interop,
-)
 from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import Base
+from cuml.internals.interop import (
+    InteropMixin,
+    to_cpu,
+    to_gpu,
+    warn_legacy_device_interop,
+)
 from cuml.internals.mixins import FMajorInputTagMixin
 
 from cython.operator cimport dereference as deref
@@ -101,7 +103,8 @@ class Solver(IntEnum):
     COV_EIG_JACOBI = <underlying_type_t_solver> solver.COV_EIG_JACOBI
 
 
-class TruncatedSVD(UniversalBase,
+class TruncatedSVD(Base,
+                   InteropMixin,
                    FMajorInputTagMixin):
     """
     TruncatedSVD is used to compute the top K singular values and vectors of a
@@ -235,32 +238,69 @@ class TruncatedSVD(UniversalBase,
 
     """
 
-    _cpu_estimator_import_path = 'sklearn.decomposition.TruncatedSVD'
     components_ = CumlArrayDescriptor(order='F')
     explained_variance_ = CumlArrayDescriptor(order='F')
     explained_variance_ratio_ = CumlArrayDescriptor(order='F')
     singular_values_ = CumlArrayDescriptor(order='F')
 
-    _hyperparam_interop_translator = {
-        "algorithm": {
-            "randomized": "full",
-            "arpack": "full",
-        },
-        "tol": {
-            # tolerance controls tolerance of different solvers
-            # between sklearn and cuML, so at least the default
-            # value needs to be translated.
-            0.0: 1e-7
-        },
-        "n_iter": {
-            # Translating the default n_iter from sklearn to the
-            # default of 15 of cuML to keep behavior consistent,
-            # and results performing closer.
-            5: 15
-        }
-    }
+    _cpu_class_path = "sklearn.decomposition.TruncatedSVD"
 
-    @device_interop_preparation
+    @classmethod
+    def _get_param_names(cls):
+        return super()._get_param_names() + \
+            ["algorithm", "n_components", "n_iter", "random_state", "tol"]
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        # Since the solvers are different, we want to adjust tol & n_iter.
+        # TODO: here we only adjust the default values, there's likely a better
+        # conversion equation we should apply.
+        if (tol := model.tol) == 0.0:
+            tol = 1e-7
+        if (n_iter := model.n_iter) == 5:
+            n_iter = 15
+
+        return {
+            "n_components": model.n_components,
+            "algorithm": "full",
+            "n_iter": n_iter,
+            "tol": tol,
+        }
+
+    def _params_to_cpu(self):
+        # Since the solvers are different, we want to adjust tol & n_iter.
+        # TODO: here we only adjust the default values, there's likely a better
+        # conversion equation we should apply.
+        if (tol := self.tol) == 1e-7:
+            tol = 0.0
+        if (n_iter := self.n_iter) == 15:
+            n_iter = 5
+
+        return {
+            "n_components": self.n_components,
+            "algorithm": "randomized",
+            "n_iter": n_iter,
+            "tol": tol,
+        }
+
+    def _attrs_from_cpu(self, model):
+        return {
+            "components_": to_gpu(model.components_, order="F"),
+            "explained_variance_": to_gpu(model.explained_variance_, order="F"),
+            "explained_variance_ratio_": to_gpu(model.explained_variance_ratio_, order="F"),
+            "singular_values_": to_gpu(model.singular_values_, order="F"),
+            **super()._attrs_from_cpu(model),
+        }
+
+    def _attrs_to_cpu(self, model):
+        return {
+            "components_": to_cpu(self.components_),
+            "explained_variance_": to_cpu(self.explained_variance_),
+            "explained_variance_ratio_": to_cpu(self.explained_variance_ratio_),
+            "singular_values_": to_cpu(self.singular_values_),
+            **super()._attrs_to_cpu(model),
+        }
+
     def __init__(self, *, algorithm='full', handle=None, n_components=1,
                  n_iter=15, random_state=None, tol=1e-7,
                  verbose=False, output_type=None):
@@ -318,7 +358,7 @@ class TruncatedSVD(UniversalBase,
                                                 dtype=self.dtype)
 
     @generate_docstring()
-    @enable_device_interop
+    @warn_legacy_device_interop
     def fit(self, X, y=None) -> "TruncatedSVD":
         """
         Fit LSI model on training cudf DataFrame X. y is currently ignored.
@@ -333,7 +373,7 @@ class TruncatedSVD(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     def fit_transform(self, X, y=None, convert_dtype=True) -> CumlArray:
         """
         Fit LSI model to X and perform dimensionality reduction on X.
@@ -400,7 +440,7 @@ class TruncatedSVD(UniversalBase,
                                        'type': 'dense',
                                        'description': 'X in original space',
                                        'shape': '(n_samples, n_features)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     def inverse_transform(self, X, convert_dtype=False) -> CumlArray:
         """
         Transform X back to its original space.
@@ -449,7 +489,7 @@ class TruncatedSVD(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     def transform(self, X, convert_dtype=True) -> CumlArray:
         """
         Perform dimensionality reduction on X.
@@ -496,13 +536,3 @@ class TruncatedSVD(UniversalBase,
         self.handle.sync()
 
         return t_input_data
-
-    @classmethod
-    def _get_param_names(cls):
-        return super()._get_param_names() + \
-            ["algorithm", "n_components", "n_iter", "random_state", "tol"]
-
-    def get_attr_names(self):
-        return ['components_', 'explained_variance_',
-                'explained_variance_ratio_', 'singular_values_',
-                'n_features_in_', 'feature_names_in_']

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -345,8 +345,7 @@ class LinearRegression(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
-    def fit(self, X, y, convert_dtype=True,
-            sample_weight=None) -> "LinearRegression":
+    def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "LinearRegression":
         """
         Fit the model with X and y.
 

--- a/python/cuml/cuml/tests/test_device_selection.py
+++ b/python/cuml/cuml/tests/test_device_selection.py
@@ -28,7 +28,6 @@ from pytest_cases import fixture, fixture_union
 from sklearn.cluster import DBSCAN as skDBSCAN
 from sklearn.cluster import KMeans as skKMeans
 from sklearn.datasets import make_blobs, make_classification, make_regression
-from sklearn.decomposition import PCA as skPCA
 from sklearn.decomposition import TruncatedSVD as skTruncatedSVD
 from sklearn.ensemble import RandomForestClassifier as skRFC
 from sklearn.ensemble import RandomForestRegressor as skRFR
@@ -44,7 +43,7 @@ import cuml
 from cuml.cluster import DBSCAN, KMeans
 from cuml.cluster.hdbscan import HDBSCAN
 from cuml.common.device_selection import DeviceType, using_device_type
-from cuml.decomposition import PCA, TruncatedSVD
+from cuml.decomposition import TruncatedSVD
 from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.memory_utils import using_memory_type
@@ -270,46 +269,6 @@ def umap_test_data(request):
         }
     )
 )
-def pca_test_data(request):
-    kwargs = {
-        "n_components": request.param["n_components"],
-        "svd_solver": "full",
-        "tol": 1e-07,
-        "iterated_power": 15,
-    }
-
-    sk_model = skPCA(**kwargs)
-    sk_model.fit(X_train_blob, y_train_blob)
-
-    input_type = request.param["input_type"]
-
-    if input_type == "dataframe":
-        modified_y_train = pd.Series(y_train_blob)
-    elif input_type == "cudf":
-        modified_y_train = cudf.Series(y_train_blob)
-    else:
-        modified_y_train = to_output_type(y_train_blob, input_type)
-
-    return {
-        "cuEstimator": PCA,
-        "kwargs": kwargs,
-        "infer_func": "transform",
-        "assert_func": check_allclose_without_sign,
-        "X_train": to_output_type(X_train_blob, input_type),
-        "y_train": modified_y_train,
-        "X_test": to_output_type(X_test_blob, input_type),
-        "ref_y_test": sk_model.transform(X_test_blob),
-    }
-
-
-@fixture(
-    **fixture_generation_helper(
-        {
-            "input_type": ["numpy", "dataframe", "cupy", "cudf", "numba"],
-            "n_components": [2, 8],
-        }
-    )
-)
 def tsvd_test_data(request):
     kwargs = {
         "n_components": request.param["n_components"],
@@ -379,7 +338,6 @@ fixture_union(
     "test_data",
     [
         "umap_test_data",
-        "pca_test_data",
         "tsvd_test_data",
         "nn_test_data",
     ],
@@ -485,7 +443,6 @@ def test_pickle_interop(tmp_path, test_data):
     "estimator",
     [
         UMAP,
-        PCA,
         TruncatedSVD,
         NearestNeighbors,
     ],
@@ -572,23 +529,6 @@ def test_tsne_methods(device):
 
     tol = 0.02
     assert trust >= ref_trust - tol
-
-
-@pytest.mark.parametrize("train_device", ["cpu", "gpu"])
-@pytest.mark.parametrize("infer_device", ["cpu", "gpu"])
-def test_pca_methods(train_device, infer_device):
-    n, p = 500, 5
-    rng = np.random.RandomState(0)
-    X = rng.randn(n, p) * 0.1 + np.array([3, 4, 2, 3, 5])
-
-    model = PCA(n_components=3)
-    with using_device_type(train_device):
-        transformation = model.fit_transform(X)
-    with using_device_type(infer_device):
-        output = model.inverse_transform(transformation)
-
-    output = to_output_type(output, "numpy")
-    np.testing.assert_allclose(X, output, rtol=0.15)
 
 
 @pytest.mark.parametrize("train_device", ["cpu", "gpu"])
@@ -853,17 +793,27 @@ def test_svr_methods(train_device, infer_device):
 
 @pytest.mark.parametrize(
     "cls",
-    ["LogisticRegression", "LinearRegression", "ElasticNet", "Lasso", "Ridge"],
+    [
+        "LogisticRegression",
+        "LinearRegression",
+        "ElasticNet",
+        "Lasso",
+        "Ridge",
+        "PCA",
+    ],
 )
 def test_legacy_device_selection_warns(cls):
     """Check that running in a `using_device_type("cpu")` block warns
     and doesn't fail for classes that used to support CPU execution in
     this manner."""
     model = getattr(cuml, cls)()
-    if model._estimator_type == "classifier":
+    estimator_type = getattr(model, "_estimator_type", None)
+    if estimator_type == "classifier":
         X, y, X_test = (X_train_reg, y_train_reg, X_test_reg)
-    else:
+    elif estimator_type == "regressor":
         X, y, X_test = (X_train_class, y_train_class, X_test_class)
+    else:
+        X, y, X_test = (X_train_blob, y_train_blob, X_test_blob)
 
     with pytest.warns(
         UserWarning, match="Support for setting the `device_type`"
@@ -871,10 +821,17 @@ def test_legacy_device_selection_warns(cls):
         with using_device_type("cpu"):
             model.fit(X, y)
 
-    with pytest.warns(
-        UserWarning, match="Support for setting the `device_type`"
-    ):
-        with using_device_type("cpu"):
-            res = model.predict(X_test)
+    if hasattr(model, "predict"):
+        with pytest.warns(
+            UserWarning, match="Support for setting the `device_type`"
+        ):
+            with using_device_type("cpu"):
+                res = model.predict(X_test)
+    elif hasattr(model, "transform"):
+        with pytest.warns(
+            UserWarning, match="Support for setting the `device_type`"
+        ):
+            with using_device_type("cpu"):
+                res = model.transform(X_test)
 
     assert type(res) is type(X_test)

--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -177,7 +177,7 @@ def test_pca(random_state):
 
 def test_truncated_svd(random_state):
     X = np.random.RandomState(random_state).rand(50, 5)
-    original = TruncatedSVD(n_components=2, random_state=random_state)
+    original = TruncatedSVD(n_components=2)
     assert_estimator_roundtrip(original, SkTruncatedSVD, X, transform=True)
 
 

--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -171,7 +171,7 @@ def test_dbscan(random_state):
 
 def test_pca(random_state):
     X = np.random.RandomState(random_state).rand(50, 5)
-    original = PCA(n_components=2, random_state=random_state)
+    original = PCA(n_components=2)
     assert_estimator_roundtrip(original, SkPCA, X, transform=True)
 
 

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -26,6 +26,7 @@ import sklearn
 from packaging.version import Version
 from sklearn.base import check_is_fitted, is_classifier, is_regressor
 from sklearn.datasets import make_classification, make_regression
+from sklearn.decomposition import PCA
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import (
     ElasticNet,
@@ -112,6 +113,21 @@ def test_BaseEstimator__get_param_names():
     names = LogisticRegression._get_param_names()
     sol = LogisticRegression._cpu_class._get_param_names()
     assert names == sol
+
+
+def test_init_positional_and_keyword():
+    model = PCA()
+    assert model.n_components is None
+
+    model = PCA(n_components=10)
+    assert model.n_components == 10
+
+    model = PCA(10)
+    assert model.n_components == 10
+
+    with pytest.raises(TypeError):
+        # Can't pass keyword-only parameters in as positional
+        PCA(10, False)
 
 
 def test_repr():


### PR DESCRIPTION
This PR:

- Ports `PCA` and `TruncatedSVD` to subclass from `Base` & `InteropMixin` instead of `UniversalBase`
- Ports our wrappers in `cuml.accel` to subclass from `ProxyBase` instead of `ProxyMixin`
- Updates `ProxyBase` to handle the sparse support checks in the base class rather than delegating these to the `_gpu_*` override methods. These checks are common, for now it makes sense to keep them in the base class (this is also how the old `dispatch_func` method worked).
- Updates the xfail list accordingly.

Fixes #6706.