### PR TITLE
Pin Cython pre-3.2.0 and PyTest pre-9

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==25.12.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0
+- cython>=3.0.0,<3.2.0a0
 - dask-cuda==25.12.*,>=0.0.0a0
 - dask-cudf==25.12.*,>=0.0.0a0
 - dask-ml

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==25.12.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0
+- cython>=3.0.0,<3.2.0a0
 - dask-cuda==25.12.*,>=0.0.0a0
 - dask-cudf==25.12.*,>=0.0.0a0
 - dask-ml

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==25.12.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0
+- cython>=3.0.0,<3.2.0a0
 - dask-cuda==25.12.*,>=0.0.0a0
 - dask-cudf==25.12.*,>=0.0.0a0
 - dask-ml

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==25.12.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0
+- cython>=3.0.0,<3.2.0a0
 - dask-cuda==25.12.*,>=0.0.0a0
 - dask-cudf==25.12.*,>=0.0.0a0
 - dask-ml

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -59,7 +59,7 @@ requirements:
   host:
     - cuda-version =${{ cuda_version }}
     - cudf =${{ minor_version }}
-    - cython >=3.0.0
+    - cython >=3.0.0,<3.2.0a0
     - libcuml =${{ version }}
     - libcumlprims =${{ minor_version }}
     - pip

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -318,7 +318,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cython cython>=3.0.0
+          - &cython cython>=3.0.0,<3.2.0a0
           - treelite
   py_run_cuml:
     common:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -107,7 +107,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "certifi",
-    "cython>=3.0.0",
+    "cython>=3.0.0,<3.2.0a0",
     "hdbscan>=0.8.39,<0.8.40",
     "hypothesis>=6.0,<7",
     "nltk",
@@ -176,7 +176,7 @@ matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.30.4",
     "cuda-python>=13.0.1,<14.0a0",
-    "cython>=3.0.0",
+    "cython>=3.0.0,<3.2.0a0",
     "libcuml==25.12.*,>=0.0.0a0",
     "libraft==25.12.*,>=0.0.0a0",
     "librmm==25.12.*,>=0.0.0a0",


### PR DESCRIPTION
Pin to workaround for issues:
* https://github.com/rapidsai/build-planning/issues/229
* https://github.com/rapidsai/build-planning/issues/230

Extends the previous workaround:
* https://github.com/rapidsai/cuml/pull/7468

## Description

Recently Cython 3.2.0 was released and we have seen a few subtle issues building with it. While we work out these issues, this pins to Cython 3.1, which know to be working for us.

Similarly PyTest 9 was recently released, but we have ran into some issues with it as well. So pin to PyTest 8 while we work through PyTest 9 issues.