### PR TITLE
CI Fix tests to be compatible with new stricter cudf dtype handling

### DIFF
--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -203,7 +203,13 @@ def test_accuracy_score(
         if kind == "cupy":
             return cp.array(x, dtype=dtype)
         elif kind == "cudf":
-            return cudf.Series(x).astype(dtype)
+            s = cudf.Series(x)
+            # cudf no longer accepts "str" as a valid dtype argument to astype().
+            # When input is already string data, cudf.Series() creates the
+            # correct string dtype automatically.
+            if dtype == "str":
+                return s
+            return s.astype(dtype)
         else:
             return x
 


### PR DESCRIPTION
See https://github.com/rapidsai/cudf/pull/21281 for cudf changes. This changed what cudf accepts as a valid dtype.