### PR TITLE
Use `except +` everywhere in cython

### DIFF
--- a/python/cuml/cuml/cluster/hdbscan/headers.pxd
+++ b/python/cuml/cuml/cluster/hdbscan/headers.pxd
@@ -26,7 +26,7 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common" nogi
         LEAF "ML::HDBSCAN::Common::CLUSTER_SELECTION_METHOD::LEAF"
 
     cdef cppclass CondensedHierarchy[value_idx, value_t]:
-        CondensedHierarchy(const handle_t &handle, size_t n_leaves)
+        CondensedHierarchy(const handle_t &handle, size_t n_leaves) except +
 
         CondensedHierarchy(const handle_t& handle_,
                            size_t n_leaves_,
@@ -34,15 +34,15 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common" nogi
                            value_idx* parents_,
                            value_idx* children_,
                            value_t* lambdas_,
-                           value_idx* sizes_)
+                           value_idx* sizes_) except +
 
-        value_idx *get_parents()
-        value_idx *get_children()
-        value_t *get_lambdas()
-        value_idx *get_sizes()
-        value_idx get_n_edges()
-        value_idx get_n_leaves()
-        int get_n_clusters()
+        value_idx *get_parents() except +
+        value_idx *get_children() except +
+        value_t *get_lambdas() except +
+        value_idx *get_sizes() except +
+        value_idx get_n_edges() except +
+        value_idx get_n_leaves() except +
+        int get_n_clusters() except +
 
     cdef cppclass hdbscan_output[int, float]:
         hdbscan_output(const handle_t &handle,
@@ -54,14 +54,14 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common" nogi
                        float *deltas,
                        int *mst_src,
                        int *mst_dst,
-                       float *mst_weights)
-        int get_n_leaves()
-        int get_n_clusters()
-        float *get_stabilities()
-        int *get_labels()
-        int *get_inverse_label_map()
-        float *get_core_dists()
-        CondensedHierarchy[int, float] &get_condensed_tree()
+                       float *mst_weights) except +
+        int get_n_leaves() except +
+        int get_n_clusters() except +
+        float *get_stabilities() except +
+        int *get_labels() except +
+        int *get_inverse_label_map() except +
+        float *get_core_dists() except +
+        CondensedHierarchy[int, float] &get_condensed_tree() except +
 
     cdef cppclass HDBSCANParams:
         int min_samples
@@ -78,7 +78,7 @@ cdef extern from "cuml/cluster/hdbscan.hpp" namespace "ML::HDBSCAN::Common" nogi
         PredictionData(const handle_t &handle,
                        int m,
                        int n,
-                       float *core_dists)
+                       float *core_dists) except +
 
         size_t n_rows
         size_t n_cols

--- a/python/cuml/cuml/datasets/arima.pyx
+++ b/python/cuml/cuml/datasets/arima.pyx
@@ -41,7 +41,7 @@ cdef extern from "cuml/datasets/make_arima.hpp" namespace "ML" nogil:
         float noise_scale,
         float intercept_scale,
         uint64_t seed
-    )
+    ) except +
 
     void cpp_make_arima "ML::Datasets::make_arima" (
         const handle_t& handle,
@@ -53,7 +53,7 @@ cdef extern from "cuml/datasets/make_arima.hpp" namespace "ML" nogil:
         double noise_scale,
         double intercept_scale,
         uint64_t seed
-    )
+    ) except +
 
 
 inp_to_dtype = {

--- a/python/cuml/cuml/datasets/regression.pyx
+++ b/python/cuml/cuml/datasets/regression.pyx
@@ -46,7 +46,7 @@ cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML" nogil:
         float tail_strength,
         float noise,
         bool shuffle,
-        uint64_t seed)
+        uint64_t seed) except +
 
     void cpp_make_regression "ML::Datasets::make_regression" (
         const handle_t& handle,
@@ -62,7 +62,7 @@ cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML" nogil:
         double tail_strength,
         double noise,
         bool shuffle,
-        uint64_t seed)
+        uint64_t seed) except +
 
 inp_to_dtype = {
     'single': np.float32,

--- a/python/cuml/cuml/ensemble/randomforest_shared.pxd
+++ b/python/cuml/cuml/ensemble/randomforest_shared.pxd
@@ -107,4 +107,4 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
                                  int,
                                  int) except +
 
-    cdef vector[unsigned char] save_model(TreeliteModelHandle)
+    cdef vector[unsigned char] save_model(TreeliteModelHandle) except +

--- a/python/cuml/cuml/manifold/simpl_set.pyx
+++ b/python/cuml/cuml/manifold/simpl_set.pyx
@@ -43,7 +43,7 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP" nogil:
                               int d,
                               int64_t* knn_indices,
                               float* knn_dists,
