### PR TITLE
Reflect output type in `hdbscan` prediction functions

### DIFF
--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -995,6 +995,7 @@ def _check_clusterer(clusterer):
     return state
 
 
+@cuml.internals.api_return_array()
 def all_points_membership_vectors(clusterer, batch_size=4096):
     """
     Predict soft cluster membership vectors for all points in the
@@ -1025,13 +1026,24 @@ def all_points_membership_vectors(clusterer, batch_size=4096):
     if batch_size <= 0:
         raise ValueError("batch_size must be > 0")
 
+    # Reflect the output type from global settings or the clusterer
+    cuml.internals.set_api_output_type(clusterer._get_output_type())
+
     n_rows = clusterer._raw_data.shape[0]
 
     if clusterer.n_clusters_ == 0:
-        return np.zeros(n_rows, dtype=np.float32)
+        return CumlArray.zeros(
+            n_rows,
+            dtype=np.float32,
+            order="C",
+            index=clusterer._raw_data.index,
+        )
 
     membership_vec = CumlArray.empty(
-        (n_rows * clusterer.n_clusters_,), dtype="float32"
+        (n_rows, clusterer.n_clusters_,),
+        dtype="float32",
+        order="C",
+        index=clusterer._raw_data.index,
     )
 
     cdef _HDBSCANState state = <_HDBSCANState?>clusterer._state
@@ -1048,12 +1060,10 @@ def all_points_membership_vectors(clusterer, batch_size=4096):
     )
     clusterer.handle.sync()
 
-    return membership_vec.to_output(
-        output_type="numpy",
-        output_dtype="float32",
-    ).reshape((n_rows, clusterer.n_clusters_))
+    return membership_vec
 
 
+@cuml.internals.api_return_array()
 def membership_vector(clusterer, points_to_predict, batch_size=4096, convert_dtype=True):
     """
     Predict soft cluster membership. The result produces a vector
