### PR TITLE
Bring back `KMeansMG`

### DIFF
--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -31,14 +31,24 @@ from cuml.metrics.distance_type cimport DistanceType
 
 cdef _kmeans_init_params(kmeans, lib.KMeansParams& params):
     """Initialize a passed KMeansParams instance from a KMeans instance."""
+    cdef bool multi_gpu = kmeans._multi_gpu
+
     params.n_clusters = kmeans.n_clusters
     params.max_iter = kmeans.max_iter
     params.tol = kmeans.tol
-    params.rng_state.seed = check_random_seed(kmeans.random_state)
     params.verbosity = <level_enum>(<int>kmeans.verbose)
     params.metric = DistanceType.L2Expanded
     params.batch_samples = int(kmeans.max_samples_per_batch)
     params.oversampling_factor = kmeans.oversampling_factor
+
+    # Ensure random_state is set when running on multi-gpu
+    if multi_gpu and kmeans.random_state is None:
+        raise ValueError(
+            "KMeansMG requires `random_state != None`, please select a consistent "
+            "non-None `random_state` to use across all partitions when calling "
+            "KMeansMG"
+        )
+    params.rng_state.seed = check_random_seed(kmeans.random_state)
 
     if isinstance(kmeans.init, str):
         if kmeans.init == "k-means++":
@@ -52,6 +62,11 @@ cdef _kmeans_init_params(kmeans, lib.KMeansParams& params):
             params.init = lib.InitMethod.Random
     else:
         params.init = lib.InitMethod.Array
+
+    if multi_gpu and params.oversampling_factor == 0:
+        raise ValueError(
+            "init='k-means++' or oversampling_factor=0 not supported for KMeansMG"
+        )
 
     if kmeans.n_init == "auto":
         if isinstance(kmeans.init, str) and params.init == lib.InitMethod.KMeansPlusPlus:
@@ -380,6 +395,8 @@ class KMeans(Base,
     For additional docs, see `scikitlearn's Kmeans
     <http://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html>`_.
     """
+    _multi_gpu = False
+
     labels_ = CumlArrayDescriptor(order="C")
     cluster_centers_ = CumlArrayDescriptor(order="C")
 
@@ -505,11 +522,6 @@ class KMeans(Base,
         Compute k-means clustering with X.
 
         """
-        return self._fit(X, y=y, sample_weight=sample_weight, convert_dtype=convert_dtype)
-
-    def _fit(
-        self, X, y=None, sample_weight=None, *, convert_dtype=True, multigpu=False
-    ) -> "KMeans":
         # Process input arrays
         X_m, n_rows, n_cols, dtype = input_to_cuml_array(
             X,
@@ -540,11 +552,6 @@ class KMeans(Base,
         if n_rows < self.n_clusters:
             raise ValueError(
                 f"n_samples={n_rows} should be >= n_clusters={self.n_clusters}."
-            )
-        if multigpu and (self.init == "k-means++" or self.oversampling_factor <= 0):
-            raise ValueError(
-                "k-means++ init or oversampling_factor=0 not supported "
-                "for multi-GPU KMeans"
             )
 
         # Allocate output cluster_centers_

--- a/python/cuml/cuml/cluster/kmeans_mg.py
+++ b/python/cuml/cuml/cluster/kmeans_mg.py
@@ -1,0 +1,14 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from cuml.cluster import KMeans
+
+
+class KMeansMG(KMeans):
+    """
+    A Multi-Node Multi-GPU implementation of KMeans
+    """
+
+    _multi_gpu = True

--- a/python/cuml/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/cuml/dask/cluster/kmeans.py
@@ -88,7 +88,7 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
     @staticmethod
     @mnmg_import
     def _func_fit(sessionId, objs, datatype, has_weights, **kwargs):
-        from cuml.cluster.kmeans import KMeans
+        from cuml.cluster.kmeans_mg import KMeansMG
 
         handle = get_raft_comm_state(sessionId, get_worker())["handle"]
 
@@ -99,8 +99,8 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
             inp_data = concatenate([X for X, weights in objs])
             inp_weights = concatenate([weights for X, weights in objs])
 
-        return KMeans(handle=handle, output_type=datatype, **kwargs)._fit(
-            inp_data, sample_weight=inp_weights, multigpu=True
+        return KMeansMG(handle=handle, output_type=datatype, **kwargs).fit(
+            inp_data, sample_weight=inp_weights
         )
 
     @staticmethod
@@ -143,12 +143,9 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
         data = DistributedDataHandler.create(inputs, client=self.client)
         self.datatype = data.datatype
 
-        if "random_state" not in self.kwargs:
-            self.kwargs["random_state"] = None
-
-        self.kwargs["random_state"] = check_random_seed(
-            self.kwargs["random_state"]
-        )
+        # Ensure a consistent `random_state` across all calls
+        kwargs = self.kwargs.copy()
+        kwargs["random_state"] = check_random_seed(kwargs.get("random_state"))
 
         # This needs to happen on the scheduler
         comms = Comms(comms_p2p=False, client=self.client)
@@ -161,7 +158,7 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
                 wf[1],
                 self.datatype,
                 data.multiple,
-                **self.kwargs,
+                **kwargs,
                 workers=[wf[0]],
                 pure=False,
             )


### PR DESCRIPTION
During a recent refactor we removed the `KMeansMG` class, viewing it as internal. It turns out this class was used by a few external projects.

Since we still need to support external users accessing the non-dask multi-gpu implementation, we'll want a public way to do so that isn't the private `_fit` method. Additionally, since we want to special case the `MG` case a little more, making it a separate class (even if as a thin shim) makes sense.

This PR:

- Brings back the `KMeansMG` class
- Adds a check that `random_state` is non-None in the `KMeansMG` case, ensuring external users also set `random_state` properly
- Removes mutation of kwargs in the dask `KMeans` case (as suggested [here](https://github.com/rapidsai/cuml/pull/7417#discussion_r2481592878))
- Simplifies and moves the multi-gpu `kmeans++`/`oversampling_factor` check (as suggested [here](https://github.com/rapidsai/cuml/pull/7391#discussion_r2466134980))

Fixes #7387.
Fixes #7389.