### PR TITLE
Avoid usage of deprecated cudf `from_pandas`

### DIFF
--- a/notebooks/random_forest_demo.ipynb
+++ b/notebooks/random_forest_demo.ipynb
@@ -104,8 +104,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "X_cudf_train = cudf.DataFrame.from_pandas(X_train)\n",
-    "X_cudf_test = cudf.DataFrame.from_pandas(X_test)\n",
+    "X_cudf_train = cudf.DataFrame(X_train)\n",
+    "X_cudf_test = cudf.DataFrame(X_test)\n",
     "\n",
     "y_cudf_train = cudf.Series(y_train.values)"
    ]

--- a/python/cuml/cuml/benchmark/datagen.py
+++ b/python/cuml/cuml/benchmark/datagen.py
@@ -361,9 +361,9 @@ def _convert_to_cudf(data):
     elif isinstance(data, (cudf.DataFrame, cudf.Series)):
         return data
     elif isinstance(data, pd.DataFrame):
-        return cudf.DataFrame.from_pandas(data)
+        return cudf.DataFrame(data)
     elif isinstance(data, pd.Series):
-        return cudf.Series.from_pandas(data)
+        return cudf.Series(data)
     elif isinstance(data, np.ndarray):
         data = np.squeeze(data)
         if data.ndim == 1:
@@ -411,11 +411,9 @@ def _convert_to_gpuarray(data, order="F"):
     elif isinstance(data, tuple):
         return tuple([_convert_to_gpuarray(d, order=order) for d in data])
     elif isinstance(data, pd.DataFrame):
-        return _convert_to_gpuarray(
-            cudf.DataFrame.from_pandas(data), order=order
-        )
+        return _convert_to_gpuarray(cudf.DataFrame(data), order=order)
     elif isinstance(data, pd.Series):
-        gs = cudf.Series.from_pandas(data)
+        gs = cudf.Series(data)
         return cuda.as_cuda_array(gs)
     else:
         return input_utils.input_to_cuml_array(data, order=order)[0].to_output(
@@ -575,10 +573,8 @@ def gen_data(
         if n_features == 0:
             n_features = X.shape[1]
 
-        X_df = cudf.DataFrame.from_pandas(
-            X.iloc[0:n_samples, 0:n_features].astype(dtype)
-        )
-        y_df = cudf.Series.from_pandas(y.iloc[0:n_samples].astype(dtype))
+        X_df = cudf.DataFrame(X.iloc[0:n_samples, 0:n_features].astype(dtype))
+        y_df = cudf.Series(y.iloc[0:n_samples].astype(dtype))
 
     data = (X_df, y_df)
     if test_fraction != 0.0:

--- a/python/cuml/cuml/internals/array.py
+++ b/python/cuml/cuml/internals/array.py
@@ -669,7 +669,7 @@ class CumlArray:
                 output_mem_type.is_device_accessible
                 and not self.mem_type.is_device_accessible
             ):
-                out_index = cudf.Index.from_pandas(self.index)
+                out_index = cudf.Index(self.index)
             elif (
                 output_mem_type.is_host_accessible
                 and not self.mem_type.is_host_accessible
@@ -1064,10 +1064,7 @@ class CumlArray:
             elif convert_to_mem_type is MemoryType.device and isinstance(
                 index, pd.Index
             ):
-                try:
-                    index = cudf.Index.from_pandas(index)
-                except TypeError:
-                    index = cudf.Index(index)
+                index = cudf.Index(index)
 
         if isinstance(X, cudf.Series):
             if X.null_count != 0:

--- a/python/cuml/cuml/testing/utils.py
+++ b/python/cuml/cuml/testing/utils.py
@@ -494,7 +494,7 @@ def generate_inputs_from_categories(
         if cudf_pandas_active:
             df = pandas_df
         else:
-            df = cudf.DataFrame.from_pandas(pandas_df)
+            df = cudf.DataFrame(pandas_df)
         return df, ary
 
 

--- a/python/cuml/tests/dask/test_dask_linear_regression.py
+++ b/python/cuml/tests/dask/test_dask_linear_regression.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.mg
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     workers = c.has_what().keys()
     n_partitions = partitions_per_worker * len(workers)
-    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X_train))
+    X_cudf = cudf.DataFrame(pd.DataFrame(X_train))
     X_train_df = dask_cudf.from_cudf(X_cudf, npartitions=n_partitions)
 
     y_cudf = np.array(pd.DataFrame(y_train).values)

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -44,7 +44,7 @@ def ignore_deprecated_lbfgs_params_warning():
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     workers = c.has_what().keys()
     n_partitions = partitions_per_worker * len(workers)
-    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X_train))
+    X_cudf = cudf.DataFrame(pd.DataFrame(X_train))
     X_train_df = dask_cudf.from_cudf(X_cudf, npartitions=n_partitions)
 
     y_cudf = np.array(pd.DataFrame(y_train).values)

