### PR TITLE
Add cuml.accel support for IncrementalPCA

### DIFF
--- a/docs/source/cuml-accel/faq.rst
+++ b/docs/source/cuml-accel/faq.rst
@@ -55,6 +55,7 @@ the following estimators are mostly or entirely accelerated when run with
     * ``sklearn.covariance.EmpiricalCovariance``
     * ``sklearn.covariance.LedoitWolf``
     * ``sklearn.decomposition.PCA``
+    * ``sklearn.decomposition.IncrementalPCA``
     * ``sklearn.decomposition.TruncatedSVD``
     * ``sklearn.ensemble.RandomForestClassifier``
     * ``sklearn.ensemble.RandomForestRegressor``

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -156,6 +156,16 @@ Additional notes:
 - Parameters for the ``"randomized"`` solver like ``random_state``,
   ``n_oversamples``, ``power_iteration_normalizer`` are ignored.
 
+IncrementalPCA
+^^^^^^^^^^^^^^
+
+``IncrementalPCA`` has no known estimator-specific ``cuml.accel`` limitations.
+
+Additional notes:
+
+- ``partial_fit`` does not support sparse input. This matches scikit-learn;
+  use ``fit`` for sparse input or provide dense batches to ``partial_fit``.
+
 TruncatedSVD
 ^^^^^^^^^^^^
 

--- a/python/cuml/cuml/accel/_overrides/sklearn/decomposition.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/decomposition.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/python/cuml/cuml/accel/_overrides/sklearn/decomposition.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/decomposition.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 import cuml.decomposition
 from cuml.accel.estimator_proxy import ProxyBase
 
-__all__ = ("PCA", "TruncatedSVD")
+__all__ = ("IncrementalPCA", "PCA", "TruncatedSVD")
 
 # In sklearn 1.5 the sign flipping behavior changed. For sklearn < 1.5 we
 # enable the old behavior.
@@ -42,3 +42,13 @@ class TruncatedSVD(ProxyBase):
         def _gpu_fit_transform(self, X, y=None):
             self._gpu._u_based_sign_flip = True
             return self._gpu.fit_transform(X, y)
+
+
+class IncrementalPCA(ProxyBase):
+    _gpu_class = cuml.decomposition.IncrementalPCA
+
+    def _gpu_fit_transform(self, X, y=None, **fit_params):
+        return self._gpu.fit_transform(X, y)
+
+    def _gpu_partial_fit(self, X, y=None, check_input=True, **fit_params):
+        return self._gpu.partial_fit(X, y, check_input=check_input)

--- a/python/cuml/cuml/accel/_overrides/sklearn/decomposition.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/decomposition.py
@@ -48,7 +48,13 @@ class IncrementalPCA(ProxyBase):
     _gpu_class = cuml.decomposition.IncrementalPCA
 
     def _gpu_fit_transform(self, X, y=None, **fit_params):
+        if fit_params:
+            param = next(iter(fit_params))
+            raise TypeError(
+                "IncrementalPCA.fit() got an unexpected keyword argument "
+                f"{param!r}"
+            )
         return self._gpu.fit_transform(X, y)
 
-    def _gpu_partial_fit(self, X, y=None, check_input=True, **fit_params):
+    def _gpu_partial_fit(self, X, y=None, check_input=True):
         return self._gpu.partial_fit(X, y, check_input=check_input)

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -8,6 +8,7 @@ import numbers
 import cupy as cp
 
 import cuml.internals
+from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.sparse_utils import is_sparse
 from cuml.decomposition.pca import PCA
 from cuml.internals.array import CumlArray
