### PR TITLE
Remove unnecessary `syncthreads` in UMAP optimize

### DIFF
--- a/cpp/src/umap/simpl_set_embed/optimize_batch_kernel.cuh
+++ b/cpp/src/umap/simpl_set_embed/optimize_batch_kernel.cuh
@@ -296,7 +296,6 @@ CUML_KERNEL void optimize_batch_kernel(T const* head_embedding,
     }
     // storing gradients for negative samples back to global memory
     if (use_shared_mem && move_other) {
-      __syncthreads();
       for (int d = 0; d < n_components; d++) {
         auto grad = grads_buffer[d * TPB_X];
         raft::myAtomicAdd<T>((T*)oth_write + d, truncate_gradient(rounding, -grad));
@@ -355,7 +354,6 @@ CUML_KERNEL void optimize_batch_kernel(T const* head_embedding,
 
     // storing gradients for positive samples back to global memory
     if constexpr (use_shared_mem) {
-      __syncthreads();
       for (int d = 0; d < n_components; d++) {
         raft::myAtomicAdd<T>((T*)cur_write + d,
                              truncate_gradient(rounding, grads_buffer[d * TPB_X]));


### PR DESCRIPTION
We have unnecessary `syncthreads` in the UMAP optimize step that can lead to hangs.

The kernel has a big `while (row < nnz) ` loop where each thread progresses through a few rows.
If some threads in a block break out of this loop, and other threads are still working, `__syncthreads` will hang.

We don't need `__syncthreads` here because all threads read/write to independent slots in both the `grads_buffer` and `current_buffer`.