### PR TITLE
DOC Rework LinearRegression documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,8 +184,11 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
+    "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 # Config numpydoc

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -140,9 +140,10 @@ class LinearRegression(Base,
     LinearRegression is a simple machine learning model where the response y is
     modelled by a linear combination of the predictors in X.
 
-    cuML's LinearRegression expects either a cuDF DataFrame or a NumPy matrix
-    and provides 2 algorithms SVD and Eig to fit a linear model. SVD is more
-    stable, but Eig (default) is much faster.
+    cuML's LinearRegression expects either a :class:`cudf.DataFrame` or a
+    :class:`numpy.ndarray` (matrix), and offers two algorithms: Singular Value
+    Decomposition (SVD) and Eigndecomposition (Eig) to fit a linear model.
+    SVD is more numerically stable, but Eig (the default) is much faster.
 
     Examples
     --------
@@ -184,19 +185,19 @@ class LinearRegression(Base,
     algorithm : {'svd', 'eig', 'qr', 'svd-qr', 'svd-jacobi'}, (default = 'eig')
         Choose an algorithm:
 
-          * 'svd' - alias for svd-jacobi;
-          * 'eig' - use an eigendecomposition of the covariance matrix;
-          * 'qr'  - use QR decomposition algorithm and solve `Rx = Q^T y`
-          * 'svd-qr' - compute SVD decomposition using QR algorithm
-          * 'svd-jacobi' - compute SVD decomposition using Jacobi iterations.
+          * ``'svd'`` - alias for svd-jacobi;
+          * ``'eig'`` - use an eigendecomposition of the covariance matrix;
+          * ``'qr'``  - use QR decomposition algorithm and solve `Rx = Q^T y`
+          * ``'svd-qr'`` - compute SVD decomposition using QR algorithm
+          * ``'svd-jacobi'`` - compute SVD decomposition using Jacobi iterations.
 
-        Among these algorithms, only 'svd-jacobi' supports the case when the
+        Among these algorithms, only ``'svd-jacobi'`` supports the case when the
         number of features is larger than the sample size; this algorithm
         is force-selected automatically in such a case.
 
-        For the broad range of inputs, 'eig' and 'qr' are usually the fastest,
-        followed by 'svd-jacobi' and then 'svd-qr'. In theory, SVD-based
-        algorithms are more stable.
+        For the broad range of inputs, ``'eig'`` and ``'qr'`` are usually the fastest,
+        followed by ``'svd-jacobi'`` and then ``'svd-qr'``. In theory, `svd`-based
+        algorithms are more numerically stable.
     fit_intercept : boolean (default = True)
         If True, LinearRegression tries to correct for the global mean of y.
         If False, the model expects that you have centered the data.
@@ -204,14 +205,22 @@ class LinearRegression(Base,
         If True, it is guaranteed that a copy of X is created, leaving the
         original X unchanged. However, if set to False, X may be modified
         directly, which would reduce the memory usage of the estimator.
+        
+        .. versionchanged:: 23.08
+            Starting from version 23.08, the new `copy_X` parameter defaults
+            to ``True``, ensuring a copy of X is created after passing it to
+            `fit()`, preventing any changes to the input, but with increased
+            memory usage. This represents a change in behavior from previous
+            versions. With `copy_X=False` a copy might still be created if
+            necessary.
     normalize : boolean (default = False)
         This parameter is ignored when `fit_intercept` is set to False.
         If True, the predictors in X will be normalized by dividing by the
         column-wise standard deviation.
         If False, no scaling will be done.
         Note: this is in contrast to sklearn's deprecated `normalize` flag,
-        which divides by the column-wise L2 norm; but this is the same as if
-        using sklearn's StandardScaler.
+        which divides by the column-wise L2-norm; but this is the same as if
+        using :class:`sklearn.preprocessing.StandardScaler`.
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
@@ -240,9 +249,9 @@ class LinearRegression(Base,
     -----
     LinearRegression suffers from multicollinearity (when columns are
     correlated with each other), and variance explosions from outliers.
-    Consider using Ridge Regression to fix the multicollinearity problem, and
-    consider maybe first DBSCAN to remove the outliers, or statistical analysis
-    to filter possible outliers.
+    Consider using :class:`Ridge` to fix the multicollinearity problem, and
+    consider maybe first :class:`DBSCAN` to remove the outliers, or 
+    statistical analysis to filter possible outliers.
 
     **Applications of LinearRegression**
 
@@ -252,18 +261,11 @@ class LinearRegression(Base,
         tasks. This model should be first tried if the machine learning problem
         is a regression task (predicting a continuous variable).
 
-    For additional information, see `scikitlearn's OLS documentation
-    <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html>`__.
+    For additional information, see scikit-learn's documentation for
+    :class:`sklearn.linear_model.LinearRegression`.
 
     For an additional example see `the OLS notebook
     <https://github.com/rapidsai/cuml/blob/main/notebooks/linear_regression_demo.ipynb>`__.
-
-    .. note:: Starting from version 23.08, the new 'copy_X' parameter defaults
-              to 'True', ensuring a copy of X is created after passing it to
-              fit(), preventing any changes to the input, but with increased
-              memory usage. This represents a change in behavior from previous
-              versions. With `copy_X=False` a copy might still be created if
-              necessary.
     """
 
     coef_ = CumlArrayDescriptor(order='F')


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #1447

#### What does this implement/fix? Explain your changes.

Rework the [Linear Regression](https://docs.rapids.ai/api/cuml/stable/api/#linear-regression) documentation.

Additionally, adds `cudf`, `numpy`, and `sklearn` to the Sphinx configuration file to enable cross-library references in the future.

#### Any other comments?

N/A
