### PR TITLE
Forward `cuml.accel` logging to subprocesses

### DIFF
--- a/docs/source/cuml-accel/logging-and-profiling.rst
+++ b/docs/source/cuml-accel/logging-and-profiling.rst
@@ -64,6 +64,14 @@ Since the magic command doesn't accept arguments, use the programmatic installat
    # Install with desired log level before other imports
    cuml.accel.install(log_level="debug")
 
+Environment Variable
+~~~~~~~~~~~~~~~~~~~~
+
+The log level may also be configured by setting the ``CUML_ACCEL_LOG_LEVEL``
+environment variable to ``warn``, ``info`` or ``debug`` (case insensitive).
+This will be used if no explicit level is passed through either
+``cuml.accel.install`` or the CLI.
+
 Example
 -------
 

--- a/python/cuml/cuml/accel/__main__.py
+++ b/python/cuml/cuml/accel/__main__.py
@@ -128,7 +128,7 @@ def main(argv: list[str] | None = None):
     ns = parse_args(sys.argv[1:] if argv is None else argv)
 
     # Parse verbose into log_level
-    log_level = {0: "warn", 1: "info", 2: "debug"}.get(min(ns.verbose, 2))
+    log_level = {0: None, 1: "info", 2: "debug"}.get(min(ns.verbose, 2))
 
     # Enable acceleration
     install(disable_uvm=ns.disable_uvm, log_level=log_level)

--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -136,7 +136,7 @@ def enabled() -> bool:
 
 def install(
     disable_uvm: bool = False,
-    log_level: Literal["error", "warn", "info", "debug"] = "warn",
+    log_level: Literal["error", "warn", "info", "debug", None] = None,
 ) -> None:
     """Enable `cuml.accel`.
 
@@ -145,18 +145,24 @@ def install(
     disable_uvm : bool, optional
         Whether to disable UVM.
     log_level : {"error", "warn", "info", "debug"}, optional
-        The log level to set for the `cuml.accel` logger. Defaults to `"warn"`,
-        set to `"info"` or `"debug"` to get more information about what methods
-        `cuml.accel` accelerated for a given run.
+        The log level to set for the `cuml.accel` logger. Defaults to `None` to
+        check the value of the `CUML_ACCEL_LOG_LEVEL` environment variable,
+        falling back to `"warn"` if not configured. Set to `"info"` or
+        `"debug"` to get more information about what methods `cuml.accel`
+        accelerated for a given run.
     """
     if enabled():
         # Already enabled, no-op
         return
 
+    if log_level is None:
+        log_level = os.environ.get("CUML_ACCEL_LOG_LEVEL", "warn")
+
     logger.set_level(log_level)
     # Set the environment variable if not already set so cuml.accel will
     # be automatically enabled in subprocesses
     os.environ.setdefault("CUML_ACCEL_ENABLED", "1")
+    os.environ.setdefault("CUML_ACCEL_LOG_LEVEL", log_level)
 
     if not disable_uvm:
         if _is_concurrent_managed_access_supported():

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -59,6 +59,18 @@ def test_enabled_in_loky_executor():
         assert cuml.accel.is_proxy(remote)
 
 
+def get_level():
+    return cuml.accel.core.logger.level.name.lower()
+
+
+def test_log_level_forwarded_to_subprocesses(monkeypatch):
+    monkeypatch.setenv("CUML_ACCEL_LOG_LEVEL", "debug")
+    ctx = multiprocessing.get_context("spawn")
+    with ctx.Pool(processes=1) as pool:
+        log_level = pool.apply(get_level)
+    assert log_level == "debug"
+
+
 def iter_proxy_class_methods():
     """Generate test cases of (cls, method_name) for all ProxyBase proxied methods"""
     classes = proxy_base_subclasses()


### PR DESCRIPTION
This:
- Adds a new `CUML_ACCEL_LOG_LEVEL` environment variable for configuring the level of the `cuml.accel` logger. This log level will be used if a level isn't explicitly configured via other means (`cuml.accel.install` or `-v` in the CLI).
- Uses the `CUML_ACCEL_LOG_LEVEL` environment variable to forward logging configuration on to subprocesses by default. Fixes #7572.
- Also updates the log handler to flush on every write, avoiding delays in logs appearing. Thanks to @betatim for reporting this issue.

Fixes #7572