### PR TITLE
Disable SciPy intersphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -200,7 +200,8 @@ intersphinx_mapping = {
     "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    # TODO: re-enable once scipy docs are more reliable
+    # "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 


### PR DESCRIPTION
The scipy docs site has some reliability issues, and can sometimes cause our docs to fail to build. While they're resolving this, we'll disable scipy intersphinx mappings. We rarely make use of scipy intersphinx mappings anyway, so this won't be a huge docs UX degradation.