### PR TITLE
Deprecate a few missed cuml-only non-keyword-only kwargs

### DIFF
--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -623,6 +623,7 @@ class PCA(Base,
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_features)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "return_sparse", "sparse_tol")
     def inverse_transform(self, X, convert_dtype=False,
                           return_sparse=False, sparse_tol=1e-10) -> CumlArray:
         """

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -442,6 +442,7 @@ class TruncatedSVD(Base,
                                        'description': 'X in original space',
                                        'shape': '(n_samples, n_features)'})
     @warn_legacy_device_interop
+    @deprecate_non_keyword_only("convert_dtype")
     def inverse_transform(self, X, convert_dtype=False) -> CumlArray:
         """
         Transform X back to its original space.

--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -276,6 +276,7 @@ class KernelDensity(Base):
 
         return self
 
+    @deprecate_non_keyword_only("convert_dtype")
     def score_samples(self, X, convert_dtype=True):
         """Compute the log-likelihood of each sample under the model.
 

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -479,6 +479,7 @@ class NearestNeighbors(UniversalBase,
                                           ('dense',
                                            '(n_samples, n_features)')])
     @enable_device_interop
+    @deprecate_non_keyword_only("convert_dtype", "two_pass_precision")
     def kneighbors(
         self,
         X=None,

--- a/python/cuml/cuml/preprocessing/label.py
+++ b/python/cuml/cuml/preprocessing/label.py
@@ -21,7 +21,7 @@ import cuml.internals
 from cuml.common import CumlArray
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.base import Base
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.prims.label import check_labels, invert_labels, make_monotonic
 
 
@@ -251,6 +251,7 @@ class LabelBinarizer(Base):
             sparse_output=self.sparse_output,
         )
 
+    @deprecate_non_keyword_only("threshold")
     def inverse_transform(self, y, threshold=None) -> CumlArray:
         """
         Transform binary labels back to original multi-class labels


### PR DESCRIPTION
My original script for finding these had a bug, missed a few cases in #6738. This should be the last of them.