### PR TITLE
Extend nightlies breakage window

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
-          max_days_without_success: 7
+          max_days_without_success: 14
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
Due to some upstream breakages our nightlies haven't succeeded in 7 days. Temporarily bumping the window to et things back on track.