### PR TITLE
Fix overflow in coordinate descent

### DIFF
--- a/cpp/src/solver/cd.cuh
+++ b/cpp/src/solver/cd.cuh
@@ -211,8 +211,9 @@ void cdFit(const raft::handle_t& handle,
     math_t scalar = math_t(n_rows) + l2_alpha;
     raft::matrix::setValue(squared.data(), squared.data(), scalar, n_cols, stream);
   } else {
+    /* (n_cols * n_rows) may overflow, upcast for indexing */
     raft::linalg::colNorm<raft::linalg::NormType::L2Norm, false>(
-      squared.data(), input, n_cols, n_rows, stream);
+      squared.data(), input, int64_t(n_cols), int64_t(n_rows), stream);
     raft::linalg::addScalar(squared.data(), squared.data(), l2_alpha, n_cols, stream);
   }
 
@@ -233,10 +234,10 @@ void cdFit(const raft::handle_t& handle,
 
     for (int j = 0; j < n_cols; j++) {
       raft::common::nvtx::range iter_scope("ML::Solver::cdFit::col-%d", j);
-      int ci                = ri[j];
+      int64_t ci            = ri[j];
       math_t* coef_loc      = coef + ci;
       math_t* squared_loc   = squared.data() + ci;
-      math_t* input_col_loc = input + (ci * n_rows);
+      math_t* input_col_loc = input + (ci * int64_t(n_rows));
 
       // remember current coef
       raft::copy(&(convStateLoc->coef), coef_loc, 1, stream);


### PR DESCRIPTION
Previously our coordinate descent solver would fail on problems where `n_cols * n_rows > INT_MAX` due to an `int` overflow.

There were two locations where this was happening:

- Calculating the offset into the input matrix
- Within the computation of the L2Norm

The former is a quick local fix. The latter I also fixed locally by switching from an `int` to a `int64_t` in the template call. However, I'm not sure if that's the best fix, or if it'd be better to handle this upstream within the template itself to avoid overflow of the index types. This was easy to do so I did it here for now.

I've checked, and with this we can solve very large coordinate descent problems, with the dimension limitation now being `INT_MAX` in both rows and columns. Moving larger than that would require using the 64 bit cublas API, but I have no need for that now.

Additionally, on the python side if a user tries to pass a larger value they'll get a nicer python-side error, rather than a cublas error code (and a potentially corrupted handle).

Fixes #6736.