### PR TITLE
Add `cuml.metrics.median_absolute_error`

### DIFF
--- a/python/cuml/cuml/metrics/__init__.py
+++ b/python/cuml/cuml/metrics/__init__.py
@@ -46,6 +46,7 @@ from cuml.metrics.regression import (
     mean_absolute_error,
     mean_squared_error,
     mean_squared_log_error,
+    median_absolute_error,
     r2_score,
 )
 from cuml.metrics.trustworthiness import trustworthiness
@@ -56,6 +57,7 @@ __all__ = [
     "mean_squared_error",
     "mean_squared_log_error",
     "mean_absolute_error",
+    "median_absolute_error",
     "accuracy_score",
     "adjusted_rand_score",
     "roc_auc_score",

--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -571,6 +571,7 @@ def test_completeness_score_big_array(use_handle, input_range):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )
@@ -593,6 +594,7 @@ def test_regression_metrics(n_samples, y_dtype, pred_dtype, func):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )
@@ -612,6 +614,7 @@ def test_regression_metrics_cudf(func):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )
@@ -632,6 +635,7 @@ def test_regression_metrics_zero_error(func):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )
@@ -653,6 +657,7 @@ def test_regression_metrics_multioutput(func):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )
@@ -674,6 +679,7 @@ def test_regression_metrics_multioutput_raw_values(func):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )
@@ -696,6 +702,7 @@ def test_regression_metrics_multioutput_custom_weights(func):
         "r2_score",
         "mean_squared_error",
         "mean_absolute_error",
+        "median_absolute_error",
         "mean_squared_log_error",
     ],
 )


### PR DESCRIPTION
This adds a new `median_absolute_error` metric, modeled after the sklearn metric of the same name.

This was motivated by `cuml.ensemble.RandomForestRegressor` supporting this as a builtin metric. We've deprecated that functionality (see #7170); `median_absolute_error` was the only metric it supported that didn't already exist in `cuml.metrics`.