### PR TITLE
Port UMAP to InteropMixin/ProxyBase

### DIFF
--- a/python/cuml/cuml/accel/_wrappers/umap.py
+++ b/python/cuml/cuml/accel/_wrappers/umap.py
@@ -15,10 +15,10 @@
 #
 
 import cuml.manifold
-from cuml.accel.estimator_proxy_mixin import ProxyMixin
+from cuml.accel.estimator_proxy import ProxyBase
 
 __all__ = ("UMAP",)
 
 
-class UMAP(ProxyMixin, cuml.manifold.UMAP):
-    pass
+class UMAP(ProxyBase):
+    _gpu_class = cuml.manifold.UMAP

--- a/python/cuml/cuml/accel/_wrappers/umap.py
+++ b/python/cuml/cuml/accel/_wrappers/umap.py
@@ -22,3 +22,19 @@ __all__ = ("UMAP",)
 
 class UMAP(ProxyBase):
     _gpu_class = cuml.manifold.UMAP
+
+    def _gpu_fit(self, X, y=None, force_all_finite=True, **kwargs):
+        # **kwargs is here for signature compatibility - umap.UMAP has them,
+        # but ignores all but the ones named here.
+        # TODO: cuml.UMAP currently doesn't handle non-finite inputs.
+        # force_alL_finite is in here for _signature_ compatibility
+        # with umap.UMAP, but we don't properly implement it (yet).
+        return self._gpu.fit(X, y=y)
+
+    def _gpu_fit_transform(self, X, y=None, force_all_finite=True, **kwargs):
+        # **kwargs is here for signature compatibility - umap.UMAP has them,
+        # but ignores all but the ones named here.
+        return self._gpu.fit_transform(X, y=y)
+
+    def _gpu_transform(self, X, force_all_finite=True):
+        return self._gpu.transform(X)

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -20,7 +20,7 @@ from typing import Any
 import sklearn
 from sklearn.base import BaseEstimator
 
-from cuml.internals.interop import UnsupportedOnGPU
+from cuml.internals.interop import UnsupportedOnGPU, is_fitted
 
 
 class _ReconstructProxy:
@@ -199,7 +199,7 @@ class ProxyBase(BaseEstimator):
         self = cls.__new__(cls)
         self._cpu = cpu
         self._synced = False
-        if hasattr(self._cpu, "n_features_in_"):
+        if is_fitted(self._cpu):
             # This is a fit estimator. Try to convert model back to GPU
             try:
                 self._gpu = self._gpu_class.from_sklearn(self._cpu)
@@ -240,8 +240,7 @@ class ProxyBase(BaseEstimator):
         if is_fit:
             # Attempt to call CPU param validation to validate hyperparameters.
             # This ensures we match errors for invalid hyperparameters during fitting.
-            if hasattr(self._cpu, "_validate_params"):
-                self._cpu._validate_params()
+            self._validate_params()
 
             # Attempt to create a new GPU estimator with the current hyperparameters.
             try:
@@ -350,7 +349,7 @@ class ProxyBase(BaseEstimator):
 
     def __sklearn_is_fitted__(self):
         model = self._cpu if self._gpu is None else self._gpu
-        return getattr(model, "n_features_in_", None) is not None
+        return is_fitted(model)
 
     def __sklearn_clone__(self):
         cls = type(self)
@@ -378,7 +377,10 @@ class ProxyBase(BaseEstimator):
         return cls._cpu_class._get_param_names()
 
     def _validate_params(self):
-        self._cpu._validate_params()
+        if hasattr(self._cpu, "_validate_params") and hasattr(
+            self._cpu, "_parameter_constraints"
+        ):
+            self._cpu._validate_params()
 
     def _get_tags(self):
         return self._cpu._get_tags()

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -116,7 +116,7 @@ class ProxyBase(BaseEstimator):
         super().__init_subclass__(**kwargs)
 
         # Store `_cpu_class` from `_gpu_class` for parity and ease-of-reference
