### PR TITLE
chore: reduce ceiling of `cuml` wheel size

### DIFF
--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -25,7 +25,7 @@ select = [
 ]
 
 # detect when package size grows significantly
-max_allowed_size_compressed = '1.5G'
+max_allowed_size_compressed = '75MB'
 
 [tool.pytest.ini_options]
 addopts = "--tb=native"


### PR DESCRIPTION
The `cuml` wheels are currently on the order of ~20 MB.  No issues there, but the size-limit check here should be something closer in magnitude.
