### PR TITLE
Add warning in UMAP for nondeterministic behavior when `build_algo=nn_descent`

### DIFF
--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -324,7 +324,6 @@ cdef init_params(self, lib.UMAPParams &params, n_rows, is_sparse=False, is_fit=T
         )
 
     if build_algo == "nn_descent" and self.random_state is not None:
-        print("warning here")
         warnings.warn("build_algo='nn_descent' is not deterministic. Please use "
                       "build_algo='brute_force_knn' instead with random_state set.")
 


### PR DESCRIPTION
We don't support deterministic NN Descent. This PR raises a warning to the user when `build_algo` is given as `nn_descent` and `random_state` is also set.