### PR TITLE
Expose `_fit_X` and `_y` on neighbors estimators in cuml.accel

### DIFF
--- a/python/cuml/cuml/accel/_wrappers/sklearn/neighbors.py
+++ b/python/cuml/cuml/accel/_wrappers/sklearn/neighbors.py
@@ -16,17 +16,17 @@ __all__ = (
 
 class NearestNeighbors(ProxyBase):
     _gpu_class = cuml.neighbors.NearestNeighbors
-    _other_attributes = frozenset(("_fit_method", "_tree"))
+    _other_attributes = frozenset(("_fit_method", "_tree", "_fit_X"))
 
 
 class KNeighborsClassifier(ProxyBase):
     _gpu_class = cuml.neighbors.KNeighborsClassifier
-    _other_attributes = frozenset(("_fit_method", "_tree"))
+    _other_attributes = frozenset(("_fit_method", "_tree", "_fit_X", "_y"))
 
 
 class KNeighborsRegressor(ProxyBase):
     _gpu_class = cuml.neighbors.KNeighborsRegressor
-    _other_attributes = frozenset(("_fit_method", "_tree"))
+    _other_attributes = frozenset(("_fit_method", "_tree", "_fit_X", "_y"))
 
 
 class KernelDensity(ProxyBase):

--- a/python/cuml/cuml_accel_tests/integration/test_kneighbors_classifier.py
+++ b/python/cuml/cuml_accel_tests/integration/test_kneighbors_classifier.py
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
-
 import numpy as np
 import pytest
 from sklearn.datasets import make_classification
@@ -150,6 +148,14 @@ def test_knn_classifier_predict_proba(classification_data):
         X.shape[0],
         len(np.unique(y)),
     ), "Probability matrix shape should be (n_samples, n_classes)"
+
+
+def test_knn_classifier_private_attrs(classification_data):
+    model = KNeighborsClassifier().fit(*classification_data)
+    assert isinstance(model._fit_X, np.ndarray)
+    assert isinstance(model._y, np.ndarray)
+    assert model._tree is None
+    assert model._fit_method == "brute"
 
 
 def test_knn_classifier_sparse_input():

--- a/python/cuml/cuml_accel_tests/integration/test_kneighbors_regressor.py
+++ b/python/cuml/cuml_accel_tests/integration/test_kneighbors_regressor.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
 import numpy as np
 import pytest
 from sklearn.datasets import make_regression
@@ -130,6 +129,14 @@ def test_knn_regressor_invalid_weights(regression_data):
     with pytest.raises(ValueError):
         model = KNeighborsRegressor(weights="invalid_weight")
         model.fit(X, y)
+
+
+def test_knn_regressor_private_attrs(regression_data):
+    model = KNeighborsRegressor().fit(*regression_data)
+    assert isinstance(model._fit_X, np.ndarray)
+    assert isinstance(model._y, np.ndarray)
+    assert model._tree is None
+    assert model._fit_method == "brute"
 
 
 def test_knn_regressor_sparse_input():


### PR DESCRIPTION
This exposes `_fit_X` and `_y` on `KNeighborsClassifier`/`KNeighborsRegressor`, and `_fit_X` on `NearestNeighbors` when running on `cuml.accel`. While these are private attributes, some applications (like autogluon) access them and they're cheap to expose.

Fixes #7434.