### PR TITLE
UMAP fix int32 overflow causing illegal mem access

### DIFF
--- a/cpp/src/umap/simpl_set_embed/optimize_batch_kernel.cuh
+++ b/cpp/src/umap/simpl_set_embed/optimize_batch_kernel.cuh
@@ -108,8 +108,8 @@ CUML_KERNEL void optimize_batch_kernel_reg(T const* head_embedding,
                                            T nsr_inv,
                                            T rounding)
 {
-  size_t row       = (blockIdx.x * static_cast<nnz_t>(TPB_X)) + threadIdx.x;
-  size_t skip_size = blockDim.x * gridDim.x;
+  size_t row       = (static_cast<size_t>(blockIdx.x) * static_cast<size_t>(TPB_X)) + threadIdx.x;
+  size_t skip_size = static_cast<size_t>(blockDim.x) * gridDim.x;
 
   T current_reg[n_components], other_reg[n_components], grads[n_components];
   while (row < nnz) {
@@ -231,8 +231,8 @@ CUML_KERNEL void optimize_batch_kernel(T const* head_embedding,
                                        T rounding)
 {
   extern __shared__ T embedding_shared_mem_updates[];
-  size_t row       = (blockIdx.x * static_cast<nnz_t>(TPB_X)) + threadIdx.x;
-  size_t skip_size = blockDim.x * gridDim.x;
+  size_t row       = (static_cast<size_t>(blockIdx.x) * static_cast<size_t>(TPB_X)) + threadIdx.x;
+  size_t skip_size = static_cast<size_t>(blockDim.x) * gridDim.x;
 
   while (row < nnz) {
     auto _epoch_of_next_sample = epoch_of_next_sample[row];


### PR DESCRIPTION
Resolves #7517

The `optimize_batch_kernel` and `optimize_batch_kernel_reg` use the following condition to check for out of bounds

`while (row < nnz)`

Inside the loop `row += skip_size` is used for iteration. However, when row is close to `INT32_MAX` it can cause an overflow, which leads to the value of row wrapping around to become a negative number. The loop will then be run again since row < nnz still, which will lead to a cuda illegal memory access since row is negative.

To solve this we can check for the overflow case and break from the while loop
`if (row > nnz - skip_size) break;`

Update: We can use `size_t` for row and skip_size instead.

See #7517 for a concrete reproducer.