### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -65,7 +65,7 @@ requirements:
     - pylibraft =${{ minor_version }}
     - python =${{ py_version }}
     - raft-dask =${{ minor_version }}
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - rapids-logger =0.1
     - scikit-build-core >=0.10.0
     - treelite ${{ treelite_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -213,7 +213,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - rapids-build-backend>=0.4.0,<0.5.0.dev0
       - output_types: [conda]
         packages:
           - scikit-build-core>=0.10.0


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
