### PR TITLE
Ensure sklearn roundtrip attribute consistency

### DIFF
--- a/python/cuml/cuml/manifold/spectral_embedding.pyx
+++ b/python/cuml/cuml/manifold/spectral_embedding.pyx
@@ -302,7 +302,7 @@ class SpectralEmbedding(Base,
     (100, 2)
     """
     _cpu_class_path = "sklearn.manifold.SpectralEmbedding"
-    embedding_ = CumlArrayDescriptor()
+    embedding_ = CumlArrayDescriptor(order="F")
 
     def __init__(self, n_components=2, affinity="nearest_neighbors",
                  random_state=None, n_neighbors=None,
@@ -345,15 +345,15 @@ class SpectralEmbedding(Base,
 
     def _attrs_from_cpu(self, model):
         return {
-            "n_neighbors_": to_gpu(model.n_neighbors_),
-            "embedding_": to_gpu(model.embedding_),
+            "n_neighbors_": model.n_neighbors_,
+            "embedding_": to_gpu(model.embedding_, order="F"),
             **super()._attrs_from_cpu(model)
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "n_neighbors_": to_cpu(self.n_neighbors_),
-            "embedding_": to_cpu(self.embedding_),
+            "n_neighbors_": self.n_neighbors_,
+            "embedding_": to_cpu(self.embedding_, order="F"),
             **super()._attrs_to_cpu(model),
         }
 

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -147,9 +147,9 @@ class KNeighborsClassifier(ClassifierMixin,
 
     def _attrs_from_cpu(self, model):
         if isinstance(model.classes_, list):
-            classes = [to_gpu(c) for c in model.classes_]
+            classes = [to_gpu(c, dtype=np.int32) for c in model.classes_]
         else:
-            classes = to_gpu(model.classes_)
+            classes = to_gpu(model.classes_, dtype=np.int32)
 
         return {
             "_classes": classes,

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -653,8 +653,8 @@ class SVMBase(Base,
                     shape=(self.n_support_, self.n_features_in_))
                 self.support_vectors_ = SparseCumlArray(data=sparse_input)
 
-        self.n_classes_ = n_classes
-        if self.n_classes_ > 0:
+        if n_classes > 0:
+            self.n_classes_ = n_classes
             self._unique_labels_ = CumlArray(
                 data=unique_labels,
                 shape=(self.n_classes_,),


### PR DESCRIPTION
This was motivated by a segfault in our sklearn test suite that turns out to be due to `SpectralEmbedding` having a C-contiguous array where an F-contiguous array was expected.

While fixing this, I added a generic test for attribute consistency, and fixed a few minor occurrences where we weren't 100% correct.

I was able to reproduce the segfault locally, and confirm that this PR fixes it.

Fixes #7274.