### PR TITLE
Remove raft `math.cuh` and `matrix.cuh`

### DIFF
--- a/cpp/src_prims/opg/linalg/svd.cu
+++ b/cpp/src_prims/opg/linalg/svd.cu
@@ -11,8 +11,6 @@
 #include <raft/linalg/eig.cuh>
 #include <raft/linalg/gemm.cuh>
 #include <raft/linalg/matrix_vector.cuh>
-#include <raft/matrix/math.cuh>
-#include <raft/matrix/matrix.cuh>
 #include <raft/matrix/reverse.cuh>
 #include <raft/matrix/sqrt.cuh>
 


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/cuml/pull/7752. Remove two remaining headers that were supposed to be removed.