### PR TITLE
FIX: Ensure FIL models have minimum trees and outputs #7821

### DIFF
--- a/python/cuml/cuml/fil/fil.pyx
+++ b/python/cuml/cuml/fil/fil.pyx
@@ -947,6 +947,12 @@ class ForestInference(Base, CMajorInputTagMixin):
             For GPU execution, the device on which to load and execute this
             model. For CPU execution, this value is currently ignored.
         """
+        if tl_model.num_trees < 1:
+            raise ValueError("The Treelite model must have at least one decision tree.")
+
+        if tl_model.num_outputs < 1:
+            raise ValueError("The Treelite model must have at least one output.")
+        # -------------------------------
         return cls(
             treelite_model=tl_model,
             output_type=output_type,


### PR DESCRIPTION
Description
Overview
This PR addresses issue #7821 by implementing validation logic for Treelite models at import time within the Forest Inference Library (FIL).

Changes
Input Validation: Added explicit checks to the load_from_treelite_model method in python/cuml/cuml/fil/fil.pyx to ensure that a model being loaded contains at least one decision tree and at least one output.

Error Handling: Introduced ValueError exceptions with descriptive messages to catch empty or malformed models early in the process.

Reasoning: This prevents potential runtime errors or undefined behavior in the underlying C++ and CUDA layers when processing invalid model handles.

Impact
This is a non-breaking change that improves the robustness of the FIL model import pipeline by providing standard scikit-learn style validation.

Related Issues
Closes #7821.