### PR TITLE
Use `pytest.ini` for all upstream tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,7 @@ compile_commands.json
 # ref: https://github.com/rapidsai/cuml/pull/6201
 pytest.ini
 !python/cuml/cuml/benchmark/automated/pytest.ini
-!python/cuml/cuml_accel_tests/upstream/umap/pytest.ini
+!python/cuml/cuml_accel_tests/upstream/pytest.ini
 
 # testing
 python/cuml/cuml_accel_tests/upstream/umap/umap-upstream

--- a/python/cuml/cuml_accel_tests/upstream/pytest.ini
+++ b/python/cuml/cuml_accel_tests/upstream/pytest.ini
@@ -1,0 +1,15 @@
+# pytest config to be used when running the upstream test suites.
+#
+# Without this, the config in `pyproject.toml` will be loaded, which
+# can turn DeprecationWarning/FutureWarnings in the upstream tests/code
+# into errors.
+#
+# This also gives us a shared place to store some common options as they come up
+[pytest]
+filterwarnings =
+    # Error if the xfail list contains unknown entries
+    error::cuml.accel.pytest_plugin.UnmatchedXfailTests
+    # Error for FutureWarnings raised by cuml
+    error::FutureWarning:cuml
+    # Ignore unknown pytest marks, the xfail-list currently adds a bunch of these
+    ignore::pytest.PytestUnknownMarkWarning

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/run-tests.sh
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/run-tests.sh
@@ -11,10 +11,12 @@
 
 set -eu
 
-# Base arguments
-PYTEST_ARGS=("-p" "cuml.accel" "--pyargs" "sklearn" "--xfail-list=$(dirname "$0")/xfail-list.yaml")
-# Fail on unmatched xfail tests
-PYTEST_ARGS+=("-W" "error::cuml.accel.pytest_plugin.UnmatchedXfailTests")
+THIS_DIRECTORY=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
-# Run pytest with all arguments
-pytest "${PYTEST_ARGS[@]}" "$@"
+# Run the sklearn test suite
+pytest -p cuml.accel \
+    --pyargs sklearn \
+    --rootdir="${THIS_DIRECTORY}" \
+    --config-file="${THIS_DIRECTORY}/../pytest.ini" \
+    --xfail-list="${THIS_DIRECTORY}/xfail-list.yaml" \
+    "$@"

--- a/python/cuml/cuml_accel_tests/upstream/umap/pytest.ini
+++ b/python/cuml/cuml_accel_tests/upstream/umap/pytest.ini
@@ -1,2 +1,0 @@
-# Empty pytest config file so pytest doesn't use the pytest config for cuml itself
-[pytest]

--- a/python/cuml/cuml_accel_tests/upstream/umap/run-tests.sh
+++ b/python/cuml/cuml_accel_tests/upstream/umap/run-tests.sh
@@ -13,17 +13,18 @@ set -eu
 
 UMAP_TAG="release-0.5.7"
 
-# cd into this directory so we can use relative paths
 THIS_DIRECTORY=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd "$THIS_DIRECTORY"
+UMAP_REPO="${THIS_DIRECTORY}/umap-upstream"
 
 # Shallow clone the tag if not already cloned
-if [ ! -d umap-upstream ]; then
-    git clone --branch $UMAP_TAG --depth 1 "https://github.com/lmcinnes/umap.git" umap-upstream
+if [ ! -d "$UMAP_REPO" ]; then
+    git clone --branch $UMAP_TAG --depth 1 "https://github.com/lmcinnes/umap.git" "$UMAP_REPO"
 fi
 
 # Run upstream tests
-pytest -p cuml.accel umap-upstream/umap/tests/ \
-    --xfail-list=xfail-list.yaml \
-    -W "error::cuml.accel.pytest_plugin.UnmatchedXfailTests" \
+pytest -p cuml.accel \
+    "${UMAP_REPO}/umap/tests/" \
+    --rootdir="${THIS_DIRECTORY}" \
+    --config-file="${THIS_DIRECTORY}/../pytest.ini" \
+    --xfail-list="${THIS_DIRECTORY}/xfail-list.yaml" \
     "$@"

--- a/python/cuml/cuml_accel_tests/upstream/umap/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/umap/xfail-list.yaml
@@ -14,7 +14,6 @@
   - "umap.tests.test_umap_ops::test_disconnected_data[True-hellinger-1]"
   - "umap.tests.test_umap_ops::test_disconnected_data[True-hellinger-5]"
   - "umap.tests.test_umap_ops::test_umap_graph_layout"
-  - "umap.tests.test_umap_ops::test_umap_transform_embedding_stability"
   - "umap.tests.test_umap_ops::test_umap_update"
   - "umap.tests.test_umap_ops::test_umap_update_large"
   - "umap.tests.test_umap_repeated_data::test_repeated_points_large_n"
@@ -45,6 +44,7 @@
   tests:
   - "umap.tests.test_umap_on_iris::test_umap_sparse_transform_on_iris"
   - "umap.tests.test_umap_on_iris::test_umap_transform_on_iris_w_pynndescent"
+  - "umap.tests.test_umap_ops::test_umap_transform_embedding_stability"
 - reason: Test fails with newer sklearn
   marker: cuml_accel_sklearn_pin
   condition: scikit-learn>=1.6


### PR DESCRIPTION
Without a `pytest.ini`, the upstream tests will use the pytest config for cuml itself (which turns DeprecationWarning & FutureWarning into errors). This can lead to test failures due to things outside our control.

This PR adds a small `pytest.ini` to the upstream tests, and changes the pytest invocation so all our upstream tests use it. It currently contains the following warning config:

- `UnmatchedXfailTests`: error if there's an issue with the xfail list
- `FutureWarning` raised by cuml: error if our code warns of a deprecation.
- `PytestUnknownMarkWarning`: ignored, our xfail-list plugin creates a bunch of unknown marks, no need to warn about these.

Also fixes some annoying UX in the umap/run-tests.sh script where it would `cd` into the directory before executing, meaning any forwarded args (like `--junit-xml`) with relative paths to the caller would be handled incorrectly. This doesn't affect CI at all, but does affect the local dev experience.