@@ -179,6 +180,7 @@ class IncrementalPCA(PCA):
     """
 
     _cpu_class_path = "sklearn.decomposition.IncrementalPCA"
+    var_ = CumlArrayDescriptor(order="F")
 
     def __init__(
         self,

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -282,7 +282,8 @@ class IncrementalPCA(PCA):
 
         if first_call := getattr(self, "n_samples_seen_", 0) == 0:
             self._set_output_type(X)
-        check_features(self, X, reset=first_call)
+        if check_input or not hasattr(self, "n_features_in_"):
+            check_features(self, X, reset=first_call)
 
         if check_input:
             X = check_array(X, dtype=("float32", "float64"))
@@ -312,11 +313,11 @@ class IncrementalPCA(PCA):
                 "more rows than columns for IncrementalPCA "
                 "processing" % (self.n_components, n_features)
             )
-        elif not self.n_components <= n_samples:
+        elif self.n_components > n_samples and first_call:
             raise ValueError(
-                "n_components=%r must be less or equal to "
-                "the batch number of samples "
-                "%d." % (self.n_components, n_samples)
+                f"n_components={self.n_components} must be less or equal to "
+                f"the batch number of samples {n_samples} for the first "
+                "partial_fit call."
             )
         else:
             self.n_components_ = self.n_components
@@ -488,10 +489,9 @@ class IncrementalPCA(PCA):
             "var_": to_gpu(model.var_, order="F"),
             "n_components_": model.n_components_,
             "n_samples_seen_": model.n_samples_seen_,
-            "batch_size_": model.batch_size_,
             "noise_variance_": model.noise_variance_,
         }
-        for name in ["n_features_in_", "feature_names_in_"]:
+        for name in ["batch_size_", "n_features_in_", "feature_names_in_"]:
             try:
                 out[name] = getattr(model, name)
             except AttributeError:
@@ -515,9 +515,10 @@ class IncrementalPCA(PCA):
             "var_": var_,
             "n_components_": self.n_components_,
             "n_samples_seen_": self.n_samples_seen_,
-            "batch_size_": self.batch_size_,
             "noise_variance_": self.noise_variance_,
         }
+        if (batch_size_ := getattr(self, "batch_size_", None)) is not None:
+            out["batch_size_"] = batch_size_
         if (
             n_features_in_ := getattr(self, "n_features_in_", None)
         ) is not None:

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -375,7 +375,7 @@ class IncrementalPCA(PCA):
         )
         self.singular_values_ = CumlArray(data=S[: self.n_components_])
         self.mean_ = CumlArray(data=col_mean)
-        self.var_ = col_var
+        self.var_ = CumlArray(data=col_var)
         self.explained_variance_ = CumlArray(
             data=explained_variance[: self.n_components_]
         )
@@ -491,19 +491,19 @@ class IncrementalPCA(PCA):
             "n_samples_seen_": model.n_samples_seen_,
             "noise_variance_": model.noise_variance_,
         }
-        for name in ["batch_size_", "n_features_in_", "feature_names_in_"]:
-            try:
-                out[name] = getattr(model, name)
-            except AttributeError:
-                pass
+        if (batch_size_ := getattr(model, "batch_size_", None)) is not None:
+            out["batch_size_"] = batch_size_
+        if (
+            n_features_in_ := getattr(model, "n_features_in_", None)
+        ) is not None:
+            out["n_features_in_"] = n_features_in_
+        if (
+            feature_names_in_ := getattr(model, "feature_names_in_", None)
+        ) is not None:
+            out["feature_names_in_"] = feature_names_in_
         return out
 
     def _attrs_to_cpu(self, model):
-        var_ = self.var_
-        try:
-            var_ = to_cpu(var_)
-        except AttributeError:
-            var_ = cp.asnumpy(var_)
         out = {
             "components_": to_cpu(self.components_),
             "explained_variance_": to_cpu(self.explained_variance_),
@@ -512,7 +512,7 @@ class IncrementalPCA(PCA):
             ),
             "singular_values_": to_cpu(self.singular_values_),
             "mean_": to_cpu(self.mean_),
-            "var_": var_,
+            "var_": to_cpu(self.var_),
             "n_components_": self.n_components_,
             "n_samples_seen_": self.n_samples_seen_,
             "noise_variance_": self.noise_variance_,

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -522,6 +522,10 @@ class IncrementalPCA(PCA):
             n_features_in_ := getattr(self, "n_features_in_", None)
         ) is not None:
             out["n_features_in_"] = n_features_in_
+        if (
+            feature_names_in_ := getattr(self, "feature_names_in_", None)
+        ) is not None:
+            out["feature_names_in_"] = feature_names_in_
         return out
 
 

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -282,6 +282,8 @@ class IncrementalPCA(PCA):
 
         if first_call := getattr(self, "n_samples_seen_", 0) == 0:
             self._set_output_type(X)
+        # `fit()` pre-validates X once and calls us per batch with
+        # check_input=False; skip re-running check_features in that case.
         if check_input or not hasattr(self, "n_features_in_"):
             check_features(self, X, reset=first_call)
 

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -12,6 +12,7 @@ from cuml.common.sparse_utils import is_sparse
 from cuml.decomposition.pca import PCA
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
+from cuml.internals.interop import to_cpu, to_gpu
 from cuml.internals.validation import (
     check_array,
     check_features,
@@ -173,9 +174,11 @@ class IncrementalPCA(PCA):
         array([0.02693948, 0.0326928 , 0.03818463, 0.03861492])
         >>>
         >>> # Noise Variance:
-        >>> ipca.noise_variance_.item() # doctest: +SKIP
-        0.0037122774558343763
+    >>> ipca.noise_variance_.item() # doctest: +SKIP
+    0.0037122774558343763
     """
