### PR TITLE
Refactor pointer comparison in check_ptr function for input validation

### DIFF
--- a/python/cuml/tests/test_input_utils.py
+++ b/python/cuml/tests/test_input_utils.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 


### PR DESCRIPTION
Replace `Buffer.get_ptr(mode="read")` with `Buffer.ptr` property in `test_input_utils.py`.

The `get_ptr()` method was removed in https://github.com/rapidsai/cudf/pull/20949.

Closes #7638