### PR TITLE
Reduce `arima` kernels binary size

### DIFF
--- a/cpp/src/arima/batched_kalman.cu
+++ b/cpp/src/arima/batched_kalman.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,7 @@
 namespace ML {
 
 //! Thread-local Matrix-Vector multiplication.
-template <int n>
-DI void Mv_l(const double* A, const double* v, double* out)
+DI void Mv_l(int n, const double* A, const double* v, double* out)
 {
   for (int i = 0; i < n; i++) {
     double sum = 0.0;
@@ -53,8 +52,7 @@ DI void Mv_l(const double* A, const double* v, double* out)
   }
 }
 
-template <int n>
-DI void Mv_l(double alpha, const double* A, const double* v, double* out)
+DI void Mv_l(int n, double alpha, const double* A, const double* v, double* out)
 {
   for (int i = 0; i < n; i++) {
     double sum = 0.0;
@@ -66,8 +64,8 @@ DI void Mv_l(double alpha, const double* A, const double* v, double* out)
 }
 
 //! Thread-local Matrix-Matrix multiplication.
-template <int n, bool aT = false, bool bT = false>
-DI void MM_l(const double* A, const double* B, double* out)
+template <bool aT = false, bool bT = false>
+DI void MM_l(int n, const double* A, const double* B, double* out)
 {
   for (int i = 0; i < n; i++) {
     for (int j = 0; j < n; j++) {
@@ -85,8 +83,7 @@ DI void MM_l(const double* A, const double* B, double* out)
 /** Improve stability by making a covariance matrix symmetric and forcing
  * diagonal elements to be positive
  */
-template <int n>
-DI void numerical_stability(double* A)
+DI void numerical_stability(int n, double* A)
 {
   // A = 0.5 * (A + A')
   for (int i = 0; i < n - 1; i++) {
@@ -106,7 +103,7 @@ DI void numerical_stability(double* A)
  * Kalman loop kernel. Each thread computes kalman filter for a single series
  * and stores relevant matrices in registers.
  *
- * @tparam     rd              Dimension of the state vector
+ * @param[in]  rd              Dimension of the state vector
  * @param[in]  ys              Batched time series
  * @param[in]  nobs            Number of observation per series
  * @param[in]  T               Batched transition matrix.            (r x r)
@@ -127,8 +124,8 @@ DI void numerical_stability(double* A)
  * @param[in]  conf_int        Whether to compute confidence intervals
  * @param[out] d_F_fc          Batched variance of forecast errors   (fc_steps)
  */
-template <int rd>
-CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
+CUML_KERNEL void batched_kalman_loop_kernel(int rd,
+                                            const double* ys,
                                             int nobs,
                                             const double* T,
                                             const double* Z,
@@ -148,15 +145,17 @@ CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
                                             bool conf_int  = false,
                                             double* d_F_fc = nullptr)
 {
-  constexpr int rd2 = rd * rd;
-  double l_RQR[rd2];
-  double l_T[rd2];
-  double l_Z[rd];
-  double l_P[rd2];
-  double l_alpha[rd];
-  double l_K[rd];
-  double l_tmp[rd2];
-  double l_TP[rd2];
+  constexpr int rd_max  = 8;
+  constexpr int rd2_max = rd_max * rd_max;
+  int rd2               = rd * rd;
+  double l_RQR[rd2_max];
+  double l_T[rd2_max];
+  double l_Z[rd_max];
+  double l_P[rd2_max];
+  double l_alpha[rd_max];
+  double l_K[rd_max];
+  double l_tmp[rd2_max];
+  double l_TP[rd2_max];
 
   int bid = blockDim.x * blockIdx.x + threadIdx.x;
 
@@ -226,7 +225,7 @@ CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
 
       // 3. K = 1/Fs[it] * T*P*Z'
       // TP = T*P
-      MM_l<rd>(l_T, l_P, l_TP);
+      MM_l(rd, l_T, l_P, l_TP);
       if (!missing) {
         // K = 1/Fs[it] * TP*Z'
         double _1_Fs = 1.0 / _Fs;
@@ -235,13 +234,13 @@ CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
             l_K[i] = _1_Fs * l_TP[i];
           }
         } else {
-          Mv_l<rd>(_1_Fs, l_TP, l_Z, l_K);
+          Mv_l(rd, _1_Fs, l_TP, l_Z, l_K);
         }
       }
 
       // 4. alpha = T*alpha + K*vs[it] + c
       // tmp = T*alpha
-      Mv_l<rd>(l_T, l_alpha, l_tmp);
+      Mv_l(rd, l_T, l_alpha, l_tmp);
       // alpha = tmp + K*vs[it]
       for (int i = 0; i < rd; i++) {
         l_alpha[i] = l_tmp[i] + (missing ? 0.0 : l_K[i] * vs_it);
@@ -271,14 +270,14 @@ CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
 
       // 6. P = T*P*L' + R*Q*R'
       // P = TP*L'
-      MM_l<rd, false, true>(l_TP, l_tmp, l_P);
+      MM_l<false, true>(rd, l_TP, l_tmp, l_P);
       // P = P + RQR
       for (int i = 0; i < rd2; i++) {
         l_P[i] += l_RQR[i];
       }
 
       // Numerical stability: enforce symmetry of P and positivity of diagonal
-      numerical_stability<rd>(l_P);
+      numerical_stability(rd, l_P);
     }
 
     // Compute log-likelihood
@@ -305,7 +304,7 @@ CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
         b_fc[it] = pred;
 
         // alpha = T*alpha + c
-        Mv_l<rd>(l_T, l_alpha, l_tmp);
+        Mv_l(rd, l_T, l_alpha, l_tmp);
         for (int i = 0; i < rd; i++) {
           l_alpha[i] = l_tmp[i];
         }
@@ -326,16 +325,16 @@ CUML_KERNEL void batched_kalman_loop_kernel(const double* ys,
 
           // P = T*P*T' + RR'
           // TP = T*P
-          MM_l<rd>(l_T, l_P, l_TP);
+          MM_l(rd, l_T, l_P, l_TP);
           // P = TP*T'
-          MM_l<rd, false, true>(l_TP, l_T, l_P);
+          MM_l<false, true>(rd, l_TP, l_T, l_P);
           // P = P + RR'
           for (int i = 0; i < rd2; i++) {
             l_P[i] += l_RQR[i];
           }
 
           // Numerical stability: enforce symmetry of P and positivity of diagonal
-          numerical_stability<rd>(l_P);
+          numerical_stability(rd, l_P);
         }
       }
     }
@@ -782,184 +781,26 @@ void batched_kalman_loop(raft::handle_t& handle,
   dim3 numThreadsPerBlock(32, 1);
   dim3 numBlocks(raft::ceildiv<int>(batch_size, numThreadsPerBlock.x), 1);
   if (rd <= 8) {
-    switch (rd) {
-      case 1:
-        batched_kalman_loop_kernel<1>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 2:
-        batched_kalman_loop_kernel<2>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 3:
-        batched_kalman_loop_kernel<3>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 4:
-        batched_kalman_loop_kernel<4>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 5:
-        batched_kalman_loop_kernel<5>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 6:
-        batched_kalman_loop_kernel<6>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 7:
-        batched_kalman_loop_kernel<7>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-      case 8:
-        batched_kalman_loop_kernel<8>
-          <<<numBlocks, numThreadsPerBlock, 0, stream>>>(ys,
-                                                         nobs,
-                                                         T.raw_data(),
-                                                         Z.raw_data(),
-                                                         RQR.raw_data(),
-                                                         P0.raw_data(),
-                                                         alpha.raw_data(),
-                                                         intercept,
-                                                         d_mu,
-                                                         batch_size,
-                                                         d_obs_inter,
-                                                         d_obs_inter_fut,
-                                                         d_pred,
-                                                         d_loglike,
-                                                         n_diff,
-                                                         fc_steps,
-                                                         d_fc,
-                                                         conf_int,
-                                                         d_F_fc);
-        break;
-    }
+    batched_kalman_loop_kernel<<<numBlocks, numThreadsPerBlock, 0, stream>>>(rd,
+                                                                             ys,
+                                                                             nobs,
+                                                                             T.raw_data(),
+                                                                             Z.raw_data(),
+                                                                             RQR.raw_data(),
+                                                                             P0.raw_data(),
+                                                                             alpha.raw_data(),
+                                                                             intercept,
+                                                                             d_mu,
+                                                                             batch_size,
+                                                                             d_obs_inter,
+                                                                             d_obs_inter_fut,
+                                                                             d_pred,
+                                                                             d_loglike,
+                                                                             n_diff,
+                                                                             fc_steps,
+                                                                             d_fc,
+                                                                             conf_int,
+                                                                             d_F_fc);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
   } else {
     int num_sm;

--- a/cpp/src/arima/batched_kalman.cu
+++ b/cpp/src/arima/batched_kalman.cu
@@ -803,157 +803,29 @@ void batched_kalman_loop(raft::handle_t& handle,
                                                                              d_F_fc);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
   } else {
-    int num_sm;
-    cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, 0);
-    if (rd <= 16) {
-      if (batch_size <= 2 * num_sm) {
-        using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 16, 1, 1, 16, 16>;
-        using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<16, 16>;
-        using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 1, 16, 16>;
-        _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
-                                                                             ys,
-                                                                             nobs,
-                                                                             T,
-                                                                             Z,
-                                                                             RQR,
-                                                                             P0,
-                                                                             alpha,
-                                                                             intercept,
-                                                                             d_mu,
-                                                                             rd,
-                                                                             d_obs_inter,
-                                                                             d_obs_inter_fut,
-                                                                             d_pred,
-                                                                             d_loglike,
-                                                                             n_diff,
-                                                                             fc_steps,
-                                                                             d_fc,
-                                                                             conf_int,
-                                                                             d_F_fc);
-      } else {
-        using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 16, 1, 4, 16, 4>;
-        using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<16, 4>;
-        using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 4, 16, 4>;
-        _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
-                                                                             ys,
-                                                                             nobs,
-                                                                             T,
-                                                                             Z,
-                                                                             RQR,
-                                                                             P0,
-                                                                             alpha,
-                                                                             intercept,
-                                                                             d_mu,
-                                                                             rd,
-                                                                             d_obs_inter,
-                                                                             d_obs_inter_fut,
-                                                                             d_pred,
-                                                                             d_loglike,
-                                                                             n_diff,
-                                                                             fc_steps,
-                                                                             d_fc,
-                                                                             conf_int,
-                                                                             d_F_fc);
-      }
-    } else if (rd <= 32) {
-      if (batch_size <= 2 * num_sm) {
-        using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 32, 1, 4, 32, 8>;
-        using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<32, 8>;
-        using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 4, 32, 8>;
-        _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
-                                                                             ys,
-                                                                             nobs,
-                                                                             T,
-                                                                             Z,
-                                                                             RQR,
-                                                                             P0,
-                                                                             alpha,
-                                                                             intercept,
-                                                                             d_mu,
-                                                                             rd,
-                                                                             d_obs_inter,
-                                                                             d_obs_inter_fut,
-                                                                             d_pred,
-                                                                             d_loglike,
-                                                                             n_diff,
-                                                                             fc_steps,
-                                                                             d_fc,
-                                                                             conf_int,
-                                                                             d_F_fc);
-      } else {
-        using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 32, 1, 8, 32, 4>;
-        using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<32, 4>;
-        using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 8, 32, 4>;
-        _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
-                                                                             ys,
-                                                                             nobs,
-                                                                             T,
-                                                                             Z,
-                                                                             RQR,
-                                                                             P0,
-                                                                             alpha,
-                                                                             intercept,
-                                                                             d_mu,
-                                                                             rd,
-                                                                             d_obs_inter,
-                                                                             d_obs_inter_fut,
-                                                                             d_pred,
-                                                                             d_loglike,
-                                                                             n_diff,
-                                                                             fc_steps,
-                                                                             d_fc,
-                                                                             conf_int,
-                                                                             d_F_fc);
-      }
-    } else if (rd > 64 && rd <= 128) {
-      using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 16, 1, 16, 128, 2>;
-      using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<128, 2>;
-      using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 8, 64, 4>;
-      _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
-                                                                           ys,
-                                                                           nobs,
-                                                                           T,
-                                                                           Z,
-                                                                           RQR,
-                                                                           P0,
-                                                                           alpha,
-                                                                           intercept,
-                                                                           d_mu,
-                                                                           rd,
-                                                                           d_obs_inter,
-                                                                           d_obs_inter_fut,
-                                                                           d_pred,
-                                                                           d_loglike,
-                                                                           n_diff,
-                                                                           fc_steps,
-                                                                           d_fc,
-                                                                           conf_int,
-                                                                           d_F_fc);
-    } else {
-      using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 32, 1, 16, 64, 4>;
-      using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<64, 4>;
-      using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 16, 64, 4>;
-      _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
-                                                                           ys,
-                                                                           nobs,
-                                                                           T,
-                                                                           Z,
-                                                                           RQR,
-                                                                           P0,
-                                                                           alpha,
-                                                                           intercept,
-                                                                           d_mu,
-                                                                           rd,
-                                                                           d_obs_inter,
-                                                                           d_obs_inter_fut,
-                                                                           d_pred,
-                                                                           d_loglike,
-                                                                           n_diff,
-                                                                           fc_steps,
-                                                                           d_fc,
-                                                                           conf_int,
-                                                                           d_F_fc);
-    }
+    using GemmPolicy = MLCommon::LinAlg::BlockGemmPolicy<1, 32, 1, 4, 32, 8>;
+    using GemvPolicy = MLCommon::LinAlg::BlockGemvPolicy<32, 8>;
+    using CovPolicy  = MLCommon::LinAlg::BlockPolicy<1, 4, 32, 8>;
+    _batched_kalman_device_loop_large<GemmPolicy, GemvPolicy, CovPolicy>(arima_mem,
+                                                                         ys,
+                                                                         nobs,
+                                                                         T,
+                                                                         Z,
+                                                                         RQR,
+                                                                         P0,
+                                                                         alpha,
+                                                                         intercept,
+                                                                         d_mu,
+                                                                         rd,
+                                                                         d_obs_inter,
+                                                                         d_obs_inter_fut,
+                                                                         d_pred,
+                                                                         d_loglike,
+                                                                         n_diff,
+                                                                         fc_steps,
+                                                                         d_fc,
+                                                                         conf_int,
+                                                                         d_F_fc);
   }
 }
 

