### PR TITLE
Use a generated dataset in place of the actual Covertype dataset.

### DIFF
--- a/docs/source/cuml-accel/examples/getting_started.ipynb
+++ b/docs/source/cuml-accel/examples/getting_started.ipynb
@@ -44,9 +44,9 @@
         "id": "vT5RNLwdce-O"
       },
       "source": [
-        "We will generate a dataset with similar characteristics as the Covertype dataset, which contains a number of features that can be used to predict forest cover type, such as elevation, aspect, slope, and soil-type.\n",
+        "We will randomly generate a dataset for this example. Alternatively, if you prefer a real-world dataset, you can use the Covertype dataset, which contains features such as elevation, aspect, slope, and soil type to predict forest cover type.\n",
         "\n",
-        "More information on this dataset can be found at https://archive.ics.uci.edu/dataset/31/covertype."
+        "More information on the Covertype dataset can be found at https://archive.ics.uci.edu/dataset/31/covertype."
       ]
     },
     {
@@ -69,7 +69,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "X, y = make_classification(n_samples=581012, n_features=54, n_classes=7)\n",
+        "# We generate a dataset with roughly the same characteristics as the Covertype dataset\n",
+        "X, y = make_classification(n_samples=500000, n_features=50, n_informative=20, n_classes=7)\n",
         "\n",
         "# Uncomment this to use the actual Covertype dataset\n",
         "# from sklearn.datasets import fetch_covtype\n",


### PR DESCRIPTION
To make this notebook more robust by not relying on remote datasets.

Closes #7633 .