### PR TITLE
A few fixes to the profiler IPython magics

### DIFF
--- a/python/cuml/cuml/accel/magics.py
+++ b/python/cuml/cuml/accel/magics.py
@@ -13,27 +13,150 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import ast
+import os
+import re
+import sys
 
+from cuml.accel import profilers
 from cuml.accel.core import install
-from cuml.accel.runners import exec_source
+
+
+def run_cell_with_profiler(source, namespace, profiler):
+    """Run a cell source with an active profiler.
+
+    Returns the cell output (if any).
+    """
+    # Generate a unique filename for this cell
+    filename = f"<cuml-accel-input-{os.urandom(6).hex()}>"
+
+    # Any cell ending with an expression and not a statement should render the
+    # output. The way IPython handles this is a bit nuanced, and relies on some
+    # obscure details of the Python interpreter
+    #
+    # - Expressions to generate output cells (and populate magic output
+    # variables like `_`) should be compiled as interactive nodes. The easiest
+    # way to do this is to work at the ast layer and wrap the ``ast.Expr`` in a
+    # ``ast.Interactive`` node before compilation.
+    #
+    # - Upon execution of an interactive node, the python interpreter will call
+    # `sys.displayhook`. IPython overrides this hook to handle rendering
+    # output, etc...
+    #
+    # - We temporarily override the hook ourselves to allow extracting the cell
+    # output to return directly. This allows our magics to compose nicely with
+    # other IPython features. Failing to do this (and instead letting IPython's
+    # displayhook be called upon execution) can result in double rendering of
+    # results, and/or results rendered before the magic cells complete. IPython
+    # will re-call the displayhook on our returned result.
+    #
+    # - IPython itself handles silencing lines that end with `;`. We always
+    # generate an Interactive node for these and let IPython do the filtering
+    # later.
+    #
+    # While this uses some obscure features, these features are how both the
+    # builtin and IPython interpreters work and are documented in the standard library.
+    # I don't expect this code to be brittle to upstream changes, as the standard library
+    # is pretty stable.
+
+    output = None
+
+    def displayhook(obj):
+        """A displayhook for capturing the cell output (if any)"""
+        nonlocal output
+        output = obj
+
+    tree = ast.parse(source, filename=filename, mode="exec")
+    if tree.body and isinstance(tree.body[-1], ast.Expr):
+        # The last element of the body is an expression. Split the body
+        # into non-interactive/interactive bits.
+        blocks = []
+        if head := tree.body[:-1]:
+            blocks.append(compile(ast.Module(head), filename, "exec"))
+        blocks.append(
+            compile(ast.Interactive([tree.body[-1]]), filename, "single")
+        )
+    else:
+        # No interactive components needed, just compile as normal
+        blocks = [compile(tree, filename, "exec")]
+
+    # Temporarily patch out the displayhook so we can grab the output
+    orig_displayhook = sys.displayhook
+    sys.displayhook = displayhook
+    try:
+        with profiler:
+            # Execute the blocks in order
+            for block in blocks:
+                exec(block, namespace)
+    finally:
+        sys.displayhook = orig_displayhook
+
+    return output
 
 
 def load_ipython_extension(ip):
-    from IPython.core.magic import Magics, cell_magic, magics_class
+    from IPython.core.magic import (
+        Magics,
+        cell_magic,
+        magics_class,
+        output_can_be_silenced,
+    )
 
     @magics_class
     class CumlAccelMagics(Magics):
         @cell_magic("cuml.accel.profile")
+        @output_can_be_silenced
         def profile(self, _, cell):
             """Run a cell with the cuml.accel profiler."""
             cell = self.shell.transform_cell(cell)
-            exec_source(cell, self.shell.user_ns, profile=True)
+
+            return run_cell_with_profiler(
+                cell, self.shell.user_ns, profilers.profile()
+            )
 
         @cell_magic("cuml.accel.line_profile")
+        @output_can_be_silenced
         def line_profile(self, _, cell):
             """Run a cell with the cuml.accel line profiler."""
