### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       hooks:
           - id: cython-lint
     - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: v20.1.4
+      rev: v20.1.8
       hooks:
           - id: clang-format
             types_or: [c, c++, cuda]

--- a/BUILD.md
+++ b/BUILD.md
@@ -55,7 +55,7 @@ cuML has limited support for multi-GPU and multi-node operations. The following 
 - **UCX** (>= 1.7) - optional; only required for multi-node operations (not needed for multi-GPU on a single node); must be explicitly enabled during build with `WITH_UCX=ON` (see [Using Infiniband for MNMG](wiki/mnmg/Using_Infiniband_for_MNMG.md))
 
 **For development only:**
-- clang-format (= 20.1.4) - enforces uniform C++ coding style; required for pre-commit hooks and CI checks. The packages `clang=20` and `clang-tools=20` from the conda-forge channel should be sufficient, if you are using conda. If not using conda, install the right version using your OS package manager.
+- clang-format (= 20.1.8) - enforces uniform C++ coding style; required for pre-commit hooks and CI checks. The packages `clang=20` and `clang-tools=20` from the conda-forge channel should be sufficient, if you are using conda. If not using conda, install the right version using your OS package manager.
 
 ### Recommended Conda Setup
 

--- a/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-129_arch-x86_64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -23,7 +23,7 @@ dependencies:
 - libcuvs==26.6.*,>=0.0.0a0
 - libraft-headers==26.6.*,>=0.0.0a0
 - librmm==26.6.*,>=0.0.0a0
-- llvm-openmp==20.1.4
+- llvm-openmp==20.1.8
 - ninja
 - sysroot_linux-64==2.28
 - tomli

--- a/conda/environments/clang_tidy_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/clang_tidy_cuda-131_arch-x86_64.yaml
@@ -6,8 +6,8 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-cudart-dev
 - cuda-nvcc
@@ -23,7 +23,7 @@ dependencies:
 - libcuvs==26.6.*,>=0.0.0a0
 - libraft-headers==26.6.*,>=0.0.0a0
 - librmm==26.6.*,>=0.0.0a0
-- llvm-openmp==20.1.4
+- llvm-openmp==20.1.8
 - ninja
 - sysroot_linux-64==2.28
 - tomli

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -18,7 +18,7 @@ The `test` directory has subdirectories that reflect this distinction between th
 1. cmake (>= 3.26.4)
 2. CUDA (>= 12.2)
 3. gcc (>=13.0)
-4. clang-format (= 20.1.4) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=20` and `clang-tools=20` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
+4. clang-format (= 20.1.8) - enforces uniform C++ coding style; required to build cuML from source. The packages `clang=20` and `clang-tools=20` from the conda-forge channel should be sufficient, if you are on conda. If not using conda, install the right version using your OS package manager.
 
 ### Building cuML:
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -274,9 +274,9 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - clang==20.1.4
-          - clang-tools==20.1.4
-          - llvm-openmp==20.1.4
+          - clang==20.1.8
+          - clang-tools==20.1.8
+          - llvm-openmp==20.1.8
           - ninja
           - tomli
   common_build:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
