### PR TITLE
Don't call to_output on a cupy array

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -291,6 +291,16 @@ def _list_indexing(X, key, key_dtype):
 
 def _transform_one(transformer, X, y, weight, **fit_params):
     res = transformer.transform(X)
+
+    if isinstance(res, cpu_np.ndarray):
+        res = np.asarray(res)
+    elif hasattr(res, 'to_output'):
+        res = res.to_output('cupy')
+    elif not isinstance(res, np.ndarray):
+        raise TypeError(
+            f"Transformer '{type(transformer).__name__}' returned an unsupported type: "
+            f"{type(res).__name__}"
+        )
     # if we have a weight for this transformer, multiply output
     if weight is None:
         return res

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -290,17 +290,9 @@ def _list_indexing(X, key, key_dtype):
 
 
 def _transform_one(transformer, X, y, weight, **fit_params):
-    res = transformer.transform(X)
+    with cuml.using_output_type("cupy"):
+        res = transformer.transform(X)
 
-    if isinstance(res, cpu_np.ndarray):
-        res = np.asarray(res)
-    elif hasattr(res, 'to_output'):
-        res = res.to_output('cupy')
-    elif not isinstance(res, np.ndarray):
-        raise TypeError(
-            f"Transformer '{type(transformer).__name__}' returned an unsupported type: "
-            f"{type(res).__name__}"
-        )
     # if we have a weight for this transformer, multiply output
     if weight is None:
         return res

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -290,7 +290,7 @@ def _list_indexing(X, key, key_dtype):
 
 
 def _transform_one(transformer, X, y, weight, **fit_params):
-    res = transformer.transform(X).to_output('cupy')
+    res = transformer.transform(X)
     # if we have a weight for this transformer, multiply output
     if weight is None:
         return res

--- a/python/cuml/tests/test_compose.py
+++ b/python/cuml/tests/test_compose.py
@@ -315,16 +315,15 @@ def test_column_transformer_index(clf_dataset):  # noqa: F811
     transformer.fit_transform(X)
 
 
-def test_column_transform_correct_output_dtype():
-    df = pd.DataFrame({"Sex": ["male", "female", "male"]})
-    cdf = cudf.from_pandas(df)
+def test_column_transform_properly_handles_sub_output_type():
+    """Check that ColumnTransformer properly handles child estimators
+    with different output types configured"""
+    df = cudf.DataFrame({"x": ["a", "b", "a", "b"], "y": [1, 10, 100, 5]})
 
     transformer = cuColumnTransformer(
         [
-            ("sex_encoder", cuOneHotEncoder(sparse_output=False), ["Sex"]),
+            ("x_enc", cuOneHotEncoder(sparse_output=False), ["x"]),
+            ("y_enc", cuStandardScaler(output_type="numpy"), ["y"]),
         ]
-    )
-
-    transformer.fit(cdf)
-
+    ).fit(df)
     transformer.transform(df)

--- a/python/cuml/tests/test_compose.py
+++ b/python/cuml/tests/test_compose.py
@@ -313,3 +313,18 @@ def test_column_transformer_index(clf_dataset):  # noqa: F811
 
     transformer = cuColumnTransformer(cu_transformers)
     transformer.fit_transform(X)
+
+
+def test_column_transform_correct_output_dtype():
+    df = pd.DataFrame({"Sex": ["male", "female", "male"]})
+    cdf = cudf.from_pandas(df)
+
+    transformer = cuColumnTransformer(
+        [
+            ("sex_encoder", cuOneHotEncoder(sparse_output=False), ["Sex"]),
+        ]
+    )
+
+    transformer.fit(cdf)
+
+    transformer.transform(df)


### PR DESCRIPTION
- Closes https://github.com/rapidsai/cuml/issues/7039
AFAIK https://github.com/rapidsai/cuml/blob/242829b414b7e25645e8b2428977c37175270f74/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py#L292-L297 https://github.com/rapidsai/cuml/blob/242829b414b7e25645e8b2428977c37175270f74/python/cuml/cuml/preprocessing/encoders.py#L443-L447 the call to `transformer.transform(X)` returns a `cupy` array, so we shouldn't need to call `to_output('cupy')` on it.
