### PR TITLE
Deprecate `penalty='none'` in `MBSGDClassifier`/`MBSGDRegressor`/`SGD`

### DIFF
--- a/python/cuml/cuml/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/linear_model/logistic_regression.py
@@ -113,9 +113,9 @@ class LogisticRegression(
 
     Parameters
     ----------
-    penalty : 'none', 'l1', 'l2', 'elasticnet' (default = 'l2')
+    penalty : {'l1', 'l2', 'elasticnet', None} (default = 'l2')
         Used to specify the norm used in the penalization.
-        If 'none' or 'l2' are selected, then L-BFGS solver will be used.
+        If None or 'l2' are selected, then L-BFGS solver will be used.
         If 'l1' is selected, solver OWL-QN will be used.
         If 'elasticnet' is selected, OWL-QN will be used if l1_ratio > 0,
         otherwise L-BFGS will be used.

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -84,17 +84,13 @@ class MBSGDClassifier(Base, ClassifierMixin, FMajorInputTagMixin):
 
        'squared_loss' uses linear regression
 
-    penalty : {'none', 'l1', 'l2', 'elasticnet'} (default = 'l2')
-       'none' does not perform any regularization
+    penalty : {'l1', 'l2', 'elasticnet', None} (default = 'l2')
+        The penalty (aka regularization term) to be used.
 
-       'l1' performs L1 norm (Lasso) which minimizes the sum of the abs value
-       of coefficients
-
-       'l2' performs L2 norm (Ridge) which minimizes the sum of the square of
-       the coefficients
-
-       'elasticnet' performs Elastic Net regularization which is a weighted
-       average of L1 and L2 norms
+        - 'l1': L1 norm (Lasso) regularization
+        - 'l2': L2 norm (Ridge) regularazation (the default)
+        - 'elasticnet': Elastic Net regularization, a weighted average of L1 and L2
+        - None: no penalty is added
 
     alpha : float (default = 0.0001)
         The constant value which decides the degree of regularization

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -85,10 +85,10 @@ class MBSGDClassifier(Base, ClassifierMixin, FMajorInputTagMixin):
        'squared_loss' uses linear regression
 
     penalty : {'l1', 'l2', 'elasticnet', None} (default = 'l2')
-        The penalty (aka regularization term) to be used.
+        The penalty (aka regularization term) to apply.
 
         - 'l1': L1 norm (Lasso) regularization
-        - 'l2': L2 norm (Ridge) regularazation (the default)
+        - 'l2': L2 norm (Ridge) regularization (the default)
         - 'elasticnet': Elastic Net regularization, a weighted average of L1 and L2
         - None: no penalty is added
 

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -80,10 +80,10 @@ class MBSGDRegressor(Base, RegressorMixin, FMajorInputTagMixin):
     loss : 'squared_loss' (default = 'squared_loss')
        'squared_loss' uses linear regression
     penalty : {'l1', 'l2', 'elasticnet', None} (default = 'l2')
-        The penalty (aka regularization term) to be used.
+        The penalty (aka regularization term) to apply.
 
         - 'l1': L1 norm (Lasso) regularization
-        - 'l2': L2 norm (Ridge) regularazation (the default)
+        - 'l2': L2 norm (Ridge) regularization (the default)
         - 'elasticnet': Elastic Net regularization, a weighted average of L1 and L2
         - None: no penalty is added
 

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -79,14 +79,14 @@ class MBSGDRegressor(Base, RegressorMixin, FMajorInputTagMixin):
     ----------
     loss : 'squared_loss' (default = 'squared_loss')
        'squared_loss' uses linear regression
-    penalty : 'none', 'l1', 'l2', 'elasticnet' (default = 'l2')
-       'none' does not perform any regularization
-       'l1' performs L1 norm (Lasso) which minimizes the sum of the abs value
-       of coefficients
-       'l2' performs L2 norm (Ridge) which minimizes the sum of the square of
-       the coefficients
-       'elasticnet' performs Elastic Net regularization which is a weighted
-       average of L1 and L2 norms
+    penalty : {'l1', 'l2', 'elasticnet', None} (default = 'l2')
+        The penalty (aka regularization term) to be used.
+
+        - 'l1': L1 norm (Lasso) regularization
+        - 'l2': L2 norm (Ridge) regularazation (the default)
+        - 'elasticnet': Elastic Net regularization, a weighted average of L1 and L2
+        - None: no penalty is added
+
     alpha : float (default = 0.0001)
        The constant value which decides the degree of regularization
     fit_intercept : boolean (default = True)

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -162,10 +162,10 @@ class SGD(Base,
         'log' uses logistic regression
         'squared_loss' uses linear regression
     penalty : {'l1', 'l2', 'elasticnet', None} (default = None)
-        The penalty (aka regularization term) to be used.
+        The penalty (aka regularization term) to apply.
 
         - 'l1': L1 norm (Lasso) regularization
-        - 'l2': L2 norm (Ridge) regularazation
+        - 'l2': L2 norm (Ridge) regularization
         - 'elasticnet': Elastic Net regularization, a weighted average of L1 and L2
         - None: no penalty is added (the default)
 

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -14,6 +14,7 @@
 #
 
 # distutils: language = c++
+import warnings
 
 import cupy as cp
 import numpy as np
@@ -141,7 +142,7 @@ class SGD(Base,
         >>> pred_data['col2'] = np.asarray([5, 5], dtype=np.float32)
         >>> cu_sgd = cumlSGD(learning_rate='constant', eta0=0.005, epochs=2000,
         ...                  fit_intercept=True, batch_size=2,
-        ...                  tol=0.0, penalty='none', loss='squared_loss')
+        ...                  tol=0.0, penalty=None, loss='squared_loss')
         >>> cu_sgd.fit(X, y)
         SGD()
         >>> cu_pred = cu_sgd.predict(pred_data).to_numpy()
@@ -160,14 +161,14 @@ class SGD(Base,
         'hinge' uses linear SVM
         'log' uses logistic regression
         'squared_loss' uses linear regression
-    penalty : 'none', 'l1', 'l2', 'elasticnet' (default = 'none')
-        'none' does not perform any regularization
-        'l1' performs L1 norm (Lasso) which minimizes the sum of the abs value
-        of coefficients
-        'l2' performs L2 norm (Ridge) which minimizes the sum of the square of
-        the coefficients
-        'elasticnet' performs Elastic Net regularization which is a weighted
-        average of L1 and L2 norms
+    penalty : {'l1', 'l2', 'elasticnet', None} (default = None)
+        The penalty (aka regularization term) to be used.
+
+        - 'l1': L1 norm (Lasso) regularization
+        - 'l2': L2 norm (Ridge) regularazation
+        - 'elasticnet': Elastic Net regularization, a weighted average of L1 and L2
+        - None: no penalty is added (the default)
+
     alpha : float (default = 0.0001)
         The constant value which decides the degree of regularization
     fit_intercept : boolean (default = True)
@@ -218,7 +219,7 @@ class SGD(Base,
     coef_ = CumlArrayDescriptor()
     classes_ = CumlArrayDescriptor()
 
-    def __init__(self, *, loss='squared_loss', penalty='none', alpha=0.0001,
+    def __init__(self, *, loss='squared_loss', penalty=None, alpha=0.0001,
                  l1_ratio=0.15, fit_intercept=True, epochs=1000, tol=1e-3,
                  shuffle=True, learning_rate='constant', eta0=0.001,
                  power_t=0.5, batch_size=32, n_iter_no_change=5, handle=None,
@@ -227,16 +228,19 @@ class SGD(Base,
         if loss in ['hinge', 'log', 'squared_loss']:
             self.loss = loss
         else:
-            msg = "loss {!r} is not supported"
-            raise TypeError(msg.format(loss))
+            raise ValueError(f"loss {loss!r} is not supported")
 
-        if penalty is None:
-            penalty = 'none'
-        if penalty in ['none', 'l1', 'l2', 'elasticnet']:
+        if penalty == 'none':
+            warnings.warn(
+                "penalty='none' is deprecated and will be removed in 25.10. Please use "
+                "`penalty=None` instead.",
+                FutureWarning,
+            )
+            self.penalty = None
+        elif penalty in [None, 'l1', 'l2', 'elasticnet']:
             self.penalty = penalty
         else:
-            msg = "penalty {!r} is not supported"
-            raise TypeError(msg.format(penalty))
+            raise ValueError(f"penalty {penalty!r} is not supported")
 
         super().__init__(handle=handle,
                          verbose=verbose,
@@ -301,7 +305,7 @@ class SGD(Base,
 
     def _get_penalty_int(self):
         return {
-            'none': 0,
+            None: 0,
             'l1': 1,
             'l2': 2,
             'elasticnet': 3

--- a/python/cuml/cuml/tests/test_mbsgd_classifier.py
+++ b/python/cuml/cuml/tests/test_mbsgd_classifier.py
@@ -69,7 +69,7 @@ def make_dataset(request):
     # while still keeping good coverage of the different features of MBSGD
     ("lrate", "penalty", "loss"),
     [
-        ("constant", "none", "log"),
+        ("constant", None, "log"),
         ("invscaling", "l2", "hinge"),
         ("adaptive", "l1", "squared_loss"),
         ("constant", "elasticnet", "hinge"),
@@ -116,7 +116,7 @@ def test_mbsgd_classifier_vs_skl(lrate, penalty, loss, make_dataset):
     # while still keeping good coverage of the different features of MBSGD
     ("lrate", "penalty", "loss"),
     [
-        ("constant", "none", "log"),
+        ("constant", None, "log"),
         ("invscaling", "l2", "hinge"),
         ("adaptive", "l1", "squared_loss"),
         ("constant", "elasticnet", "hinge"),

--- a/python/cuml/cuml/tests/test_mbsgd_classifier.py
+++ b/python/cuml/cuml/tests/test_mbsgd_classifier.py
@@ -63,7 +63,6 @@ def make_dataset(request):
     return nrows, X_train, X_test, y_train, y_test
 
 
-@pytest.mark.xfail(reason="Related to CuPy 9.0 update (see issue #3813)")
 @pytest.mark.parametrize(
     # Grouped those tests to reduce the total number of individual tests
     # while still keeping good coverage of the different features of MBSGD
@@ -110,7 +109,6 @@ def test_mbsgd_classifier_vs_skl(lrate, penalty, loss, make_dataset):
         assert cu_acc >= skl_acc - 0.08
 
 
-@pytest.mark.xfail(reason="Related to CuPy 9.0 update (see issue #3813)")
 @pytest.mark.parametrize(
     # Grouped those tests to reduce the total number of individual tests
     # while still keeping good coverage of the different features of MBSGD
@@ -142,7 +140,6 @@ def test_mbsgd_classifier(lrate, penalty, loss, make_dataset):
     assert cu_acc > 0.79
 
 
-@pytest.mark.xfail(reason="Related to CuPy 9.0 update (see issue #3813)")
 def test_mbsgd_classifier_default(make_dataset):
     nrows, X_train, X_test, y_train, y_test = make_dataset
 

--- a/python/cuml/cuml/tests/test_mbsgd_regressor.py
+++ b/python/cuml/cuml/tests/test_mbsgd_regressor.py
@@ -121,7 +121,7 @@ def test_mbsgd_regressor_vs_skl(lrate, penalty, make_dataset):
     # while still keeping good coverage of the different features of MBSGD
     ("lrate", "penalty"),
     [
-        ("constant", "none"),
+        ("constant", None),
         ("invscaling", "l1"),
         ("adaptive", "l2"),
         ("constant", "elasticnet"),

--- a/python/cuml/cuml/tests/test_sgd.py
+++ b/python/cuml/cuml/tests/test_sgd.py
@@ -22,9 +22,15 @@ from sklearn.model_selection import train_test_split
 from cuml.solvers import SGD as cumlSGD
 
 
+def test_sgd_penalty_none_deprecated():
+    with pytest.warns(FutureWarning):
+        solver = cumlSGD(penalty="none")
+    assert solver.penalty is None
+
+
 @pytest.mark.parametrize("lrate", ["constant", "invscaling", "adaptive"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("penalty", ["none", "l1", "l2", "elasticnet"])
+@pytest.mark.parametrize("penalty", [None, "l1", "l2", "elasticnet"])
 @pytest.mark.parametrize("loss", ["hinge", "log", "squared_loss"])
 @pytest.mark.parametrize("datatype", ["dataframe", "numpy"])
 def test_sgd(dtype, lrate, penalty, loss, datatype):

--- a/python/cuml/cuml/tests/test_sgd.py
+++ b/python/cuml/cuml/tests/test_sgd.py
@@ -23,7 +23,7 @@ from cuml.solvers import SGD as cumlSGD
 
 
 def test_sgd_penalty_none_deprecated():
-    with pytest.warns(FutureWarning):
+    with pytest.warns(FutureWarning, match="penalty='none' is deprecated"):
         solver = cumlSGD(penalty="none")
     assert solver.penalty is None
 


### PR DESCRIPTION
We'd already deprecated `penalty='none'` in favor of `penalty=None` for other estimators, just not these. Switching to `penalty=None` everywhere is more uniform and also improves compatibility with sklearn.

Also:
- Un-xfails some MBSGDClassifier tests that don't need to be xfailed (and haven't for a while)
- Fixes the LogisticRegression docstring on `penalty` to match the valid options