### PR TITLE
Fix output dtype of `LinearSVC.predict`

### DIFF
--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -14,6 +14,7 @@
 #
 
 from cuml.common import input_to_cuml_array
+from cuml.internals.array import CumlArray
 from cuml.internals.mixins import ClassifierMixin
 from cuml.svm.linear import LinearSVM, LinearSVM_defaults  # noqa: F401
 from cuml.svm.svc import apply_class_weight
@@ -40,7 +41,7 @@ class LinearSVC(LinearSVM, ClassifierMixin):
         >>> clf.fit(X, y)
         LinearSVC()
         >>> print("Predicted labels:", clf.predict(X))
-        Predicted labels: [0. 0. 1. 0. 1. 1.]
+        Predicted labels: [0 0 1 0 1 1]
 
     Parameters
     ----------
@@ -207,3 +208,8 @@ class LinearSVC(LinearSVM, ClassifierMixin):
             X.dtype,
         )
         return super(LinearSVC, self).fit(X, y, sample_weight, convert_dtype)
+
+    def predict(self, X, convert_dtype=True) -> CumlArray:
+        y_pred = super().predict(X, convert_dtype=convert_dtype)
+        # Cast to int64 to match expected classifier interface
+        return y_pred.to_output("cupy", output_dtype="int64")

--- a/python/cuml/cuml/tests/test_linear_svm.py
+++ b/python/cuml/cuml/tests/test_linear_svm.py
@@ -423,3 +423,4 @@ def test_linear_svc_input_types(kind, weighted):
     y_pred = model.predict(X)
     # predict output type matches input type
     assert type(y_pred).__module__.split(".")[0] == kind
+    assert y_pred.dtype == "int64"


### PR DESCRIPTION
Scikit-Learn expects classifiers to return integers, previously `LinearSVC.predict` would return floats.

To fix this, we do a small copy + cast in the python layer. I don't _think_ the C++ layer can be made to return integers from predict without doing the same kind of copy we're doing here with `cupy`, and a copy w/ cast like this should be very cheap anyway.

Fixes #5946.