### PR TITLE
Use GCC 14 in conda builds.

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - dask-cudf==25.8.*,>=0.0.0a0
 - dask-ml
 - doxygen=1.9.1
-- gcc_linux-aarch64=13.*
+- gcc_linux-aarch64=14.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
 - hypothesis>=6.0,<7

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -23,7 +23,7 @@ dependencies:
 - dask-cudf==25.8.*,>=0.0.0a0
 - dask-ml
 - doxygen=1.9.1
-- gcc_linux-64=13.*
+- gcc_linux-64=14.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
 - hypothesis>=6.0,<7

--- a/conda/environments/clang_tidy_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-128_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-version=12.8
 - cxx-compiler
-- gcc_linux-64=13.*
+- gcc_linux-64=14.*
 - libcublas-dev
 - libcufft-dev
 - libcumlprims==25.8.*,>=0.0.0a0

--- a/conda/environments/cpp_all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-128_arch-x86_64.yaml
@@ -13,7 +13,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-version=12.8
 - cxx-compiler
-- gcc_linux-64=13.*
+- gcc_linux-64=14.*
 - libcublas-dev
 - libcufft-dev
 - libcumlprims==25.8.*,>=0.0.0a0

--- a/conda/recipes/cuml/conda_build_config.yaml
+++ b/conda/recipes/cuml/conda_build_config.yaml
@@ -1,8 +1,8 @@
 c_compiler_version:
-  - 13
+  - 14
 
 cxx_compiler_version:
-  - 13
+  - 14
 
 cuda_compiler:
   - cuda-nvcc

--- a/conda/recipes/libcuml/conda_build_config.yaml
+++ b/conda/recipes/libcuml/conda_build_config.yaml
@@ -1,8 +1,8 @@
 c_compiler_version:
-  - 13
+  - 14
 
 cxx_compiler_version:
-  - 13
+  - 14
 
 cuda_compiler:
   - cuda-nvcc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -235,13 +235,13 @@ dependencies:
               cuda: "12.*"
             packages:
               - cuda-nvcc
-              - gcc_linux-64=13.*
+              - gcc_linux-64=14.*
           - matrix:
               arch: aarch64
               cuda: "12.*"
             packages:
               - cuda-nvcc
-              - gcc_linux-aarch64=13.*
+              - gcc_linux-aarch64=14.*
   py_build_cuml:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
## Description
conda-forge is migrating to gcc 14, so this PR is updating for alignment.
