### PR TITLE
Handle new sklearn LARS error message in test_typeerror_input

### DIFF
--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -346,7 +346,11 @@ def test_typeerror_input():
     try:
         exp.shap_values(X)
     except ValueError as error:
-        if "operands could not be broadcast together" in str(error):
+        error_str = str(error)
+        if (
+            "operands could not be broadcast together" in error_str
+            or "dimension must be fixed to" in error_str
+        ):
             pytest.xfail(
                 "Known sklearn LARS broadcasting bug - see scikit-learn#9603"
             )


### PR DESCRIPTION
The sklearn LARS path solver now raises a different error message ('dimension must be fixed to') instead of the previously expected 'operands could not be broadcast together'. Both are likely  manifestations of the same underlying bug (scikit-learn/scikit-learn#9603).

Update the test to catch both error patterns and mark them as xfail.

Likely related to https://github.com/rapidsai/cuml/issues/6971 .