-        cls._cpu_class = cls._gpu_class._cpu_class
+        cls._cpu_class = cls._gpu_class._get_cpu_class()
 
         # Store whether sparse inputs are supported, unless overridden
         if not hasattr(cls, "_gpu_supports_sparse"):

--- a/python/cuml/cuml/internals/interop.py
+++ b/python/cuml/cuml/internals/interop.py
@@ -58,6 +58,17 @@ class UnsupportedOnCPU(ValueError):
     """An exception raised when a conversion of a GPU to a CPU estimator isn't supported"""
 
 
+def is_fitted(model) -> bool:
+    """Check if a sklearn model is fitted."""
+    if hasattr(model, "__sklearn_is_fitted__"):
+        return model.__sklearn_is_fitted__()
+    if getattr(model, "n_features_in_", None) is not None:
+        return True
+    return any(
+        v for v in vars(model) if v.endswith("_") and not v.startswith("__")
+    )
+
+
 class InteropMixin:
     """A mixin for enabling conversion of a cuml estimator to/from its
     CPU-based counterpart.
@@ -199,7 +210,7 @@ class InteropMixin:
         model
             An instance of ``self._cpu_class``.
         """
-        if getattr(self, "n_features_in_", None) is None:
+        if not is_fitted(self):
             # GPU model not fitted, nothing to do
             return
 
@@ -220,7 +231,7 @@ class InteropMixin:
         model
             An instance of ``self._cpu_class``.
         """
-        if getattr(model, "n_features_in_", None) is None:
+        if not is_fitted(model):
             # CPU model not fitted, nothing to do
             return
 

--- a/python/cuml/cuml/internals/interop.py
+++ b/python/cuml/cuml/internals/interop.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.memory_utils import using_output_type
-from cuml.internals.utils import classproperty
 
 __all__ = (
     "UnsupportedOnGPU",
@@ -88,8 +87,8 @@ class InteropMixin:
     # The import path to use to import the CPU model class
     _cpu_class_path: str
 
-    @classproperty
-    def _cpu_class(cls):
+    @classmethod
+    def _get_cpu_class(cls):
         """The CPU class that corresponds to this GPU model"""
         module, _, name = cls._cpu_class_path.rpartition(".")
         return getattr(import_module(module), name)
@@ -101,7 +100,7 @@ class InteropMixin:
         Parameters
         ----------
         model
-            The CPU model, of the same type as ``self._cpu_class``.
+            The CPU model, matching the type of ``self._cpu_class_path``.
 
         Returns
         -------
@@ -122,8 +121,8 @@ class InteropMixin:
         Returns
         -------
         dict
-            A mapping of keyword arguments that may be used to instantiate
-            ``self._cpu_class`` to create an equivalent CPU model.
+            A mapping of keyword arguments that may be used to create
+            an equivalent CPU model.
 
         Raises
         ------
@@ -144,7 +143,7 @@ class InteropMixin:
         Parameters
         ----------
         model
-            The CPU model, of the same type as ``self._cpu_class``.
+            The CPU model, matching the type of ``self._cpu_class_path``.
 
         Returns
         -------
@@ -177,7 +176,7 @@ class InteropMixin:
         Parameters
         ----------
         model
-            The CPU model, of the same type as ``self._cpu_class``.
+            The CPU model, matching the type of ``self._cpu_class_path``.
 
         Returns
         -------
@@ -208,7 +207,7 @@ class InteropMixin:
         Parameters
         ----------
         model
-            An instance of ``self._cpu_class``.
+            A CPU model, matching the type of ``self._cpu_class_path``.
         """
         if not is_fitted(self):
             # GPU model not fitted, nothing to do
@@ -229,7 +228,7 @@ class InteropMixin:
         Parameters
         ----------
         model
-            An instance of ``self._cpu_class``.
+            A CPU model, matching the type of ``self._cpu_class_path``.
         """
         if not is_fitted(model):
             # CPU model not fitted, nothing to do
@@ -251,7 +250,7 @@ class InteropMixin:
             state of the current estimator.
         """
         params = self._params_to_cpu()
-        model = self._cpu_class(**params)
+        model = self._get_cpu_class()(**params)
         self._sync_attrs_to_cpu(model)
         return model
 