+            # When cell magics are composed the `exec` call that executes the
+            # code in this cell may come from a different nested magic. As
+            # such, we cannot rely on the filename generated here matching the
+            # one that's used for execution. Instead, we inject a call to
+            # `LineProfiler.start` into the user code, and rely on that to both
+            # start the profiler and detect the frame/filename to use.
+
+            # Split off any leading cell magics from the rest of the user code
+            index = 0
+            for match in re.finditer("(?m)^%%.*$", cell):
+                index = match.end()
+
+            source = cell[index:].strip("\n\r")
+
+            # Inject a private call to `LineProfiler.start` before the rest of
+            # the python source
+            cell = "\n".join(
+                [cell[:index], "__start_cuml_accel_line_profiler__()", source]
+            )
+
+            # Next apply IPython's standard cell transformations. After this ``cell``
+            # is just standard python code.
             cell = self.shell.transform_cell(cell)
-            exec_source(cell, self.shell.user_ns, line_profile=True)
+
+            profiler = profilers.LineProfiler(source=source, filename=None)
+
+            # Temporarily inject ``profiler.start`` into the user's namespace
+            # so it may be called during execution.
+            self.shell.user_ns[
+                "__start_cuml_accel_line_profiler__"
+            ] = profiler.start
+            try:
+                return run_cell_with_profiler(
+                    cell, self.shell.user_ns, profiler
+                )
+            finally:
+                self.shell.user_ns.pop(
+                    "__start_cuml_accel_line_profiler__", None
+                )
 
     install()
     ip.register_magics(CumlAccelMagics)

--- a/python/cuml/cuml_accel_tests/test_magics.py
+++ b/python/cuml/cuml_accel_tests/test_magics.py
@@ -18,8 +18,6 @@ from textwrap import dedent
 
 import pytest
 
-from cuml.accel.profilers import LineProfiler
-
 pytest.importorskip("IPython")
 
 
@@ -28,6 +26,7 @@ from IPython.core.interactiveshell import InteractiveShell
 from traitlets.config import Config
 c = Config()
 c.HistoryManager.hist_file = ":memory:"
+c.InteractiveShell.colors = "nocolor"
 ip = InteractiveShell(config=c)
 """
 
@@ -102,37 +101,222 @@ def test_magic_cudf_pandas_after():
 
 
 @pytest.mark.parametrize(
-    "magic", ["cuml.accel.profile", "cuml.accel.line_profile"]
+    "magics",
+    [
+        ("cuml.accel.profile",),
+        ("cuml.accel.line_profile",),
+        ("cuml.accel.profile", "cuml.accel.line_profile"),
+        ("cuml.accel.line_profile", "cuml.accel.profile"),
+        ("cuml.accel.line_profile", "cuml.accel.profile", "time"),
+    ],
 )
-def test_profiler_magics(magic):
-    profiled_script = dedent(
-        """
-        from sklearn.datasets import make_regression
-        from sklearn.linear_model import Ridge
-        X, y = make_regression()
-        model = Ridge().fit(X, y)
-        """
-    ).strip()
+def test_profiler_magics(magics):
+    """Check the profiler magics work and can be combined in any order"""
+    magic_lines = [f"%%{magic}" for magic in magics]
+    cell = "\n".join(
+        [
+            *magic_lines,
+            "from sklearn.datasets import make_regression",
+            "from sklearn.linear_model import Ridge",
+            "X, y = make_regression()",
+            "model = Ridge().fit(X, y)",
+            "'something ' + 'to ' + 'output'",
+        ]
+    )
 
     stdout = run_script(
         f"""
         ip.run_line_magic("load_ext", "cuml.accel")
 
-        script = {profiled_script!r}
-        ip.run_cell_magic("{magic}", "", script)
+        ip.run_cell({cell!r})
+
+        # Check that the output of the cell exists
+        ip.run_cell("assert _ == 'something to output'").raise_error()
 
         # Check that variables defined in the cell persist outside the cell
         ip.run_cell("assert isinstance(model, Ridge)").raise_error()
 
         # Check that the cell ran under cuml.accel
         ip.run_cell("from cuml.accel import is_proxy; assert is_proxy(model)").raise_error()
