### PR TITLE
Use CUDA 12.9 in Conda, Devcontainers, Spark, GHA, etc.

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -3,7 +3,7 @@
     "context": "${localWorkspaceFolder}/.devcontainer",
     "dockerfile": "${localWorkspaceFolder}/.devcontainer/Dockerfile",
     "args": {
-      "CUDA": "12.8",
+      "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "conda",
       "BASE": "rapidsai/devcontainers:25.08-cpp-mambaforge-ubuntu22.04"
     }
@@ -11,7 +11,7 @@
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-25.08-cuda12.8-conda"
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-25.08-cuda12.9-conda"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
@@ -20,7 +20,7 @@
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils"
   ],
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda12.8-envs}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda12.9-envs}"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cuml,type=bind,consistency=consistent",
@@ -29,7 +29,7 @@
     "source=${localWorkspaceFolder}/../.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.config,target=/home/coder/.config,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.conda/pkgs,target=/home/coder/.conda/pkgs,type=bind,consistency=consistent",
-    "source=${localWorkspaceFolder}/../.conda/${localWorkspaceFolderBasename}-cuda12.8-envs,target=/home/coder/.conda/envs,type=bind,consistency=consistent"
+    "source=${localWorkspaceFolder}/../.conda/${localWorkspaceFolderBasename}-cuda12.9-envs,target=/home/coder/.conda/envs,type=bind,consistency=consistent"
   ],
   "customizations": {
     "vscode": {

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -3,20 +3,20 @@
     "context": "${localWorkspaceFolder}/.devcontainer",
     "dockerfile": "${localWorkspaceFolder}/.devcontainer/Dockerfile",
     "args": {
-      "CUDA": "12.8",
+      "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.8-ucx1.18.0-openmpi-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.9-ucx1.18.0-openmpi-ubuntu22.04"
     }
   },
   "runArgs": [
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-25.08-cuda12.8-pip"
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-25.08-cuda12.9-pip"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/cuda:25.8": {
-      "version": "12.8",
+      "version": "12.9",
       "installcuBLAS": true,
       "installcuSOLVER": true,
       "installcuRAND": true,
@@ -28,7 +28,7 @@
     "ghcr.io/rapidsai/devcontainers/features/cuda",
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils"
   ],
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda12.8-venvs}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda12.9-venvs}"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/cuml,type=bind,consistency=consistent",
@@ -36,7 +36,7 @@
     "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.config,target=/home/coder/.config,type=bind,consistency=consistent",
-    "source=${localWorkspaceFolder}/../.local/share/${localWorkspaceFolderBasename}-cuda12.8-venvs,target=/home/coder/.local/share/venvs,type=bind,consistency=consistent"
+    "source=${localWorkspaceFolder}/../.local/share/${localWorkspaceFolderBasename}-cuda12.9-venvs,target=/home/coder/.local/share/venvs,type=bind,consistency=consistent"
   ],
   "customizations": {
     "vscode": {

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -245,7 +245,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.08
     with:
       arch: '["amd64"]'
-      cuda: '["12.8"]'
+      cuda: '["12.9"]'
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       build_command: |
         sccache -z;

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - cuda-nvcc
 - cuda-profiler-api
 - cuda-python>=12.6.2,<13.0a0
-- cuda-version=12.8
+- cuda-version=12.9
 - cudf==25.8.*,>=0.0.0a0
 - cupy>=12.0.0
 - cuvs==25.8.*,>=0.0.0a0
@@ -22,7 +22,7 @@ dependencies:
 - dask-cudf==25.8.*,>=0.0.0a0
 - dask-ml
 - doxygen=1.9.1
-- gcc_linux-64=13.*
+- gcc_linux-aarch64=13.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
 - hypothesis>=6.0,<7
@@ -71,9 +71,9 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx<8.2.0
 - statsmodels
-- sysroot_linux-64==2.28
+- sysroot_linux-aarch64==2.28
 - tenacity
 - treelite==4.4.1
 - umap-learn==0.5.7
 - xgboost>=2.1.0
-name: all_cuda-128_arch-x86_64
+name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - cuda-nvcc
 - cuda-profiler-api
 - cuda-python>=12.6.2,<13.0a0
-- cuda-version=12.8
+- cuda-version=12.9
 - cudf==25.8.*,>=0.0.0a0
 - cupy>=12.0.0
 - cuvs==25.8.*,>=0.0.0a0
@@ -22,7 +22,7 @@ dependencies:
 - dask-cudf==25.8.*,>=0.0.0a0
 - dask-ml
 - doxygen=1.9.1
-- gcc_linux-aarch64=13.*
+- gcc_linux-64=13.*
 - graphviz
 - hdbscan>=0.8.39,<0.8.40
 - hypothesis>=6.0,<7
@@ -71,9 +71,9 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx<8.2.0
 - statsmodels
-- sysroot_linux-aarch64==2.28
+- sysroot_linux-64==2.28
 - tenacity
 - treelite==4.4.1
 - umap-learn==0.5.7
 - xgboost>=2.1.0
-name: all_cuda-128_arch-aarch64
+name: all_cuda-129_arch-x86_64

--- a/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
@@ -6,11 +6,13 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
+- clang-tools==15.0.7
+- clang==15.0.7
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api
-- cuda-version=12.8
+- cuda-version=12.9
 - cxx-compiler
 - gcc_linux-64=13.*
 - libcublas-dev
@@ -22,6 +24,8 @@ dependencies:
 - libcuvs==25.8.*,>=0.0.0a0
 - libraft-headers==25.8.*,>=0.0.0a0
 - librmm==25.8.*,>=0.0.0a0
+- llvm-openmp==15.0.7
 - ninja
 - sysroot_linux-64==2.28
-name: cpp_all_cuda-128_arch-x86_64
+- tomli
+name: clang_tidy_cuda-129_arch-x86_64

--- a/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/cpp_all_cuda-129_arch-x86_64.yaml
@@ -6,13 +6,11 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==15.0.7
-- clang==15.0.7
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api
-- cuda-version=12.8
+- cuda-version=12.9
 - cxx-compiler
 - gcc_linux-64=13.*
 - libcublas-dev
@@ -24,8 +22,6 @@ dependencies:
 - libcuvs==25.8.*,>=0.0.0a0
 - libraft-headers==25.8.*,>=0.0.0a0
 - librmm==25.8.*,>=0.0.0a0
-- llvm-openmp==15.0.7
 - ninja
 - sysroot_linux-64==2.28
-- tomli
-name: clang_tidy_cuda-128_arch-x86_64
+name: cpp_all_cuda-129_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.8"]
+      cuda: ["12.9"]
       arch: [x86_64, aarch64]
     includes:
       - common_build
@@ -31,7 +31,7 @@ files:
   cpp_all:
     output: conda
     matrix:
-      cuda: ["12.8"]
+      cuda: ["12.9"]
       arch: [x86_64]
     includes:
       - common_build
@@ -49,7 +49,7 @@ files:
   clang_tidy:
     output: conda
     matrix:
-      cuda: ["12.8"]
+      cuda: ["12.9"]
       arch: [x86_64]
     includes:
       - clang_tidy


### PR DESCRIPTION
Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Use CUDA 12.9 throughout different build and test environments.