### PR TITLE
Support `set_output` and `get_feature_names_out` in `cuml.accel`

### DIFF
--- a/docs/source/zero-code-change-limitations.rst
+++ b/docs/source/zero-code-change-limitations.rst
@@ -21,11 +21,8 @@ the following general limitations:
   compatibility ensures that cuML's implementation of scikit-learn compatible
   APIs works as expected.
 
-* The `set_output
-  <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep018/proposal.html>`__
-  and `Metadata Routing
-  <https://scikit-learn.org/stable/metadata_routing.html>`__ APIs are not
-  currently supported.
+* The `Metadata Routing <https://scikit-learn.org/stable/metadata_routing.html>`__
+  APIs are not currently supported.
 
 * When running in Windows Subsystem for Linux 2 (WSL2), managed memory (unified
   memory) is not supported. This means that automatic memory management between

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -18,7 +18,8 @@ import functools
 from typing import Any
 
 import sklearn
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, ClassNamePrefixFeaturesOutMixin
+from sklearn.utils._set_output import _wrap_data_with_container
 
 from cuml.internals.interop import UnsupportedOnGPU, is_fitted
 
@@ -239,6 +240,11 @@ class ProxyBase(BaseEstimator):
                 raise UnsupportedOnGPU
 
         out = gpu_func(*args, **kwargs)
+
+        if method in ("transform", "fit_transform"):
+            # Ensure transform result is properly wrapped for `set_output`
+            out = _wrap_data_with_container("transform", out, args[0], self)
+
         return self if out is self._gpu else out
 
     def _call_method(self, method: str, *args: Any, **kwargs: Any) -> Any:
@@ -278,6 +284,40 @@ class ProxyBase(BaseEstimator):
         self._sync_attrs_to_cpu()
         out = getattr(self._cpu, method)(*args, **kwargs)
         return self if out is self._cpu else out
+
+    ############################################################
+    # set_output handling                                      #
+    ############################################################
+
+    def _gpu_set_output(self, *, transform=None):
+        # `set_output` can always call the CPU model (where the output config state
+        # is stored). It's defined as a `_gpu_*` method so it only shows up on the
+        # proxy for models that define `set_output`, and can avoid unnecessary calls
+        # to sync fit attributes to CPU
+        self._cpu.set_output(transform=transform)
+        return self._gpu
+
+    def _gpu_get_feature_names_out(self, input_features=None):
+        # In the common case `get_feature_names_out` doesn't require fitted attributes
+        # on the CPU. Here we detect and special case a common mixin, falling back to
+        # CPU when necessary. This helps avoid unnecessary device -> host transfers.
+        cpu_method = self._cpu_class.get_feature_names_out
+        if cpu_method is ClassNamePrefixFeaturesOutMixin.get_feature_names_out:
+            # Can run cpu method directly on GPU instance, it only references `_n_features_out`
+            return cpu_method(self._gpu, input_features=input_features)
+
+        # Fallback to CPU
+        raise UnsupportedOnGPU
+
+    @property
+    def _sklearn_output_config(self):
+        # Used by sklearn to handle wrapping output type, just proxy through to the CPU model
+        return self._cpu._sklearn_output_config
+
+    @property
+    def _sklearn_auto_wrap_output_keys(self):
+        # Used by sklearn to handle wrapping output type, just proxy through to the CPU model
+        return self._cpu._sklearn_auto_wrap_output_keys
 
     ############################################################
     # Standard magic methods                                   #

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -283,7 +283,7 @@ class KMeans(Base,
             "inertia_": to_cpu(self.inertia_),
             "n_iter_": self.n_iter_,
             # sklearn's KMeans relies on a few private attributes to work
-            "_n_features_out": self.n_clusters,
+            "_n_features_out": self._n_features_out,
             "_n_threads": n_threads,
             **super()._attrs_to_cpu(model),
         }
@@ -361,6 +361,12 @@ class KMeans(Base,
                                       else None),
                     check_dtype=[np.float32, np.float64]
                 )
