### PR TITLE
Port KMeans to use `ProxyBase`/`InteropMixin`

### DIFF
--- a/python/cuml/cuml/accel/_wrappers/sklearn/cluster.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/cluster.py
@@ -15,13 +15,22 @@
 #
 
 import cuml.cluster
+from cuml.accel.estimator_proxy import ProxyBase
 from cuml.accel.estimator_proxy_mixin import ProxyMixin
 
 __all__ = ("KMeans", "DBSCAN")
 
 
-class KMeans(ProxyMixin, cuml.cluster.KMeans):
-    pass
+class KMeans(ProxyBase):
+    _gpu_class = cuml.cluster.KMeans
+
+    def _gpu_fit_transform(self, X, y=None, sample_weight=None):
+        # Fixes signature mismatch with cuml.KMeans.
+        return self._gpu.fit_transform(X, y=y, sample_weight=sample_weight)
+
+    def _init_centroids(self, *args, **kwargs):
+        # Exposed for use by the sklearn test suite
+        return self._cpu._init_centroids(*args, **kwargs)
 
 
 class DBSCAN(ProxyMixin, cuml.cluster.DBSCAN):

--- a/python/cuml/cuml/accel/_wrappers/sklearn/cluster.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/cluster.py
@@ -25,7 +25,7 @@ class KMeans(ProxyBase):
     _gpu_class = cuml.cluster.KMeans
 
     def _gpu_fit_transform(self, X, y=None, sample_weight=None):
-        # Fixes signature mismatch with cuml.KMeans.
+        # Fixes signature mismatch with cuml.KMeans. Can be removed after #6741.
         return self._gpu.fit_transform(X, y=y, sample_weight=sample_weight)
 
     def _init_centroids(self, *args, **kwargs):

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -21,7 +21,6 @@ import sklearn
 from sklearn.base import BaseEstimator
 
 from cuml.internals.interop import UnsupportedOnGPU
-from cuml.internals.utils import classproperty
 
 
 class _ReconstructProxy:
@@ -135,6 +134,11 @@ class ProxyBase(BaseEstimator):
         # the original full module path so that the class (not an instance) can
         # be pickled properly.
         cls.__module__ = cls._gpu_class._cpu_class_path.rsplit(".", 1)[0]
+
+        # Forward _estimator_type as a class attribute if available
+        _estimator_type = getattr(cls._cpu_class, "_estimator_type", None)
+        if isinstance(_estimator_type, str):
+            cls._estimator_type = _estimator_type
 
         # Add proxy method definitions for all public methods on CPU class
         # that aren't already defined on the proxy class
@@ -357,9 +361,9 @@ class ProxyBase(BaseEstimator):
     # Methods on BaseEstimator used internally by sklearn      #
     ############################################################
 
-    @classproperty
+    @property
     def _estimator_type(cls):
-        return cls._cpu_class._estimator_type
+        return cls._cpu._estimator_type
 
     @property
     def _parameter_constraints(self):

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -21,6 +21,7 @@ import sklearn
 from sklearn.base import BaseEstimator
 
 from cuml.internals.interop import UnsupportedOnGPU
+from cuml.internals.utils import classproperty
 
 
 class _ReconstructProxy:
@@ -356,9 +357,9 @@ class ProxyBase(BaseEstimator):
     # Methods on BaseEstimator used internally by sklearn      #
     ############################################################
 
-    @property
-    def _estimator_type(self):
-        return self._cpu._estimator_type
+    @classproperty
+    def _estimator_type(cls):
+        return cls._cpu_class._estimator_type
 
     @property
     def _parameter_constraints(self):

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -362,8 +362,8 @@ class ProxyBase(BaseEstimator):
     ############################################################
 
     @property
-    def _estimator_type(cls):
-        return cls._cpu._estimator_type
+    def _estimator_type(self):
+        return self._cpu._estimator_type
 
     @property
     def _parameter_constraints(self):

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -689,7 +689,6 @@
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-True-Lasso]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_lasso_not_as_toy_dataset[csc_array]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_lasso_not_as_toy_dataset[csc_matrix]"
-  - "sklearn.manifold.tests.test_spectral_embedding::test_pipeline_spectral_clustering"
   - "sklearn.manifold.tests.test_t_sne::test_accessible_kl_divergence"
   - "sklearn.manifold.tests.test_t_sne::test_bad_precomputed_distances[D0-.* square distance matrix-barnes_hut-asarray]"
   - "sklearn.manifold.tests.test_t_sne::test_bad_precomputed_distances[D0-.* square distance matrix-barnes_hut-csr_array]"

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -76,17 +76,10 @@
   - "sklearn.semi_supervised.tests.test_self_training::test_classification[k_best-estimator0]"
   - "sklearn.semi_supervised.tests.test_self_training::test_classification[threshold-estimator0]"
   - "sklearn.semi_supervised.tests.test_self_training::test_zero_iterations[y1-estimator0]"
