### PR TITLE
Expand sklearn matrix used in tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -170,8 +170,8 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_python_scikit_learn_tests.sh"
-      # Select the amd64 entry with the highest CUDA and Python version
-      matrix_filter: map(select(.ARCH=="amd64")) | [max_by([.CUDA_VER,.PY_VER]|map(split(".")|map(tonumber)))]
+      # One run for each dependencies config on amd64, breaking ties by highest Python version
+      matrix_filter: map(select(.ARCH == "amd64")) | sort_by(.PY_VER) | unique_by(.DEPENDENCIES)
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit


### PR DESCRIPTION
Previously we were only running one run of the sklearn test suite in PRs. Now that we support multiple versions of sklearn, we amend this list to select one run with the oldest deps and one run with the latest deps.