### PR TITLE
Expose `n_iter_` in SVC/SVR

### DIFF
--- a/cpp/bench/sg/svc.cu
+++ b/cpp/bench/sg/svc.cu
@@ -87,9 +87,10 @@ std::vector<SvcParams<D>> getInputs()
   p.blobs.center_box_max = 2.0;
   p.blobs.seed           = 12345ULL;
 
-  // SvmParameter{C, cache_size, max_iter, nochange_steps, tol, verbosity})
+  // SvmParameter{C, cache_size, max_outer_iter, max_iter, nochange_steps, tol, verbosity,
+  //              epsilon, svmType})
   p.svm_param = ML::SVM::SvmParameter{
-    1, 200, 100, 100, 1e-3, rapids_logger::level_enum::info, 0, ML::SVM::C_SVC};
+    1, 200, 100, -1, 100, 1e-3, rapids_logger::level_enum::info, 0, ML::SVM::C_SVC};
   p.model = ML::SVM::SvmModel<D>{0, 0, 0, nullptr, {}, nullptr, 0, nullptr};
 
   std::vector<Triplets> rowcols = {{50000, 2, 2}, {2048, 100000, 2}, {50000, 1000, 2}};

--- a/cpp/bench/sg/svr.cu
+++ b/cpp/bench/sg/svr.cu
@@ -87,10 +87,10 @@ std::vector<SvrParams<D>> getInputs()
   p.regression.tail_strength  = 0.5;  // unused when effective_rank = -1
   p.regression.noise          = 1;
 
-  // SvmParameter{C, cache_size, max_iter, nochange_steps, tol, verbosity,
+  // SvmParameter{C, cache_size, max_outer_iter, max_iter, nochange_steps, tol, verbosity,
   //              epsilon, svmType})
   p.svm_param = ML::SVM::SvmParameter{
-    1, 200, 200, 100, 1e-3, rapids_logger::level_enum::info, 0.1, ML::SVM::EPSILON_SVR};
+    1, 200, 200, -1, 100, 1e-3, rapids_logger::level_enum::info, 0.1, ML::SVM::EPSILON_SVR};
   p.model = new ML::SVM::SvmModel<D>{0, 0, 0, 0};
 
   std::vector<Triplets> rowcols = {{50000, 2, 2}, {1024, 10000, 10}, {3000, 200, 200}};

