### PR TITLE
Fix test reference object in test_onehot_inverse_transform_handle_unknown

### DIFF
--- a/python/cuml/tests/test_one_hot_encoder.py
+++ b/python/cuml/tests/test_one_hot_encoder.py
@@ -36,7 +36,9 @@ def _from_df_to_cupy(df):
             if isinstance(df, pd.DataFrame):
                 df[col] = [ord(c) for c in df[col]]
             else:
-                df[col] = [ord(c) for c in df[col].values_host]
+                df[col] = [
+                    ord(c) if c is not None else c for c in df[col].values_host
+                ]
     return cp.array(from_df_to_numpy(df))
 
 
@@ -143,7 +145,7 @@ def test_onehot_inverse_transform_handle_unknown(as_array):
     ref = DataFrame({"chars": [None, "b"], "int": [0, 2]})
     if as_array:
         X = _from_df_to_cupy(X)
-        ref = DataFrame({0: [None, ord("b")], 1: [0, 2]})
+        ref = _from_df_to_cupy(ref)
 
     enc = OneHotEncoder(handle_unknown="ignore")
     enc = enc.fit(X)


### PR DESCRIPTION
It appears this test was failing since this test was trying to call `np.asarray` on a `cudf.DataFrame` which isn't supported https://github.com/rapidsai/cuml/actions/runs/17840162015/job/50731263271?pr=7243#step:10:1774

However this test was comparing a `cupy.array` input to a `cudf.DataFrame` output which seems incorrect give that the other related tests compare a `cupy.array` input to a `cupy.array` output, so this PR corrects this test to match the later pattern.