### PR TITLE
Ensure kwarg order matches sklearn expectations

### DIFF
--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -434,22 +434,22 @@ class DBSCAN(UniversalBase,
 
     @generate_docstring(skip_parameters_heading=True)
     @enable_device_interop
-    def fit(self, X, y=None, out_dtype="int32", sample_weight=None,
+    def fit(self, X, y=None, sample_weight=None, out_dtype="int32",
             convert_dtype=True) -> "DBSCAN":
         """
         Perform DBSCAN clustering from features.
 
         Parameters
         ----------
-        out_dtype: dtype Determines the precision of the output labels array.
-            default: "int32". Valid values are { "int32", np.int32,
-            "int64", np.int64}.
-
         sample_weight: array-like of shape (n_samples,), default=None
             Weight of each sample, such that a sample with a weight of at
             least min_samples is by itself a core sample; a sample with a
             negative weight may inhibit its eps-neighbor from being core.
             default: None (which is equivalent to weight 1 for all samples).
+
+        out_dtype: dtype Determines the precision of the output labels array.
+            default: "int32". Valid values are { "int32", np.int32,
+            "int64", np.int64}.
         """
         return self._fit(X, out_dtype, False, sample_weight)
 
@@ -459,21 +459,21 @@ class DBSCAN(UniversalBase,
                                        'description': 'Cluster labels',
                                        'shape': '(n_samples, 1)'})
     @enable_device_interop
-    def fit_predict(self, X, y=None, out_dtype="int32", sample_weight=None) -> CumlArray:
+    def fit_predict(self, X, y=None, sample_weight=None, out_dtype="int32") -> CumlArray:
         """
         Performs clustering on X and returns cluster labels.
 
         Parameters
         ----------
-        out_dtype: dtype Determines the precision of the output labels array.
-            default: "int32". Valid values are { "int32", np.int32,
-            "int64", np.int64}.
-
         sample_weight: array-like of shape (n_samples,), default=None
             Weight of each sample, such that a sample with a weight of at
             least min_samples is by itself a core sample; a sample with a
             negative weight may inhibit its eps-neighbor from being core.
             default: None (which is equivalent to weight 1 for all samples).
+
+        out_dtype: dtype Determines the precision of the output labels array.
+            default: "int32". Valid values are { "int32", np.int32,
+            "int64", np.int64}.
         """
         self.fit(X, out_dtype=out_dtype, sample_weight=sample_weight)
         return self.labels_

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -703,8 +703,7 @@ class KMeans(UniversalBase,
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
     @enable_device_interop
-    def fit_transform(self, X, y=None, convert_dtype=False,
-                      sample_weight=None) -> CumlArray:
+    def fit_transform(self, X, y=None, sample_weight=None, convert_dtype=False) -> CumlArray:
         """
         Compute clustering and transform X to cluster-distance space.
 

--- a/python/cuml/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/cuml/linear_model/elastic_net.pyx
@@ -311,8 +311,7 @@ class ElasticNet(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
-    def fit(self, X, y, convert_dtype=True,
-            sample_weight=None) -> "ElasticNet":
+    def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "ElasticNet":
         """
         Fit the model with X and y.
 

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -345,8 +345,7 @@ class LinearRegression(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
-    def fit(self, X, y, convert_dtype=True,
-            sample_weight=None) -> "LinearRegression":
+    def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "LinearRegression":
         """
         Fit the model with X and y.
 

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -318,7 +318,7 @@ class Ridge(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
-    def fit(self, X, y, convert_dtype=True, sample_weight=None) -> "Ridge":
+    def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "Ridge":
         """
         Fit the model with X and y.
         """

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -216,7 +216,7 @@ class CD(Base,
         }[self.loss]
 
     @generate_docstring()
-    def fit(self, X, y, convert_dtype=True, sample_weight=None) -> "CD":
+    def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "CD":
         """
         Fit the model with X and y.
 


### PR DESCRIPTION
Some common sklearn methods take positional-or-keyword arguments (like `sample_weight`). While users _should_ pass these in by keyword, the standard signatures accept them by position as well (and some parts of the sklearn test suite and examples pass them positionally). For optimal sklearn compatibility, our signatures should have these parameters in the same standard order sklearn expects.

This PR adds a test for this, and fixes the few locations where we weren't compatible.