### PR TITLE
Remove reachability.hpp Header

### DIFF
--- a/cpp/tests/sg/hdbscan_test.cu
+++ b/cpp/tests/sg/hdbscan_test.cu
@@ -26,7 +26,6 @@
 #include <cuvs/cluster/agglomerative.hpp>
 #include <cuvs/distance/distance.hpp>
 #include <cuvs/neighbors/all_neighbors.hpp>
-#include <cuvs/neighbors/reachability.hpp>
 #include <gtest/gtest.h>
 #include <hdbscan/detail/condense.cuh>
 #include <hdbscan/detail/extract.cuh>


### PR DESCRIPTION
HDBSCAN tests have been updated to build the MR graph using `all_neighbors`. The reachability header is not needed and will be deprecated from cuVS.

Closes #6861 