### PR TITLE
Document `cuml.accel` doesn't support `set_output`

### DIFF
--- a/docs/source/zero-code-change-limitations.rst
+++ b/docs/source/zero-code-change-limitations.rst
@@ -4,12 +4,34 @@ Known Limitations
 General Limitations
 ~~~~~~~~~~~~~~~~~~~
 
-The cuML Accelerator present in RAPIDS release 25.02.01 is a beta version, with the following general limitations:
+The cuML Accelerator present in RAPIDS release 25.02.01 is a beta version, with
+the following general limitations:
 
-* Ingestion of lists of numbers by estimator functions is unsupported. Convert lists to structured formats (e.g., NumPy arrays or Pandas DataFrames) to ensure compatibility. This limitation will be removed in the next version of the cuML Accelerator.
-* Labels provided as arrays of strings are not supported. Pre-encode string labels into numerical or categorical formats (e.g., using scikit-learn's LabelEncoder) prior to processing. This limitation will be removed in the next version of the cuML Accelerator.
-* The accelerator is compatible with scikit-learn version 1.5 or higher. This compatibility ensures that cuML's implementation of scikit-learn compatible APIs works as expected.
-* When running in Windows Subsystem for Linux 2 (WSL2), managed memory (unified memory) is not supported. This means that automatic memory management between host and device memory is not available. Users may need to be more careful about memory management and consider using the ``--disable-uvm`` flag if experiencing memory-related issues.
+* Ingestion of lists of numbers by estimator functions is unsupported. Convert
+  lists to structured formats (e.g., NumPy arrays or Pandas DataFrames) to
+  ensure compatibility. This limitation will be removed in the next version of
+  the cuML Accelerator.
+
+* Labels provided as arrays of strings are not supported. Pre-encode string
+  labels into numerical or categorical formats (e.g., using scikit-learn's
+  LabelEncoder) prior to processing. This limitation will be removed in the
+  next version of the cuML Accelerator.
+
+* The accelerator is compatible with scikit-learn version 1.5 or higher. This
+  compatibility ensures that cuML's implementation of scikit-learn compatible
+  APIs works as expected.
+
+* The `set_output
+  <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep018/proposal.html>`__
+  and `Metadata Routing
+  <https://scikit-learn.org/stable/metadata_routing.html>`__ APIs are not
+  currently supported.
+
+* When running in Windows Subsystem for Linux 2 (WSL2), managed memory (unified
+  memory) is not supported. This means that automatic memory management between
+  host and device memory is not available. Users may need to be more careful
+  about memory management and consider using the ``--disable-uvm`` flag if
+  experiencing memory-related issues.
 
 For notes on each algorithm, please refer to its specific section on this file.
 


### PR DESCRIPTION
Adds a note to the `cuml.accel` docs that we don't currently support the `set_output` or Metadata Routing apis.

Fixes #6605.