### PR TITLE
Improve timeout verbosity and graceful shutdown for pytest CI jobs

### DIFF
--- a/ci/test_python_cuml_accel_upstream.sh
+++ b/ci/test_python_cuml_accel_upstream.sh
@@ -14,7 +14,7 @@ set +e
 
 # Run UMAP tests
 rapids-logger "UMAP test suite"
-timeout -v 15m ./python/cuml/cuml_accel_tests/upstream/umap/run-tests.sh
+timeout -v --signal=SIGINT --kill-after=60s 15m ./python/cuml/cuml_accel_tests/upstream/umap/run-tests.sh
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_dask.sh
+++ b/ci/test_python_dask.sh
@@ -19,10 +19,10 @@ test_args=(
 
 # Run tests
 rapids-logger "pytest cuml-dask (No UCXX)"
-timeout -v 1h ./ci/run_cuml_dask_pytests.sh "${test_args[@]}"
+timeout -v --signal=SIGINT --kill-after=60s 1h ./ci/run_cuml_dask_pytests.sh "${test_args[@]}"
 
 rapids-logger "pytest cuml-dask (UCXX only)"
-timeout -v 10m ./ci/run_cuml_dask_pytests.sh "${test_args[@]}" --run_ucx
+timeout -v --signal=SIGINT --kill-after=60s 10m ./ci/run_cuml_dask_pytests.sh "${test_args[@]}" --run_ucx
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python_integration.sh
+++ b/ci/test_python_integration.sh
@@ -13,7 +13,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml integration"
-timeout 1h ./ci/run_cuml_integration_pytests.sh \
+timeout -v --signal=SIGINT --kill-after=60s 1h ./ci/run_cuml_integration_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml"

--- a/ci/test_python_scikit_learn_tests.sh
+++ b/ci/test_python_scikit_learn_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # Support invoking test script outside the script directory
@@ -12,7 +12,7 @@ rapids-logger "Running scikit-learn tests with cuML acceleration"
 # Do not immediately exit on error
 set +e
 
-timeout 1h ./python/cuml/cuml_accel_tests/upstream/scikit-learn/run-tests.sh \
+timeout -v --signal=SIGINT --kill-after=60s 1h ./python/cuml/cuml_accel_tests/upstream/scikit-learn/run-tests.sh \
     --numprocesses=8 \
     --dist=worksteal \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-accel-scikit-learn.xml"

--- a/ci/test_python_singlegpu.sh
+++ b/ci/test_python_singlegpu.sh
@@ -21,13 +21,13 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml single GPU"
-timeout 1h ./ci/run_cuml_singlegpu_pytests.sh \
+timeout -v --signal=SIGINT --kill-after=60s 1h ./ci/run_cuml_singlegpu_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml"
 
   rapids-logger "pytest cuml accelerator"
-timeout 15m ./ci/run_cuml_singlegpu_accel_pytests.sh \
+timeout -v --signal=SIGINT --kill-after=60s 15m ./ci/run_cuml_singlegpu_accel_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-accel.xml"

--- a/ci/test_python_sklearn_examples.sh
+++ b/ci/test_python_sklearn_examples.sh
@@ -16,7 +16,7 @@ SKLEARN_EXAMPLES_JUNITXML="${RAPIDS_TESTS_DIR}/junit-sklearn-examples.xml"
 
 # Run scikit-learn examples under cuml.accel
 rapids-logger "scikit-learn examples"
-timeout 60m ./python/cuml/cuml_accel_tests/upstream/scikit-learn/run-examples.sh \
+timeout -v --signal=SIGINT --kill-after=60s 60m ./python/cuml/cuml_accel_tests/upstream/scikit-learn/run-examples.sh \
     -n 4 --dist worksteal \
     --junitxml="${SKLEARN_EXAMPLES_JUNITXML}"
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -53,14 +53,14 @@ rapids-logger "Testing libcuml linkage"
 python -m pytest --cache-clear python/libcuml/tests/test_libcuml_linkage.py -v
 
 rapids-logger "pytest cuml single GPU"
-timeout -v 1h ./ci/run_cuml_singlegpu_pytests.sh \
+timeout -v --signal=SIGINT --kill-after=60s 1h ./ci/run_cuml_singlegpu_pytests.sh \
   --numprocesses=8 \
   --dist=worksteal \
   -k 'not test_sparse_pca_inputs' \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml.xml"
 
 # Run test_sparse_pca_inputs separately
-timeout -v 10m ./ci/run_cuml_singlegpu_pytests.sh \
+timeout -v --signal=SIGINT --kill-after=60s 10m ./ci/run_cuml_singlegpu_pytests.sh \
   -k 'test_sparse_pca_inputs' \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-sparse-pca.xml"
 

--- a/ci/test_wheel_dask.sh
+++ b/ci/test_wheel_dask.sh
@@ -33,7 +33,7 @@ trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest cuml dask"
-timeout -v 1h ./ci/run_cuml_dask_pytests.sh --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml"
+timeout -v --signal=SIGINT --kill-after=60s 1h ./ci/run_cuml_dask_pytests.sh --junitxml="${RAPIDS_TESTS_DIR}/junit-cuml-dask.xml"
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
## Summary

- Adds `-v` to all `timeout` invocations that were missing it, so cancellations are reported to the CI log.
- Adds `--signal=SIGINT --kill-after=60s` to every `timeout` wrapping a pytest invocation, so pytest receives `SIGINT` on timeout (prints a partial test summary) and is hard-killed 60 s later if it has not exited.
- Non-pytest `timeout` calls (`run_ctests.sh`, BERTopic smoke test) are left unchanged (already had `-v`).

Eight files changed, all in `ci/`: `test_python_singlegpu.sh`, `test_python_integration.sh`, `test_python_dask.sh`, `test_python_scikit_learn_tests.sh`, `test_python_sklearn_examples.sh`, `test_python_cuml_accel_upstream.sh`, `test_wheel.sh`, `test_wheel_dask.sh`.