### PR TITLE
fix verify-hardcoded-version issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,6 +171,17 @@ repos:
             (?x)
               ^pyproject[.]toml$
         - id: verify-hardcoded-version
+          exclude: |
+            (?x)
+              (^|/)devcontainer[.]json$|
+              (^|/)dependencies[.]yaml$|
+              ^[.]github/(workflows|ISSUE_TEMPLATE)/|
+              (^|/)pom[.]xml$|
+              ^[.]pre-commit-config[.]yaml$|
+              ^conda/environments/|
+              (^|/)VERSION$|
+              (^|/)RAPIDS_BRANCH$|
+              [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$
     - repo: https://github.com/rapidsai/dependency-file-generator
       rev: v1.20.0
       hooks:


### PR DESCRIPTION
Fixes this `pre-commit` error that's blocking CI:

```text
verify-hardcoded-version.................................................Failed
- hook id: verify-hardcoded-version
- exit code: 1

In file RAPIDS_BRANCH:1:9:
 release/26.04
warning: do not hard-code version, read from VERSION file instead

In file RAPIDS_BRANCH:1:9:
 release/26.04
```

See https://github.com/rapidsai/pre-commit-hooks/issues/121 for more details.