### PR TITLE
Deprecate hdbscan prediction functions in `cuml.cluster` namespace

### DIFF
--- a/python/cuml/cuml/cluster/__init__.py
+++ b/python/cuml/cuml/cluster/__init__.py
@@ -16,11 +16,21 @@
 
 from cuml.cluster.agglomerative import AgglomerativeClustering
 from cuml.cluster.dbscan import DBSCAN
-
-# TODO: These need to be deprecated and moved to hdbscan namespace
-from cuml.cluster.hdbscan import (
-    HDBSCAN,
-    all_points_membership_vectors,
-    approximate_predict,
-)
+from cuml.cluster.hdbscan import HDBSCAN
 from cuml.cluster.kmeans import KMeans
+
+
+def __getattr__(name):
+    import warnings
+
+    if name in ("all_points_membership_vectors", "approximate_predict"):
+        warnings.warn(
+            f"Accessing {name!r} from the `cuml.cluster` namespace is deprecated "
+            "and will be removed in 25.10. Please access it from the "
+            "`cuml.cluster.hdbscan` namespace instead.",
+            FutureWarning,
+        )
+        import cuml.cluster.hdbscan as mod
+
+        return getattr(mod, name)
+    raise AttributeError(f"module `cuml.cluster` has no attribute {name!r}")

--- a/python/cuml/cuml/cluster/hdbscan/prediction.py
+++ b/python/cuml/cuml/cluster/hdbscan/prediction.py
@@ -32,5 +32,5 @@ def __getattr__(name):
 
         return getattr(mod, name)
     raise AttributeError(
-        "module `cuml.cluster.hdbscan.prediction` has no attribute 'foo'"
+        f"module `cuml.cluster.hdbscan.prediction` has no attribute {name!r}"
     )

--- a/python/cuml/cuml/tests/test_hdbscan.py
+++ b/python/cuml/cuml/tests/test_hdbscan.py
@@ -1165,3 +1165,25 @@ def test_prediction_namespace_deprecated():
         )
 
     assert func is cuml.cluster.hdbscan.all_points_membership_vectors
+
+    # Unknown attribute errors
+    with pytest.raises(AttributeError, match="not_a_real_attr"):
+        cuml.cluster.hdbscan.prediction.not_a_real_attr
+
+
+def test_prediction_functions_cluster_namespace_deprecated():
+    # Attribute access warns
+    with pytest.warns(FutureWarning, match="all_points_membership_vectors"):
+        func = cuml.cluster.all_points_membership_vectors
+
+    assert func is cuml.cluster.hdbscan.all_points_membership_vectors
+
+    # Imports warn
+    with pytest.warns(FutureWarning, match="all_points_membership_vectors"):
+        from cuml.cluster import all_points_membership_vectors as func
+
+    assert func is cuml.cluster.hdbscan.all_points_membership_vectors
+
+    # Unknown attribute errors
+    with pytest.raises(AttributeError, match="not_a_real_attr"):
+        cuml.cluster.not_a_real_attr


### PR DESCRIPTION
This finishes up a TODO in the codebase to remove these from the `cuml.cluster` namespace. We just did a similar deprecation removing the `cuml.cluster.hdbscan.prediction` namespace. The canonical import path for all of these is now `cuml.cluster.hdbscan`.

Also fixes a typo (and adds a test) in the recent deprecation of the `cuml.cluster.hdbscan.prediction` namespace.