### PR TITLE
FIX Allow prereleases when evaluating xfail conditions

### DIFF
--- a/python/cuml/cuml/accel/pytest_plugin.py
+++ b/python/cuml/cuml/accel/pytest_plugin.py
@@ -63,7 +63,7 @@ def create_version_condition(condition_str: str) -> bool:
     try:
         req = Requirement(condition_str)
         installed_version = version(req.name)
-        return req.specifier.contains(installed_version)
+        return req.specifier.contains(installed_version, prereleases=True)
     except Exception:
         return False
 


### PR DESCRIPTION
To test `cuml.accel` with the scikit-learn test suite we maintain a list of expected failures which can contain conditionals.

This PR makes it so that a condition like `scikit-learn >= 1.6` will evaluate to true when scikit-learn 1.7.0rc0 is installed. This is useful when we want to test a upcoming release of scikit-learn (or other packages) for `cuml.accel`.