-  - "sklearn.tests.test_common::test_estimators[ElasticNet()-check_n_features_in_after_fitting]"
-  - "sklearn.tests.test_common::test_estimators[Lasso()-check_n_features_in_after_fitting]"
-  - "sklearn.tests.test_common::test_estimators[PCA()-check_n_features_in_after_fitting]"
-  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_n_features_in_after_fitting]"
-  - "sklearn.tests.test_common::test_estimators[LinearRegression()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_estimator_sparse_tag]"
-  - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_non_transformer_estimators_n_iter]"
   - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_sample_weight_equivalence_on_sparse_data]"
-  - "sklearn.tests.test_common::test_estimators[Ridge()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[Ridge()-check_non_transformer_estimators_n_iter]"
   - "sklearn.utils.tests.test_validation::test_cross_val_predict[coo_matrix]"
 - reason: Test should fail with cuml.accel (scikit-learn 1.7)
@@ -1262,9 +1255,6 @@
 - reason: "cuml.accel does not support callable initialization for KMeans"
   marker: cuml_accel_kmeans_callable_init
   tests:
-  - "sklearn.cluster.tests.test_k_means::test_all_init[KMeans-callable-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_all_init[KMeans-callable-sparse_array]"
-  - "sklearn.cluster.tests.test_k_means::test_all_init[KMeans-callable-sparse_matrix]"
   - "sklearn.cluster.tests.test_k_means::test_kmeans_init_auto_with_initial_centroids[KMeans-<lambda>-default]"
 - reason: "cuml.accel fails for KMeans with AttributeError: 'KMeans' object has no attribute '_n_init'"
   marker: cuml_accel_kmeans_n_init
@@ -1306,13 +1296,6 @@
   - "sklearn.cluster.tests.test_k_means::test_dense_sparse[42-KMeans-X_csr0]"
   - "sklearn.cluster.tests.test_k_means::test_dense_sparse[42-KMeans-X_csr1]"
   - "sklearn.cluster.tests.test_spectral::test_precomputed_nearest_neighbors_filtering"
-- reason: "cuml.accel fails on sparse matrix inputs for KMeans"
-  marker: cuml_accel_kmeans_sparse_unsupported
-  tests:
-  - "sklearn.cluster.tests.test_k_means::test_predict_dense_sparse[KMeans-k-means++-X_csr0]"
-  - "sklearn.cluster.tests.test_k_means::test_predict_dense_sparse[KMeans-k-means++-X_csr1]"
-  - "sklearn.cluster.tests.test_k_means::test_predict_dense_sparse[KMeans-random-X_csr0]"
-  - "sklearn.cluster.tests.test_k_means::test_predict_dense_sparse[KMeans-random-X_csr1]"
 - reason: "Integer inputs are converted to float32 instead of float64 with cuml.accel"
   marker: cuml_accel_kmeans_integer_dtype
   tests:
@@ -1329,19 +1312,13 @@
   tests:
   - "sklearn.cluster.tests.test_k_means::test_wrong_params[param0-n_samples.* should be >= n_clusters-KMeans]"
   - "sklearn.cluster.tests.test_k_means::test_wrong_params[param1-The shape of the initial centers .* does not match the number of clusters-KMeans]"
-  - "sklearn.cluster.tests.test_k_means::test_wrong_params[param2-The shape of the initial centers .* does not match the number of clusters-KMeans]"
   - "sklearn.cluster.tests.test_k_means::test_wrong_params[param3-The shape of the initial centers .* does not match the number of features of the data-KMeans]"
-  - "sklearn.cluster.tests.test_k_means::test_wrong_params[param4-The shape of the initial centers .* does not match the number of features of the data-KMeans]"
   - "sklearn.cluster.tests.test_k_means::test_relocating_with_duplicates[elkan-dense]"
   - "sklearn.cluster.tests.test_k_means::test_relocating_with_duplicates[lloyd-dense]"
 - reason: "cuml.accel deviates in KMeans empty cluster reloacation (number of labels)"
   marker: cuml_accel_kmeans_empty_clusters_num_labels
   tests:
   - "sklearn.cluster.tests.test_k_means::test_kmeans_empty_cluster_relocated[dense]"
