### PR TITLE
fix(devcontainers): build with Python 3.13 while dependencies are unavailable

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -16,6 +16,8 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
+  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
+  "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.4": {}
   },

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -16,6 +16,8 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
+  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
+  "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/cuda:26.4": {
       "version": "12.9",

--- a/.devcontainer/cuda13.1-conda/devcontainer.json
+++ b/.devcontainer/cuda13.1-conda/devcontainer.json
@@ -16,6 +16,8 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
+  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
+  "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.4": {}
   },

--- a/.devcontainer/cuda13.1-pip/devcontainer.json
+++ b/.devcontainer/cuda13.1-pip/devcontainer.json
@@ -16,6 +16,8 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
+  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
+  "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/cuda:26.4": {
       "version": "13.1",


### PR DESCRIPTION
We bumped the default devcontainer Python version to 3.14 in https://github.com/rapidsai/devcontainers/pull/677 but some repos (like `cuml`) have optional dependencies without Python 3.14 support. 

We need to override the Python version temporarily until those deps catch up.

I'll also open a tracking issue so we remember to undo this.
