### PR TITLE
Restart xdist workers on corrupted CUDA context

### DIFF
--- a/python/cuml/tests/conftest.py
+++ b/python/cuml/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -34,6 +34,8 @@ HYPOTHESIS_ENABLED = os.environ.get("HYPOTHESIS_ENABLED") in (
     "true",
     "1",
 )
+IS_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER") is not None
+
 
 # =============================================================================
 # Hypothesis Configuration
@@ -313,6 +315,32 @@ def _get_gpu_memory(device_index=0):
         return ceil(pynvml.nvmlDeviceGetMemoryInfo(handle).total / 2**30)
     except pynvml.NVMLError_NotSupported:
         return None
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_logreport(report):
+    """Some CUDA errors are "sticky" and cause subsequent CUDA calls in a
+    process to error.
+
+    When running under pytest-xdist, this hook checks for sticky errors on
+    failed tests, and if present will crash the worker after reporting the
+    failure. pytest-xdist will then start a new worker with a clean CUDA
+    context, avoiding sticky errors.
+
+    This hook is a no-op when run outside of pytest-xdist.
+    """
+    if not IS_XDIST_WORKER:
+        return
+
+    # Only check on failed test runs, not other events
+    if report.when == "call" and report.failed:
+        try:
+            # Try allocating a tiny array to invoke a CUDA API. If this fails,
+            # then the context is definitely corrupted.
+            cp.ones(1)
+        except Exception:
+            # Hardcrash the worker
+            os._exit(1)
 
 
 # =============================================================================


### PR DESCRIPTION
Some CUDA errors are sticky, and cause subsequent CUDA calls in a process to error. This can cause cascading errors, where actual bug leads to 100s of potentially false errors, making debugging trickier.

This PR adds a new pytest hook to help with this.

When running under pytest-xdist, sticky errors will now cause the executing xdist worker to crash (after reporting the error). pytest-xdist will then start a new worker with a clean CUDA context, avoiding cascading failures.

The check is cheap, and is only run on test failures, so in a successful CI run we should see no difference in execution.

Part of debugging #7906.