### PR TITLE
Revert precomputed kNN on CPU for UMAP

### DIFF
--- a/cpp/include/cuml/manifold/common.hpp
+++ b/cpp/include/cuml/manifold/common.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <raft/spatial/knn/detail/ann_utils.cuh>
-
 #include <stdint.h>
 
 namespace ML {
@@ -106,15 +104,7 @@ struct manifold_precomputed_knn_inputs_t : public manifold_inputs_t<value_t> {
 
   knn_graph<value_idx, value_t> knn_graph;
 
-  bool alloc_knn_graph() const
-  {
-    // Return true if data is on CPU (need to allocate device memory)
-    // Return false if data is already on device (no allocation needed)
-    auto pointer_residency = raft::spatial::knn::detail::utils::check_pointer_residency(
-      knn_graph.knn_indices, knn_graph.knn_dists);
-    return pointer_residency == raft::spatial::knn::detail::utils::pointer_residency::host_only ||
-           pointer_residency == raft::spatial::knn::detail::utils::pointer_residency::mixed;
-  }
+  bool alloc_knn_graph() const { return false; }
 };
 
 };  // end namespace ML

--- a/cpp/src/umap/knn_graph/algo.cuh
+++ b/cpp/src/umap/knn_graph/algo.cuh
@@ -197,14 +197,8 @@ inline void launcher(const raft::handle_t& handle,
                      const ML::UMAPParams* params,
                      cudaStream_t stream)
 {
-  if (inputsA.alloc_knn_graph()) {
-    // if new space for the knn graph is allocated, copy the data from the precomputed knn graph
-    raft::copy(out.knn_indices, inputsA.knn_graph.knn_indices, inputsA.n * n_neighbors, stream);
-    raft::copy(out.knn_dists, inputsA.knn_graph.knn_dists, inputsA.n * n_neighbors, stream);
-  } else {
-    out.knn_indices = inputsA.knn_graph.knn_indices;
-    out.knn_dists   = inputsA.knn_graph.knn_dists;
-  }
+  out.knn_indices = inputsA.knn_graph.knn_indices;
+  out.knn_dists   = inputsA.knn_graph.knn_dists;
 }
 
 // Instantiation for precomputed inputs, int indices
@@ -217,14 +211,8 @@ inline void launcher(const raft::handle_t& handle,
                      const ML::UMAPParams* params,
                      cudaStream_t stream)
 {
-  if (inputsA.alloc_knn_graph()) {
-    // if new space for the knn graph is allocated, copy the data from the precomputed knn graph
-    raft::copy(out.knn_indices, inputsA.knn_graph.knn_indices, inputsA.n * n_neighbors, stream);
-    raft::copy(out.knn_dists, inputsA.knn_graph.knn_dists, inputsA.n * n_neighbors, stream);
-  } else {
-    out.knn_indices = inputsA.knn_graph.knn_indices;
-    out.knn_dists   = inputsA.knn_graph.knn_dists;
-  }
+  out.knn_indices = inputsA.knn_graph.knn_indices;
+  out.knn_dists   = inputsA.knn_graph.knn_dists;
 }
 
 }  // namespace Algo

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -522,9 +522,7 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
         sparse array (preferably CSR/COO). This feature allows
         the precomputation of the KNN outside of UMAP
         and also allows the use of a custom distance function. This function
-        should match the metric used to train the UMAP embeedings. For most efficient
-        memory usage, the precomputed knn graph should be CPU-accessible arrays
-        such as numpy arrays.
+        should match the metric used to train the UMAP embeedings.
     random_state : int, RandomState instance or None, optional (default=None)
         random_state is the seed used by the random number generator during
         embedding initialization and during sampling used by the optimizer.
@@ -902,9 +900,7 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
             the precomputation of the KNN outside of UMAP
             and also allows the use of a custom distance function. This function
             should match the metric used to train the UMAP embeedings.
-            Takes precedence over the precomputed_knn parameter. For most efficient
-            memory usage, the precomputed knn graph should be CPU-accessible arrays
-            such as numpy arrays.
+            Takes precedence over the precomputed_knn parameter.
         """
         if len(X.shape) != 2:
             raise ValueError("Reshape your data: data should be two dimensional")
@@ -972,7 +968,6 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
             knn_indices, knn_dists = extract_knn_graph(
                 (knn_graph if knn_graph is not None else self.precomputed_knn),
                 self._n_neighbors,
-                mem_type=False,     # mirrors the input graph mem type
             )
             if X_is_sparse:
                 knn_indices = input_to_cuml_array(
@@ -1077,9 +1072,7 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
             the precomputation of the KNN outside of UMAP
             and also allows the use of a custom distance function. This function
             should match the metric used to train the UMAP embeedings.
-            Takes precedence over the precomputed_knn parameter. For most efficient
-            memory usage, the precomputed knn graph should be CPU-accessible arrays
-            such as numpy arrays.
+            Takes precedence over the precomputed_knn parameter.
         """
         self.fit(X, y, convert_dtype=convert_dtype, knn_graph=knn_graph)
         return self.embedding_


### PR DESCRIPTION
Reverting this PR: https://github.com/rapidsai/cuml/pull/7481 because it needs further testing on pointer residency on HMM-configure machines.

Related issue: https://github.com/rapidsai/cuml/issues/7540