### PR TITLE
Add ruff formatting migration to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -36,3 +36,6 @@ b01e2d1d4cf358dbc0a435a663c546fa9cf3e3cb
 
 # Use SPDX for all copyright headers
 6f7a1052f545c7d51d6893ac5791ace574671ed5
+
+# Use ruff-check, ruff-format instead of black, flake8, isort
+da72b463715e28d29e8db3be8d7c339ddcba4dcb


### PR DESCRIPTION
This PR adds commit da72b463715e28d29e8db3be8d7c339ddcba4dcb (PR #7429) to .git-blame-ignore-revs to exclude it from git blame annotations.

PR #7429 migrated the codebase from black, flake8, and isort to ruff-check and ruff-format, which reformatted many files. Adding this commit to .git-blame-ignore-revs ensures that git blame continues to show the original authors of code changes rather than attributing lines to the formatting migration.