### PR TITLE
`n_streams=1` is not required for determinism in `cuml.ensemble`

### DIFF
--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -167,10 +167,6 @@ class BaseRandomForestModel(Base, InteropMixin):
         elif model.max_samples is not None:
             conditional_params["max_samples"] = model.max_samples
 
-        if model.random_state is not None:
-            # determinism requires 1 CUDA stream
-            conditional_params["n_streams"] = 1
-
         if model.max_depth is not None:
             conditional_params["max_depth"] = model.max_depth
 

--- a/python/cuml/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.pyx
@@ -179,9 +179,6 @@ class RandomForestClassifier(BaseRandomForestModel,
         increasing the number of bins may improve accuracy.
     n_streams : int (default = 4)
         Number of parallel streams used for forest building.
-        For nearly reproducible results, set ``n_streams=1``. If ``n_streams``
-        is greater than 1, results may vary due to unpredictable differences in
-        stream/thread timing, even when a ``random_state`` is specified.
     min_samples_leaf : int or float (default = 1)
         The minimum number of samples (rows) in each leaf node.\n
          * If type ``int``, then ``min_samples_leaf`` represents the minimum
@@ -202,8 +199,7 @@ class RandomForestClassifier(BaseRandomForestModel,
     max_batch_size : int (default = 4096)
         Maximum number of nodes that can be processed in a given batch.
     random_state : int (default = None)
-        Seed for the random number generator. Unseeded by default. Does not
-        currently fully guarantee the exact same results.
+        Seed for the random number generator. Unseeded by default.
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -171,9 +171,6 @@ class RandomForestRegressor(BaseRandomForestModel,
         increasing the number of bins may improve accuracy.
     n_streams : int (default = 4 )
         Number of parallel streams used for forest building
-        For nearly reproducible results, set ``n_streams=1``. If ``n_streams``
-        is greater than 1, results may vary due to unpredictable differences in
-        stream/thread timing, even when a ``random_state`` is specified.
     min_samples_leaf : int or float (default = 1)
         The minimum number of samples (rows) in each leaf node.\n
          * If type ``int``, then ``min_samples_leaf`` represents the minimum
@@ -202,8 +199,7 @@ class RandomForestRegressor(BaseRandomForestModel,
     max_batch_size : int (default = 4096)
         Maximum number of nodes that can be processed in a given batch.
     random_state : int (default = None)
-        Seed for the random number generator. Unseeded by default. Does not
-        currently fully guarantee the exact same results.
+        Seed for the random number generator. Unseeded by default.
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA


### PR DESCRIPTION
I've experimented with a bunch of different inputs/distributions and I can't find a case of non-deterministic output even if `n_streams=4`. There might be one, but we'd need someone more familiar with this code to verify.

For now it seems sufficiently safe to remove forcing `n_streams=1` if `random_state is not None` in `cuml.accel`. Forcing `n_streams=1` is slower, and doesn't seem to matter for any workload I've tried.

This also removes the caveats in the docs for `cuml.ensemble` proper.

Fixes #7111.