### PR TITLE
Remove `GlobalSettings.device_type`

### DIFF
--- a/python/cuml/cuml/internals/base.pyx
+++ b/python/cuml/cuml/internals/base.pyx
@@ -711,7 +711,6 @@ class UniversalBase(Base):
             keyword arguments to be passed to the function for the call
         """
         # look for current device_type
-        # device_type = cuml.global_settings.device_type
         device_type = self._dispatch_selector(func_name, *args, **kwargs)
 
         if device_type == DeviceType.device:
@@ -778,20 +777,16 @@ class UniversalBase(Base):
                     "Estimator does not support sparse inputs currently"
                 )
 
-        # if not using accelerator, then return global device
         if not hasattr(self, "_gpuaccel"):
-            return cuml.global_settings.device_type
-
-        # otherwise we select CPU when _gpuaccel is off
+            # if not using accelerator, select device type
+            return DeviceType.device
         elif not self._gpuaccel:
-            device_type = DeviceType.host
+            # otherwise we select CPU when _gpuaccel is off
+            return DeviceType.host
+        elif not self._should_dispatch_cpu(func_name, *args, **kwargs):
+            return DeviceType.device
         else:
-            if not self._should_dispatch_cpu(func_name, *args, **kwargs):
-                device_type = DeviceType.device
-            else:
-                device_type = DeviceType.host
-
-        return device_type
+            return DeviceType.host
 
     def _should_dispatch_cpu(self, func_name, *args, **kwargs):
         """

--- a/python/cuml/cuml/internals/global_settings.py
+++ b/python/cuml/cuml/internals/global_settings.py
@@ -67,10 +67,6 @@ class GlobalSettings:
         self.__dict__ = _global_settings_data.shared_state
 
     @property
-    def device_type(self):
-        return DeviceType.device
-
-    @property
     def memory_type(self):
         return self._memory_type
 


### PR DESCRIPTION
This removes the global `device_type` setting and all downstream consumers of it. As of 25.06 `GlobalSettings.device_type` is always `DeviceType.device`, and all methods of changing it have been deprecated and removed. This API is no longer needed, removing it is another step towards stripping out the remnants of `cuml-cpu`.

Fixes #6889