### PR TITLE
CI: Increase nightly CI check window to 14 days.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cuml
-          max_days_without_success: 7
+          max_days_without_success: 14
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
Due to ongoing issues with conda timeouts, we need to increase the nightly CI check window.