### PR TITLE
xfail ARIMA test on 'endog_hourly_earnings_by_industry_missing_exog' dataset

### DIFF
--- a/python/cuml/tests/test_arima.py
+++ b/python/cuml/tests/test_arima.py
@@ -26,7 +26,6 @@ import cudf
 import numpy as np
 import pandas as pd
 import pytest
-from cudf.pandas import LOADED as cudf_pandas_active
 from scipy.optimize import approx_fprime
 from sklearn.model_selection import train_test_split
 
@@ -243,13 +242,7 @@ test_data = [
     # Skip due to update to Scipy 1.15
     # ((1, 1, 1, 2, 0, 0, 4, 1), test_111_200_4c),
     # ((1, 1, 1, 2, 0, 0, 4, 1), test_111_200_4c_missing),
-    pytest.param(
-        (1, 1, 1, 2, 0, 0, 4, 1),
-        test_111_200_4c_missing_exog,
-        marks=pytest.mark.xfail(
-            reason="test_111_200_4c_missing_exog dataset causes issues on some GPU architectures"
-        ),
-    ),
+    ((1, 1, 1, 2, 0, 0, 4, 1), test_111_200_4c_missing_exog),
     ((1, 1, 2, 0, 1, 2, 4, 0), test_112_012_4),
     stress_param((1, 1, 1, 1, 1, 1, 12, 0), test_111_111_12),
     stress_param((1, 1, 1, 1, 1, 1, 12, 0), test_111_111_12_missing),
@@ -401,11 +394,10 @@ def fill_interpolation(df_in):
 @pytest.mark.parametrize("dtype", [np.float64])
 def test_integration(key, data, dtype):
     """Full integration test: estimate, fit, forecast"""
-    if (
-        data.dataset == "endog_hourly_earnings_by_industry_missing_exog"
-        and cudf_pandas_active
-    ):
-        pytest.skip(reason="https://github.com/rapidsai/cuml/issues/6209")
+    if data.dataset == "endog_hourly_earnings_by_industry_missing_exog":
+        pytest.xfail(
+            reason="test_111_200_4c_missing_exog dataset causes issues on some GPU architectures (see https://github.com/rapidsai/cuml/issues/6209)"
+        )
     order, seasonal_order, intercept = extract_order(key)
     s = max(1, seasonal_order[3])
 

--- a/python/cuml/tests/test_arima.py
+++ b/python/cuml/tests/test_arima.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -243,7 +243,13 @@ test_data = [
     # Skip due to update to Scipy 1.15
     # ((1, 1, 1, 2, 0, 0, 4, 1), test_111_200_4c),
     # ((1, 1, 1, 2, 0, 0, 4, 1), test_111_200_4c_missing),
-    ((1, 1, 1, 2, 0, 0, 4, 1), test_111_200_4c_missing_exog),
+    pytest.param(
+        (1, 1, 1, 2, 0, 0, 4, 1),
+        test_111_200_4c_missing_exog,
+        marks=pytest.mark.xfail(
+            reason="test_111_200_4c_missing_exog dataset causes issues on some GPU architectures"
+        ),
+    ),
     ((1, 1, 2, 0, 1, 2, 4, 0), test_112_012_4),
     stress_param((1, 1, 1, 1, 1, 1, 12, 0), test_111_111_12),
     stress_param((1, 1, 1, 1, 1, 1, 12, 0), test_111_111_12_missing),


### PR DESCRIPTION
Python test `tests/test_arima.py::test_integration[float64-key9-data9]` has been broken on GH200 and similar hardware for a while, like this:

```text
AssertionError: assert np.float64(870.7586089734763) < (np.float64(0.7963644739490708) * (1.0 + 0.01))
 +  where 0.01 = <test_arima.ARIMAData object at 0xe1e752024e50>.tolerance_integration
```

This proposes xfailing that test, unconditionally just for simplicity.

## Notes for Reviewers

### How I tested this

```shell
conda create --yes \
  --name cuml-dev \
  --yes \
  --file ./conda/environments/all_cuda-131_arch-x86_64.yaml

conda install --yes \
  --name cuml-dev \
  -c rapidsai-nightly \
  -c conda-forge \
  'cuml=26.6.*' \
  'pytest-repeat>=0.9.4'

source activate cuml-dev
```

```console
$ pushd python/cuml/
$ pytest -rxXa -vv 'tests/test_arima.py::test_integration[float64-key9-data9]'
========================================================= test session starts =========================================================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0 -- /home/jlamb/miniforge3/envs/cuml-dev/bin/python3.13
cachedir: .pytest_cache
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
hypothesis profile 'unit' -> max_examples=20, phases=(Phase.explicit,), deadline=timedelta(milliseconds=2000), suppress_health_check=(HealthCheck.data_too_large, HealthCheck.too_slow)
rootdir: /home/jlamb/repos/cuml/python/cuml
configfile: pyproject.toml
plugins: benchmark-5.2.3, repeat-0.9.4, cov-7.1.0, hypothesis-6.152.1, xdist-3.8.0, cases-3.10.1
collected 14 items                                                                                                                    

tests/test_arima.py::test_integration[float64-key0-data0] PASSED                                                                [  7%]
tests/test_arima.py::test_integration[float64-key1-data1] PASSED                                                                [ 14%]
tests/test_arima.py::test_integration[float64-key2-data2] PASSED                                                                [ 21%]
tests/test_arima.py::test_integration[float64-key3-data3] PASSED                                                                [ 28%]
tests/test_arima.py::test_integration[float64-key4-data4] PASSED                                                                [ 35%]
tests/test_arima.py::test_integration[float64-key5-data5] PASSED                                                                [ 42%]
tests/test_arima.py::test_integration[float64-key6-data6] PASSED                                                                [ 50%]
tests/test_arima.py::test_integration[float64-key7-data7] PASSED                                                                [ 57%]
tests/test_arima.py::test_integration[float64-key8-data8] PASSED                                                                [ 64%]
tests/test_arima.py::test_integration[float64-key9-data9] XPASS (test_111_200_4c_missing_exog dataset causes issues on some GPU
architectures)                                                                                                                  [ 71%]
tests/test_arima.py::test_integration[float64-key10-data10] PASSED                                                              [ 78%]
tests/test_arima.py::test_integration[float64-key11-data11] SKIPPED (Stress tests run with --run_stress flag.)                  [ 85%]
tests/test_arima.py::test_integration[float64-key12-data12] SKIPPED (Stress tests run with --run_stress flag.)                  [ 92%]
tests/test_arima.py::test_integration[float64-key13-data13] SKIPPED (Stress tests run with --run_stress flag.)                  [100%]

=============================================================== XPASSES ===============================================================
________________________________________________ test_integration[float64-key9-data9] _________________________________________________
-------------------------------------------------------- Captured stdout call ---------------------------------------------------------
[2026-04-16 17:00:52.018] [CUML] [warning] Missing observations detected. Forcing simple_differencing=False
======================================================= short test summary info =======================================================
SKIPPED [3] tests/test_arima.py:400: Stress tests run with --run_stress flag.
XPASS tests/test_arima.py::test_integration[float64-key9-data9] - test_111_200_4c_missing_exog dataset causes issues on some GPU architectures
============================================== 10 passed, 3 skipped, 1 xpassed in 16.84s ==============================================
```