### PR TITLE
A few fixes for CI

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -46,6 +46,7 @@ dependencies:
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
+- numpydoc<1.9
 - packaging
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==25.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -46,6 +46,7 @@ dependencies:
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
+- numpydoc<1.9
 - packaging
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==25.8.*,>=0.0.0a0

--- a/cpp/src/holtwinters/internal/hw_eval.cuh
+++ b/cpp/src/holtwinters/internal/hw_eval.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ CUML_KERNEL void holtwinters_eval_gpu_shared_kernel(const Dtype* ts,
                                                     bool additive_seasonal)
 {
   int tid = GET_TID;
-  extern __shared__ __align__(sizeof(Dtype)) unsigned char pseason_[];
+  extern __shared__ unsigned char pseason_[];
   Dtype* pseason = reinterpret_cast<Dtype*>(pseason_);
 
   if (tid < batch_size) {

--- a/cpp/src/holtwinters/internal/hw_optim.cuh
+++ b/cpp/src/holtwinters/internal/hw_optim.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -619,7 +619,7 @@ CUML_KERNEL void holtwinters_optim_gpu_shared_kernel(const Dtype* ts,
                                                      bool single_param)
 {
   int tid = GET_TID;
-  extern __shared__ __align__(sizeof(Dtype)) unsigned char pseason_[];
+  extern __shared__ unsigned char pseason_[];
   Dtype* pseason = reinterpret_cast<Dtype*>(pseason_);
 
   if (tid < batch_size) {

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -407,7 +407,8 @@ dependencies:
           - hdbscan>=0.8.39,<0.8.40
           - hypothesis>=6.0,<7
           - nltk
-          - numpydoc
+          # upstream sklearn docstring tests require numpydoc<1.9
+          - numpydoc<1.9
           - pyyaml
           - pytest==7.*
           - pytest-benchmark

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -14,6 +14,8 @@
 #
 
 import random
+import warnings
+from contextlib import contextmanager
 
 import cudf
 import cupy as cp
@@ -29,6 +31,14 @@ from sklearn.metrics import accuracy_score
 from cuml.dask.common import utils as dask_utils
 from cuml.internals import logger
 from cuml.testing.utils import array_equal
+
+
+@contextmanager
+def ignore_deprecated_lbfgs_params_warning():
+    """Ignores a warning in sklearn raised by scipy.optimize deprecated params"""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", module="sklearn")
+        yield
 
 
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
@@ -307,7 +317,9 @@ def _test_lbfgs(
         l1_ratio=l1_ratio,
         C=C,
     )
-    sk_model.fit(X, y)
+    with ignore_deprecated_lbfgs_params_warning():
+        sk_model.fit(X, y)
+
     sk_coef = sk_model.coef_
     sk_intercept = sk_model.intercept_
 
@@ -775,7 +787,8 @@ def test_standardization_on_scaled_dataset(
         l1_ratio=l1_ratio,
         C=C,
     )
-    cpu.fit(X_train_scaled, y_train)
+    with ignore_deprecated_lbfgs_params_warning():
+        cpu.fit(X_train_scaled, y_train)
     cpu_preds = cpu.predict(X_test_scaled)
     cpu_accuracy = accuracy_score(y_test, cpu_preds)
 
@@ -1117,7 +1130,8 @@ def test_sparse_all_zeroes(
         ) = standardize_dataset(X, X, fit_intercept)
 
     cpu_lr = LogisticRegression(fit_intercept=fit_intercept)
-    cpu_lr.fit(X_cpu, y)
+    with ignore_deprecated_lbfgs_params_warning():
+        cpu_lr.fit(X_cpu, y)
     cpu_preds = cpu_lr.predict(X_cpu)
 
     assert array_equal(mg_preds, cpu_preds)

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -37,7 +37,7 @@ from cuml.testing.utils import array_equal
 def ignore_deprecated_lbfgs_params_warning():
     """Ignores a warning in sklearn raised by scipy.optimize deprecated params"""
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", module="sklearn")
+        warnings.filterwarnings("ignore")
         yield
 
 

--- a/python/cuml/cuml/tests/test_arima.py
+++ b/python/cuml/cuml/tests/test_arima.py
@@ -37,7 +37,6 @@ import cudf
 import numpy as np
 import pandas as pd
 import pytest
-import statsmodels.api as sm
 from cudf.pandas import LOADED as cudf_pandas_active
 from scipy.optimize import approx_fprime
 from sklearn.model_selection import train_test_split
@@ -45,6 +44,8 @@ from sklearn.model_selection import train_test_split
 import cuml.tsa.arima as arima
 from cuml.internals.input_utils import input_to_host_array
 from cuml.testing.utils import stress_param
+
+sm = pytest.importorskip("statsmodels.api")
 
 ###############################################################################
 #                                  Test data                                  #

--- a/python/cuml/cuml/tests/test_holtwinters.py
+++ b/python/cuml/cuml/tests/test_holtwinters.py
@@ -15,9 +15,11 @@
 import numpy as np
 import pytest
 from sklearn.metrics import r2_score
-from statsmodels.tsa.holtwinters import ExponentialSmoothing as sm_ES
 
 from cuml.tsa.holtwinters import ExponentialSmoothing as cuml_ES
+
+holtwinters = pytest.importorskip("statsmodels.tsa.holtwinters")
+sm_ES = holtwinters.ExponentialSmoothing
 
 airpassengers = [
     112,

--- a/python/cuml/cuml/tests/test_stationarity.py
+++ b/python/cuml/cuml/tests/test_stationarity.py
@@ -19,9 +19,10 @@ import warnings
 
 import numpy as np
 import pytest
-from statsmodels.tsa import stattools
 
 from cuml.tsa import stationarity
+
+stattools = pytest.importorskip("statsmodels.tsa.stattools")
 
 ###############################################################################
 #                       Helpers and reference functions                       #

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -132,7 +132,7 @@ test = [
     "hdbscan>=0.8.39,<0.8.40",
     "hypothesis>=6.0,<7",
     "nltk",
-    "numpydoc",
+    "numpydoc<1.9",
     "pynndescent",
     "pytest-benchmark",
     "pytest-cases",


### PR DESCRIPTION
~For unknown reasons our pytest config isn't being uniformly applied in the dask tests module. This is leading to warnings that should be filtered not being ignored and causing errors during test runs.~

~One such warning was recently introduced with the release of scipy 1.16. This deprecates a few parameters in a `scipy.optimize` routine that are used by sklearn's `LogisticRegression`. Due to how the deprecation warning is raised this warning shows up under sklearn's module instead of scipy (the actual source).~

~Barring figuring out why our config isn't being uniformly applied, I've opted to explicitly ignore these warnings in the few places they pop up for now.~

*(edited - I have a better understanding of the issues now, and the PR has expanded a bit in scope)*

This does 4 fixes to fix CI:
- Explicitly ignores a `DeprecationWarning` raised by scipy 1.16 within sklearn. Due to how the `rapids-dask-dependency` patches modules when imported this causes the warning to be raised from an incorrect module, making our existing filter not effective. This seems like an upstream bug in the patching mechanism, but I've been unable to reproduce the issue locally so far.
- Skips tests requiring `statsmodels` if it fails to import. The recent scipy 1.16 causes parts of statsmodels to fail to import. This will require an upstream fix to fully work, but using `importorskip` to skip if statsmodels fails to import (or isn't installed) seems like a sane way to handle this.
- Removes two calls to `__align__` that were causing compilation errors on CUDA 12.9.1 on conda. From internal discussions it sounds like these alignment declarations weren't necessary, and removing them gets the build to pass.
- Pins `numpydoc<1.9` to allow the sklearn upstream tests to pass. The new release of `numpydoc` broke the released test suite for sklearn.

Fixes #6927.