### PR TITLE
Avoid deprecated conversion of numpy array->scalar

### DIFF
--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -436,7 +436,7 @@ class PCA(Base,
         self.explained_variance_ratio_ = explained_variance_ratio
         self.mean_ = mean
         self.singular_values_ = singular_values
-        self.noise_variance_ = float(noise_variance.to_output("numpy"))
+        self.noise_variance_ = noise_variance.to_output("numpy").item()
 
     def _fit_sparse(self, X):
         covariance, mean, _ = cov(X, X, return_mean=True)

--- a/python/cuml/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/cuml/decomposition/pca_mg.pyx
@@ -133,4 +133,4 @@ class PCAMG(BaseDecompositionMG, PCA):
         self.explained_variance_ratio_ = explained_variance_ratio
         self.mean_ = mean
         self.singular_values_ = singular_values
-        self.noise_variance_ = float(noise_variance.to_output("numpy"))
+        self.noise_variance_ = noise_variance.to_output("numpy").item()


### PR DESCRIPTION
This drops a few places where we were relying on `float(one_element_array)` to convert an array to a float. This behavior is deprecated in numpy; instead we can rely on `.item()` to do the same.

Fixes #7617