### PR TITLE
[DO NOT MERGE] Triage test_single_linkage_sklearn_compare failure

### DIFF
--- a/cpp/cmake/thirdparty/get_cuvs.cmake
+++ b/cpp/cmake/thirdparty/get_cuvs.cmake
@@ -49,7 +49,7 @@ function(find_and_configure_cuvs)
       INSTALL_EXPORT_SET  cuml-exports
       CPM_ARGS
         GIT_REPOSITORY         https://github.com/${PKG_FORK}/cuvs.git
-        GIT_TAG                ${PKG_PINNED_TAG}
+        GIT_TAG                branch-25.06
         SOURCE_SUBDIR          cpp
         EXCLUDE_FROM_ALL       ${PKG_EXCLUDE_FROM_ALL}
         OPTIONS


### PR DESCRIPTION
Find out if this CI failure crept in due to recent changes to cuVS.