### PR TITLE
Note non-determinism in random projection transforms

### DIFF
--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -246,6 +246,9 @@ class GaussianRandomProjection(_BaseRandomProjection):
     -----
     Inspired by Scikit-learn's implementation:
     https://scikit-learn.org/stable/modules/random_projection.html
+
+    Currently passing a sparse array to `transform` may result in close (but
+    not exactly identical) results due to https://github.com/cupy/cupy/issues/9323.
     """
 
     def _gen_random_matrix(self, n_components, n_features, dtype):
@@ -362,6 +365,9 @@ class SparseRandomProjection(_BaseRandomProjection):
     -----
     Inspired by Scikit-learn's implementation:
     https://scikit-learn.org/stable/modules/random_projection.html
+
+    Currently passing a dense array to `transform` may result in close (but
+    not exactly identical) results due to https://github.com/cupy/cupy/issues/9323.
     """
 
     def __init__(


### PR DESCRIPTION
Due to an upstream cupy bug (https://github.com/cupy/cupy/issues/9323), mixing sparse/dense arrays may result in close but not perfectly reproducible results. This means that passing a sparse array to `GaussianRandomProjection.transform` (or a dense array to `SparseRandomProjection.transform`) won't produce exactly identical results each run, even with a `random_state` set.

For now we document this limitation and relax the bounds on a flaky test.