### PR TITLE
Fixup rst formatting of 0cc limitations doc

### DIFF
--- a/docs/source/zero-code-change-limitations.rst
+++ b/docs/source/zero-code-change-limitations.rst
@@ -224,9 +224,11 @@ regression) and Log Loss (for classification). You can use functions from the
 ``sklearn.metrics`` module to obtain these measures.
 
 Some parameters have limited support:
+
 * ``max_samples`` must be float, not integer.
 
 The following parameters are not supported and will trigger a CPU fallback:
+
 * ``min_weight_fraction_leaf``
 * ``monotonic_cst``
 * ``ccp_alpha``
@@ -235,6 +237,7 @@ The following parameters are not supported and will trigger a CPU fallback:
 * ``oob_score``
 
 The following values for ``criterion`` will trigger a CPU fallback:
+
 * ``log_loss``
 * ``friedman_mse``
 
@@ -262,7 +265,7 @@ limitations:
   and cuml.accel will not accelerate Linear Regression if the parameter is set to
   ``True``
 * cuML's Linear Regression only implements dense inputs currently, so cuml.accel offers no
-    acceleration for sparse inputs to model training.
+  acceleration for sparse inputs to model training.
 
 Another important consideration is that, unlike more complex models, like manifold
 or clustering algorithms, linear models are quite efficient and fast to run. Even on larger
@@ -292,7 +295,7 @@ Similar to Linear Regression, Elastic Net has the following limitations:
 * ``warm_start`` parameter is not supported for GPU acceleration.
 * ``precompute`` parameter is not supported.
 * cuML's ElasticNet only implements dense inputs currently, so cuml.accel offers no
-    acceleration for sparse inputs to model training.
+  acceleration for sparse inputs to model training.
 
 ``sklearn.linear_model.Ridge``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -312,7 +315,7 @@ Similar to Linear Regression, Elastic Net has the following limitations:
 
 * ``precompute`` parameter is not supported.
 * cuML's Lasso only implements dense inputs currently, so cuml.accel offers no
-    acceleration for sparse inputs to model training.
+  acceleration for sparse inputs to model training.
 
 
 ``sklearn.manifold.TSNE``
@@ -416,10 +419,10 @@ coefficients. To compare results you should compare the performance of the
 model using ``model.score`` or ``sklearn.metrics.accuracy_score``.
 
 * Algorithm Limitations:
-  * ``probability=True`` will fallback to scikit-learn
-  * ``kernel="precomputed"`` or callable kernels will fallback to scikit-learn
-  * Multiclass classification will fallback to scikit-learn
-  * Sparse inputs will fallback to scikit-learn
+    * ``probability=True`` will fallback to scikit-learn
+    * ``kernel="precomputed"`` or callable kernels will fallback to scikit-learn
+    * Multiclass classification will fallback to scikit-learn
+    * Sparse inputs will fallback to scikit-learn
 
 ``sklearn.svm.SVR``
 ^^^^^^^^^^^^^^^^^^^
@@ -430,5 +433,5 @@ coefficients. To compare results you should compare the performance of the
 model using ``model.score`` or ``sklearn.metrics.r2_score``.
 
 * Algorithm Limitations:
-  * ``kernel="precomputed"`` or callable kernels will fallback to scikit-learn
-  * Sparse inputs will fallback to scikit-learn
+    * ``kernel="precomputed"`` or callable kernels will fallback to scikit-learn
+    * Sparse inputs will fallback to scikit-learn


### PR DESCRIPTION
This fixes the formatting of the 0cc limitations doc so the list elements properly render as lists. There's probably more cleanups we could do here, but at least things are formatted as intended now.