### PR TITLE
Avoid pyyaml runtime dependency.

### DIFF
--- a/python/cuml/cuml/accel/pytest_plugin.py
+++ b/python/cuml/cuml/accel/pytest_plugin.py
@@ -93,11 +93,12 @@ def pytest_collection_modifyitems(config, items):
     # Import pytest lazily to avoid requiring it for normal cuml usage.
     # pytest is only needed when running tests.
     import pytest
-    import yaml
 
     xfail_list_path = config.getoption("xfail_list")
     if not xfail_list_path:
         return
+
+    import yaml  # needed to parse the YAML-formatted xfail list
 
     xfail_list_path = Path(xfail_list_path)
     if not xfail_list_path.exists():

--- a/python/cuml/cuml/accel/pytest_plugin.py
+++ b/python/cuml/cuml/accel/pytest_plugin.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 from importlib.metadata import version
 from pathlib import Path
 
-import yaml
 from packaging.requirements import Requirement
 
 from cuml.accel._sklearn_patch import apply_sklearn_patches
@@ -94,6 +93,7 @@ def pytest_collection_modifyitems(config, items):
     # Import pytest lazily to avoid requiring it for normal cuml usage.
     # pytest is only needed when running tests.
     import pytest
+    import yaml
 
     xfail_list_path = config.getoption("xfail_list")
     if not xfail_list_path:


### PR DESCRIPTION
Through local import.

We lost a transitive dependency on pyyaml after the removal of dask with #7303.
