### PR TITLE
Fix string slicing dtype mismatch in PorterStemmer for cudf-pandas mode

### DIFF
--- a/python/cuml/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
+++ b/python/cuml/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py
@@ -66,6 +66,6 @@ def get_stem_series(word_str_ser, suffix_len, can_replace_mask):
     can_repalce_mask: bool array marking strings where to replace
     """
     starts = cudf.Series(cp.zeros(len(word_str_ser), dtype=cp.int32))
-    stops = (word_str_ser.str.len() - suffix_len).fillna(0)
+    stops = (word_str_ser.str.len() - suffix_len).fillna(0).astype(cp.int32)
     sliced = word_str_ser.str.slice_from(starts, stops)
     return sliced.where(can_replace_mask, word_str_ser)


### PR DESCRIPTION
## Description

Fixes #7411 - PorterStemmer failures in cudf-pandas integration tests due to dtype mismatch in string slicing operations.

## Changes

Cast `stops` parameter to `int32` in `get_stem_series()` to match the dtype of `starts`, ensuring type consistency when calling `cudf.Series.str.slice_from()`.

**File changed:** `python/cuml/cuml/preprocessing/text/stem/porter_stemmer_utils/suffix_utils.py`

```python
# Before
stops = (word_str_ser.str.len() - suffix_len).fillna(0)

# After  
stops = (word_str_ser.str.len() - suffix_len).fillna(0).astype(cp.int32)
```

## Root Cause

In rapidsai/cudf#20368 (merged Oct 28, 2025), `Series.str.len()` was modified to return `int64` in pandas-compatible mode to match pandas behavior. This created a type mismatch with cuML's explicit `int32` for the `starts` parameter, causing libcudf's C++ layer to reject the call with:

> `TypeError: Parameters starts and stops must be of the same type.`

## Testing

All 16 PorterStemmer tests now pass with cudf-pandas integration mode enabled:
- `stemmer_tests/test_stemmer.py::test_same_results` ✓
- `stemmer_tests/test_steps.py::test_step*` (9 tests) ✓
- `stemmer_tests/test_suffix_utils.py` (2 tests) ✓
- `test_doctest.py::test_docstring[PorterStemmer]` ✓