@@ -277,7 +276,7 @@ class InteropMixin:
         cannot be inferred from training arguments. If something different is
         required, then please use cuml's output_type configuration utilities.
         """
-        if not isinstance(model, cls._cpu_class):
+        if not isinstance(model, cls._get_cpu_class()):
             raise TypeError(
                 f"Expected instance of {cls._cpu_class_path!r}, got "
                 f"{type(model).__name__!r}"

--- a/python/cuml/cuml/internals/utils.py
+++ b/python/cuml/cuml/internals/utils.py
@@ -20,16 +20,6 @@ import cupy as cp
 import numpy as np
 
 
-class classproperty:
-    """Like ``property``, but on a class rather than an instance."""
-
-    def __init__(self, fget):
-        self.fget = fget
-
-    def __get__(self, obj, owner):
-        return self.fget(owner)
-
-
 def check_random_seed(seed):
     """Turn a np.random.RandomState instance into a seed.
 

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -19,9 +19,10 @@
 import warnings
 
 import cupy
-import cupyx
+import cupyx.scipy.sparse
 import joblib
 import numpy as np
+import scipy.sparse
 
 import cuml.accel
 import cuml.internals
@@ -30,14 +31,16 @@ from cuml.common.doc_utils import generate_docstring
 from cuml.common.sparse_utils import is_sparse
 from cuml.common.sparsefuncs import extract_knn_infos
 from cuml.internals import logger
-from cuml.internals.api_decorators import (
-    device_interop_preparation,
-    enable_device_interop,
-)
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.base import UniversalBase, deprecate_non_keyword_only
+from cuml.internals.base import Base, deprecate_non_keyword_only
 from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.interop import (
+    InteropMixin,
+    UnsupportedOnGPU,
+    to_cpu,
+    to_gpu,
+)
 from cuml.internals.mem_type import MemoryType
 from cuml.internals.mixins import CMajorInputTagMixin, SparseInputTagMixin
 from cuml.internals.utils import check_random_seed
@@ -109,7 +112,20 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP" nogil:
                           float *transformed) except +
 
 
