### PR TITLE
Add AgglomerativeClustering to common checks

### DIFF
--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -18,7 +18,7 @@ from functools import partial
 import pytest
 from sklearn.utils import estimator_checks
 
-from cuml.cluster import DBSCAN, HDBSCAN, KMeans
+from cuml.cluster import DBSCAN, HDBSCAN, AgglomerativeClustering, KMeans
 from cuml.decomposition import PCA, IncrementalPCA, TruncatedSVD
 from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
 from cuml.kernel_ridge import KernelRidge
@@ -51,6 +51,22 @@ pytest.importorskip("sklearn", minversion="1.7")
 
 
 PER_ESTIMATOR_XFAIL_CHECKS = {
+    AgglomerativeClustering: {
+        "check_estimator_tags_renamed": "No support for modern tags infrastructure",
+        "check_no_attributes_set_in_init": "AgglomerativeClustering sets attributes during init",
+        "check_dont_overwrite_parameters": "AgglomerativeClustering overwrites parameters during fit",
+        "check_do_not_raise_errors_in_init_or_set_params": "AgglomerativeClustering raises errors in init or set_params",
+        "check_complex_data": "AgglomerativeClustering does not handle complex data",
+        "check_dtype_object": "AgglomerativeClustering does not handle object dtype",
+        "check_estimators_empty_data_messages": "AgglomerativeClustering does not handle empty data",
+        "check_estimators_nan_inf": "AgglomerativeClustering does not check for NaN and inf",
+        "check_estimator_sparse_tag": "AgglomerativeClustering does not support sparse data",
+        "check_estimator_sparse_array": "AgglomerativeClustering does not handle sparse arrays gracefully",
+        "check_estimator_sparse_matrix": "AgglomerativeClustering does not handle sparse matrices gracefully",
+        "check_parameters_default_constructible": "AgglomerativeClustering parameters are mutated on init",
+        "check_fit_check_is_fitted": "AgglomerativeClustering passes check_is_fitted before being fit",
+        "check_fit1d": "AgglomerativeClustering does not raise ValueError for 1D input",
+    },
     KMeans: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",
         "check_no_attributes_set_in_init": "KMeans sets attributes during init",
@@ -724,6 +740,7 @@ def _check_name(check):
 
 @estimator_checks.parametrize_with_checks(
     [
+        AgglomerativeClustering(),
         KernelRidge(),
         GaussianNB(),
         ComplementNB(),


### PR DESCRIPTION
This adds`AgglomerativeClustering` to the list of estimators that get tested with the common tests
