### PR TITLE
Deprecate `predict_model` in `cuml.ensemble`/`cuml.dask.ensemble`

### DIFF
--- a/python/cuml/cuml/dask/ensemble/base.py
+++ b/python/cuml/cuml/dask/ensemble/base.py
@@ -368,6 +368,18 @@ class BaseRandomForestModel(object):
         else:
             return delayed_res.persist()
 
+    def _handle_deprecated_predict_model(self, predict_model):
+        if predict_model != "deprecated":
+            warnings.warn(
+                (
+                    "`predict_model` is deprecated (and ignored) and will be removed "
+                    "in 25.12. The default of `predict_model='GPU'` should suffice in "
+                    "all situations. When inferring on small datasets you may also "
+                    "want to try setting ``broadcast_data=True``."
+                ),
+                FutureWarning,
+            )
+
 
 def _func_fit(model, input_data, convert_dtype):
     X = concatenate([item[0] for item in input_data])

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -15,8 +15,6 @@
 #
 import cupy as cp
 import dask.array
-import numpy as np
-from dask.distributed import default_client
 
 from cuml.dask.common.base import (
     BaseEstimator,
@@ -275,7 +273,7 @@ class RandomForestClassifier(
         X,
         threshold=0.5,
         convert_dtype=True,
-        predict_model="GPU",
+        predict_model="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -285,40 +283,25 @@ class RandomForestClassifier(
         """
         Predicts the labels for X.
 
-        GPU-based prediction in a multi-node, multi-GPU context works
-        by sending the sub-forest from each worker to the client,
-        concatenating these into one forest with the full
-        `n_estimators` set of trees, and sending this combined forest to
-        the workers, which will each infer on their local set of data.
-        Within the worker, this uses the cuML Forest Inference Library
-        (cuml.fil) for high-throughput prediction.
-
-        This allows inference to scale to large datasets, but the forest
-        transmission incurs overheads for very large trees. For inference
-        on small datasets, this overhead may dominate prediction time.
-
-        The 'CPU' fallback method works with sub-forests in-place, broadcasting
-        the datasets to all workers and combining predictions via a voting
-        method at the end. This method is slower on a per-row basis but may be
-        faster for problems with many trees and few rows.
-
         Parameters
         ----------
         X : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, n_features)
             Distributed dense matrix (floats or doubles) of shape
             (n_samples, n_features).
         threshold : float (default = 0.5)
-            Threshold used for classification. Optional and required only
-            while performing the predict operation on the GPU, that is for,
-            predict_model='GPU'.
+            Threshold used for classification.
         convert_dtype : bool, optional (default = True)
             When set to True, the predict method will, when necessary, convert
             the input to the data type which was used to train the model. This
             will increase memory used for the method.
-        predict_model : String (default = 'GPU')
-            'GPU' to predict using the GPU, 'CPU' otherwise. The GPU can only
-            be used if the model was trained on float32 data and `X` is float32
-            or convert_dtype is set to True.
+        predict_model : string (default = 'deprecated')
+
+            .. deprecated:: 25.10
+                `predict_model` is deprecated (and ignored) and will be removed
+                in 25.12. The default of `predict_model="GPU"` should suffice in
+                all situations. When inferring on small datasets you may also
+                want to try setting ``broadcast_data=True``.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -330,11 +313,10 @@ class RandomForestClassifier(
             If specified, trees will be padded such that their in-memory size is
             a multiple of this value. This can improve performance by guaranteeing
             that memory reads from trees begin on a cache line boundary.
-            Typical values are 0 or 128 on GPU and 0 or 64 on CPU.
+            Typical values are 0 or 128.
         delayed : bool (default = True)
             Whether to do a lazy prediction (and return Delayed objects) or an
-            eagerly executed one.  It is not required  while using
-            predict_model='CPU'.
+            eagerly executed one.
         broadcast_data : bool (default = False)
             If False, the trees are merged in a single model before the workers
             perform inference on their share of the prediction workload.
@@ -348,29 +330,26 @@ class RandomForestClassifier(
         y : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, 1)
             The predicted class labels.
         """
-        if predict_model == "CPU":
-            preds = self.predict_model_on_cpu(X=X, convert_dtype=convert_dtype)
-        else:
-            if broadcast_data:
-                preds = self.partial_inference(
-                    X,
-                    convert_dtype=convert_dtype,
-                    layout=layout,
-                    default_chunk_size=default_chunk_size,
-                    align_bytes=align_bytes,
-                    delayed=delayed,
-                )
-            else:
-                preds = self._predict_using_fil(
-                    X,
-                    threshold=threshold,
-                    convert_dtype=convert_dtype,
-                    layout=layout,
-                    default_chunk_size=default_chunk_size,
-                    align_bytes=align_bytes,
-                    delayed=delayed,
-                )
-        return preds
+        self._handle_deprecated_predict_model(predict_model)
+
+        if broadcast_data:
+            return self.partial_inference(
+                X,
+                convert_dtype=convert_dtype,
+                layout=layout,
+                default_chunk_size=default_chunk_size,
+                align_bytes=align_bytes,
+                delayed=delayed,
+            )
+        return self._predict_using_fil(
+            X,
+            threshold=threshold,
+            convert_dtype=convert_dtype,
+            layout=layout,
+            default_chunk_size=default_chunk_size,
+            align_bytes=align_bytes,
+            delayed=delayed,
+        )
 
     def partial_inference(self, X, delayed, **kwargs):
         partial_infs = self._partial_inference(
@@ -391,78 +370,6 @@ class RandomForestClassifier(
             return pred_class
         else:
             return pred_class.persist()
-
-    def predict_using_fil(self, X, delayed, **kwargs):
-        if self._get_internal_model() is None:
-            self._set_internal_model(self._concat_treelite_models())
-
-        return self._predict_using_fil(X=X, delayed=delayed, **kwargs)
-
-    """
-    TODO : Update function names used for CPU predict.
-        Cuml issue #1854 has been created to track this.
-    """
-
-    def predict_model_on_cpu(self, X, convert_dtype=True):
-        """
-        Predicts the labels for X.
-
-        Parameters
-        ----------
-        X : Dask cuDF dataframe  or CuPy backed Dask Array (n_rows, n_features)
-            Distributed dense matrix (floats or doubles) of shape
-            (n_samples, n_features).
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will, when necessary, convert
-            the input to the data type which was used to train the model. This
-            will increase memory used for the method.
-
-        Returns
-        -------
-        y : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, 1)
-        """
-        c = default_client()
-        workers = self.workers
-
-        X_Scattered = c.scatter(X)
-        futures = list()
-        for n, w in enumerate(workers):
-            futures.append(
-                c.submit(
-                    RandomForestClassifier._predict_model_on_cpu,
-                    self.rfs[w],
-                    X_Scattered,
-                    convert_dtype,
-                    workers=[w],
-                )
-            )
-
-        rslts = self.client.gather(futures, errors="raise")
-        indexes = np.zeros(len(futures), dtype=np.int32)
-        pred = list()
-
-        for i in range(len(X)):
-            classes = dict()
-            max_class = -1
-            max_val = 0
-
-            for d in range(len(rslts)):
-                for j in range(self.n_estimators_per_worker[d]):
-                    sub_ind = indexes[d] + j
-                    cls = rslts[d][sub_ind]
-                    if cls not in classes.keys():
-                        classes[cls] = 1
-                    else:
-                        classes[cls] = classes[cls] + 1
-
-                    if classes[cls] > max_val:
-                        max_val = classes[cls]
-                        max_class = cls
-
-                indexes[d] = indexes[d] + self.n_estimators_per_worker[d]
-
-            pred.append(max_class)
-        return pred
 
     def predict_proba(self, X, delayed=True, **kwargs):
         """

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -453,3 +453,15 @@ class BaseRandomForestModel(Base, InteropMixin):
         if predict_proba:
             return fil_model.predict_proba(X)
         return fil_model.predict(X, threshold=threshold)
+
+    def _handle_deprecated_predict_model(self, predict_model):
+        if predict_model != "deprecated":
+            warnings.warn(
+                (
+                    "`predict_model` is deprecated (and ignored) and will be removed "
+                    "in 25.12. To infer on CPU use `model.convert_to_fil_model` to get "
+                    "a `FIL` instance which may then be used to perform inference on "
+                    "both CPU and GPU."
+                ),
+                FutureWarning,
+            )

--- a/python/cuml/cuml/ensemble/randomforestclassifier.pyx
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.pyx
@@ -62,22 +62,6 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
                   RF_params,
                   level_enum) except +
 
-    cdef void predict(handle_t& handle,
-                      RandomForestMetaData[float, int] *,
-                      float*,
-                      int,
-                      int,
-                      int*,
-                      level_enum) except +
-
-    cdef void predict(handle_t& handle,
-                      RandomForestMetaData[double, int]*,
-                      double*,
-                      int,
-                      int,
-                      int*,
-                      level_enum) except +
-
     cdef RF_metrics score(handle_t& handle,
                           RandomForestMetaData[float, int]*,
                           int*,
@@ -219,16 +203,8 @@ class RandomForestClassifier(BaseRandomForestModel,
 
     Notes
     -----
-    **Known Limitations**\n
-    This is an early release of the cuML
-    Random Forest code. It contains a few known limitations:
-
-      * GPU-based inference is only supported with 32-bit (float32) datatypes.
-        Alternatives are to use CPU-based inference for 64-bit (float64)
-        datatypes, or let the default automatic datatype conversion occur
-        during GPU inference.
-      * While training the model for multi class classification problems,
-        using deep trees or `max_features=1.0` provides better performance.
+    While training the model for multi class classification problems, using
+    deep trees or `max_features=1.0` provides better performance.
 
     For additional docs, see `scikitlearn's RandomForestClassifier
     <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
@@ -485,57 +461,6 @@ class RandomForestClassifier(BaseRandomForestModel,
         del y_m
         return self
 
-    @cuml.internals.api_base_return_array(get_output_dtype=True)
-    def _predict_model_on_cpu(
-        self,
-        X,
-        convert_dtype = True,
-    ) -> CumlArray:
-        cdef uintptr_t X_ptr
-        X_m, n_rows, n_cols, _dtype = \
-            input_to_cuml_array(X, order='C',
-                                convert_to_dtype=(self.dtype if convert_dtype
-                                                  else None),
-                                check_cols=self.n_cols)
-        X_ptr = X_m.ptr
-        preds = CumlArray.zeros(n_rows, dtype=np.int32)
-        cdef uintptr_t preds_ptr = preds.ptr
-
-        cdef handle_t* handle_ = \
-            <handle_t*> <uintptr_t> self.handle.getHandle()
-
-        cdef RandomForestMetaData[float, int] *rf_forest = \
-            <RandomForestMetaData[float, int]*> <uintptr_t> self.rf_forest
-
-        cdef RandomForestMetaData[double, int] *rf_forest64 = \
-            <RandomForestMetaData[double, int]*> <uintptr_t> self.rf_forest64
-        if self.dtype == np.float32:
-            predict(handle_[0],
-                    rf_forest,
-                    <float*> X_ptr,
-                    <int> n_rows,
-                    <int> n_cols,
-                    <int*> preds_ptr,
-                    <level_enum> self.verbose)
-
-        elif self.dtype == np.float64:
-            predict(handle_[0],
-                    rf_forest64,
-                    <double*> X_ptr,
-                    <int> n_rows,
-                    <int> n_cols,
-                    <int*> preds_ptr,
-                    <level_enum> self.verbose)
-        else:
-            raise TypeError("supports only np.float32 and np.float64 input,"
-                            " but input of type '%s' passed."
-                            % (str(self.dtype)))
-
-        self.handle.sync()
-        # synchronous w/o a stream
-        del X_m
-        return preds
-
     @nvtx.annotate(
         message="predict RF-Classifier @randomforestclassifier.pyx",
         domain="cuml_python")
@@ -546,12 +471,12 @@ class RandomForestClassifier(BaseRandomForestModel,
         self,
         X,
         *,
-        threshold = 0.5,
-        convert_dtype = True,
-        predict_model = "GPU",
-        layout = "depth_first",
-        default_chunk_size = None,
-        align_bytes = None,
+        threshold=0.5,
+        convert_dtype=True,
+        layout="depth_first",
+        default_chunk_size=None,
+        align_bytes=None,
+        predict_model="deprecated",
     ) -> CumlArray:
         """
         Predicts the labels for X.
@@ -560,44 +485,43 @@ class RandomForestClassifier(BaseRandomForestModel,
         ----------
         X : {}
         threshold : float (default = 0.5)
-            Threshold used for classification. Only used when predict_model='GPU'.
+            Threshold used for classification.
         convert_dtype : bool (default = True)
             When True, automatically convert the input to the data type used
             to train the model. This may increase memory usage.
-        predict_model : string (default = 'GPU')
-            Device to use for prediction: 'GPU' or 'CPU'.
         layout : string (default = 'depth_first')
             Forest layout for GPU inference. Options: 'depth_first', 'layered',
-            'breadth_first'. Only used when predict_model='GPU'.
+            'breadth_first'.
         default_chunk_size : int, optional (default = None)
             Controls batch subdivision for parallel processing. Optimal value depends
             on hardware, model and batch size. If None, determined automatically.
-            Only used when predict_model='GPU'.
         align_bytes : int, optional (default = None)
             If specified, trees will be padded to this byte alignment, which can
-            improve performance. Typical values are 0 or 128 on GPU, 0 or 64 on CPU.
-            Only used when predict_model='GPU'.
+            improve performance. Typical values are 0 or 128 on GPU.
+        predict_model : string (default = 'deprecated')
+
+            .. deprecated:: 25.10
+                `predict_model` is deprecated (and ignored) and will be removed
+                in 25.12. To infer on CPU use `model.convert_to_fil_model` to get
+                a `FIL` instance which may then be used to perform inference on
+                both CPU and GPU.
 
         Returns
         -------
         y : {}
         """
-        if predict_model == "CPU":
-            preds = self._predict_model_on_cpu(
-                X=X,
-                convert_dtype=convert_dtype,
-            )
-        else:
-            preds = self._predict_model_on_gpu(
-                X=X,
-                is_classifier=True,
-                predict_proba=False,
-                threshold=threshold,
-                convert_dtype=convert_dtype,
-                layout=layout,
-                default_chunk_size=default_chunk_size,
-                align_bytes=align_bytes,
-            )
+        self._handle_deprecated_predict_model(predict_model)
+
+        preds = self._predict_model_on_gpu(
+            X=X,
+            is_classifier=True,
+            predict_proba=False,
+            threshold=threshold,
+            convert_dtype=convert_dtype,
+            layout=layout,
+            default_chunk_size=default_chunk_size,
+            align_bytes=align_bytes,
+        )
 
         if self.update_labels:
             preds = preds.to_output().astype(self.classes_.dtype)
@@ -662,12 +586,12 @@ class RandomForestClassifier(BaseRandomForestModel,
         X,
         y,
         *,
-        threshold = 0.5,
-        convert_dtype = True,
-        predict_model = "GPU",
-        layout = "depth_first",
-        default_chunk_size = None,
-        align_bytes = None,
+        threshold=0.5,
+        convert_dtype=True,
+        layout="depth_first",
+        default_chunk_size=None,
+        align_bytes=None,
+        predict_model="deprecated",
     ):
         """
         Calculates the accuracy metric score of the model for X.
@@ -681,8 +605,6 @@ class RandomForestClassifier(BaseRandomForestModel,
         convert_dtype : bool (default = True)
             When True, automatically convert the input to the data type used
             to train the model. This may increase memory usage.
-        predict_model : string (default = 'GPU')
-            Device to use for prediction: 'GPU' or 'CPU'.
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -695,6 +617,13 @@ class RandomForestClassifier(BaseRandomForestModel,
             a multiple of this value. This can improve performance by guaranteeing
             that memory reads from trees begin on a cache line boundary.
             Typical values are 0 or 128 on GPU and 0 or 64 on CPU.
+        predict_model : string (default = 'deprecated')
+
+            .. deprecated:: 25.10
+                `predict_model` is deprecated (and ignored) and will be removed
+                in 25.12. To infer on CPU use `model.convert_to_fil_model` to get
+                a `FIL` instance which may then be used to perform inference on
+                both CPU and GPU.
 
         Returns
         -------

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -56,22 +56,6 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
                   RF_params,
                   level_enum) except +
 
-    cdef void predict(handle_t& handle,
-                      RandomForestMetaData[float, float] *,
-                      float*,
-                      int,
-                      int,
-                      float*,
-                      level_enum) except +
-
-    cdef void predict(handle_t& handle,
-                      RandomForestMetaData[double, double]*,
-                      double*,
-                      int,
-                      int,
-                      double*,
-                      level_enum) except +
-
     cdef RF_metrics score(handle_t& handle,
                           RandomForestMetaData[float, float]*,
                           float*,
@@ -219,15 +203,6 @@ class RandomForestRegressor(BaseRandomForestModel,
 
     Notes
     -----
-    **Known Limitations**\n
-    This is an early release of the cuML
-    Random Forest code. It contains a few known limitations:
-
-      * GPU-based inference is only supported with 32-bit (float32) data-types.
-        Alternatives are to use CPU-based inference for 64-bit (float64)
-        data-types, or let the default automatic datatype conversion occur
-        during GPU inference.
-
     For additional docs, see `scikitlearn's RandomForestRegressor
     <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html>`_.
     """
@@ -452,57 +427,6 @@ class RandomForestRegressor(BaseRandomForestModel,
         del y_m
         return self
 
-    def _predict_model_on_cpu(
-        self,
-        X,
-        convert_dtype = True,
-    ) -> CumlArray:
-        cdef uintptr_t X_ptr
-        X_m, n_rows, n_cols, dtype = \
-            input_to_cuml_array(X, order='C',
-                                convert_to_dtype=(self.dtype if convert_dtype
-                                                  else None),
-                                check_cols=self.n_cols)
-        X_ptr = X_m.ptr
-
-        preds = CumlArray.zeros(n_rows, dtype=dtype)
-        cdef uintptr_t preds_ptr = preds.ptr
-
-        cdef handle_t* handle_ = \
-            <handle_t*> <uintptr_t> self.handle.getHandle()
-
-        cdef RandomForestMetaData[float, float] *rf_forest = \
-            <RandomForestMetaData[float, float] *> <uintptr_t> self.rf_forest
-
-        cdef RandomForestMetaData[double, double] *rf_forest64 = \
-            <RandomForestMetaData[double, double] *> <uintptr_t> self.rf_forest64
-        if self.dtype == np.float32:
-            predict(handle_[0],
-                    rf_forest,
-                    <float*> X_ptr,
-                    <int> n_rows,
-                    <int> n_cols,
-                    <float*> preds_ptr,
-                    <level_enum> self.verbose)
-
-        elif self.dtype == np.float64:
-            predict(handle_[0],
-                    rf_forest64,
-                    <double*> X_ptr,
-                    <int> n_rows,
-                    <int> n_cols,
-                    <double*> preds_ptr,
-                    <level_enum> self.verbose)
-        else:
-            raise TypeError("supports only float32 and float64 input,"
-                            " but input of type '%s' passed."
-                            % (str(self.dtype)))
-
-        self.handle.sync()
-        # synchronous w/o a stream
-        del X_m
-        return preds
-
     @nvtx.annotate(
         message="predict RF-Regressor @randomforestclassifier.pyx",
         domain="cuml_python")
@@ -512,11 +436,11 @@ class RandomForestRegressor(BaseRandomForestModel,
         self,
         X,
         *,
-        convert_dtype = True,
-        predict_model = "GPU",
-        layout = "depth_first",
-        default_chunk_size = None,
-        align_bytes = None,
+        convert_dtype=True,
+        layout="depth_first",
+        default_chunk_size=None,
+        align_bytes=None,
+        predict_model="deprecated",
     ) -> CumlArray:
         """
         Predicts the values for X.
@@ -528,43 +452,41 @@ class RandomForestRegressor(BaseRandomForestModel,
             When set to True, the predict method will, when necessary, convert
             the input to the data type which was used to train the model. This
             will increase memory used for the method.
-        predict_model : string (default = 'GPU')
-            'GPU' to predict using the GPU, 'CPU' otherwise. The GPU can only
-            be used if the model was trained on float32 data and `X` is float32
-            or convert_dtype is set to True.
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
-            'depth_first', 'layered', 'breadth_first'. Only used when predict_model='GPU'.
+            'depth_first', 'layered', 'breadth_first'.
         default_chunk_size : int, optional (default = None)
             Determines how batches are further subdivided for parallel processing.
             The optimal value depends on hardware, model, and batch size.
-            If None, will be automatically determined. Only used when predict_model='GPU'.
+            If None, will be automatically determined.
         align_bytes : int, optional (default = None)
             If specified, trees will be padded such that their in-memory size is
             a multiple of this value. This can improve performance by guaranteeing
             that memory reads from trees begin on a cache line boundary.
-            Typical values are 0 or 128 on GPU and 0 or 64 on CPU.
-            Only used when predict_model='GPU'.
+            Typical values are 0 or 128.
+        predict_model : string (default = 'deprecated')
+
+            .. deprecated:: 25.10
+                `predict_model` is deprecated (and ignored) and will be removed
+                in 25.12. To infer on CPU use `model.convert_to_fil_model` to get
+                a `FIL` instance which may then be used to perform inference on
+                both CPU and GPU.
 
         Returns
         -------
         y : {}
         """
-        if predict_model == "CPU":
-            preds = self._predict_model_on_cpu(
-                X=X,
-                convert_dtype=convert_dtype,
-            )
-        else:
-            preds = self._predict_model_on_gpu(
-                X=X,
-                is_classifier=False,
-                predict_proba=False,
-                convert_dtype=convert_dtype,
-                layout=layout,
-                default_chunk_size=default_chunk_size,
-                align_bytes=align_bytes,
-            )
+        self._handle_deprecated_predict_model(predict_model)
+
+        preds = self._predict_model_on_gpu(
+            X=X,
+            is_classifier=False,
+            predict_proba=False,
+            convert_dtype=convert_dtype,
+            layout=layout,
+            default_chunk_size=default_chunk_size,
+            align_bytes=align_bytes,
+        )
 
         # Reshape to 1D array if the output would be (n, 1) to match
         # the output shape behavior of scikit-learn.
@@ -583,11 +505,11 @@ class RandomForestRegressor(BaseRandomForestModel,
         X,
         y,
         *,
-        convert_dtype = True,
-        predict_model = "GPU",
-        layout = "depth_first",
-        default_chunk_size = None,
-        align_bytes = None,
+        convert_dtype=True,
+        layout="depth_first",
+        default_chunk_size=None,
+        align_bytes=None,
+        predict_model="deprecated",
     ):
         """
         Calculates the accuracy metric score of the model for X.
@@ -601,8 +523,6 @@ class RandomForestRegressor(BaseRandomForestModel,
         convert_dtype : bool (default = True)
             When True, automatically convert the input to the data type used
             to train the model. This may increase memory usage.
-        predict_model : string (default = 'GPU')
-            Device to use for prediction: 'GPU' or 'CPU'.
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -614,7 +534,14 @@ class RandomForestRegressor(BaseRandomForestModel,
             If specified, trees will be padded such that their in-memory size is
             a multiple of this value. This can improve performance by guaranteeing
             that memory reads from trees begin on a cache line boundary.
-            Typical values are 0 or 128 on GPU and 0 or 64 on CPU.
+            Typical values are 0 or 128.
+        predict_model : string (default = 'deprecated')
+
+            .. deprecated:: 25.10
+                `predict_model` is deprecated (and ignored) and will be removed
+                in 25.12. To infer on CPU use `model.convert_to_fil_model` to get
+                a `FIL` instance which may then be used to perform inference on
+                both CPU and GPU.
 
         Returns
         -------

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -660,3 +660,27 @@ def test_rf_broadcast(model_type, fit_broadcast, transform_broadcast, client):
 
     if transform_broadcast:
         assert cuml_mod.internal_model is None
+
+
+@pytest.mark.parametrize("cls", [cuRFC_mg, cuRFR_mg])
+def test_predict_model_deprecated(cls, client):
+    n_workers = len(client.scheduler_info(n_workers=-1)["workers"])
+
+    if cls is cuRFC_mg:
+        X, y = make_classification(n_samples=1000 * n_workers)
+        y = y.astype("int32")
+    else:
+        X, y = make_regression(n_samples=1000 * n_workers)
+        y = y.astype("float32")
+
+    X = X.astype("float32")
+    dask_X, dask_y = _prep_training_data(client, X, y, 3)
+
+    model = cls().fit(dask_X, dask_y)
+    sol = model.predict(dask_X)
+    with pytest.warns(FutureWarning, match="predict_model"):
+        res = model.predict(dask_X, predict_model="CPU")
+
+    np.testing.assert_array_equal(
+        res.compute().to_numpy(), sol.compute().to_numpy()
+    )

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -740,13 +740,12 @@ def learn_model(draw, X, y, task, learner, n_estimators, n_targets):
             model = model.get_booster()
         return model, pred
     elif learner == "rf":
-        predict_model = "GPU" if y.dtype == np.float32 else "CPU"
         if task == "regression":
             model = cuml.ensemble.RandomForestRegressor(
                 n_estimators=n_estimators
             )
             model.fit(X, y)
-            pred = model.predict(X, predict_model=predict_model)
+            pred = model.predict(X)
         elif task == "classification":
             model = cuml.ensemble.RandomForestClassifier(
                 n_estimators=n_estimators

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -182,12 +182,7 @@ def make_dataset(datatype, nrows, ncols, n_info):
 def test_rf_regression_pickle(
     tmpdir, datatype, nrows, ncols, n_info, n_classes, key
 ):
-
     result = {}
-    if datatype == np.float64:
-        pytest.xfail(
-            "Pickling is not supported for dataset with" " dtype float64"
-        )
 
     def create_mod():
         if key == "RandomForestRegressor":
@@ -202,20 +197,14 @@ def test_rf_regression_pickle(
         model = rf_models[key]()
 
         model.fit(X_train, y_train)
-        if datatype == np.float32:
-            predict_model = "GPU"
-        else:
-            predict_model = "CPU"
-        result["rf_res"] = model.predict(X_test, predict_model=predict_model)
+        result["rf_res"] = model.predict(X_test)
         return model, X_test
 
     def assert_model(pickled_model, X_test):
 
         assert array_equal(result["rf_res"], pickled_model.predict(X_test))
         # Confirm no crash from score
-        pickled_model.score(
-            X_test, np.zeros(X_test.shape[0]), predict_model="GPU"
-        )
+        pickled_model.score(X_test, np.zeros(X_test.shape[0]))
 
         pickle_save_load(tmpdir, create_mod, assert_model)
 

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -1368,3 +1368,24 @@ def test_ensemble_estimator_length():
         clf.fit(X, y)
 
     assert len(clf) == 3
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        cuml.ensemble.RandomForestClassifier,
+        cuml.ensemble.RandomForestRegressor,
+    ],
+)
+def test_predict_model_deprecated(cls):
+    if cls is cuml.ensemble.RandomForestClassifier:
+        X, y = make_classification(n_samples=500)
+    else:
+        X, y = make_regression(n_samples=500)
+
+    model = cls().fit(X, y)
+    sol = model.predict(X)
+    with pytest.warns(FutureWarning, match="predict_model"):
+        res = model.predict(X, predict_model="CPU")
+
+    np.testing.assert_array_equal(res, sol)


### PR DESCRIPTION
The `predict` methods of our ensemble estimators (`cuml.ensemble.RandomForestClassifier`, `cuml.ensemble.RandomForestRegressor`, and the dask equivalents) include an old `predict_model` kwarg. This kwarg may be one of `("GPU", "CPU")`, with `"GPU"` as the default.

On single node:

- `predict_model="GPU"`: used FIL on GPU to do inference
- `predict_model="CPU"`: used the internal decision tree representation used for fitting (so tied to the GPU), but does the predict on CPU. This is less performant _and_ still doesn't let users do inference without a GPU.

On multi node (dask):

- `predict_model="GPU"`: used FIL on GPU to do inference (broadcasting the complete model to every worker node)
- `predict_model="CPU"`: used the internal decision tree repr from fitting, but with some _very inefficient post processing_ (looping over the full length of the data! building up a python list of responses!). Using `broadcast_data=True` seems to better match the intent here (more efficient with small datasets), and is available with the default FIL codepath.

This PR:

- Deprecates `predict_model` everywhere. The FIL codepath is always taken. A warning is raised if `predict_model` is explicitly set, but the old codepaths no longer exist.
- Deletes the old codepaths. We could also delete some C++ used for inference, but I left that out for now.
- Updates the tests accordingly (including tests for the deprecated behavior).

No existing code should be broken by this (at most users will see a warning telling them the kwargs are going away), and all use cases should still be supported without the `predict_model` kwarg.

This PR is part of cleaning up the memory management and internals of our `cuml.ensemble` estimators.