### PR TITLE
Fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -766,18 +766,24 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-        - numba-cuda>=0.22.1,<0.23.0
+        - &numba_cuda numba-cuda>=0.22.1,<0.23.0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
               cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - numba-cuda[cu12]>=0.22.1,<0.23.0
-          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
+              cuda: "13.*"
+              cuda_suffixed: "true"
             packages:
               - numba-cuda[cu13]>=0.22.1,<0.23.0
+          # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
+          - matrix:
+            packages:
+              - *numba_cuda
   depends_on_pylibraft:
     common:
       - output_types: conda

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
     "cupy-cuda13x>=13.6.0",
     "joblib>=0.11",
     "libcuml==26.2.*,>=0.0.0a0",
-    "numba-cuda[cu13]>=0.22.1,<0.23.0",
+    "numba-cuda>=0.22.1,<0.23.0",
     "numba>=0.60.0,<0.62.0",
     "numpy>=1.23,<3.0",
     "packaging",


### PR DESCRIPTION
This PR prevents installing `numba-cuda[cu13]` when rapids-dependency-file-generator is run without `cuda_suffixed=True` in its matrix.