### PR TITLE
Set the same `random_state` value for `None` in `cuml.dask.KMeans` for all workers

### DIFF
--- a/python/cuml/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/cuml/dask/cluster/kmeans.py
@@ -143,10 +143,12 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
         data = DistributedDataHandler.create(inputs, client=self.client)
         self.datatype = data.datatype
 
-        if "random_state" in self.kwargs:
-            self.kwargs["random_state"] = check_random_seed(
-                self.kwargs["random_state"]
-            )
+        if "random_state" not in self.kwargs:
+            self.kwargs["random_state"] = None
+
+        self.kwargs["random_state"] = check_random_seed(
+            self.kwargs["random_state"]
+        )
 
         # This needs to happen on the scheduler
         comms = Comms(comms_p2p=False, client=self.client)


### PR DESCRIPTION
When `cuml.dask.KMeans` calls into `cuml.KMeans` with `random_state=None`, each worker will set its own `seed` value https://github.com/rapidsai/cuml/blob/f53d49d8e86b9bc310449c7ac3e459d803e91a25/python/cuml/cuml/cluster/kmeans.pyx#L37
This can cause synchronization problems because each worker will assign a different seed. This PR fixes that by generating a seed in the `dask` module before calling into the standard module.

Related to https://github.com/rapidsai/cuml/issues/7389