### PR TITLE
Remove CuPy version constraint

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - cuda-python>=12.6.2,<13.0a0
 - cuda-version=12.9
 - cudf==25.8.*,>=0.0.0a0
-- cupy>=12.0.0,<13.5.0
+- cupy>=12.0.0
 - cuvs==25.8.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.0.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - cuda-python>=12.6.2,<13.0a0
 - cuda-version=12.9
 - cudf==25.8.*,>=0.0.0a0
-- cupy>=12.0.0,<13.5.0
+- cupy>=12.0.0
 - cuvs==25.8.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.0.0

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -74,7 +74,7 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
-    - cupy >=12.0.0,<13.5.0 # upper constraint due to CuPy 13.5.0 memory access issues (https://github.com/rapidsai/cuml/issues/6960)
+    - cupy >=12.0.0
     - dask-cudf =${{ minor_version }}
     - joblib >=0.11
     - libcuml =${{ version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -478,13 +478,13 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=12.0.0,<13.5.0  # upper constraint due to CuPy 13.5.0 memory access issues (https://github.com/rapidsai/cuml/issues/6960)
+          - cupy>=12.0.0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix: # All CUDA 12 versions
             packages:
-              - cupy-cuda12x>=12.0.0,<13.5.0 # upper constraint due to CuPy 13.5.0 memory access issues (https://github.com/rapidsai/cuml/issues/6960)
+              - cupy-cuda12x>=12.0.0
   depends_on_cuvs:
     common:
       - output_types: conda

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -94,7 +94,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cuda-python",
     "cudf==25.8.*,>=0.0.0a0",
-    "cupy-cuda12x>=12.0.0,<13.5.0",
+    "cupy-cuda12x>=12.0.0",
     "cuvs==25.8.*,>=0.0.0a0",
     "dask-cuda==25.8.*,>=0.0.0a0",
     "dask-cudf==25.8.*,>=0.0.0a0",


### PR DESCRIPTION
This PR removes the upper constraint on CuPy 13.5.0 that was added due to memory access issues. The constraint was originally added in #6961 but is no longer needed as the affected release was yanked.

Closes https://github.com/rapidsai/cuml/issues/6963