### PR TITLE
Support non-contiguous input in `input_to_host_array`

### DIFF
--- a/python/cuml/cuml/internals/array.py
+++ b/python/cuml/cuml/internals/array.py
@@ -612,7 +612,7 @@ class CumlArray:
                         )
                 return cp.asnumpy(
                     cp_arr,
-                    order=self.order,
+                    order=self.order or "A",  # self.order may be None
                 )
             return output_mem_type.xpy.asarray(
                 self, dtype=output_dtype, order=self.order

--- a/python/cuml/tests/test_input_utils.py
+++ b/python/cuml/tests/test_input_utils.py
@@ -194,6 +194,22 @@ def test_input_to_host_array(dtype, input_type, num_rows, num_cols, order):
     del real_data
 
 
+@pytest.mark.parametrize("dtype", test_dtypes_acceptable)
+@pytest.mark.parametrize("input_type", ["numpy", "cupy"])
+@pytest.mark.parametrize("order", ["C", "F", "K"])
+def test_non_contiguous_input_to_host_array(dtype, input_type, order):
+    input_data, real_data = get_input(input_type, 10, 8, dtype)
+    input_data = input_data[:-3]
+    real_data = real_data[:-3]
+
+    res = input_to_host_array(input_data, order=order).array
+    np.testing.assert_equal(real_data, res)
+    if order == "F":
+        assert res.flags.f_contiguous
+    else:
+        assert res.flags.c_contiguous
+
+
 @pytest.mark.parametrize("dtype", test_dtypes_all)
 @pytest.mark.parametrize("check_dtype", test_dtypes_all)
 @pytest.mark.parametrize("input_type", test_input_types)


### PR DESCRIPTION
Previously passing a non-contiguous cupy array to `input_to_host_array` could result in a runtime error. This is because:

- `CumlArray.order` may be `None` if the input isn't C or F contiguous
- `cupy.asnumpy` has an `order` kwarg, but unlike `asarray` this cannot be `None`.

The solution is to use the default of `'A'` in cases where the order input isn't contiguous.

Fixes #7205.