### PR TITLE
First pass of removing tests, codepaths and other bits related to CUDA 11

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -134,21 +134,17 @@ if(all_algo OR genetic_algo)
   ConfigureTest(PREFIX SG NAME GENETIC_PARAM_TEST  sg/genetic/param_test.cu ML_INCLUDE)
 endif()
 
-if("${CMAKE_CUDA_COMPILER_VERSION}" VERSION_GREATER_EQUAL "11.2")
-    # An HDBSCAN gtest is failing w/ CUDA 11.2 for some reason.
-    if(all_algo OR hdbscan_algo)
-      ConfigureTest(PREFIX SG NAME HDBSCAN_TEST  sg/hdbscan_test.cu ML_INCLUDE)
-      # When using GCC 13, some maybe-uninitialized warnings appear from CCCL and are treated as errors.
-      # See this issue: https://github.com/rapidsai/cuml/issues/6225
-      set_property(
-        SOURCE sg/hdbscan_test.cu
-        APPEND_STRING
-        PROPERTY COMPILE_FLAGS
-        " -Xcompiler=-Wno-maybe-uninitialized"
-      )
-    endif()
-endif()
-
+  if(all_algo OR hdbscan_algo)
+    ConfigureTest(PREFIX SG NAME HDBSCAN_TEST  sg/hdbscan_test.cu ML_INCLUDE)
+    # When using GCC 13, some maybe-uninitialized warnings appear from CCCL and are treated as errors.
+    # See this issue: https://github.com/rapidsai/cuml/issues/6225
+    set_property(
+      SOURCE sg/hdbscan_test.cu
+      APPEND_STRING
+      PROPERTY COMPILE_FLAGS
+      " -Xcompiler=-Wno-maybe-uninitialized"
+    )
+  endif()
 
 if(all_algo OR holtwinters_algo)
   ConfigureTest(PREFIX SG NAME HOLTWINTERS_TEST  sg/holtwinters_test.cu ML_INCLUDE)

--- a/cpp/tests/sg/lars_test.cu
+++ b/cpp/tests/sg/lars_test.cu
@@ -692,19 +692,11 @@ TYPED_TEST_CASE(LarsTestFitPredict, FloatTypes);
 
 TYPED_TEST(LarsTestFitPredict, fitGram)
 {
-#if CUDART_VERSION >= 11020
-  GTEST_SKIP();
-#else
   this->testFitGram();
-#endif
 }
 TYPED_TEST(LarsTestFitPredict, fitX)
 {
-#if CUDART_VERSION >= 11020
-  GTEST_SKIP();
-#else
   this->testFitX();
-#endif
 }
 TYPED_TEST(LarsTestFitPredict, fitLarge) { this->testFitLarge(); }
 TYPED_TEST(LarsTestFitPredict, predictV1) { this->testPredictV1(); }

