### PR TITLE
Pin scikit-learn<1.8 in test dependencies

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -71,7 +71,7 @@ dependencies:
 - rmm==25.12.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - scikit-learn>=1.4
-- scikit-learn>=1.4,<1.8.0.dev0
+- scikit-learn>=1.4,<1.8.0
 - scipy>=1.11.0
 - seaborn
 - sphinx

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -71,7 +71,7 @@ dependencies:
 - rmm==25.12.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - scikit-learn>=1.4
-- scikit-learn>=1.4,<1.8.0.dev0
+- scikit-learn>=1.4,<1.8.0
 - scipy>=1.11.0
 - seaborn
 - sphinx

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -71,7 +71,7 @@ dependencies:
 - rmm==25.12.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - scikit-learn>=1.4
-- scikit-learn>=1.4,<1.8.0.dev0
+- scikit-learn>=1.4,<1.8.0
 - scipy>=1.11.0
 - seaborn
 - sphinx

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -71,7 +71,7 @@ dependencies:
 - rmm==25.12.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - scikit-learn>=1.4
-- scikit-learn>=1.4,<1.8.0.dev0
+- scikit-learn>=1.4,<1.8.0
 - scipy>=1.11.0
 - seaborn
 - sphinx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -485,7 +485,7 @@ dependencies:
           - pytest-cov
           - pytest-xdist
           - seaborn
-          - scikit-learn>=1.4,<1.8.0.dev0
+          - scikit-learn>=1.4,<1.8.0
           - statsmodels
           - tenacity
           - umap-learn==0.5.7

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -120,7 +120,7 @@ test = [
     "pytest-xdist",
     "pytest<9.0",
     "pyyaml",
-    "scikit-learn>=1.4,<1.8.0.dev0",
+    "scikit-learn>=1.4,<1.8.0",
     "seaborn",
     "statsmodels",
     "tenacity",


### PR DESCRIPTION
While cuML itself is compatible with scikit-learn 1.8, some of our dependencies (umap-learn, hdbscan, xgboost) are not. A very small number of tests is not yet compatible either.