### PR TITLE
Add a reason to all `UnsupportedOnGPU`/`UnsupportedOnCPU` errors

### DIFF
--- a/python/cuml/cuml/accel/_wrappers/sklearn/ensemble.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/ensemble.py
@@ -26,12 +26,12 @@ class RandomForestRegressor(ProxyBase):
 
     def _gpu_fit(self, X, y, sample_weight=None):
         if sample_weight is not None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`sample_weight` is not supported")
         return self._gpu.fit(X, y)
 
     def _gpu_score(self, X, y, sample_weight=None):
         if sample_weight is not None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`sample_weight` is not supported")
         return self._gpu.score(X, y)
 
     def __len__(self):
@@ -49,12 +49,12 @@ class RandomForestClassifier(ProxyBase):
 
     def _gpu_fit(self, X, y, sample_weight=None):
         if sample_weight is not None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`sample_weight` is not supported")
         return self._gpu.fit(X, y)
 
     def _gpu_score(self, X, y, sample_weight=None):
         if sample_weight is not None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`sample_weight` is not supported")
         return self._gpu.score(X, y)
 
     def __len__(self):

--- a/python/cuml/cuml/accel/_wrappers/sklearn/linear_model.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/linear_model.py
@@ -50,7 +50,7 @@ class Ridge(ProxyBase):
     def _gpu_fit(self, X, y, sample_weight=None):
         y = input_to_cuml_array(y, convert_to_mem_type=False)[0]
         if len(y.shape) > 1:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("Multioutput `y` is not supported")
         return self._gpu.fit(X, y, sample_weight=sample_weight)
 
 

--- a/python/cuml/cuml/accel/_wrappers/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/svm.py
@@ -44,7 +44,7 @@ class SVC(ProxyBase):
     def _gpu_fit(self, X, y, sample_weight=None):
         n_classes = len(np.unique(np.asanyarray(y)))
         if n_classes > 2:
-            raise UnsupportedOnGPU("SVC.fit doesn't support multiclass")
+            raise UnsupportedOnGPU("Multiclass `y` is not supported")
         return self._gpu.fit(X, y, sample_weight=sample_weight)
 
     def _gpu_decision_function(self, X):

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -229,7 +229,7 @@ class ProxyBase(BaseEstimator):
 
         if args and is_sparse(args[0]) and not self._gpu_supports_sparse:
             # Sparse inputs not supported
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("Sparse inputs are not supported")
 
         # Determine the function to call. Check for an override on the proxy class,
         # falling back to the GPU class method if one exists.
@@ -237,7 +237,7 @@ class ProxyBase(BaseEstimator):
         if gpu_func is None:
             if (gpu_func := getattr(self._gpu, method, None)) is None:
                 # Method is not implemented in cuml
