### PR TITLE
Explicitly initialize uninitialized SvmParameter fields in SVC constructor

### DIFF
--- a/cpp/src/svm/svc.cu
+++ b/cpp/src/svm/svc.cu
@@ -128,7 +128,8 @@ SVC<math_t>::SVC(raft::handle_t& handle,
                  int nochange_steps,
                  rapids_logger::level_enum verbosity)
   : handle(handle),
-    param(SvmParameter{C, cache_size, max_outer_iter, -1, nochange_steps, tol, verbosity, 0, C_SVC}),
+    param(
+      SvmParameter{C, cache_size, max_outer_iter, -1, nochange_steps, tol, verbosity, 0, C_SVC}),
     kernel_params(kernel_params)
 {
   model.n_support      = 0;


### PR DESCRIPTION
closes #7603 

Fixes missing `epsilon` and `svmType` fields in the `SVC` class constructor's aggregate initialization of `SvmParameter`.

After #7461 added `max_outer_iter` to `SvmParameter`, the constructor in `svc.cu` was updated but still omitted the final two fields:

```C++
// Before (missing epsilon and svmType):
--param(SvmParameter{C, cache_size, max_outer_iter, -1, nochange_steps, tol, verbosity})

// After (explicit initialization):
++param(SvmParameter{C, cache_size, max_outer_iter, -1, nochange_steps, tol, verbosity, 0, C_SVC})
```
While C++ value-initializes omitted aggregate members to zero, this behavior can vary across compilers and build configurations. The missing `svmType` field caused intermittent CI failures in `SmoSolverTest/0.SvcTest` with the error:

> "Incorrect training: cannot calculate the constant in the decision function"

This occurred because an undefined `svmType` value could cause the SMO solver to misinterpret training data, leading to invalid support vector selection.