### PR TITLE
Nicer error message for not implemented fitted attributes in `cuml.accel`

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -197,11 +197,6 @@ RandomForestClassifier
 - If ``sample_weight`` is passed to ``fit`` or ``score``.
 - If ``X`` is sparse.
 
-Additionally, the following fitted attributes are currently not computed:
-
-- ``feature_importances_``
-- ``estimators_samples_``
-
 RandomForestRegressor
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -216,11 +211,6 @@ RandomForestRegressor
 - If ``ccp_alpha`` is not ``0``.
 - If ``sample_weight`` is passed to ``fit`` or ``score``.
 - If ``X`` is sparse.
-
-Additionally, the following fitted attributes are currently not computed:
-
-- ``feature_importances_``
-- ``estimators_samples_``
 
 
 sklearn.kernel_ridge

--- a/python/cuml/cuml/accel/_wrappers/hdbscan.py
+++ b/python/cuml/cuml/accel/_wrappers/hdbscan.py
@@ -22,3 +22,6 @@ __all__ = ("HDBSCAN",)
 
 class HDBSCAN(ProxyBase):
     _gpu_class = cuml.cluster.HDBSCAN
+    _not_implemented_attributes = frozenset(
+        ("exemplars_", "outlier_scores_", "relative_validity_")
+    )

--- a/python/cuml/cuml/accel/_wrappers/sklearn/linear_model.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/linear_model.py
@@ -30,6 +30,7 @@ __all__ = (
 
 class LinearRegression(ProxyBase):
     _gpu_class = cuml.linear_model.LinearRegression
+    _not_implemented_attributes = frozenset(("rank_", "singular_"))
 
 
 class LogisticRegression(ProxyBase):
@@ -38,6 +39,7 @@ class LogisticRegression(ProxyBase):
 
 class ElasticNet(ProxyBase):
     _gpu_class = cuml.linear_model.ElasticNet
+    _not_implemented_attributes = frozenset(("dual_gap_", "n_iter_"))
 
     def _gpu_fit(self, X, y, sample_weight=None, check_input=True):
         # Fixes signature mismatch with cuml.ElasticNet. check_input can be ignored.
@@ -46,6 +48,7 @@ class ElasticNet(ProxyBase):
 
 class Ridge(ProxyBase):
     _gpu_class = cuml.linear_model.Ridge
+    _not_implemented_attributes = frozenset(("n_iter_",))
 
     def _gpu_fit(self, X, y, sample_weight=None):
         X = input_to_cuml_array(X, convert_to_mem_type=False)[0]
@@ -63,6 +66,7 @@ class Ridge(ProxyBase):
 
 class Lasso(ProxyBase):
     _gpu_class = cuml.linear_model.Lasso
+    _not_implemented_attributes = frozenset(("dual_gap_", "n_iter_"))
 
     def _gpu_fit(self, X, y, sample_weight=None, check_input=True):
         # Fixes signature mismatch with cuml.Lasso. check_input can be ignored.

--- a/python/cuml/cuml/accel/_wrappers/sklearn/manifold.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/manifold.py
@@ -22,3 +22,4 @@ __all__ = ("TSNE",)
 
 class TSNE(ProxyBase):
     _gpu_class = cuml.manifold.TSNE
+    _not_implemented_attributes = frozenset(("n_iter_",))

--- a/python/cuml/cuml/accel/_wrappers/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/svm.py
@@ -43,6 +43,12 @@ class SVC(ProxyBase):
     # cuml.SVC supports sparse X for some but not all operations,
     # easier to just fallback for now
     _gpu_supports_sparse = False
+    _not_implemented_attributes = frozenset(
+        (
+            "class_weight_",
+            "n_iter_",
+        )
+    )
 
     def _gpu_fit(self, X, y, sample_weight=None):
         n_classes = len(np.unique(np.asanyarray(y)))
@@ -85,11 +91,14 @@ class SVR(ProxyBase):
     # cuml.SVC supports sparse X for some but not all operations,
     # easier to just fallback for now
     _gpu_supports_sparse = False
+    _not_implemented_attributes = frozenset(("n_iter_",))
 
 
 class LinearSVC(ProxyBase):
     _gpu_class = cuml.svm.LinearSVC
+    _not_implemented_attributes = frozenset(("n_iter_",))
 
 
 class LinearSVR(ProxyBase):
     _gpu_class = cuml.svm.LinearSVR
+    _not_implemented_attributes = frozenset(("n_iter_",))

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -192,6 +192,30 @@ def test_getattr():
     assert model.coef_ is model._cpu.coef_
 
 
+def test_not_implemented_attr_error():
+    X, y = make_regression()
+    model = ElasticNet()
+
+    msg = (
+        "The `ElasticNet.dual_gap_` attribute is not yet "
+        "implemented in `cuml.accel`"
+    )
+
+    # For unfit models the original error is raised
+    with pytest.raises(AttributeError) as rec:
+        model.dual_gap_
+    assert msg not in str(rec.value)
+
+    model.fit(X, y)
+    # Fit models raise the nicer error message
+    with pytest.raises(AttributeError, match=msg):
+        model.dual_gap_
+
+    # If trained on CPU though then there's no error
+    model2 = ElasticNet(positive=True).fit(X, y)
+    assert hasattr(model2, "dual_gap_")
+
+
 def test_setattr():
     model = LinearRegression()
 


### PR DESCRIPTION
`cuml.accel` doesn't support every fitted attribute that sklearn does. For many users this won't matter - many of the fitted attributes aren't accessed for typical usage (some only exist to hold state and aren't something a user would want to see; others are only used for introspecting results in rare circumstances).

Currently we just raise the default `AttributeError` for these attributes, which doesn't make it clear to the user what went wrong (was it their code? Did they have a typo? Was it cuml.accel?).

With this PR we raise a nicer error message telling users that the attribute isn't implemented, and asking them to open an issue if this attribute is necessary for their use case.

With this I _think_ the pressure for finishing up all missing attributes noted in #6966 decreases. We should still fill these in as best as we can, but having a nicer user-facing error message should help users understand what went wrong (and if they open issues, help us understand the importance of some of these that are missing).

Part of #6966.