### PR TITLE
Add basic infrastructure for common tests

### DIFF
--- a/python/cuml/cuml/tests/test_common.py
+++ b/python/cuml/cuml/tests/test_common.py
@@ -15,9 +15,70 @@
 #
 import numpy as np
 import pytest
+from sklearn.utils import estimator_checks
 
 import cuml
+from cuml.cluster import KMeans
 from cuml.datasets import make_blobs
+from cuml.linear_model import LogisticRegression
+
+PER_ESTIMATOR_XFAIL_CHECKS = {
+    KMeans: {
+        "check_estimator_tags_renamed": "No support for modern tags infrastructure",
+        "check_no_attributes_set_in_init": "KMeans sets attributes during init",
+        "check_dont_overwrite_parameters": "KMeans overwrites parameters during fit",
+        "check_estimators_unfitted": "KMeans does not raise NotFittedError before fit",
+        "check_do_not_raise_errors_in_init_or_set_params": "KMeans raises errors in init or set_params",
+        "check_n_features_in_after_fitting": "KMeans does not check n_features_in consistency",
+        "check_sample_weights_not_an_array": "KMeans does not handle non-array sample weights",
+        "check_sample_weights_list": "KMeans does not handle list sample weights",
+        "check_sample_weights_shape": "KMeans does not validate sample weights shape",
+        "check_sample_weight_equivalence_on_dense_data": "KMeans sample weight equivalence not implemented",
+        "check_complex_data": "KMeans does not handle complex data",
+        "check_dtype_object": "KMeans does not handle object dtype",
+        "check_estimators_nan_inf": "KMeans does not check for NaN and inf",
+        "check_estimator_sparse_tag": "KMeans does not support sparse data",
+        "check_estimator_sparse_array": "KMeans does not handle sparse arrays gracefully",
+        "check_estimator_sparse_matrix": "KMeans does not handle sparse matrices gracefully",
+        "check_transformer_data_not_an_array": "KMeans does not handle non-array data",
+        "check_parameters_default_constructible": "KMeans parameters are mutated on init",
+        "check_fit_check_is_fitted": "KMeans passes check_is_fitted before being fit",
+        "check_fit1d": "KMeans does not raise ValueError for 1D input",
+        "check_fit2d_predict1d": "KMeans does not handle 1D prediction input gracefully",
+    },
+    LogisticRegression: {
+        "check_estimator_tags_renamed": "No support for modern tags infrastructure",
+        "check_no_attributes_set_in_init": "LogisticRegression sets attributes during init",
+        "check_dont_overwrite_parameters": "LogisticRegression overwrites parameters during fit",
+        "check_estimators_unfitted": "LogisticRegression does not raise NotFittedError before fit",
+        "check_do_not_raise_errors_in_init_or_set_params": "LogisticRegression raises errors in init or set_params",
+        "check_n_features_in_after_fitting": "LogisticRegression does not check n_features_in consistency",
+        "check_sample_weights_not_an_array": "LogisticRegression does not handle non-array sample weights",
+        "check_sample_weights_list": "LogisticRegression does not handle list sample weights",
+        "check_sample_weight_equivalence_on_dense_data": "LogisticRegression sample weight equivalence not implemented",
+        "check_sample_weight_equivalence_on_sparse_data": "LogisticRegression does not handle sparse data",
+        "check_complex_data": "LogisticRegression does not handle complex data",
+        "check_dtype_object": "LogisticRegression does not handle object dtype",
+        "check_estimators_empty_data_messages": "LogisticRegression does not handle empty data",
+        "check_estimators_nan_inf": "LogisticRegression does not check for NaN and inf",
+        "check_estimator_sparse_tag": "LogisticRegression does not support sparse data",
+        "check_classifier_data_not_an_array": "LogisticRegression does not handle non-array data",
+        "check_classifiers_one_label": "LogisticRegression cannot train with one class",
+        "check_classifiers_train": "LogisticRegression does not handle list inputs",
+        "check_classifiers_train(readonly_memmap=True)": "LogisticRegression does not handle readonly memmap",
+        "check_classifiers_train(readonly_memmap=True,X_dtype=float32)": "LogisticRegression does not handle readonly memmap with float32",
+        "check_classifiers_regression_target": "LogisticRegression does not handle regression targets",
+        "check_supervised_y_no_nan": "LogisticRegression does not check for NaN in y",
+        "check_supervised_y_2d": "LogisticRegression does not handle 2D y",
+        "check_class_weight_classifiers": "LogisticRegression does not handle class weights properly",
+        "check_parameters_default_constructible": "LogisticRegression parameters are mutated on init",
+        "check_fit2d_1sample": "LogisticRegression does not handle single sample",
+        "check_set_params": "LogisticRegression does not handle set_params properly",
+        "check_fit1d": "LogisticRegression does not raise ValueError for 1D input",
+        "check_fit2d_predict1d": "LogisticRegression does not handle 1D prediction input gracefully",
+        "check_requires_y_none": "LogisticRegression does not handle y=None",
+    },
+}
 
 
 @pytest.mark.parametrize(
@@ -40,3 +101,16 @@ def test_random_state_argument(Estimator):
             est.fit(X, y)
         else:
             est.fit(X)
+
+
+def get_xfails(estimator):
+    return PER_ESTIMATOR_XFAIL_CHECKS.get(type(estimator), {})
+
+
+@estimator_checks.parametrize_with_checks(
+    [KMeans(), LogisticRegression()], expected_failed_checks=get_xfails
+)
+def test_sklearn_compatible_estimator(estimator, check):
+    # Check that all estimators pass the "common estimator" checks
+    # provided by scikit-learn
+    check(estimator)


### PR DESCRIPTION
This adds basic infrastructure to run the common tests from scikit-learn on cuml estimators.

It uses `parametrize_with_checks` which is a decorator for a pytest test function. You pass it a list of estimator instances you want to have tested and a function that will return the expected to fail checks per estimator.

I started with two estimators to get the infrastructure setup. We can now parallelise work on this, one PR per estimator.

In the future we might want to switch from a hardcoded list of estimators to something like 
`all_estimators()` from https://github.com/rapidsai/cuml/pull/6107/files#diff-662334e448b926be8016aa021cc183ff43bda82c781cefe3bff649ae1b5d2226R151 (a function that yields all estimators). For meta estimators we will also need a registry of constructor arguments to use to create an instance (e.g. which estimator to use in `GridSearchCV`). Again, we can tackle that later once we want to test such an estimator.

Towards #6432