### PR TITLE
Remove caveat in cuml.accel docs about PCA/TSVD sign

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -125,24 +125,6 @@ These differences should be small for most algorithms, but may be larger for
 randomized or less-numerically-stable solvers like ``"randomized"`` or
 ``"covariance_eigh"``.
 
-Likewise, note that the implementation in ``cuml.accel`` currently may result
-in some of the vectors in ``components_`` having inverted signs. This result is
-not incorrect, but can make it harder to do direct numeric comparisons without
-first normalizing the signs. One common way of handling this is by normalizing
-the first non-zero values in each vector to be positive. You might find the
-following ``numpy`` function useful for this.
-
-.. code-block:: python
-
-    import numpy as np
-
-    def normalize(components):
-        """Normalize the sign of components for easier numeric comparison"""
-        nonzero = components != 0
-        inds = np.where(nonzero.any(axis=1), nonzero.argmax(axis=1), 0)[:, None]
-        first_nonzero = np.take_along_axis(components, inds, 1)
-        return np.sign(first_nonzero) * components
-
 PCA
 ^^^
 


### PR DESCRIPTION
The sign normalization behavior in `PCA`/`TruncatedSVD` now matches that of sklearn (#7331), we no longer need this callout in the `cuml.accel` limitations docs page.