### PR TITLE
Remove baked in datasets from preloading plugin

### DIFF
--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -445,14 +445,10 @@ def nlp_20news():
         (X, Y) where X is the feature matrix and Y is the target vector
     """
 
-    @dataset_fetch_retry
-    def _fetch_20news():
-        return fetch_20newsgroups(
+    try:
+        twenty_train = fetch_20newsgroups(
             subset="train", shuffle=True, random_state=42
         )
-
-    try:
-        twenty_train = _fetch_20news()
     except Exception as e:
         pytest.xfail(f"Error fetching 20 newsgroup dataset: {str(e)}")
 
@@ -477,12 +473,8 @@ def housing_dataset():
         vector, and feature_names is a list of feature names
     """
 
-    @dataset_fetch_retry
-    def _fetch_housing():
-        return fetch_california_housing()
-
     try:
-        data = _fetch_housing()
+        data = fetch_california_housing()
     except Exception as e:
         pytest.xfail(f"Error fetching housing dataset: {str(e)}")
 

--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -417,9 +417,6 @@ class DownloadDataPlugin:
             # the datasets we might use.
             fetch_20newsgroups()
             fetch_california_housing()
-            datasets.load_digits()
-            datasets.load_diabetes()
-            datasets.load_breast_cancer()
 
 
 def dataset_fetch_retry(func, attempts=3, min_wait=1, max_wait=10):


### PR DESCRIPTION
We do not need to "pre-fetch" these datasets as they are "baked in" to scikit-learn. So there is no downloading data involved.

I've run `git grep fetch_` to find out which datasets are used. This showed that `fetch_covtype` is used in a benchmarking script (`python/cuml/cuml/benchmark/datagen.py`). Otherwise we've got them all covered.

I've also removed the retry decorator, the `fetch_` functions already retry downloading the dataset, we don't need to retry the retrying.

We can't fully remove the retry decorator because we still rely on the deprecated boston housing dataset.