### PR TITLE
Update container image for clang-tidy job to use CUDA 12.8.0 and Python 3.12

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -108,7 +108,7 @@ jobs:
       build_type: pull-request
       node_type: "cpu8"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
+      container_image: "rapidsai/ci-conda:cuda12.8.0-ubuntu22.04-py3.12"
       run_script: "ci/run_clang_tidy.sh"
   conda-cpp-build:
     needs: checks


### PR DESCRIPTION
Update container image for clang-tidy job to use CUDA 12.8.0 and Python 3.12