### PR TITLE
Deprecate `normalize` option to all linear models

### DIFF
--- a/python/cuml/cuml/dask/common/base.py
+++ b/python/cuml/cuml/dask/common/base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import warnings
 from collections.abc import Iterable
 from functools import wraps
 
@@ -470,3 +471,17 @@ def _transform_func(model, data, **kwargs):
 
 def _inverse_transform_func(model, data, **kwargs):
     return model.inverse_transform(data, **kwargs)
+
+
+def check_deprecated_normalize(model):
+    """Warn if the deprecated `normalize` option is used."""
+    if model.kwargs.get("normalize"):
+        cls_name = type(model).__name__
+        warnings.warn(
+            (
+                f"The `normalize` option to `{cls_name}` was deprecated in "
+                f"25.12 and will be removed in 26.02. Please use a `StandardScaler` "
+                f"to normalize your data external to `{cls_name}`."
+            ),
+            FutureWarning,
+        )

--- a/python/cuml/cuml/dask/linear_model/elastic_net.py
+++ b/python/cuml/cuml/dask/linear_model/elastic_net.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from cuml.dask.common.base import BaseEstimator
+from cuml.dask.common.base import BaseEstimator, check_deprecated_normalize
 from cuml.dask.solvers import CD
 
 
@@ -36,10 +36,13 @@ class ElasticNet(BaseEstimator):
     fit_intercept : boolean (default = True)
         If True, Lasso tries to correct for the global mean of y.
         If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        If True, the predictors in X will be normalized by dividing by it's L2
-        norm.
-        If False, no scaling will be done.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     max_iter : int (default = 1000)
         The maximum number of iterations
     tol : float (default = 1e-3)
@@ -103,7 +106,7 @@ class ElasticNet(BaseEstimator):
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
 
         """
-
+        check_deprecated_normalize(self)
         self.solver.fit(X, y)
         return self
 

--- a/python/cuml/cuml/dask/linear_model/lasso.py
+++ b/python/cuml/cuml/dask/linear_model/lasso.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from cuml.dask.common.base import BaseEstimator
+from cuml.dask.common.base import BaseEstimator, check_deprecated_normalize
 from cuml.dask.solvers import CD
 
 
@@ -30,10 +30,13 @@ class Lasso(BaseEstimator):
     fit_intercept : boolean (default = True)
         If True, Lasso tries to correct for the global mean of y.
         If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        If True, the predictors in X will be normalized by dividing by it's L2
-        norm.
-        If False, no scaling will be done.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     max_iter : int (default = 1000)
         The maximum number of iterations
     tol : float (default = 1e-3)
@@ -83,6 +86,7 @@ class Lasso(BaseEstimator):
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
 
         """
+        check_deprecated_normalize(self)
 
         self.solver.fit(X, y)
 

--- a/python/cuml/cuml/dask/linear_model/linear_regression.py
+++ b/python/cuml/cuml/dask/linear_model/linear_regression.py
@@ -9,6 +9,7 @@ from cuml.dask.common.base import (
     BaseEstimator,
     DelayedPredictionMixin,
     SyncFitMixinLinearModel,
+    check_deprecated_normalize,
     mnmg_import,
 )
 
