### PR TITLE
Fix dask warning in FIL demo notebook

### DIFF
--- a/notebooks/forest_inference_demo.ipynb
+++ b/notebooks/forest_inference_demo.ipynb
@@ -471,7 +471,7 @@
    "outputs": [],
    "source": [
     "df = df.persist()\n",
-    "wait(df)"
+    "wait(df);"
    ]
   },
   {
@@ -549,7 +549,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "distributed_predictions = df.map_partitions(predict, meta=\"float\")"
+    "distributed_predictions = df.map_partitions(predict, meta=(\"predict\", int))"
    ]
   },
   {
@@ -602,7 +602,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There are still some warnings due to the FIL deprecation, but those will go away once the deprecation is removed before this release.

Fixes #4688.