-                              UMAPParams* params)
+                              UMAPParams* params) except +
 
     void refine(handle_t &handle,
                 float* X,
@@ -51,7 +51,7 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP" nogil:
                 int d,
                 COO* cgraph_coo,
                 UMAPParams* params,
-                float* embeddings)
+                float* embeddings) except +
 
     void init_and_refine(handle_t &handle,
                          float* X,
@@ -59,7 +59,7 @@ cdef extern from "cuml/manifold/umap.hpp" namespace "ML::UMAP" nogil:
                          int d,
                          COO* cgraph_coo,
                          UMAPParams* params,
-                         float* embeddings)
+                         float* embeddings) except +
 
 
 def fuzzy_simplicial_set(X,

--- a/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -31,7 +31,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
     double adjusted_rand_index(handle_t &handle,
                                int *y,
                                int *y_hat,
-                               int n)
+                               int n) except +
 
 
 @cuml.internals.api_return_any()

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -50,10 +50,10 @@ cdef extern from "cuml/tsa/arima_common.h" namespace "ML" nogil:
 
     cdef cppclass ARIMAMemory[DataT]:
         ARIMAMemory(const ARIMAOrder& order, int batch_size, int n_obs,
-                    char* in_buf)
+                    char* in_buf) except +
 
         @staticmethod
-        size_t compute_size(const ARIMAOrder& order, int batch_size, int n_obs)
+        size_t compute_size(const ARIMAOrder& order, int batch_size, int n_obs) except +
 
 
 cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML" nogil:
@@ -61,55 +61,55 @@ cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML" nogil:
 
     void cpp_pack "pack" (
         handle_t& handle, const ARIMAParams[double]& params,
-        const ARIMAOrder& order, int batch_size, double* param_vec)
+        const ARIMAOrder& order, int batch_size, double* param_vec) except +
 
     void cpp_unpack "unpack" (
         handle_t& handle, ARIMAParams[double]& params,
-        const ARIMAOrder& order, int batch_size, const double* param_vec)
+        const ARIMAOrder& order, int batch_size, const double* param_vec) except +
 
     bool detect_missing(
-        handle_t& handle, const double* d_y, int n_elem)
+        handle_t& handle, const double* d_y, int n_elem) except +
 
     void batched_diff(
         handle_t& handle, double* d_y_diff, const double* d_y, int batch_size,
-        int n_obs, const ARIMAOrder& order)
+        int n_obs, const ARIMAOrder& order) except +
 
     void batched_loglike(
         handle_t& handle, const ARIMAMemory[double]& arima_mem,
         const double* y, const double* d_exog, int batch_size, int nobs,
         const ARIMAOrder& order, const double* params, double* loglike,
-        bool trans, bool host_loglike, LoglikeMethod method, int truncate)
+        bool trans, bool host_loglike, LoglikeMethod method, int truncate) except +
 
     void batched_loglike(
         handle_t& handle, const ARIMAMemory[double]& arima_mem,
         const double* y, const double* d_exog, int batch_size, int n_obs,
         const ARIMAOrder& order, const ARIMAParams[double]& params,
         double* loglike, bool trans, bool host_loglike, LoglikeMethod method,
-        int truncate)
+        int truncate) except +
 
     void batched_loglike_grad(
         handle_t& handle, const ARIMAMemory[double]& arima_mem,
         const double* d_y, const double* d_exog, int batch_size, int nobs,
         const ARIMAOrder& order, const double* d_x, double* d_grad, double h,
-        bool trans, LoglikeMethod method, int truncate)
+        bool trans, LoglikeMethod method, int truncate) except +
 
     void cpp_predict "predict" (
         handle_t& handle, const ARIMAMemory[double]& arima_mem,
         const double* d_y, const double* d_exog, const double* d_exog_fut,
         int batch_size, int nobs, int start, int end, const ARIMAOrder& order,
         const ARIMAParams[double]& params, double* d_y_p, bool pre_diff,
-        double level, double* d_lower, double* d_upper)
+        double level, double* d_lower, double* d_upper) except +
 
     void information_criterion(
         handle_t& handle, const ARIMAMemory[double]& arima_mem,
         const double* d_y, const double* d_exog, int batch_size, int nobs,
         const ARIMAOrder& order, const ARIMAParams[double]& params,
-        double* ic, int ic_type)
+        double* ic, int ic_type) except +
 
     void estimate_x0(
         handle_t& handle, ARIMAParams[double]& params, const double* d_y,
         const double* d_exog, int batch_size, int nobs,
-        const ARIMAOrder& order, bool missing)
+        const ARIMAOrder& order, bool missing) except +
 
 
 cdef extern from "cuml/tsa/batched_kalman.hpp" namespace "ML" nogil:
