### PR TITLE
Fixes for CCCL 3.4 update

### DIFF
--- a/cpp/bench/common/ml_benchmark.hpp
+++ b/cpp/bench/common/ml_benchmark.hpp
@@ -186,7 +186,7 @@ struct Registrar {
       if (!testName.empty()) oss << "/" << testName;
       oss << "/" << counter;
       auto testFullName = oss.str();
-      auto* b = ::benchmark::internal::RegisterBenchmarkInternal(
+      auto* b           = ::benchmark::internal::RegisterBenchmarkInternal(
         std::make_unique<Class>(testFullName, param));
       ///@todo: expose a currying-like interface to the final macro
       b->UseManualTime();

--- a/cpp/src/randomforest/randomforest.cuh
+++ b/cpp/src/randomforest/randomforest.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,8 +19,8 @@
 
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
-#include <thrust/sequence.h>
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust/sequence.h>
 
 #include <decisiontree/batched-levelalgo/quantiles.cuh>
 #include <decisiontree/decisiontree.cuh>


### PR DESCRIPTION
This PR fixes two build issues exposed by recent dependency updates: https://github.com/rapidsai/rapids-cmake/pull/996. It adds the explicit Thrust constant-iterator header needed for randomforest.cuh to compile with CCCL 3.4, where thrust::make_constant_iterator is no longer available through transitive includes.

It also updates cuML benchmark registration to match the benchmark@1.9.5 API by passing ownership with std::unique_ptr instead of a raw pointer, which resolves the SG benchmark compile failures.

cc @bdice  could use an eye in the quick change in `randomforest.cuh`