--- a/python/cuml/tests/dask/test_dask_nearest_neighbors.py
+++ b/python/cuml/tests/dask/test_dask_nearest_neighbors.py
@@ -48,7 +48,7 @@ def _prep_training_data(
 
     n_partitions = partitions_per_worker * len(workers)
 
-    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X_train))
+    X_cudf = cudf.DataFrame(pd.DataFrame(X_train))
 
     X_train_df = dask_cudf.from_cudf(X_cudf, npartitions=n_partitions)
     (X_train_df,) = dask_utils.persist_across_workers(

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -56,7 +56,7 @@ from cuml.ensemble import RandomForestRegressor as cuRFR_sg
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     workers = c.has_what().keys()
     n_partitions = partitions_per_worker * len(workers)
-    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X_train))
+    X_cudf = cudf.DataFrame(pd.DataFrame(X_train))
     X_train_df = dask_cudf.from_cudf(X_cudf, npartitions=n_partitions)
 
     y_cudf = cudf.Series(y_train)
@@ -152,12 +152,12 @@ def test_rf_regression_dask_fil(partitions_per_worker, dtype, client):
     workers = client.has_what().keys()
     n_partitions = partitions_per_worker * len(workers)
 
-    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X_train))
+    X_cudf = cudf.DataFrame(pd.DataFrame(X_train))
     X_train_df = dask_cudf.from_cudf(X_cudf, npartitions=n_partitions)
 
     y_cudf = cudf.Series(y_train)
     y_train_df = dask_cudf.from_cudf(y_cudf, npartitions=n_partitions)
-    X_cudf_test = cudf.DataFrame.from_pandas(pd.DataFrame(X_test))
+    X_cudf_test = cudf.DataFrame(pd.DataFrame(X_test))
     X_test_df = dask_cudf.from_cudf(X_cudf_test, npartitions=n_partitions)
 
     cuml_mod = cuRFR_mg(**cu_rf_params, ignore_empty_partitions=True)

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.mg
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     workers = c.has_what().keys()
     n_partitions = partitions_per_worker * len(workers)
-    X_cudf = cudf.DataFrame.from_pandas(pd.DataFrame(X_train))
+    X_cudf = cudf.DataFrame(pd.DataFrame(X_train))
     X_train_df = dask_cudf.from_cudf(X_cudf, npartitions=n_partitions)
 
     y_cudf = np.array(pd.DataFrame(y_train).values)

--- a/python/cuml/tests/test_kneighbors_classifier.py
+++ b/python/cuml/tests/test_kneighbors_classifier.py
@@ -237,10 +237,10 @@ def test_predict_non_gaussian(n_samples, n_features, n_neighbors, n_query):
     y_host_train = pd.DataFrame(np.random.randint(0, 5, (n_samples, 1)))
     X_host_test = pd.DataFrame(np.random.uniform(0, 1, (n_query, n_features)))
 
-    X_device_train = cudf.DataFrame.from_pandas(X_host_train)
-    y_device_train = cudf.DataFrame.from_pandas(y_host_train)
+    X_device_train = cudf.DataFrame(X_host_train)
+    y_device_train = cudf.DataFrame(y_host_train)
 
-    X_device_test = cudf.DataFrame.from_pandas(X_host_test)
+    X_device_test = cudf.DataFrame(X_host_test)
 
     knn_sk = skKNN(algorithm="brute", n_neighbors=n_neighbors, n_jobs=1)
     knn_sk.fit(X_host_train, y_host_train.values.ravel())

--- a/python/cuml/tests/test_nearest_neighbors.py
+++ b/python/cuml/tests/test_nearest_neighbors.py
@@ -442,7 +442,7 @@ def test_nn_downcast_fails(input_type, nrows, n_feats):
     knn_cu = cuKNN()
     if input_type == "dataframe":
         X_pd = pd.DataFrame({"fea%d" % i: X[0:, i] for i in range(X.shape[1])})
-        X_cudf = cudf.DataFrame.from_pandas(X_pd)
+        X_cudf = cudf.DataFrame(X_pd)
         knn_cu.fit(X_cudf, convert_dtype=True)
 
     with pytest.raises(Exception):


### PR DESCRIPTION
https://github.com/rapidsai/cudf/pull/19996 deprecated various `.from_pandas` constructors in cudf-pandas. This PR updates those uses to just use the class `__init__` itself.