### PR TITLE
Fix import in benchmark code in algorithms.py that was causing an error

### DIFF
--- a/python/cuml/cuml/benchmark/algorithms.py
+++ b/python/cuml/cuml/benchmark/algorithms.py
@@ -697,7 +697,18 @@ def all_algorithms():
         ),
     ]
     try:
-        import cuml.dask
+        from importlib import import_module
+
+        # Importing via import_module avoids rebinding the name `cuml`, which
+        # would otherwise make it a *local* variable and break earlier
+        # references inside this function (see Python's scoping rules) and
+        # causes an error like:
+        #   File "algorithms.py", line 227, in all_algorithms
+        #   cuml.cluster.KMeans,
+        #     ^^^^
+        # UnboundLocalError: cannot access local variable 'cuml' where it is
+        # not associated with a value
+        import_module("cuml.dask")
     except ImportError:
         warnings.warn(
             "Not all dependencies required for `cuml.dask` are installed, the "

--- a/python/cuml/cuml/benchmark/algorithms.py
+++ b/python/cuml/cuml/benchmark/algorithms.py
@@ -15,6 +15,7 @@
 #
 import tempfile
 import warnings
+from importlib import import_module
 
 import numpy as np
 import sklearn
@@ -697,8 +698,6 @@ def all_algorithms():
         ),
     ]
     try:
-        from importlib import import_module
-
         # Importing via import_module avoids rebinding the name `cuml`, which
         # would otherwise make it a *local* variable and break earlier
         # references inside this function (see Python's scoping rules) and


### PR DESCRIPTION
Moving the import to the local context was causing the following issue:

```python
(rapids) coder ➜ ~/cuml/cuml-accel-bench $ bash bench.sh 
Traceback (most recent call last):
  File "/home/coder/cuml/python/cuml/cuml/benchmark/run_benchmarks.py", line 262, in <module>
    algo = algorithms.algorithm_by_name(name)
  File "/home/coder/cuml/python/cuml/cuml/benchmark/algorithms.py", line 837, in algorithm_by_name
    algos = all_algorithms()
  File "/home/coder/cuml/python/cuml/cuml/benchmark/algorithms.py", line 227, in all_algorithms
    cuml.cluster.KMeans,
    ^^^^
UnboundLocalError: cannot access local variable 'cuml' where it is not associated with a value
```

where bench.sh was just a call to use the benchmark code:

```bash
export NROWS=1000000

python /opt/conda/lib/python3.12/site-packages/cuml/benchmark/run_benchmarks.py LinearRegression ElasticNet Lasso --num-rows $NROWS --dataset regression --input-type numpy --csv LinearRegressionCPU$NROWS.csv
```

this PR fixes that by using importlib. 