### PR TITLE
Use matplotlib-base in docs/notebooks environments.

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -42,7 +42,7 @@ dependencies:
 - libcuvs==25.6.*,>=0.0.0a0
 - libraft==25.6.*,>=0.0.0a0
 - librmm==25.6.*,>=0.0.0a0
-- matplotlib
+- matplotlib-base
 - nbsphinx
 - ninja
 - nltk

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -42,7 +42,7 @@ dependencies:
 - libcuvs==25.6.*,>=0.0.0a0
 - libraft==25.6.*,>=0.0.0a0
 - librmm==25.6.*,>=0.0.0a0
-- matplotlib
+- matplotlib-base
 - nbsphinx
 - ninja
 - nltk

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - libcuvs==25.6.*,>=0.0.0a0
 - libraft==25.6.*,>=0.0.0a0
 - librmm==25.6.*,>=0.0.0a0
-- matplotlib
+- matplotlib-base
 - nbsphinx
 - ninja
 - nltk

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - libcuvs==25.6.*,>=0.0.0a0
 - libraft==25.6.*,>=0.0.0a0
 - librmm==25.6.*,>=0.0.0a0
-- matplotlib
+- matplotlib-base
 - nbsphinx
 - ninja
 - nltk

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -437,7 +437,6 @@ dependencies:
           - ipykernel
           - nbsphinx
           - numpydoc
-          - matplotlib
           # https://github.com/pydata/pydata-sphinx-theme/issues/1539
           - pydata-sphinx-theme!=0.14.2
           - recommonmark
@@ -448,6 +447,10 @@ dependencies:
       - output_types: conda
         packages:
           - doxygen=1.9.1
+          - matplotlib-base
+      - output_types: requirements
+        packages:
+          - matplotlib
   py_version:
     specific:
       - output_types: conda
@@ -520,12 +523,17 @@ dependencies:
         packages:
           - dask-ml==2023.3.24
           - jupyter
-          - matplotlib
           - numpy
           - pandas
           - *scikit_learn
           - seaborn
           - *xgboost
+      - output_types: conda
+        packages:
+          - matplotlib-base
+      - output_types: requirements
+        packages:
+          - matplotlib
   depends_on_cuda_python:
     specific:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
Recently an issue arose where `matplotlib` was causing a conda solve failure because it pulls in lots of GUI libraries like `pyside6`. We should instead rely on `matplotlib-base` conda packages, which are much slimmer.

xref: https://github.com/rapidsai/build-planning/issues/177
