### PR TITLE
Configure `--import-mode` in `pyproject.toml`

### DIFF
--- a/ci/run_cuml_dask_pytests.sh
+++ b/ci/run_cuml_dask_pytests.sh
@@ -4,4 +4,4 @@
 # Support invoking run_cuml_dask_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/tests/dask || exit 1
 
-python -m pytest --cache-clear --import-mode=append "$@" .
+python -m pytest --cache-clear "$@" .

--- a/ci/run_cuml_integration_pytests.sh
+++ b/ci/run_cuml_integration_pytests.sh
@@ -4,4 +4,4 @@
 # Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/tests || exit 1
 
-python -m pytest -p cudf.pandas --cache-clear --ignore=dask --import-mode=append "$@" --quick_run .
+python -m pytest -p cudf.pandas --cache-clear --ignore=dask "$@" --quick_run .

--- a/ci/run_cuml_singlegpu_pytests.sh
+++ b/ci/run_cuml_singlegpu_pytests.sh
@@ -4,4 +4,4 @@
 # Support invoking run_cuml_singlegpu_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cuml/tests || exit 1
 
-python -m pytest --cache-clear --ignore=dask --import-mode=append "$@" .
+python -m pytest --cache-clear --ignore=dask "$@" .

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -28,7 +28,7 @@ select = [
 max_allowed_size_compressed = '75MB'
 
 [tool.pytest.ini_options]
-addopts = "--tb=native"
+addopts = "--tb=native --import-mode=append"
 
 markers = [
   "unit: Quickest tests focused on accuracy and correctness",


### PR DESCRIPTION
This lets devs use `pytest` as they normally would without needing to remember to include this option.