### PR TITLE
Cap numba-cuda upper bound at <0.29.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - nbsphinx
 - ninja
 - nltk
-- numba-cuda>=0.22.2
+- numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - nbsphinx
 - ninja
 - nltk
-- numba-cuda>=0.22.2
+- numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - nbsphinx
 - ninja
 - nltk
-- numba-cuda>=0.22.2
+- numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -43,7 +43,7 @@ dependencies:
 - nbsphinx
 - ninja
 - nltk
-- numba-cuda>=0.22.2
+- numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -99,7 +99,7 @@ requirements:
     - joblib >=0.11
     - libcuml =${{ version }}
     - numba >=0.60.0,<0.65.0
-    - numba-cuda >=0.22.2
+    - numba-cuda >=0.22.2,<0.29.0
     - numpy >=1.23,<3.0
     - scikit-learn >=1.4
     - scipy >=1.11.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -824,7 +824,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-        - &numba_cuda numba-cuda>=0.22.2
+        - &numba_cuda numba-cuda>=0.22.2,<0.29.0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
@@ -832,12 +832,12 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - numba-cuda[cu12]>=0.22.2
+              - numba-cuda[cu12]>=0.22.2,<0.29.0
           - matrix:
               cuda: "13.*"
               cuda_suffixed: "true"
             packages:
-              - numba-cuda[cu13]>=0.22.2
+              - numba-cuda[cu13]>=0.22.2,<0.29.0
           # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
           - matrix:
             packages:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
     "cupy-cuda13x>=13.6.0",
     "joblib>=0.11",
     "libcuml==26.6.*,>=0.0.0a0",
-    "numba-cuda>=0.22.2",
+    "numba-cuda>=0.22.2,<0.29.0",
     "numba>=0.60.0,<0.65.0",
     "numpy>=1.23,<3.0",
     "packaging",


### PR DESCRIPTION
This PR sets an upper bound on the `numba-cuda` dependency to `<0.29.0`
while preserving each repo's existing lower bound.