+
+    _cpu_class_path = "sklearn.decomposition.IncrementalPCA"
 
     def __init__(
         self,
@@ -453,6 +456,73 @@ class IncrementalPCA(PCA):
             "copy",
             "batch_size",
         ]
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        return {
+            "n_components": model.n_components,
+            "whiten": model.whiten,
+            "copy": model.copy,
+            "batch_size": model.batch_size,
+        }
+
+    def _params_to_cpu(self):
+        return {
+            "n_components": self.n_components,
+            "whiten": self.whiten,
+            "copy": self.copy,
+            "batch_size": self.batch_size,
+        }
+
+    def _attrs_from_cpu(self, model):
+        out = {
+            "components_": to_gpu(model.components_, order="F"),
+            "explained_variance_": to_gpu(
+                model.explained_variance_, order="F"
+            ),
+            "explained_variance_ratio_": to_gpu(
+                model.explained_variance_ratio_, order="F"
+            ),
+            "singular_values_": to_gpu(model.singular_values_, order="F"),
+            "mean_": to_gpu(model.mean_, order="F"),
+            "var_": to_gpu(model.var_, order="F"),
+            "n_components_": model.n_components_,
+            "n_samples_seen_": model.n_samples_seen_,
+            "batch_size_": model.batch_size_,
+            "noise_variance_": model.noise_variance_,
+        }
+        for name in ["n_features_in_", "feature_names_in_"]:
+            try:
+                out[name] = getattr(model, name)
+            except AttributeError:
+                pass
+        return out
+
+    def _attrs_to_cpu(self, model):
+        var_ = self.var_
+        try:
+            var_ = to_cpu(var_)
+        except AttributeError:
+            var_ = cp.asnumpy(var_)
+        out = {
+            "components_": to_cpu(self.components_),
+            "explained_variance_": to_cpu(self.explained_variance_),
+            "explained_variance_ratio_": to_cpu(
+                self.explained_variance_ratio_
+            ),
+            "singular_values_": to_cpu(self.singular_values_),
+            "mean_": to_cpu(self.mean_),
+            "var_": var_,
+            "n_components_": self.n_components_,
+            "n_samples_seen_": self.n_samples_seen_,
+            "batch_size_": self.batch_size_,
+            "noise_variance_": self.noise_variance_,
+        }
+        if (
+            n_features_in_ := getattr(self, "n_features_in_", None)
+        ) is not None:
+            out["n_features_in_"] = n_features_in_
+        return out
 
 
 def _gen_batches(n, batch_size, min_batch_size=0):

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -174,8 +174,8 @@ class IncrementalPCA(PCA):
         array([0.02693948, 0.0326928 , 0.03818463, 0.03861492])
         >>>
         >>> # Noise Variance:
-    >>> ipca.noise_variance_.item() # doctest: +SKIP
-    0.0037122774558343763
+        >>> ipca.noise_variance_.item() # doctest: +SKIP
+        0.0037122774558343763
     """
 
     _cpu_class_path = "sklearn.decomposition.IncrementalPCA"

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -12,7 +12,7 @@ from cuml.common.sparse_utils import is_sparse
 from cuml.decomposition.pca import PCA
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.interop import to_cpu, to_gpu
+from cuml.internals.interop import InteropMixin, to_cpu, to_gpu
 from cuml.internals.validation import (
     check_array,
     check_features,
@@ -477,6 +477,9 @@ class IncrementalPCA(PCA):
             "batch_size": self.batch_size,
         }
 
+    # Bypass PCA._attrs_*: sklearn IncrementalPCA lacks PCA's `n_samples_`.
+    # Call InteropMixin directly for universal `n_features_in_` /
+    # `feature_names_in_` handling.
     def _attrs_from_cpu(self, model):
         out = {
             "components_": to_gpu(model.components_, order="F"),
@@ -492,17 +495,10 @@ class IncrementalPCA(PCA):
             "n_components_": model.n_components_,
             "n_samples_seen_": model.n_samples_seen_,
             "noise_variance_": model.noise_variance_,
+            **InteropMixin._attrs_from_cpu(self, model),
         }
         if (batch_size_ := getattr(model, "batch_size_", None)) is not None:
             out["batch_size_"] = batch_size_
-        if (
-            n_features_in_ := getattr(model, "n_features_in_", None)
-        ) is not None:
-            out["n_features_in_"] = n_features_in_
-        if (
-            feature_names_in_ := getattr(model, "feature_names_in_", None)
-        ) is not None:
-            out["feature_names_in_"] = feature_names_in_
         return out
 
     def _attrs_to_cpu(self, model):
@@ -518,17 +514,10 @@ class IncrementalPCA(PCA):
             "n_components_": self.n_components_,
             "n_samples_seen_": self.n_samples_seen_,
             "noise_variance_": self.noise_variance_,
+            **InteropMixin._attrs_to_cpu(self, model),
         }
         if (batch_size_ := getattr(self, "batch_size_", None)) is not None:
             out["batch_size_"] = batch_size_
-        if (
-            n_features_in_ := getattr(self, "n_features_in_", None)
-        ) is not None:
-            out["n_features_in_"] = n_features_in_
-        if (
-            feature_names_in_ := getattr(self, "feature_names_in_", None)
-        ) is not None:
-            out["feature_names_in_"] = feature_names_in_
         return out
 
 

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -17,7 +17,7 @@ import sklearn
 from packaging.version import Version
 from sklearn.base import check_is_fitted, is_classifier, is_regressor
 from sklearn.datasets import make_blobs, make_classification, make_regression
-from sklearn.decomposition import IncrementalPCA, PCA
+from sklearn.decomposition import PCA, IncrementalPCA
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import (
@@ -689,16 +689,37 @@ def test_set_output(methods):
     # No host transfer required
     assert not hasattr(model._cpu, "n_features_in_")
 
+    # If input has an index, the output has an aligned index
+    X_df = pd.DataFrame(
+        X,
+        columns=[f"x{i}" for i in range(X.shape[1])],
+        index=[f"row{i}" for i in range(X.shape[0])],
+    )
+    out = model.transform(X_df)
+    assert (out.index == X_df.index).all()
+
+    # Can change back to default without requiring a host transfer either
+    model.set_output(transform="default")
+    out = model.transform(X)
+    assert isinstance(out, np.ndarray)
+    # No host transfer required
+    assert not hasattr(model._cpu, "n_features_in_")
+
 
 def test_incremental_pca_partial_fit():
-    X, _ = make_classification(
-        n_samples=40, n_features=8, random_state=42
-    )
+    X, _ = make_classification(n_samples=40, n_features=8, random_state=42)
     model = IncrementalPCA(n_components=3, batch_size=10)
 
-    model.partial_fit(X)
+    model.partial_fit(X[:20])
+    gpu = model._gpu
 
-    assert model._gpu is not None
+    assert gpu is not None
+    assert int(gpu.n_samples_seen_) == 20
+
+    model.partial_fit(X[20:])
+
+    assert model._gpu is gpu
+    assert int(model._gpu.n_samples_seen_) == 40
     assert not hasattr(model._cpu, "components_")
 
     out = model.transform(X)
@@ -706,11 +727,8 @@ def test_incremental_pca_partial_fit():
     assert out.shape[1] == 3
 
 
-
 def test_incremental_pca_set_output():
-    X, _ = make_classification(
-        n_samples=40, n_features=8, random_state=42
-    )
+    X, _ = make_classification(n_samples=40, n_features=8, random_state=42)
     model = IncrementalPCA(n_components=3, batch_size=10)
 
     assert model.set_output(transform="pandas") is model

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -739,6 +739,15 @@ def test_incremental_pca_set_output():
     assert out.columns[0].startswith("incrementalpca")
 
 
+@pytest.mark.parametrize("method", ["fit_transform", "partial_fit"])
+def test_incremental_pca_rejects_unsupported_fit_params(method):
+    X, _ = make_classification(n_samples=40, n_features=8, random_state=42)
+    model = IncrementalPCA(n_components=3, batch_size=10)
+
+    with pytest.raises(TypeError):
+        getattr(model, method)(X, sample_weight=np.ones(X.shape[0]))
+
+
 def test_get_feature_names_out():
     model = PCA(n_components=5)
 

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -17,7 +17,7 @@ import sklearn
 from packaging.version import Version
 from sklearn.base import check_is_fitted, is_classifier, is_regressor
 from sklearn.datasets import make_blobs, make_classification, make_regression
-from sklearn.decomposition import PCA
+from sklearn.decomposition import IncrementalPCA, PCA
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import (
@@ -141,6 +141,15 @@ def test_init_positional_and_keyword():
     with pytest.raises(TypeError):
         # Can't pass keyword-only parameters in as positional
         PCA(10, False)
+
+    model = IncrementalPCA()
+    assert model.n_components is None
+
+    model = IncrementalPCA(n_components=10)
+    assert model.n_components == 10
+
+    model = IncrementalPCA(10)
+    assert model.n_components == 10
 
 
 def test_repr():
@@ -680,21 +689,36 @@ def test_set_output(methods):
     # No host transfer required
     assert not hasattr(model._cpu, "n_features_in_")
 
-    # If input has an index, the output has an aligned index
-    X_df = pd.DataFrame(
-        X,
-        columns=[f"x{i}" for i in range(X.shape[1])],
-        index=[f"row{i}" for i in range(X.shape[0])],
-    )
-    out = model.transform(X_df)
-    assert (out.index == X_df.index).all()
 
-    # Can change back to default without requiring a host transfer either
-    model.set_output(transform="default")
+def test_incremental_pca_partial_fit():
+    X, _ = make_classification(
+        n_samples=40, n_features=8, random_state=42
+    )
+    model = IncrementalPCA(n_components=3, batch_size=10)
+
+    model.partial_fit(X)
+
+    assert model._gpu is not None
+    assert not hasattr(model._cpu, "components_")
+
     out = model.transform(X)
     assert isinstance(out, np.ndarray)
-    # No host transfer required
-    assert not hasattr(model._cpu, "n_features_in_")
+    assert out.shape[1] == 3
+
+
+
+def test_incremental_pca_set_output():
+    X, _ = make_classification(
+        n_samples=40, n_features=8, random_state=42
+    )
+    model = IncrementalPCA(n_components=3, batch_size=10)
+
+    assert model.set_output(transform="pandas") is model
+    model.partial_fit(X)
+
+    out = model.transform(X)
+    assert isinstance(out, pd.DataFrame)
+    assert out.columns[0].startswith("incrementalpca")
 
 
 def test_get_feature_names_out():

--- a/python/cuml/tests/test_incremental_pca.py
+++ b/python/cuml/tests/test_incremental_pca.py
@@ -112,6 +112,55 @@ def test_partial_fit(
     assert array_equal(cu_inv, sk_inv, 1e-3, with_sign=True)
 
 
+@pytest.mark.parametrize("whiten", [False, True])
+@pytest.mark.parametrize("method", ["fit", "partial_fit"])
+def test_sklearn_parity_attrs(method, whiten):
+    """Check fitted-attribute parity with sklearn for fit() and partial_fit()."""
+    nrows, ncols, n_components = 1000, 8, 4
+    X, _ = make_blobs(
+        n_samples=nrows, n_features=ncols, random_state=0, dtype="float64"
+    )
+    X_np = cp.asnumpy(X)
+
+    cu_ipca = cuIPCA(n_components=n_components, whiten=whiten, batch_size=100)
+    sk_ipca = skIPCA(n_components=n_components, whiten=whiten, batch_size=100)
+
+    if method == "fit":
+        cu_ipca.fit(X)
+        sk_ipca.fit(X_np)
+    else:
+        batch = 100
+        for i in range(0, nrows, batch):
+            cu_ipca.partial_fit(X[i : i + batch])
+            sk_ipca.partial_fit(X_np[i : i + batch])
+
+    assert array_equal(
+        cu_ipca.components_, sk_ipca.components_, 1e-3, with_sign=True
+    )
+    assert array_equal(
+        cu_ipca.explained_variance_,
+        sk_ipca.explained_variance_,
+        1e-3,
+        with_sign=True,
+    )
+    assert array_equal(
+        cu_ipca.explained_variance_ratio_,
+        sk_ipca.explained_variance_ratio_,
+        1e-3,
+        with_sign=True,
+    )
+    assert array_equal(
+        cu_ipca.singular_values_,
+        sk_ipca.singular_values_,
+        1e-3,
+        with_sign=True,
+    )
+    assert array_equal(cu_ipca.mean_, sk_ipca.mean_, 1e-3, with_sign=True)
+    assert array_equal(cu_ipca.var_, sk_ipca.var_, 1e-3, with_sign=True)
+    assert int(cu_ipca.n_samples_seen_) == int(sk_ipca.n_samples_seen_)
+    assert cu_ipca.n_components_ == sk_ipca.n_components_
+
+
 def test_exceptions():
     X = cupyx.scipy.sparse.eye(10)
     ipca = cuIPCA()


### PR DESCRIPTION
Adds `sklearn.decomposition.IncrementalPCA` to `cuml.accel`, including `fit_transform` and `partial_fit` dispatch through the estimator proxy.

This also tightens sklearn parity for cuML `IncrementalPCA` fitted attributes, CPU/GPU interop, `var_` handling, first-batch validation behavior, and `set_output` support.

Closes #7779