@@ -117,7 +117,7 @@ cdef extern from "cuml/tsa/batched_kalman.hpp" namespace "ML" nogil:
     void batched_jones_transform(
         handle_t& handle, ARIMAMemory[double]& arima_mem,
         const ARIMAOrder& order, int batchSize, bool isInv,
-        const double* h_params, double* h_Tparams)
+        const double* h_params, double* h_Tparams) except +
 
 
 cdef class ARIMAParamsWrapper:

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -48,59 +48,59 @@ from cuml.tsa.stationarity import kpss_test
 
 cdef extern from "cuml/tsa/auto_arima.h" namespace "ML" nogil:
     int divide_by_mask_build_index(const handle_t& handle, const bool* mask,
-                                   int* index, int batch_size)
+                                   int* index, int batch_size) except +
 
     void divide_by_mask_execute(const handle_t& handle, const float* d_in,
                                 const bool* mask, const int* index,
                                 float* d_out0, float* d_out1, int batch_size,
-                                int n_obs)
+                                int n_obs) except +
     void divide_by_mask_execute(const handle_t& handle, const double* d_in,
                                 const bool* mask, const int* index,
                                 double* d_out0, double* d_out1,
-                                int batch_size, int n_obs)
+                                int batch_size, int n_obs) except +
     void divide_by_mask_execute(const handle_t& handle, const int* d_in,
                                 const bool* mask, const int* index,
                                 int* d_out0, int* d_out1, int batch_size,
-                                int n_obs)
+                                int n_obs) except +
 
     void divide_by_min_build_index(const handle_t& handle,
                                    const float* d_matrix, int* d_batch,
                                    int* d_index, int* h_size,
-                                   int batch_size, int n_sub)
+                                   int batch_size, int n_sub) except +
     void divide_by_min_build_index(const handle_t& handle,
                                    const double* d_matrix, int* d_batch,
                                    int* d_index, int* h_size,
-                                   int batch_size, int n_sub)
+                                   int batch_size, int n_sub) except +
 
     void divide_by_min_execute(const handle_t& handle, const float* d_in,
                                const int* d_batch, const int* d_index,
                                float** hd_out, int batch_size, int n_sub,
-                               int n_obs)
+                               int n_obs) except +
     void divide_by_min_execute(const handle_t& handle, const double* d_in,
                                const int* d_batch, const int* d_index,
                                double** hd_out, int batch_size, int n_sub,
-                               int n_obs)
+                               int n_obs) except +
     void divide_by_min_execute(const handle_t& handle, const int* d_in,
                                const int* d_batch, const int* d_index,
                                int** hd_out, int batch_size, int n_sub,
-                               int n_obs)
+                               int n_obs) except +
 
     void cpp_build_division_map "ML::build_division_map" (
         const handle_t& handle, const int* const* hd_id, const int* h_size,
-        int* d_id_to_pos, int* d_id_to_model, int batch_size, int n_sub)
+        int* d_id_to_pos, int* d_id_to_model, int batch_size, int n_sub) except +
 
     void cpp_merge_series "ML::merge_series" (
         const handle_t& handle, const float* const* hd_in,
         const int* d_id_to_pos, const int* d_id_to_sub, float* d_out,
-        int batch_size, int n_sub, int n_obs)
+        int batch_size, int n_sub, int n_obs) except +
     void cpp_merge_series "ML::merge_series" (
         const handle_t& handle, const double* const* hd_in,
         const int* d_id_to_pos, const int* d_id_to_sub, double* d_out,
-        int batch_size, int n_sub, int n_obs)
+        int batch_size, int n_sub, int n_obs) except +
 
 cdef extern from "cuml/tsa/batched_arima.hpp" namespace "ML" nogil:
     bool detect_missing(
-        handle_t& handle, const double* d_y, int n_elem)
+        handle_t& handle, const double* d_y, int n_elem) except +
 
 tests_map = {
     "kpss": kpss_test,

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -38,7 +38,7 @@ cdef extern from "cuml/tsa/stationarity.h" namespace "ML" nogil:
         int batch_size,
         int n_obs,
         int d, int D, int s,
-        float pval_threshold)
+        float pval_threshold) except +
 
     int cpp_kpss "ML::Stationarity::kpss_test" (
         const handle_t& handle,
@@ -47,7 +47,7 @@ cdef extern from "cuml/tsa/stationarity.h" namespace "ML" nogil:
         int batch_size,
         int n_obs,
         int d, int D, int s,
-        double pval_threshold)
+        double pval_threshold) except +
 
 
 @cuml.internals.api_return_array(input_arg="y", get_output_type=True)


### PR DESCRIPTION
Previously _most_ of our `libcuml` API calls were wrapped in cython with `except +` (which converts c++ exceptions to python exceptions). Not all were though. Without this, an exception raised in c++ will cause the process to terminate.

This PR goes through all of our `cdef extern` definitions and adds `except +` everywhere that it should be but was missing.

Followup for #7202: with this the bug there would have raised an exception rather than crashing.