### PR TITLE
Don't fail on `cuda.core.experimental` deprecation warnings

### DIFF
--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -64,6 +64,8 @@ filterwarnings = [
   "ignore:Estimator .* does not inherit from.*:UserWarning",
   # From numba - GPU under-utilization warnings in tests with small data
   "ignore::numba.core.errors.NumbaPerformanceWarning",
+  # numba-cuda makes use of deprecated cuda.core.experimental apis
+  "ignore:The cuda.core.experimental namespace is deprecated:DeprecationWarning",
   # Allow informational benchmark warnings (pytest-benchmark plugin)
   "default::pytest_benchmark.logger.PytestBenchmarkWarning",
 ]


### PR DESCRIPTION
Stopgap until https://github.com/NVIDIA/numba-cuda/pull/676 is in.