### PR TITLE
Support invoking `cuml_accel_tests` without extra pytest flags

### DIFF
--- a/ci/run_cuml_singlegpu_accel_pytests.sh
+++ b/ci/run_cuml_singlegpu_accel_pytests.sh
@@ -4,4 +4,4 @@
 # Support invoking run_cuml_singlegpu_accel_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/cuml_accel_tests || exit 1
 
-python -m pytest -p cuml.accel --cache-clear "$@" .
+python -m pytest --cache-clear "$@" .

--- a/python/cuml/cuml_accel_tests/conftest.py
+++ b/python/cuml/cuml_accel_tests/conftest.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cuml.accel import install
+
+# Install the accelerator
+install()
+
+# Ignore the upstream directory, those tests need to be invoked separately
+collect_ignore = ["upstream"]


### PR DESCRIPTION
This removes the need for adding a `-p cuml.accel` when invoking the `cuml_accel_tests` tests. This makes it easier for devs to run the tests just as they would other pytests.

The plugin is still needed to run the upstream test suites, but that's really what it's for anyway.

Also adds a small config option to ignore tests in the `cuml_accel_tests/upstream` directory. This won't affect CI (since there are no tests in that dir on a fresh clone), but improves the local dev experience since without it the upstream umap test suite would accidentally be collected when running the `cuml_accel_tests`.