### PR TITLE
Set NCCL rpath for `cu13` wheels

### DIFF
--- a/python/libcuml/CMakeLists.txt
+++ b/python/libcuml/CMakeLists.txt
@@ -82,6 +82,7 @@ if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
   # starting with CTK 13 wheels, all libraries are grouped in this 'nvidia/cu13/lib' directory
   set(rpaths
     "$ORIGIN/../../nvidia/cu13/lib"
+    "$ORIGIN/../../nvidia/nccl/lib"
   )
 else()
   set(rpaths


### PR DESCRIPTION
For `cu13`, other NVIDIA libraries are now grouped in `nvidia/cu13/lib` directory. However, this is not true for NCCL binary which is still in `nvidia/nccl/lib` like the `cu12` variant.

```
dgala@g482-z54-0002:/raid/dgala/cuml$ find /home/nfs/dgala/myenv -name libnccl.so*
/home/nfs/dgala/myenv/lib/python3.12/site-packages/nvidia/nccl/lib/libnccl.so.2

dgala@g482-z54-0002:/raid/dgala/cuml$ find /home/nfs/dgala/myenv -name libcublas.so*
/home/nfs/dgala/myenv/lib/python3.12/site-packages/nvidia/cu13/lib/libcublas.so.13
```