### PR TITLE
`KernelDensity.score_samples` output type & dtype fixes

### DIFF
--- a/python/cuml/cuml/neighbors/kernel_density.py
+++ b/python/cuml/cuml/neighbors/kernel_density.py
@@ -21,6 +21,7 @@ import numpy as np
 from cupyx.scipy.special import gammainc
 
 from cuml.common.exceptions import NotFittedError
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cuml_array, input_to_cupy_array
 from cuml.metrics import pairwise_distances
@@ -53,20 +54,12 @@ def tophat_log_kernel(x, h):
 
 
 @cp.fuse()
-def _epanechnikov_log_kernel(x, h, h_squared):
+def epanechnikov_log_kernel(x, h):
     # don't call log(0) otherwise we get NaNs
-    z = cp.maximum(1.0 - (x * x) / h_squared, 1e-30)
+    z = cp.maximum(1.0 - (x * x) / (h * h), 1e-30)
     y = (x < h) * cp.log(z)
     y += (x >= h) * np.finfo(y.dtype).min
     return y
-
-
-def epanechnikov_log_kernel(x, h):
-    # TODO: Due to https://github.com/cupy/cupy/issues/8536 cupy.fuse errors when trying
-    # to compile the elementwise operation in epanechnikov. Handling `h * h` on host
-    # (where `h` is a host scalar) seems to work around the bug completely. Once the upstream
-    # issue is fixed this can be reverted.
-    return _epanechnikov_log_kernel(x, h, h * h)
 
 
 @cp.fuse()
@@ -110,7 +103,7 @@ def logSn(n):
     return np.log(2 * np.pi) + logVn(n - 1)
 
 
-def norm_log_probabilities(log_probabilities, kernel, h, d):
+def norm_factor(kernel, h, d):
     if kernel == "gaussian":
         factor = 0.5 * d * np.log(2 * np.pi)
     elif kernel == "tophat":
@@ -131,7 +124,7 @@ def norm_log_probabilities(log_probabilities, kernel, h, d):
     else:
         raise ValueError("Unsupported kernel.")
 
-    return log_probabilities - (factor + d * np.log(h))
+    return factor + d * np.log(h)
 
 
 # Implements a reduction similar to `numpy.logaddexp.reduce`. `cupy` currently
@@ -274,7 +267,7 @@ class KernelDensity(Base):
 
         return self
 
-    def score_samples(self, X, *, convert_dtype=True):
+    def score_samples(self, X, *, convert_dtype=True) -> CumlArray:
         """Compute the log-likelihood of each sample under the model.
 
         Parameters
@@ -294,9 +287,10 @@ class KernelDensity(Base):
         """
         if not hasattr(self, "X_"):
             raise NotFittedError()
-        X_cuml = input_to_cuml_array(
+        X_m = input_to_cuml_array(
             X,
-            convert_to_dtype=(np.float32 if convert_dtype else None),
+            convert_to_dtype=(self.X_.dtype if convert_dtype else None),
+            check_dtype=[self.X_.dtype],
         )
         if self.metric_params:
             if len(self.metric_params) != 1:
@@ -305,21 +299,25 @@ class KernelDensity(Base):
                 )
             metric_arg = list(self.metric_params.values())[0]
             distances = pairwise_distances(
-                X_cuml.array,
+                X_m.array,
                 self.X_,
                 metric=self.metric,
                 metric_arg=metric_arg,
             )
         else:
             distances = pairwise_distances(
-                X_cuml.array, self.X_, metric=self.metric
+                X_m.array, self.X_, metric=self.metric
             )
 
         distances = cp.asarray(distances)
 
-        h = self.bandwidth
+        h = distances.dtype.type(self.bandwidth)
         if self.kernel in log_probability_kernels_:
-            distances = log_probability_kernels_[self.kernel](distances, h)
+            # XXX: passing `h` as a 0-dim array works around dtype inference
+            # issues in cupy.fuse. See https://github.com/cupy/cupy/issues/9400
+            distances = log_probability_kernels_[self.kernel](
+                distances, cp.array(h, dtype=distances.dtype)
+            )
         else:
             raise ValueError("Unsupported kernel.")
 
@@ -349,18 +347,16 @@ class KernelDensity(Base):
         log_probabilities -= np.log(sum_weights)
 
         # norm
-        if len(X_cuml.array.shape) == 1:
+        if len(X_m.array.shape) == 1:
             # if X is one dimensional, we have 1 feature
             dimension = 1
         else:
-            dimension = X_cuml.array.shape[1]
-        log_probabilities = norm_log_probabilities(
-            log_probabilities, self.kernel, h, dimension
-        )
+            dimension = X_m.array.shape[1]
+        log_probabilities -= norm_factor(self.kernel, h, dimension)
 
         return log_probabilities
 
-    def score(self, X, y=None):
+    def score(self, X, y=None) -> float:
         """Compute the total log-likelihood under the model.
 
         Parameters
@@ -380,7 +376,7 @@ class KernelDensity(Base):
             probability density, so the value will be low for high-dimensional
             data.
         """
-        return cp.sum(self.score_samples(X))
+        return float(cp.sum(self.score_samples(X).to_output("cupy")))
 
     def sample(self, n_samples=1, random_state=None):
         """


### PR DESCRIPTION
Previously `KernelDensity.score_samples`:

- Always returned a `cupy` array, instead of following our `output_type` handling conventions.
- Returned inconsistent `dtype`, depending on the kernel specified.

We now ensure that `output_type` is followed, and that the output type matches that of the original `X` input to `KernelDensity.fit` (matching our dtype conventions elsewhere).

This also fixes the overflow in a test function, which was caused by returning a `float32` from a `float64` input, leading to overflows in the test. To further avoid this I've updated the test code to apply float64 anyway just to be sure. To be clear - the overflow here was in our test code, not in `KernelDensity` itself.

Fixes #7236.