### PR TITLE
Add `-v` option to `timeout` in CI scripts

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -40,7 +40,7 @@ nvidia-smi
 rapids-logger "Run gtests"
 export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
 # Run libcuml gtests from libcuml-tests package
-timeout 20m ./ci/run_ctests.sh -j9 && EXITCODE=$? || EXITCODE=$?;
+timeout -v 20m ./ci/run_ctests.sh -j9 && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit "${EXITCODE}"

--- a/ci/test_python_cuml_accel_upstream.sh
+++ b/ci/test_python_cuml_accel_upstream.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # Support invoking test script outside the script directory
@@ -14,7 +14,7 @@ set +e
 
 # Run UMAP tests
 rapids-logger "UMAP test suite"
-timeout 15m ./python/cuml/cuml_accel_tests/upstream/umap/run-tests.sh
+timeout -v 15m ./python/cuml/cuml_accel_tests/upstream/umap/run-tests.sh
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -19,10 +19,10 @@ test_args=(
 
 # Run tests
 rapids-logger "pytest cuml-dask (No UCXX)"
-timeout 1h ./ci/run_cuml_dask_pytests.sh "${test_args[@]}"
+timeout -v 1h ./ci/run_cuml_dask_pytests.sh "${test_args[@]}"
 
 rapids-logger "pytest cuml-dask (UCXX only)"
-timeout 10m ./ci/run_cuml_dask_pytests.sh "${test_args[@]}" --run_ucx
+timeout -v 10m ./ci/run_cuml_dask_pytests.sh "${test_args[@]}" --run_ucx
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -53,14 +53,14 @@ rapids-logger "Testing libcuml linkage"
 python -m pytest --cache-clear python/libcuml/tests/test_libcuml_linkage.py -v
 
 rapids-logger "pytest cuml single GPU"
-timeout 1h ./ci/run_cuml_singlegpu_pytests.sh \
+timeout -v 1h ./ci/run_cuml_singlegpu_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   -k 'not test_sparse_pca_inputs' \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml"
 
 # Run test_sparse_pca_inputs separately
-timeout 10m ./ci/run_cuml_singlegpu_pytests.sh \
+timeout -v 10m ./ci/run_cuml_singlegpu_pytests.sh \
   -k 'test_sparse_pca_inputs' \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-sparse-pca.xml"
 

--- a/ci/test_wheel_dask.sh
+++ b/ci/test_wheel_dask.sh
@@ -33,7 +33,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml dask"
-timeout 1h ./ci/run_cuml_dask_pytests.sh --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml"
+timeout -v 1h ./ci/run_cuml_dask_pytests.sh --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml"
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -42,7 +42,7 @@ print('✓ Import test passed')
 
 # Test 2: Run minimal end-to-end example
 rapids-logger "Running BERTopic end-to-end smoke test"
-timeout 20m python -c "
+timeout -v 20m python -c "
 import warnings
 warnings.filterwarnings('ignore')
 


### PR DESCRIPTION
This better indicates when `timeout` kills a command, rather than the logs just mysteriously stopping.

Fixes #7964.