### PR TITLE
Fix compatibility with nodiscard compiler checks

### DIFF
--- a/cpp/tests/prims/fillna.cu
+++ b/cpp/tests/prims/fillna.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,11 +132,11 @@ class FillnaTest : public ::testing::TestWithParam<FillnaInputs<T>> {
     }
 
     /* Check results */
-    match = devArrMatchHost(h_y.data(),
-                            y.data(),
-                            params.n_obs * params.batch_size,
-                            MLCommon::CompareApprox<T>(params.tolerance),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_y.data(),
+                                y.data(),
+                                params.n_obs * params.batch_size,
+                                MLCommon::CompareApprox<T>(params.tolerance),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -145,8 +145,6 @@ class FillnaTest : public ::testing::TestWithParam<FillnaInputs<T>> {
 
  protected:
   FillnaInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<FillnaInputs<float>> inputsf = {
@@ -162,10 +160,10 @@ const std::vector<FillnaInputs<double>> inputsd = {
 };
 
 typedef FillnaTest<float> FillnaTestF;
-TEST_P(FillnaTestF, Result) { EXPECT_TRUE(match); }
+TEST_P(FillnaTestF, Result) {}
 
 typedef FillnaTest<double> FillnaTestD;
-TEST_P(FillnaTestD, Result) { EXPECT_TRUE(match); }
+TEST_P(FillnaTestD, Result) {}
 
 INSTANTIATE_TEST_CASE_P(FillnaTests, FillnaTestF, ::testing::ValuesIn(inputsf));
 

--- a/cpp/tests/prims/linalg_block.cu
+++ b/cpp/tests/prims/linalg_block.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,11 +136,11 @@ class BlockGemmTest : public ::testing::TestWithParam<BlockGemmInputs<T>> {
     }
 
     /* Check results */
-    match = devArrMatchHost(h_c_ref.data(),
-                            c.data(),
-                            params.m * params.n * params.batch_size,
-                            MLCommon::CompareApprox<T>(params.eps),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_c_ref.data(),
+                                c.data(),
+                                params.m * params.n * params.batch_size,
+                                MLCommon::CompareApprox<T>(params.eps),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -149,8 +149,6 @@ class BlockGemmTest : public ::testing::TestWithParam<BlockGemmInputs<T>> {
 
  protected:
   BlockGemmInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<BlockGemmInputs<float>> gemm_inputsf = {
@@ -182,34 +180,34 @@ const std::vector<BlockGemmInputs<double>> gemm_inputsd_vec2 = {
 };
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 16, 1, 4, 16, 4>, float> BlockGemmTestF_1_16_1_4_16_4;
-TEST_P(BlockGemmTestF_1_16_1_4_16_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestF_1_16_1_4_16_4, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 16, 1, 4, 16, 4>, double> BlockGemmTestD_1_16_1_4_16_4;
-TEST_P(BlockGemmTestD_1_16_1_4_16_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestD_1_16_1_4_16_4, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 32, 1, 4, 32, 8>, float> BlockGemmTestF_1_32_1_4_32_8;
-TEST_P(BlockGemmTestF_1_32_1_4_32_8, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestF_1_32_1_4_32_8, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 32, 1, 4, 32, 8>, double> BlockGemmTestD_1_32_1_4_32_8;
-TEST_P(BlockGemmTestD_1_32_1_4_32_8, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestD_1_32_1_4_32_8, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 32, 1, 16, 64, 4>, float> BlockGemmTestF_1_32_1_16_64_4;
-TEST_P(BlockGemmTestF_1_32_1_16_64_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestF_1_32_1_16_64_4, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 32, 1, 16, 64, 4>, double> BlockGemmTestD_1_32_1_16_64_4;
-TEST_P(BlockGemmTestD_1_32_1_16_64_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestD_1_32_1_16_64_4, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 16, 1, 16, 128, 2>, float> BlockGemmTestF_1_16_1_16_128_2;
-TEST_P(BlockGemmTestF_1_16_1_16_128_2, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestF_1_16_1_16_128_2, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<1, 16, 1, 16, 128, 2>, double> BlockGemmTestD_1_16_1_16_128_2;
-TEST_P(BlockGemmTestD_1_16_1_16_128_2, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestD_1_16_1_16_128_2, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<2, 32, 2, 2, 16, 16>, float> BlockGemmTestF_2_32_2_2_16_16;
-TEST_P(BlockGemmTestF_2_32_2_2_16_16, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestF_2_32_2_2_16_16, Result) {}
 
 typedef BlockGemmTest<BlockGemmPolicy<2, 32, 2, 2, 16, 16>, double> BlockGemmTestD_2_32_2_2_16_16;
-TEST_P(BlockGemmTestD_2_32_2_2_16_16, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemmTestD_2_32_2_2_16_16, Result) {}
 
 INSTANTIATE_TEST_CASE_P(BlockGemmTests,
                         BlockGemmTestF_1_16_1_4_16_4,
@@ -348,11 +346,11 @@ class BlockGemvTest : public ::testing::TestWithParam<BlockGemvInputs<T>> {
     }
 
     /* Check results */
-    match = devArrMatchHost(h_y_ref.data(),
-                            y.data(),
-                            params.m * params.batch_size,
-                            MLCommon::CompareApprox<T>(params.eps),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_y_ref.data(),
+                                y.data(),
+                                params.m * params.batch_size,
+                                MLCommon::CompareApprox<T>(params.eps),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -361,8 +359,6 @@ class BlockGemvTest : public ::testing::TestWithParam<BlockGemvInputs<T>> {
 
  protected:
   BlockGemvInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<BlockGemvInputs<float>> gemv_inputsf = {{true, 42, 42, 20, 1e-4, 12345U},
@@ -374,22 +370,22 @@ const std::vector<BlockGemvInputs<double>> gemv_inputsd = {{true, 42, 42, 20, 1e
                                                            {false, 5, 80, 100, 1e-4, 12345U}};
 
 typedef BlockGemvTest<BlockGemvPolicy<16, 4>, float> BlockGemvTestF_16_4;
-TEST_P(BlockGemvTestF_16_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemvTestF_16_4, Result) {}
 
 typedef BlockGemvTest<BlockGemvPolicy<16, 4>, double> BlockGemvTestD_16_4;
-TEST_P(BlockGemvTestD_16_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemvTestD_16_4, Result) {}
 
 typedef BlockGemvTest<BlockGemvPolicy<32, 8>, float> BlockGemvTestF_32_8;
-TEST_P(BlockGemvTestF_32_8, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemvTestF_32_8, Result) {}
 
 typedef BlockGemvTest<BlockGemvPolicy<32, 8>, double> BlockGemvTestD_32_8;
-TEST_P(BlockGemvTestD_32_8, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemvTestD_32_8, Result) {}
 
 typedef BlockGemvTest<BlockGemvPolicy<128, 2>, float> BlockGemvTestF_128_2;
-TEST_P(BlockGemvTestF_128_2, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemvTestF_128_2, Result) {}
 
 typedef BlockGemvTest<BlockGemvPolicy<128, 2>, double> BlockGemvTestD_128_2;
-TEST_P(BlockGemvTestD_128_2, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockGemvTestD_128_2, Result) {}
 
 INSTANTIATE_TEST_CASE_P(BlockGemvTests, BlockGemvTestF_16_4, ::testing::ValuesIn(gemv_inputsf));
 
@@ -480,11 +476,11 @@ class BlockDotTest : public ::testing::TestWithParam<BlockDotInputs<T>> {
     }
 
     /* Check results */
-    match = devArrMatchHost(h_dot_ref.data(),
-                            dot_dev.data(),
-                            params.batch_size,
-                            MLCommon::CompareApprox<T>(params.eps),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_dot_ref.data(),
+                                dot_dev.data(),
+                                params.batch_size,
+                                MLCommon::CompareApprox<T>(params.eps),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -493,8 +489,6 @@ class BlockDotTest : public ::testing::TestWithParam<BlockDotInputs<T>> {
 
  protected:
   BlockDotInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<BlockDotInputs<float>> dot_inputsf = {{true, 9, 20, 1e-4, 12345U},
@@ -508,10 +502,10 @@ const std::vector<BlockDotInputs<double>> dot_inputsd = {{true, 9, 20, 1e-4, 123
                                                          {false, 200, 100, 1e-4, 12345U}};
 
 typedef BlockDotTest<float> BlockDotTestF;
-TEST_P(BlockDotTestF, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockDotTestF, Result) {}
 
 typedef BlockDotTest<double> BlockDotTestD;
-TEST_P(BlockDotTestD, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockDotTestD, Result) {}
 
 INSTANTIATE_TEST_CASE_P(BlockDotTests, BlockDotTestF, ::testing::ValuesIn(dot_inputsf));
 
@@ -614,11 +608,11 @@ class BlockXaxtTest : public ::testing::TestWithParam<BlockXaxtInputs<T>> {
     }
 
     /* Check results */
-    match = devArrMatchHost(h_res_ref.data(),
-                            res_dev.data(),
-                            params.batch_size,
-                            MLCommon::CompareApprox<T>(params.eps),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_res_ref.data(),
+                                res_dev.data(),
+                                params.batch_size,
+                                MLCommon::CompareApprox<T>(params.eps),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -627,8 +621,6 @@ class BlockXaxtTest : public ::testing::TestWithParam<BlockXaxtInputs<T>> {
 
  protected:
   BlockXaxtInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<BlockXaxtInputs<float>> xAxt_inputsf = {{true, true, 9, 20, 1e-2, 12345U},
@@ -644,10 +636,10 @@ const std::vector<BlockXaxtInputs<double>> xAxt_inputsd = {{true, true, 9, 20, 1
                                                            {true, false, 200, 100, 1e-2, 12345U}};
 
 typedef BlockXaxtTest<float> BlockXaxtTestF;
-TEST_P(BlockXaxtTestF, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockXaxtTestF, Result) {}
 
 typedef BlockXaxtTest<double> BlockXaxtTestD;
-TEST_P(BlockXaxtTestD, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockXaxtTestD, Result) {}
 
 INSTANTIATE_TEST_CASE_P(BlockXaxtTests, BlockXaxtTestF, ::testing::ValuesIn(xAxt_inputsf));
 
@@ -716,11 +708,11 @@ class BlockAxTest : public ::testing::TestWithParam<BlockAxInputs<T>> {
     }
 
     /* Check results */
-    match = devArrMatchHost(h_y_ref.data(),
-                            y.data(),
-                            params.n * params.batch_size,
-                            MLCommon::CompareApprox<T>(params.eps),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_y_ref.data(),
+                                y.data(),
+                                params.n * params.batch_size,
+                                MLCommon::CompareApprox<T>(params.eps),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -729,8 +721,6 @@ class BlockAxTest : public ::testing::TestWithParam<BlockAxInputs<T>> {
 
  protected:
   BlockAxInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<BlockAxInputs<float>> ax_inputsf = {
@@ -740,10 +730,10 @@ const std::vector<BlockAxInputs<double>> ax_inputsd = {
   {9, 20, 1e-4, 12345U}, {65, 50, 1e-4, 12345U}, {200, 100, 1e-4, 12345U}};
 
 typedef BlockAxTest<float> BlockAxTestF;
-TEST_P(BlockAxTestF, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockAxTestF, Result) {}
 
 typedef BlockAxTest<double> BlockAxTestD;
-TEST_P(BlockAxTestD, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockAxTestD, Result) {}
 
 INSTANTIATE_TEST_CASE_P(BlockAxTests, BlockAxTestF, ::testing::ValuesIn(ax_inputsf));
 
@@ -820,11 +810,11 @@ class BlockCovStabilityTest : public ::testing::TestWithParam<BlockCovStabilityI
     }
 
     /* Check results */
-    match = devArrMatchHost(h_out.data(),
-                            d_out.data(),
-                            params.n * params.n * params.batch_size,
-                            MLCommon::CompareApprox<T>(params.eps),
-                            handle.get_stream());
+    EXPECT_TRUE(devArrMatchHost(h_out.data(),
+                                d_out.data(),
+                                params.n * params.n * params.batch_size,
+                                MLCommon::CompareApprox<T>(params.eps),
+                                handle.get_stream()));
   }
 
   void SetUp() override { basicTest(); }
@@ -833,8 +823,6 @@ class BlockCovStabilityTest : public ::testing::TestWithParam<BlockCovStabilityI
 
  protected:
   BlockCovStabilityInputs<T> params;
-
-  testing::AssertionResult match = testing::AssertionFailure();
 };
 
 const std::vector<BlockCovStabilityInputs<float>> cs_inputsf = {
@@ -850,16 +838,16 @@ const std::vector<BlockCovStabilityInputs<double>> cs_inputsd = {
 };
 
 typedef BlockCovStabilityTest<BlockPolicy<1, 1, 8, 4>, float> BlockCovStabilityTestF_1_1_8_4;
-TEST_P(BlockCovStabilityTestF_1_1_8_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockCovStabilityTestF_1_1_8_4, Result) {}
 
 typedef BlockCovStabilityTest<BlockPolicy<1, 1, 8, 4>, double> BlockCovStabilityTestD_1_1_8_4;
-TEST_P(BlockCovStabilityTestD_1_1_8_4, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockCovStabilityTestD_1_1_8_4, Result) {}
 
 typedef BlockCovStabilityTest<BlockPolicy<1, 4, 32, 8>, float> BlockCovStabilityTestF_1_4_32_8;
-TEST_P(BlockCovStabilityTestF_1_4_32_8, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockCovStabilityTestF_1_4_32_8, Result) {}
 
 typedef BlockCovStabilityTest<BlockPolicy<1, 4, 32, 8>, double> BlockCovStabilityTestD_1_4_32_8;
-TEST_P(BlockCovStabilityTestD_1_4_32_8, Result) { EXPECT_TRUE(match); }
+TEST_P(BlockCovStabilityTestD_1_4_32_8, Result) {}
 
 INSTANTIATE_TEST_CASE_P(BlockCovStabilityTests,
                         BlockCovStabilityTestF_1_1_8_4,

--- a/cpp/tests/sg/svc_test.cu
+++ b/cpp/tests/sg/svc_test.cu
@@ -132,7 +132,7 @@ TYPED_TEST(WorkingSetTest, Select)
   EXPECT_EQ(this->ws->GetSize(), 4);
   this->ws->SimpleSelect(
     this->f_dev.data(), this->alpha_dev.data(), this->y_dev.data(), this->C_dev.data());
-  ASSERT_TRUE(devArrMatchHost(this->expected_idx,
+  EXPECT_TRUE(devArrMatchHost(this->expected_idx,
                               this->ws->GetIndices(),
                               this->ws->GetSize(),
                               MLCommon::Compare<int>(),
@@ -140,7 +140,7 @@ TYPED_TEST(WorkingSetTest, Select)
 
   this->ws->Select(
     this->f_dev.data(), this->alpha_dev.data(), this->y_dev.data(), this->C_dev.data());
-  ASSERT_TRUE(devArrMatchHost(this->expected_idx,
+  EXPECT_TRUE(devArrMatchHost(this->expected_idx,
                               this->ws->GetIndices(),
                               this->ws->GetSize(),
                               MLCommon::Compare<int>(),
@@ -148,7 +148,7 @@ TYPED_TEST(WorkingSetTest, Select)
   this->ws->Select(
     this->f_dev.data(), this->alpha_dev.data(), this->y_dev.data(), this->C_dev.data());
 
-  ASSERT_TRUE(devArrMatchHost(this->expected_idx2,
+  EXPECT_TRUE(devArrMatchHost(this->expected_idx2,
                               this->ws->GetIndices(),
                               this->ws->GetSize(),
                               MLCommon::Compare<int>(),
@@ -306,7 +306,7 @@ TYPED_TEST_P(KernelCacheTest, EvalTest)
 
     // apply nonlinearity on tile_host_expected
     this->ApplyNonlin(params);
-    ASSERT_TRUE(devArrMatchHost(this->tile_host_expected,
+    EXPECT_TRUE(devArrMatchHost(this->tile_host_expected,
                                 batch_descriptor.kernel_data,
                                 this->n_rows * this->n_ws,
                                 MLCommon::CompareApprox<TypeParam>(1e-6f),
@@ -625,7 +625,8 @@ class SmoUpdateTest : public ::testing::Test {
     smo.UpdateF(f_dev.data(), n_rows, delta_alpha_dev.data(), n_ws, kernel_dev.data());
 
     float f_host_expected[] = {0.1f, 7.4505806e-9f, 0.3f, 0.2f, 0.5f, 0.4f};
-    devArrMatchHost(f_host_expected, f_dev.data(), n_rows, MLCommon::CompareApprox<math_t>(1e-6));
+    EXPECT_TRUE(devArrMatchHost(
+      f_host_expected, f_dev.data(), n_rows, MLCommon::CompareApprox<math_t>(1e-6)));
   }
 
   raft::handle_t handle;
@@ -688,8 +689,8 @@ class SmoBlockSolverTest : public ::testing::Test {
     RAFT_CUDA_TRY(cudaPeekAtLastError());
 
     math_t return_buff_exp[2] = {0.2, 1};
-    devArrMatchHost(
-      return_buff_exp, return_buff_dev.data(), 2, MLCommon::CompareApprox<math_t>(1e-6), stream);
+    EXPECT_TRUE(devArrMatchHost(
+      return_buff_exp, return_buff_dev.data(), 2, MLCommon::CompareApprox<math_t>(1e-6), stream));
 
     rmm::device_uvector<math_t> delta_alpha_calc(n_rows, stream);
     raft::linalg::binaryOp(
@@ -699,14 +700,14 @@ class SmoBlockSolverTest : public ::testing::Test {
       n_rows,
       [] __device__(math_t a, math_t b) { return a * b; },
       stream);
-    MLCommon::devArrMatch(delta_alpha_dev.data(),
-                          delta_alpha_calc.data(),
-                          n_rows,
-                          MLCommon::CompareApprox<math_t>(1e-6),
-                          stream);
+    EXPECT_TRUE(MLCommon::devArrMatch(delta_alpha_dev.data(),
+                                      delta_alpha_calc.data(),
+                                      n_rows,
+                                      MLCommon::CompareApprox<math_t>(1e-6),
+                                      stream));
     math_t alpha_expected[] = {0, 0.1f, 0.1f, 0};
-    MLCommon::devArrMatch(
-      alpha_expected, alpha_dev.data(), n_rows, MLCommon::CompareApprox<math_t>(1e-6), stream);
+    EXPECT_TRUE(MLCommon::devArrMatch(
+      alpha_expected, alpha_dev.data(), n_rows, MLCommon::CompareApprox<math_t>(1e-6), stream));
   }
 
  protected:
@@ -949,16 +950,16 @@ class SmoSolverTest : public ::testing::Test {
       n_rows,
       [] __device__(math_t a, math_t b) { return a * b; },
       stream);
-    MLCommon::devArrMatch(delta_alpha_dev.data(),
-                          delta_alpha_calc.data(),
-                          n_rows,
-                          MLCommon::CompareApprox<math_t>(1e-6),
-                          stream);
+    EXPECT_TRUE(MLCommon::devArrMatch(delta_alpha_dev.data(),
+                                      delta_alpha_calc.data(),
+                                      n_rows,
+                                      MLCommon::CompareApprox<math_t>(1e-6),
+                                      stream));
 
     math_t alpha_expected[] = {0.6f, 0, 1, 1, 0, 0.6f};
     // for C=10: {0.25f, 0, 2.25f, 3.75f, 0, 1.75f};
-    MLCommon::devArrMatch(
-      alpha_expected, alpha_dev.data(), n_rows, MLCommon::CompareApprox<math_t>(1e-6), stream);
+    EXPECT_TRUE(MLCommon::devArrMatch(
+      alpha_expected, alpha_dev.data(), n_rows, MLCommon::CompareApprox<math_t>(1e-6), stream));
 
     math_t host_alpha[6];
     raft::update_host(host_alpha, alpha_dev.data(), n_rows, stream);
@@ -1016,12 +1017,12 @@ class SmoSolverTest : public ::testing::Test {
     EXPECT_LT(return_buff[1], 10) << return_buff[1];
 
     math_t alpha_exp[] = {0, 0.8, 0.8, 0};
-    MLCommon::devArrMatch(
-      alpha_exp, alpha_dev.data(), 4, MLCommon::CompareApprox<math_t>(1e-6), stream);
+    EXPECT_TRUE(MLCommon::devArrMatch(
+      alpha_exp, alpha_dev.data(), 4, MLCommon::CompareApprox<math_t>(1e-6), stream));
 
     math_t dalpha_exp[] = {-0.8, 0.8};
-    MLCommon::devArrMatch(
-      dalpha_exp, delta_alpha_dev.data(), 2, MLCommon::CompareApprox<math_t>(1e-6), stream);
+    EXPECT_TRUE(MLCommon::devArrMatch(
+      dalpha_exp, delta_alpha_dev.data(), 2, MLCommon::CompareApprox<math_t>(1e-6), stream));
   }
 
  protected:
@@ -1781,8 +1782,8 @@ TYPED_TEST(SmoSolverTest, SparseBatching)
                        y_pred.data(),
                        (TypeParam)200.0,
                        false);
-      MLCommon::devArrMatch(
-        y.data(), y_pred.data(), input.n_rows, MLCommon::CompareApprox<TypeParam>(1e-6), stream);
+      EXPECT_TRUE(MLCommon::devArrMatch(
+        y.data(), y_pred.data(), input.n_rows, MLCommon::CompareApprox<TypeParam>(1e-6), stream));
 
       // predict with subset csr & dense for all edge cases
       if (model.support_matrix.nnz >= 0) {
@@ -1825,11 +1826,11 @@ TYPED_TEST(SmoSolverTest, SparseBatching)
                    y_pred_dense.data(),
                    (TypeParam)50.0,
                    false);
-        MLCommon::devArrMatch(y_pred_csr.data(),
-                              y_pred_dense.data(),
-                              n_extract,
-                              MLCommon::CompareApprox<TypeParam>(1e-6),
-                              stream);
+        EXPECT_TRUE(MLCommon::devArrMatch(y_pred_csr.data(),
+                                          y_pred_dense.data(),
+                                          n_extract,
+                                          MLCommon::CompareApprox<TypeParam>(1e-6),
+                                          stream));
       }
 
       svmFreeBuffers(this->handle, model);
@@ -1913,7 +1914,7 @@ class SvrTest : public ::testing::Test {
 
     ws->Select(f.data(), alpha.data(), yc.data(), C_dev.data());
     int exp_idx[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
-    ASSERT_TRUE(
+    EXPECT_TRUE(
       devArrMatchHost(exp_idx, ws->GetIndices(), ws->GetSize(), MLCommon::Compare<int>(), stream));
 
     delete ws;
@@ -1922,7 +1923,7 @@ class SvrTest : public ::testing::Test {
     EXPECT_EQ(ws->GetSize(), 10);
     ws->Select(f.data(), alpha.data(), yc.data(), C_dev.data());
     int exp_idx2[] = {6, 12, 5, 11, 3, 9, 8, 1, 7, 0};
-    ASSERT_TRUE(
+    EXPECT_TRUE(
       devArrMatchHost(exp_idx2, ws->GetIndices(), ws->GetSize(), MLCommon::Compare<int>(), stream));
     delete ws;
   }


### PR DESCRIPTION
When compiling with the latest devcontainers I get compiler warnings (promoted to errors) saying that we are discarding return values marked as nodiscard. From looking through, the diagnostics are only partially correct. In some cases we are ignoring the value, but in others we are storing the value into a class member that is checked later. I'm not sure why that is happening, but I think the changes to more local checking are simpler anyway so I think we might as well just make the changes necessary to make the compiler happy and move on, especially since they're all in tests. My guess is that some subtle interplay between gtest macros and compiler logic is making the compiler not see that the values are getting used.