### PR TITLE
fix more verify-hardcoded-version findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,7 +181,7 @@ repos:
               ^conda/environments/|
               (^|/)VERSION$|
               (^|/)RAPIDS_BRANCH$|
-              [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$
+              [.](csv|json|md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$
     - repo: https://github.com/rapidsai/dependency-file-generator
       rev: v1.20.0
       hooks:

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -97,7 +97,7 @@ def _warn_or_error(exc_cls, msg):
     else:
         warnings.warn(
             "cuml is adding support for `feature_names_in_` for validating "
-            "the feature names of dataframe-like inputs. In cuml 26.06 this "
+            "the feature names of dataframe-like inputs. In version 26.06 of cuML this "
             f"will error with the following message:\n\n{msg}",
             FutureWarning,
         )


### PR DESCRIPTION
Similar to #7882 

Fixes new `verify-hardcoded-version` findings on `main`

```text
In file python/cuml/cuml/internals/validation.py💯66:
             "the feature names of dataframe-like inputs. In cuml 26.06 this "
warning: do not hard-code version, read from VERSION file instead

In file python/cuml/cuml/internals/validation.py💯66:
             "the feature names of dataframe-like inputs. In cuml 26.06 this "

In file python/cuml/tests/ts_datasets/hourly_earnings_by_industry.csv:102:14:
 2014Q1,29.29,26.6,35.07,26.02,29.01,19,17.16,26.57,38.91,40.75,28.84,31.03,34.1
,29.29
warning: do not hard-code version, read from VERSION file instead

In file python/cuml/tests/ts_datasets/hourly_earnings_by_industry.csv:102:14:
 2014Q1,29.29,26.6,35.07,26.02,29.01,19,17.16,26.57,38.91,40.75,28.84,31.03,34.1
,29.29
```