### PR TITLE
Document support for and limitations of TargetEncoder in cuml.accel.

### DIFF
--- a/docs/source/cuml-accel/faq.rst
+++ b/docs/source/cuml-accel/faq.rst
@@ -68,6 +68,7 @@ the following estimators are mostly or entirely accelerated when run with
     * ``sklearn.neighbors.KNeighborsClassifier``
     * ``sklearn.neighbors.KNeighborsRegressor``
     * ``sklearn.neighbors.KernelDensity``
+    * ``sklearn.preprocessing.TargetEncoder``
     * ``sklearn.svm.SVC``
     * ``sklearn.svm.SVR``
     * ``sklearn.svm.LinearSVC``

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -399,6 +399,30 @@ Additional notes:
   implementation in cuml will always be used.
 
 
+sklearn.preprocessing
+---------------------
+
+TargetEncoder
+^^^^^^^^^^^^^
+
+``TargetEncoder`` will fall back to CPU in the following cases:
+
+- If ``categories`` is not ``"auto"``.
+- If ``y`` is a multiclass target (sklearn uses one-hot encoding internally).
+- If ``random_state`` is a ``numpy.random.RandomState`` object (integer seeds work fine).
+- If ``X`` has object dtype with numeric values.
+- If ``y`` has object dtype.
+
+Additional notes:
+
+- cuML and sklearn use different cross-validation fold assignment strategies
+  during ``fit_transform``. Both are valid target encoding implementations, but
+  samples are assigned to different folds, resulting in different leave-fold-out
+  encodings for training data. The ``transform`` method on test data produces
+  equivalent results since it uses global statistics computed from all training
+  samples.
+
+
 sklearn.svm
 -----------
 


### PR DESCRIPTION
Adds documentation for the cuml.accel'eration of TargetEncoder.

Follow-up to https://github.com/rapidsai/cuml/pull/7476 .