### PR TITLE
Fix issue in Dask DBSCAN

### DIFF
--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -78,7 +78,7 @@ cdef extern from "cuml/cluster/dbscan.hpp" namespace "ML::Dbscan" nogil:
                   float *input,
                   int64_t n_rows,
                   int64_t n_cols,
-                  double eps,
+                  float eps,
                   int min_pts,
                   DistanceType metric,
                   int64_t *labels,


### PR DESCRIPTION
Closes #7341

Each worker processes the full dataset, and the resulting labels are merged toward the rank 0 through the communicator. The rank zero (only) then transforms the sentinel values into -1. However, the `internal_model` in charge of returning the final labels was selected as the first one in the alphabetical ordering of Dask workers IP addresses and not as the first rank in RAFT communicators clique. This caused the labels to be incorrect if the rank and alphabetic order did not coincide.

The PR also fixes an issue in the Cython code.