### PR TITLE
Use cuvs spectral clustering dataset api

### DIFF
--- a/cpp/src/spectral/spectral_clustering.cu
+++ b/cpp/src/spectral/spectral_clustering.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cuvs/pull/1653

This PR calls the spectral clustering dataset api from cuvs instead of doing it in cuml.