### PR TITLE
Unxfail tests affected by numba compilation error on Python 3.13.4

### DIFF
--- a/python/cuml/cuml/tests/test_simpl_set.py
+++ b/python/cuml/cuml/tests/test_simpl_set.py
@@ -43,9 +43,6 @@ def correctness_sparse(a, b, atol=0.1, rtol=0.2, threshold=0.95):
     return correctness >= threshold
 
 
-@pytest.mark.xfail(
-    reason="Numba compilation error with Python 3.13.4 in pynndescent (see #6867)"
-)
 @pytest.mark.parametrize("n_rows", [800, 5000])
 @pytest.mark.parametrize("n_features", [8, 32])
 @pytest.mark.parametrize("n_neighbors", [8, 16])
@@ -111,9 +108,6 @@ def test_fuzzy_simplicial_set(
     )
 
 
-@pytest.mark.xfail(
-    reason="Numba compilation error with Python 3.13.4 in pynndescent (see #6867)"
-)
 @pytest.mark.parametrize("n_rows", [800, 5000])
 @pytest.mark.parametrize("n_features", [8, 32])
 @pytest.mark.parametrize("n_neighbors", [8, 16])


### PR DESCRIPTION
This partially reverts commit 9379c883e7dbb3333d94816f9582bcb8cf0755f5, removing the xfail markers from tests in test_simpl_set.py that were related to Python 3.13.4 compatibility issues.