### PR TITLE
Remove `UniversalBase`

### DIFF
--- a/python/cuml/cuml/__init__.py
+++ b/python/cuml/cuml/__init__.py
@@ -46,7 +46,7 @@ from cuml.explainer.kernel_shap import KernelExplainer
 from cuml.explainer.permutation_shap import PermutationExplainer
 from cuml.explainer.tree_shap import TreeExplainer
 from cuml.fil import ForestInference, fil
-from cuml.internals.base import Base, UniversalBase
+from cuml.internals.base import Base
 from cuml.internals.global_settings import (
     GlobalSettings,
     _global_settings_data,
@@ -152,7 +152,6 @@ __all__ = [
     "TreeExplainer",
     "TSNE",
     "UMAP",
-    "UniversalBase",
     # Functions
     "johnson_lindenstrauss_min_dim",
     "make_arima",

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -204,15 +204,6 @@ class KMeans(Base,
 
     _cpu_class_path = "sklearn.cluster.KMeans"
 
-    _hyperparam_interop_translator = {
-        "init": {
-            # k-means++ would work, but setting it explicitly changes the configuration
-            # of the estimator compared to not specifying it. So we explicitly translate
-            # it to the default value.
-            "k-means++": "scalable-k-means++",
-        },
-    }
-
     @classmethod
     def _get_param_names(cls):
         return [

--- a/python/cuml/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.pyx
@@ -339,9 +339,6 @@ class RandomForestClassifier(BaseRandomForestModel,
         self.treelite_serialized_bytes = None
         self.n_cols = None
 
-    def get_attr_names(self):
-        return []
-
     def convert_to_treelite_model(self):
         """
         Converts the cuML RF model to a Treelite model

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -329,9 +329,6 @@ class RandomForestRegressor(BaseRandomForestModel,
         self.treelite_serialized_bytes = None
         self.n_cols = None
 
-    def get_attr_names(self):
-        return []
-
     def convert_to_treelite_model(self):
         """
         Converts the cuML RF model to a Treelite model

--- a/python/cuml/cuml/internals/mixins.py
+++ b/python/cuml/cuml/internals/mixins.py
@@ -19,10 +19,7 @@ from copy import deepcopy
 
 from cuml._thirdparty._sklearn_compat import _to_new_tags
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.api_decorators import (
-    api_base_return_any_skipall,
-    enable_device_interop,
-)
+from cuml.internals.api_decorators import api_base_return_any_skipall
 from cuml.internals.base_helpers import _tags_class_and_instance
 
 ###############################################################################
@@ -205,7 +202,6 @@ class RegressorMixin:
         }
     )
     @api_base_return_any_skipall
-    @enable_device_interop
     def score(self, X, y, sample_weight=None, **kwargs):
         """
         Scoring function for regression estimators
@@ -241,7 +237,6 @@ class ClassifierMixin:
         }
     )
     @api_base_return_any_skipall
-    @enable_device_interop
     def score(self, X, y, sample_weight=None, **kwargs):
         """
         Scoring function for classifier estimators based on mean accuracy.

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.pyx
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.pyx
@@ -222,9 +222,6 @@ class KernelRidge(Base, InteropMixin, RegressorMixin):
             "kernel_params",
         ]
 
-    def get_attr_names(self):
-        return ['dual_coef_', 'X_fit_']
-
     @classmethod
     def _params_from_cpu(cls, model):
         return {

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -509,9 +509,6 @@ class LinearRegression(Base,
     def _predict(self, X, convert_dtype=True) -> CumlArray:
         self.dtype = self.coef_.dtype
         self.features_in_ = self.coef_.shape[0]
-        # Adding UniversalBase here skips it in the Method Resolution Order
-        # (MRO) Since UniversalBase and LinearPredictMixin now both have a
-        # `predict` method
         return super()._predict(X, convert_dtype=convert_dtype)
 
     @staticmethod

--- a/python/cuml/cuml/tests/test_api.py
+++ b/python/cuml/cuml/tests/test_api.py
@@ -54,10 +54,7 @@ def dataset():
     return X, y
 
 
-models_config = ClassEnumerator(
-    module=cuml, exclude_classes=(cuml.UniversalBase,)
-)
-models = models_config.get_models()
+models = ClassEnumerator(module=cuml).get_models()
 
 # tag system based on experimental tag system from Scikit-learn >=0.21
 # https://scikit-learn.org/stable/developers/develop.html#estimator-tags

--- a/python/cuml/cuml/tests/test_exceptions.py
+++ b/python/cuml/cuml/tests/test_exceptions.py
@@ -35,7 +35,7 @@ from cuml.neighbors import (  # noqa: F401
     NearestNeighbors,
 )
 
-# Currently only UniversalBase estimators raise a NotImplementedError
+# Currently only certain estimators raise a NotImplementedError
 estimators = {
     "KMeans": lambda: KMeans(n_clusters=2, random_state=0),
     "DBSCAN": lambda: DBSCAN(eps=1.0),


### PR DESCRIPTION
This removes `UniversalBase` and all remaining infrastructure surrounding it. This is possible now that we've fully transitioned to using `InteropMixin` for managing sklearn <> cuml conversion. This is a continuation of the work ripping out dead code leftover from `cuml-cpu`.