-- reason: "cuml.accel fails with AttributeError: 'memmap' object has no attribute 'ptr'."
-  marker: cuml-accel_kmeans_fails_with_attribute_error_memmap_ptr
-  tests:
-  - "sklearn.cluster.tests.test_k_means::test_predict_does_not_change_cluster_centers[None]"
 - reason: "The signs of the principal components are swapped with cuml.accel (insignificant deviation)"
   condition: "cuda-python >= 12.9"
   tests:
@@ -1437,6 +1414,16 @@
   - "sklearn.tests.test_common::test_estimators[TSNE()-check_estimators_empty_data_messages]"
   - "sklearn.tests.test_common::test_estimators[TSNE()-check_estimators_nan_inf]"
   - "sklearn.tests.test_common::test_estimators[TSNE()-check_estimator_sparse_matrix]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weights_not_an_array]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weights_shape]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_dense_data]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_sparse_data]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_complex_data]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_dtype_object]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_estimators_nan_inf]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_transformer_data_not_an_array]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_fit1d]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_fit2d_predict1d]"
 - reason: "cuml doesn't set `feature_names_in_` properly"
   marker: cuml_accel_feature_names_in
   tests:
@@ -1448,16 +1435,26 @@
   - "sklearn.tests.test_common::test_pandas_column_name_consistency[PCA()]"
   - "sklearn.tests.test_common::test_pandas_column_name_consistency[TruncatedSVD()]"
   - "sklearn.tests.test_common::test_pandas_column_name_consistency[TSNE()]"
