### PR TITLE
Fix Dask KMeans performance regression

### DIFF
--- a/cpp/include/cuml/cluster/kmeans_params.hpp
+++ b/cpp/include/cuml/cluster/kmeans_params.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@ struct KMeansParams {
   int max_iter                        = 300;
   double tol                          = 1e-4;
   rapids_logger::level_enum verbosity = rapids_logger::level_enum::info;
-  raft::random::RngState rng_state{0};
+  raft::random::RngState rng_state{0, raft::random::GeneratorType::GenPhilox};
   int n_init                 = 1;
   double oversampling_factor = 2.0;
   int batch_samples          = 1 << 15;


### PR DESCRIPTION
Closes #7749 

The KMeans parameter struct on cuML side used to be [calloc'ed](https://github.com/rapidsai/cuml/blob/00094f7e4e4b5da3a968d193a4da6085fa38f11b/python/cuml/cuml/cluster/kmeans.pyx#L292-L293), and is now [constructed on stack](https://github.com/rapidsai/cuml/blob/f28df8d5894b6ac26221b8e0677f4398600ace1c/python/cuml/cuml/cluster/kmeans.pyx#L586). Because of this, Dask Kmeans used to use `raft::random::GeneratorType::GenPhilox` (value of 0) as its random number generator type and now uses `raft::random::GeneratorType::GenPC` (constructor default of 1). This somehow causes the KMeans initialization or convergence steps to be of lower quality. Converges in ~40 steps instead of 2.

This PR fixes the issue by setting `raft::random::GeneratorType::GenPhilox` as the default inside of the cuML parameter struct default values.