### PR TITLE
Update title of `cuml.accel` documentation to "Zero Code Change Acceleration"

### DIFF
--- a/docs/source/cuml-accel/index.rst
+++ b/docs/source/cuml-accel/index.rst
@@ -1,5 +1,5 @@
-Zero Code Change Accelerator
-============================
+Zero Code Change Acceleration
+=============================
 
 The ``cuml.accel`` zero code change accelerator provides a mechanism to
 accelerate existing python machine learning code on the GPU, *without requiring

--- a/docs/source/cuml-accel/index.rst
+++ b/docs/source/cuml-accel/index.rst
@@ -1,5 +1,5 @@
-cuml.accel
-==========
+Zero Code Change Accelerator
+============================
 
 The ``cuml.accel`` zero code change accelerator provides a mechanism to
 accelerate existing python machine learning code on the GPU, *without requiring


### PR DESCRIPTION
I think that `cuml.accel` as a section header doesn't work well because it's not immediately clear what it means before learning about it. A more descriptive title would be better. From here on, we can refer to it more briefly as `cuml.accel` within the text.

I am also not a fan of using "code" as a section title, since `cuml.accel` is primarily a namespace and program name in the form of a CLI entrypoint.