+
+    @property
+    def _n_features_out(self):
+        """Number of transformed output features."""
+        # Exposed to support sklearn's `get_feature_names_out`
+        return self.n_clusters
 
     @generate_docstring()
     def fit(self, X, y=None, sample_weight=None, *, convert_dtype=True) -> "KMeans":

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -383,6 +383,12 @@ class PCA(Base,
         # between cuml.array and cupy.ndarray
         self._sparse_model = None
 
+    @property
+    def _n_features_out(self):
+        """Number of transformed output features."""
+        # Exposed to support sklearn's `get_feature_names_out`
+        return self.components_.shape[0]
+
     def _get_algorithm_c_name(self, algorithm):
         algo_map = {
             'full': Solver.COV_EIG_DQ,

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -318,6 +318,12 @@ class TruncatedSVD(Base,
 
         self.singular_values_ = None
 
+    @property
+    def _n_features_out(self):
+        """Number of transformed output features."""
+        # Exposed to support sklearn's `get_feature_names_out`
+        return self.components_.shape[0]
+
     def _get_algorithm_c_name(self, algorithm):
         algo_map = {
             'full': Solver.COV_EIG_DQ,

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -500,6 +500,12 @@ class TSNE(Base,
         self.precomputed_knn = extract_knn_infos(precomputed_knn,
                                                  n_neighbors)
 
+    @property
+    def _n_features_out(self):
+        """Number of transformed output features."""
+        # Exposed to support sklearn's `get_feature_names_out`
+        return self.embedding_.shape[1]
+
     @generate_docstring(skip_parameters_heading=True,
                         X='dense_sparse',
                         convert_dtype_cast='np.float32')

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -51,7 +51,23 @@ def iter_proxy_class_methods():
             if not name.startswith("_") and callable(
                 getattr(cls._cpu_class, name)
             ):
-                yield cls, name
+                # XXX: xfail umap.UMAP.get_feature_names_out for now
+                if (
+                    cls._cpu_class.__name__ == "UMAP"
+                    and name == "get_feature_names_out"
+                ):
+                    yield pytest.param(
+                        cls,
+                        name,
+                        marks=[
+                            pytest.mark.xfail(
+                                reason="umap-learn <= 0.5.7 doesn't implement `get_feature_names_out` properly",
+                                strict=True,
+                            )
+                        ],
+                    )
+                else:
+                    yield cls, name
 
 
 @pytest.mark.parametrize("cls, name", iter_proxy_class_methods())

--- a/python/cuml/cuml_accel_tests/test_set_output.py
+++ b/python/cuml/cuml_accel_tests/test_set_output.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.datasets import make_blobs
+
+from cuml.accel.core import ACCELERATED_MODULES
+from cuml.accel.estimator_proxy import ProxyBase
+
+
+def proxy_classes_with_set_output():
+    for mod in ACCELERATED_MODULES:
+        importlib.import_module(mod)
+
+    return sorted(
+        (
+            cls
+            for cls in ProxyBase.__subclasses__()
+            if hasattr(cls, "set_output")
+        ),
+        key=lambda cls: cls.__name__,
+    )
+
+
+@pytest.mark.parametrize("cls", proxy_classes_with_set_output())
+def test_set_output(cls):
+    """Check that all proxy classes that define `set_output` handle it appropriately"""
+    X, y = make_blobs(n_features=20, n_samples=100, random_state=42)
+
+    model = cls().set_output(transform="pandas")
+    if hasattr(model, "transform"):
+        out = model.fit(X, y).transform(X)
+    else:
+        out = model.fit_transform(X, y)
+
+    # Output is a pandas dataframe with non-default column names
+    assert isinstance(out, pd.DataFrame)
+    assert all(isinstance(c, str) for c in out.columns)
+
+    # Can call `get_feature_names_out` without error
+    names = model.get_feature_names_out()
+    assert isinstance(names, np.ndarray)
+    assert names.dtype == object
+
+    # No host transfer required (this isn't strictly necessary, but is currently
+    # true for all proxied estimators). Can revisit this check if it proves tricky
+    # when adding new estimators.
+    assert not hasattr(model._cpu, "n_features_in_")


### PR DESCRIPTION
This adds support for `set_output` and `get_feature_names_out` in `cuml.accel`. This API addition affects any `Transformer` exposed through `cuml.accel` (currently only `KMeans`, `TSNE`, `PCA`, and `TruncatedSVD`). The support is automatic and implemented in the `ProxyBase` class, so any newly wrapped estimators should automatically support it. Likewise, a test is added to auto-test any estimators exposing these methods.

Fixes #6606.