### PR TITLE
Improve performance of `KernelDensity`'s `logsumexp_kernel`

### DIFF
--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -362,7 +362,7 @@ class KernelDensity(Base):
         if self.sample_weight_ is not None:
             distances += cp.log(self.sample_weight_)
 
-        logsumexp_kernel[(log_probabilities.size,),(256,)](
+        logsumexp_kernel[(log_probabilities.size,), (256,)](
             distances, log_probabilities
         )
         # Note that sklearns user guide is wrong

--- a/python/cuml/tests/test_kernel_density.py
+++ b/python/cuml/tests/test_kernel_density.py
@@ -162,11 +162,11 @@ def test_kernel_density(arrays, kernel, metric, bandwidth):
 def test_logaddexp():
     X = np.array([[0.0, 0.0], [0.0, 0.0]])
     out = np.zeros(X.shape[0])
-    logsumexp_kernel.forall(out.size)(X, out)
+    logsumexp_kernel[(out.size,), (256,)](X, out)
     assert np.allclose(out, np.logaddexp.reduce(X, axis=1))
 
     X = np.array([[3.0, 1.0], [0.2, 0.7]])
-    logsumexp_kernel.forall(out.size)(X, out)
+    logsumexp_kernel[(out.size,), (256,)](X, out)
     assert np.allclose(out, np.logaddexp.reduce(X, axis=1))
 
 


### PR DESCRIPTION
This speeds up KernelDensity's `logsumexp_kernel` by switching to more efficient block row based kernel.