--- a/cpp/tests/sg/quasi_newton.cu
+++ b/cpp/tests/sg/quasi_newton.cu
@@ -201,9 +201,6 @@ T run_api(const raft::handle_t& cuml_handle,
 
 TEST_F(QuasiNewtonTest, binary_logistic_vs_sklearn)
 {
-#if CUDART_VERSION >= 11020
-  GTEST_SKIP();
-#endif
   MLCommon::CompareApprox<double> compApprox(tol);
   // Test case generated in python and solved with sklearn
   double y[N] = {1, 1, 1, 0, 1, 0, 1, 0, 1, 0};
@@ -324,9 +321,6 @@ TEST_F(QuasiNewtonTest, binary_logistic_vs_sklearn)
 
 TEST_F(QuasiNewtonTest, multiclass_logistic_vs_sklearn)
 {
-#if CUDART_VERSION >= 11020
-  GTEST_SKIP();
-#endif
   // The data seems to small for the objective to be strongly convex
   // leaving out exact param checks
 
@@ -627,9 +621,6 @@ TEST_F(QuasiNewtonTest, predict_softmax)
 
 TEST_F(QuasiNewtonTest, dense_vs_sparse_logistic)
 {
-#if CUDART_VERSION >= 11020
-  GTEST_SKIP();
-#endif
   // Prepare a sparse input matrix from the dense matrix X.
   // Yes, it's not sparse at all, yet the test does check whether the behaviour
   // of dense and sparse variants is the same.

--- a/cpp/tests/sg/umap_parametrizable_test.cu
+++ b/cpp/tests/sg/umap_parametrizable_test.cu
@@ -300,31 +300,20 @@ class UMAPParametrizableTest : public ::testing::Test {
 
     float* e1 = embeddings1.data();
 
-#if CUDART_VERSION >= 11020
-    // Always use random init w/ CUDA 11.2. For some reason the
-    // spectral solver doesn't always converge w/ this CUDA version.
     umap_params.init         = 0;
     umap_params.random_state = 43;
     umap_params.n_epochs     = 500;
-#endif
     get_embedding(handle, X_d.data(), (float*)y_d.data(), e1, test_params, umap_params);
 
     assertions(handle, X_d.data(), e1, test_params, umap_params);
 
-    // v21.08: Reproducibility looks to be busted for CTK 11.4. Need to figure out
-    // why this is happening and re-enable this.
-#if CUDART_VERSION == 11040
-    return;
-#else
     // Disable reproducibility tests after transformation
     if (!test_params.fit_transform) { return; }
-#endif
 
     rmm::device_uvector<float> embeddings2(n_samples * umap_params.n_components, stream);
     float* e2 = embeddings2.data();
     get_embedding(handle, X_d.data(), (float*)y_d.data(), e2, test_params, umap_params);
 
-#if CUDART_VERSION >= 11020
     auto equal = are_equal(e1, e2, n_samples * umap_params.n_components, stream);
 
     if (!equal) {
@@ -333,10 +322,6 @@ class UMAPParametrizableTest : public ::testing::Test {
     }
 
     ASSERT_TRUE(equal);
-#else
-    ASSERT_TRUE(MLCommon::devArrMatch(
-      e1, e2, n_samples * umap_params.n_components, MLCommon::Compare<float>{}));
-#endif
   }
 
   void SetUp() override

--- a/python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh
+++ b/python/cuml/cuml/accel/tests/scikit-learn/run-tests.sh
@@ -17,11 +17,7 @@ CUDA_VERSION=$(nvcc --version | grep "release" | awk '{print $5}' | cut -d',' -f
 # Base arguments
 PYTEST_ARGS="-p cuml.accel --pyargs sklearn --xfail-list=\"$(dirname "$0")/xfail-list.yaml\""
 
-# Skip sequential tests for CUDA 11.x until
-# https://github.com/rapidsai/cuml/issues/6622 is resolved
-if [[ "$CUDA_VERSION" == "11"* ]]; then
-    PYTEST_ARGS="$PYTEST_ARGS -k \"not test_sequential\""
-fi
+PYTEST_ARGS="$PYTEST_ARGS -k \"not test_sequential\""
 
 # Run pytest with all arguments
 eval "pytest $PYTEST_ARGS" "$@"

--- a/python/cuml/cuml/tests/dask/test_dask_nearest_neighbors.py
+++ b/python/cuml/cuml/tests/dask/test_dask_nearest_neighbors.py
@@ -33,15 +33,6 @@ from cuml.testing.utils import (
     unit_param,
 )
 
-IS_ARM = platform.processor() == "aarch64"
-
-if IS_ARM and cp.cuda.runtime.runtimeGetVersion() < 11080:
-    pytest.skip(
-        "Test hang in AARCH64 with CUDA < 11.8: "
-        "https://github.com/rapidsai/cuml/issues/5673",
-        allow_module_level=True,
-    )
-
 
 def predict(neigh_ind, _y, n_neighbors):
     neigh_ind = neigh_ind.astype(np.int64)

--- a/python/cuml/cuml/tests/test_hdbscan.py
+++ b/python/cuml/cuml/tests/test_hdbscan.py
@@ -214,10 +214,6 @@ def test_hdbscan_blobs(
     )
 
 
-@pytest.mark.skipif(
-    cp.cuda.driver.get_build_version() <= 11020,
-    reason="Test failing on driver 11.2",
-)
 @pytest.mark.parametrize("cluster_selection_epsilon", [0.0, 50.0, 150.0])
 @pytest.mark.parametrize(
     "min_samples_cluster_size_bounds", [(150, 150, 0), (50, 25, 0)]
@@ -711,10 +707,6 @@ def test_all_points_membership_vectors_circles(
     assert_membership_vectors(cu_membership_vectors, sk_membership_vectors)
 
 
-@pytest.mark.skipif(
-    cp.cuda.driver.get_build_version() <= 11020,
-    reason="Test failing on driver 11.2",
-)
 @pytest.mark.parametrize("nrows", [1000])
 @pytest.mark.parametrize("n_points_to_predict", [200, 500])
 @pytest.mark.parametrize("ncols", [10, 25])

--- a/python/cuml/cuml/tests/test_linear_model.py
+++ b/python/cuml/cuml/tests/test_linear_model.py
@@ -189,11 +189,6 @@ def test_weighted_linear_regression(
     np.testing.assert_almost_equal(cu_score, sk_score)
 
 
-@pytest.mark.skipif(
-    rmm._cuda.gpu.runtimeGetVersion() < 11000,
-    reason="svd solver does not support more than 46340 rows or columns for"
-    " CUDA<11 and other solvers do not support single-column input",
-)
 def test_linear_regression_single_column():
     """Test that linear regression can be run on single column with more than
     46340 rows (a limitation on CUDA <11)"""


### PR DESCRIPTION
Related to #cuda11

Version 25.08 drops CUDA 11.x support, this PR removes codepaths, tests and other small bits related to it. 