### PR TITLE
Revert "Extend nightlies breakage window (#7137)"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
-          max_days_without_success: 14
+          max_days_without_success: 7
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
This reverts commit 5453981b5956bc1e655c1b3832be6c9fbf82e85a.

Closes #7148.