### PR TITLE
Check that `as_sklearn`'ed models can be fitted

### DIFF
--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -135,6 +135,15 @@ def assert_estimator_roundtrip(
                 "No known method to compare outputs of this model."
             )
 
+    # Check that the scikit-learn estimator can be fitted again which checks
+    # that the hyper-parameter translation from cuml to scikit-learn works
+    # Has to happen after comparing predictions/transforms as refitting might
+    # change cluster IDs and the like
+    if y is not None:
+        sklearn_model.fit(X, y)
+    else:
+        sklearn_model.fit(X)
+
 
 ###############################################################################
 #                                     Tests                                   #


### PR DESCRIPTION
Closes https://github.com/rapidsai/cuml/issues/6533

Small change to make sure that the model that we get from calling `as_sklearn` can be fitted. This checks that the hyper-parameter translation from cuml to scikit-learn works.