### PR TITLE
Deprecate `TotalIters` for SVC/SVR

### DIFF
--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -94,19 +94,8 @@ class SVC(SVMBase, ClassifierMixin):
         string 'balanced' is also accepted, in which case ``class_weight[i] =
         n_samples / (n_classes * n_samples_of_class[i])``
     max_iter : int (default = -1)
-        Limit the number of outer iterations in the solver.
-        If -1 (default) then ``max_iter=100*n_samples``
-
-        .. deprecated::25.12
-
-            In 25.12 max_iter meaning "max outer iterations" was deprecated, in
-            favor of instead meaning "max total iterations". To opt in to the
-            new behavior now, you may pass in an instance of `SVC.TotalIters`.
-            For example ``SVC(max_iter=SVC.TotalIters(1000))`` would limit the
-            solver to a max of 1000 total iterations. In 26.02 the new behavior
-            will become the default and the `SVC.TotalIters` wrapper class will
-            be deprecated.
-
+        Limit the number of total iterations in the solver. Default of -1 for
+        "no limit".
     decision_function_shape : str ('ovo' or 'ovr', default 'ovo')
         Multiclass classification strategy. ``'ovo'`` uses `OneVsOneClassifier
         <https://scikit-learn.org/stable/modules/generated/sklearn.multiclass.OneVsOneClassifier.html>`_

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -131,7 +131,14 @@ cdef class _SVMModel:
 
 
 class TotalIters(int):
-    """Indicates the maximum number of total iterations the solver may run."""
+    """Indicates the maximum number of total iterations the solver may run.
+
+    .. deprecated:: 26.02
+
+        TotalIters was deprecated in 26.02 and will be removed in 26.04.
+        The `max_iter` parameter now always places a limit on total iterations,
+        wrapping with `TotalIters` is no longer necessary.
+    """
     def __repr__(self):
         return f"TotalIters({int(self)})"
 
@@ -181,7 +188,7 @@ class SVMBase(Base,
             "tol": model.tol,
             "C": model.C,
             "cache_size": cache_size,
-            "max_iter": TotalIters(model.max_iter),
+            "max_iter": model.max_iter,
             "epsilon": model.epsilon,
         }
 
@@ -189,8 +196,7 @@ class SVMBase(Base,
         if isinstance(self.max_iter, TotalIters):
             max_iter = int(self.max_iter)
         else:
-            # No way to restrict outer iters only in sklearn, just use the default
-            max_iter = -1
+            max_iter = self.max_iter
 
         return {
             "kernel": self.kernel,
@@ -401,29 +407,20 @@ class SVMBase(Base,
         param.epsilon = self.epsilon
         param.svmType = lib.SvmType.C_SVC if is_classifier else lib.SvmType.EPSILON_SVR
 
+        param.max_outer_iter = -1
         if isinstance(self.max_iter, TotalIters):
-            param.max_iter = int(self.max_iter)
-            param.max_outer_iter = -1
-        elif self.max_iter == -1:
-            param.max_iter = -1
-            param.max_outer_iter = -1
-        else:
-            name = type(self).__name__
             warnings.warn(
                 (
-                    "The meaning of `max_iter` will change in version 26.02 from "
-                    "'max outer iterations' to 'max total iterations'.\n\n"
-                    "You may opt into the new behavior now with:\n\n"
-                    f"  {name}(max_iter={name}.TotalIters(max_total_iter), ...)\n\n"
-                    "The number of total iterations run during a fit may be accessed "
-                    "through the `n_iter_` attribute. In 26.02 the `TotalIters` "
-                    "wrapper will be deprecated and `max_iter` will put a limit "
-                    "on total iterations."
+                    "Passing `TotalIters` to `max_iter` was deprecated in 26.02 "
+                    "and will be removed in 26.04. `max_iter` now always places a "
+                    "limit on total iterations, please pass an integer directly "
+                    "instead of wrapping with `TotalIters`."
                 ),
                 FutureWarning,
             )
-            param.max_iter = -1
-            param.max_outer_iter = self.max_iter
+            param.max_iter = int(self.max_iter)
+        else:
+            param.max_iter = self.max_iter
 
         cdef handle_t* handle_ = <handle_t*><size_t>self.handle.getHandle()
         cdef int n_rows, n_cols, X_nnz

--- a/python/cuml/cuml/svm/svr.py
+++ b/python/cuml/cuml/svm/svr.py
@@ -58,19 +58,8 @@ class SVR(SVMBase, RegressorMixin):
         The cache_size variable sets an upper limit to the prediction
         buffer as well.
     max_iter : int (default = -1)
-        Limit the number of outer iterations in the solver.
-        If -1 (default) then ``max_iter=100*n_samples``
-
-        .. deprecated::25.12
-
-            In 25.12 max_iter meaning "max outer iterations" was deprecated, in
-            favor of instead meaning "max total iterations". To opt in to the
-            new behavior now, you may pass in an instance of `SVR.TotalIters`.
-            For example ``SVR(max_iter=SVR.TotalIters(1000))`` would limit the
-            solver to a max of 1000 total iterations. In 26.02 the new behavior
-            will become the default and the `SVR.TotalIters` wrapper class will
-            be deprecated.
-
+        Limit the number of total iterations in the solver. Default of -1 for
+        "no limit".
     nochange_steps : int (default = 1000)
         We monitor how much our stopping criteria changes during outer
         iterations. If it does not change (changes less then 1e-3*tol)

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -876,7 +876,7 @@ def test_sparse_svr_pickle(tmpdir, datatype, nrows, ncols, n_info):
         )
         y_train = np.random.RandomState(42).rand(nrows)
         X_test = X_train
-        model = cuml.svm.SVR(max_iter=cuml.svm.SVR.TotalIters(300))
+        model = cuml.svm.SVR(max_iter=300)
         model.fit(X_train, y_train)
         result["svr"] = model.predict(X_test)
         return model, X_test


### PR DESCRIPTION
This is the 2nd part of the deprecation plan for changing the behavior of `max_iter` for `SVC`/`SVR`. Previously we added a `TotalIters` wrapper so users could opt-in to the new behavior, now we make the new behavior the default and deprecate the wrapper. `max_iter` now always places a limit on _total iterations_ in the solver.

Follow-up to #7461.