### PR TITLE
Validate `sample_weight` in `KernelDensity.fit`

### DIFF
--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -255,23 +255,25 @@ class KernelDensity(Base):
         self : object
             Returns the instance itself.
         """
-        if sample_weight is not None:
-            self.sample_weight_ = input_to_cupy_array(
-                sample_weight,
-                convert_to_dtype=(np.float32 if convert_dtype else None),
-                check_dtype=[cp.float32, cp.float64],
-            ).array
-            if self.sample_weight_.min() <= 0:
-                raise ValueError("sample_weight must have positive values")
-        else:
-            self.sample_weight_ = None
-
         self.X_ = input_to_cupy_array(
             X,
             order="C",
             convert_to_dtype=(np.float32 if convert_dtype else None),
             check_dtype=[cp.float32, cp.float64],
         ).array
+
+        if sample_weight is not None:
+            self.sample_weight_ = input_to_cupy_array(
+                sample_weight,
+                convert_to_dtype=(np.float32 if convert_dtype else None),
+                check_dtype=[cp.float32, cp.float64],
+                check_cols=1,
+                check_rows=self.X_.shape[0],
+            ).array
+            if self.sample_weight_.min() <= 0:
+                raise ValueError("sample_weight must have positive values")
+        else:
+            self.sample_weight_ = None
 
         return self
 

--- a/python/cuml/tests/test_kernel_density.py
+++ b/python/cuml/tests/test_kernel_density.py
@@ -195,3 +195,16 @@ def test_not_fitted():
         kde.sample(X)
     with pytest.raises(NotFittedError):
         kde.score_samples(X)
+
+
+def test_bad_sample_weight_errors():
+    kde = KernelDensity()
+    X = np.array([[0.0, 1.0], [2.0, 0.5]])
+
+    with pytest.raises(ValueError, match="Expected 2 rows but got 3 rows."):
+        kde.fit(X, sample_weight=np.array([1, 2, 3]))
+
+    with pytest.raises(
+        ValueError, match="Expected 1 columns but got 2 columns."
+    ):
+        kde.fit(X, sample_weight=np.array([[1, 2], [3, 4]]))


### PR DESCRIPTION
Previously we weren't checking the `sample_weight` arg was the right shape, now we do.

Fixes #7204.