### PR TITLE
Fix to compile FIL `infer_kernel` with CUDA arch 1210

### DIFF
--- a/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/gpu_introspection.hpp
@@ -104,7 +104,7 @@ auto constexpr static const WARP_SIZE             = index_type{32};
 auto constexpr static const MAX_THREADS_PER_BLOCK = index_type{256};
 #ifdef __CUDACC__
 #if __CUDA_ARCH__ == 720 || __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860 || \
-  __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200
+  __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200 || __CUDA_ARCH__ == 1210
 auto constexpr static const MAX_THREADS_PER_SM = index_type{1024};
 #else
 auto constexpr static const MAX_THREADS_PER_SM = index_type{2048};


### PR DESCRIPTION
`infer_kernel` uses the value of 2048 as a fallback for `MAX_THREADS_PER_SM` for all unspecified GPU architectures. This PR adds `sm121` to the list of architectures whose `MAX_THREADS_PER_SM` value is 1024.