### PR TITLE
Mark some SpectralEmbedding() common test_estimators tests as flaky.

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -1306,6 +1306,7 @@
 - reason: test_estimators checks fail (1.5)
   marker: cuml_accel_test_estimators
   condition: scikit-learn==1.5
+  strict: false
   tests:
   - "sklearn.tests.test_common::test_estimators[SpectralEmbedding()-check_estimators_fit_returns_self(readonly_memmap=True)]"
 - reason: test_estimators checks fail (1.7.2+)


### PR DESCRIPTION
Mitigates https://github.com/rapidsai/cuml/issues/7671