### PR TITLE
Deprecate `accuracy_metric`

### DIFF
--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -117,14 +117,18 @@ class RandomForestRegressor(
          * If type ``float``, then ``min_samples_split`` represents a fraction
            and ``ceil(min_samples_split * n_rows)`` is the minimum number of
            samples for each split.
-    accuracy_metric : string (default = 'r2')
+    accuracy_metric : string (default = 'deprecated')
         Decides the metric used to evaluate the performance of the model.
-        In the 0.16 release, the default scoring metric was changed
-        from mean squared error to r-squared.\n
-         * for r-squared : ``'r2'``
+         * for r-squared : ``'r2'`` (default)
          * for median of abs error : ``'median_ae'``
          * for mean of abs error : ``'mean_ae'``
          * for mean square error' : ``'mse'``
+
+        .. deprecated:: 25.10
+            `accuracy_metric` is deprecated and will be removed in 25.12. To
+            evaluate models with metrics other than r2, please call the respective
+            metric function from `cuml.metrics` directly.
+
     n_streams : int (default = 4 )
         Number of parallel streams used for forest building
     workers : optional, list of strings

--- a/python/cuml/cuml/ensemble/randomforestregressor.pyx
+++ b/python/cuml/cuml/ensemble/randomforestregressor.pyx
@@ -15,6 +15,8 @@
 #
 # distutils: language = c++
 
+import warnings
+
 import numpy as np
 from treelite import Model as TreeliteModel
 
@@ -100,12 +102,12 @@ class RandomForestRegressor(BaseRandomForestModel,
         >>> cuml_model = curfr(max_features=1.0, n_bins=128,
         ...                    min_samples_leaf=1,
         ...                    min_samples_split=2,
-        ...                    n_estimators=40, accuracy_metric='r2')
+        ...                    n_estimators=40)
         >>> cuml_model.fit(X,y)
         RandomForestRegressor()
         >>> cuml_score = cuml_model.score(X,y)
-        >>> print("MSE score of cuml : ", cuml_score) # doctest: +SKIP
-        MSE score of cuml :  0.9076250195503235
+        >>> print("R2 score of cuml : ", cuml_score) # doctest: +SKIP
+        R2 score of cuml :  0.9076250195503235
 
     Parameters
     ----------
@@ -172,14 +174,18 @@ class RandomForestRegressor(BaseRandomForestModel,
            number of samples for each split.
     min_impurity_decrease : float (default = 0.0)
         The minimum decrease in impurity required for node to be split
-    accuracy_metric : string (default = 'r2')
+    accuracy_metric : string (default = 'deprecated')
         Decides the metric used to evaluate the performance of the model.
-        In the 0.16 release, the default scoring metric was changed
-        from mean squared error to r-squared.\n
-         * for r-squared : ``'r2'``
+         * for r-squared : ``'r2'`` (default)
          * for median of abs error : ``'median_ae'``
          * for mean of abs error : ``'mean_ae'``
          * for mean square error' : ``'mse'``
+
+        .. deprecated:: 25.10
+            `accuracy_metric` is deprecated and will be removed in 25.12. To
+            evaluate models with metrics other than r2, please call the respective
+            metric function from `cuml.metrics` directly.
+
     max_batch_size : int (default = 4096)
         Maximum number of nodes that can be processed in a given batch.
     random_state : int (default = None)
@@ -217,11 +223,20 @@ class RandomForestRegressor(BaseRandomForestModel,
     def __init__(self, *,
                  split_criterion=2,
                  max_features=1.0,
-                 accuracy_metric='r2',
+                 accuracy_metric='deprecated',
                  handle=None,
                  verbose=False,
                  output_type=None,
                  **kwargs):
+
+        if accuracy_metric != "deprecated":
+            warnings.warn(
+                "`accuracy_metric` was deprecated in 25.10 and will be removed "
+                "in 25.12. To evaluate models with metrics other than r2, please call "
+                "the respective metric function from `cuml.metrics` directly.",
+                FutureWarning
+            )
+
         self.accuracy_metric = accuracy_metric
         super().__init__(
             split_criterion=split_criterion,
@@ -576,7 +591,7 @@ class RandomForestRegressor(BaseRandomForestModel,
         preds_ptr = preds_m.ptr
 
         # shortcut for default accuracy metric of r^2
-        if self.accuracy_metric == "r2":
+        if self.accuracy_metric in ("r2", "deprecated"):
             stats = r2_score(y_m, preds)
             self.handle.sync()
             del y_m

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -259,7 +259,6 @@ def test_degenerate_cases():
         n_estimators=10,
         max_leaves=-1,
         max_depth=16,
-        accuracy_metric="mse",
     )
     # Attempt to import un-fitted model
     with pytest.raises(NotFittedError):
@@ -304,7 +303,6 @@ def test_cuml_rf_regressor(input_type):
         n_estimators=10,
         max_leaves=-1,
         max_depth=16,
-        accuracy_metric="mse",
     )
     cuml_model.fit(X, y)
     pred = cuml_model.predict(X).squeeze()
@@ -354,7 +352,6 @@ def test_cuml_rf_classifier(n_classes, input_type):
         n_estimators=10,
         max_leaves=-1,
         max_depth=16,
-        accuracy_metric="mse",
     )
     cuml_model.fit(X, y)
     pred = cuml_model.predict_proba(X)

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -450,7 +450,6 @@ def test_rf_regression(
         handle=handle,
         max_leaves=-1,
         max_depth=16,
-        accuracy_metric="mse",
     )
     cuml_model.fit(X_train, y_train)
     preds = cuml_model.predict(X_test)
@@ -766,7 +765,6 @@ def test_rf_regression_sparse(special_reg, datatype, fil_layout):
         handle=handle,
         max_leaves=-1,
         max_depth=40,
-        accuracy_metric="mse",
     )
     cuml_model.fit(X_train, y_train)
 
@@ -1389,3 +1387,23 @@ def test_predict_model_deprecated(cls):
         res = model.predict(X, predict_model="CPU")
 
     np.testing.assert_array_equal(res, sol)
+
+
+def test_accuracy_metric_deprecated():
+    X, y = make_regression(n_samples=500)
+
+    # r2 score used by default
+    model = cuml.RandomForestRegressor().fit(X, y)
+    score = model.score(X, y)
+    np.testing.assert_allclose(score, r2_score(y, model.predict(X)))
+
+    # explicit use warns but still works
+    with pytest.warns(FutureWarning, match="accuracy_metric"):
+        model = cuml.RandomForestRegressor(accuracy_metric="r2")
+    score = model.fit(X, y).score(X, y)
+    np.testing.assert_allclose(score, r2_score(y, model.predict(X)))
+
+    with pytest.warns(FutureWarning, match="accuracy_metric"):
+        model = cuml.RandomForestRegressor(accuracy_metric="mse")
+    score = model.fit(X, y).score(X, y)
+    np.testing.assert_allclose(score, mean_squared_error(y, model.predict(X)))


### PR DESCRIPTION
This deprecates the `accuracy_metric` kwarg to `RandomForestRegressor`. Those wishing to evaluate model performance using an alternative to the default metric may to the typical sklearn thing and call the metric function directly from the `metrics` namespace.

Fixes #7160.