### PR TITLE
Temporarily increase nightly CI check window to 14 days

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,6 +55,7 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
+          max_days_without_success: 14
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
While we are not running nightly tests on branch-25.08 yet.