### PR TITLE
Remove `Base.__getattr__`/`Base.__getstate__`/`Base.__setstate__`

### DIFF
--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -963,7 +963,7 @@ class HDBSCAN(Base, InteropMixin, ClusterMixin, CMajorInputTagMixin):
 
     def __setstate__(self, state):
         state_dict = state.pop("_state_dict", None)
-        super().__setstate__(state)
+        self.__dict__.update(state)
         if state_dict is not None:
             self._state = _HDBSCANState.from_dict(self.handle, state_dict)
         if self.prediction_data:

--- a/python/cuml/cuml/internals/base.py
+++ b/python/cuml/cuml/internals/base.py
@@ -328,25 +328,6 @@ class Base(TagsMixin, metaclass=cuml.internals.BaseMetaClass):
                 setattr(self, key, value)
         return self
 
-    def __getstate__(self):
-        # getstate and setstate are needed to tell pickle to treat this
-        # as regular python classes instead of triggering __getattr__
-        return self.__dict__
-
-    def __setstate__(self, d):
-        self.__dict__.update(d)
-
-    def __getattr__(self, attr):
-        """
-        Redirects to `solver_model` if the attribute exists.
-        """
-        if attr == "solver_model":
-            return self.__dict__["solver_model"]
-        if "solver_model" in self.__dict__.keys():
-            return getattr(self.solver_model, attr)
-        else:
-            raise AttributeError(attr)
-
     def _set_base_attributes(
         self, output_type=None, target_dtype=None, n_features=None
     ):

--- a/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
@@ -188,19 +188,23 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         self.solver_model.coef_ = value
 
     def create_qnparams(self):
+        # TODO: this is effectively identical to how QNParams is created in
+        # `qn.pyx`, we should do some refactoring to avoid duplicating that here
+        solver = self.solver_model
         return QNParams(
             loss=self.loss,
-            penalty_l1=self.l1_strength,
-            penalty_l2=self.l2_strength,
-            grad_tol=self.tol,
-            change_tol=self.delta
-            if self.delta is not None else (self.tol * 0.01),
-            max_iter=self.max_iter,
-            linesearch_max_iter=self.linesearch_max_iter,
-            lbfgs_memory=self.lbfgs_memory,
-            verbose=self.verbose,
-            fit_intercept=self.fit_intercept,
-            penalty_normalized=self.penalty_normalized
+            penalty_l1=solver.l1_strength,
+            penalty_l2=solver.l2_strength,
+            grad_tol=solver.tol,
+            change_tol=(
+                solver.delta if solver.delta is not None else (solver.tol * 0.01)
+            ),
+            max_iter=solver.max_iter,
+            linesearch_max_iter=solver.linesearch_max_iter,
+            lbfgs_memory=solver.lbfgs_memory,
+            verbose=solver.verbose,
+            fit_intercept=solver.fit_intercept,
+            penalty_normalized=solver.penalty_normalized
         )
 
     def prepare_for_fit(self, n_classes):
@@ -245,7 +249,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
         else:
             coef_size = (self.n_cols, self._num_classes_dim)
 
-        if self.coef_ is None or not self.warm_start:
+        if self.coef_ is None or not self.solver_model.warm_start:
             self.solver_model._coef_ = CumlArray.zeros(
                 coef_size, dtype=self.dtype, order='C')
 

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -199,6 +199,10 @@ class MBSGDClassifier(Base, ClassifierMixin, FMajorInputTagMixin):
         return self
 
     @property
+    def dtype(self):
+        return self.solver_model.dtype
+
+    @property
     def coef_(self) -> CumlArray:
         return self.solver_model.coef_
 

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -198,6 +198,30 @@ class MBSGDClassifier(Base, ClassifierMixin, FMajorInputTagMixin):
         self.solver_model.fit(X, y, convert_dtype=convert_dtype)
         return self
 