-
-        # Check that the namespace modifications in LineProfiler don't persist
-        ip.run_cell("assert {LineProfiler.FLAG!r} not in globals()").raise_error()
         """
     )
-    if magic == "cuml.accel.profile":
+    # Get the index of the output cell to assert that the profiler output
+    # renders _before_ the output cell.
+    output_index = stdout.index("Out[1]:")
+
+    # Check that the output of the cell is displayed
+    assert "something to output" in stdout
+
+    if "cuml.accel.profile" in magics:
         assert "cuml.accel profile" in stdout
-    else:
+        assert stdout.rindex("cuml.accel profile") < output_index
+    if "cuml.accel.line_profile" in magics:
         assert "cuml.accel line profile" in stdout
-        assert profiled_script.splitlines()[0] in stdout
+        assert stdout.rindex("cuml.accel line profile") < output_index
+        assert "%%cuml.accel" not in stdout
+        assert "from sklearn.datasets import make_regression" in stdout
+        # Ensure the line profile includes the original script and not
+        # the transformed one with `get_ipython`
+        assert "get_ipython()" not in stdout
+
+
+def test_profiler_magics_output():
+    """Check the profiler magic handles outputs from cells properly"""
+    # Multi-line interactive cell
+    cell1 = dedent(
+        """
+        %%cuml.accel.profile
+        a = 1
+        f"string from cell {a}"
+        """
+    ).strip()
+
+    # Single-line interactive cell
+    cell2 = dedent(
+        """
+        %%cuml.accel.profile
+        f"string from cell {a + 1}"
+        """
+    )
+
+    # Not interactive, silenced by semicolon
+    cell3 = dedent(
+        """
+        %%cuml.accel.profile
+        f"string from cell {a + 2}";
+        """
+    ).strip()
+
+    # Not interactive, statement comes after expression
+    cell4 = dedent(
+        """
+        %%cuml.accel.profile
+        f"string from cell {a + 3}"
+        a += 3
+        """
+    )
+
+    # Not interactive, only statements
+    cell5 = dedent(
+        """
+        %%cuml.accel.profile
+        b = a + 1
+        """
+    )
+
+    stdout = run_script(
+        f"""
+        ip.run_line_magic("load_ext", "cuml.accel")
+
+        ip.run_cell({cell1!r}, store_history=True)
+        ip.run_cell("assert _ == 'string from cell 1'").raise_error()
+
+        ip.run_cell({cell2!r}, store_history=True)
+        ip.run_cell("assert _ == 'string from cell 2'").raise_error()
+
+        ip.run_cell({cell3!r}, store_history=True)
+        ip.run_cell("assert _ == 'string from cell 2'").raise_error()
+
+        ip.run_cell({cell4!r}, store_history=True)
+        ip.run_cell("assert _ == 'string from cell 2'").raise_error()
+
+        ip.run_cell({cell5!r}, store_history=True)
+        ip.run_cell("assert _ == 'string from cell 2'").raise_error()
+        """
+    )
+    assert "Out[1]:" in stdout
+    assert "Out[2]:" in stdout
+    for cell in [3, 4, 5]:
+        assert f"Out[{cell}]:" not in stdout
+        assert f"string from cell {cell}" not in stdout
+
+
+def test_profiler_magics_error_before_exec():
+    stdout = run_script(
+        """
+        ip.run_line_magic("load_ext", "cuml.accel")
+
+        script = '''
+        %%cuml.accel.profile
+        print('got ' + 'here')
+        this is not valid python
+        '''
+
+        status = ip.run_cell(script)
+        assert isinstance(status.error_in_exec, SyntaxError)
+        """
+    )
+    assert "got here" not in stdout
+    # Table not rendered
+    assert "cuml.accel profile" not in stdout
+    # Only one traceback rendered
+    assert stdout.count("Traceback (most recent call last)") == 1
+
+
+def test_profiler_magics_error_during_exec():
+    stdout = run_script(
+        """
+        ip.run_line_magic("load_ext", "cuml.accel")
+
+        script = '''
+        %%cuml.accel.profile
+        print('got ' + 'here')
+        raise ValueError("oh no!")
+        '''
+
+        status = ip.run_cell(script)
+        assert isinstance(status.error_in_exec, ValueError)
+        """
+    )
+    assert "got here" in stdout
+    # Table still rendered
+    assert "cuml.accel profile" in stdout
+    # Only one traceback rendered
+    assert stdout.count("Traceback (most recent call last)") == 1
+
+
+def test_line_profiler_magic_applies_to_the_correct_source():
+    """Test that only selected lines are profiled, and that the source lines
+    are properly matched to the execution lines."""
+    stdout = run_script(
+        """
+        ip.run_line_magic("load_ext", "cuml.accel")
+
+        cell1 = '''
+        def run_fit(model, X, y):
+            # A function defined in an earlier cell, shouldn't be traced
+            model.fit(X, y)
+            return model
+        '''
+
+        cell2 = '''
+
+
+        %%cuml.accel.line_profile
+        %%cuml.accel.profile
+        from sklearn.datasets import make_regression
+        from sklearn.linear_model import Ridge
+        X, y = make_regression()
+        run_fit(Ridge(), X, y)
+        model = Ridge().fit(X, y)
+
+
+        '''
+
+        ip.run_cell(cell1).raise_error()
+        ip.run_cell(cell2).raise_error()
+        """
+    )
+    # Rows in the line profiler table.
+    rows = (
+        stdout.split("cuml.accel line profile")[-1].strip().splitlines()[3:-2]
+    )
+    assert len(rows) == 5
+    counts = []
+    gpu_used = []
+    for row in rows:
+        parts = row.split("│")[1:-1]
+        counts.append(int(parts[1].strip()))
+        gpu_used.append(parts[3].strip() != "-")
+    assert counts == [1, 1, 1, 1, 1]
+    assert gpu_used == [False, False, False, True, True]

--- a/python/cuml/cuml_accel_tests/test_profilers.py
+++ b/python/cuml/cuml_accel_tests/test_profilers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import textwrap
 
 import pytest
@@ -29,11 +30,10 @@ def wide_terminal(monkeypatch):
 
 
 def line_profile(source: str) -> LineProfiler:
-    code = compile(source, "<stdin>", "exec")
-    namespace = {"__name__": "__main__"}
-    with LineProfiler(source=source, namespace=namespace, quiet=True) as lprof:
-        exec(code, namespace)
-
+    filename = f"<cuml-accel-input-{os.urandom(6).hex()}>"
+    code = compile(source, filename, "exec")
+    with LineProfiler(source=source, filename=filename, quiet=True) as lprof:
+        exec(code, {"__name__": "__main__"})
     return lprof
 
 
@@ -150,14 +150,13 @@ def test_line_profile_errors():
         """
     ).strip()
 