-class UMAP(UniversalBase,
+def _joblib_hash(X):
+    """A thin shim around joblib.hash"""
+    if scipy.sparse.issparse(X):
+        # XXX: joblib.hash doesn't special case sparse inputs, meaning that
+        # it's sensitive to what should be irrelevant internal state. For now
+        # we trigger a cached attribute to ensure state is always fully filled
+        # in so hashing is consistent. This is a relatively cheap operation and
+        # has no measurable impact on performance.
+        X.has_sorted_indices
+    return joblib.hash(X)
+
+
+class UMAP(Base,
+           InteropMixin,
            CMajorInputTagMixin,
            SparseInputTagMixin):
     """
@@ -336,33 +352,188 @@ class UMAP(UniversalBase,
        <https://arxiv.org/abs/2008.00325>`_
     """
 
-    _cpu_estimator_import_path = 'umap.UMAP'
     embedding_ = CumlArrayDescriptor(order='C')
 
-    _hyperparam_interop_translator = {
-        "metric": {
-            "sokalsneath": "NotImplemented",
-            "rogerstanimoto": "NotImplemented",
-            "sokalmichener": "NotImplemented",
-            "yule": "NotImplemented",
-            "ll_dirichlet": "NotImplemented",
-            "russellrao": "NotImplemented",
-            "kulsinski": "NotImplemented",
-            "dice": "NotImplemented",
-            "wminkowski": "NotImplemented",
-            "mahalanobis": "NotImplemented",
-            "haversine": "NotImplemented",
-        },
-        "init": {
-            "pca": "NotImplemented",
-            "tswspectral": "NotImplemented"
-        },
-        "target_metric": {
-            "l2": "euclidean"
-        }
-    }
+    _cpu_class_path = "umap.UMAP"
 
-    @device_interop_preparation
+    @classmethod
+    def _get_param_names(cls):
+        return [
+            *super()._get_param_names(),
+            "n_neighbors",
+            "n_components",
+            "n_epochs",
+            "learning_rate",
+            "min_dist",
+            "spread",
+            "set_op_mix_ratio",
+            "local_connectivity",
+            "repulsion_strength",
+            "negative_sample_rate",
+            "transform_queue_size",
+            "init",
+            "a",
+            "b",
+            "target_n_neighbors",
+            "target_weight",
+            "target_metric",
+            "hash_input",
+            "random_state",
+            "callback",
+            "metric",
+            "metric_kwds",
+            "precomputed_knn",
+            "build_algo",
+            "build_kwds"
+        ]
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        if not (isinstance(model.init, str) and model.init in ("spectral", "random")):
+            raise UnsupportedOnGPU
+
+        if isinstance(model.metric, str):
+            try:
+                coerce_metric(model.metric)
+            except (ValueError, NotImplementedError):
+                raise UnsupportedOnGPU
+        else:
+            raise UnsupportedOnGPU
+
+        if model.target_metric not in ("categorical", "l2", "euclidean"):
+            raise UnsupportedOnGPU
+
+        if model.unique:
+            raise UnsupportedOnGPU
+
+        if model.densmap:
+            raise UnsupportedOnGPU
+
+        precomputed_knn = model.precomputed_knn[:2]
+        if all(item is None for item in precomputed_knn):
+            precomputed_knn = None
+
+        return {
+            "n_neighbors": model.n_neighbors,
+            "n_components": model.n_components,
+            "metric": model.metric,
+            "metric_kwds": model.metric_kwds,
+            "n_epochs": model.n_epochs,
+            "learning_rate": model.learning_rate,
+            "min_dist": model.min_dist,
+            "spread": model.spread,
+            "set_op_mix_ratio": model.set_op_mix_ratio,
+            "local_connectivity": model.local_connectivity,
+            "repulsion_strength": model.repulsion_strength,
+            "negative_sample_rate": model.negative_sample_rate,
+            "transform_queue_size": model.transform_queue_size,
+            "init": model.init,
+            "a": model.a,
+            "b": model.b,
+            "target_n_neighbors": model.target_n_neighbors,
+            "target_weight": model.target_weight,
+            "target_metric": model.target_metric,
+            "hash_input": True,
+            "random_state": model.random_state,
+            "precomputed_knn": precomputed_knn,
+        }
+
+    def _params_to_cpu(self):
+        if (precomputed_knn := self.precomputed_knn) is None:
+            precomputed_knn = (None, None, None)
+
+        return {
+            "n_neighbors": self.n_neighbors,
+            "n_components": self.n_components,
+            "metric": self.metric,
+            "metric_kwds": self.metric_kwds,
+            "n_epochs": self.n_epochs,
+            "learning_rate": self.learning_rate,
+            "min_dist": self.min_dist,
+            "spread": self.spread,
+            "set_op_mix_ratio": self.set_op_mix_ratio,
+            "local_connectivity": self.local_connectivity,
+            "repulsion_strength": self.repulsion_strength,
+            "negative_sample_rate": self.negative_sample_rate,
+            "transform_queue_size": self.transform_queue_size,
+            "init": self.init,
+            "a": self.a,
+            "b": self.b,
+            "target_n_neighbors": self.target_n_neighbors,
+            "target_weight": self.target_weight,
+            "target_metric": self.target_metric,
+            "random_state": self.random_state,
+            "precomputed_knn": precomputed_knn,
+        }
+
+    def _attrs_from_cpu(self, model):
+        if scipy.sparse.issparse(model._raw_data):
+            raw_data = SparseCumlArray(
+                model._raw_data,
+                convert_to_dtype=cupy.float32,
+                convert_format=True
+            )
+        else:
+            raw_data = to_gpu(model._raw_data)
+
+        return {
+            "embedding_": to_gpu(model.embedding_, order="C"),
+            "graph_": cupyx.scipy.sparse.coo_matrix(model.graph_),
+            "_raw_data": raw_data,
+            "_input_hash": model._input_hash,
+            "sparse_fit": model._sparse_data,
+            **super()._attrs_from_cpu(model),
+        }
+
+    def _attrs_to_cpu(self, model):
+        from umap.umap_ import DISCONNECTION_DISTANCES
+
+        disconnection_distance = DISCONNECTION_DISTANCES.get(self.metric, np.inf)
+
+        raw_data = self._raw_data.to_output("numpy")
+
+        if (input_hash := getattr(self, "_input_hash", None)) is None:
+            input_hash = _joblib_hash(raw_data)
+
+        if (knn_dists := getattr(self, "_knn_dists", None)) is not None:
+            knn_dists = to_cpu(knn_dists)
+
+        if (knn_indices := getattr(self, "_knn_indices", None)) is not None:
+            knn_indices = to_cpu(knn_indices)
+
+        return {
+            "embedding_": to_cpu(self.embedding_),
+            "graph_": self.graph_.get().tocsr(),
+            "graph_dists_": None,
+            "_raw_data": raw_data,
+            "_input_hash": input_hash,
+            "_sparse_data": self.sparse_fit,
+            "_a": self.a,
+            "_b": self.b,
+            "_disconnection_distance": disconnection_distance,
+            "_initial_alpha": self.learning_rate,
+            "_n_neighbors": self.n_neighbors,
+            "_supervised": self._supervised,
+            "_small_data": False,
+            "_knn_dists": knn_dists,
+            "_knn_indices": knn_indices,
+            # XXX: umap.UMAP requires _knn_search_index to transform on new data.
+            # This is an instance of pynndescent.NNDescent, which can _currently_
+            # only be recreated by rerunning the nndescent algorithm, effectively
+            # repeating any work already done on GPU. Instead, we opt to set
+            # _knn_search_index to None (which is allowed). In this case
+            # calling umap.UMAP.transform on _new_ data will result in
+            # a nicer NotImplementedError being raised informing the user
+            # that that's not supported on the instance.
+            "_knn_search_index": None,
+            **super()._attrs_to_cpu(model),
+        }
+
+    def _sync_attrs_to_cpu(self, model):
+        super()._sync_attrs_to_cpu(model)
+        # _validate_parameters constructs the rest of umap.UMAP's internal state
+        model._validate_parameters()
+
     def __init__(self, *,
                  n_neighbors=15,
                  n_components=2,
@@ -431,9 +602,9 @@ class UMAP(UniversalBase,
 
         self.random_state = random_state
 
-        if target_metric == "euclidean" or target_metric == "categorical":
+        if target_metric in {"euclidean", "l2", "categorical"}:
             self.target_metric = target_metric
-        elif not cuml.accel.enabled():
+        else:
             raise Exception(f"Invalid target metric: {target_metric}")
 
         self.callback = callback  # prevent callback destruction
@@ -443,7 +614,6 @@ class UMAP(UniversalBase,
 
         self.sparse_fit = False
         self._input_hash = None
-        self._small_data = False
 
         self.precomputed_knn = extract_knn_infos(precomputed_knn, n_neighbors)
 
@@ -494,7 +664,7 @@ class UMAP(UniversalBase,
         else:  # self.init == "random"
             umap_params.init = <int> 0
 
-        if self.target_metric == "euclidean":
+        if self.target_metric in {"euclidean", "l2"}:
             umap_params.target_metric = MetricType.EUCLIDEAN
         else:  # self.target_metric == "categorical"
             umap_params.target_metric = MetricType.CATEGORICAL
@@ -554,7 +724,6 @@ class UMAP(UniversalBase,
     @generate_docstring(convert_dtype_cast='np.float32',
                         X='dense_sparse',
                         skip_parameters_heading=True)
-    @enable_device_interop
     @deprecate_non_keyword_only("convert_dtype", "knn_graph", "data_on_host")
     def fit(self, X, y=None, convert_dtype=True,
             knn_graph=None, data_on_host=False) -> "UMAP":
@@ -665,7 +834,7 @@ class UMAP(UniversalBase,
                                           index=self._raw_data.index)
 
         if self.hash_input:
-            self._input_hash = joblib.hash(self._raw_data.to_output('numpy'))
+            self._input_hash = _joblib_hash(self._raw_data.to_output('numpy'))
 
         cdef uintptr_t _embed_raw_ptr = self.embedding_.ptr
 
@@ -678,6 +847,9 @@ class UMAP(UniversalBase,
                                                       if convert_dtype
                                                       else None))
             _y_raw_ptr = y_m.ptr
+            self._supervised = True
+        else:
+            self._supervised = False
 
         cdef handle_t * handle_ = \
             <handle_t*> <size_t> self.handle.getHandle()
@@ -729,7 +901,6 @@ class UMAP(UniversalBase,
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.api_base_fit_transform()
-    @enable_device_interop
     @deprecate_non_keyword_only("convert_dtype", "knn_graph", "data_on_host")
     def fit_transform(self, X, y=None, convert_dtype=True,
                       knn_graph=None, data_on_host=False) -> CumlArray:
@@ -779,7 +950,6 @@ class UMAP(UniversalBase,
                                                        data in \
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
-    @enable_device_interop
     @deprecate_non_keyword_only("convert_dtype")
     def transform(self, X, convert_dtype=True) -> CumlArray:
         """
@@ -828,8 +998,7 @@ class UMAP(UniversalBase,
                              "training data")
 
         if self.hash_input:
-            if joblib.hash(X_m.to_output('numpy')) == self._input_hash:
-                del X_m
+            if _joblib_hash(X_m.to_output('numpy')) == self._input_hash:
                 return self.embedding_
 
         embedding = CumlArray.zeros((n_rows, self.n_components),
@@ -880,95 +1049,3 @@ class UMAP(UniversalBase,
 
         del X_m
         return embedding
-
-    @property
-    def _n_neighbors(self):
-        return self.n_neighbors
-
-    @_n_neighbors.setter
-    def _n_neighbors(self, value):
-        self.n_neighbors = value
-
-    @property
-    def _a(self):
-        return self.a
-
-    @_a.setter
-    def _a(self, value):
-        self.a = value
-
-    @property
-    def _b(self):
-        return self.b
-
-    @_b.setter
-    def _b(self, value):
-        self.b = value
-
-    @property
-    def _initial_alpha(self):
-        return self.learning_rate
-
-    @_initial_alpha.setter
-    def _initial_alpha(self, value):
-        self.learning_rate = value
-
-    @property
-    def _disconnection_distance(self):
-        from umap.umap_ import DISCONNECTION_DISTANCES
-        self.disconnection_distance = DISCONNECTION_DISTANCES.get(self.metric, np.inf)
-        return self.disconnection_distance
-
-    @_disconnection_distance.setter
-    def _disconnection_distance(self, value):
-        self.disconnection_distance = value
-
-    def gpu_to_cpu(self):
-        from umap.umap_ import nearest_neighbors
-        if hasattr(self, 'knn_dists') and hasattr(self, 'knn_indices'):
-            self._knn_dists = self.knn_dists
-            self._knn_indices = self.knn_indices
-            self._knn_search_index = None
-        if hasattr(self, '_raw_data'):
-            self._knn_dists, self._knn_indices, self._knn_search_index = \
-                nearest_neighbors(self._raw_data.to_output('numpy'), self.n_neighbors, self.metric,
-                                  self.metric_kwds, False, self.random_state)
-
-        super().gpu_to_cpu()
-        self._cpu_model._validate_parameters()
-
-    @classmethod
-    def _get_param_names(cls):
-        return super()._get_param_names() + [
-            "n_neighbors",
-            "n_components",
-            "n_epochs",
-            "learning_rate",
-            "min_dist",
-            "spread",
-            "set_op_mix_ratio",
-            "local_connectivity",
-            "repulsion_strength",
-            "negative_sample_rate",
-            "transform_queue_size",
-            "init",
-            "a",
-            "b",
-            "target_n_neighbors",
-            "target_weight",
-            "target_metric",
-            "hash_input",
-            "random_state",
-            "callback",
-            "metric",
-            "metric_kwds",
-            "precomputed_knn",
-            "build_algo",
-            "build_kwds"
-        ]
-
-    def get_attr_names(self):
-        return ['_raw_data', 'embedding_', '_input_hash', '_small_data',
-                '_knn_dists', '_knn_indices', '_knn_search_index',
-                '_disconnection_distance', '_n_neighbors', '_a', '_b',
-                '_initial_alpha', '_sparse_data']

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -578,7 +578,7 @@ class UMAP(Base,
 
         if init == "spectral" or init == "random":
             self.init = init
-        elif not cuml.accel.enabled():
+        else:
             raise Exception(f"Initialization strategy not supported: {init}")
 
         if a is None or b is None:

--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 import scipy.sparse
 import sklearn.svm
+import umap
 from numpy.testing import assert_allclose
 from sklearn.cluster import KMeans as SkKMeans
 from sklearn.datasets import make_blobs, make_classification, make_regression
@@ -27,6 +28,8 @@ from sklearn.linear_model import Lasso as SkLasso
 from sklearn.linear_model import LinearRegression as SkLinearRegression
 from sklearn.linear_model import LogisticRegression as SkLogisticRegression
 from sklearn.linear_model import Ridge as SkRidge
+from sklearn.manifold import trustworthiness
+from sklearn.model_selection import train_test_split
 from sklearn.utils.validation import check_is_fitted
 
 import cuml
@@ -54,6 +57,44 @@ def random_state():
     return 42
 
 
+def assert_params_equal(original, roundtrip):
+    original_params = original.get_params()
+    roundtrip_params = roundtrip.get_params()
+
+    # Remove parameters that are not serialized
+    _ = original_params.pop("handle", None)
+    _ = roundtrip_params.pop("handle", None)
+
+    _ = original_params.pop("output_type", None)
+    _ = roundtrip_params.pop("output_type", None)
+
+    _ = original_params.pop("verbose", None)
+    _ = roundtrip_params.pop("verbose", None)
+
+    if isinstance(original, KMeans):
+        # for KMeans, the roundtrip changes the string of
+        # init from scalable-k-means++ to k-means++ which
+        # in principle should change the value of oversampling_factor
+        # But this value at 2 will lead to better centroids,
+        # so ignoring this issue for now will have no ill
+        # consequences
+        _ = original_params.pop("init", None)
+        _ = roundtrip_params.pop("init", None)
+
+    def dict_diff(a, b):
+        # Get all keys from both dictionaries
+        all_keys = set(a.keys()) | set(b.keys())
+        differences = {}
+        for key in all_keys:
+            if a.get(key) != b.get(key):
+                differences[key] = {"a_dict": a.get(key), "b_dict": b.get(key)}
+        return differences
+
+    assert (
+        original_params == roundtrip_params
+    ), f"Differences found: {dict_diff(original_params, roundtrip_params)}"
+
+
 def assert_estimator_roundtrip(
     cuml_model, sklearn_class, X, y=None, transform=False
 ):
@@ -72,49 +113,14 @@ def assert_estimator_roundtrip(
 
     # Convert to sklearn model
     sklearn_model = cuml_model.as_sklearn()
-    check_is_fitted(sklearn_model)
-
-    original_params = cuml_model.get_params()
-
     assert isinstance(sklearn_model, sklearn_class)
+    check_is_fitted(sklearn_model)
 
     # Convert back
     roundtrip_model = type(cuml_model).from_sklearn(sklearn_model)
 
-    rm_params = roundtrip_model.get_params()
-
-    # Remove parameters that are not serialized
-    _ = original_params.pop("handle", None)
-    _ = rm_params.pop("handle", None)
-
-    _ = original_params.pop("output_type", None)
-    _ = rm_params.pop("output_type", None)
-
-    _ = original_params.pop("verbose", None)
-    _ = rm_params.pop("verbose", None)
-
-    if isinstance(cuml_model, KMeans):
-        # for KMeans, the roundtrip changes the string of
-        # init from scalable-k-means++ to k-means++ which
-        # in principle should change the value of oversampling_factor
-        # But this value at 2 will lead to better centroids,
-        # so ignoring this issue for now will have no ill
-        # consequences
-        _ = original_params.pop("init", None)
-        _ = rm_params.pop("init", None)
-
-    def dict_diff(a, b):
-        # Get all keys from both dictionaries
-        all_keys = set(a.keys()) | set(b.keys())
-        differences = {}
-        for key in all_keys:
-            if a.get(key) != b.get(key):
-                differences[key] = {"a_dict": a.get(key), "b_dict": b.get(key)}
-        return differences
-
-    assert (
-        original_params == rm_params
-    ), f"Differences found: {dict_diff(original_params, rm_params)}"
+    # Ensure params roundtrip
+    assert_params_equal(cuml_model, roundtrip_model)
 
     # Ensure roundtrip model is fitted
     check_is_fitted(roundtrip_model)
@@ -336,3 +342,64 @@ def test_svc_probability_true_unsupported(random_state):
 
     with pytest.raises(UnsupportedOnCPU):
         cu_model.as_sklearn()
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+@pytest.mark.parametrize("supervised", [False, True])
+def test_umap(random_state, sparse, supervised):
+    n_neighbors = 10
+    X, y = make_blobs(n_samples=1000, random_state=random_state)
+    X = X.astype("float32")
+    X_train, X_test, y_train, _ = train_test_split(
+        X, y, test_size=0.2, random_state=random_state
+    )
+    if sparse:
+        X_train = scipy.sparse.csr_matrix(X_train)
+        X_test = scipy.sparse.csr_matrix(X_test)
+    if not supervised:
+        y_train = None
+
+    cu_model = cuml.UMAP(n_neighbors=n_neighbors, hash_input=True).fit(
+        X_train, y_train
+    )
+    sk_model = umap.UMAP(n_neighbors=n_neighbors).fit(X_train, y_train)
+
+    sk_model2 = cu_model.as_sklearn()
+    cu_model2 = cuml.UMAP.from_sklearn(sk_model)
+
+    # Ensure parameters roundtrip
+    assert_params_equal(cu_model, cu_model2)
+
+    # Can infer on converted models
+    np.testing.assert_array_equal(
+        sk_model2.transform(X_train), sk_model2.embedding_
+    )
+    with pytest.raises(NotImplementedError):
+        # Can't currently infer on new data in umap.UMAP.transform implementation
+        assert isinstance(sk_model2.transform(X_test), np.ndarray)
+
+    np.testing.assert_array_equal(
+        cu_model2.transform(X_train), cu_model2.embedding_
+    )
+    assert isinstance(cu_model2.transform(X_test), np.ndarray)
+
+    # Can refit on converted models
+    cu_model2.fit(X_train, y_train)
+    sk_model2.fit(X_train, y_train)
+
+    # Refit embeddings have similar scores
+    cu_trust1 = trustworthiness(
+        X_train, cu_model.embedding_, n_neighbors=n_neighbors
+    )
+    cu_trust2 = trustworthiness(
+        X_train, cu_model2.embedding_, n_neighbors=n_neighbors
+    )
+    np.testing.assert_allclose(cu_trust1, cu_trust2, atol=0.05)
+
+    sk_trust1 = trustworthiness(
+        X_train, sk_model.embedding_, n_neighbors=n_neighbors
+    )
+    sk_trust2 = trustworthiness(
+        X_train, sk_model2.embedding_, n_neighbors=n_neighbors
+    )
+    np.testing.assert_allclose(sk_trust1, sk_trust2, atol=0.05)


### PR DESCRIPTION
This ports `cuml.UMAP` to subclass from `InteropMixin` instead of `UniversalBase`, and switches to using `ProxyBase` to define the respective proxy estimator.

This turned up a few gross bugs and edge cases with the previous implementation. I've opted to add testing as I think makes sense here covering the most common operating paths. I believe this to be strictly better than what we had before, but don't doubt there's still cases we don't handle smoothly. For best results we'll want to start running the upstream umap-learn test suite, but IMO this falls outside the scope of this PR.

Fixes #6710.