### PR TITLE
Remove nvidia and dask channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
         - id: verify-codeowners
           args: [--fix, --project-prefix=cuml]
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.17.1
+      rev: v1.19.0
       hooks:
           - id: rapids-dependency-file-generator
             args: ["--clean"]

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - c-compiler
 - certifi

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - c-compiler
 - certifi

--- a/conda/environments/clang_tidy_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-128_arch-x86_64.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - c-compiler
 - clang-tools==15.0.7

--- a/conda/environments/cpp_all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-128_arch-x86_64.yaml
@@ -4,7 +4,6 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - conda-forge
-- nvidia
 dependencies:
 - c-compiler
 - cmake>=3.30.4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -179,7 +179,6 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - conda-forge
-  - nvidia
 dependencies:
   rapids_build_backend:
     common:
@@ -248,7 +247,6 @@ dependencies:
         packages:
           - &cython cython>=3.0.0
           - &treelite treelite==4.4.1
-
   py_run_cuml:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
Now that we have dropped support for CUDA 11 we no longer require the nvidia channel.
With the changes in https://github.com/rapidsai/rapids-dask-dependency/pull/85, RAPIDS now only uses released versions of dask, so we no longer need the dask channel either.
Contributes to https://github.com/rapidsai/build-planning/issues/184
