### PR TITLE
Fixup `test_nearest_neighbors`

### DIFF
--- a/python/cuml/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/cuml/tests/test_sklearn_import_export.py
@@ -406,17 +406,23 @@ def test_nearest_neighbors(random_state, sparse):
     # Ensure parameters roundtrip
     assert_params_equal(cu_model, cu_model2)
 
+    def assert_kneighbors_close(m1, m2):
+        inds1, dists1 = m1.kneighbors(X)
+        inds2, dists2 = m2.kneighbors(X)
+        np.testing.assert_array_equal(inds1, inds2)
+        np.testing.assert_allclose(dists1, dists2, atol=1e-4)
+
     # Can infer on converted models
-    assert_allclose(sk_model.kneighbors(X), sk_model2.kneighbors(X))
-    assert_allclose(cu_model.kneighbors(X), cu_model2.kneighbors(X))
+    assert_kneighbors_close(sk_model, sk_model2)
+    assert_kneighbors_close(cu_model, cu_model2)
 
     # Can refit on converted models
     cu_model2.fit(X)
     sk_model2.fit(X)
 
     # Refit models have similar results
-    assert_allclose(sk_model.kneighbors(X), sk_model2.kneighbors(X))
-    assert_allclose(cu_model.kneighbors(X), cu_model2.kneighbors(X))
+    assert_kneighbors_close(sk_model, sk_model2)
+    assert_kneighbors_close(cu_model, cu_model2)
 
 
 @pytest.mark.parametrize("sparse", [False, True])


### PR DESCRIPTION
Previously this was erroneously passing two arrays to `assert_allclose`, which would then combine them into a single array before checking equality. This only happened to work, but due to dtype precision issues would _sometimes_ lead the test to fail. We now properly separate the checks for inds and dists and relax the constraint on dists a bit.