### PR TITLE
Update cython-lint, fix long lines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
             exclude: thirdparty
             additional_dependencies: [flake8-force]
     - repo: https://github.com/MarcoGorelli/cython-lint
-      rev: v0.15.0
+      rev: v0.16.6
       hooks:
           - id: cython-lint
     - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ builtin = "clear"
 quiet-level = 3
 
 [tool.cython-lint]
-max-line-length = 100
+max-line-length = 95
 
 
 [tool.run-clang-tidy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ builtin = "clear"
 quiet-level = 3
 
 [tool.cython-lint]
-# TODO: Re-enable E501 with a reasonable line length
-max-line-length = 999
-ignore = ['E501']
+max-line-length = 100
 
 
 [tool.run-clang-tidy]

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -172,7 +172,9 @@ cdef class _HDBSCANState:
         self.n_clusters = mapping["n_clusters"]
         self.core_dists = mapping["core_dists"]
         self.inverse_label_map = mapping["inverse_label_map"]
-        self._init_from_condensed_tree_array(handle, mapping["condensed_tree"], mapping["n_leaves"])
+        self._init_from_condensed_tree_array(
+            handle, mapping["condensed_tree"], mapping["n_leaves"]
+        )
         return self
 
     @staticmethod
@@ -653,7 +655,10 @@ class HDBSCAN(Base, InteropMixin, ClusterMixin, CMajorInputTagMixin):
         if callable(model.metric) or model.metric not in _metrics_mapping:
             raise UnsupportedOnGPU(f"`metric={model.metric!r}` is not supported")
 
-        if isinstance(model.memory, str) or getattr(model.memory, "location", None) is not None:
+        if (
+            isinstance(model.memory, str)
+            or getattr(model.memory, "location", None) is not None
+        ):
             # Result caching is unsupported
             raise UnsupportedOnGPU(f"`memory={model.memory!r}` is not supported")
 

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -417,7 +417,11 @@ class KMeans(Base,
 
         cdef uintptr_t sample_weight_ptr = sample_weight_m.ptr
 
-        int_dtype = np.int32 if np.int64(n_rows) * np.int64(self.n_features_in_) < 2**31-1 else np.int64
+        int_dtype = (
+            np.int32
+            if np.int64(n_rows) * np.int64(self.n_features_in_) < 2**31-1
+            else np.int64
+        )
 
         self.labels_ = CumlArray.zeros(shape=n_rows, dtype=int_dtype)
         cdef uintptr_t labels_ptr = self.labels_.ptr
@@ -775,7 +779,9 @@ class KMeans(Base,
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    def fit_transform(self, X, y=None, sample_weight=None, *, convert_dtype=False) -> CumlArray:
+    def fit_transform(
+        self, X, y=None, sample_weight=None, *, convert_dtype=False
+    ) -> CumlArray:
         """
         Compute clustering and transform X to cluster-distance space.
 

--- a/python/cuml/cuml/fil/fil.pyx
+++ b/python/cuml/cuml/fil/fil.pyx
@@ -461,10 +461,6 @@ class ForestInference(Base, CMajorInputTagMixin):
         For GPU execution, the device on which to load and execute this
         model. For CPU execution, this value is currently ignored.
     """
-    _param_names = [
-        "treelite_model", "handle", "output_type", "verbose", "is_classifier",
-        "default_threshold", "layout", "default_chunk_size", "align_bytes", "precision", "device_id",
-    ]
 
     def _reload_model(self):
         """Reload model on any device (CPU/GPU) where model has already been
@@ -625,7 +621,8 @@ class ForestInference(Base, CMajorInputTagMixin):
         super().__init__(
             handle=handle, verbose=verbose, output_type=output_type
         )
-        # TODO(hcho3): 25.10: Remove this parameter; direct users to set `threshold` in predict()
+        # TODO(hcho3): 25.10: Remove this parameter; direct users to set `threshold`
+        # in predict()
         self.default_threshold = default_threshold if default_threshold else 0.5
         self.is_classifier = is_classifier
         self.default_chunk_size = default_chunk_size
@@ -1389,7 +1386,20 @@ class ForestInference(Base, CMajorInputTagMixin):
 
     @classmethod
     def _get_param_names(cls):
-        return super()._get_param_names() + ForestInference._param_names
+        return [
+            *super()._get_param_names(),
+            "treelite_model",
+            "handle",
+            "output_type",
+            "verbose",
+            "is_classifier",
+            "default_threshold",
+            "layout",
+            "default_chunk_size",
+            "align_bytes",
+            "precision",
+            "device_id",
+        ]
 
     def set_params(self, **params):
         super().set_params(**params)

--- a/python/cuml/cuml/internals/logger.pyx
+++ b/python/cuml/cuml/internals/logger.pyx
@@ -331,4 +331,6 @@ def flush():
 
 # Clear existing sinks and add a callback sink to redirect to sys.stdout
 default_logger().sinks().clear()
-default_logger().sinks().push_back(<sink_ptr> make_shared[callback_sink_mt](_log_callback, _log_flush))
+default_logger().sinks().push_back(
+    <sink_ptr> make_shared[callback_sink_mt](_log_callback, _log_flush)
+)

--- a/python/cuml/cuml/linear_model/base_mg.pyx
+++ b/python/cuml/cuml/linear_model/base_mg.pyx
@@ -38,7 +38,16 @@ from cuml.internals.array_sparse import SparseCumlArray
 class MGFitMixin(object):
 
     @cuml.internals.api_base_return_any_skipall
-    def fit(self, input_data, n_rows, n_cols, partsToSizes, rank, order='F', convert_index=np.int32):
+    def fit(
+        self,
+        input_data,
+        n_rows,
+        n_cols,
+        partsToSizes,
+        rank,
+        order='F',
+        convert_index=np.int32,
+    ):
         """
         Fit function for MNMG linear regression classes
         This not meant to be used as

--- a/python/cuml/cuml/manifold/umap_utils.pyx
+++ b/python/cuml/cuml/manifold/umap_utils.pyx
@@ -153,7 +153,11 @@ _METRICS = {
 _SUPPORTED_METRICS = {
     "nn_descent": {
         "sparse": frozenset(),
-        "dense": frozenset((DistanceType.L2SqrtExpanded, DistanceType.L2Expanded, DistanceType.CosineExpanded))
+        "dense": frozenset((
+            DistanceType.L2SqrtExpanded,
+            DistanceType.L2Expanded,
+            DistanceType.CosineExpanded,
+        ))
     },
     "brute_force_knn": {
         "sparse": frozenset((

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -766,14 +766,22 @@ class NearestNeighbors(Base,
             zero_found = cp.zeros(1, dtype=cp.int32)
 
             # Run the kernel to check for zeros
-            check_zero_kernel((blocks,), (threads_per_block,), (D_ndarr.ravel(), rows, cols, zero_found.ravel()))
+            check_zero_kernel(
+                (blocks,),
+                (threads_per_block,),
+                (D_ndarr.ravel(), rows, cols, zero_found.ravel())
+            )
 
             threads_per_block = 32
             blocks = (rows + threads_per_block - 1) // threads_per_block
 
             # only run kernel if there are multiple zero distances
             if zero_found:
-                swap_kernel((blocks,), (threads_per_block,), (I_ndarr.ravel(), D_ndarr.ravel(), rows, cols))
+                swap_kernel(
+                    (blocks,),
+                    (threads_per_block,),
+                    (I_ndarr.ravel(), D_ndarr.ravel(), rows, cols)
+                )
 
             # slicing does not copy
             I_ndarr = I_ndarr[:, 1:]

--- a/python/cuml/cuml/solvers/qn.pyx
+++ b/python/cuml/cuml/solvers/qn.pyx
@@ -535,7 +535,9 @@ class QN(Base,
                 f" more than 2 classes ({self._num_classes} discovered).")
 
         if qnpams.loss == qn_loss_type.QN_LOSS_SOFTMAX and self._num_classes <= 2:
-            raise ValueError("Two classes or less cannot be trained with softmax (multinomial).")
+            raise ValueError(
+                "Two classes or less cannot be trained with softmax (multinomial)."
+            )
 
         if solves_classification and not solves_multiclass:
             self._num_classes_dim = self._num_classes - 1

--- a/python/cuml/cuml/svm/svc.pyx
+++ b/python/cuml/cuml/svm/svc.pyx
@@ -110,7 +110,9 @@ cdef extern from "cuml/svm/svc.hpp" namespace "ML::SVM" nogil:
                                    const math_t *sample_weight) except +
 
 
-def apply_class_weight(handle, sample_weight, class_weight, y, verbose, output_type, dtype) -> CumlArray:
+def apply_class_weight(
+    handle, sample_weight, class_weight, y, verbose, output_type, dtype
+) -> CumlArray:
     """
     Scale the sample weights with the class weights.
 
@@ -538,16 +540,30 @@ class SVC(SVMBase,
                                                cv=5,
                                                method='sigmoid')
 
-        # Apply class weights to sample weights, necessary, so it doesn't crash when sample_weight is None
-        sample_weight = apply_class_weight(self.handle, sample_weight, self.class_weight, y, self.verbose,
-                                           self.output_type, self.dtype)
+        # Apply class weights to sample weights, necessary, so it doesn't crash
+        # when sample_weight is None
+        sample_weight = apply_class_weight(
+            self.handle,
+            sample_weight,
+            self.class_weight,
+            y,
+            self.verbose,
+            self.output_type,
+            self.dtype,
+        )
 
-        # If sample_weight is not None, it is a cupy array, and we need to convert it to a numpy array for sklearn
+        # If sample_weight is not None, it is a cupy array, and we need to
+        # convert it to a numpy array for sklearn
         if sample_weight is not None:
-            # Currently, fitting a probabilistic SVC with class weights requires at least 3 classes, otherwise the following,
-            # ambiguous error is raised: ValueError: Buffer dtype mismatch, expected 'const float' but got 'double'
+            # Currently, fitting a probabilistic SVC with class weights
+            # requires at least 3 classes, otherwise the following, ambiguous
+            # error is raised: ValueError: Buffer dtype mismatch, expected
+            # 'const float' but got 'double'
             if len(set(y)) < 3:
-                raise ValueError("At least 3 classes are required to use probabilistic SVC with class weights.")
+                raise ValueError(
+                    "At least 3 classes are required to use probabilistic "
+                    "SVC with class weights."
+                )
 
             # Convert cupy array to numpy array
             sample_weight = sample_weight.get()
@@ -602,7 +618,15 @@ class SVC(SVMBase,
 
         cdef uintptr_t y_ptr = y_m.ptr
 
-        sample_weight = apply_class_weight(self.handle, sample_weight, self.class_weight, y_m, self.verbose, self.output_type, self.dtype)
+        sample_weight = apply_class_weight(
+            self.handle,
+            sample_weight,
+            self.class_weight,
+            y_m,
+            self.verbose,
+            self.output_type,
+            self.dtype
+        )
         cdef uintptr_t sample_weight_ptr = <uintptr_t> nullptr
         if sample_weight is not None:
             sample_weight_m, _, _, _ = \

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -450,7 +450,10 @@ class SVMBase(Base,
                     num_elements = self.n_features_in_ * self.n_rows
                     extended_mean = data_cupy.mean()*X.nnz/num_elements
                     data_cupy = (data_cupy - extended_mean)**2
-                    x_var = (data_cupy.sum() + (num_elements-X.nnz)*extended_mean*extended_mean)/num_elements
+                    x_var = (
+                        data_cupy.sum()
+                        + (num_elements - X.nnz) * extended_mean * extended_mean
+                    ) / num_elements
                 else:
                     x_var = cupy.asarray(X).var().item()
                 return 1 / (self.n_features_in_ * x_var)
@@ -544,22 +547,27 @@ class SVMBase(Base,
             model_f.n_support = n_support
             model_f.n_cols = self.n_features_in_
             model_f.b = self._intercept_.item()
-            model_f.dual_coefs = \
-                <float*><size_t>self.dual_coef_.ptr
+            model_f.dual_coefs = <float*><size_t>self.dual_coef_.ptr
             if isinstance(self.support_vectors_, SparseCumlArray):
                 model_f.support_matrix.nnz = self.support_vectors_.nnz
-                model_f.support_matrix.indptr = <int*><uintptr_t>self.support_vectors_.indptr.ptr
-                model_f.support_matrix.indices = <int*><uintptr_t>self.support_vectors_.indices.ptr
-                model_f.support_matrix.data = <float*><uintptr_t>self.support_vectors_.data.ptr
+                model_f.support_matrix.indptr = (
+                    <int*><uintptr_t>self.support_vectors_.indptr.ptr
+                )
+                model_f.support_matrix.indices = (
+                    <int*><uintptr_t>self.support_vectors_.indices.ptr
+                )
+                model_f.support_matrix.data = (
+                    <float*><uintptr_t>self.support_vectors_.data.ptr
+                )
             else:
-                model_f.support_matrix.data = <float*><uintptr_t>self.support_vectors_.ptr
-            model_f.support_idx = \
-                <int*><uintptr_t>self.support_.ptr
+                model_f.support_matrix.data = (
+                    <float*><uintptr_t>self.support_vectors_.ptr
+                )
+            model_f.support_idx = <int*><uintptr_t>self.support_.ptr
             if hasattr(self, 'n_classes_'):
                 model_f.n_classes = self.n_classes_
                 if self.n_classes_ > 0:
-                    model_f.unique_labels = \
-                        <float*><uintptr_t>self._unique_labels_.ptr
+                    model_f.unique_labels = <float*><uintptr_t>self._unique_labels_.ptr
                 else:
                     model_f.unique_labels = NULL
             return <uintptr_t>model_f
@@ -572,23 +580,41 @@ class SVMBase(Base,
                 <double*><size_t>self.dual_coef_.ptr
             if isinstance(self.support_vectors_, SparseCumlArray):
                 model_d.support_matrix.nnz = self.support_vectors_.nnz
-                model_d.support_matrix.indptr = <int*><uintptr_t>self.support_vectors_.indptr.ptr
-                model_d.support_matrix.indices = <int*><uintptr_t>self.support_vectors_.indices.ptr
-                model_d.support_matrix.data = <double*><uintptr_t>self.support_vectors_.data.ptr
+                model_d.support_matrix.indptr = (
+                    <int*><uintptr_t>self.support_vectors_.indptr.ptr
+                )
+                model_d.support_matrix.indices = (
+                    <int*><uintptr_t>self.support_vectors_.indices.ptr
+                )
+                model_d.support_matrix.data = (
+                    <double*><uintptr_t>self.support_vectors_.data.ptr
+                )
             else:
-                model_d.support_matrix.data = <double*><uintptr_t>self.support_vectors_.ptr
-            model_d.support_idx = \
-                <int*><uintptr_t>self.support_.ptr
+                model_d.support_matrix.data = (
+                    <double*><uintptr_t>self.support_vectors_.ptr
+                )
+            model_d.support_idx = <int*><uintptr_t>self.support_.ptr
             if hasattr(self, 'n_classes_'):
                 model_d.n_classes = self.n_classes_
                 if self.n_classes_ > 0:
-                    model_d.unique_labels = \
-                        <double*><uintptr_t>self._unique_labels_.ptr
+                    model_d.unique_labels = <double*><uintptr_t>self._unique_labels_.ptr
                 else:
                     model_d.unique_labels = NULL
             return <uintptr_t>model_d
 
-    def _unpack_svm_model(self, b, n_support, dual_coefs, support_idx, nnz, indptr, indices, data, n_classes, unique_labels):
+    def _unpack_svm_model(
+        self,
+        b,
+        n_support,
+        dual_coefs,
+        support_idx,
+        nnz,
+        indptr,
+        indices,
+        data,
+        n_classes,
+        unique_labels
+    ):
         self._intercept_ = CumlArray.full(1, b, self.dtype)
         self.n_support_ = n_support
 


### PR DESCRIPTION
This:
- Updates `cython-lint` to the current version
- Re-adds a max line length limit (fixing a TODO in the codebase). I picked 95 semi-arbitrarily. It's small enough to fit on a tmux pane on my laptop, but also didn't require fixing hundreds of long lines. Cython is more verbose than python, and our current code uses _lots_ of casts which can result in many wide lines. 95 seemed a decent compromise over the 79 used elsewhere.
- Fixes all the too long lines. All fixes should be effectively the same as what was there before, and in most cases are just reformatting the existing code. A few cases were easier to handle by moving some stuff around, but nothing too major.

With this PR we no longer have files (`<cough>umap.pyx</cough>`) that were much wider than a single tmux pane on my laptop. My editor is happy, and I'm happy.