### PR TITLE
WIP: wheels CI: write constraints directly to PIP_CONSTRAINT

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+# TODO(jameslamb): revert before merging
+git clone --branch generate-pip-constraints \
+    https://github.com/rapidsai/gha-tools.git \
+    /tmp/gha-tools
+
+export PATH="/tmp/gha-tools/tools:${PATH}"
+
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/ci/test_wheel_dask.sh
+++ b/ci/test_wheel_dask.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+# TODO(jameslamb): revert before merging
+git clone --branch generate-pip-constraints \
+    https://github.com/rapidsai/gha-tools.git \
+    /tmp/gha-tools
+
+export PATH="/tmp/gha-tools/tools:${PATH}"
+
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/256 / https://github.com/rapidsai/build-planning/issues/257

https://github.com/rapidsai/gha-tools/pull/247 updates `rapids-generate-pip-constraints` in the following ways:

* generates output for `RAPIDS_DEPENDENCIES="latest"` (previously silently generated an empty list of constraints)
* appends to the passed-in file if it already exists
* always passes `use_cuda_wheels=true`

That new behavior will help with testing wheels against different CTK versions via constraints on the `cuda-toolkit` metapackage.