### PR TITLE
CI Fix wrong script name in nightly job with nightly versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,7 +128,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
-      script: ci/test_wheel_nightly_versions.sh
+      script: ci/test_wheel_nightly_dependencies_versions.sh
       continue-on-error: true
   wheel-tests-cuml-dask:
     secrets: inherit


### PR DESCRIPTION
Dumb mistake. Forgot to rename the script that the workflow refers to after renaming the script.

https://github.com/rapidsai/cuml/actions/runs/21059500000/job/60562379341

Follow up to https://github.com/rapidsai/cuml/pull/7621