+    @property
+    def coef_(self) -> CumlArray:
+        return self.solver_model.coef_
+
+    @coef_.setter
+    def coef_(self, value):
+        self.solver_model.coef_ = value
+
+    @property
+    def intercept_(self) -> float:
+        return self.solver_model.intercept_
+
+    @intercept_.setter
+    def intercept_(self, value):
+        self.solver_model.intercept_ = value
+
+    @property
+    def classes_(self) -> CumlArray:
+        return self.solver_model.classes_
+
+    @classes_.setter
+    def classes_(self, value):
+        self.solver_model.classes_ = value
+
     @generate_docstring(
         return_values={
             "name": "preds",

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -198,6 +198,10 @@ class MBSGDRegressor(Base, RegressorMixin, FMajorInputTagMixin):
         return self
 
     @property
+    def dtype(self):
+        return self.solver_model.dtype
+
+    @property
     def coef_(self) -> CumlArray:
         return self.solver_model.coef_
 

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -197,6 +197,22 @@ class MBSGDRegressor(Base, RegressorMixin, FMajorInputTagMixin):
         self.solver_model.fit(X, y, convert_dtype=convert_dtype)
         return self
 
+    @property
+    def coef_(self) -> CumlArray:
+        return self.solver_model.coef_
+
+    @coef_.setter
+    def coef_(self, value):
+        self.solver_model.coef_ = value
+
+    @property
+    def intercept_(self) -> float:
+        return self.solver_model.intercept_
+
+    @intercept_.setter
+    def intercept_(self, value):
+        self.solver_model.intercept_ = value
+
     @generate_docstring(
         return_values={
             "name": "preds",

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -287,8 +287,6 @@ class SGD(Base,
         self.batch_size = batch_size
         self.n_iter_no_change = n_iter_no_change
         self.intercept_value = 0.0
-        self.coef_ = None
-        self.intercept_ = None
 
     def _check_alpha(self, alpha):
         for el in alpha:

--- a/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/cuml/tests/dask/test_dask_logistic_regression.py
@@ -194,7 +194,7 @@ def test_lbfgs_init(client):
         )
 
         lr.fit(X_df, y_df)
-        qnpams = lr.qnparams.params
+        qnpams = lr.solver_model.qnparams.params
         assert qnpams["grad_tol"] == tol
         assert qnpams["loss"] == 0  # "sigmoid" loss
         assert qnpams["penalty_l1"] == 0.0
@@ -393,7 +393,7 @@ def test_noreg(fit_intercept, client):
         penalty=None,
     )
 
-    qnpams = lr.qnparams.params
+    qnpams = lr.solver_model.qnparams.params
     assert qnpams["penalty_l1"] == 0.0
     assert qnpams["penalty_l2"] == 0.0
 

--- a/python/cuml/cuml/tests/test_base.py
+++ b/python/cuml/cuml/tests/test_base.py
@@ -50,14 +50,6 @@ def test_base_class_usage_with_handle():
     del base
 
 
-def test_base_hasattr():
-    base = cuml.Base()
-    # With __getattr__ overriding magic, hasattr should still return
-    # True only for valid attributes
-    assert hasattr(base, "handle")
-    assert not hasattr(base, "somefakeattr")
-
-
 @pytest.mark.parametrize("datatype", ["float32", "float64"])
 @pytest.mark.parametrize("use_integer_n_features", [True, False])
 def test_base_n_features_in(datatype, use_integer_n_features):

--- a/python/cuml/cuml/tests/test_mbsgd_classifier.py
+++ b/python/cuml/cuml/tests/test_mbsgd_classifier.py
@@ -123,7 +123,7 @@ def test_mbsgd_classifier_vs_skl(lrate, penalty, loss, make_dataset):
 def test_mbsgd_classifier(lrate, penalty, loss, make_dataset):
     nrows, X_train, X_test, y_train, y_test = make_dataset
 
-    cu_mbsgd_classifier = cumlMBSGClassifier(
+    model = cumlMBSGClassifier(
         learning_rate=lrate,
         eta0=0.005,
         epochs=100,
@@ -132,9 +132,18 @@ def test_mbsgd_classifier(lrate, penalty, loss, make_dataset):
         tol=0.0,
         penalty=penalty,
     )
+    # Fitted attributes don't exist before fit
+    assert not hasattr(model, "coef_")
+    assert not hasattr(model, "intercept_")
 
-    cu_mbsgd_classifier.fit(X_train, y_train)
-    cu_pred = cu_mbsgd_classifier.predict(X_test)
+    model.fit(X_train, y_train)
+
+    # Fitted attributes exist and have correct types after fit
+    assert isinstance(model.coef_, type(X_train))
+    assert isinstance(model.intercept_, float)
+    assert isinstance(model.classes_, type(X_train))
+
+    cu_pred = model.predict(X_test)
     cu_acc = accuracy_score(cp.asnumpy(cu_pred), cp.asnumpy(y_test))
 
     assert cu_acc > 0.79

--- a/python/cuml/cuml/tests/test_mbsgd_regressor.py
+++ b/python/cuml/cuml/tests/test_mbsgd_regressor.py
@@ -130,7 +130,7 @@ def test_mbsgd_regressor_vs_skl(lrate, penalty, make_dataset):
 def test_mbsgd_regressor(lrate, penalty, make_dataset):
     nrows, datatype, X_train, X_test, y_train, y_test = make_dataset
 
-    cu_mbsgd_regressor = cumlMBSGRegressor(
+    model = cumlMBSGRegressor(
         learning_rate=lrate,
         eta0=0.005,
         epochs=100,
@@ -139,9 +139,17 @@ def test_mbsgd_regressor(lrate, penalty, make_dataset):
         tol=0.0,
         penalty=penalty,
     )
+    # Fitted attributes don't exist before fit
+    assert not hasattr(model, "coef_")
+    assert not hasattr(model, "intercept_")
 
-    cu_mbsgd_regressor.fit(X_train, y_train)
-    cu_pred = cu_mbsgd_regressor.predict(X_test)
+    model.fit(X_train, y_train)
+
+    # Fitted attributes exist and have correct types after fit
+    assert isinstance(model.coef_, type(X_train))
+    assert isinstance(model.intercept_, float)
+
+    cu_pred = model.predict(X_test)
     cu_r2 = r2_score(cu_pred, y_test)
 
     assert cu_r2 >= 0.88

--- a/python/cuml/cuml/tests/test_solver_attributes.py
+++ b/python/cuml/cuml/tests/test_solver_attributes.py
@@ -31,7 +31,6 @@ def test_mbsgd_regressor_attributes():
         "coef_",
         "intercept_",
         "l1_ratio",
-        "n_cols",
         "loss",
         "eta0",
         "batch_size",
@@ -51,7 +50,6 @@ def test_logistic_regression_attributes():
         "coef_",
         "intercept_",
         "l1_ratio",
-        "n_cols",
         "C",
         "penalty",
         "fit_intercept",
@@ -73,7 +71,6 @@ def test_mbsgd_classifier_attributes():
         "coef_",
         "intercept_",
         "l1_ratio",
-        "n_cols",
         "eta0",
         "batch_size",
         "fit_intercept",
@@ -94,7 +91,6 @@ def test_elastic_net_attributes():
         "coef_",
         "intercept_",
         "l1_ratio",
-        "n_cols",
         "alpha",
         "max_iter",
         "fit_intercept",
@@ -115,7 +111,6 @@ def test_lasso_attributes():
         "intercept_",
         "solver_model",
         "l1_ratio",
-        "n_cols",
     ]
     for attr in attrs:
         assert hasattr(clf, attr)

--- a/python/cuml/cuml/tests/test_umap.py
+++ b/python/cuml/cuml/tests/test_umap.py
@@ -532,8 +532,8 @@ def test_exp_decay_params(build_algo):
         cuml_model = cuUMAP(
             a=a, b=b, min_dist=min_dist, spread=spread, build_algo=build_algo
         )
-        state = cuml_model.__getstate__()
-        cuml_a, cuml_b = state["a"], state["b"]
+        cuml_a = cuml_model.a
+        cuml_b = cuml_model.b
         skl_model = umap.UMAP(a=a, b=b, min_dist=min_dist, spread=spread)
         skl_model.fit(np.zeros((1, 1)))
         sklearn_a, sklearn_b = skl_model._a, skl_model._b


### PR DESCRIPTION
`Base.__getattr__` existed to forward any missing attributes on a model to the underlying `solver_model` attribute (if any). Beyond being implicit, this led to nicer user error messages raised in properties on subclasses being swallowed up as a generic `AttributeError`.

This PR removes the magic `__getattr__` in favor of explicitly surfacing attributes in the parent model. The only place this was needed was the `MBSGD*` estimators.

The `__getstate__`/`__setstate__` implementations on `Base` were only needed due to the `__getattr__` implementation, since without them `model.__getstate__` would return `model.solver_model.__getstate__`. Removing these as well in favor of relying on python's standard behavior (which matched the previous implementations).