### PR TITLE
Remove verbose descriptor

### DIFF
--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -386,7 +386,7 @@ class DBSCAN(Base,
 
         cdef float eps = self.eps
         cdef int min_samples = self.min_samples
-        cdef level_enum verbose = self.verbose
+        cdef level_enum verbose = self._verbose_level
         cdef bool multi_gpu = self._multi_gpu
         cdef size_t max_mbytes_per_batch = self.max_mbytes_per_batch or 0
 

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -25,7 +25,6 @@ from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
 
 cimport cuml.cluster.cpp.kmeans as lib
-from cuml.internals.logger cimport level_enum
 from cuml.metrics.distance_type cimport DistanceType
 
 
@@ -36,7 +35,7 @@ cdef _kmeans_init_params(kmeans, lib.KMeansParams& params):
     params.n_clusters = kmeans.n_clusters
     params.max_iter = kmeans.max_iter
     params.tol = kmeans.tol
-    params.verbosity = <level_enum>(<int>kmeans.verbose)
+    params.verbosity = kmeans._verbose_level
     params.metric = DistanceType.L2Expanded
     params.batch_samples = int(kmeans.max_samples_per_batch)
     params.oversampling_factor = kmeans.oversampling_factor

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -187,7 +187,6 @@ class BaseRandomForestModel(Base, InteropMixin):
             "min_impurity_decrease",
             "max_batch_size",
             "random_state",
-            "criterion",
             "n_streams",
             "oob_score",
             "handle",
@@ -421,7 +420,7 @@ class BaseRandomForestModel(Base, InteropMixin):
         cdef uintptr_t y_ptr = y.ptr
         cdef int n_rows = X.shape[0]
         cdef int n_cols = X.shape[1]
-        cdef level_enum verbose = <level_enum> self.verbose
+        cdef level_enum verbose = <level_enum> self._verbose_level
         cdef int n_classes = self.n_classes_ if is_classifier else 0
 
         if self.max_depth <= 0:

--- a/python/cuml/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/cuml/experimental/linear_model/lars.pyx
@@ -262,13 +262,13 @@ class Lars(Base, RegressorMixin):
             larsFit(handle_[0], <float*> X_ptr, n_rows, <int> self.n_cols,
                     <float*> y_ptr, <float*> beta_ptr, <int*> active_idx_ptr,
                     <float*> alphas_ptr, &n_active, <float*> Gram_ptr,
-                    max_iter, <float*> coef_path_ptr, self.verbose, ld_X,
+                    max_iter, <float*> coef_path_ptr, self._verbose_level, ld_X,
                     ld_G, <float> self.eps)
         else:
             larsFit(handle_[0], <double*> X_ptr, n_rows, <int> self.n_cols,
                     <double*> y_ptr, <double*> beta_ptr, <int*> active_idx_ptr,
                     <double*> alphas_ptr, &n_active, <double*> Gram_ptr,
-                    max_iter, <double*> coef_path_ptr, self.verbose,
+                    max_iter, <double*> coef_path_ptr, self._verbose_level,
                     ld_X, ld_G, <double> self.eps)
         self.n_active = n_active
         self.n_iter_ = n_active

--- a/python/cuml/cuml/internals/logger.pyx
+++ b/python/cuml/cuml/internals/logger.pyx
@@ -34,7 +34,7 @@ def _verbose_to_level(verbose: bool | int) -> level_enum:
     elif verbose is False:
         return level_enum.info
     else:
-        return level_enum(max(6 - verbose, 0))
+        return level_enum(min(max(6 - verbose, 0), 6))
 
 
 cdef class LogLevelSetter:

--- a/python/cuml/cuml/linear_model/elastic_net.py
+++ b/python/cuml/cuml/linear_model/elastic_net.py
@@ -265,7 +265,7 @@ class ElasticNet(
                 max_iter=self.max_iter,
                 tol=self.tol,
                 penalty_normalized=False,
-                verbose=self.verbose,
+                verbose=self._verbose_level,
                 handle=self.handle,
             )
             coef = CumlArray(data=coef.to_output("cupy").flatten())

--- a/python/cuml/cuml/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/linear_model/logistic_regression.py
@@ -312,7 +312,7 @@ class LogisticRegression(
             max_iter=self.max_iter,
             tol=self.tol,
             linesearch_max_iter=self.linesearch_max_iter,
-            verbose=self.verbose,
+            verbose=self._verbose_level,
             handle=self.handle,
             lbfgs_memory=self.lbfgs_memory,
             penalty_normalized=self.penalty_normalized,

--- a/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
@@ -186,7 +186,7 @@ class LogisticRegressionMG(MGFitMixin, LogisticRegression):
             linesearch_max_iter=self.linesearch_max_iter,
             lbfgs_memory=self.lbfgs_memory,
             penalty_normalized=self.penalty_normalized,
-            verbose=self.verbose,
+            verbose=self._verbose_level,
         )
 
         # Allocate outputs

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -253,7 +253,7 @@ cdef _init_params(self, int n_samples, TSNEParams &params):
     params.pre_momentum = pre_momentum
     params.post_momentum = post_momentum
     params.random_state = seed
-    params.verbosity = self.verbose
+    params.verbosity = self._verbose_level
     params.square_distances = self.square_distances
     params.algorithm = algo
     params.init = init

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -337,7 +337,7 @@ cdef init_params(self, lib.UMAPParams &params, n_rows, is_sparse=False, is_fit=T
     params.repulsion_strength = self.repulsion_strength
     params.negative_sample_rate = self.negative_sample_rate
     params.transform_queue_size = self.transform_queue_size
-    params.verbosity = self.verbose
+    params.verbosity = self._verbose_level
     params.a = self._a
     params.b = self._b
     params.target_n_neighbors = self.target_n_neighbors

--- a/python/cuml/cuml/solvers/qn.pyx
+++ b/python/cuml/cuml/solvers/qn.pyx
@@ -561,7 +561,7 @@ class QN(Base):
             lbfgs_memory=self.lbfgs_memory,
             penalty_normalized=self.penalty_normalized,
             init_coef=init_coef,
-            verbose=self.verbose,
+            verbose=self._verbose_level,
             handle=self.handle,
         )
         self.coef_ = coef

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -99,7 +99,7 @@ def fit(
     C,
     tol,
     epsilon,
-    verbose,
+    level_enum verbose,
 ):
     """Perform a Linear SVR or SVC fit.
 
@@ -173,7 +173,7 @@ def fit(
     params.epsilon = epsilon
     params.grad_tol = tol
     params.change_tol = 0.1 * tol
-    params.verbose = <level_enum>verbose
+    params.verbose = verbose
 
     # Extract dimensions
     cdef size_t n_rows = X.shape[0]

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -281,7 +281,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             C=self.C,
             tol=self.tol,
             epsilon=0.0,
-            verbose=self.verbose,
+            verbose=self._verbose_level,
         )
         self.coef_ = coef
         self.intercept_ = intercept

--- a/python/cuml/cuml/svm/linear_svr.py
+++ b/python/cuml/cuml/svm/linear_svr.py
@@ -252,7 +252,7 @@ class LinearSVR(Base, InteropMixin, LinearPredictMixin, RegressorMixin):
             C=self.C,
             tol=self.tol,
             epsilon=self.epsilon,
-            verbose=self.verbose,
+            verbose=self._verbose_level,
         )
         self.coef_ = coef
         self.intercept_ = intercept

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -397,7 +397,7 @@ class SVMBase(Base,
         param.cache_size = self.cache_size
         param.nochange_steps = self.nochange_steps
         param.tol = self.tol
-        param.verbosity = self.verbose
+        param.verbosity = self._verbose_level
         param.epsilon = self.epsilon
         param.svmType = lib.SvmType.C_SVC if is_classifier else lib.SvmType.EPSILON_SVR
 

--- a/python/cuml/tests/test_hdbscan.py
+++ b/python/cuml/tests/test_hdbscan.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
 import cupy as cp
 import hdbscan
 import numpy as np
@@ -20,7 +19,6 @@ from cuml.cluster.hdbscan import (
     membership_vector,
 )
 from cuml.cluster.hdbscan.hdbscan import _condense_hierarchy, _extract_clusters
-from cuml.internals import logger
 from cuml.metrics import adjusted_rand_score
 from cuml.testing.datasets import make_pattern
 from cuml.testing.utils import array_equal
@@ -166,7 +164,6 @@ def test_hdbscan_blobs(
     )
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         min_samples=min_samples,
         max_cluster_size=max_cluster_size,
@@ -225,7 +222,6 @@ def test_hdbscan_sklearn_datasets(
     X = supervised_learning_dataset
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         gen_min_span_tree=True,
         min_samples=min_samples,
@@ -326,7 +322,6 @@ def test_hdbscan_cluster_patterns(
     X, y = make_pattern(dataset, nrows)[0]
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         min_samples=min_samples,
         max_cluster_size=max_cluster_size,
@@ -526,7 +521,6 @@ def test_all_points_membership_vectors_blobs(
     )
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,
         min_cluster_size=min_cluster_size,
@@ -576,7 +570,6 @@ def test_all_points_membership_vectors_moons(
     X, y = datasets.make_moons(n_samples=nrows, noise=0.05, random_state=42)
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         min_samples=min_samples,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,
@@ -632,7 +625,6 @@ def test_all_points_membership_vectors_circles(
     )
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         min_samples=min_samples,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,
@@ -704,7 +696,6 @@ def test_approximate_predict_blobs(
     )
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,
         min_cluster_size=min_cluster_size,
@@ -762,7 +753,6 @@ def test_approximate_predict_moons(
     X_test = X[nrows:]
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         min_samples=min_samples,
         max_cluster_size=max_cluster_size,
@@ -827,7 +817,6 @@ def test_approximate_predict_circles(
     X_test = X[nrows:]
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         min_samples=min_samples,
         max_cluster_size=max_cluster_size,
@@ -893,7 +882,6 @@ def test_approximate_predict_digits(
     )
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         min_samples=min_samples,
         max_cluster_size=max_cluster_size,
@@ -967,7 +955,6 @@ def test_membership_vector_blobs(
     )
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,
         min_cluster_size=min_cluster_size,
@@ -1030,7 +1017,6 @@ def test_membership_vector_moons(
     X_test = X[nrows:]
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         min_samples=min_samples,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,
@@ -1094,7 +1080,6 @@ def test_membership_vector_circles(
     X_test = X[nrows:]
 
     cuml_agg = HDBSCAN(
-        verbose=logger.level_enum.info,
         min_samples=min_samples,
         allow_single_cluster=allow_single_cluster,
         max_cluster_size=max_cluster_size,

--- a/python/cuml/tests/test_logger.py
+++ b/python/cuml/tests/test_logger.py
@@ -11,22 +11,23 @@ import cuml.internals.logger as logger
 
 
 @pytest.mark.parametrize(
-    "verbose, level, verbose_numeric",
+    "verbose, level",
     [
-        (False, logger.level_enum.info, 4),
-        (True, logger.level_enum.debug, 5),
-        (0, logger.level_enum.off, 0),
-        (1, logger.level_enum.critical, 1),
-        (2, logger.level_enum.error, 2),
-        (3, logger.level_enum.warn, 3),
-        (4, logger.level_enum.info, 4),
-        (5, logger.level_enum.debug, 5),
-        (6, logger.level_enum.trace, 6),
+        (False, logger.level_enum.info),
+        (True, logger.level_enum.debug),
+        (-1, logger.level_enum.off),
+        (0, logger.level_enum.off),
+        (1, logger.level_enum.critical),
+        (2, logger.level_enum.error),
+        (3, logger.level_enum.warn),
+        (4, logger.level_enum.info),
+        (5, logger.level_enum.debug),
+        (6, logger.level_enum.trace),
+        (10, logger.level_enum.trace),
     ],
 )
-def test_verbose_to_from_level(verbose, level, verbose_numeric):
+def test_verbose_to_level(verbose, level):
     assert logger._verbose_to_level(verbose) == level
-    assert logger._verbose_from_level(level) == verbose_numeric
 
 
 def test_logger():

--- a/python/cuml/tests/test_umap.py
+++ b/python/cuml/tests/test_umap.py
@@ -19,7 +19,7 @@ from sklearn.metrics import adjusted_rand_score
 from sklearn.neighbors import NearestNeighbors
 
 import cuml
-from cuml.internals import GraphBasedDimRedCallback, logger
+from cuml.internals import GraphBasedDimRedCallback
 from cuml.manifold.umap import UMAP as cuUMAP
 from cuml.metrics import pairwise_distances
 from cuml.testing.utils import (
@@ -181,7 +181,6 @@ def test_umap_transform_on_digits_sparse(
 
     fitter = cuUMAP(
         n_neighbors=15,
-        verbose=logger.level_enum.info,
         init="random",
         n_epochs=0,
         min_dist=0.01,
@@ -219,7 +218,6 @@ def test_umap_transform_on_digits(target_metric):
 
     fitter = cuUMAP(
         n_neighbors=15,
-        verbose=logger.level_enum.debug,
         init="random",
         n_epochs=0,
         min_dist=0.01,


### PR DESCRIPTION
Previously the `verbose` attribute on an estimator had some magic in it where the value when accessed internally would be a `cuml.internals.logger.level_enum`, but externally would be an `int` or `bool` value as described by the public API.

This PR removes that magic in favor of simpler mechanisms. Now `model.verbose` is a normal attribute, and `model._verbose_level` a property that converts `model.verbose` to a `level_enum`.

Part of #5022.