### PR TITLE
Fix missing header in hdbscan test

### DIFF
--- a/cpp/tests/sg/hdbscan_test.cu
+++ b/cpp/tests/sg/hdbscan_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,6 +21,7 @@
 
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 #include <cuvs/cluster/agglomerative.hpp>
 #include <cuvs/distance/distance.hpp>


### PR DESCRIPTION
Small fix for compatibility with CCCL `main`.

https://github.com/NVIDIA/cccl/actions/runs/21235113836/job/61176235846
