### PR TITLE
Fix DistributedDataHandler.calculate_parts_to_sizes

### DIFF
--- a/python/cuml/cuml/dask/common/input_utils.py
+++ b/python/cuml/cuml/dask/common/input_utils.py
@@ -153,6 +153,8 @@ class DistributedDataHandler:
             sizes, total = sizes_parts
             self.parts_to_sizes[self.worker_info[w]["rank"]] = sizes
 
+            self.total_rows += total
+
 
 def _get_datatype_from_inputs(data):
     """

--- a/python/cuml/cuml/dask/common/input_utils.py
+++ b/python/cuml/cuml/dask/common/input_utils.py
@@ -146,13 +146,12 @@ class DistributedDataHandler:
             for idx, wf in enumerate(self.worker_to_parts.items())
         ]
 
-        sizes = self.client.compute(parts, sync=True)
+        wfs, sizes_futures = zip(*parts)
+        all_sizes = self.client.compute(sizes_futures, sync=True)
 
-        for w, sizes_parts in sizes:
+        for w, sizes_parts in zip(wfs, all_sizes):
             sizes, total = sizes_parts
             self.parts_to_sizes[self.worker_info[w]["rank"]] = sizes
-
-            self.total_rows += total
 
 
 def _get_datatype_from_inputs(data):


### PR DESCRIPTION
Newer versions of Dask don't like a mixture of dask and non-dask objects in `client.compute()`. Previously, `calculate_parts_to_sizes()` passed a list[tuple[str, Future]] to `client.compute()`. This updates it to only pass through the Futures.