### PR TITLE
Use `cuvs::neighbors::knn_merge_parts`

### DIFF
--- a/cpp/src/knn/knn.cu
+++ b/cpp/src/knn/knn.cu
@@ -32,6 +32,7 @@
 #include <cuvs/neighbors/brute_force.hpp>
 #include <cuvs/neighbors/ivf_flat.hpp>
 #include <cuvs/neighbors/ivf_pq.hpp>
+#include <cuvs/neighbors/knn_merge_parts.hpp>
 #include <ml_mg_utils.cuh>
 #include <selection/knn.cuh>
 
@@ -158,8 +159,13 @@ void brute_force_knn(const raft::handle_t& handle,
     // This is necessary for proper index translations. If there are
     // no translations or partitions to combine, it can be skipped.
     // TODO: sort out where this knn_merge_parts should live
-    raft::spatial::knn::knn_merge_parts(
-      out_D, out_I, res_D, res_I, n, input.size(), k, userStream, trans.data());
+    cuvs::neighbors::knn_merge_parts(
+      handle,
+      raft::make_device_matrix_view<const float, int64_t>(out_D, n * input.size(), k),
+      raft::make_device_matrix_view<const int64_t, int64_t>(out_I, n * input.size(), k),
+      raft::make_device_matrix_view<float, int64_t>(res_D, n, k),
+      raft::make_device_matrix_view<int64_t, int64_t>(res_I, n, k),
+      raft::make_device_vector_view<int64_t>(trans.data(), trans.size()));
   }
 
   if (translations == nullptr) delete id_ranges;


### PR DESCRIPTION
This moves to use `cuvs::neighbors::knn_merge_parts` instead of `raft::spatial::knn::knn_merge_parts`. The latter was the 2nd largest kernel used in cuml, and will also be going away in favor of an equivalent version in `cuvs` (which we also link to). No sense in having both in the binary.

This drops 7.6 MiB in kernels from the `cuml` binary (for one SM).

Fixes #7002.