### PR TITLE
WIP: use versioned CI image tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
       arch: "amd64"
       branch: ${{ inputs.branch }}
       build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
       script: "ci/build_docs.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,7 +110,7 @@ jobs:
       build_type: pull-request
       node_type: "cpu8"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       script: "ci/run_clang_tidy.sh"
   conda-cpp-build:
     needs: checks
@@ -195,7 +195,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       script: "ci/test_notebooks.sh"
   docs-build:
     needs: conda-python-build
@@ -205,7 +205,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       script: "ci/build_docs.sh"
   wheel-build-libcuml:
     needs: checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ methods to run clang-tidy on your local machine: using Docker or Conda.
         docker run --rm --pull always \
             --mount type=bind,source="$(pwd)",target=/opt/repo --workdir /opt/repo \
             -e SCCACHE_S3_NO_CREDENTIALS=1 \
-            rapidsai/ci-conda:latest /opt/repo/ci/run_clang_tidy.sh
+            rapidsai/ci-conda:25.08-latest /opt/repo/ci/run_clang_tidy.sh
         ```
 
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -63,15 +63,20 @@ for DEP in "${DEPENDENCIES[@]}"; do
   done
 done
 
+# CI image tags of the form {rapids_version}-{something}
+sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" ./CONTRIBUTING.md
+
+# branch references in docs
 sed_runner "s|/branch-[^/]*/|/branch-${NEXT_SHORT_TAG}/|g" README.md
 sed_runner "s|/branch-[^/]*/|/branch-${NEXT_SHORT_TAG}/|g" python/cuml/README.md
-
 
 # CI files
 for FILE in .github/workflows/*.yaml .github/workflows/*.yml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
   # Wheel builds clone cumlprims_mg, update its branch
   sed_runner "s/extra-repo-sha: branch-.*/extra-repo-sha: branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  # CI image tags of the form {rapids_version}-{something}
+  sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
 # .devcontainer files


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/187

Last night's docs build failed like this:

```text
[rapids-github-run-id] Detected CI=true. Skipping running 'gh auth status'.
[rapids-github-run-id] ERROR: failed to find a GitHub Actions run for [RAPIDS_BUILD_TYPE=nightly, RAPID_REPOSITORY=rapidsai/cuml, RAPIDS_REF_NAME=branch-25.08, RAPIDS_SHA=3cf51baa936cdeb64cf1ab848766238f5a604ec5]
```

([build link](https://github.com/rapidsai/cuml/actions/runs/16338111821/job/46154881645))

I think that would have been avoided by having the improvements to artifact-handling from https://github.com/rapidsai/gha-tools/pull/196, but that build is using an older version of `gha-tools`.

The docs builds here are getting an older `gha-tools` because they use `rapidsai/ci-conda:latest`... since https://github.com/rapidsai/ci-imgs/pull/287 was merged about a month ago, `:latest` hasn't received any updates. We now publish to RAPIDS-versioned tags like `25.08-latest`.

To reduce the risk of this happening again, this proposes updated all uses of `rapidsai/{something}:latest` image tags to `rapidsai/{something}:25.08-latest`.

## Notes for Reviewers

### How I tested this

Found these references:

```shell
git grep -E '\:latest'
```

Tested `update-version.sh`:

```shell
./ci/release/update-version.sh '25.10.00'
```