### PR TITLE
Ensure finite values passed to SpectralEmbedding

### DIFF
--- a/python/cuml/tests/test_spectral_embedding.py
+++ b/python/cuml/tests/test_spectral_embedding.py
@@ -232,6 +232,15 @@ def test_spectral_embedding_invalid_affinity():
         spectral_embedding(X, affinity="oops!")
 
 
+@pytest.mark.parametrize("value", [float("inf"), float("nan")])
+@pytest.mark.parametrize("affinity", ["nearest_neighbors", "precomputed"])
+def test_spectral_embedding_nonfinite(value, affinity):
+    X = np.array([[0, 1], [2, 3], [0, value]], dtype="float32")
+
+    with pytest.raises(ValueError, match="nonfinite"):
+        spectral_embedding(X, affinity=affinity)
+
+
 @pytest.mark.parametrize(
     "input_type,expected_type",
     [


### PR DESCRIPTION
The C++ implementation doesn't support non-finite values. Sometimes this results in a failure-to-converge error, sometimes this results in an illegal memory access (and downstream failures eventually leading to potential segfaults).

I _believe_ this to be the root cause of #7274 (if we see a failure, it's preceded by illegal memory accesses here). I've run things locally a bunch after this fix and haven't seen a failure, going to try it in CI.

Fixes #7274.