### PR TITLE
Adjust CI timeouts

### DIFF
--- a/ci/test_python_integration.sh
+++ b/ci/test_python_integration.sh
@@ -13,7 +13,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml integration"
-./ci/run_cuml_integration_pytests.sh \
+timeout 1h ./ci/run_cuml_integration_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -21,7 +21,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml single GPU"
-timeout 2h ./ci/run_cuml_singlegpu_pytests.sh \
+timeout 1h ./ci/run_cuml_singlegpu_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml" \
@@ -30,7 +30,7 @@ timeout 2h ./ci/run_cuml_singlegpu_pytests.sh \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuml-coverage.xml"
 
   rapids-logger "pytest cuml accelerator"
-timeout 2h ./ci/run_cuml_singlegpu_accel_pytests.sh \
+timeout 15m ./ci/run_cuml_singlegpu_accel_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-accel.xml" \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -55,7 +55,7 @@ timeout 1h ./ci/run_cuml_singlegpu_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml"
 
 # Run test_sparse_pca_inputs separately
-timeout 1h ./ci/run_cuml_singlegpu_pytests.sh \
+timeout 10m ./ci/run_cuml_singlegpu_pytests.sh \
   -k 'test_sparse_pca_inputs' \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-sparse-pca.xml"
 


### PR DESCRIPTION
- Adds a missing timeout to the `cudf.pandas` tests
- Shortens the timeouts for a few to more reasonable limits