### PR TITLE
Fix HTML representation's fitted status

### DIFF
--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -516,8 +516,10 @@ class ProxyBase(BaseEstimator):
         return self._cpu._more_tags()
 
     def _repr_mimebundle_(self, **kwargs):
+        self._sync_attrs_to_cpu()
         return self._cpu._repr_mimebundle_(**kwargs)
 
     @property
     def _repr_html_(self):
+        self._sync_attrs_to_cpu()
         return self._cpu._repr_html_

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -142,6 +142,18 @@ def test_repr():
     assert isinstance(model._repr_mimebundle_(), dict)
 
 
+def test_repr_mimebundle():
+    model = LogisticRegression(C=1.5)
+    unfitted_html_repr = model._repr_mimebundle_()["text/html"]
+
+    X, y = make_classification()
+    model.fit(X, y)
+    fitted_html_repr = model._repr_mimebundle_()["text/html"]
+
+    assert "<span>Not fitted</span>" in unfitted_html_repr
+    assert "<span>Fitted</span>" in fitted_html_repr
+
+
 def test_pipeline_repr():
     """sklearn's pretty printer requires you not override __repr__
     for pipelines to repr properly"""


### PR DESCRIPTION
Need to sync the attributes to the CPU model for the HTML repr to work properly. This is because we delegate the HTML repr building to the CPU model. The advantage of this is that users get exactly what they are expecting, the downside is that we need to sync fitted attributes so that the fitted/not fitted detection works correctly. In theory we could dig into how the detection is done and only sync "that one attribute" needed to pass the test. I think that is a premature optimisation and relies on the internals of scikit-learn which means it is fragile.

closes #7145