### PR TITLE
Fix test_typeerror_input test with xfail for known sklearn LARS broadcasting bug

### DIFF
--- a/python/cuml/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -348,10 +348,14 @@ def test_typeerror_input():
     clf.fit(X, y)
     exp = KernelExplainer(model=clf.predict, data=X, nsamples=10)
     try:
-        _ = exp.shap_values(X)
-        assert True
-    except TypeError:
-        assert False
+        exp.shap_values(X)
+    except ValueError as error:
+        if "operands could not be broadcast together" in str(error):
+            pytest.xfail(
+                "Known sklearn LARS broadcasting bug - see scikit-learn#9603"
+            )
+        else:
+            raise error
 
 
 ###############################################################################


### PR DESCRIPTION
This PR adds an xfail for the known scikit-learn LARS broadcasting bug (scikit-learn#9603) to improve test robustness. The test was previously failing due to a ValueError with 'operands could not be broadcast together' message, which is a known issue in scikit-learn's LARS implementation.

Closes https://github.com/rapidsai/cuml/issues/6971