### PR TITLE
Accelerate `KernelDensity.score_samples`

### DIFF
--- a/python/cuml/cuml/neighbors/__init__.py
+++ b/python/cuml/cuml/neighbors/__init__.py
@@ -14,11 +14,7 @@
 # limitations under the License.
 #
 
-from cuml.neighbors.kernel_density import (
-    VALID_KERNELS,
-    KernelDensity,
-    logsumexp_kernel,
-)
+from cuml.neighbors.kernel_density import VALID_KERNELS, KernelDensity
 from cuml.neighbors.kneighbors_classifier import KNeighborsClassifier
 from cuml.neighbors.kneighbors_regressor import KNeighborsRegressor
 from cuml.neighbors.nearest_neighbors import NearestNeighbors, kneighbors_graph

--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -19,7 +19,6 @@ import math
 import cupy as cp
 import numpy as np
 from cupyx.scipy.special import gammainc
-from numba import cuda
 
 from cuml.common.exceptions import NotFittedError
 from cuml.internals.base import Base
@@ -135,19 +134,17 @@ def norm_log_probabilities(log_probabilities, kernel, h, d):
     return log_probabilities - (factor + d * np.log(h))
 
 
-@cuda.jit()
-def logsumexp_kernel(distances, log_probabilities):
-    i = cuda.grid(1)
-    if i >= log_probabilities.size:
-        return
-    max_exp = distances[i, 0]
-    for j in range(1, distances.shape[1]):
-        if distances[i, j] > max_exp:
-            max_exp = distances[i, j]
-    sum = 0.0
-    for j in range(0, distances.shape[1]):
-        sum += math.exp(distances[i, j] - max_exp)
-    log_probabilities[i] = math.log(sum) + max_exp
+# Implements a reduction similar to `numpy.logaddexp.reduce`. `cupy` currently
+# does not support this method natively: https://github.com/cupy/cupy/issues/9391
+logaddexp_reduce = cp.ReductionKernel(
+    "T d",
+    "T out",
+    "exp(d)",
+    "a + b",
+    "out = log(a)",
+    "0",
+    "logaddexp_reduce",
+)
 
 
 class KernelDensity(Base):
@@ -326,13 +323,18 @@ class KernelDensity(Base):
         else:
             raise ValueError("Unsupported kernel.")
 
-        log_probabilities = cp.zeros(distances.shape[0])
         if self.sample_weight_ is not None:
             distances += cp.log(self.sample_weight_)
 
-        logsumexp_kernel.forall(log_probabilities.size)(
-            distances, log_probabilities
-        )
+        # To avoid overflow, we apply
+        # log(exp(x).sum()) -> log(exp(x - x.max())) + x.max()
+        # We subtract the max inplace to avoid an extra allocation,
+        # since `distances` is no longer needed after this point.
+        max_distances = distances.max(axis=1)
+        distances -= max_distances[:, None]
+        log_probabilities = logaddexp_reduce(distances, axis=1)
+        log_probabilities += max_distances
+
         # Note that sklearns user guide is wrong
         # It says the (unnormalised) probability output for
         #  the kernel density is sum(K(x,h)).

--- a/python/cuml/tests/test_kernel_density.py
+++ b/python/cuml/tests/test_kernel_density.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import cupy as cp
 import numpy as np
 import pytest
 from hypothesis import assume, example, given, settings
@@ -24,7 +25,8 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors._ball_tree import kernel_norm
 
 from cuml.common.exceptions import NotFittedError
-from cuml.neighbors import VALID_KERNELS, KernelDensity, logsumexp_kernel
+from cuml.neighbors import VALID_KERNELS, KernelDensity
+from cuml.neighbors.kernel_density import logaddexp_reduce
 from cuml.testing.utils import as_type
 
 
@@ -159,14 +161,13 @@ def test_kernel_density(arrays, kernel, metric, bandwidth):
             kde.sample(100)
 
 
-def test_logaddexp():
+def test_logaddexp_reduce():
     X = np.array([[0.0, 0.0], [0.0, 0.0]])
-    out = np.zeros(X.shape[0])
-    logsumexp_kernel.forall(out.size)(X, out)
+    out = logaddexp_reduce(cp.asarray(X), axis=1).get()
     assert np.allclose(out, np.logaddexp.reduce(X, axis=1))
 
     X = np.array([[3.0, 1.0], [0.2, 0.7]])
-    logsumexp_kernel.forall(out.size)(X, out)
+    out = logaddexp_reduce(cp.asarray(X), axis=1).get()
     assert np.allclose(out, np.logaddexp.reduce(X, axis=1))
 
 


### PR DESCRIPTION
This does away with the handwritten numba kernel entirely, replacing it with a `cupy.ReductionKernel` (until `cp.logaddexp.reduce` is implemented). This scales _much_ better than the old implementation (5000x on large inputs when benchmarking just this part of the kernel). For the whole `score_samples` routine we see a more modest 2-5x speedup on typical problem sizes.

Supersedes #7211.