### PR TITLE
Deprecate non-keyword-only cuml-only kwargs

### DIFF
--- a/python/cuml/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cuml/cluster/agglomerative.pyx
@@ -24,7 +24,7 @@ import numpy as np
 
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 
 from pylibraft.common.handle cimport handle_t
 
@@ -188,6 +188,7 @@ class AgglomerativeClustering(Base, ClusterMixin, CMajorInputTagMixin):
         self.distances_ = None
 
     @generate_docstring()
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, convert_dtype=True) -> "AgglomerativeClustering":
         """
         Fit the hierarchical clustering from features.

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -26,7 +26,7 @@ from cuml.internals.api_decorators import (
     enable_device_interop,
 )
 from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
 from libc.stdint cimport int64_t, uintptr_t
@@ -434,6 +434,7 @@ class DBSCAN(UniversalBase,
 
     @generate_docstring(skip_parameters_heading=True)
     @enable_device_interop
+    @deprecate_non_keyword_only("out_dtype", "convert_dtype")
     def fit(self, X, y=None, out_dtype="int32", sample_weight=None,
             convert_dtype=True) -> "DBSCAN":
         """
@@ -459,6 +460,7 @@ class DBSCAN(UniversalBase,
                                        'description': 'Cluster labels',
                                        'shape': '(n_samples, 1)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("out_dtype")
     def fit_predict(self, X, y=None, out_dtype="int32", sample_weight=None) -> CumlArray:
         """
         Performs clustering on X and returns cluster labels.

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -33,7 +33,7 @@ from cuml.internals.api_decorators import (
     enable_device_interop,
 )
 from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
 from cython.operator cimport dereference as deref
@@ -763,6 +763,7 @@ class HDBSCAN(UniversalBase, ClusterMixin, CMajorInputTagMixin):
 
     @generate_docstring()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, convert_dtype=True) -> "HDBSCAN":
         """
         Fit HDBSCAN model from features.

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -45,7 +45,7 @@ from cuml.internals.api_decorators import (
     enable_device_interop,
 )
 from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
 try:
@@ -299,6 +299,7 @@ class KMeans(UniversalBase,
 
     @generate_docstring()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, sample_weight=None, convert_dtype=True) -> "KMeans":
         """
         Compute k-means clustering with X.
@@ -581,6 +582,7 @@ class KMeans(UniversalBase,
                                        'description': 'Cluster indexes',
                                        'shape': '(n_samples, 1)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "normalize_weights")
     def predict(self, X, y=None, convert_dtype=True, sample_weight=None,
                 normalize_weights=True) -> CumlArray:
         """
@@ -600,6 +602,7 @@ class KMeans(UniversalBase,
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, y=None, convert_dtype=True) -> CumlArray:
         """
         Transform X to a cluster-distance space.
@@ -688,6 +691,7 @@ class KMeans(UniversalBase,
                                                         of X on the K-means \
                                                         objective.'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def score(self, X, y=None, sample_weight=None, convert_dtype=True):
         """
         Opposite of the value of X on the K-means objective.
@@ -703,6 +707,7 @@ class KMeans(UniversalBase,
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit_transform(self, X, y=None, convert_dtype=False,
                       sample_weight=None) -> CumlArray:
         """

--- a/python/cuml/cuml/dask/ensemble/base.py
+++ b/python/cuml/cuml/dask/ensemble/base.py
@@ -380,7 +380,7 @@ class BaseRandomForestModel(object):
 def _func_fit(model, input_data, convert_dtype):
     X = concatenate([item[0] for item in input_data])
     y = concatenate([item[1] for item in input_data])
-    return model.fit(X, y, convert_dtype)
+    return model.fit(X, y, convert_dtype=convert_dtype)
 
 
 def _func_predict_partial(model, input_data, **kwargs):

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -24,7 +24,7 @@ import cuml.internals
 from cuml.common import input_to_cuml_array
 from cuml.decomposition.pca import PCA
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cupy_array
 
 
@@ -216,6 +216,7 @@ class IncrementalPCA(PCA):
         self.batch_size = batch_size
         self._sparse_model = True
 
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, convert_dtype=True) -> "IncrementalPCA":
         """
         Fit the model with X, using minibatches of size batch_size.
@@ -272,6 +273,7 @@ class IncrementalPCA(PCA):
         return self
 
     @cuml.internals.api_base_return_any_skipall
+    @deprecate_non_keyword_only("check_input")
     def partial_fit(self, X, y=None, check_input=True) -> "IncrementalPCA":
         """
         Incremental fit with X. All of X is processed as a single batch.
@@ -401,6 +403,7 @@ class IncrementalPCA(PCA):
 
         return self
 
+    @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, convert_dtype=False) -> CumlArray:
         """
         Apply dimensionality reduction to X.

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -33,7 +33,7 @@ from cuml.common.doc_utils import generate_docstring
 from cuml.common.exceptions import NotFittedError
 from cuml.common.sparse_utils import is_sparse
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.input_utils import (
     input_to_cuml_array,
     input_to_cupy_array,
@@ -477,6 +477,7 @@ class PCA(Base,
 
     @generate_docstring(X='dense_sparse')
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, convert_dtype=True) -> "PCA":
         """
         Fit the model with X. y is currently ignored.
@@ -725,6 +726,7 @@ class PCA(Base,
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, convert_dtype=True) -> CumlArray:
         """
         Apply dimensionality reduction to X.

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -26,7 +26,7 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.interop import (
     InteropMixin,
     to_cpu,
@@ -374,6 +374,7 @@ class TruncatedSVD(Base,
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit_transform(self, X, y=None, convert_dtype=True) -> CumlArray:
         """
         Fit LSI model to X and perform dimensionality reduction on X.
@@ -490,6 +491,7 @@ class TruncatedSVD(Base,
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, convert_dtype=True) -> CumlArray:
         """
         Perform dimensionality reduction on X.

--- a/python/cuml/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.pyx
@@ -32,6 +32,7 @@ from cuml.internals.api_decorators import (
     enable_device_interop,
 )
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.mixins import ClassifierMixin
 from cuml.internals.utils import check_random_seed
 from cuml.legacy.fil.fil import TreeliteModel
@@ -438,6 +439,7 @@ class RandomForestClassifier(BaseRandomForestModel,
                                         set_output_dtype=True,
                                         set_n_features_in=False)
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True):
         """
         Perform Random Forest Classification on the input data
@@ -576,6 +578,13 @@ class RandomForestClassifier(BaseRandomForestModel,
                            return_values=[('dense', '(n_samples, 1)')])
     @cuml.internals.api_base_return_array(get_output_dtype=True)
     @enable_device_interop
+    @deprecate_non_keyword_only(
+        "predict_model",
+        "threshold",
+        "algo",
+        "convert_dtype",
+        "fil_sparse_format",
+    )
     def predict(self, X, predict_model="GPU", threshold=0.5,
                 algo='auto', convert_dtype=True,
                 fil_sparse_format='auto') -> CumlArray:
@@ -642,6 +651,7 @@ class RandomForestClassifier(BaseRandomForestModel,
 
     @insert_into_docstring(parameters=[('dense', '(n_samples, n_features)')],
                            return_values=[('dense', '(n_samples, 1)')])
+    @deprecate_non_keyword_only("algo", "convert_dtype", "fil_sparse_format")
     def predict_proba(self, X, algo='auto',
                       convert_dtype=True,
                       fil_sparse_format='auto') -> CumlArray:
@@ -698,6 +708,9 @@ class RandomForestClassifier(BaseRandomForestModel,
         domain="cuml_python")
     @insert_into_docstring(parameters=[('dense', '(n_samples, n_features)'),
                                        ('dense_intdtype', '(n_samples, 1)')])
+    @deprecate_non_keyword_only(
+        "threshold", "algo", "predict_model", "convert_dtype", "fil_sparse_format",
+    )
     def score(self, X, y, threshold=0.5,
               algo='auto', predict_model="GPU",
               convert_dtype=True, fil_sparse_format='auto'):

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -24,6 +24,7 @@ from cuml.internals.api_decorators import (
     enable_device_interop,
 )
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.mixins import RegressorMixin
 
 from cuml.internals.logger cimport level_enum
@@ -434,6 +435,7 @@ class RandomForestRegressor(BaseRandomForestModel,
     @generate_docstring()
     @cuml.internals.api_base_return_any_skipall
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True):
         """
         Perform Random Forest Regression on the input data
@@ -557,6 +559,7 @@ class RandomForestRegressor(BaseRandomForestModel,
     @insert_into_docstring(parameters=[('dense', '(n_samples, n_features)')],
                            return_values=[('dense', '(n_samples, 1)')])
     @enable_device_interop
+    @deprecate_non_keyword_only("predict_model", "algo", "convert_dtype", "fil_sparse_format")
     def predict(self, X, predict_model="GPU",
                 algo='auto', convert_dtype=True,
                 fil_sparse_format='auto') -> CumlArray:
@@ -618,6 +621,9 @@ class RandomForestRegressor(BaseRandomForestModel,
     @insert_into_docstring(parameters=[('dense', '(n_samples, n_features)'),
                                        ('dense', '(n_samples, 1)')])
     @enable_device_interop
+    @deprecate_non_keyword_only(
+        "algo", "convert_dtype", "fil_sparse_format", "predict_model"
+    )
     def score(self, X, y, algo='auto', convert_dtype=True,
               fil_sparse_format='auto', predict_model="GPU"):
         """

--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -17,9 +17,11 @@
 # distutils: language = c++
 
 import copy
+import functools
 import inspect
 import numbers
 import os
+import warnings
 from importlib import import_module
 
 import numpy as np
@@ -64,6 +66,40 @@ from cuml.internals.output_type import (
     INTERNAL_VALID_OUTPUT_TYPES,
     VALID_OUTPUT_TYPES,
 )
+
+
+def deprecate_non_keyword_only(*deprecated):
+    """Deprecate passing non-sklearn-standard keyword arguments positionally.
+
+    Parameters
+    ----------
+    *deprecated : str
+        The parameter names to deprecate passing positionally.
+    """
+
+    def decorator(func):
+        params = list(inspect.signature(func).parameters)
+        for pos, name in enumerate(params):
+            if name in deprecated:
+                break
+        npos = pos
+
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            if (ndepr := len(args) - npos) > 0:
+                plural = ndepr > 1
+                params = repr(list(deprecated[:ndepr])) if plural else repr(deprecated[0])
+                warnings.warn(
+                    f"Passing parameter{'s' if plural else ''} {params} positionally to "
+                    f"{func.__qualname__} is deprecated and will be removed in cuml 25.08. "
+                    "Please pass by keyword only.",
+                    FutureWarning,
+                )
+            return func(*args, **kwargs)
+
+        return inner
+
+    return decorator
 
 
 class VerbosityDescriptor:

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.pyx
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.pyx
@@ -32,7 +32,7 @@ from cuml.internals.api_decorators import (
     enable_device_interop,
 )
 from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 from cuml.internals.mixins import RegressorMixin
 from cuml.metrics import pairwise_kernels
 
@@ -256,6 +256,7 @@ class KernelRidge(UniversalBase, RegressorMixin):
 
     @generate_docstring()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None,
             convert_dtype=True) -> "KernelRidge":
 

--- a/python/cuml/cuml/linear_model/base.pyx
+++ b/python/cuml/cuml/linear_model/base.pyx
@@ -24,6 +24,7 @@ from libc.stdint cimport uintptr_t
 
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.interop import warn_legacy_device_interop
 
@@ -56,6 +57,7 @@ class LinearPredictMixin:
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_array_skipall
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts `y` values for `X`.

--- a/python/cuml/cuml/linear_model/elastic_net.pyx
+++ b/python/cuml/cuml/linear_model/elastic_net.pyx
@@ -22,7 +22,7 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.interop import (
     InteropMixin,
     UnsupportedOnGPU,
@@ -311,6 +311,7 @@ class ElasticNet(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True,
             sample_weight=None) -> "ElasticNet":
         """

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -26,7 +26,7 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.interop import (
     InteropMixin,
     UnsupportedOnGPU,
@@ -345,6 +345,7 @@ class LinearRegression(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "LinearRegression":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/linear_model/logistic_regression.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression.pyx
@@ -29,7 +29,7 @@ from cuml.common.doc_utils import generate_docstring
 from cuml.common.sparse_utils import is_sparse
 from cuml.internals import logger
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.interop import (
     InteropMixin,
@@ -340,6 +340,7 @@ class LogisticRegression(Base,
     @generate_docstring(X='dense_sparse')
     @cuml.internals.api_base_return_any()
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None,
             convert_dtype=True) -> "LogisticRegression":
         """
@@ -463,6 +464,7 @@ class LogisticRegression(Base,
                                        'description': 'Confidence score',
                                        'shape': '(n_samples, n_classes)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def decision_function(self, X, convert_dtype=True) -> CumlArray:
         """
         Gives confidence score for X
@@ -480,6 +482,7 @@ class LogisticRegression(Base,
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_any()
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the y for X.
@@ -544,6 +547,7 @@ class LogisticRegression(Base,
                                                        probabilities',
                                        'shape': '(n_samples, n_classes)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict_proba(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the class probabilities for each class in X
@@ -561,6 +565,7 @@ class LogisticRegression(Base,
                                                        class probabilities',
                                        'shape': '(n_samples, n_classes)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict_log_proba(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the log class probabilities for each class in X

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.pyx
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.pyx
@@ -19,7 +19,7 @@
 import cuml.internals
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.mixins import ClassifierMixin, FMajorInputTagMixin
 from cuml.solvers import SGD
 
@@ -182,6 +182,7 @@ class MBSGDClassifier(Base,
         self.solver_model = SGD(**self.get_params())
 
     @generate_docstring()
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True) -> "MBSGDClassifier":
         """
         Fit the model with X and y.
@@ -196,6 +197,7 @@ class MBSGDClassifier(Base,
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_array_skipall
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the y for X.

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.pyx
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.pyx
@@ -19,7 +19,7 @@
 import cuml.internals
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.solvers import SGD
 
@@ -178,6 +178,7 @@ class MBSGDRegressor(Base,
         self.solver_model = SGD(**self.get_params())
 
     @generate_docstring()
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True) -> "MBSGDRegressor":
         """
         Fit the model with X and y.
@@ -191,6 +192,7 @@ class MBSGDRegressor(Base,
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_array_skipall
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the y for X.

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -26,7 +26,7 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.interop import (
     InteropMixin,
     UnsupportedOnGPU,
@@ -318,6 +318,7 @@ class Ridge(Base,
 
     @generate_docstring()
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True, sample_weight=None) -> "Ridge":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -25,7 +25,7 @@ import numpy as np
 
 import cuml.internals
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 
 from pylibraft.common.handle cimport handle_t
 
@@ -416,6 +416,7 @@ class TSNE(UniversalBase,
                         X='dense_sparse',
                         convert_dtype_cast='np.float32')
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "knn_graph")
     def fit(self, X, y=None, convert_dtype=True, knn_graph=None) -> "TSNE":
         """
         Fit X into an embedded space.
@@ -580,6 +581,7 @@ class TSNE(UniversalBase,
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.api_base_fit_transform()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "knn_graph")
     def fit_transform(self, X, y=None, convert_dtype=True,
                       knn_graph=None) -> CumlArray:
         """

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -36,7 +36,7 @@ from cuml.internals.api_decorators import (
 )
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.mixins import CMajorInputTagMixin, SparseInputTagMixin
@@ -511,6 +511,7 @@ class UMAP(UniversalBase,
                         X='dense_sparse',
                         skip_parameters_heading=True)
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "knn_graph", "data_on_host")
     def fit(self, X, y=None, convert_dtype=True,
             knn_graph=None, data_on_host=False) -> "UMAP":
         """
@@ -672,6 +673,7 @@ class UMAP(UniversalBase,
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.api_base_fit_transform()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "knn_graph", "data_on_host")
     def fit_transform(self, X, y=None, convert_dtype=True,
                       knn_graph=None, data_on_host=False) -> CumlArray:
         """
@@ -718,6 +720,7 @@ class UMAP(UniversalBase,
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, convert_dtype=True) -> CumlArray:
         """
         Transform X into the existing embedded space and return that

--- a/python/cuml/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/cuml/naive_bayes/naive_bayes.py
@@ -25,7 +25,7 @@ from cuml.common import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.kernel_utils import cuda_kernel_factory
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.internals.mixins import ClassifierMixin
 from cuml.prims.array import binarize
@@ -171,6 +171,7 @@ class _BaseNB(Base, ClassifierMixin):
             "shape": "(n_rows, 1)",
         },
     )
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Perform classification on an array of test vectors X.
@@ -214,6 +215,7 @@ class _BaseNB(Base, ClassifierMixin):
             "shape": "(n_rows, 1)",
         },
     )
+    @deprecate_non_keyword_only("convert_dtype")
     def predict_log_proba(self, X, convert_dtype=True) -> CumlArray:
         """
         Return log-probability estimates for the test vector X.

--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -22,7 +22,7 @@ from numba import cuda
 from scipy.special import gammainc
 
 from cuml.common.exceptions import NotFittedError
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.metrics import pairwise_distances
 
@@ -235,6 +235,7 @@ class KernelDensity(Base):
             "metric_params",
         ]
 
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, sample_weight=None, convert_dtype=True):
         """Fit the Kernel Density model on the data.
 

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -27,6 +27,7 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.api_decorators import enable_device_interop
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.mixins import ClassifierMixin, FMajorInputTagMixin
 from cuml.neighbors.nearest_neighbors import NearestNeighbors
 
@@ -154,6 +155,7 @@ class KNeighborsClassifier(ClassifierMixin,
     @generate_docstring(convert_dtype_cast='np.float32')
     @cuml.internals.api_base_return_any(set_output_dtype=True)
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True) -> "KNeighborsClassifier":
         """
         Fit a GPU index for k-nearest neighbors classifier model.
@@ -179,6 +181,7 @@ class KNeighborsClassifier(ClassifierMixin,
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_array(get_output_dtype=True)
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Use the trained k-nearest neighbors classifier to
@@ -237,6 +240,7 @@ class KNeighborsClassifier(ClassifierMixin,
                                        'shape': '(n_samples, 1)'})
     @cuml.internals.api_base_return_generic()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict_proba(
             self,
             X,

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -24,6 +24,7 @@ from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.api_decorators import enable_device_interop
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
 from cuml.neighbors.nearest_neighbors import NearestNeighbors
 
@@ -160,6 +161,7 @@ class KNeighborsRegressor(RegressorMixin,
 
     @generate_docstring(convert_dtype_cast='np.float32')
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True) -> "KNeighborsRegressor":
         """
         Fit a GPU index for k-nearest neighbors regression model.
@@ -184,6 +186,7 @@ class KNeighborsRegressor(RegressorMixin,
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, n_features)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Use the trained k-nearest neighbors regression model to

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -35,7 +35,7 @@ from cuml.internals.api_decorators import (
 )
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.base import UniversalBase
+from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cupy_array
 from cuml.internals.mixins import CMajorInputTagMixin, SparseInputTagMixin
 
@@ -327,6 +327,7 @@ class NearestNeighbors(UniversalBase,
 
     @generate_docstring(X='dense_sparse')
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, convert_dtype=True) -> "NearestNeighbors":
         """
         Fit GPU index for performing nearest neighbor queries.

--- a/python/cuml/cuml/random_projection/random_projection.pyx
+++ b/python/cuml/cuml/random_projection/random_projection.pyx
@@ -23,7 +23,7 @@ from libcpp cimport bool
 
 import cuml.internals
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 
 from pylibraft.common.handle cimport *
 
@@ -226,6 +226,7 @@ cdef class BaseRandomProjection():
         self.params.density = value
 
     @cuml.internals.api_base_return_any()
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, convert_dtype=True):
         """
         Fit the model. This function generates the random matrix on GPU.
@@ -263,6 +264,7 @@ cdef class BaseRandomProjection():
         return self
 
     @cuml.internals.api_base_return_array()
+    @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, convert_dtype=True):
         """
         Apply transformation on provided data. This function outputs
@@ -324,6 +326,7 @@ cdef class BaseRandomProjection():
         return X_new
 
     @cuml.internals.api_base_return_array(get_output_type=False)
+    @deprecate_non_keyword_only("convert_dtype")
     def fit_transform(self, X, y=None, convert_dtype=True):
         return self.fit(X).transform(X, convert_dtype)
 

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -25,7 +25,7 @@ from cuml.common import input_to_cuml_array
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.mixins import FMajorInputTagMixin
 
 from libcpp cimport bool
@@ -309,6 +309,7 @@ class SGD(Base,
 
     @generate_docstring()
     @cuml.internals.api_base_return_any(set_output_dtype=True)
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, convert_dtype=True) -> "SGD":
         """
         Fit the model with X and y.
@@ -402,6 +403,7 @@ class SGD(Base,
                                        'type': 'dense',
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the y for X.

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -31,7 +31,7 @@ from cython.operator cimport dereference as deref
 
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.array import CumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.base_helpers import BaseMetaClass
 
 from cuml.internals.logger cimport level_enum
@@ -502,6 +502,7 @@ cdef class LinearSVMWrapper:
 
         return y
 
+    @deprecate_non_keyword_only("log")
     def predict_proba(self, X, log=False) -> CumlArray:
         y = CumlArray.empty(
             shape=(X.shape[0], self.classes_.shape[0]),
@@ -649,6 +650,7 @@ class LinearSVM(Base, metaclass=WithReexportedParams):
             return self.classes_.shape[0]
         return self.model_.classes_.shape[0]
 
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None, convert_dtype=True) -> 'LinearSVM':
 
         X_m, n_rows, _n_cols, self.dtype = input_to_cuml_array(X, order='F')
@@ -701,6 +703,7 @@ class LinearSVM(Base, metaclass=WithReexportedParams):
             if self.probScale_ is not self.model_.probScale_:
                 self.model_.probScale_ = self.probScale_
 
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         convert_to_dtype = self.dtype if convert_dtype else None
         X_m, _, _, _ = input_to_cuml_array(
@@ -709,6 +712,7 @@ class LinearSVM(Base, metaclass=WithReexportedParams):
         self.__sync_model()
         return self.model_.predict(X_m)
 
+    @deprecate_non_keyword_only("convert_dtype")
     def decision_function(self, X, convert_dtype=True) -> CumlArray:
         convert_to_dtype = self.dtype if convert_dtype else None
         X_m, _, _, _ = input_to_cuml_array(
@@ -717,6 +721,7 @@ class LinearSVM(Base, metaclass=WithReexportedParams):
         self.__sync_model()
         return self.model_.decision_function(X_m)
 
+    @deprecate_non_keyword_only("log", "convert_dtype")
     def predict_proba(self, X, log=False, convert_dtype=True) -> CumlArray:
         convert_to_dtype = self.dtype if convert_dtype else None
         X_m, _, _, _ = input_to_cuml_array(

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -15,6 +15,7 @@
 
 from cuml.common import input_to_cuml_array
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.mixins import ClassifierMixin
 from cuml.svm.linear import LinearSVM, LinearSVM_defaults  # noqa: F401
 from cuml.svm.svc import apply_class_weight
@@ -196,6 +197,7 @@ class LinearSVC(LinearSVM, ClassifierMixin):
             }.union(super()._get_param_names())
         )
 
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "LinearSVM":
         X = input_to_cuml_array(X, order="F").array
         sample_weight = apply_class_weight(
@@ -207,8 +209,11 @@ class LinearSVC(LinearSVM, ClassifierMixin):
             self.output_type,
             X.dtype,
         )
-        return super(LinearSVC, self).fit(X, y, sample_weight, convert_dtype)
+        return super(LinearSVC, self).fit(
+            X, y, sample_weight, convert_dtype=convert_dtype
+        )
 
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         y_pred = super().predict(X, convert_dtype=convert_dtype)
         # Cast to int64 to match expected classifier interface

--- a/python/cuml/cuml/svm/svc.pyx
+++ b/python/cuml/cuml/svm/svc.pyx
@@ -28,6 +28,7 @@ import cuml.internals
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.logger import warn
 from cuml.internals.mixins import ClassifierMixin
 
@@ -585,6 +586,7 @@ class SVC(SVMBase,
     @generate_docstring(y='dense_anydtype')
     @cuml.internals.api_base_return_any(set_output_dtype=True)
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "SVC":
         """
         Fit the model with X and y.
@@ -708,6 +710,7 @@ class SVC(SVMBase,
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the class labels for X. The returned y values are the class
@@ -736,6 +739,7 @@ class SVC(SVMBase,
                                        probabilities',
                                        'shape': '(n_samples, n_classes)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("log")
     def predict_proba(self, X, log=False) -> CumlArray:
         """
         Predicts the class probabilities for X.

--- a/python/cuml/cuml/svm/svr.pyx
+++ b/python/cuml/cuml/svm/svr.pyx
@@ -26,6 +26,7 @@ from cuml.internals.api_decorators import (
 )
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals.base import deprecate_non_keyword_only
 from cuml.internals.input_utils import determine_array_type_full
 from cuml.internals.mixins import RegressorMixin
 
@@ -260,6 +261,7 @@ class SVR(SVMBase, RegressorMixin):
 
     @generate_docstring()
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "SVR":
         """
         Fit the model with X and y.
@@ -352,6 +354,7 @@ class SVR(SVMBase, RegressorMixin):
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def predict(self, X, convert_dtype=True) -> CumlArray:
         """
         Predicts the values for X.


### PR DESCRIPTION
The sklearn interface has a bunch of standard methods (`fit`, `transform`, ...). cuml strives to match this interface. Some cuml methods take cuml-specific keyword arguments. To improve our sklearn compatibility and avoid potential signature compatibility issues in the future if sklearn makes changes, this PR deprecates passing cuml-specific kwargs positionally.

Addressing the suggestion made here: https://github.com/rapidsai/cuml/pull/6716#issuecomment-2880537721