### PR TITLE
Add some devtools to `all_*` environments

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -6,6 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
+- ccache
 - certifi
 - cmake>=3.30.4
 - cuda-cudart-dev
@@ -47,6 +48,7 @@ dependencies:
 - numpydoc
 - numpydoc<1.9
 - packaging
+- pre-commit
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==25.10.*,>=0.0.0a0
 - pynndescent

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -6,6 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
+- ccache
 - certifi
 - cmake>=3.30.4
 - cuda-cudart-dev
@@ -47,6 +48,7 @@ dependencies:
 - numpydoc
 - numpydoc<1.9
 - packaging
+- pre-commit
 - pydata-sphinx-theme!=0.14.2
 - pylibraft==25.10.*,>=0.0.0a0
 - pynndescent

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -22,6 +22,7 @@ files:
       - depends_on_raft_dask
       - depends_on_rapids_logger
       - depends_on_rmm
+      - develop
       - docs
       - py_build_cuml
       - py_run_cuml
@@ -270,6 +271,14 @@ dependencies:
             packages:
               - cuda-nvcc
               - gcc_linux-aarch64=14.*
+  develop:
+    common:
+      - output_types: [conda, requirements]
+        packages:
+          - pre-commit
+      - output_types: conda
+        packages:
+          - ccache
   py_build_cuml:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
This adds a new `develop` section of dependencies for common devtools to include in the generated conda environments. So far this includes:

- `pre-commit`
- `ccache`

This is mostly self serving. Every time I recreate my cuml env I immediately have to install those 2 before continuing development. This lets me skip that step.

FWIW `cudf`'s `dependencies.yaml` includes a similar section with just `pre-commit`. I _think_ including `ccache` as well should be harmless, but :shrug:.