+  - "sklearn.tests.test_common::test_pandas_column_name_consistency[KMeans()]"
 - reason: "cuml raises a different error if X doesn't have expected n features"
   marker: cuml_accel_check_n_features_in
   tests:
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[ElasticNet()]"
+  - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[KMeans()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[Lasso()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[LinearRegression()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[LogisticRegression()]"
-  - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[Ridge()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[PCA()]"
+  - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[Ridge()]"
   - "sklearn.tests.test_common::test_check_n_features_in_after_fitting[TruncatedSVD()]"
+  - "sklearn.tests.test_common::test_estimators[ElasticNet()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[Lasso()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[LinearRegression()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[LogisticRegression()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[PCA()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[Ridge()-check_n_features_in_after_fitting]"
+  - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_n_features_in_after_fitting]"
 - reason: "cuml missing certain fit attributes"
   marker: cuml_accel_missing_fit_attributes
   tests:

--- a/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml/accel/tests/scikit-learn/xfail-list.yaml
@@ -1218,6 +1218,8 @@
   - "sklearn.manifold.tests.test_t_sne::test_optimization_minimizes_kl_divergence"
   - "sklearn.model_selection.tests.test_validation::test_cross_val_predict[coo_array]"
   - "sklearn.model_selection.tests.test_validation::test_cross_val_predict[coo_matrix]"
+  - "sklearn.manifold.tests.test_t_sne::test_uniform_grid[barnes_hit]"
+  - "sklearn.manifold.tests.test_spectral_embedding::test_pipeline_spectral_clustering"
 - reason: "cuml.accel bug: Missing components_ attribute"
   tests:
   - "sklearn.cluster.tests.test_dbscan::test_dbscan_no_core_samples[csr_array]"

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -20,10 +20,23 @@ import typing
 
 import numpy as np
 
+from cuml.common import input_to_cuml_array
+from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base, deprecate_non_keyword_only
+from cuml.internals.interop import (
+    InteropMixin,
+    UnsupportedOnGPU,
+    to_cpu,
+    to_gpu,
+    warn_legacy_device_interop,
+)
+from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 from cuml.internals.utils import check_random_seed
 
 from cython.operator cimport dereference as deref
-from libc.stdint cimport int64_t, uintptr_t
+from libc.stdint cimport int64_t, uint64_t, uintptr_t
 from libc.stdlib cimport calloc, free
 from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
@@ -36,26 +49,9 @@ from cuml.cluster.kmeans_utils cimport params as KMeansParams
 from cuml.internals.logger cimport level_enum
 from cuml.metrics.distance_type cimport DistanceType
 
-from cuml.common import input_to_cuml_array
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.common.doc_utils import generate_docstring
-from cuml.common.sparse_utils import is_sparse
-from cuml.internals.api_decorators import (
-    device_interop_preparation,
-    enable_device_interop,
-)
-from cuml.internals.array import CumlArray
-from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
-from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
 
-try:
-    from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
-except ImportError:
-    def _openmp_effective_n_threads():
-        return 1
-
-
-class KMeans(UniversalBase,
+class KMeans(Base,
+             InteropMixin,
              ClusterMixin,
              CMajorInputTagMixin):
 
@@ -132,7 +128,7 @@ class KMeans(UniversalBase,
     random_state : int (default = 1)
         If you want results to be the same when you restart Python, select a
         state.
-    init : {'scalable-kmeans++', 'k-means||', 'random'} or an \
+    init : {'scalable-k-means++', 'k-means||', 'random'} or an \
             ndarray (default = 'scalable-k-means++')
 
          - ``'scalable-k-means++'`` or ``'k-means||'``: Uses fast and stable
@@ -205,6 +201,10 @@ class KMeans(UniversalBase,
     For additional docs, see `scikitlearn's Kmeans
     <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html>`_.
     """
+    labels_ = CumlArrayDescriptor(order='C')
+    cluster_centers_ = CumlArrayDescriptor(order='C')
+
+    _cpu_class_path = "sklearn.cluster.KMeans"
 
     _hyperparam_interop_translator = {
         "init": {
@@ -215,9 +215,82 @@ class KMeans(UniversalBase,
         },
     }
 
-    _cpu_estimator_import_path = 'sklearn.cluster.KMeans'
-    labels_ = CumlArrayDescriptor(order='C')
-    cluster_centers_ = CumlArrayDescriptor(order='C')
+    @classmethod
+    def _get_param_names(cls):
+        return [
+            *super()._get_param_names(),
+            "n_init",
+            "oversampling_factor",
+            "max_samples_per_batch",
+            "init",
+            "max_iter",
+            "n_clusters",
+            "random_state",
+            "tol",
+            "convert_dtype"
+        ]
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        init = model.init
+        if callable(init):
+            raise UnsupportedOnGPU
+        elif isinstance(init, str) and init == "k-means++":
+            init = "scalable-k-means++"
+
+        return {
+            "n_clusters": model.n_clusters,
+            "init": init,
+            "n_init": model.n_init,
+            "max_iter": model.max_iter,
+            "tol": model.tol,
+            "random_state": model.random_state,
+        }
+
+    def _params_to_cpu(self):
+        init = self.init
+        if not isinstance(init, str):
+            init = to_cpu(init)
+        elif init == "scalable-k-means++":
+            init = "k-means++"
+        return {
+            "n_clusters": self.n_clusters,
+            "init": init,
+            "n_init": self.n_init,
+            "max_iter": self.max_iter,
+            "tol": self.tol,
+            "random_state": self.random_state,
+        }
+
+    def _attrs_from_cpu(self, model):
+        return {
+            "cluster_centers_": to_gpu(model.cluster_centers_, order="C"),
+            "labels_": to_gpu(model.labels_, order="C"),
+            "inertia_": to_gpu(model.inertia_),
+            "n_iter_": model.n_iter_,
+            **super()._attrs_from_cpu(model),
+        }
+
+    def _attrs_to_cpu(self, model):
+        try:
+            from sklearn.utils._openmp_helpers import (
+                _openmp_effective_n_threads,
+            )
+        except ImportError:
+            n_threads = 1
+        else:
+            n_threads = _openmp_effective_n_threads()
+
+        return {
+            "cluster_centers_": to_cpu(self.cluster_centers_),
+            "labels_": to_cpu(self.labels_),
+            "inertia_": to_cpu(self.inertia_),
+            "n_iter_": self.n_iter_,
+            # sklearn's KMeans relies on a few private attributes to work
+            "_n_features_out": self.n_clusters,
+            "_n_threads": n_threads,
+            **super()._attrs_to_cpu(model),
+        }
 
     def _get_kmeans_params(self):
         cdef KMeansParams* params = \
@@ -229,7 +302,7 @@ class KMeans(UniversalBase,
         # After transferring from one device to another `_seed` might not be set
         # so we need to pass a dummy value here. Its value does not matter as the
         # seed is only used during fitting
-        params.rng_state.seed = <int>getattr(self, "_seed", 0)
+        params.rng_state.seed = <uint64_t>getattr(self, "_seed", 0)
         params.verbosity = <level_enum>(<int>self.verbose)
         params.metric = DistanceType.L2Expanded   # distance metric as squared L2: @todo - support other metrics # noqa: E501
         params.batch_samples = <int>self.max_samples_per_batch
@@ -244,7 +317,6 @@ class KMeans(UniversalBase,
             params.n_init = <int>self.n_init
         return <size_t>params
 
-    @device_interop_preparation
     def __init__(self, *, handle=None, n_clusters=8, max_iter=300, tol=1e-4,
                  verbose=False, random_state=1,
                  init='scalable-k-means++', n_init="auto", oversampling_factor=2.0,
@@ -266,9 +338,6 @@ class KMeans(UniversalBase,
         # internal array attributes
         self.labels_ = None
         self.cluster_centers_ = None
-
-        # For sklearn interoperability
-        self._n_threads = _openmp_effective_n_threads()
 
         # cuPy does not allow comparing with string. See issue #2372
         init_str = init if isinstance(init, str) else None
@@ -298,14 +367,13 @@ class KMeans(UniversalBase,
                 )
 
     @generate_docstring()
-    @enable_device_interop
+    @warn_legacy_device_interop
     @deprecate_non_keyword_only("convert_dtype")
     def fit(self, X, y=None, sample_weight=None, convert_dtype=True) -> "KMeans":
         """
         Compute k-means clustering with X.
 
         """
-        self._n_features_out = self.n_clusters
         if self.init == 'preset':
             check_cols = self.n_features_in_
             check_dtype = self.dtype
@@ -315,7 +383,7 @@ class KMeans(UniversalBase,
             check_dtype = [np.float32, np.float64]
             target_dtype = np.float32
 
-        _X_m, _n_rows, self.n_features_in_, self.dtype = \
+        X_m, n_rows, n_cols, self.dtype = \
             input_to_cuml_array(X,
                                 order='C',
                                 check_cols=check_cols,
@@ -323,26 +391,35 @@ class KMeans(UniversalBase,
                                                   else None),
                                 check_dtype=check_dtype)
 
-        self._seed = check_random_seed(self.random_state)
-        self.feature_names_in_ = _X_m.index
+        # KMeans requires at least 1 row and 1 column. Error message for sklearn compat.
+        for kind, n in [("sample", n_rows), ("feature", n_cols)]:
+            if n == 0:
+                raise ValueError(
+                    f"Found array with 0 {kind}(s) (shape=({n_rows}, {n_cols})) "
+                    "while a minimum of 1 is required by KMeans."
+                )
 
-        cdef uintptr_t input_ptr = _X_m.ptr
+        self._seed = check_random_seed(self.random_state)
+        self.n_features_in_ = n_cols
+        self.feature_names_in_ = X_m.index
+
+        cdef uintptr_t input_ptr = X_m.ptr
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
 
         if sample_weight is None:
-            sample_weight_m = CumlArray.ones(shape=_n_rows, dtype=self.dtype)
+            sample_weight_m = CumlArray.ones(shape=n_rows, dtype=self.dtype)
         else:
             sample_weight_m, _, _, _ = \
                 input_to_cuml_array(sample_weight, order='C',
                                     convert_to_dtype=self.dtype,
-                                    check_rows=_n_rows)
+                                    check_rows=n_rows)
 
         cdef uintptr_t sample_weight_ptr = sample_weight_m.ptr
 
-        int_dtype = np.int32 if np.int64(_n_rows) * np.int64(self.n_features_in_) < 2**31-1 else np.int64
+        int_dtype = np.int32 if np.int64(n_rows) * np.int64(self.n_features_in_) < 2**31-1 else np.int64
 
-        self.labels_ = CumlArray.zeros(shape=_n_rows, dtype=int_dtype)
+        self.labels_ = CumlArray.zeros(shape=n_rows, dtype=int_dtype)
         cdef uintptr_t labels_ptr = self.labels_.ptr
 
         if (self.init in ['scalable-k-means++', 'k-means||', 'random']):
@@ -367,7 +444,7 @@ class KMeans(UniversalBase,
                     handle_[0],
                     <KMeansParams> deref(params),
                     <const float*> input_ptr,
-                    <int> _n_rows,
+                    <int> n_rows,
                     <int> self.n_features_in_,
                     <const float *>sample_weight_ptr,
                     <float*> cluster_centers_ptr,
@@ -380,7 +457,7 @@ class KMeans(UniversalBase,
                     handle_[0],
                     <KMeansParams> deref(params),
                     <const float*> input_ptr,
-                    <int64_t> _n_rows,
+                    <int64_t> n_rows,
                     <int64_t> self.n_features_in_,
                     <const float *>sample_weight_ptr,
                     <float*> cluster_centers_ptr,
@@ -397,7 +474,7 @@ class KMeans(UniversalBase,
                     handle_[0],
                     <KMeansParams> deref(params),
                     <const double*> input_ptr,
-                    <int> _n_rows,
+                    <int> n_rows,
                     <int> self.n_features_in_,
                     <const double *>sample_weight_ptr,
                     <double*> cluster_centers_ptr,
@@ -411,7 +488,7 @@ class KMeans(UniversalBase,
                      handle_[0],
                      <KMeansParams> deref(params),
                      <const double*> input_ptr,
-                     <int64_t> _n_rows,
+                     <int64_t> n_rows,
                      <int64_t> self.n_features_in_,
                      <const double *>sample_weight_ptr,
                      <double*> cluster_centers_ptr,
@@ -427,7 +504,7 @@ class KMeans(UniversalBase,
                             ' passed.')
 
         self.handle.sync()
-        del _X_m
+        del X_m
         del sample_weight_m
         free(params)
         return self
@@ -436,7 +513,7 @@ class KMeans(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Cluster indexes',
                                        'shape': '(n_samples, 1)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     def fit_predict(self, X, y=None, sample_weight=None) -> CumlArray:
         """
         Compute cluster centers and predict cluster index for each sample.
@@ -581,7 +658,7 @@ class KMeans(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Cluster indexes',
                                        'shape': '(n_samples, 1)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     @deprecate_non_keyword_only("convert_dtype", "normalize_weights")
     def predict(self, X, y=None, convert_dtype=True, sample_weight=None,
                 normalize_weights=True) -> CumlArray:
@@ -601,7 +678,7 @@ class KMeans(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, y=None, convert_dtype=True) -> CumlArray:
         """
@@ -690,7 +767,7 @@ class KMeans(UniversalBase,
                                        'description': 'Opposite of the value \
                                                         of X on the K-means \
                                                         objective.'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     @deprecate_non_keyword_only("convert_dtype")
     def score(self, X, y=None, sample_weight=None, convert_dtype=True):
         """
@@ -706,7 +783,7 @@ class KMeans(UniversalBase,
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    @enable_device_interop
+    @warn_legacy_device_interop
     @deprecate_non_keyword_only("convert_dtype")
     def fit_transform(self, X, y=None, convert_dtype=False,
                       sample_weight=None) -> CumlArray:
@@ -716,24 +793,3 @@ class KMeans(UniversalBase,
         """
         self.fit(X, sample_weight=sample_weight)
         return self.transform(X, convert_dtype=convert_dtype)
-
-    @classmethod
-    def _get_param_names(cls):
-        return super()._get_param_names() + \
-            ['n_init', 'oversampling_factor', 'max_samples_per_batch',
-                'init', 'max_iter', 'n_clusters', 'random_state',
-                'tol', "convert_dtype"]
-
-    def get_attr_names(self):
-        return ['cluster_centers_', 'labels_', 'inertia_',
-                'n_iter_', 'n_features_in_', '_n_threads',
-                "feature_names_in_", "_n_features_out"]
-
-    def _should_dispatch_cpu(self, func_name, *args, **kwargs):
-        """
-        Dispatch to CPU implementation when sparse arrays are detected in the input
-        """
-        if func_name == "fit" and len(args) > 0:
-            X = args[0]
-            return is_sparse(X)
-        return False

--- a/python/cuml/cuml/internals/interop.py
+++ b/python/cuml/cuml/internals/interop.py
@@ -24,6 +24,7 @@ from cuml.internals.device_type import DeviceType
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.memory_utils import using_output_type
+from cuml.internals.utils import classproperty
 
 __all__ = (
     "UnsupportedOnGPU",
@@ -90,16 +91,6 @@ class UnsupportedOnGPU(ValueError):
 
 class UnsupportedOnCPU(ValueError):
     """An exception raised when a conversion of a GPU to a CPU estimator isn't supported"""
-
-
-class classproperty:
-    """Like ``property``, but on a class rather than an instance."""
-
-    def __init__(self, fget):
-        self.fget = fget
-
-    def __get__(self, obj, owner):
-        return self.fget(owner)
 
 
 class InteropMixin:

--- a/python/cuml/cuml/internals/utils.py
+++ b/python/cuml/cuml/internals/utils.py
@@ -20,6 +20,16 @@ import cupy as cp
 import numpy as np
 
 
+class classproperty:
+    """Like ``property``, but on a class rather than an instance."""
+
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, obj, owner):
+        return self.fget(owner)
+
+
 def check_random_seed(seed):
     """Turn a np.random.RandomState instance into a seed.
 

--- a/python/cuml/cuml/tests/test_device_selection.py
+++ b/python/cuml/cuml/tests/test_device_selection.py
@@ -26,7 +26,6 @@ import pytest
 from hdbscan import HDBSCAN as refHDBSCAN
 from pytest_cases import fixture, fixture_union
 from sklearn.cluster import DBSCAN as skDBSCAN
-from sklearn.cluster import KMeans as skKMeans
 from sklearn.datasets import make_blobs, make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier as skRFC
 from sklearn.ensemble import RandomForestRegressor as skRFR
@@ -38,7 +37,7 @@ from sklearn.svm import SVR as skSVR
 from umap import UMAP as refUMAP
 
 import cuml
-from cuml.cluster import DBSCAN, KMeans
+from cuml.cluster import DBSCAN
 from cuml.cluster.hdbscan import HDBSCAN
 from cuml.common.device_selection import DeviceType, using_device_type
 from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
@@ -539,24 +538,6 @@ def test_hdbscan_methods(train_device, infer_device):
 
 @pytest.mark.parametrize("train_device", ["cpu", "gpu"])
 @pytest.mark.parametrize("infer_device", ["cpu", "gpu"])
-def test_kmeans_methods(train_device, infer_device):
-    n_clusters = 20
-    ref_model = skKMeans(n_clusters=n_clusters, random_state=42)
-    ref_model.fit(X_train_blob)
-    ref_output = ref_model.predict(X_test_blob)
-
-    model = KMeans(n_clusters=n_clusters, random_state=42, n_init="auto")
-
-    with using_device_type(train_device):
-        model.fit(X_train_blob)
-    with using_device_type(infer_device):
-        output = model.predict(X_test_blob)
-
-    assert adjusted_rand_score(ref_output, output) >= 0.9
-
-
-@pytest.mark.parametrize("train_device", ["cpu", "gpu"])
-@pytest.mark.parametrize("infer_device", ["cpu", "gpu"])
 def test_dbscan_methods(train_device, infer_device):
     eps = 8.0
     ref_model = skDBSCAN(eps=eps)
@@ -726,6 +707,7 @@ def test_svr_methods(train_device, infer_device):
         "PCA",
         "TruncatedSVD",
         "TSNE",
+        "KMeans",
     ],
 )
 def test_legacy_device_selection_warns(cls):

--- a/python/cuml/cuml/tests/test_kmeans.py
+++ b/python/cuml/cuml/tests/test_kmeans.py
@@ -434,3 +434,18 @@ def test_fit_transform_weighted_kmeans(
         assert diff / avg_score <= relative_tolerance
 
     assert sk_transf.shape == cuml_transf.shape
+
+
+def test_kmeans_empty_x():
+    """Check that a nice error happens if X is empty, rather than a segfault"""
+    model = cuml.KMeans()
+
+    X = np.empty(shape=(0, 10))
+    y = np.ones(shape=0)
+    with pytest.raises(ValueError, match=r"Found array with 0 sample\(s\)"):
+        model.fit(X, y)
+
+    X = np.empty(shape=(10, 0))
+    y = np.ones(shape=10)
+    with pytest.raises(ValueError, match=r"Found array with 0 feature\(s\)"):
+        model.fit(X, y)

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -77,6 +77,8 @@ def test_method_metadata():
 
 
 def test_sklearn_introspect_estimator_type():
+    assert LogisticRegression._estimator_type == "classifier"
+    assert LogisticRegression()._estimator_type == "classifier"
     assert is_classifier(LogisticRegression())
     assert is_regressor(LinearRegression())
 


### PR DESCRIPTION
This ports `cuml.KMeans` to use the new `ProxyBase`/`InteropMixin` architecture.

Part of #6705.