### PR TITLE
Move cert configuration to `pytest_configure` hook

### DIFF
--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -42,17 +42,6 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 pytest_plugins = "cuml.testing.plugins.quick_run_plugin"
 
 
-def pytest_sessionstart(session):
-    """Initialize SSL certificates for secure HTTP connections.
-
-    This function is called at the start of the test session to ensure
-    proper SSL certificate handling for dataset downloads.
-    """
-    ssl_context = create_default_context(cafile=certifi.where())
-    https_handler = HTTPSHandler(context=ssl_context)
-    install_opener(build_opener(https_handler))
-
-
 # =============================================================================
 # Test Configuration Constants
 # =============================================================================
@@ -263,6 +252,12 @@ def pytest_configure(config):
         hypothesis.settings.load_profile("quality")
     else:
         hypothesis.settings.load_profile("unit")
+
+    # Initialize SSL certificates for secure HTTP connections. This ensures
+    # we use the certifi certs for all urllib downloads.
+    ssl_context = create_default_context(cafile=certifi.where())
+    https_handler = HTTPSHandler(context=ssl_context)
+    install_opener(build_opener(https_handler))
 
     config.pluginmanager.register(DownloadDataPlugin(), "download_data")
 

--- a/python/cuml/tests/dask/conftest.py
+++ b/python/cuml/tests/dask/conftest.py
@@ -1,21 +1,9 @@
 # Copyright (c) 2020-2025, NVIDIA CORPORATION.
-
-from ssl import create_default_context
-from urllib.request import HTTPSHandler, build_opener, install_opener
-
-import certifi
 import pytest
 
 enable_tcp_over_ucx = True
 enable_nvlink = False
 enable_infiniband = False
-
-
-# Install SSL certificates
-def pytest_sessionstart(session):
-    ssl_context = create_default_context(cafile=certifi.where())
-    https_handler = HTTPSHandler(context=ssl_context)
-    install_opener(build_opener(https_handler))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Previously we had a `pytest_sessionstart` hook setup to install certifi certs to be used by `urllib` when downloading datasets. Recently we also added a `pytest_configure` hook to predownload the datasets at the start of the test run.

`pytest_configure` runs before `pytest_sessionstart`, which means the downloads were no longer using the certifi certs. This PR moves the cert install to also be part of `pytest_configure` and explicitly earlier than the downloads, fixing the problem.

Also removes the duplicate hook in the dask conftest file, there's no reason for that to be there, the parent `conftest.py` is already used.