### PR TITLE
Ignore warnings caused by sklearn/scipy incompatibility.

### DIFF
--- a/python/cuml/tests/test_linear_model.py
+++ b/python/cuml/tests/test_linear_model.py
@@ -360,7 +360,7 @@ def test_logistic_regression_unscaled(dtype, l1_ratio, C):
 
 
 # Ignore scipy 1.17.0+ deprecation warning from sklearn 1.5.x LogisticRegression
-# using deprecated L-BFGS-B parameters. Will be fixed in sklearn 1.6.0+
+# using deprecated L-BFGS-B parameters. This is fixed in sklearn 1.6.0+.
 @pytest.mark.filterwarnings(
     "ignore:.*The `disp` and `iprint` options.*:DeprecationWarning"
 )
@@ -576,7 +576,7 @@ def test_logistic_regression_input_type_consistency(constructor, dtype):
 
 
 # Ignore scipy 1.17.0+ deprecation warning from sklearn 1.5.x LogisticRegression
-# using deprecated L-BFGS-B parameters. Will be fixed in sklearn 1.6.0+
+# using deprecated L-BFGS-B parameters. This is fixed in sklearn 1.6.0+.
 @pytest.mark.filterwarnings(
     "ignore:.*The `disp` and `iprint` options.*:DeprecationWarning"
 )
@@ -770,7 +770,7 @@ def test_logistic_predict_convert_dtype(dataset, test_dtype):
     class_weight_option=None,
 )
 # Ignore scipy 1.17.0+ deprecation warning from sklearn 1.5.x LogisticRegression
-# using deprecated L-BFGS-B parameters. Will be fixed in sklearn 1.6.0+
+# using deprecated L-BFGS-B parameters. This is fixed in sklearn 1.6.0+.
 @pytest.mark.filterwarnings(
     "ignore:.*The `disp` and `iprint` options.*:DeprecationWarning"
 )

--- a/python/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/tests/test_sklearn_import_export.py
@@ -214,7 +214,7 @@ def test_linear_regression(random_state):
 
 
 # Ignore scipy 1.17.0+ deprecation warning from sklearn 1.5.x LogisticRegression
-# using deprecated L-BFGS-B parameters. Will be fixed in sklearn 1.6.0+
+# using deprecated L-BFGS-B parameters. This is fixed in sklearn 1.6.0+.
 @pytest.mark.filterwarnings(
     "ignore:.*The `disp` and `iprint` options.*:DeprecationWarning"
 )


### PR DESCRIPTION
Adds `@pytest.mark.filterwarnings` decorators to 4 LogisticRegression tests that use sklearn as a reference implementation.

Fixes #7733