### PR TITLE
A few `max_features` fixups for `cuml.ensemble`

### DIFF
--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -197,31 +197,11 @@ class BaseRandomForestModel(UniversalBase):
             return 1/np.sqrt(self.n_cols)
         elif self.max_features == 'log2':
             return math.log2(self.n_cols)/self.n_cols
-        elif self.max_features == 'auto':
-            if self.RF_type == CLASSIFICATION:
-                warnings.warn(
-                    "`max_features='auto'` has been deprecated in 24.06 "
-                    "and will be removed in 25.08. To keep the past behaviour "
-                    "and silence this warning, explicitly set "
-                    "`max_features='sqrt'`.",
-                    FutureWarning
-                )
-                return 1/np.sqrt(self.n_cols)
-            else:
-                warnings.warn(
-                    "`max_features='auto'` has been deprecated in 24.06 "
-                    "and will be removed in 25.08. To keep the past behaviour "
-                    "and silence this warning, explicitly set "
-                    "`max_features=1.0`.",
-                    FutureWarning
-                )
-                return 1.0
         else:
             raise ValueError(
-                "Wrong value passed in for max_features"
-                " please read the documentation present at "
-                "(https://docs.rapids.ai/api/cuml/nightly/api.html"
-                "#random-forest)")
+                "Expected `max_features` to be an int, float, or one of ['sqrt', 'log2']."
+                "Got {max_features!r} instead."
+            )
 
     def _serialize_treelite_bytes(self) -> bytes:
         """

--- a/python/cuml/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.pyx
@@ -164,17 +164,17 @@ class RandomForestClassifier(BaseRandomForestModel,
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited,
         If ``-1``.
-    max_features : int, float, or string (default = 'sqrt')
-        Ratio of number of features (columns) to consider per node
-        split.\n
-         * If type ``int`` then ``max_features`` is the absolute count of
-           features to be used
-         * If type ``float`` then ``max_features`` is used as a fraction.
-         * If ``'sqrt'`` then ``max_features=1/sqrt(n_features)``.
-         * If ``'log2'`` then ``max_features=log2(n_features)/n_features``.
+    max_features : {'sqrt', 'log2', None}, int or float (default = 'sqrt')
+        The number of features to consider per node split:
+
+        * If an int then ``max_features`` is the absolute count of features to be used.
+        * If a float then ``max_features`` is used as a fraction.
+        * If ``'sqrt'`` then ``max_features=1/sqrt(n_features)``.
+        * If ``'log2'`` then ``max_features=log2(n_features)/n_features``.
+        * If ``None`` then ``max_features=n_features``
 
         .. versionchanged:: 24.06
-           The default of `max_features` changed from `"auto"` to `"sqrt"`.
+          The default of `max_features` changed from `"auto"` to `"sqrt"`.
 
     n_bins : int (default = 128)
         Maximum number of bins used by the split algorithm per feature.

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -160,14 +160,14 @@ class RandomForestRegressor(BaseRandomForestModel,
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited,
         If ``-1``.
-    max_features : int, float, or string (default = 1.0)
-        Ratio of number of features (columns) to consider
-        per node split.\n
-         * If type ``int`` then ``max_features`` is the absolute count of
-           features to be used.
-         * If type ``float`` then ``max_features`` is used as a fraction.
-         * If ``'sqrt'`` then ``max_features=1/sqrt(n_features)``.
-         * If ``'log2'`` then ``max_features=log2(n_features)/n_features``.
+    max_features : {'sqrt', 'log2', None}, int or float (default = 1.0)
+        The number of features to consider per node split:
+
+        * If an int then ``max_features`` is the absolute count of features to be used.
+        * If a float then ``max_features`` is used as a fraction.
+        * If ``'sqrt'`` then ``max_features=1/sqrt(n_features)``.
+        * If ``'log2'`` then ``max_features=log2(n_features)/n_features``.
+        * If ``None`` then ``max_features=n_features``
 
         .. versionchanged:: 24.06
           The default of `max_features` changed from `"auto"` to 1.0.

--- a/python/cuml/cuml/tests/test_random_forest.py
+++ b/python/cuml/cuml/tests/test_random_forest.py
@@ -14,6 +14,7 @@
 #
 
 import json
+import math
 import os
 import random
 import warnings
@@ -44,6 +45,7 @@ import cuml
 import cuml.internals.logger as logger
 from cuml.ensemble import RandomForestClassifier as curfc
 from cuml.ensemble import RandomForestRegressor as curfr
+from cuml.ensemble.randomforest_common import compute_max_features
 from cuml.metrics import r2_score
 from cuml.testing.utils import (
     get_handle,
@@ -1384,23 +1386,19 @@ def test_rf_min_samples_split_with_small_float(estimator, make_data):
         clf.fit(X, y)
 
 
-# TODO: Remove in v24.08
 @pytest.mark.parametrize(
-    "Estimator",
+    "max_features, sol",
     [
-        curfr,
-        curfc,
+        (2, 0.02),
+        (0.5, 0.5),
+        ("sqrt", math.sqrt(100) / 100),
+        ("log2", math.log2(100) / 100),
+        (None, 1.0),
     ],
 )
-def test_random_forest_max_features_deprecation(Estimator):
-    X = np.array([[1.0, 2], [3, 4]])
-    y = np.array([1, 0])
-    est = Estimator(max_features="auto")
-
-    error_msg = "`max_features='auto'` has been deprecated in 24.06 "
-
-    with pytest.warns(FutureWarning, match=error_msg):
-        est.fit(X, y)
+def test_max_features(max_features, sol):
+    res = compute_max_features(max_features, 100)
+    assert res == sol
 
 
 def test_rf_predict_returns_int():


### PR DESCRIPTION
This:

- Removes the no-longer-necessary deprecation of `max_features="auto"`
- Adds support for `max_features=None` (supported by sklearn)
- Adds a test for the spread of `max_features` values
- Cleans up the docstring formatting to better match sklearn conventions