### PR TITLE
Don't infer dtype from model in `cuml.explainer`

### DIFF
--- a/python/cuml/cuml/explainer/common.py
+++ b/python/cuml/cuml/explainer/common.py
@@ -70,27 +70,6 @@ def get_handle_from_cuml_model_func(func, create_new=False):
     return handle
 
 
-def get_dtype_from_model_func(func, default=None):
-    """
-    Function detect if model that `func` is bound to prefers data of certain
-    data type. It checks the attribute model.dtype.
-
-    Parameters
-    ----------
-    func: object
-        Function to check whether the object it is bound to has a _get_tags
-        attribute, and return tags from it.
-    create_new: boolean (default = False)
-        Whether to return a new RAFT handle if none could be fetched. Otherwise
-        the function will return None.
-    """
-    dtype = getattr(getattr(func, "__self__", None), "dtype", None)
-
-    dtype = default if dtype is None else dtype
-
-    return dtype
-
-
 def model_func_call(X, model_func, gpu_model=False):
     """
     Function to call `model_func(X)` using either `NumPy` arrays if

--- a/python/cuml/cuml/explainer/kernel_shap.pyx
+++ b/python/cuml/cuml/explainer/kernel_shap.pyx
@@ -133,11 +133,9 @@ class KernelExplainer(SHAPBase):
         the model's computations, so users can run different models
         concurrently in different streams by creating handles in several
         streams.
-    dtype : np.float32 or np.float64 (default = None)
+    dtype : np.float32 or np.float64 (default = np.float32)
         Parameter to specify the precision of data to generate to call the
-        model. If not specified, the explainer will try to get the dtype
-        of the model, if it cannot be queried, then it will default to
-        np.float32.
+        model.
     output_type : 'cupy' or 'numpy' (default = 'numpy')
         Parameter to specify the type of data to output.
         If not specified, the explainer will default to 'numpy' for the time
@@ -194,7 +192,7 @@ class KernelExplainer(SHAPBase):
                  random_state=None,
                  is_gpu_model=None,
                  handle=None,
-                 dtype=None,
+                 dtype=np.float32,
                  output_type=None):
 
         super().__init__(

--- a/python/cuml/cuml/explainer/permutation_shap.pyx
+++ b/python/cuml/cuml/explainer/permutation_shap.pyx
@@ -16,6 +16,7 @@
 import time
 
 import cupy as cp
+import numpy as np
 
 from cuml.explainer.base import SHAPBase
 from cuml.explainer.common import get_cai_ptr, model_func_call
@@ -136,11 +137,9 @@ class PermutationExplainer(SHAPBase):
         the model's computations, so users can run different models
         concurrently in different streams by creating handles in several
         streams.
-    dtype : np.float32 or np.float64 (default = None)
+    dtype : np.float32 or np.float64 (default = np.float32)
         Parameter to specify the precision of data to generate to call the
-        model. If not specified, the explainer will try to get the dtype
-        of the model, if it cannot be queried, then it will default to
-        np.float32.
+        model.
     output_type : 'cupy' or 'numpy' (default = 'numpy')
         Parameter to specify the type of data to output.
         If not specified, the explainer will default to 'numpy' for the time
@@ -193,7 +192,7 @@ class PermutationExplainer(SHAPBase):
                  handle=None,
                  is_gpu_model=None,
                  random_state=None,
-                 dtype=None,
+                 dtype=np.float32,
                  output_type=None,
                  verbose=False,):
         super().__init__(

--- a/python/cuml/tests/explainer/test_explainer_common.py
+++ b/python/cuml/tests/explainer/test_explainer_common.py
@@ -26,7 +26,6 @@ from cuml import LinearRegression as reg
 from cuml.datasets import make_regression
 from cuml.explainer.common import (
     get_cai_ptr,
-    get_dtype_from_model_func,
     get_handle_from_cuml_model_func,
     get_link_fn_from_str_or_fn,
     get_tag_from_model_func,
@@ -59,40 +58,6 @@ _default_tags = [
     "requires_y",
     "pairwise",
 ]
-
-
-def test_get_dtype_from_model_func():
-    X, y = make_regression(
-        n_samples=81,
-        n_features=10,
-        noise=0.1,
-        random_state=42,
-        dtype=np.float32,
-    )
-
-    # checking model with float32 dtype
-    model_f32 = reg().fit(X, y)
-
-    assert get_dtype_from_model_func(model_f32.predict) == np.float32
-
-    # checking model with float64 dtype
-    X = X.astype(np.float64)
-    y = y.astype(np.float64)
-
-    model_f64 = reg().fit(X, y)
-
-    assert get_dtype_from_model_func(model_f64.predict) == np.float64
-
-    # checking model that has not been fitted yet
-    model_not_fit = reg()
-
-    assert get_dtype_from_model_func(model_not_fit.predict) is None
-
-    # checking arbitrary function
-    def dummy_func(x):
-        return x + x
-
-    assert get_dtype_from_model_func(dummy_func) is None
 
 
 def test_get_gpu_tag_from_model_func():


### PR DESCRIPTION
Previously the classes in `cuml.explainer` would try to infer the dtype of the model function from `func.__self__.dtype`. This only worked for some models (only those that exposed an undocumented `.dtype` attribute), and led to inconsistent behavior between model functions. As we cleanup our model internals we're also removing the `.dtype` attribute from models, so this method no longer works.

Aiming for consistency, we change the default of `dtype` in `cuml.explainer` to `float32` everywhere - if a user wants to use `float64` they'll need to specify it manually.