### PR TITLE
Add devcontainer fallback for C++ test location

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 # Support customizing the ctests' install location
-cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/"
+# First, try the installed location (CI/conda environments)
+installed_test_location="${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcuml/"
+# Fall back to the build directory (devcontainer environments)
+devcontainers_test_location="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../cpp/build/latest"
+
+if [[ -d "${installed_test_location}" ]]; then
+    cd "${installed_test_location}"
+elif [[ -d "${devcontainers_test_location}" ]]; then
+    cd "${devcontainers_test_location}"
+else
+    echo "Error: Test location not found. Searched:" >&2
+    echo "  - ${installed_test_location}" >&2
+    echo "  - ${devcontainers_test_location}" >&2
+    exit 1
+fi
 
 ctest --output-on-failure --no-tests=error "$@"


### PR DESCRIPTION
## Summary
- Update `run_ctests.sh` to first try the installed test location (CI/conda environments) and fall back to the build directory (devcontainer environments)
- Enables testing in devcontainers with `test-cuml-cpp`

xref: https://github.com/rapidsai/devcontainers/pull/630