### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -64,7 +64,7 @@ It is recommended to use conda for environment/package management. If doing so, 
 
 ```bash
 conda create -n cuml_dev python=3.13
-conda env update -n cuml_dev --file=conda/environments/all_cuda-130_arch-$(arch).yaml
+conda env update -n cuml_dev --file=conda/environments/all_cuda-130_arch-$(uname -m).yaml
 conda activate cuml_dev
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ methods to run clang-tidy on your local machine: using Docker or Conda.
     1. Navigate to the repository root directory.
     2. Create and activate the needed conda environment:
         ```bash
-        conda env create --yes -n cuml-clang-tidy -f conda/environments/clang_tidy_cuda-130_arch-$(arch).yaml
+        conda env create --yes -n cuml-clang-tidy -f conda/environments/clang_tidy_cuda-130_arch-$(uname -m).yaml
         conda activate cuml-clang-tidy
         ```
     3. Generate the compile command database with


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.