### PR TITLE
Deprecate some `cuml.accel` CLI options

### DIFF
--- a/docs/source/zero-code-change.rst
+++ b/docs/source/zero-code-change.rst
@@ -227,21 +227,13 @@ Bugs affecting ``cuml.accel`` can be reported via the `cuML issue tracker <https
 
 10. If I serialize a model using ``cuml.accel``, can I load it without ``cuml.accel``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This is a common use case for ``cuml.accel`` and cuML in general, since it may be useful to train
-a model using NVIDIA GPUs but deploy it for inference in an environment that
-does not have access to NVIDIA GPUs.
+This is a common use case for ``cuml.accel`` and cuML in general, since it may
+be useful to train a model using NVIDIA GPUs but deploy it for inference in an
+environment that does not have access to NVIDIA GPUs.
 
-Currently, models serialized with
-``cuml.accel`` need to be converted to pure Scikit-Learn (or UMAP/HDBSCAN/...).
-After serializing a model, using either pickle or joblib, for example to `model_pickled.pkl`,
-that model can then be converted to a regular sklearn/umap-learn/hdbscan pickled model with:
+Models serialized with ``cuml.accel`` may be loaded in environments without
+``cuml.accel`` - in this case they'll be loaded as their normal
+sklearn/umap-learn/hdbscan counterpart.
 
-.. code-block:: console
-
-    python -m cuml.accel --convert-to-sklearn model_pickled.pkl --format pickle --output converted_model.pkl
-
-
-The `converted_model.pkl` is now a regular pickled/joblib serialized model,
-that can be deserialized and used in a computer/environment without cuML or GPUs.
-
-This conversion step should become unnecessary in a future release of cuML.
+Note that the same serialized model may also be loaded with ``cuml.accel``
+active, in which case they'll be accelerated ``cuml.accel`` backed models.

--- a/docs/source/zero-code-change.rst
+++ b/docs/source/zero-code-change.rst
@@ -200,12 +200,12 @@ Both projects serve a similar role. Just as ``cuml.accel`` offers zero code
 change acceleration for Scikit-Learn and similar packages, ``cudf.pandas``
 offers zero code change acceleration for Pandas.
 
-Using them together is supported as an experimental feature. To do this from the
-CLI, the flag ``--cudf-pandas`` can be added to the ``cuml.accel`` call:
+Using them together is supported. To do this from the CLI, both accelerators
+may be invoked like:
 
 .. code-block:: console
 
-   python -m cuml.accel --cudf-pandas
+   python -m cudf.pandas -m cuml.accel ...
 
 For Jupyter notebooks, use the following approach to turn on both:
 

--- a/python/cuml/cuml/accel/__main__.py
+++ b/python/cuml/cuml/accel/__main__.py
@@ -19,6 +19,7 @@ import argparse
 import code
 import runpy
 import sys
+import warnings
 from textwrap import dedent
 
 from cuml.accel.core import install
@@ -91,21 +92,20 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Disable UVM (managed memory) allocations.",
     )
-    parser.add_argument(
-        "--convert-to-sklearn",
-        help="Path to a pickled accelerated estimator to convert to a scikit-learn estimator.",
-    )
+    # --convert-to-sklearn, --format, and --output are deprecated and hidden
+    # from the CLI --help with `argparse.SUPPRESS
+    parser.add_argument("--convert-to-sklearn", help=argparse.SUPPRESS)
     parser.add_argument(
         "--format",
         choices=["pickle", "joblib"],
         type=str.lower,
         default="pickle",
-        help="Format to save the converted scikit-learn estimator.",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--output",
         default="converted_sklearn_model.pkl",
-        help="Output path for the converted scikit-learn estimator file.",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--cudf-pandas",
@@ -154,6 +154,12 @@ def main(argv: list[str] | None = None):
 
     # If the user requested a conversion, handle it and exit
     if ns.convert_to_sklearn:
+        warnings.warn(
+            "`--convert-to-sklearn`, `--format`, and `--output` are deprecated and will "
+            "be removed in 25.10. Estimators created with `cuml.accel` may now be "
+            "serialized and loaded in environments without `cuml` without the need for "
+            "running a conversion step."
+        )
         with open(ns.convert_to_sklearn, "rb") as f:
             if ns.format == "pickle":
                 import pickle as serializer

--- a/python/cuml/cuml/accel/__main__.py
+++ b/python/cuml/cuml/accel/__main__.py
@@ -73,6 +73,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             Instead of a script, a module may be specified instead.
 
               $ python -m cuml.accel -m mymodule --some-option
+
+            If you also wish to use the `cudf.pandas` accelerator, you can invoke both
+            as part of a single call like:
+
+              $ python -m cudf.pandas -m cuml.accel myscript.py
             """
         ),
         allow_abbrev=False,
@@ -92,8 +97,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Disable UVM (managed memory) allocations.",
     )
-    # --convert-to-sklearn, --format, and --output are deprecated and hidden
-    # from the CLI --help with `argparse.SUPPRESS
+    # --convert-to-sklearn, --format, --output, and --cudf-pandas are deprecated
+    # and hidden from the CLI --help with `argparse.SUPPRESS
     parser.add_argument("--convert-to-sklearn", help=argparse.SUPPRESS)
     parser.add_argument(
         "--format",
@@ -110,7 +115,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--cudf-pandas",
         action="store_true",
-        help="Turn on cudf.pandas alongside cuml.accel.",
+        help=argparse.SUPPRESS,
     )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -158,7 +163,8 @@ def main(argv: list[str] | None = None):
             "`--convert-to-sklearn`, `--format`, and `--output` are deprecated and will "
             "be removed in 25.10. Estimators created with `cuml.accel` may now be "
             "serialized and loaded in environments without `cuml` without the need for "
-            "running a conversion step."
+            "running a conversion step.",
+            FutureWarning,
         )
         with open(ns.convert_to_sklearn, "rb") as f:
             if ns.format == "pickle":
@@ -179,6 +185,12 @@ def main(argv: list[str] | None = None):
 
     # Enable cudf.pandas if requested
     if ns.cudf_pandas:
+        warnings.warn(
+            "`--cudf-pandas` is deprecated and will be removed in 25.10. Instead, please "
+            "invoke both accelerators explicitly like\n\n"
+            "  $ python -m cudf.pandas -m cuml.accel ...",
+            FutureWarning,
+        )
         import cudf.pandas
 
         cudf.pandas.install()


### PR DESCRIPTION
This deprecates a few `cuml.accel` CLI options:

- `--convert-to-sklearn`/`--output`/`--format`: these are no longer needed, models serialized with `cuml.accel` may be reloaded in non-cuml-accel environments without an additional conversion step.
- `--cudf-pandas`: this is no longer needed, accelerator CLIs may be combined like `python -m cudf.pandas -m cuml.accel ...`

Deprecated options will continue to work, they'll just through a warning. They are hidden from the `--help` docs though, and our documentation has been updated to reflect the new recommendations.