### PR TITLE
Fixup `StandardScaler.n_samples_seen_`

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -786,7 +786,7 @@ class StandardScaler(TransformerMixin,
         # missing values)
         ptp = np.amax(self.n_samples_seen_) - np.amin(self.n_samples_seen_)
         if ptp == 0:
-            self.n_samples_seen_ = self.n_samples_seen_[0]
+            self.n_samples_seen_ = self.n_samples_seen_[0].item()
         del ptp
 
         if self.with_std:

--- a/python/cuml/tests/test_preprocessing.py
+++ b/python/cuml/tests/test_preprocessing.py
@@ -165,6 +165,8 @@ def test_standard_scaler_sparse(
     if scipy.sparse.issparse(t_X):
         assert scipy.sparse.issparse(r_X)
 
+    assert scaler.n_samples_seen_ == X.shape[0]
+
     scaler = skStandardScaler(copy=True, with_mean=False, with_std=with_std)
     sk_t_X = scaler.fit_transform(X_np)
     sk_r_X = scaler.inverse_transform(sk_t_X)


### PR DESCRIPTION
Previously accessing `n_samples_seen_` would sometimes error as the input was a cupy 0-dim array rather than a scalar. We now always store this as either an integer or a non-0-dim array.

Fixes #7200.