### PR TITLE
Update cufft defines to CUDA 13 types

### DIFF
--- a/cpp/src_prims/cufft_utils.h
+++ b/cpp/src_prims/cufft_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
cufft has removed certain types in CUDA 13, so we need to update our mapping table.