### PR TITLE
Remove `PoolMemoryResource` wrapper

### DIFF
--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -186,12 +186,8 @@ def install(
             import rmm
 
             mr = rmm.mr.get_current_device_resource()
-            if (
-                isinstance(mr, rmm.mr.PrefetchResourceAdaptor)
-                and isinstance(mr.upstream_mr, rmm.mr.PoolMemoryResource)
-                and isinstance(
-                    mr.upstream_mr.upstream_mr, rmm.mr.ManagedMemoryResource
-                )
+            if isinstance(mr, rmm.mr.PrefetchResourceAdaptor) and isinstance(
+                mr.upstream_mr, rmm.mr.ManagedMemoryResource
             ):
                 # Nothing to do
                 pass
@@ -203,9 +199,7 @@ def install(
             else:
                 rmm.mr.set_current_device_resource(
                     rmm.mr.PrefetchResourceAdaptor(
-                        rmm.mr.PoolMemoryResource(
-                            rmm.mr.ManagedMemoryResource()
-                        )
+                        rmm.mr.ManagedMemoryResource()
                     )
                 )
                 logger.debug("Enabled managed memory.")


### PR DESCRIPTION
I'm seeing some OOMs in CI after the `PoolMemoryResource` was added. Trying removing it to see if that fixes it.