### PR TITLE
UMAP with `int64_t` spectral initialization

### DIFF
--- a/cpp/include/cuml/manifold/spectral_embedding.hpp
+++ b/cpp/include/cuml/manifold/spectral_embedding.hpp
@@ -18,6 +18,8 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resources.hpp>
 
+#include <cstdint>
+
 namespace cuvs::preprocessing::spectral_embedding {
 
 struct params;
@@ -60,9 +62,26 @@ void transform(raft::resources const& handle,
 
 void transform(raft::resources const& handle,
                ML::SpectralEmbedding::params config,
+               raft::device_coo_matrix_view<float, int, int, int64_t> connectivity_graph,
+               raft::device_matrix_view<float, int, raft::col_major> embedding);
+
+void transform(raft::resources const& handle,
+  ML::SpectralEmbedding::params config,
+  raft::device_coo_matrix_view<float, int64_t, int64_t, int64_t> connectivity_graph,
+  raft::device_matrix_view<float, int64_t, raft::col_major> embedding);
+
+void transform(raft::resources const& handle,
+               ML::SpectralEmbedding::params config,
                raft::device_vector_view<int, int> rows,
                raft::device_vector_view<int, int> cols,
                raft::device_vector_view<float, int> vals,
+               raft::device_matrix_view<float, int, raft::col_major> embedding);
+
+void transform(raft::resources const& handle,
+               ML::SpectralEmbedding::params config,
+               raft::device_vector_view<int, int64_t> rows,
+               raft::device_vector_view<int, int64_t> cols,
+               raft::device_vector_view<float, int64_t> vals,
                raft::device_matrix_view<float, int, raft::col_major> embedding);
 
 }  // namespace ML::SpectralEmbedding

--- a/cpp/src/spectral/spectral_embedding.cu
+++ b/cpp/src/spectral/spectral_embedding.cu
@@ -22,6 +22,8 @@
 
 #include <cuvs/preprocessing/spectral_embedding.hpp>
 
+#include <cstdint>
+
 namespace ML::SpectralEmbedding {
 
 cuvs::preprocessing::spectral_embedding::params to_cuvs(ML::SpectralEmbedding::params& config)
@@ -56,6 +58,24 @@ void transform(raft::resources const& handle,
 
 void transform(raft::resources const& handle,
                ML::SpectralEmbedding::params config,
+               raft::device_coo_matrix_view<float, int, int, int64_t> connectivity_graph,
+               raft::device_matrix_view<float, int, raft::col_major> embedding)
+{
+  cuvs::preprocessing::spectral_embedding::transform(
+    handle, to_cuvs(config), connectivity_graph, embedding);
+}
+
+void transform(raft::resources const& handle,
+  ML::SpectralEmbedding::params config,
+  raft::device_coo_matrix_view<float, int64_t, int64_t, int64_t> connectivity_graph,
+  raft::device_matrix_view<float, int64_t, raft::col_major> embedding)
+{
+  cuvs::preprocessing::spectral_embedding::transform(
+  handle, to_cuvs(config), connectivity_graph, embedding);
+}
+
+void transform(raft::resources const& handle,
+               ML::SpectralEmbedding::params config,
                raft::device_vector_view<int, int> rows,
                raft::device_vector_view<int, int> cols,
                raft::device_vector_view<float, int> vals,
@@ -68,6 +88,24 @@ void transform(raft::resources const& handle,
                                                                embedding.extent(0),
                                                                embedding.extent(0),
                                                                vals.size()));
+
+  ML::SpectralEmbedding::transform(handle, config, connectivity_graph_view, embedding);
+}
+
+void transform(raft::resources const& handle,
+               ML::SpectralEmbedding::params config,
+               raft::device_vector_view<int, int64_t> rows,
+               raft::device_vector_view<int, int64_t> cols,
+               raft::device_vector_view<float, int64_t> vals,
+               raft::device_matrix_view<float, int, raft::col_major> embedding)
+{
+  auto connectivity_graph_view = raft::make_device_coo_matrix_view<float, int, int, int64_t>(
+    vals.data_handle(),
+    raft::make_device_coordinate_structure_view<int, int, int64_t>(rows.data_handle(),
+                                                                    cols.data_handle(),
+                                                                    embedding.extent(0),
+                                                                    embedding.extent(0),
+                                                                    vals.size()));
 
   ML::SpectralEmbedding::transform(handle, config, connectivity_graph_view, embedding);
 }


### PR DESCRIPTION
For larger datasets UMAP dispatches a COO matrix with `uint64_t` nnz template types. This PR add support to correctly forward this template type to spectral initialization.