### PR TITLE
Fix integer overflow in FIL

### DIFF
--- a/cpp/include/cuml/fil/detail/infer/gpu.cuh
+++ b/cpp/include/cuml/fil/detail/infer/gpu.cuh
@@ -226,8 +226,8 @@ std::enable_if_t<D == raft_proto::device_type::gpu, void> infer(
       // does not overflow past the uint32_t limit.
     }
     if (row_count > max_num_row) {
-      throw type_error(std::string("Input size too large! Input should be at most ") +
-                       std::to_string(max_num_row) + ".");
+      throw runtime_error(std::string("Input size too large! Input should be at most ") +
+                          std::to_string(max_num_row) + ".");
     }
   }
 

--- a/cpp/include/cuml/fil/detail/infer_kernel/cpu.hpp
+++ b/cpp/include/cuml/fil/detail/infer_kernel/cpu.hpp
@@ -116,8 +116,8 @@ void infer_kernel_cpu(forest_t const& forest,
       // does not overflow past the uint32_t limit.
     }
     if (row_count > max_num_row) {
-      throw type_error(std::string("Input size too large! Input should be at most ") +
-                       std::to_string(max_num_row) + ".");
+      throw runtime_error(std::string("Input size too large! Input should be at most ") +
+                          std::to_string(max_num_row) + ".");
     }
   }
 

--- a/cpp/include/cuml/fil/exceptions.hpp
+++ b/cpp/include/cuml/fil/exceptions.hpp
@@ -40,7 +40,19 @@ struct model_import_error : std::exception {
 struct type_error : std::exception {
   type_error() : type_error("Model cannot be used with given data type") {}
   type_error(char const* msg) : msg_{msg} {}
-  type_error(std::string const& msg) : msg_{msg} {}
+  virtual char const* what() const noexcept { return msg_; }
+
+ private:
+  char const* msg_;
+};
+
+/**
+ * Exception indicating a runtime error.
+ */
+struct runtime_error : std::exception {
+  runtime_error() : runtime_error("Runtime error") {}
+  runtime_error(char const* msg) : msg_{msg} {}
+  runtime_error(std::string const& msg) : msg_{msg} {}
   virtual char const* what() const noexcept { return msg_.c_str(); }
 
  private:


### PR DESCRIPTION
Closes #7711

* Check the input size to ensure that the index type does not overflow. If the input is too large, throw an error.