### PR TITLE
chore: remove comment in devcontainer.json that breaks jq

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -16,7 +16,6 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
-  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
   "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.6": {}

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -16,7 +16,6 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
-  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
   "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/cuda:26.6": {

--- a/.devcontainer/cuda13.1-conda/devcontainer.json
+++ b/.devcontainer/cuda13.1-conda/devcontainer.json
@@ -16,7 +16,6 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
-  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
   "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:26.6": {}

--- a/.devcontainer/cuda13.1-pip/devcontainer.json
+++ b/.devcontainer/cuda13.1-pip/devcontainer.json
@@ -16,7 +16,6 @@
     "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
-  // TODO: remove the PYTHON_VERSION override when all of cuml's dependencies have Python 3.14 support
   "containerEnv": {"PYTHON_VERSION": "3.13"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/cuda:26.6": {


### PR DESCRIPTION
Followup to #7916 to remove the commend. Technically not valid javascript -- while github and devcontainers don't seem to mind, it does break other tooling that relies on `jq` being able to parse the devcontainer config files