### PR TITLE
Skip test_extract_partitions_shape

### DIFF
--- a/python/cuml/tests/dask/test_dask_input_utils.py
+++ b/python/cuml/tests/dask/test_dask_input_utils.py
@@ -45,7 +45,7 @@ def test_extract_partitions_worker_list(
     assert len(parts) == n_parts
 
 
-@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.skip(reason="Segfault with pathological parameters (issue #7452)")
 @pytest.mark.mg
 @pytest.mark.parametrize("nrows", [24])
 @pytest.mark.parametrize("ncols", [2])


### PR DESCRIPTION
Closes #7451

This PR skips the `test_extract_partitions_shape` test that is causing reproducible segmentation faults in CI.

The test is marked with `@pytest.mark.skip` to prevent the crash while the underlying issue (#7452) is investigated and resolved.

**Background:**
- The test has been causing segfaults consistently across multiple CI runs (see #7451)
- Crashes occur when creating 23 partitions for only 24 rows of data
- The segfault happens in cudf's column creation during dask metadata generation
- This is a temporary workaround to stabilize CI while the root cause is addressed in #7452