@@ -1090,6 +1100,9 @@ def membership_vector(clusterer, points_to_predict, batch_size=4096, convert_dty
     if batch_size <= 0:
         raise ValueError("batch_size must be > 0")
 
+    # Reflect the output type from global settings, the clusterer, or the input
+    cuml.internals.set_api_output_type(clusterer._get_output_type(points_to_predict))
+
     points_to_predict_m, n_prediction_points, n_cols, _ = input_to_cuml_array(
         points_to_predict,
         order="C",
@@ -1101,11 +1114,15 @@ def membership_vector(clusterer, points_to_predict, batch_size=4096, convert_dty
         raise ValueError("New points dimension does not match fit data!")
 
     if clusterer.n_clusters_ == 0:
-        return np.zeros(n_prediction_points, dtype=np.float32)
+        return CumlArray.zeros(
+            n_prediction_points, dtype=np.float32, index=points_to_predict_m.index
+        )
 
     membership_vec = CumlArray.empty(
-        (n_prediction_points * clusterer.n_clusters_,),
-        dtype="float32"
+        (n_prediction_points, clusterer.n_clusters_,),
+        dtype="float32",
+        order="C",
+        index=points_to_predict_m.index,
     )
 
     cdef _HDBSCANState state = <_HDBSCANState?>clusterer._state
@@ -1125,12 +1142,10 @@ def membership_vector(clusterer, points_to_predict, batch_size=4096, convert_dty
     )
     clusterer.handle.sync()
 
-    return membership_vec.to_output(
-        output_type="numpy",
-        output_dtype="float32"
-    ).reshape((n_prediction_points, clusterer.n_clusters_))
+    return membership_vec
 
 
+@cuml.internals.api_return_generic()
 def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
     """Predict the cluster label of new points. The returned labels
     will be those of the original clustering found by ``clusterer``,
@@ -1165,6 +1180,9 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
     """
     _check_clusterer(clusterer)
 
+    # Reflect the output type from global settings, the clusterer, or the input
+    cuml.internals.set_api_output_type(clusterer._get_output_type(points_to_predict))
+
     if clusterer.n_clusters_ == 0:
         logger.warn(
             "Clusterer does not have any defined clusters, new data "
@@ -1181,8 +1199,16 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
     if n_cols != clusterer._raw_data.shape[1]:
         raise ValueError("New points dimension does not match fit data!")
 
-    prediction_labels = CumlArray.empty((n_prediction_points,), dtype="int32")
-    prediction_probs = CumlArray.empty((n_prediction_points,), dtype="float32")
+    prediction_labels = CumlArray.empty(
+        (n_prediction_points,),
+        dtype="int32",
+        index=points_to_predict_m.index,
+    )
+    prediction_probs = CumlArray.empty(
+        (n_prediction_points,),
+        dtype="float32",
+        index=points_to_predict_m.index,
+    )
 
     with cuml.using_output_type("cuml"):
         labels = clusterer.labels_
@@ -1205,10 +1231,7 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
     )
     clusterer.handle.sync()
 
-    return (
-        prediction_labels.to_output(output_type="numpy"),
-        prediction_probs.to_output(output_type="numpy", output_dtype="float32")
-    )
+    return prediction_labels, prediction_probs
 
 
 ###########################################################

--- a/python/cuml/cuml/internals/api_decorators.py
+++ b/python/cuml/cuml/internals/api_decorators.py
@@ -193,10 +193,6 @@ def _make_decorator_function(
                         if self_val is None:
                             assert input_val is not None
                             out_type = iu.determine_array_type(input_val)
-                        elif input_val is None or input_val is inspect._empty:
-                            out_type = self_val.output_type
-                            if out_type == "input":
-                                out_type = self_val._input_type
                         else:
                             out_type = self_val._get_output_type(input_val)
 

--- a/python/cuml/cuml/internals/base.py
+++ b/python/cuml/cuml/internals/base.py
@@ -376,7 +376,7 @@ class Base(TagsMixin, metaclass=cuml.internals.BaseMetaClass):
     def _set_output_mem_type(self, inp):
         self._input_mem_type = determine_array_memtype(inp)
 
-    def _get_output_type(self, inp):
+    def _get_output_type(self, inp=None):
         """
         Method to be called by predict/transform methods of inheriting classes.
         Returns the appropriate output type depending on the type of the input,
@@ -390,9 +390,14 @@ class Base(TagsMixin, metaclass=cuml.internals.BaseMetaClass):
         if output_type is None or output_type == "mirror":
             output_type = self.output_type
 
-        # If we are input, get the type from the input
+        # If we are input, get the type from the input (if available)
         if output_type == "input":
-            output_type = determine_array_type(inp)
+            if inp is None:
+                # No input value provided, use the estimator input type
+                output_type = self._input_type
+            else:
+                # Determine the output from the input
+                output_type = determine_array_type(inp)
 
         return output_type
 

--- a/python/cuml/cuml/tests/test_hdbscan.py
+++ b/python/cuml/cuml/tests/test_hdbscan.py
@@ -16,6 +16,7 @@
 import cupy as cp
 import hdbscan
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn import datasets
 from sklearn.datasets import make_blobs
@@ -1187,3 +1188,78 @@ def test_prediction_functions_cluster_namespace_deprecated():
     # Unknown attribute errors
     with pytest.raises(AttributeError, match="not_a_real_attr"):
         cuml.cluster.not_a_real_attr
+
+
+def test_all_points_membership_vectors_output_type():
+    X, y = make_blobs(random_state=42)
+    X_df = pd.DataFrame(X, index=[f"row{i}" for i in range(X.shape[0])])
+
+    model = HDBSCAN(prediction_data=True).fit(X_df, y)
+
+    # The model input_type is used if `output_type="input"`
+    out = all_points_membership_vectors(model)
+    assert isinstance(out, pd.DataFrame)
+    assert (out.index == X_df.index).all()
+
+    # The model output_type takes precedence over model input_type
+    model.output_type = "numpy"
+    out = all_points_membership_vectors(model)
+    assert isinstance(out, np.ndarray)
+
+    # The global output type takes precedence over model output_type
+    with cuml.using_output_type("cupy"):
+        out = all_points_membership_vectors(model)
+    assert isinstance(out, cp.ndarray)
+
+
+def test_membership_vector_output_type():
+    X, y = make_blobs(random_state=42)
+    model = HDBSCAN(prediction_data=True).fit(X, y)
+
+    X2 = X[:10]
+    X2_df = pd.DataFrame(X2, index=[f"row{i}" for i in range(X2.shape[0])])
+
+    # The function input_type is used if `output_type="input"`
+    out = membership_vector(model, X2_df)
+    assert isinstance(out, pd.DataFrame)
+    assert (out.index == X2_df.index).all()
+
+    out = membership_vector(model, X2)
+    assert isinstance(out, np.ndarray)
+
+    # The model output_type takes precedence over function input_type
+    model.output_type = "pandas"
+    out = membership_vector(model, X2)
+    assert isinstance(out, pd.DataFrame)
+
+    # The global output type takes precedence over model output_type
+    with cuml.using_output_type("cupy"):
+        out = membership_vector(model, X2_df)
+    assert isinstance(out, cp.ndarray)
+
+
+def test_approximate_predict_output_type():
+    X, y = make_blobs(random_state=42)
+    model = HDBSCAN(prediction_data=True).fit(X, y)
+
+    X2 = X[:10]
+    X2_df = pd.DataFrame(X2, index=[f"row{i}" for i in range(X2.shape[0])])
+
+    # The function input_type is used if `output_type="input"`
+    out = approximate_predict(model, X2_df)
+    for val in out:
+        assert isinstance(val, pd.Series)
+        assert (val.index == X2_df.index).all()
+
+    out = approximate_predict(model, X2)
+    assert all(isinstance(val, np.ndarray) for val in out)
+
+    # The model output_type takes precedence over function input_type
+    model.output_type = "pandas"
+    out = approximate_predict(model, X2)
+    assert all(isinstance(val, pd.Series) for val in out)
+
+    # The global output type takes precedence over model output_type
+    with cuml.using_output_type("cupy"):
+        out = approximate_predict(model, X2_df)
+    assert all(isinstance(val, cp.ndarray) for val in out)


### PR DESCRIPTION
This implements type reflection for the output types of the `hdbscan` prediction functions.

For `all_points_membership_vectors`, the output type is the global output type (if set), falling back to the model output type. Since there is no input to this method, relying on the model output type makes the most sense to me.

For `membership_vector` and `approximate_predict`, the output type is the global output type (if set), falling back to the model output type, or the type of `points_to_predict` if `model.output_type == "input"` (the default). I _think_ this makes sense, since the freestanding functions take a model as their first argument they're effectively the same as methods on the model and should infer their output type the same IMO.

This is effectively a breaking change, since the output types of these functions will change. I don't see a way to deprecate this cleanly, and think the improvement is worth the API churn. Users passing in numpy arrays to any of these methods won't see a change, only those using other input types.

Fixes #6914.