### PR TITLE
Document `SVC(probability=True)` requires 5 samples per class

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -436,6 +436,7 @@ SVC
 
 - If ``kernel="precomputed"`` or is a callable.
 - If ``y`` is multiclass.
+- If ``probability=True`` and ``y`` doesn't have at least 5 samples per class.
 
 SVR
 ^^^

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -124,10 +124,13 @@ class SVC(SVMBase, ClassifierMixin):
         type. If None, the output type set at the module level
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
-    probability: bool (default = False)
-        Enable or disable probability estimates.
+    probability : bool (default = False)
+        Set to ``True`` to enable probability estimates
+        (``predict_proba``/``predict_log_proba``). Note that
+        ``probability=True`` requires your training data have at least 5
+        samples per class.
     random_state: int (default = None)
-        Seed for random number generator (used only when probability = True).
+        Seed for random number generator (used only when ``probability=True``).
     verbose : int or boolean, default=False
         Sets logging level. It must be one of `cuml.common.logger.level_*`.
         See :ref:`verbosity-levels` for more info.


### PR DESCRIPTION
- Updates the `SVC` docstring to note that `probability=True` requires at least 5 samples per class
- Adds an equal note to the `cuml.accel` limitations page as a fallback case.

Found this while going through `SVC` issues and it was a quick thing to fix. Fixes #5576.