### PR TITLE
`k-means++` documented as a init option

### DIFF
--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -423,7 +423,7 @@ class KMeans(Base,
             raise UnsupportedOnGPU(f"`init={model.init!r}` is not supported")
         elif isinstance(model.init, str):
             if model.init == "k-means++":
-                init = "k-means++"
+                init = "scalable-k-means++"
             elif model.init == "random":
                 init = "random"
             else:


### PR DESCRIPTION
Resolves https://github.com/rapidsai/cuml/issues/7352

This PR documents `k-means++` as a init option in the `KMeans` estimator.