-    code = compile(script, "<stdin>", "exec")
-    ns = {"__name__": "__main__"}
+    filename = f"<cuml-accel-input-{os.urandom(6).hex()}>"
+    code = compile(script, filename, "exec")
     with pytest.raises(ValueError, match="Oh no!"):
-        with LineProfiler(source=script, namespace=ns, quiet=True) as lprof:
-            exec(code, ns)
-
-    # FLAG removed from namespace
-    assert lprof.FLAG not in ns
+        with LineProfiler(
+            source=script, filename=filename, quiet=True
+        ) as lprof:
+            exec(code, {"__name__": "__main__"})
 
     # Timers properly unwound
     assert not lprof._timers


### PR DESCRIPTION
This fixes several bugs and UX rough edges with the `cuml.accel` IPython magics:

- For cells with outputs, still render the output when run under the profiler magics.
- Ensure composing the profiler magics in either order works appropriately. This means you can combine both profilers (or other cell magics like `%%time`) in the same cell without issue.
- Ensure that code from previous cells isn't mistakenly traced, leading to incorrect measurements.
- Make matching the source to executed lines more robust to IPython source transformations.
- Don't render the reports for invalid cells (e.g. `SyntaxError`), but do for execution errors.
- A few small formatting niceties.

The first 2 issues were found and reported by others through internal usage, the rest I found while debugging and testing.