### PR TITLE
Remove SpectralEmbedding from xfail list

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -951,7 +951,6 @@
   - "sklearn.tests.test_common::test_estimators[Ridge()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[SVC()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_n_features_in_after_fitting]"
-  - "sklearn.tests.test_common::test_estimators[SpectralEmbedding()-check_n_features_in_after_fitting]"
   - "sklearn.tests.test_common::test_estimators[TruncatedSVD()-check_n_features_in_after_fitting]"
 - reason: cuml doesn't set `feature_names_in_` properly
   marker: cuml_accel_feature_names_in


### PR DESCRIPTION
Removes `SpectralEmbedding()-check_n_features_in_after_fitting` from the xfail list as the test now passes.

The test was marked as `xfail(strict=true)` but unexpectedly passed, causing CI failure:
```
FAILED test_estimators[SpectralEmbedding()-check_n_features_in_after_fitting]
[XPASS(strict)] cuml raises a different error if X doesn't have expected n features
```

Closes https://github.com/rapidsai/cuml/issues/7486