### PR TITLE
Expose `n_iter_` in `Ridge`

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -289,10 +289,6 @@ Ridge
 - If ``positive=True`` or ``solver="lbfgs"``.
 - If ``X`` is sparse.
 
-Additionally, the following fitted attributes are currently not computed:
-
-- ``n_iter_``
-
 Lasso
 ^^^^^
 

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -237,6 +237,7 @@ class Ridge(Base,
             "intercept_": to_cpu(self.intercept_),
             "coef_": to_cpu(self.coef_),
             "solver_": solver,
+            "n_iter_": None,
             **super()._attrs_to_cpu(model),
         }
 


### PR DESCRIPTION
`Ridge.n_iter_` is _usually_ none, as only a few of the sklearn solvers support it. For now we just always expose it as `None` so the attribute is present.

Part of #6966