### PR TITLE
Update Cython lower bound pin to 3.2.2

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0
 - cuvs==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -78,7 +78,7 @@ requirements:
   host:
     - cuda-version =${{ cuda_version }}
     - cudf =${{ minor_version }}
-    - cython >=3.0.0,<3.2.0
+    - cython >=3.2.2
     - libcuml =${{ version }}
     - pip
     - pylibraft =${{ minor_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -315,7 +315,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cython cython>=3.0.0,<3.2.0
+          - &cython cython>=3.2.2
           - &treelite treelite>=4.6.1,<5.0.0
   py_run_cuml:
     common:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -107,7 +107,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "certifi",
-    "cython>=3.0.0,<3.2.0",
+    "cython>=3.2.2",
     "hdbscan>=0.8.39,<0.8.40",
     "hypothesis>=6.0,<7",
     "ipython>=7.32.0",
@@ -178,7 +178,7 @@ matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.30.4",
     "cuda-python>=13.0.1,<14.0",
-    "cython>=3.0.0,<3.2.0",
+    "cython>=3.2.2",
     "libcuml==26.4.*,>=0.0.0a0",
     "libraft==26.4.*,>=0.0.0a0",
     "librmm==26.4.*,>=0.0.0a0",


### PR DESCRIPTION
## Summary

Refs https://github.com/rapidsai/build-planning/issues/229

Updates the Cython lower bound pin to `>=3.2.2`. The `<3.2.0` upper bound was added as a workaround for a code-generation bug introduced in Cython 3.2.0. That bug was fixed in Cython 3.2.1 (https://github.com/cython/cython/pull/7313) and additional related fixes landed in Cython 3.2.2 (https://github.com/cython/cython/pull/7320). Cython 3.2.2 has been released, so we can now raise the lower bound and remove the upper bound cap.

Changes:
- Update `dependencies.yaml`: set `cython>=3.2.2` (no upper bound), remove the old workaround comment
- Update `conda/recipes/*/recipe.yaml`: same pin change (not managed by `rapids-dependency-file-generator`)
- Regenerate all derived files via `rapids-dependency-file-generator`