@@ -42,10 +43,12 @@ class LinearRegression(
         LinearRegression adds an additional term c to correct for the global
         mean of y, modeling the response as "x * beta + c".
         If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        If True, the predictors in X will be normalized by dividing by its
-        L2 norm.
-        If False, no scaling will be done.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
 
     Attributes
     ----------
@@ -69,6 +72,7 @@ class LinearRegression(
         y : Dask cuDF dataframe  or CuPy backed Dask Array (n_rows, 1)
             Labels (outcome values)
         """
+        check_deprecated_normalize(self)
 
         models = self._fit(
             model_func=LinearRegression._create_model, data=(X, y)

--- a/python/cuml/cuml/dask/linear_model/ridge.py
+++ b/python/cuml/cuml/dask/linear_model/ridge.py
@@ -9,6 +9,7 @@ from cuml.dask.common.base import (
     BaseEstimator,
     DelayedPredictionMixin,
     SyncFitMixinLinearModel,
+    check_deprecated_normalize,
     mnmg_import,
 )
 
@@ -46,10 +47,12 @@ class Ridge(BaseEstimator, SyncFitMixinLinearModel, DelayedPredictionMixin):
         If True, Ridge adds an additional term c to correct for the global
         mean of y, modeling the response as "x * beta + c".
         If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        If True, the predictors in X will be normalized by dividing by it's L2
-        norm.
-        If False, no scaling will be done.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
 
     Attributes
     ----------
@@ -79,6 +82,7 @@ class Ridge(BaseEstimator, SyncFitMixinLinearModel, DelayedPredictionMixin):
         y : Dask cuDF dataframe  or CuPy backed Dask Array (n_rows, 1)
             Labels (outcome values)
         """
+        check_deprecated_normalize(self)
 
         models = self._fit(model_func=Ridge._create_model, data=(X, y))
 

--- a/python/cuml/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/cuml/experimental/linear_model/lars.pyx
@@ -26,6 +26,7 @@ from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.mixins import RegressorMixin
+from cuml.linear_model.base import check_deprecated_normalize
 
 from pylibraft.common.handle cimport handle_t
 
@@ -78,14 +79,12 @@ class Lars(Base, RegressorMixin):
     fit_intercept : boolean (default = True)
         If True, Lars tries to correct for the global mean of y.
         If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        This parameter is ignored when `fit_intercept` is set to False.
-        If True, the predictors in X will be normalized by removing its mean
-        and dividing by it's variance. If False, then the solver expects that
-        the data is already normalized.
+    normalize : boolean, default=False
 
-        .. versionchanged:: 24.06
-            The default of `normalize` changed from `True` to `False`.
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
 
     copy_X : boolean (default = True)
         The solver permutes the columns of X. Set `copy_X` to True to prevent
@@ -157,7 +156,7 @@ class Lars(Base, RegressorMixin):
     coef_ = CumlArrayDescriptor()
     intercept_ = CumlArrayDescriptor()
 
-    def __init__(self, *, fit_intercept=True, normalize=True,
+    def __init__(self, *, fit_intercept=True, normalize=False,
                  handle=None, verbose=False, output_type=None, copy_X=True,
                  fit_path=True, n_nonzero_coefs=500, eps=None,
                  precompute='auto'):
@@ -291,6 +290,8 @@ class Lars(Base, RegressorMixin):
         Fit the model with X and y.
 
         """
+        check_deprecated_normalize(self)
+
         self._set_n_features_in(X)
         self._set_output_type(X)
 

--- a/python/cuml/cuml/linear_model/base.py
+++ b/python/cuml/cuml/linear_model/base.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+import warnings
+
 import cuml.internals
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
@@ -47,3 +49,17 @@ class LinearPredictMixin:
         out += intercept
 
         return CumlArray(out, index=X.index)
+
+
+def check_deprecated_normalize(model):
+    """Warn if the deprecated `normalize` option is used."""
+    if model.normalize:
+        cls_name = type(model).__name__
+        warnings.warn(
+            (
+                f"The `normalize` option to `{cls_name}` was deprecated in "
+                f"25.12 and will be removed in 26.02. Please use a `StandardScaler` "
+                f"to normalize your data external to `{cls_name}`."
+            ),
+            FutureWarning,
+        )

--- a/python/cuml/cuml/linear_model/elastic_net.py
+++ b/python/cuml/cuml/linear_model/elastic_net.py
@@ -13,7 +13,10 @@ from cuml.internals.interop import (
     to_gpu,
 )
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
-from cuml.linear_model.base import LinearPredictMixin
+from cuml.linear_model.base import (
+    LinearPredictMixin,
+    check_deprecated_normalize,
+)
 from cuml.solvers import QN
 from cuml.solvers.cd import fit_coordinate_descent
 
@@ -62,12 +65,12 @@ class ElasticNet(
         leads to significantly faster convergence especially when tol is higher
         than 1e-4.
     normalize : boolean, default=False
-        If True, the predictors in X will be normalized by dividing by the
-        column-wise standard deviation.
-        If False, no scaling will be done.
-        Note: this is in contrast to sklearn's deprecated `normalize` flag,
-        which divides by the column-wise L2 norm; but this is the same as if
-        using sklearn's StandardScaler.
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
@@ -230,6 +233,8 @@ class ElasticNet(
         Fit the model with X and y.
 
         """
+        check_deprecated_normalize(self)
+
         if self.alpha < 0.0:
             raise ValueError(f"Expected alpha >= 0, got {self.alpha}")
         if self.selection not in ["cyclic", "random"]:

--- a/python/cuml/cuml/linear_model/lasso.py
+++ b/python/cuml/cuml/linear_model/lasso.py
@@ -43,13 +43,13 @@ class Lasso(ElasticNet):
         rather than looping over features sequentially by default.
         This (setting to 'random') often leads to significantly faster
         convergence especially when tol is higher than 1e-4.
-    normalize : boolean (default = False)
-        If True, the predictors in X will be normalized by dividing by the
-        column-wise standard deviation.
-        If False, no scaling will be done.
-        Note: this is in contrast to sklearn's deprecated `normalize` flag,
-        which divides by the column-wise L2 norm; but this is the same as if
-        using sklearn's StandardScaler.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -21,7 +21,10 @@ from cuml.internals.interop import (
     to_gpu,
 )
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
-from cuml.linear_model.base import LinearPredictMixin
+from cuml.linear_model.base import (
+    LinearPredictMixin,
+    check_deprecated_normalize,
+)
 
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool
@@ -162,14 +165,13 @@ class LinearRegression(Base,
         If True, cuml will copy X when needed to avoid mutating the input array.
         If you're ok with X being overwritten, setting to False may avoid a copy,
         reducing memory usage for certain algorithms.
-    normalize : boolean (default = False)
-        This parameter is ignored when `fit_intercept` is set to False.
-        If True, the predictors in X will be normalized by dividing by the
-        column-wise standard deviation.
-        If False, no scaling will be done.
-        Note: this is in contrast to sklearn's deprecated `normalize` flag,
-        which divides by the column-wise L2 norm; but this is the same as if
-        using sklearn's StandardScaler.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
@@ -315,6 +317,8 @@ class LinearRegression(Base,
         Fit the model with X and y.
 
         """
+        check_deprecated_normalize(self)
+
         X_m = input_to_cuml_array(
             X,
             convert_to_dtype=(np.float32 if convert_dtype else None),

--- a/python/cuml/cuml/linear_model/linear_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression_mg.pyx
@@ -4,6 +4,7 @@
 import numpy as np
 
 import cuml.internals
+from cuml.linear_model.base import check_deprecated_normalize
 from cuml.linear_model.base_mg import MGFitMixin
 from cuml.linear_model.linear_regression import Algo, LinearRegression
 
@@ -43,6 +44,8 @@ cdef extern from "cuml/linear_model/ols_mg.hpp" namespace "ML::OLS::opg" nogil:
 class LinearRegressionMG(MGFitMixin, LinearRegression):
     @cuml.internals.api_base_return_any_skipall
     def _fit(self, X, y, coef_ptr, input_desc):
+        check_deprecated_normalize(self)
+
         cdef int algo = (
             Algo.EIG if self.algorithm == "auto" else Algo.parse(self.algorithm)
         )

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -13,7 +13,10 @@ from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.interop import InteropMixin, UnsupportedOnGPU, to_gpu
 from cuml.internals.mixins import FMajorInputTagMixin, RegressorMixin
-from cuml.linear_model.base import LinearPredictMixin
+from cuml.linear_model.base import (
+    LinearPredictMixin,
+    check_deprecated_normalize,
+)
 
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool
@@ -134,13 +137,13 @@ class Ridge(Base,
     fit_intercept : boolean (default = True)
         If True, Ridge tries to correct for the global mean of y.
         If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        If True, the predictors in X will be normalized by dividing by the
-        column-wise standard deviation.
-        If False, no scaling will be done.
-        Note: this is in contrast to sklearn's deprecated `normalize` flag,
-        which divides by the column-wise L2 norm; but this is the same as if
-        using sklearn's StandardScaler.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     handle : cuml.Handle
         Specifies the cuml.handle that holds internal CUDA state for
         computations in this model. Most importantly, this specifies the CUDA
@@ -283,6 +286,8 @@ class Ridge(Base,
         """
         Fit the model with X and y.
         """
+        check_deprecated_normalize(self)
+
         cdef size_t n_rows, n_cols
         X, n_rows, n_cols, dtype = input_to_cuml_array(
             X,

--- a/python/cuml/cuml/linear_model/ridge_mg.pyx
+++ b/python/cuml/cuml/linear_model/ridge_mg.pyx
@@ -5,6 +5,7 @@ import numpy as np
 
 import cuml.internals
 from cuml.linear_model import Ridge
+from cuml.linear_model.base import check_deprecated_normalize
 from cuml.linear_model.base_mg import MGFitMixin
 
 from cython.operator cimport dereference as deref
@@ -47,6 +48,8 @@ cdef extern from "cuml/linear_model/ridge_mg.hpp" namespace "ML::Ridge::opg" nog
 class RidgeMG(MGFitMixin, Ridge):
     @cuml.internals.api_base_return_any_skipall
     def _fit(self, X, y, coef_ptr, input_desc):
+        check_deprecated_normalize(self)
+
         cdef int algo = self._pre_fit()
 
         cdef float float_intercept

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -239,8 +239,13 @@ class CD(Base, FMajorInputTagMixin):
     fit_intercept : boolean (default = True)
        If True, the model tries to correct for the global mean of y.
        If False, the model expects that you have centered the data.
-    normalize : boolean (default = False)
-        Whether to normalize the data or not.
+    normalize : boolean, default=False
+
+        .. deprecated:: 25.12
+            ``normalize`` is deprecated and will be removed in 26.02. When
+            needed, please use a ``StandardScaler`` to normalize your data
+            before passing to ``fit``.
+
     max_iter : int (default = 1000)
         The number of times the model should iterate through the entire
         dataset during training
@@ -337,6 +342,9 @@ class CD(Base, FMajorInputTagMixin):
         """
         Fit the model with X and y.
         """
+        from cuml.linear_model.base import check_deprecated_normalize
+        check_deprecated_normalize(self)
+
         coef, intercept = fit_coordinate_descent(
             X,
             y,

--- a/python/cuml/tests/dask/test_dask_base.py
+++ b/python/cuml/tests/dask/test_dask_base.py
@@ -166,3 +166,20 @@ def test_getattr(client):
 
     assert nb_model.feature_count_ is not None
     assert isinstance(nb_model.feature_count_, cupy.ndarray)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        cuml.dask.linear_model.LinearRegression,
+        cuml.dask.linear_model.Lasso,
+        cuml.dask.linear_model.Ridge,
+        cuml.dask.linear_model.ElasticNet,
+    ],
+)
+def test_deprecated_normalize(client, cls):
+    X, y = make_regression(random_state=42)
+    model = cls(normalize=True, client=client)
+
+    with pytest.warns(FutureWarning, match="normalize"):
+        model.fit(X, y)

--- a/python/cuml/tests/dask/test_dask_coordinate_descent.py
+++ b/python/cuml/tests/dask/test_dask_coordinate_descent.py
@@ -47,7 +47,6 @@ def test_lasso(
     lasso = Lasso(
         alpha=np.array([alpha]),
         fit_intercept=True,
-        normalize=False,
         max_iter=1000,
         selection=algorithm,
         tol=1e-10,
@@ -133,7 +132,6 @@ def test_elastic_net(
     elasticnet = ElasticNet(
         alpha=np.array([alpha]),
         fit_intercept=True,
-        normalize=False,
         max_iter=1000,
         selection=algorithm,
         tol=1e-10,

--- a/python/cuml/tests/dask/test_dask_linear_regression.py
+++ b/python/cuml/tests/dask/test_dask_linear_regression.py
@@ -47,12 +47,9 @@ def make_regression_dataset(datatype, nrows, ncols, n_info):
 @pytest.mark.parametrize("ncols", [20])
 @pytest.mark.parametrize("n_parts", [2, 23])
 @pytest.mark.parametrize("fit_intercept", [False, True])
-@pytest.mark.parametrize("normalize", [False])
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize("delayed", [True, False])
-def test_ols(
-    nrows, ncols, n_parts, fit_intercept, normalize, datatype, delayed, client
-):
+def test_ols(nrows, ncols, n_parts, fit_intercept, datatype, delayed, client):
     def imp():
         import cuml.comm.serialize  # NOQA
 
@@ -67,7 +64,7 @@ def test_ols(
 
     X_df, y_df = _prep_training_data(client, X, y, n_parts)
 
-    lr = cumlOLS_dask(fit_intercept=fit_intercept, normalize=normalize)
+    lr = cumlOLS_dask(fit_intercept=fit_intercept)
 
     lr.fit(X_df, y_df)
 

--- a/python/cuml/tests/dask/test_dask_ridge_regression.py
+++ b/python/cuml/tests/dask/test_dask_ridge_regression.py
@@ -47,11 +47,10 @@ def make_regression_dataset(datatype, nrows, ncols, n_info):
 @pytest.mark.parametrize("ncols", [10])
 @pytest.mark.parametrize("n_parts", [2, 23])
 @pytest.mark.parametrize("fit_intercept", [False, True])
-@pytest.mark.parametrize("normalize", [False])
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize("delayed", [True, False])
 def test_ridge(
-    nrows, ncols, n_parts, fit_intercept, normalize, datatype, delayed, client
+    nrows, ncols, n_parts, fit_intercept, datatype, delayed, client
 ):
 
     from cuml.dask.linear_model import Ridge as cumlRidge_dask
@@ -63,9 +62,7 @@ def test_ridge(
 
     X_df, y_df = _prep_training_data(client, X, y, n_parts)
 
-    lr = cumlRidge_dask(
-        alpha=0.5, fit_intercept=fit_intercept, normalize=normalize
-    )
+    lr = cumlRidge_dask(alpha=0.5, fit_intercept=fit_intercept)
 
     lr.fit(X_df, y_df)
 

--- a/python/cuml/tests/test_lars.py
+++ b/python/cuml/tests/test_lars.py
@@ -8,7 +8,7 @@ import cupy as cp
 import numpy as np
 import pytest
 import sklearn
-from sklearn.datasets import fetch_california_housing
+from sklearn.datasets import fetch_california_housing, make_regression
 from sklearn.linear_model import Lars as skLars
 
 from cuml.experimental.linear_model import Lars as cuLars
@@ -85,8 +85,8 @@ def test_lars_model(datatype, nrows, column_info, precompute):
         # scikit-learn accuracy.
         accuracy_target = sklars.score(X_test, y_test)
         tol = 1.96 * np.sqrt(accuracy_target * (1.0 - accuracy_target) / 100.0)
-        if tol < 0.001:
-            tol = 0.001  # We allow at least 0.1% tolerance
+        if tol < 0.002:
+            tol = 0.002  # We allow at least 0.2% tolerance
         print(cu_score_train, cu_score_test, accuracy_target, tol)
         assert cu_score_train >= sklars.score(X_train, y_train) - tol
         assert cu_score_test >= accuracy_target - tol
@@ -216,3 +216,11 @@ def test_lars_copy_X(datatype):
     # assert cp.any(X0 != X)
     #
     # assert abs(culars1.score(X, y) - culars2.score(X, y)) < 1e-9
+
+
+def test_deprecated_normalize():
+    X, y = make_regression(random_state=42)
+    model = cuLars(normalize=True)
+
+    with pytest.warns(FutureWarning, match="normalize"):
+        model.fit(X, y)

--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -1242,3 +1242,14 @@ def test_elasticnet_model(datatype, solver, nrows, column_info, ntargets):
             total_tol=1e-0,
             with_sign=True,
         )
+
+
+@pytest.mark.parametrize(
+    "cls", [cuml.Ridge, cuml.ElasticNet, cuml.Lasso, cuml.LinearRegression]
+)
+def test_deprecated_normalize(cls):
+    X, y = make_regression()
+    model = cls(normalize=True)
+
+    with pytest.raises(FutureWarning, match="normalize"):
+        model.fit(X, y)


### PR DESCRIPTION
This deprecates the `normalize` option to all linear models that still supported it.

It includes one _potentially_ breaking change (I'm viewing it more as a bug-fix).
`cuml.experimental.linear_model.Lars` was documented to have `normalize` default to `False` (and clearly should have), but still had it default to `True`. Since it's in the experimental namespace and feels like a bug to me I've updated the value here to `False` with no deprecation period. The tests had to have their tolerance slightly expanded.

AFAICT no model was testing (intentionally) with `normalize=True` anywhere, which makes me feel pretty confident that we should rip this option out. There's no way to ensure it was even doing the right thing anymore.

Fixes #7400.