-                raise UnsupportedOnGPU
+                raise UnsupportedOnGPU("Method is not implemented in cuml")
 
         out = gpu_func(*args, **kwargs)
 

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -250,13 +250,11 @@ class DBSCAN(Base,
 
     @classmethod
     def _params_from_cpu(cls, model):
-        if callable(model.metric):
-            raise UnsupportedOnGPU
-        elif model.metric not in _SUPPORTED_METRICS:
-            raise UnsupportedOnGPU
+        if callable(model.metric) or model.metric not in _SUPPORTED_METRICS:
+            raise UnsupportedOnGPU(f"`metric={model.metric!r}` is not supported")
 
         if model.algorithm not in ("auto", "brute"):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`algorithm={model.algorithm!r}` is not supported")
 
         return {
             "eps": model.eps,

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -222,7 +222,7 @@ class KMeans(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if callable(model.init):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`init={model.init!r}` is not supported")
         elif isinstance(model.init, str):
             if model.init == "k-means++":
                 init = "scalable-k-means++"
@@ -230,7 +230,7 @@ class KMeans(Base,
                 init = "random"
             else:
                 # Should be unreachable, here in case sklearn adds more init values
-                raise UnsupportedOnGPU
+                raise UnsupportedOnGPU(f"`init={model.init!r}` is not supported")
         else:
             init = model.init  # array-like
 

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -287,7 +287,7 @@ class PCA(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.n_components == "mle":
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`n_components='mle'` is not supported")
 
         svd_solver = "auto" if model.svd_solver == "auto" else "full"
 

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -140,22 +140,22 @@ class BaseRandomForestModel(Base, InteropMixin):
     @classmethod
     def _params_from_cpu(cls, model):
         if model.oob_score:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`oob_score=True` is not supported")
 
         if model.warm_start:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`warm_start=True` is not supported")
 
         if model.monotonic_cst is not None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`monotonic_cst={model.monotonic_cst!r} is not supported")
 
         if (split_criterion := _criterion_to_split_criterion.get(model.criterion)) is None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`criterion={model.criterion!r}` is not supported")
 
         # We only forward some parameters, falling back to cuml defaults otherwise
         conditional_params = {}
 
         if isinstance(model.max_samples, int):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`int` values for `max_samples` are not supported")
         elif model.max_samples is not None:
             conditional_params["max_samples"] = model.max_samples
 
@@ -181,7 +181,9 @@ class BaseRandomForestModel(Base, InteropMixin):
 
     def _params_to_cpu(self):
         if (criterion := _split_criterion_to_criterion.get(self.split_criterion)) is None:
-            raise UnsupportedOnCPU
+            raise UnsupportedOnCPU(
+                f"`split_criterion={self.split_criterion!r}` is not supported"
+            )
 
         return {
             "n_estimators": self.n_estimators,

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.py
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.py
@@ -247,6 +247,8 @@ class KernelRidge(Base, InteropMixin, RegressorMixin):
 
     def _attrs_from_cpu(self, model):
         if not isinstance(model.X_fit_, np.ndarray):
+            # We only support coercing dense X_fit_ values, but in sklearn
+            # this may also be a sparse matrix
             raise UnsupportedOnGPU("Sparse inputs are not supported")
 
         return {

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.py
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.py
@@ -247,7 +247,7 @@ class KernelRidge(Base, InteropMixin, RegressorMixin):
 
     def _attrs_from_cpu(self, model):
         if not isinstance(model.X_fit_, np.ndarray):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("Sparse inputs are not supported")
 
         return {
             "dual_coef_": to_gpu(model.dual_coef_),

--- a/python/cuml/cuml/linear_model/elastic_net.py
+++ b/python/cuml/cuml/linear_model/elastic_net.py
@@ -169,13 +169,13 @@ class ElasticNet(
     @classmethod
     def _params_from_cpu(cls, model):
         if model.positive:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`positive=True` is not supported")
 
         if model.warm_start:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`warm_start=True` is not supported")
 
         if model.precompute is not False:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`precompute` is not supported")
 
         # We use different algorithms than sklearn, adjust tolerance by a
         # factor empirically determined to be ~equivalent.

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -279,7 +279,7 @@ class LinearRegression(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.positive:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`positive=True` is not supported")
 
         return {
             "fit_intercept": model.fit_intercept,

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -215,11 +215,11 @@ class Ridge(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.positive:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`positive=True` is not supported")
 
         solver = _SOLVER_SKLEARN_TO_CUML.get(model.solver)
         if solver is None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`solver={model.solver!r}` is not supported")
 
         return {
             "alpha": model.alpha,
@@ -238,7 +238,7 @@ class Ridge(Base,
     def _attrs_from_cpu(self, model):
         solver = _SOLVER_SKLEARN_TO_CUML.get(model.solver_)
         if solver is None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`solver={model.solver_!r}` is not supported")
 
         return {
             "intercept_": float(model.intercept_),

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -303,16 +303,16 @@ class TSNE(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.n_components != 2:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("Only `n_components=2` is supported")
 
         # Our barnes_hut implementation can sometimes hang, see #3865 and #3360.
         # fft should be at least as good, and doesn't have this issue.
         method = {"exact": "exact", "barnes_hut": "fft"}.get(model.method, None)
         if method is None:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`method={model.method!r}` is not supported")
 
         if not (isinstance(model.init, str) and model.init in ("pca", "random")):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`init={model.init!r}` is not supported")
 
         params = {
             "n_components": model.n_components,

--- a/python/cuml/cuml/manifold/umap.pyx
+++ b/python/cuml/cuml/manifold/umap.pyx
@@ -390,24 +390,21 @@ class UMAP(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if not (isinstance(model.init, str) and model.init in ("spectral", "random")):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`init={model.init!r}` is not supported")
 
-        if isinstance(model.metric, str):
-            try:
-                coerce_metric(model.metric)
-            except (ValueError, NotImplementedError):
-                raise UnsupportedOnGPU
-        else:
-            raise UnsupportedOnGPU
+        try:
+            coerce_metric(model.metric)
+        except (ValueError, TypeError, NotImplementedError):
+            raise UnsupportedOnGPU(f"`metric={model.metric!r}` is not supported")
 
         if model.target_metric not in ("categorical", "l2", "euclidean"):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`target_metric={model.target_metric!r}` is not supported")
 
         if model.unique:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`unique=True` is not supported")
 
         if model.densmap:
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("`densmap=True` is not supported")
 
         precomputed_knn = model.precomputed_knn[:2]
         if all(item is None for item in precomputed_knn):

--- a/python/cuml/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/cuml/manifold/umap_utils.pyx
@@ -195,6 +195,9 @@ def coerce_metric(
 
     Also checks that the metric is valid and supported.
     """
+    if not isinstance(metric, str):
+        raise TypeError(f"Expected `metric` to be a str, got {type(metric).__name__}")
+
     try:
         out = _METRICS[metric.lower()]
     except KeyError:

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -132,7 +132,7 @@ class KNeighborsClassifier(ClassifierMixin,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.weights != "uniform":
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("Only `weights='uniform'` is supported")
 
         return {
             "weights": "uniform",

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -144,7 +144,7 @@ class KNeighborsRegressor(RegressorMixin,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.weights != "uniform":
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU("Only `weights='uniform'` is supported")
 
         return {
             "weights": "uniform",

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -332,10 +332,11 @@ class NearestNeighbors(Base,
 
     @classmethod
     def _params_from_cpu(cls, model):
-        if not isinstance(model.metric, str):
-            raise UnsupportedOnGPU
-        elif model.metric not in cuml.neighbors.VALID_METRICS["brute"]:
-            raise UnsupportedOnGPU
+        if not (
+            isinstance(model.metric, str) and
+            model.metric in cuml.neighbors.VALID_METRICS["brute"]
+        ):
+            raise UnsupportedOnGPU(f"`metric={model.metric!r}` is not supported")
 
         return {
             "n_neighbors": model.n_neighbors,

--- a/python/cuml/cuml/svm/svc.pyx
+++ b/python/cuml/cuml/svm/svc.pyx
@@ -341,9 +341,7 @@ class SVC(SVMBase,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.probability:
-            raise UnsupportedOnGPU(
-                "SVC with probability=True is not currently supported"
-            )
+            raise UnsupportedOnGPU("`probability=True` is not supported")
         params = super()._params_from_cpu(model)
         params.pop("epsilon")  # SVC doesn't expose `epsilon` in the constructor
         params.update(
@@ -358,9 +356,7 @@ class SVC(SVMBase,
 
     def _params_to_cpu(self):
         if self.probability:
-            raise UnsupportedOnCPU(
-                "SVC with probability=True is not currently supported"
-            )
+            raise UnsupportedOnCPU("`probability=True` is not supported")
 
         params = super()._params_to_cpu()
         params.pop("epsilon")  # SVC doesn't expose `epsilon` in the constructor
@@ -377,9 +373,7 @@ class SVC(SVMBase,
     def _attrs_from_cpu(self, model):
         n_classes = len(model.classes_)
         if n_classes > 2:
-            raise UnsupportedOnGPU(
-                "Converting multiclass models to GPU is not yet supported"
-            )
+            raise UnsupportedOnGPU("multiclass models are not supported")
 
         return {
             "n_classes_": n_classes,

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -231,7 +231,7 @@ class SVMBase(Base,
     @classmethod
     def _params_from_cpu(cls, model):
         if model.kernel == "precomputed" or callable(model.kernel):
-            raise UnsupportedOnGPU
+            raise UnsupportedOnGPU(f"`kernel={model.kernel!r}` is not supported")
 
         if (cache_size := model.cache_size) == 200:
             # XXX: the cache sizes differ between cuml and sklearn, for now we


### PR DESCRIPTION
This adds a useful error message to all `UnsupportedOnGPU`/`UnsupportedOnCPU` errors raised. These error messages can later be surfaced in debug tooling/logging to inform users of why a certain method wasn't accelerated in `cuml.accel`.