--- a/cpp/src_prims/timeSeries/jones_transform.cuh
+++ b/cpp/src_prims/timeSeries/jones_transform.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,66 +34,37 @@ namespace MLCommon {
 namespace TimeSeries {
 
 /**
- * @brief Lambda to map to the partial autocorrelation
- *
- * @tparam Type: Data type of the input
- * @param in: the input to the functional mapping
- * @return : the Partial autocorrelation (ie, tanh(in/2))
- */
-template <typename Type>
-struct PAC {
-  HDI Type operator()(Type in) { return raft::tanh(in * 0.5); }
-};
-
-/**
 * @brief Inline device function for the transformation operation
 
 * @tparam Type: Data type of the input
-* @tparam IdxT: indexing data type
-* @tparam value: the pValue/qValue for the transformation
 * @param tmp: the temporary array used in transformation
 * @param myNewParams: will contain the transformed params
+* @param parameter: the pValue/qValue for the transformation
 * @param isAr: tell the type of transform (if ar or ma transform)
 * @param clamp: whether to clamp transformed params between -1 and 1
 */
-template <typename DataT, typename IdxT, int VALUE>
-inline __device__ void transform(DataT* tmp, DataT* myNewParams, bool isAr, bool clamp)
+template <typename DataT>
+DI void transform(DataT* tmp, DataT* myNewParams, int parameter, bool isAr, bool clamp)
 {
-  // do the ar transformation
-  PAC<DataT> pac;
-  for (int i = 0; i < VALUE; ++i) {
-    tmp[i]         = pac(tmp[i]);
+  for (int i = 0; i < parameter; ++i) {
+    tmp[i]         = raft::tanh(tmp[i] * 0.5);
     myNewParams[i] = tmp[i];
   }
-  if (isAr) {
-    for (int j = 1; j < VALUE; ++j) {
-      DataT a = myNewParams[j];
 
-      for (int k = 0; k < j; ++k) {
-        tmp[k] -= a * myNewParams[j - k - 1];
-      }
-
-      for (int iter = 0; iter < j; ++iter) {
-        myNewParams[iter] = tmp[iter];
-      }
+  DataT sign = isAr ? -1 : 1;
+  for (int j = 1; j < parameter; ++j) {
+    DataT a = myNewParams[j];
+    for (int k = 0; k < j; ++k) {
+      tmp[k] += sign * (a * myNewParams[j - k - 1]);
     }
-  } else {  // do the ma transformation
-    for (int j = 1; j < VALUE; ++j) {
-      DataT a = myNewParams[j];
-
-      for (int k = 0; k < j; ++k) {
-        tmp[k] += a * myNewParams[j - k - 1];
-      }
-
-      for (int iter = 0; iter < j; ++iter) {
-        myNewParams[iter] = tmp[iter];
-      }
+    for (int iter = 0; iter < j; ++iter) {
+      myNewParams[iter] = tmp[iter];
     }
   }
 
   if (clamp) {
     // Clamp values to avoid numerical issues when very close to 1
-    for (int i = 0; i < VALUE; ++i) {
+    for (int i = 0; i < parameter; ++i) {
       myNewParams[i] = max(-0.9999, min(myNewParams[i], 0.9999));
     }
   }
@@ -103,43 +74,28 @@ inline __device__ void transform(DataT* tmp, DataT* myNewParams, bool isAr, bool
 * @brief Inline device function for the inverse transformation operation
 
 * @tparam Type: Data type of the input
-* @tparam IdxT: indexing data type
-* @tparam value: the pValue/qValue for the inverse transformation
 * @param tmp: the temporary array used in transformation
 * @param myNewParams: will contain the transformed params
+* @param parameter: the pValue/qValue for the inverse transformation
 * @param isAr: tell the type of inverse transform (if ar or ma transform)
 */
-template <typename DataT, typename IdxT, int VALUE>
-inline __device__ void invtransform(DataT* tmp, DataT* myNewParams, bool isAr)
+template <typename DataT>
+DI void invtransform(DataT* tmp, DataT* myNewParams, int parameter, bool isAr)
 {
-  // do the ar transformation
-  if (isAr) {
-    for (int j = VALUE - 1; j > 0; --j) {
-      DataT a = myNewParams[j];
+  DataT sign = isAr ? 1 : -1;
+  for (int j = parameter - 1; j > 0; --j) {
+    DataT a = myNewParams[j];
 
-      for (int k = 0; k < j; ++k) {
-        tmp[k] = (myNewParams[k] + a * myNewParams[j - k - 1]) / (1 - (a * a));
-      }
-
-      for (int iter = 0; iter < j; ++iter) {
-        myNewParams[iter] = tmp[iter];
-      }
+    for (int k = 0; k < j; ++k) {
+      tmp[k] = (myNewParams[k] + sign * (a * myNewParams[j - k - 1])) / (1 - (a * a));
     }
-  } else {  // do the ma transformation
-    for (int j = VALUE - 1; j > 0; --j) {
-      DataT a = myNewParams[j];
 
-      for (int k = 0; k < j; ++k) {
-        tmp[k] = (myNewParams[k] - a * myNewParams[j - k - 1]) / (1 - (a * a));
-      }
-
-      for (int iter = 0; iter < j; ++iter) {
-        myNewParams[iter] = tmp[iter];
-      }
+    for (int iter = 0; iter < j; ++iter) {
+      myNewParams[iter] = tmp[iter];
     }
   }
 
-  for (int i = 0; i < VALUE; ++i) {
+  for (int i = 0; i < parameter; ++i) {
     myNewParams[i] = 2 * raft::atanh(myNewParams[i]);
   }
 }
@@ -147,46 +103,46 @@ inline __device__ void invtransform(DataT* tmp, DataT* myNewParams, bool isAr)
 /**
  * @brief kernel to perform jones transformation
  * @tparam DataT: type of the params
- * @tparam VALUE: the parameter for the batch of ARIMA(p,q,d) models (either p or q depending on
- * whether coefficients are of type AR or MA respectively)
- * @tparam IdxT: type of indexing
- * @tparam BLOCK_DIM_X: number of threads in block in x dimension
- * @tparam BLOCK_DIM_Y: number of threads in block in y dimension
  * @param newParams: pointer to the memory where the new params are to be stored
  * @param params: pointer to the memory where the initial params are stored
  * @param batchSize: number of models in a batch
+ * @param parameter: the parameter for the batch of ARIMA(p,q,d) models (either p or q
+ * depending on whether coefficients are of type AR or MA respectively)
  * @param isAr: if the coefficients to be transformed are Autoregressive or moving average
  * @param isInv: if the transformation type is regular or inverse
  * @param clamp: whether to clamp transformed params between -1 and 1
  */
-template <typename DataT, int VALUE, typename IdxT, int BLOCK_DIM_X, int BLOCK_DIM_Y>
-CUML_KERNEL void jones_transform_kernel(
-  DataT* newParams, const DataT* params, IdxT batchSize, bool isAr, bool isInv, bool clamp)
+template <typename DataT>
+CUML_KERNEL void jones_transform_kernel(DataT* newParams,
+                                        const DataT* params,
+                                        int batchSize,
+                                        int parameter,
+                                        bool isAr,
+                                        bool isInv,
+                                        bool clamp)
 {
   // calculating the index of the model that the coefficients belong to
-  IdxT modelIndex = threadIdx.x + ((IdxT)blockIdx.x * blockDim.x);
+  int modelIndex = threadIdx.x + ((int)blockIdx.x * blockDim.x);
 
-  DataT tmp[VALUE];
-  DataT myNewParams[VALUE];
+  DataT tmp[8];
+  DataT myNewParams[8];
 
   if (modelIndex < batchSize) {
-// load
-#pragma unroll
-    for (int i = 0; i < VALUE; ++i) {
-      tmp[i]         = params[modelIndex * VALUE + i];
+    // load
+    for (int i = 0; i < parameter; ++i) {
+      tmp[i]         = params[modelIndex * parameter + i];
       myNewParams[i] = tmp[i];
     }
 
     // the transformation/inverse transformation operation
     if (isInv)
-      invtransform<DataT, IdxT, VALUE>(tmp, myNewParams, isAr);
+      invtransform<DataT>(tmp, myNewParams, parameter, isAr);
     else
-      transform<DataT, IdxT, VALUE>(tmp, myNewParams, isAr, clamp);
+      transform<DataT>(tmp, myNewParams, parameter, isAr, clamp);
 
-// store
-#pragma unroll
-    for (int i = 0; i < VALUE; ++i) {
-      newParams[modelIndex * VALUE + i] = myNewParams[i];
+    // store
+    for (int i = 0; i < parameter; ++i) {
+      newParams[modelIndex * parameter + i] = myNewParams[i];
     }
   }
 }
@@ -207,19 +163,20 @@ CUML_KERNEL void jones_transform_kernel(
  * @param stream: the cudaStream object
  * @param clamp: whether to clamp transformed params between -1 and 1
  */
-template <typename DataT, typename IdxT = int>
+template <typename DataT>
 void jones_transform(const DataT* params,
-                     IdxT batchSize,
-                     IdxT parameter,
+                     int batchSize,
+                     int parameter,
                      DataT* newParams,
                      bool isAr,
                      bool isInv,
                      cudaStream_t stream,
                      bool clamp = true)
 {
-  ASSERT(batchSize >= 1 && parameter >= 1, "not defined!");
+  ASSERT(batchSize >= 1, "Unsupported batchSize '%d'!", batchSize);
+  ASSERT(parameter >= 1 && parameter <= 8, "Unsupported parameter '%d'!", parameter);
 
-  IdxT nElements = batchSize * parameter;
+  int nElements = batchSize * parameter;
 
   // copying contents
   raft::copy(newParams, params, (size_t)nElements, stream);
@@ -229,51 +186,8 @@ void jones_transform(const DataT* params,
   dim3 numThreadsPerBlock(BLOCK_DIM_X, BLOCK_DIM_Y);
   dim3 numBlocks(raft::ceildiv<int>(batchSize, numThreadsPerBlock.x), 1);
 
-  // calling the kernel
-
-  switch (parameter) {
-    case 1:
-      jones_transform_kernel<DataT, 1, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 2:
-      jones_transform_kernel<DataT, 2, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 3:
-      jones_transform_kernel<DataT, 3, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 4:
-      jones_transform_kernel<DataT, 4, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 5:
-      jones_transform_kernel<DataT, 5, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 6:
-      jones_transform_kernel<DataT, 6, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 7:
-      jones_transform_kernel<DataT, 7, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    case 8:
-      jones_transform_kernel<DataT, 8, IdxT, BLOCK_DIM_X, BLOCK_DIM_Y>
-        <<<numBlocks, numThreadsPerBlock, 0, stream>>>(
-          newParams, params, batchSize, isAr, isInv, clamp);
-      break;
-    default: ASSERT(false, "Unsupported parameter '%d'!", parameter);
-  }
+  jones_transform_kernel<DataT><<<numBlocks, numThreadsPerBlock, 0, stream>>>(
+    newParams, params, batchSize, parameter, isAr, isInv, clamp);
 
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }

--- a/python/cuml/cuml/tests/test_arima.py
+++ b/python/cuml/cuml/tests/test_arima.py
@@ -205,7 +205,7 @@ test_112_012_4 = ARIMAData(
     n_obs=179,
     n_test=10,
     dataset="passenger_movements",
-    tolerance_integration=0.001,
+    tolerance_integration=0.005,
 )
 
 # ARIMA(1,1,1)(1,1,1)_12


### PR DESCRIPTION
Fixes #6775.

I'll update this description as I go:

This PR:
- Relaxes the `passenger_movements` test tolerance (this was failing on my machine (X86 A100) before any changes)
- Reduces `batched_kalman_loop_kernel` from 8 instances to 1 (-0.14 MiB for one SM)
- Reduces `jones_transform_kernel` (and helpers) from 16 instances to 2 (-0.617 MiB for one SM)
- Reduces `_batched_kalman_device_loop_large_kernel` from 6 instances to 1 (-0.585 MiB for one SM)

See the individual commits for more detailed reasoning on each change.

In total, this shaves off ~1.35 MiB (for one SM).