--- a/cpp/include/cuml/svm/svc.hpp
+++ b/cpp/include/cuml/svm/svc.hpp
@@ -36,17 +36,18 @@ namespace SVM {
  * @param [in] kernel_params parameters for the kernel function
  * @param [out] model parameters of the trained model
  * @param [in] sample_weight optional sample weights, size [n_rows]
+ * @return n_iter: the number of solver iterations run during fitting
  */
 template <typename math_t>
-void svcFit(const raft::handle_t& handle,
-            math_t* input,
-            int n_rows,
-            int n_cols,
-            math_t* labels,
-            const SvmParameter& param,
-            ML::matrix::KernelParams& kernel_params,
-            SvmModel<math_t>& model,
-            const math_t* sample_weight);
+int svcFit(const raft::handle_t& handle,
+           math_t* input,
+           int n_rows,
+           int n_cols,
+           math_t* labels,
+           const SvmParameter& param,
+           ML::matrix::KernelParams& kernel_params,
+           SvmModel<math_t>& model,
+           const math_t* sample_weight);
 
 /**
  * @brief Fit a support vector classifier to the training data.
@@ -69,20 +70,21 @@ void svcFit(const raft::handle_t& handle,
  * @param [in] kernel_params parameters for the kernel function
  * @param [out] model parameters of the trained model
  * @param [in] sample_weight optional sample weights, size [n_rows]
+ * @return n_iter: the number of solver iterations run during fitting
  */
 template <typename math_t>
-void svcFitSparse(const raft::handle_t& handle,
-                  int* indptr,
-                  int* indices,
-                  math_t* data,
-                  int n_rows,
-                  int n_cols,
-                  int nnz,
-                  math_t* labels,
-                  const SvmParameter& param,
-                  ML::matrix::KernelParams& kernel_params,
-                  SvmModel<math_t>& model,
-                  const math_t* sample_weight);
+int svcFitSparse(const raft::handle_t& handle,
+                 int* indptr,
+                 int* indices,
+                 math_t* data,
+                 int n_rows,
+                 int n_cols,
+                 int nnz,
+                 math_t* labels,
+                 const SvmParameter& param,
+                 ML::matrix::KernelParams& kernel_params,
+                 SvmModel<math_t>& model,
+                 const math_t* sample_weight);
 
 /**
  * @brief Predict classes or decision function value for samples in input.

--- a/cpp/include/cuml/svm/svm_parameter.h
+++ b/cpp/include/cuml/svm/svm_parameter.h
@@ -16,8 +16,10 @@ enum SvmType { C_SVC, NU_SVC, EPSILON_SVR, NU_SVR };
  *
  * There are several parameters that control how long we train. The training
  * stops if:
- * - max_iter iterations are reached. If you pass -1, then
+ * - max_outer_iter outer iterations are reached. If you pass -1, then
  *   max_diff = 100 * n_rows
+ * - max_iter total iterations are reached. Pass -1 for no limit on total
+ *   iterations.
  * - the diff becomes less the tol
  * - the diff is changing less then 0.001*tol in nochange_steps consecutive
  *   outer iterations.
@@ -25,8 +27,7 @@ enum SvmType { C_SVC, NU_SVC, EPSILON_SVR, NU_SVR };
 struct SvmParameter {
   double C;           //!< Penalty term C
   double cache_size;  //!< kernel cache size in MiB
-  //! maximum number of outer SMO iterations. Use -1 to let the SMO solver set
-  //! a default value (100*n_rows).
+  int max_outer_iter;
   int max_iter;
   int nochange_steps;                   //<! Number of steps to continue with non-changing diff
   double tol;                           //!< Tolerance used to stop fitting.

--- a/cpp/include/cuml/svm/svr.hpp
+++ b/cpp/include/cuml/svm/svr.hpp
@@ -35,17 +35,18 @@ struct SvmParameter;
  * @param [in] kernel_params parameters for the kernel function
  * @param [out] model parameters of the trained model
  * @param [in] sample_weight optional sample weights, size [n_rows]
+ * @return n_iter: the number of solver iterations run during fitting
  */
 template <typename math_t>
-void svrFit(const raft::handle_t& handle,
-            math_t* X,
-            int n_rows,
-            int n_cols,
-            math_t* y,
-            const SvmParameter& param,
-            ML::matrix::KernelParams& kernel_params,
-            SvmModel<math_t>& model,
-            const math_t* sample_weight = nullptr);
+int svrFit(const raft::handle_t& handle,
+           math_t* X,
+           int n_rows,
+           int n_cols,
+           math_t* y,
+           const SvmParameter& param,
+           ML::matrix::KernelParams& kernel_params,
+           SvmModel<math_t>& model,
+           const math_t* sample_weight = nullptr);
 
 /**
  * @brief Fit a support vector regressor to the training data.
@@ -67,20 +68,21 @@ void svrFit(const raft::handle_t& handle,
  * @param [in] kernel_params parameters for the kernel function
  * @param [out] model parameters of the trained model
  * @param [in] sample_weight optional sample weights, size [n_rows]
+ * @return n_iter: the number of solver iterations run during fitting
  */
 template <typename math_t>
-void svrFitSparse(const raft::handle_t& handle,
-                  int* indptr,
-                  int* indices,
-                  math_t* data,
-                  int n_rows,
-                  int n_cols,
-                  int nnz,
-                  math_t* y,
-                  const SvmParameter& param,
-                  ML::matrix::KernelParams& kernel_params,
-                  SvmModel<math_t>& model,
-                  const math_t* sample_weight = nullptr);
+int svrFitSparse(const raft::handle_t& handle,
+                 int* indptr,
+                 int* indices,
+                 math_t* data,
+                 int n_rows,
+                 int n_cols,
+                 int nnz,
+                 math_t* y,
+                 const SvmParameter& param,
+                 ML::matrix::KernelParams& kernel_params,
+                 SvmModel<math_t>& model,
+                 const math_t* sample_weight = nullptr);
 
 // For prediction we use svcPredict
 

--- a/cpp/src/svm/smosolver.cuh
+++ b/cpp/src/svm/smosolver.cuh
@@ -82,6 +82,7 @@ void SmoSolver<math_t>::GetNonzeroDeltaAlpha(const math_t* vec,
  * @param [out] support_matrix support vectors in matrix format, size [n_support, n_cols]
  * @param [out] idx the original training set indices of the support vectors, size [n_support]
  * @param [out] b scalar constant for the decision function
+ * @param [in] max_iter: maximum number of total iterations (default -1 for no limit)
  * @param [in] max_outer_iter maximum number of outer iteration (default 100 * n_rows)
  * @param [in] max_inner_iter maximum number of inner iterations (default 10000)
  */
@@ -97,6 +98,7 @@ void SmoSolver<math_t>::Solve(MatrixViewType matrix,
                               SupportStorage<math_t>* support_matrix,
                               int** idx,
                               math_t* b,
+                              int max_iter,
                               int max_outer_iter,
                               int max_inner_iter)
 {
@@ -110,8 +112,8 @@ void SmoSolver<math_t>::Solve(MatrixViewType matrix,
 
   // Init counters
   max_outer_iter        = GetDefaultMaxIter(n_train, max_outer_iter);
+  n_outer_iter          = 0;
   n_iter                = 0;
-  int n_inner_iter      = 0;
   diff_prev             = 0;
   n_small_diff          = 0;
   n_increased_diff      = 0;
@@ -121,7 +123,7 @@ void SmoSolver<math_t>::Solve(MatrixViewType matrix,
   rmm::device_uvector<math_t> nz_da(n_ws, stream);
   rmm::device_uvector<int> nz_da_idx(n_ws, stream);
 
-  while (n_iter < max_outer_iter && keep_going) {
+  while (keep_going) {
     RAFT_CUDA_TRY(cudaMemsetAsync(delta_alpha.data(), 0, n_ws * sizeof(math_t), stream));
     raft::common::nvtx::push_range("SmoSolver::ws_select");
     ws.Select(f.data(), alpha.data(), y, C_vec.data());
@@ -135,6 +137,8 @@ void SmoSolver<math_t>::Solve(MatrixViewType matrix,
 
     raft::common::nvtx::pop_range();
     raft::common::nvtx::push_range("SmoSolver::SmoBlockSolve");
+    int max_iter_this_block =
+      (max_iter == -1 ? max_inner_iter : std::min(max_inner_iter, max_iter - n_iter));
     SmoBlockSolve<math_t, SMO_WS_SIZE><<<1, n_ws, 0, stream>>>(y,
                                                                n_train,
                                                                alpha.data(),
@@ -146,7 +150,7 @@ void SmoSolver<math_t>::Solve(MatrixViewType matrix,
                                                                C_vec.data(),
                                                                tol,
                                                                return_buff.data(),
-                                                               max_inner_iter,
+                                                               max_iter_this_block,
                                                                svmType);
 
     RAFT_CUDA_TRY(cudaPeekAtLastError());
@@ -186,16 +190,22 @@ void SmoSolver<math_t>::Solve(MatrixViewType matrix,
 
     math_t diff = host_return_buff[0];
     keep_going  = CheckStoppingCondition(diff);
-    n_inner_iter += host_return_buff[1];
-    n_iter++;
-    if (n_iter % 500 == 0) { CUML_LOG_DEBUG("SMO iteration %d, diff %lf", n_iter, (double)diff); }
+    n_iter += host_return_buff[1];
+    n_outer_iter++;
+    if ((max_iter != -1 && n_iter >= max_iter) || n_outer_iter >= max_outer_iter) {
+      keep_going = false;
+    }
+
+    if (n_outer_iter % 500 == 0) {
+      CUML_LOG_DEBUG("SMO iteration %d, diff %lf", n_outer_iter, (double)diff);
+    }
   }
 
   CUML_LOG_DEBUG(
     "SMO solver finished after %d outer iterations, total inner %d"
     " iterations, and diff %lf",
+    n_outer_iter,
     n_iter,
-    n_inner_iter,
     diff_prev);
 
   Results<math_t, MatrixViewType> res(handle, matrix, n_rows, n_cols, y, C_vec.data(), svmType);

--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -22,51 +22,51 @@ namespace SVM {
 using namespace MLCommon;
 
 // Explicit instantiation for the library
-template void svcFit<float>(const raft::handle_t& handle,
-                            float* input,
+template int svcFit<float>(const raft::handle_t& handle,
+                           float* input,
+                           int n_rows,
+                           int n_cols,
+                           float* labels,
+                           const SvmParameter& param,
+                           matrix::KernelParams& kernel_params,
+                           SvmModel<float>& model,
+                           const float* sample_weight);
+
+template int svcFit<double>(const raft::handle_t& handle,
+                            double* input,
                             int n_rows,
                             int n_cols,
-                            float* labels,
+                            double* labels,
                             const SvmParameter& param,
                             matrix::KernelParams& kernel_params,
-                            SvmModel<float>& model,
-                            const float* sample_weight);
+                            SvmModel<double>& model,
+                            const double* sample_weight);
 
-template void svcFit<double>(const raft::handle_t& handle,
-                             double* input,
-                             int n_rows,
-                             int n_cols,
-                             double* labels,
-                             const SvmParameter& param,
-                             matrix::KernelParams& kernel_params,
-                             SvmModel<double>& model,
-                             const double* sample_weight);
+template int svcFitSparse<float>(const raft::handle_t& handle,
+                                 int* indptr,
+                                 int* indices,
+                                 float* data,
+                                 int n_rows,
+                                 int n_cols,
+                                 int nnz,
+                                 float* labels,
+                                 const SvmParameter& param,
+                                 matrix::KernelParams& kernel_params,
+                                 SvmModel<float>& model,
+                                 const float* sample_weight);
 
-template void svcFitSparse<float>(const raft::handle_t& handle,
+template int svcFitSparse<double>(const raft::handle_t& handle,
                                   int* indptr,
                                   int* indices,
-                                  float* data,
+                                  double* data,
                                   int n_rows,
                                   int n_cols,
                                   int nnz,
-                                  float* labels,
+                                  double* labels,
                                   const SvmParameter& param,
                                   matrix::KernelParams& kernel_params,
-                                  SvmModel<float>& model,
-                                  const float* sample_weight);
-
-template void svcFitSparse<double>(const raft::handle_t& handle,
-                                   int* indptr,
-                                   int* indices,
-                                   double* data,
-                                   int n_rows,
-                                   int n_cols,
-                                   int nnz,
-                                   double* labels,
-                                   const SvmParameter& param,
-                                   matrix::KernelParams& kernel_params,
-                                   SvmModel<double>& model,
-                                   const double* sample_weight);
+                                  SvmModel<double>& model,
+                                  const double* sample_weight);
 
 template void svcPredict<float>(const raft::handle_t& handle,
                                 float* input,
@@ -124,11 +124,11 @@ SVC<math_t>::SVC(raft::handle_t& handle,
                  math_t tol,
                  matrix::KernelParams kernel_params,
                  math_t cache_size,
-                 int max_iter,
+                 int max_outer_iter,
                  int nochange_steps,
                  rapids_logger::level_enum verbosity)
   : handle(handle),
-    param(SvmParameter{C, cache_size, max_iter, nochange_steps, tol, verbosity}),
+    param(SvmParameter{C, cache_size, max_outer_iter, -1, nochange_steps, tol, verbosity}),
     kernel_params(kernel_params)
 {
   model.n_support      = 0;

--- a/cpp/src/svm/svr.cu
+++ b/cpp/src/svm/svr.cu
@@ -20,51 +20,51 @@ namespace ML {
 namespace SVM {
 
 // Explicit instantiation for the library
-template void svrFit<float>(const raft::handle_t& handle,
-                            float* X,
+template int svrFit<float>(const raft::handle_t& handle,
+                           float* X,
+                           int n_rows,
+                           int n_cols,
+                           float* y,
+                           const SvmParameter& param,
+                           ML::matrix::KernelParams& kernel_params,
+                           SvmModel<float>& model,
+                           const float* sample_weight);
+
+template int svrFit<double>(const raft::handle_t& handle,
+                            double* X,
                             int n_rows,
                             int n_cols,
-                            float* y,
+                            double* y,
                             const SvmParameter& param,
                             ML::matrix::KernelParams& kernel_params,
-                            SvmModel<float>& model,
-                            const float* sample_weight);
+                            SvmModel<double>& model,
+                            const double* sample_weight);
 
-template void svrFit<double>(const raft::handle_t& handle,
-                             double* X,
-                             int n_rows,
-                             int n_cols,
-                             double* y,
-                             const SvmParameter& param,
-                             ML::matrix::KernelParams& kernel_params,
-                             SvmModel<double>& model,
-                             const double* sample_weight);
+template int svrFitSparse<float>(const raft::handle_t& handle,
+                                 int* indptr,
+                                 int* indices,
+                                 float* data,
+                                 int n_rows,
+                                 int n_cols,
+                                 int nnz,
+                                 float* y,
+                                 const SvmParameter& param,
+                                 ML::matrix::KernelParams& kernel_params,
+                                 SvmModel<float>& model,
+                                 const float* sample_weight);
 
-template void svrFitSparse<float>(const raft::handle_t& handle,
+template int svrFitSparse<double>(const raft::handle_t& handle,
                                   int* indptr,
                                   int* indices,
-                                  float* data,
+                                  double* data,
                                   int n_rows,
                                   int n_cols,
                                   int nnz,
-                                  float* y,
+                                  double* y,
                                   const SvmParameter& param,
                                   ML::matrix::KernelParams& kernel_params,
-                                  SvmModel<float>& model,
-                                  const float* sample_weight);
-
-template void svrFitSparse<double>(const raft::handle_t& handle,
-                                   int* indptr,
-                                   int* indices,
-                                   double* data,
-                                   int n_rows,
-                                   int n_cols,
-                                   int nnz,
-                                   double* y,
-                                   const SvmParameter& param,
-                                   ML::matrix::KernelParams& kernel_params,
-                                   SvmModel<double>& model,
-                                   const double* sample_weight);
+                                  SvmModel<double>& model,
+                                  const double* sample_weight);
 
 };  // namespace SVM
 };  // end namespace ML

--- a/cpp/src/svm/svr_impl.cuh
+++ b/cpp/src/svm/svr_impl.cuh
@@ -34,15 +34,15 @@ namespace ML {
 namespace SVM {
 
 template <typename math_t, typename MatrixViewType>
-void svrFitX(const raft::handle_t& handle,
-             MatrixViewType matrix,
-             int n_rows,
-             int n_cols,
-             math_t* y,
-             const SvmParameter& param,
-             ML::matrix::KernelParams& kernel_params,
-             SvmModel<math_t>& model,
-             const math_t* sample_weight)
+int svrFitX(const raft::handle_t& handle,
+            MatrixViewType matrix,
+            int n_rows,
+            int n_cols,
+            math_t* y,
+            const SvmParameter& param,
+            ML::matrix::KernelParams& kernel_params,
+            SvmModel<math_t>& model,
+            const math_t* sample_weight)
 {
   ASSERT(n_cols > 0, "Parameter n_cols: number of columns cannot be less than one");
   ASSERT(n_rows > 0, "Parameter n_rows: number of rows cannot be less than one");
@@ -70,45 +70,48 @@ void svrFitX(const raft::handle_t& handle,
             &(model.support_matrix),
             &(model.support_idx),
             &(model.b),
-            param.max_iter);
+            param.max_iter,
+            param.max_outer_iter);
   model.n_cols = n_cols;
   delete kernel;
+  return smo.GetNIter();
 }
 
 template <typename math_t>
-void svrFit(const raft::handle_t& handle,
-            math_t* X,
-            int n_rows,
-            int n_cols,
-            math_t* y,
-            const SvmParameter& param,
-            ML::matrix::KernelParams& kernel_params,
-            SvmModel<math_t>& model,
-            const math_t* sample_weight)
+int svrFit(const raft::handle_t& handle,
+           math_t* X,
+           int n_rows,
+           int n_cols,
+           math_t* y,
+           const SvmParameter& param,
+           ML::matrix::KernelParams& kernel_params,
+           SvmModel<math_t>& model,
+           const math_t* sample_weight)
 {
   auto dense_view = raft::make_device_strided_matrix_view<math_t, int, raft::layout_f_contiguous>(
     X, n_rows, n_cols, 0);
-  svrFitX(handle, dense_view, n_rows, n_cols, y, param, kernel_params, model, sample_weight);
+  return svrFitX(handle, dense_view, n_rows, n_cols, y, param, kernel_params, model, sample_weight);
 }
 
 template <typename math_t>
-void svrFitSparse(const raft::handle_t& handle,
-                  int* indptr,
-                  int* indices,
-                  math_t* data,
-                  int n_rows,
-                  int n_cols,
-                  int nnz,
-                  math_t* y,
-                  const SvmParameter& param,
-                  ML::matrix::KernelParams& kernel_params,
-                  SvmModel<math_t>& model,
-                  const math_t* sample_weight)
+int svrFitSparse(const raft::handle_t& handle,
+                 int* indptr,
+                 int* indices,
+                 math_t* data,
+                 int n_rows,
+                 int n_cols,
+                 int nnz,
+                 math_t* y,
+                 const SvmParameter& param,
+                 ML::matrix::KernelParams& kernel_params,
+                 SvmModel<math_t>& model,
+                 const math_t* sample_weight)
 {
   auto csr_structure_view = raft::make_device_compressed_structure_view<int, int, int>(
     indptr, indices, n_rows, n_cols, nnz);
   auto csr_matrix_view = raft::make_device_csr_matrix_view(data, csr_structure_view);
-  svrFitX(handle, csr_matrix_view, n_rows, n_cols, y, param, kernel_params, model, sample_weight);
+  return svrFitX(
+    handle, csr_matrix_view, n_rows, n_cols, y, param, kernel_params, model, sample_weight);
 }
 
 };  // end namespace SVM

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -442,7 +442,6 @@ SVC
 Additionally, the following fitted attributes are currently not computed:
 
 - ``class_weight_``
-- ``n_iter_``
 
 SVR
 ^^^
@@ -451,10 +450,6 @@ SVR
 
 - If ``kernel="precomputed"`` or is a callable.
 - If ``X`` is sparse.
-
-Additionally, the following fitted attributes are currently not computed:
-
-- ``n_iter_``
 
 LinearSVC
 ^^^^^^^^^

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+import warnings
+
 import cupy as cp
 import cupyx.scipy.sparse
 import numpy as np
@@ -128,6 +130,12 @@ cdef class _SVMModel:
         return support, support_vectors, dual_coef, intercept
 
 
+class TotalIters(int):
+    """Indicates the maximum number of total iterations the solver may run."""
+    def __repr__(self):
+        return f"TotalIters({int(self)})"
+
+
 class SVMBase(Base,
               InteropMixin,
               FMajorInputTagMixin,
@@ -173,15 +181,16 @@ class SVMBase(Base,
             "tol": model.tol,
             "C": model.C,
             "cache_size": cache_size,
-            "max_iter": model.max_iter,
+            "max_iter": TotalIters(model.max_iter),
             "epsilon": model.epsilon,
         }
 
     def _params_to_cpu(self):
-        if (cache_size := self.cache_size) == 1024:
-            # XXX: the cache sizes differ between cuml and sklearn, for now we
-            # just adjust when the value's match the defaults.
-            cache_size = 200
+        if isinstance(self.max_iter, TotalIters):
+            max_iter = int(self.max_iter)
+        else:
+            # No way to restrict outer iters only in sklearn, just use the default
+            max_iter = -1
 
         return {
             "kernel": self.kernel,
@@ -190,8 +199,8 @@ class SVMBase(Base,
             "coef0": self.coef0,
             "tol": self.tol,
             "C": self.C,
-            "cache_size": cache_size,
-            "max_iter": self.max_iter,
+            "cache_size": self.cache_size,
+            "max_iter": max_iter,
             "epsilon": self.epsilon,
         }
 
@@ -233,6 +242,7 @@ class SVMBase(Base,
             "_sparse": model._sparse,
             "fit_status_": model.fit_status_,
             "shape_fit_": model.shape_fit_,
+            "n_iter_": model.n_iter_,
             "_probA": model._probA,
             "_probB": model._probB,
             **super()._attrs_from_cpu(model),
@@ -265,6 +275,7 @@ class SVMBase(Base,
             "intercept_": intercept_,
             "_intercept_": intercept_,
             "shape_fit_": self.shape_fit_,
+            "n_iter_": self.n_iter_,
             "_n_support": np.array([self.n_support_, 0], dtype=np.int32),
             "support_": to_cpu(self.support_, order="C", dtype=np.int32),
             "support_vectors_": support_vectors_,
@@ -373,12 +384,35 @@ class SVMBase(Base,
         cdef lib.SvmParameter param
         param.C = self.C
         param.cache_size = self.cache_size
-        param.max_iter = self.max_iter
         param.nochange_steps = self.nochange_steps
         param.tol = self.tol
         param.verbosity = self.verbose
         param.epsilon = self.epsilon
         param.svmType = lib.SvmType.C_SVC if is_classifier else lib.SvmType.EPSILON_SVR
+
+        if isinstance(self.max_iter, TotalIters):
+            param.max_iter = int(self.max_iter)
+            param.max_outer_iter = -1
+        elif self.max_iter == -1:
+            param.max_iter = -1
+            param.max_outer_iter = -1
+        else:
+            name = type(self).__name__
+            warnings.warn(
+                (
+                    "The meaning of `max_iter` will change in version 26.02 from "
+                    "'max outer iterations' to 'max total iterations'.\n\n"
+                    "You may opt into the new behavior now with:\n\n"
+                    f"  {name}(max_iter={name}.TotalIters(max_total_iter), ...)\n\n"
+                    "The number of total iterations run during a fit may be accessed "
+                    "through the `n_iter_` attribute. In 26.02 the `TotalIters` "
+                    "wrapper will be deprecated and `max_iter` will put a limit "
+                    "on total iterations."
+                ),
+                FutureWarning,
+            )
+            param.max_iter = -1
+            param.max_outer_iter = self.max_iter
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
         cdef int n_rows, n_cols, X_nnz
@@ -397,12 +431,13 @@ class SVMBase(Base,
         y_ptr = y.ptr
         sample_weight_ptr = 0 if sample_weight is None else sample_weight.ptr
 
+        cdef int n_iter
         cdef _SVMModel internal = _SVMModel.new(self.handle, is_float32)
 
         with nogil:
             if is_sparse:
                 if is_float32:
-                    lib.svrFitSparse(
+                    n_iter = lib.svrFitSparse(
                         handle_[0],
                         X_indptr,
                         X_indices,
@@ -417,7 +452,7 @@ class SVMBase(Base,
                         <float*>sample_weight_ptr,
                     )
                 else:
-                    lib.svrFitSparse(
+                    n_iter = lib.svrFitSparse(
                         handle_[0],
                         X_indptr,
                         X_indices,
@@ -433,7 +468,7 @@ class SVMBase(Base,
                     )
             else:
                 if is_float32:
-                    lib.svrFit(
+                    n_iter = lib.svrFit(
                         handle_[0],
                         <float*> X_ptr,
                         n_rows,
@@ -445,7 +480,7 @@ class SVMBase(Base,
                         <float*>sample_weight_ptr,
                     )
                 else:
-                    lib.svrFit(
+                    n_iter = lib.svrFit(
                         handle_[0],
                         <double*> X_ptr,
                         n_rows,
@@ -467,6 +502,7 @@ class SVMBase(Base,
         self.n_support_ = support.shape[0]
         self.fit_status_ = 0
         self.shape_fit_ = X.shape
+        self.n_iter_ = np.array([n_iter], dtype=np.int32) if is_classifier else n_iter
         self._gamma = gamma
         self._sparse = is_sparse
         self._probA = np.empty(0, dtype=np.float64)
@@ -614,3 +650,7 @@ class SVMBase(Base,
         self.handle.sync()
 
         return out
+
+
+# Add TotalIters to the SVC/SVR class for easier access
+SVMBase.TotalIters = TotalIters

--- a/python/cuml/cuml/svm/svm_headers.pxd
+++ b/python/cuml/cuml/svm/svm_headers.pxd
@@ -31,6 +31,7 @@ cdef extern from "cuml/svm/svm_parameter.h" namespace "ML::SVM" nogil:
     cdef struct SvmParameter:
         double C
         double cache_size
+        int max_outer_iter
         int max_iter
         int nochange_steps
         double tol
@@ -95,7 +96,7 @@ cdef extern from "cuml/svm/svc.hpp" namespace "ML::SVM" nogil:
 
 cdef extern from "cuml/svm/svr.hpp" namespace "ML::SVM" nogil:
 
-    cdef void svrFit[math_t](
+    cdef int svrFit[math_t](
         const handle_t &handle,
         math_t* data,
         int n_rows,
@@ -107,7 +108,7 @@ cdef extern from "cuml/svm/svr.hpp" namespace "ML::SVM" nogil:
         const math_t *sample_weight,
     ) except+
 
-    cdef void svrFitSparse[math_t](
+    cdef int svrFitSparse[math_t](
         const handle_t &handle,
         int* indptr,
         int* indices,

--- a/python/cuml/cuml/svm/svr.py
+++ b/python/cuml/cuml/svm/svr.py
@@ -59,6 +59,17 @@ class SVR(SVMBase, RegressorMixin):
     max_iter : int (default = -1)
         Limit the number of outer iterations in the solver.
         If -1 (default) then ``max_iter=100*n_samples``
+
+        .. deprecated::25.12
+
+            In 25.12 max_iter meaning "max outer iterations" was deprecated, in
+            favor of instead meaning "max total iterations". To opt in to the
+            new behavior now, you may pass in an instance of `SVR.TotalIters`.
+            For example ``SVR(max_iter=SVR.TotalIters(1000))`` would limit the
+            solver to a max of 1000 total iterations. In 26.02 the new behavior
+            will become the default and the `SVR.TotalIters` wrapper class will
+            be deprecated.
+
     nochange_steps : int (default = 1000)
         We monitor how much our stopping criteria changes during outer
         iterations. If it does not change (changes less then 1e-3*tol)
@@ -89,6 +100,8 @@ class SVR(SVMBase, RegressorMixin):
         The constant in the decision function
     fit_status_ : int
         0 if SVM is correctly fitted
+    n_iter_ : int
+        Number of outer iterations run by the solver.
     coef_ : float, shape [1, n_cols]
         Only available for linear kernels. It is the normal of the
         hyperplane.

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -1166,7 +1166,6 @@
   - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[ElasticNet-ElasticNet]"
   - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[Lasso-Lasso]"
   - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[SVC-SVC]"
-  - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[SVR-SVR]"
 - reason: sklearn expects these algorithm/dtype/metric combos to error, cuml supports them fine
   marker: cuml_accel_neighbors_metric_errors
   condition: scikit-learn<1.6,>=1.5.0
@@ -1230,13 +1229,6 @@
   - "sklearn.tests.test_common::test_estimators[SVC()-check_requires_y_none]"
   - "sklearn.tests.test_common::test_estimators[SVC()-check_sample_weights_not_an_array]"
   - "sklearn.tests.test_common::test_estimators[SVC()-check_supervised_y_no_nan]"
-- reason: SVM missing certain fit attributes
-  marker: cuml_accel_svm_missing_fit_attributes
-  tests:
-  - "sklearn.svm.tests.test_svm::test_n_iter_libsvm[dataset0-SVC-ndarray]"
-  - "sklearn.svm.tests.test_svm::test_n_iter_libsvm[dataset0-SVR-int]"
-  - "sklearn.svm.tests.test_svm::test_n_iter_libsvm[dataset1-SVR-int]"
-  - "sklearn.svm.tests.test_svm::test_n_iter_libsvm[dataset2-SVR-int]"
 - reason: SVM doesn't handle sample_weight identically to sklearn
   marker: cuml_accel_svm_sample_weight
   tests:
@@ -1260,7 +1252,6 @@
   - "sklearn.tests.test_common::test_estimators[SVR()-check_estimators_empty_data_messages]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_estimators_nan_inf]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_fit2d_predict1d]"
-  - "sklearn.tests.test_common::test_estimators[SVR()-check_non_transformer_estimators_n_iter]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_regressor_data_not_an_array]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_requires_y_none]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_sample_weights_not_an_array]"

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -832,7 +832,7 @@ def test_sparse_svr_pickle(tmpdir, datatype, nrows, ncols, n_info):
         )
         y_train = np.random.RandomState(42).rand(nrows)
         X_test = X_train
-        model = cuml.svm.SVR(max_iter=1)
+        model = cuml.svm.SVR(max_iter=cuml.svm.SVR.TotalIters(300))
         model.fit(X_train, y_train)
         result["svr"] = model.predict(X_test)
         return model, X_test

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
 import platform
+import warnings
 
 import cudf
 import cupy as cp
@@ -701,3 +701,49 @@ def test_svm_no_support_vectors():
     assert model.support_vectors_.shape[0] == 0
     # Check disabled due to https://github.com/rapidsai/cuml/issues/4095
     # assert model.support_vectors_.shape[1] == n_cols
+
+
+@pytest.mark.parametrize("classifier", [False, True])
+def test_max_iter_n_iter(classifier):
+    if classifier:
+        model = cuml.SVC()
+        X, y = make_classification(random_state=42)
+    else:
+        model = cuml.SVR()
+        X, y = make_regression(random_state=42)
+
+    # Check that the default doesn't warn!
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=FutureWarning)
+        model.fit(X, y)
+    if classifier:
+        assert model.n_iter_.dtype == np.int32 and model.n_iter_.shape == (1,)
+    else:
+        assert isinstance(model.n_iter_, int)
+
+    # Setting to an integer warns, but uses the old limit on max outer iterations
+    model.max_iter = 1
+    with pytest.warns(FutureWarning, match="max_iter"):
+        model.fit(X, y)
+    assert (model.n_iter_.item() if classifier else model.n_iter_) > 1
+
+    # Using TotalIters gets the new behavior without a warning
+    model.max_iter = model.TotalIters(5)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=FutureWarning)
+        model.fit(X, y)
+    assert (model.n_iter_.item() if classifier else model.n_iter_) == 5
+
+
+def test_svc_multiclass_n_iter():
+    X, y = make_classification(random_state=42, n_classes=3, n_informative=4)
+    model = cuml.SVC().fit(X, y)
+    assert model.n_iter_.dtype == np.int32
+    assert model.n_iter_.shape == (3,)
+
+
+def test_svc_probability_n_iter():
+    X, y = make_classification(random_state=42)
+    model = cuml.SVC(probability=True).fit(X, y)
+    assert model.n_iter_.dtype == np.int32
+    assert model.n_iter_.shape == (1,)


### PR DESCRIPTION
This PR exposes `n_iter_` in our `SVC` and `SVR` estimators.

While doing so, we also deprecate the old meaning of `max_iter` (max outer iterations) in favor of a new meaning (max _total_ iterations). This new meaning aligns with sklearn's implementation, easing interop between the two.

The deprecation cycle is implemented as:

- 25.12: If a user passes in a non-default integer value, a warning is raised informing them of the deprecated meaning. The old behavior is still applied. To opt in to the new behavior (and silence the warning) they can pass an instance of `TotalIters` (an `int` subclass) instead. The `n_iter_` attribute reflects the number of total iterations.
- 26.02: The `TotalIters` wrapper will be deprecated. A bare integer will now mean "max total iterations".
- 26.04: The `TotalIters` wrapper will be fully removed.

Fixes #7439. Part of #6966.