### PR TITLE
Accelerate `StandardScaler`, `MinMaxScaler`, and `LabelEncoder` via sklearn's array API dispatch

### DIFF
--- a/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/preprocessing.py
@@ -3,72 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-import cupyx.scipy.sparse as cupy_sparse
 import numpy as np
-from scipy import sparse as sp_sparse
 
 import cuml.preprocessing
 from cuml.accel.estimator_proxy import ProxyBase
 from cuml.internals.interop import UnsupportedOnGPU
 
-__all__ = ("StandardScaler", "TargetEncoder")
-
-
-def _check_standardscaler_unsupported_inputs(X, **kwargs):
-    """Check if inputs are supported by cuML's StandardScaler on GPU.
-
-    Raises UnsupportedOnGPU for unsupported cases to trigger CPU fallback.
-    """
-    if kwargs.get("sample_weight") is not None:
-        raise UnsupportedOnGPU("sample_weight is not supported")
-
-    # Reject complex, object, and float16 dtypes
-    if hasattr(X, "dtype"):
-        if np.issubdtype(X.dtype, np.complexfloating):
-            raise UnsupportedOnGPU("complex dtype is not supported")
-        if X.dtype == np.object_:
-            raise UnsupportedOnGPU("object dtype is not supported")
-        if X.dtype == np.float16:
-            raise UnsupportedOnGPU("float16 dtype is not supported")
-
-    # Check for sparse matrices with unsupported properties
-    if sp_sparse.issparse(X):
-        if np.issubdtype(X.dtype, np.integer):
-            raise UnsupportedOnGPU(
-                "sparse matrix with integer dtype is not supported"
-            )
-        # cuML's StandardScaler algorithm only supports CSR/CSC formats.
-        if X.format not in ("csr", "csc"):
-            raise UnsupportedOnGPU(
-                f"sparse matrix format '{X.format}' is not supported"
-            )
-    elif cupy_sparse.issparse(X):
-        if np.issubdtype(X.dtype, np.integer):
-            raise UnsupportedOnGPU(
-                "sparse matrix with integer dtype is not supported"
-            )
-        # cuML's StandardScaler algorithm only supports CSR/CSC formats.
-        if X.format not in ("csr", "csc"):
-            raise UnsupportedOnGPU(
-                f"sparse matrix format '{X.format}' is not supported"
-            )
-
-
-class StandardScaler(ProxyBase):
-    _gpu_class = cuml.preprocessing.StandardScaler
-
-    def _gpu_fit(self, X, y=None, sample_weight=None):
-        kwargs = {"sample_weight": sample_weight}
-        _check_standardscaler_unsupported_inputs(X, **kwargs)
-        return self._gpu.fit(X, y)
-
-    def _gpu_fit_transform(self, X, y=None, **fit_params):
-        _check_standardscaler_unsupported_inputs(X, **fit_params)
-        return self._gpu.fit_transform(X, y, **fit_params)
-
-    def _gpu_partial_fit(self, X, y=None, sample_weight=None):
-        """partial_fit not supported on GPU - always fall back to CPU."""
-        raise UnsupportedOnGPU("partial_fit not supported on GPU")
+__all__ = ("TargetEncoder",)
 
 
 def _check_unsupported_inputs(X, y, cpu_model):

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -8,7 +8,7 @@ from sklearn.svm import SVC as _SVC
 from sklearn.utils.metaestimators import available_if
 
 import cuml.svm
-from cuml.accel.estimator_proxy import ProxyBase
+from cuml.accel.estimator_proxy import ProxyBase, ensure_host
 from cuml.internals.interop import UnsupportedOnGPU
 
 __all__ = (
@@ -37,7 +37,7 @@ class SVC(ProxyBase):
     )
 
     def _gpu_fit(self, X, y, sample_weight=None):
-        classes, counts = np.unique(np.asanyarray(y), return_counts=True)
+        classes, counts = np.unique(ensure_host(y), return_counts=True)
         if len(classes) > 2:
             raise UnsupportedOnGPU("Multiclass `y` is not supported")
 

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -8,7 +8,7 @@ from sklearn.svm import SVC as _SVC
 from sklearn.utils.metaestimators import available_if
 
 import cuml.svm
-from cuml.accel.estimator_proxy import ProxyBase, ensure_host
+from cuml.accel.estimator_proxy import ProxyBase
 from cuml.internals.interop import UnsupportedOnGPU
 
 __all__ = (
@@ -37,7 +37,7 @@ class SVC(ProxyBase):
     )
 
     def _gpu_fit(self, X, y, sample_weight=None):
-        classes, counts = np.unique(ensure_host(y), return_counts=True)
+        classes, counts = np.unique(np.asanyarray(y), return_counts=True)
         if len(classes) > 2:
             raise UnsupportedOnGPU("Multiclass `y` is not supported")
 

--- a/python/cuml/cuml/accel/_patches/sklearn/_utils.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/_utils.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared utilities for sklearn patch modules."""
+
+import contextlib
+import os
+
+import scipy._lib._array_api as _scipy_array_api
+
+
+@contextlib.contextmanager
+def enable_scipy_array_api():
+    """Enable scipy's array API support for the duration of a block.
+
+    Sets the SCIPY_ARRAY_API env var (checked by sklearn's config validation)
+    and updates scipy's cached config (in case scipy had already been
+    imported). Both are restored on exit.
+
+    This is required before entering
+    ``sklearn.config_context(array_api_dispatch=True)`` so that sklearn does
+    not raise a RuntimeError about scipy's array API support being absent.
+    """
+    old_env = os.environ.get("SCIPY_ARRAY_API")
+    os.environ["SCIPY_ARRAY_API"] = "1"
+
+    old_cached = _scipy_array_api._GLOBAL_CONFIG["SCIPY_ARRAY_API"]
+    _scipy_array_api._GLOBAL_CONFIG["SCIPY_ARRAY_API"] = "1"
+
+    try:
+        yield
+    finally:
+        if old_env is None:
+            os.environ.pop("SCIPY_ARRAY_API", None)
+        else:
+            os.environ["SCIPY_ARRAY_API"] = old_env
+
+        _scipy_array_api._GLOBAL_CONFIG["SCIPY_ARRAY_API"] = old_cached

--- a/python/cuml/cuml/accel/_patches/sklearn/pipeline.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/pipeline.py
@@ -8,7 +8,7 @@ from cupyx.scipy.sparse import issparse as is_cp_sparse
 from sklearn.pipeline import Pipeline
 from sklearn.utils.metaestimators import available_if
 
-from cuml.accel.estimator_proxy import is_proxy
+from cuml.accel.estimator_proxy import supports_device_data
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.outputs import using_output_type
 
@@ -40,7 +40,7 @@ def get_output_type(pipeline, reverse=False):
 
     # Skip over any non-cupy producing steps
     for step in step_iter:
-        if is_proxy(step):
+        if supports_device_data(step):
             break
     else:
         # No steps produce cupy
@@ -48,7 +48,7 @@ def get_output_type(pipeline, reverse=False):
 
     # If any remaining steps don't consume cupy, we need to fallback to numpy
     for step in step_iter:
-        if not is_proxy(step):
+        if not supports_device_data(step):
             return "numpy"
     # Tail of the pipeline supports cupy, we can use cupy
     return "cupy"

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -39,34 +39,47 @@ def _to_cupy(X):
 
 
 # ---------------------------------------------------------------------------
-# Generic fitted-attribute helpers (parameterized by attribute-name tuple)
+# Generic fitted-attribute helpers
 # ---------------------------------------------------------------------------
 
 
-def _ensure_fitted_on_host(estimator, fitted_attrs):
+def _get_fitted_attrs(estimator):
+    """Discover fitted attributes by sklearn's trailing-underscore convention."""
+    return [
+        attr
+        for attr in vars(estimator)
+        if attr.endswith("_") and not attr.startswith("_")
+    ]
+
+
+def _ensure_fitted_on_host(estimator):
     """Convert fitted attributes to host arrays when output_type is numpy."""
     if GlobalSettings().output_type in (None, "numpy"):
-        for attr in fitted_attrs:
+        for attr in _get_fitted_attrs(estimator):
             val = getattr(estimator, attr, None)
             if val is not None:
                 setattr(estimator, attr, ensure_host(val))
 
 
-def _promote_fitted_to_device(estimator, fitted_attrs):
+def _promote_fitted_to_device(estimator):
     """Convert any numpy fitted attributes to cupy in-place.
 
     After fit, fitted attrs are stored as numpy (for user convenience).
     sklearn's array-API code path needs them in the same namespace as
     the cupy input.
     """
-    for attr in fitted_attrs:
+    for attr in _get_fitted_attrs(estimator):
         val = getattr(estimator, attr, None)
-        if val is not None and isinstance(val, np.ndarray):
+        if (
+            val is not None
+            and isinstance(val, np.ndarray)
+            and np.issubdtype(val.dtype, np.number)
+        ):
             setattr(estimator, attr, cp.asarray(val))
 
 
 @contextlib.contextmanager
-def _fitted_attrs_on_device(estimator, fitted_attrs):
+def _fitted_attrs_on_device(estimator):
     """Temporarily move fitted attributes to cupy for a computation.
 
     Use this for read-only methods (transform, inverse_transform) that
@@ -75,9 +88,13 @@ def _fitted_attrs_on_device(estimator, fitted_attrs):
     directly and let ``_ensure_fitted_on_host`` convert back afterward.
     """
     saved = {}
-    for attr in fitted_attrs:
+    for attr in _get_fitted_attrs(estimator):
         val = getattr(estimator, attr, None)
-        if val is not None and isinstance(val, np.ndarray):
+        if (
+            val is not None
+            and isinstance(val, np.ndarray)
+            and np.issubdtype(val.dtype, np.number)
+        ):
             saved[attr] = val
             setattr(estimator, attr, cp.asarray(val))
     try:
@@ -124,7 +141,6 @@ def _infer_method_flags(method_name):
 def _make_method_patch(
     orig_method,
     class_name,
-    fitted_attrs,
     *,
     is_fitting=False,
     promotes_fitted=False,
@@ -139,8 +155,6 @@ def _make_method_patch(
         The original (unpatched) method.
     class_name : str
         Used in log messages.
-    fitted_attrs : tuple[str, ...]
-        Names of the estimator's fitted attributes to manage across CPU/GPU.
     is_fitting : bool
         If True, call ``_ensure_fitted_on_host`` after the method runs.
     promotes_fitted : bool
@@ -165,13 +179,11 @@ def _make_method_patch(
         logger.debug(f"{log_prefix} input data moved to GPU")
 
         if promotes_fitted:
-            _promote_fitted_to_device(self, fitted_attrs)
+            _promote_fitted_to_device(self)
 
         with contextlib.ExitStack() as stack:
             if uses_fitted_ctx:
-                stack.enter_context(
-                    _fitted_attrs_on_device(self, fitted_attrs)
-                )
+                stack.enter_context(_fitted_attrs_on_device(self))
             stack.enter_context(enable_scipy_array_api())
             stack.enter_context(
                 sklearn.config_context(array_api_dispatch=True)
@@ -180,7 +192,7 @@ def _make_method_patch(
             out = orig_method(self, _to_cupy(data), *args, **kwargs)
 
         if is_fitting:
-            _ensure_fitted_on_host(self, fitted_attrs)
+            _ensure_fitted_on_host(self)
 
         if returns_output and GlobalSettings().output_type in (None, "numpy"):
             out = ensure_host(out)
@@ -195,16 +207,13 @@ def _make_method_patch(
 # ---------------------------------------------------------------------------
 
 
-def patch_estimator(cls, fitted_attrs, methods=None):
+def patch_estimator(cls, methods=None):
     """Monkey-patch *cls* to dispatch its methods through CuPy.
 
     Parameters
     ----------
     cls : type
         The sklearn estimator class to patch.
-    fitted_attrs : tuple[str, ...]
-        Names of fitted attributes that need to be migrated between CPU and
-        GPU across method calls.
     methods : sequence of str or None
         Names of methods to patch.  When *None* (default), all methods in
         ``_TRANSFORMER_METHODS`` that exist on *cls* are patched
@@ -215,7 +224,7 @@ def patch_estimator(cls, fitted_attrs, methods=None):
     for method_name in methods:
         flags = _infer_method_flags(method_name)
         orig = getattr(cls, method_name)
-        patched = _make_method_patch(orig, cls.__name__, fitted_attrs, **flags)
+        patched = _make_method_patch(orig, cls.__name__, **flags)
         setattr(cls, method_name, patched)
     cls._cuml_accel_patched = True
 
@@ -224,16 +233,6 @@ def patch_estimator(cls, fitted_attrs, methods=None):
 # Per-estimator configuration and registration
 # ---------------------------------------------------------------------------
 
-patch_estimator(StandardScaler, ("mean_", "var_", "scale_", "n_samples_seen_"))
-patch_estimator(
-    MinMaxScaler,
-    (
-        "scale_",
-        "min_",
-        "data_min_",
-        "data_max_",
-        "data_range_",
-        "n_samples_seen_",
-    ),
-)
-patch_estimator(LabelEncoder, ("classes_",))
+patch_estimator(StandardScaler)
+patch_estimator(MinMaxScaler)
+patch_estimator(LabelEncoder)

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -7,7 +7,7 @@ import cupy as cp
 import numpy as np
 import scipy.sparse
 import sklearn
-from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
 from cuml.accel._patches.sklearn._utils import enable_scipy_array_api
 from cuml.accel.core import logger
@@ -15,7 +15,7 @@ from cuml.accel.estimator_proxy import ensure_host
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.outputs import using_output_type
 
-__all__ = ("StandardScaler",)
+__all__ = ("MinMaxScaler", "StandardScaler")
 
 _FITTED_ATTRS = ("mean_", "var_", "scale_", "n_samples_seen_")
 
@@ -249,3 +249,196 @@ _patch_fit_transform(StandardScaler)
 _patch_inverse_transform(StandardScaler)
 
 StandardScaler._cuml_accel_patched = True
+
+# ---------------------------------------------------------------------------
+# MinMaxScaler patches
+# ---------------------------------------------------------------------------
+
+_MINMAX_FITTED_ATTRS = (
+    "scale_",
+    "min_",
+    "data_min_",
+    "data_max_",
+    "data_range_",
+    "n_samples_seen_",
+)
+
+
+def _minmax_ensure_fitted_on_host(self):
+    if GlobalSettings().output_type in (None, "numpy"):
+        for attr in _MINMAX_FITTED_ATTRS:
+            val = getattr(self, attr, None)
+            if val is not None:
+                setattr(self, attr, ensure_host(val))
+
+
+def _minmax_promote_fitted_to_device(self):
+    for attr in _MINMAX_FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            setattr(self, attr, cp.asarray(val))
+
+
+@contextlib.contextmanager
+def _minmax_fitted_attrs_on_device(self):
+    saved = {}
+    for attr in _MINMAX_FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            saved[attr] = val
+            setattr(self, attr, cp.asarray(val))
+    try:
+        yield
+    finally:
+        for attr, val in saved.items():
+            setattr(self, attr, val)
+
+
+def _patch_minmax_fit(cls):
+    orig_fit = cls.fit
+
+    @functools.wraps(orig_fit)
+    def fit(self, X, y=None):
+        if not _can_accelerate(X):
+            logger.debug("`MinMaxScaler.fit` not optimized: unsupported input")
+            return orig_fit(self, X, y)
+
+        logger.debug("`MinMaxScaler.fit` input data moved to GPU")
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_fit(self, _to_cupy(X), y)
+
+        _minmax_ensure_fitted_on_host(self)
+        return out
+
+    cls.fit = fit
+
+
+def _patch_minmax_partial_fit(cls):
+    orig_partial_fit = cls.partial_fit
+
+    @functools.wraps(orig_partial_fit)
+    def partial_fit(self, X, y=None):
+        if not _can_accelerate(X):
+            logger.debug(
+                "`MinMaxScaler.partial_fit` not optimized: unsupported input"
+            )
+            return orig_partial_fit(self, X, y)
+
+        logger.debug("`MinMaxScaler.partial_fit` input data moved to GPU")
+
+        _minmax_promote_fitted_to_device(self)
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_partial_fit(self, _to_cupy(X), y)
+
+        _minmax_ensure_fitted_on_host(self)
+        return out
+
+    cls.partial_fit = partial_fit
+
+
+def _patch_minmax_transform(cls):
+    orig_transform = cls.transform
+
+    @functools.wraps(orig_transform)
+    def transform(self, X):
+        if not _can_accelerate(X):
+            logger.debug(
+                "`MinMaxScaler.transform` not optimized: unsupported input"
+            )
+            return orig_transform(self, X)
+
+        logger.debug("`MinMaxScaler.transform` input data moved to GPU")
+
+        with (
+            _minmax_fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_transform(self, _to_cupy(X))
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.transform = transform
+
+
+def _patch_minmax_fit_transform(cls):
+    orig_fit_transform = cls.fit_transform
+
+    @functools.wraps(orig_fit_transform)
+    def fit_transform(self, X, y=None, **fit_params):
+        if not _can_accelerate(X):
+            logger.debug(
+                "`MinMaxScaler.fit_transform` not optimized: unsupported input"
+            )
+            return orig_fit_transform(self, X, y, **fit_params)
+
+        logger.debug("`MinMaxScaler.fit_transform` input data moved to GPU")
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_fit_transform(self, _to_cupy(X), y, **fit_params)
+
+        _minmax_ensure_fitted_on_host(self)
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.fit_transform = fit_transform
+
+
+def _patch_minmax_inverse_transform(cls):
+    orig_inverse_transform = cls.inverse_transform
+
+    @functools.wraps(orig_inverse_transform)
+    def inverse_transform(self, X):
+        if not _can_accelerate(X):
+            logger.debug(
+                "`MinMaxScaler.inverse_transform` not optimized: "
+                "unsupported input"
+            )
+            return orig_inverse_transform(self, X)
+
+        logger.debug(
+            "`MinMaxScaler.inverse_transform` input data moved to GPU"
+        )
+
+        with (
+            _minmax_fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_inverse_transform(self, _to_cupy(X))
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.inverse_transform = inverse_transform
+
+
+_patch_minmax_fit(MinMaxScaler)
+_patch_minmax_partial_fit(MinMaxScaler)
+_patch_minmax_transform(MinMaxScaler)
+_patch_minmax_fit_transform(MinMaxScaler)
+_patch_minmax_inverse_transform(MinMaxScaler)
+
+MinMaxScaler._cuml_accel_patched = True

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -7,7 +7,7 @@ import cupy as cp
 import numpy as np
 import scipy.sparse
 import sklearn
-from sklearn.preprocessing import MinMaxScaler, StandardScaler
+from sklearn.preprocessing import LabelEncoder, MinMaxScaler, StandardScaler
 
 from cuml.accel._patches.sklearn._utils import enable_scipy_array_api
 from cuml.accel.core import logger
@@ -15,7 +15,7 @@ from cuml.accel.estimator_proxy import ensure_host
 from cuml.internals.global_settings import GlobalSettings
 from cuml.internals.outputs import using_output_type
 
-__all__ = ("MinMaxScaler", "StandardScaler")
+__all__ = ("LabelEncoder", "MinMaxScaler", "StandardScaler")
 
 _FITTED_ATTRS = ("mean_", "var_", "scale_", "n_samples_seen_")
 
@@ -442,3 +442,161 @@ _patch_minmax_fit_transform(MinMaxScaler)
 _patch_minmax_inverse_transform(MinMaxScaler)
 
 MinMaxScaler._cuml_accel_patched = True
+
+# ---------------------------------------------------------------------------
+# LabelEncoder patches
+# ---------------------------------------------------------------------------
+
+_LABEL_FITTED_ATTRS = ("classes_",)
+
+
+def _label_ensure_fitted_on_host(self):
+    if GlobalSettings().output_type in (None, "numpy"):
+        for attr in _LABEL_FITTED_ATTRS:
+            val = getattr(self, attr, None)
+            if val is not None:
+                setattr(self, attr, ensure_host(val))
+
+
+def _label_promote_fitted_to_device(self):
+    for attr in _LABEL_FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            setattr(self, attr, cp.asarray(val))
+
+
+@contextlib.contextmanager
+def _label_fitted_attrs_on_device(self):
+    saved = {}
+    for attr in _LABEL_FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            saved[attr] = val
+            setattr(self, attr, cp.asarray(val))
+    try:
+        yield
+    finally:
+        for attr, val in saved.items():
+            setattr(self, attr, val)
+
+
+def _patch_label_fit(cls):
+    orig_fit = cls.fit
+
+    @functools.wraps(orig_fit)
+    def fit(self, y):
+        if not _can_accelerate(y):
+            logger.debug("`LabelEncoder.fit` not optimized: unsupported input")
+            return orig_fit(self, y)
+
+        logger.debug("`LabelEncoder.fit` input data moved to GPU")
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_fit(self, _to_cupy(y))
+
+        _label_ensure_fitted_on_host(self)
+        return out
+
+    cls.fit = fit
+
+
+def _patch_label_fit_transform(cls):
+    orig_fit_transform = cls.fit_transform
+
+    @functools.wraps(orig_fit_transform)
+    def fit_transform(self, y):
+        if not _can_accelerate(y):
+            logger.debug(
+                "`LabelEncoder.fit_transform` not optimized: unsupported input"
+            )
+            return orig_fit_transform(self, y)
+
+        logger.debug("`LabelEncoder.fit_transform` input data moved to GPU")
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_fit_transform(self, _to_cupy(y))
+
+        _label_ensure_fitted_on_host(self)
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.fit_transform = fit_transform
+
+
+def _patch_label_transform(cls):
+    orig_transform = cls.transform
+
+    @functools.wraps(orig_transform)
+    def transform(self, y):
+        if not _can_accelerate(y):
+            logger.debug(
+                "`LabelEncoder.transform` not optimized: unsupported input"
+            )
+            return orig_transform(self, y)
+
+        logger.debug("`LabelEncoder.transform` input data moved to GPU")
+
+        with (
+            _label_fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_transform(self, _to_cupy(y))
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.transform = transform
+
+
+def _patch_label_inverse_transform(cls):
+    orig_inverse_transform = cls.inverse_transform
+
+    @functools.wraps(orig_inverse_transform)
+    def inverse_transform(self, y):
+        if not _can_accelerate(y):
+            logger.debug(
+                "`LabelEncoder.inverse_transform` not optimized: "
+                "unsupported input"
+            )
+            return orig_inverse_transform(self, y)
+
+        logger.debug(
+            "`LabelEncoder.inverse_transform` input data moved to GPU"
+        )
+
+        with (
+            _label_fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_inverse_transform(self, _to_cupy(y))
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.inverse_transform = inverse_transform
+
+
+_patch_label_fit(LabelEncoder)
+_patch_label_fit_transform(LabelEncoder)
+_patch_label_transform(LabelEncoder)
+_patch_label_inverse_transform(LabelEncoder)
+
+LabelEncoder._cuml_accel_patched = True

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -88,6 +88,35 @@ def _fitted_attrs_on_device(estimator, fitted_attrs):
 
 
 # ---------------------------------------------------------------------------
+# Method-flag inference
+# ---------------------------------------------------------------------------
+
+_TRANSFORMER_METHODS = (
+    "fit",
+    "partial_fit",
+    "transform",
+    "fit_transform",
+    "inverse_transform",
+)
+
+
+def _infer_method_flags(method_name):
+    """Derive _make_method_patch flags from a method name.
+
+    Covers the standard transformer method vocabulary:
+    fit, partial_fit, transform, fit_transform, inverse_transform.
+    """
+    is_fit = "fit" in method_name
+    is_transform = "transform" in method_name
+    return dict(
+        is_fitting=is_fit,
+        promotes_fitted=(method_name == "partial_fit"),
+        uses_fitted_ctx=(is_transform and not is_fit),
+        returns_output=is_transform,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Generic method-patch factory
 # ---------------------------------------------------------------------------
 
@@ -166,7 +195,7 @@ def _make_method_patch(
 # ---------------------------------------------------------------------------
 
 
-def patch_estimator(cls, fitted_attrs, methods):
+def patch_estimator(cls, fitted_attrs, methods=None):
     """Monkey-patch *cls* to dispatch its methods through CuPy.
 
     Parameters
@@ -176,11 +205,15 @@ def patch_estimator(cls, fitted_attrs, methods):
     fitted_attrs : tuple[str, ...]
         Names of fitted attributes that need to be migrated between CPU and
         GPU across method calls.
-    methods : dict[str, dict]
-        Mapping from method name to a dict of keyword arguments forwarded
-        to ``_make_method_patch``.
+    methods : sequence of str or None
+        Names of methods to patch.  When *None* (default), all methods in
+        ``_TRANSFORMER_METHODS`` that exist on *cls* are patched
+        automatically, with flags inferred by ``_infer_method_flags``.
     """
-    for method_name, flags in methods.items():
+    if methods is None:
+        methods = [m for m in _TRANSFORMER_METHODS if hasattr(cls, m)]
+    for method_name in methods:
+        flags = _infer_method_flags(method_name)
         orig = getattr(cls, method_name)
         patched = _make_method_patch(orig, cls.__name__, fitted_attrs, **flags)
         setattr(cls, method_name, patched)
@@ -191,21 +224,10 @@ def patch_estimator(cls, fitted_attrs, methods):
 # Per-estimator configuration and registration
 # ---------------------------------------------------------------------------
 
-patch_estimator(
-    StandardScaler,
-    fitted_attrs=("mean_", "var_", "scale_", "n_samples_seen_"),
-    methods={
-        "fit": dict(is_fitting=True),
-        "partial_fit": dict(is_fitting=True, promotes_fitted=True),
-        "transform": dict(uses_fitted_ctx=True, returns_output=True),
-        "fit_transform": dict(is_fitting=True, returns_output=True),
-        "inverse_transform": dict(uses_fitted_ctx=True, returns_output=True),
-    },
-)
-
+patch_estimator(StandardScaler, ("mean_", "var_", "scale_", "n_samples_seen_"))
 patch_estimator(
     MinMaxScaler,
-    fitted_attrs=(
+    (
         "scale_",
         "min_",
         "data_min_",
@@ -213,22 +235,5 @@ patch_estimator(
         "data_range_",
         "n_samples_seen_",
     ),
-    methods={
-        "fit": dict(is_fitting=True),
-        "partial_fit": dict(is_fitting=True, promotes_fitted=True),
-        "transform": dict(uses_fitted_ctx=True, returns_output=True),
-        "fit_transform": dict(is_fitting=True, returns_output=True),
-        "inverse_transform": dict(uses_fitted_ctx=True, returns_output=True),
-    },
 )
-
-patch_estimator(
-    LabelEncoder,
-    fitted_attrs=("classes_",),
-    methods={
-        "fit": dict(is_fitting=True),
-        "fit_transform": dict(is_fitting=True, returns_output=True),
-        "transform": dict(uses_fitted_ctx=True, returns_output=True),
-        "inverse_transform": dict(uses_fitted_ctx=True, returns_output=True),
-    },
-)
+patch_estimator(LabelEncoder, ("classes_",))

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+import contextlib
+import functools
+
+import cupy as cp
+import numpy as np
+import scipy.sparse
+import sklearn
+from sklearn.preprocessing import StandardScaler
+
+from cuml.accel._patches.sklearn._utils import enable_scipy_array_api
+from cuml.accel.core import logger
+from cuml.accel.estimator_proxy import ensure_host
+from cuml.internals.global_settings import GlobalSettings
+from cuml.internals.outputs import using_output_type
+
+__all__ = ("StandardScaler",)
+
+_FITTED_ATTRS = ("mean_", "var_", "scale_", "n_samples_seen_")
+
+
+def _can_accelerate(X):
+    """Check if X is suitable for GPU acceleration."""
+    if scipy.sparse.issparse(X):
+        return False
+    if hasattr(X, "dtype"):
+        if np.issubdtype(X.dtype, np.complexfloating):
+            return False
+        if X.dtype == np.object_:
+            return False
+        if X.dtype == np.float16:
+            return False
+    return True
+
+
+def _ensure_fitted_on_host(self):
+    """Convert fitted attributes to host arrays when output_type is numpy."""
+    if GlobalSettings().output_type in (None, "numpy"):
+        for attr in _FITTED_ATTRS:
+            val = getattr(self, attr, None)
+            if val is not None:
+                setattr(self, attr, ensure_host(val))
+
+
+def _to_cupy(X):
+    return X if isinstance(X, cp.ndarray) else cp.asarray(X)
+
+
+def _promote_fitted_to_device(self):
+    """Convert any numpy fitted attributes to cupy in-place.
+
+    After fit, fitted attrs are stored as numpy (for user convenience).
+    sklearn's array-API code path needs them in the same namespace as
+    the cupy input.
+    """
+    for attr in _FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            setattr(self, attr, cp.asarray(val))
+
+
+@contextlib.contextmanager
+def _fitted_attrs_on_device(self):
+    """Temporarily move fitted attributes to cupy for a computation.
+
+    Use this for read-only methods (transform, inverse_transform) that
+    should not permanently alter the stored attributes.  For methods
+    that update attributes (partial_fit) call ``_promote_fitted_to_device``
+    directly and let ``_ensure_fitted_on_host`` convert back afterward.
+    """
+    saved = {}
+    for attr in _FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            saved[attr] = val
+            setattr(self, attr, cp.asarray(val))
+    try:
+        yield
+    finally:
+        for attr, val in saved.items():
+            setattr(self, attr, val)
+
+
+def _patch_fit(cls):
+    orig_fit = cls.fit
+
+    @functools.wraps(orig_fit)
+    def fit(self, X, y=None, sample_weight=None):
+        if sample_weight is not None:
+            logger.debug("`StandardScaler.fit` not optimized: sample_weight")
+            return orig_fit(self, X, y, sample_weight=sample_weight)
+
+        if not _can_accelerate(X):
+            logger.debug(
+                "`StandardScaler.fit` not optimized: unsupported input"
+            )
+            return orig_fit(self, X, y)
+
+        logger.debug("`StandardScaler.fit` input data moved to GPU")
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_fit(self, _to_cupy(X), y)
+
+        _ensure_fitted_on_host(self)
+        return out
+
+    cls.fit = fit
+
+
+def _patch_partial_fit(cls):
+    orig_partial_fit = cls.partial_fit
+
+    @functools.wraps(orig_partial_fit)
+    def partial_fit(self, X, y=None, sample_weight=None):
+        if sample_weight is not None:
+            logger.debug(
+                "`StandardScaler.partial_fit` not optimized: sample_weight"
+            )
+            return orig_partial_fit(self, X, y, sample_weight=sample_weight)
+
+        if not _can_accelerate(X):
+            logger.debug(
+                "`StandardScaler.partial_fit` not optimized: unsupported input"
+            )
+            return orig_partial_fit(self, X, y)
+
+        logger.debug("`StandardScaler.partial_fit` input data moved to GPU")
+
+        _promote_fitted_to_device(self)
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_partial_fit(self, _to_cupy(X), y)
+
+        _ensure_fitted_on_host(self)
+        return out
+
+    cls.partial_fit = partial_fit
+
+
+def _patch_transform(cls):
+    orig_transform = cls.transform
+
+    @functools.wraps(orig_transform)
+    def transform(self, X, copy=None):
+        if not _can_accelerate(X):
+            logger.debug(
+                "`StandardScaler.transform` not optimized: unsupported input"
+            )
+            return orig_transform(self, X, copy=copy)
+
+        logger.debug("`StandardScaler.transform` input data moved to GPU")
+
+        with (
+            _fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_transform(self, _to_cupy(X), copy=copy)
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.transform = transform
+
+
+def _patch_fit_transform(cls):
+    orig_fit_transform = cls.fit_transform
+
+    @functools.wraps(orig_fit_transform)
+    def fit_transform(self, X, y=None, **fit_params):
+        if fit_params.get("sample_weight") is not None:
+            logger.debug(
+                "`StandardScaler.fit_transform` not optimized: sample_weight"
+            )
+            return orig_fit_transform(self, X, y, **fit_params)
+
+        if not _can_accelerate(X):
+            logger.debug(
+                "`StandardScaler.fit_transform` not optimized: "
+                "unsupported input"
+            )
+            return orig_fit_transform(self, X, y, **fit_params)
+
+        logger.debug("`StandardScaler.fit_transform` input data moved to GPU")
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_fit_transform(self, _to_cupy(X), y, **fit_params)
+
+        _ensure_fitted_on_host(self)
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.fit_transform = fit_transform
+
+
+def _patch_inverse_transform(cls):
+    orig_inverse_transform = cls.inverse_transform
+
+    @functools.wraps(orig_inverse_transform)
+    def inverse_transform(self, X, copy=None):
+        if not _can_accelerate(X):
+            logger.debug(
+                "`StandardScaler.inverse_transform` not optimized: "
+                "unsupported input"
+            )
+            return orig_inverse_transform(self, X, copy=copy)
+
+        logger.debug(
+            "`StandardScaler.inverse_transform` input data moved to GPU"
+        )
+
+        with (
+            _fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = orig_inverse_transform(self, _to_cupy(X), copy=copy)
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    cls.inverse_transform = inverse_transform
+
+
+_patch_fit(StandardScaler)
+_patch_partial_fit(StandardScaler)
+_patch_transform(StandardScaler)
+_patch_fit_transform(StandardScaler)
+_patch_inverse_transform(StandardScaler)
+
+StandardScaler._cuml_accel_patched = True

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -22,10 +22,14 @@ def _can_accelerate(X, **kwargs):
     """Check if X is suitable for GPU acceleration."""
     if kwargs.get("sample_weight") is not None:
         return False
+    if hasattr(X, "columns"):
+        return False
     if scipy.sparse.issparse(X):
         return False
     if hasattr(X, "dtype"):
         if np.issubdtype(X.dtype, np.complexfloating):
+            return False
+        if np.issubdtype(X.dtype, np.character):
             return False
         if X.dtype == np.object_:
             return False
@@ -36,6 +40,15 @@ def _can_accelerate(X, **kwargs):
 
 def _to_cupy(X):
     return X if isinstance(X, cp.ndarray) else cp.asarray(X)
+
+
+def _has_non_default_output_container(estimator):
+    """Return True when sklearn output wrapping is configured."""
+    output_config = getattr(estimator, "_sklearn_output_config", {})
+    transform_output = output_config.get("transform")
+    if transform_output is not None:
+        return transform_output != "default"
+    return sklearn.get_config().get("transform_output", "default") != "default"
 
 
 # ---------------------------------------------------------------------------
@@ -53,12 +66,19 @@ def _get_fitted_attrs(estimator):
 
 
 def _ensure_fitted_on_host(estimator):
-    """Convert fitted attributes to host arrays when output_type is numpy."""
-    if GlobalSettings().output_type in (None, "numpy"):
-        for attr in _get_fitted_attrs(estimator):
-            val = getattr(estimator, attr, None)
-            if val is not None:
-                setattr(estimator, attr, ensure_host(val))
+    """Convert fitted attributes to host (numpy) arrays.
+
+    Fitted attrs are stored as numpy regardless of the current
+    ``GlobalSettings().output_type`` so that the unaccelerated fallback
+    path (e.g. when a non-default ``transform_output`` is configured) can
+    operate on them without mixing cupy fitted attrs with a numpy input.
+    Accelerated transform paths temporarily promote these back to the
+    device via :func:`_fitted_attrs_on_device`.
+    """
+    for attr in _get_fitted_attrs(estimator):
+        val = getattr(estimator, attr, None)
+        if val is not None:
+            setattr(estimator, attr, ensure_host(val))
 
 
 def _promote_fitted_to_device(estimator):
@@ -172,6 +192,12 @@ def _make_method_patch(
 
     @functools.wraps(orig_method)
     def wrapper(self, data, *args, **kwargs):
+        if returns_output and _has_non_default_output_container(self):
+            logger.debug(
+                f"{log_prefix} not optimized: non-default output container"
+            )
+            return orig_method(self, data, *args, **kwargs)
+
         if not _can_accelerate(data, **kwargs):
             logger.debug(f"{log_prefix} not optimized: unsupported input")
             return orig_method(self, data, *args, **kwargs)

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -9,6 +9,7 @@ import scipy.sparse
 import sklearn
 from sklearn.preprocessing import LabelEncoder, MinMaxScaler, StandardScaler
 
+from cuml.accel import profilers
 from cuml.accel._patches.sklearn._utils import enable_scipy_array_api
 from cuml.accel.core import logger
 from cuml.accel.estimator_proxy import ensure_host
@@ -233,6 +234,7 @@ def _make_method_patch(
     """
     method_name = orig_method.__name__
     log_prefix = f"`{class_name}.{method_name}`"
+    qualname = f"{class_name}.{method_name}"
 
     @functools.wraps(orig_method)
     def wrapper(self, data, *args, **kwargs):
@@ -240,32 +242,42 @@ def _make_method_patch(
             logger.debug(
                 f"{log_prefix} not optimized: non-default output container"
             )
-            return orig_method(self, data, *args, **kwargs)
+            with profilers.track_cpu_call(
+                qualname, reason="non-default output container"
+            ):
+                return orig_method(self, data, *args, **kwargs)
 
         if not can_accelerate(self, data, **kwargs):
             logger.debug(f"{log_prefix} not optimized: unsupported input")
-            return orig_method(self, data, *args, **kwargs)
+            with profilers.track_cpu_call(
+                qualname, reason="unsupported input"
+            ):
+                return orig_method(self, data, *args, **kwargs)
 
         logger.debug(f"{log_prefix} input data moved to GPU")
 
-        if promotes_fitted:
-            _promote_fitted_to_device(self)
+        with profilers.track_gpu_call(qualname):
+            if promotes_fitted:
+                _promote_fitted_to_device(self)
 
-        with contextlib.ExitStack() as stack:
-            if uses_fitted_ctx:
-                stack.enter_context(_fitted_attrs_on_device(self))
-            stack.enter_context(enable_scipy_array_api())
-            stack.enter_context(
-                sklearn.config_context(array_api_dispatch=True)
-            )
-            stack.enter_context(using_output_type("cupy"))
-            out = orig_method(self, _to_cupy(data), *args, **kwargs)
+            with contextlib.ExitStack() as stack:
+                if uses_fitted_ctx:
+                    stack.enter_context(_fitted_attrs_on_device(self))
+                stack.enter_context(enable_scipy_array_api())
+                stack.enter_context(
+                    sklearn.config_context(array_api_dispatch=True)
+                )
+                stack.enter_context(using_output_type("cupy"))
+                out = orig_method(self, _to_cupy(data), *args, **kwargs)
 
-        if is_fitting:
-            _ensure_fitted_on_host(self)
+            if is_fitting:
+                _ensure_fitted_on_host(self)
 
-        if returns_output and GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
+            if returns_output and GlobalSettings().output_type in (
+                None,
+                "numpy",
+            ):
+                out = ensure_host(out)
 
         return out
 

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -18,28 +18,69 @@ from cuml.internals.outputs import using_output_type
 __all__ = ("LabelEncoder", "MinMaxScaler", "StandardScaler")
 
 
-def _can_accelerate(X, **kwargs):
-    """Check if X is suitable for GPU acceleration."""
-    if kwargs.get("sample_weight") is not None:
+def _is_accelerable_dtype(arr):
+    """True if `arr` has a numeric dtype that the cupy+array_api path can handle.
+
+    Excludes object, character, complex, and float16 (float16 is not reliably
+    supported by sklearn's array_api dispatch path).
+    """
+    if not hasattr(arr, "dtype"):
         return False
-    if hasattr(X, "columns"):
+    dt = arr.dtype
+    if dt == np.object_ or dt == np.float16:
         return False
-    if scipy.sparse.issparse(X):
+    if np.issubdtype(dt, np.complexfloating):
         return False
-    if hasattr(X, "dtype"):
-        if np.issubdtype(X.dtype, np.complexfloating):
-            return False
-        if np.issubdtype(X.dtype, np.character):
-            return False
-        if X.dtype == np.object_:
-            return False
-        if X.dtype == np.float16:
-            return False
-    return True
+    if np.issubdtype(dt, np.character):
+        return False
+    return np.issubdtype(dt, np.floating) or np.issubdtype(dt, np.integer)
 
 
 def _to_cupy(X):
     return X if isinstance(X, cp.ndarray) else cp.asarray(X)
+
+
+def _can_accelerate_standard_scaler(estimator, X, **kwargs):
+    # sample_weight is accepted by (partial_)fit. The cupy+array_api path for
+    # _incremental_mean_and_var has not been validated with cupy sample weights,
+    # so fall back to CPU when one is supplied.
+    if kwargs.get("sample_weight") is not None:
+        return False
+    if hasattr(X, "columns"):
+        return False
+    # sklearn accepts sparse input when with_mean=False, but the cupy+array_api
+    # path does not support scipy sparse matrices.
+    if scipy.sparse.issparse(X):
+        return False
+    return _is_accelerable_dtype(X)
+
+
+def _can_accelerate_min_max_scaler(estimator, X, **kwargs):
+    if hasattr(X, "columns"):
+        return False
+    # sklearn raises TypeError for sparse input; nothing to accelerate there.
+    if scipy.sparse.issparse(X):
+        return False
+    return _is_accelerable_dtype(X)
+
+
+def _can_accelerate_label_encoder(estimator, y, **kwargs):
+    # LabelEncoder operates on 1D y which may contain strings on CPU.
+    # cupy cannot hold string arrays, so only numeric y qualifies.
+    if hasattr(y, "columns"):
+        return False
+    if scipy.sparse.issparse(y):
+        return False
+    if not _is_accelerable_dtype(y):
+        return False
+    # cupy cannot hold string arrays, so if classes_ has a non-numeric dtype
+    # (e.g. the encoder was fitted on strings), any accelerated call will fail:
+    # transform() tries to cast y to classes_.dtype, and inverse_transform()
+    # calls xp.take(classes_, y) where xp=cp cannot handle a numpy string array.
+    classes = getattr(estimator, "classes_", None)
+    if classes is not None and not np.issubdtype(classes.dtype, np.number):
+        return False
+    return True
 
 
 def _has_non_default_output_container(estimator):
@@ -162,6 +203,7 @@ def _make_method_patch(
     orig_method,
     class_name,
     *,
+    can_accelerate,
     is_fitting=False,
     promotes_fitted=False,
     uses_fitted_ctx=False,
@@ -175,6 +217,8 @@ def _make_method_patch(
         The original (unpatched) method.
     class_name : str
         Used in log messages.
+    can_accelerate : callable(estimator, data, **kwargs) -> bool
+        Per-estimator predicate; when False the original method is called.
     is_fitting : bool
         If True, call ``_ensure_fitted_on_host`` after the method runs.
     promotes_fitted : bool
@@ -198,7 +242,7 @@ def _make_method_patch(
             )
             return orig_method(self, data, *args, **kwargs)
 
-        if not _can_accelerate(data, **kwargs):
+        if not can_accelerate(self, data, **kwargs):
             logger.debug(f"{log_prefix} not optimized: unsupported input")
             return orig_method(self, data, *args, **kwargs)
 
@@ -233,13 +277,16 @@ def _make_method_patch(
 # ---------------------------------------------------------------------------
 
 
-def patch_estimator(cls, methods=None):
+def patch_estimator(cls, can_accelerate, methods=None):
     """Monkey-patch *cls* to dispatch its methods through CuPy.
 
     Parameters
     ----------
     cls : type
         The sklearn estimator class to patch.
+    can_accelerate : callable(estimator, data, **kwargs) -> bool
+        Per-estimator predicate used by every patched method to decide
+        whether to route through the cupy+array_api path.
     methods : sequence of str or None
         Names of methods to patch.  When *None* (default), all methods in
         ``_TRANSFORMER_METHODS`` that exist on *cls* are patched
@@ -250,7 +297,9 @@ def patch_estimator(cls, methods=None):
     for method_name in methods:
         flags = _infer_method_flags(method_name)
         orig = getattr(cls, method_name)
-        patched = _make_method_patch(orig, cls.__name__, **flags)
+        patched = _make_method_patch(
+            orig, cls.__name__, can_accelerate=can_accelerate, **flags
+        )
         setattr(cls, method_name, patched)
     cls._cuml_accel_patched = True
 
@@ -259,6 +308,6 @@ def patch_estimator(cls, methods=None):
 # Per-estimator configuration and registration
 # ---------------------------------------------------------------------------
 
-patch_estimator(StandardScaler)
-patch_estimator(MinMaxScaler)
-patch_estimator(LabelEncoder)
+patch_estimator(StandardScaler, _can_accelerate_standard_scaler)
+patch_estimator(MinMaxScaler, _can_accelerate_min_max_scaler)
+patch_estimator(LabelEncoder, _can_accelerate_label_encoder)

--- a/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
+++ b/python/cuml/cuml/accel/_patches/sklearn/preprocessing.py
@@ -17,11 +17,11 @@ from cuml.internals.outputs import using_output_type
 
 __all__ = ("LabelEncoder", "MinMaxScaler", "StandardScaler")
 
-_FITTED_ATTRS = ("mean_", "var_", "scale_", "n_samples_seen_")
 
-
-def _can_accelerate(X):
+def _can_accelerate(X, **kwargs):
     """Check if X is suitable for GPU acceleration."""
+    if kwargs.get("sample_weight") is not None:
+        return False
     if scipy.sparse.issparse(X):
         return False
     if hasattr(X, "dtype"):
@@ -34,34 +34,39 @@ def _can_accelerate(X):
     return True
 
 
-def _ensure_fitted_on_host(self):
-    """Convert fitted attributes to host arrays when output_type is numpy."""
-    if GlobalSettings().output_type in (None, "numpy"):
-        for attr in _FITTED_ATTRS:
-            val = getattr(self, attr, None)
-            if val is not None:
-                setattr(self, attr, ensure_host(val))
-
-
 def _to_cupy(X):
     return X if isinstance(X, cp.ndarray) else cp.asarray(X)
 
 
-def _promote_fitted_to_device(self):
+# ---------------------------------------------------------------------------
+# Generic fitted-attribute helpers (parameterized by attribute-name tuple)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_fitted_on_host(estimator, fitted_attrs):
+    """Convert fitted attributes to host arrays when output_type is numpy."""
+    if GlobalSettings().output_type in (None, "numpy"):
+        for attr in fitted_attrs:
+            val = getattr(estimator, attr, None)
+            if val is not None:
+                setattr(estimator, attr, ensure_host(val))
+
+
+def _promote_fitted_to_device(estimator, fitted_attrs):
     """Convert any numpy fitted attributes to cupy in-place.
 
     After fit, fitted attrs are stored as numpy (for user convenience).
     sklearn's array-API code path needs them in the same namespace as
     the cupy input.
     """
-    for attr in _FITTED_ATTRS:
-        val = getattr(self, attr, None)
+    for attr in fitted_attrs:
+        val = getattr(estimator, attr, None)
         if val is not None and isinstance(val, np.ndarray):
-            setattr(self, attr, cp.asarray(val))
+            setattr(estimator, attr, cp.asarray(val))
 
 
 @contextlib.contextmanager
-def _fitted_attrs_on_device(self):
+def _fitted_attrs_on_device(estimator, fitted_attrs):
     """Temporarily move fitted attributes to cupy for a computation.
 
     Use this for read-only methods (transform, inverse_transform) that
@@ -70,533 +75,160 @@ def _fitted_attrs_on_device(self):
     directly and let ``_ensure_fitted_on_host`` convert back afterward.
     """
     saved = {}
-    for attr in _FITTED_ATTRS:
-        val = getattr(self, attr, None)
+    for attr in fitted_attrs:
+        val = getattr(estimator, attr, None)
         if val is not None and isinstance(val, np.ndarray):
             saved[attr] = val
-            setattr(self, attr, cp.asarray(val))
+            setattr(estimator, attr, cp.asarray(val))
     try:
         yield
     finally:
         for attr, val in saved.items():
-            setattr(self, attr, val)
+            setattr(estimator, attr, val)
 
-
-def _patch_fit(cls):
-    orig_fit = cls.fit
-
-    @functools.wraps(orig_fit)
-    def fit(self, X, y=None, sample_weight=None):
-        if sample_weight is not None:
-            logger.debug("`StandardScaler.fit` not optimized: sample_weight")
-            return orig_fit(self, X, y, sample_weight=sample_weight)
-
-        if not _can_accelerate(X):
-            logger.debug(
-                "`StandardScaler.fit` not optimized: unsupported input"
-            )
-            return orig_fit(self, X, y)
-
-        logger.debug("`StandardScaler.fit` input data moved to GPU")
-
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_fit(self, _to_cupy(X), y)
-
-        _ensure_fitted_on_host(self)
-        return out
-
-    cls.fit = fit
-
-
-def _patch_partial_fit(cls):
-    orig_partial_fit = cls.partial_fit
-
-    @functools.wraps(orig_partial_fit)
-    def partial_fit(self, X, y=None, sample_weight=None):
-        if sample_weight is not None:
-            logger.debug(
-                "`StandardScaler.partial_fit` not optimized: sample_weight"
-            )
-            return orig_partial_fit(self, X, y, sample_weight=sample_weight)
-
-        if not _can_accelerate(X):
-            logger.debug(
-                "`StandardScaler.partial_fit` not optimized: unsupported input"
-            )
-            return orig_partial_fit(self, X, y)
-
-        logger.debug("`StandardScaler.partial_fit` input data moved to GPU")
-
-        _promote_fitted_to_device(self)
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_partial_fit(self, _to_cupy(X), y)
-
-        _ensure_fitted_on_host(self)
-        return out
-
-    cls.partial_fit = partial_fit
-
-
-def _patch_transform(cls):
-    orig_transform = cls.transform
-
-    @functools.wraps(orig_transform)
-    def transform(self, X, copy=None):
-        if not _can_accelerate(X):
-            logger.debug(
-                "`StandardScaler.transform` not optimized: unsupported input"
-            )
-            return orig_transform(self, X, copy=copy)
-
-        logger.debug("`StandardScaler.transform` input data moved to GPU")
-
-        with (
-            _fitted_attrs_on_device(self),
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_transform(self, _to_cupy(X), copy=copy)
-
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.transform = transform
-
-
-def _patch_fit_transform(cls):
-    orig_fit_transform = cls.fit_transform
-
-    @functools.wraps(orig_fit_transform)
-    def fit_transform(self, X, y=None, **fit_params):
-        if fit_params.get("sample_weight") is not None:
-            logger.debug(
-                "`StandardScaler.fit_transform` not optimized: sample_weight"
-            )
-            return orig_fit_transform(self, X, y, **fit_params)
-
-        if not _can_accelerate(X):
-            logger.debug(
-                "`StandardScaler.fit_transform` not optimized: "
-                "unsupported input"
-            )
-            return orig_fit_transform(self, X, y, **fit_params)
-
-        logger.debug("`StandardScaler.fit_transform` input data moved to GPU")
-
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_fit_transform(self, _to_cupy(X), y, **fit_params)
-
-        _ensure_fitted_on_host(self)
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.fit_transform = fit_transform
-
-
-def _patch_inverse_transform(cls):
-    orig_inverse_transform = cls.inverse_transform
-
-    @functools.wraps(orig_inverse_transform)
-    def inverse_transform(self, X, copy=None):
-        if not _can_accelerate(X):
-            logger.debug(
-                "`StandardScaler.inverse_transform` not optimized: "
-                "unsupported input"
-            )
-            return orig_inverse_transform(self, X, copy=copy)
-
-        logger.debug(
-            "`StandardScaler.inverse_transform` input data moved to GPU"
-        )
-
-        with (
-            _fitted_attrs_on_device(self),
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_inverse_transform(self, _to_cupy(X), copy=copy)
-
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.inverse_transform = inverse_transform
-
-
-_patch_fit(StandardScaler)
-_patch_partial_fit(StandardScaler)
-_patch_transform(StandardScaler)
-_patch_fit_transform(StandardScaler)
-_patch_inverse_transform(StandardScaler)
-
-StandardScaler._cuml_accel_patched = True
 
 # ---------------------------------------------------------------------------
-# MinMaxScaler patches
+# Generic method-patch factory
 # ---------------------------------------------------------------------------
 
-_MINMAX_FITTED_ATTRS = (
-    "scale_",
-    "min_",
-    "data_min_",
-    "data_max_",
-    "data_range_",
-    "n_samples_seen_",
+
+def _make_method_patch(
+    orig_method,
+    class_name,
+    fitted_attrs,
+    *,
+    is_fitting=False,
+    promotes_fitted=False,
+    uses_fitted_ctx=False,
+    returns_output=False,
+):
+    """Return a patched version of *orig_method* that dispatches via CuPy.
+
+    Parameters
+    ----------
+    orig_method : callable
+        The original (unpatched) method.
+    class_name : str
+        Used in log messages.
+    fitted_attrs : tuple[str, ...]
+        Names of the estimator's fitted attributes to manage across CPU/GPU.
+    is_fitting : bool
+        If True, call ``_ensure_fitted_on_host`` after the method runs.
+    promotes_fitted : bool
+        If True, call ``_promote_fitted_to_device`` before the method runs
+        (for incremental methods like ``partial_fit``).
+    uses_fitted_ctx : bool
+        If True, wrap the call in ``_fitted_attrs_on_device`` so that fitted
+        attributes are temporarily on the device (for read-only transform
+        methods).
+    returns_output : bool
+        If True, convert the return value to a host array when appropriate.
+    """
+    method_name = orig_method.__name__
+    log_prefix = f"`{class_name}.{method_name}`"
+
+    @functools.wraps(orig_method)
+    def wrapper(self, data, *args, **kwargs):
+        if not _can_accelerate(data, **kwargs):
+            logger.debug(f"{log_prefix} not optimized: unsupported input")
+            return orig_method(self, data, *args, **kwargs)
+
+        logger.debug(f"{log_prefix} input data moved to GPU")
+
+        if promotes_fitted:
+            _promote_fitted_to_device(self, fitted_attrs)
+
+        with contextlib.ExitStack() as stack:
+            if uses_fitted_ctx:
+                stack.enter_context(
+                    _fitted_attrs_on_device(self, fitted_attrs)
+                )
+            stack.enter_context(enable_scipy_array_api())
+            stack.enter_context(
+                sklearn.config_context(array_api_dispatch=True)
+            )
+            stack.enter_context(using_output_type("cupy"))
+            out = orig_method(self, _to_cupy(data), *args, **kwargs)
+
+        if is_fitting:
+            _ensure_fitted_on_host(self, fitted_attrs)
+
+        if returns_output and GlobalSettings().output_type in (None, "numpy"):
+            out = ensure_host(out)
+
+        return out
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Top-level estimator-patching entry point
+# ---------------------------------------------------------------------------
+
+
+def patch_estimator(cls, fitted_attrs, methods):
+    """Monkey-patch *cls* to dispatch its methods through CuPy.
+
+    Parameters
+    ----------
+    cls : type
+        The sklearn estimator class to patch.
+    fitted_attrs : tuple[str, ...]
+        Names of fitted attributes that need to be migrated between CPU and
+        GPU across method calls.
+    methods : dict[str, dict]
+        Mapping from method name to a dict of keyword arguments forwarded
+        to ``_make_method_patch``.
+    """
+    for method_name, flags in methods.items():
+        orig = getattr(cls, method_name)
+        patched = _make_method_patch(orig, cls.__name__, fitted_attrs, **flags)
+        setattr(cls, method_name, patched)
+    cls._cuml_accel_patched = True
+
+
+# ---------------------------------------------------------------------------
+# Per-estimator configuration and registration
+# ---------------------------------------------------------------------------
+
+patch_estimator(
+    StandardScaler,
+    fitted_attrs=("mean_", "var_", "scale_", "n_samples_seen_"),
+    methods={
+        "fit": dict(is_fitting=True),
+        "partial_fit": dict(is_fitting=True, promotes_fitted=True),
+        "transform": dict(uses_fitted_ctx=True, returns_output=True),
+        "fit_transform": dict(is_fitting=True, returns_output=True),
+        "inverse_transform": dict(uses_fitted_ctx=True, returns_output=True),
+    },
 )
 
-
-def _minmax_ensure_fitted_on_host(self):
-    if GlobalSettings().output_type in (None, "numpy"):
-        for attr in _MINMAX_FITTED_ATTRS:
-            val = getattr(self, attr, None)
-            if val is not None:
-                setattr(self, attr, ensure_host(val))
-
-
-def _minmax_promote_fitted_to_device(self):
-    for attr in _MINMAX_FITTED_ATTRS:
-        val = getattr(self, attr, None)
-        if val is not None and isinstance(val, np.ndarray):
-            setattr(self, attr, cp.asarray(val))
-
-
-@contextlib.contextmanager
-def _minmax_fitted_attrs_on_device(self):
-    saved = {}
-    for attr in _MINMAX_FITTED_ATTRS:
-        val = getattr(self, attr, None)
-        if val is not None and isinstance(val, np.ndarray):
-            saved[attr] = val
-            setattr(self, attr, cp.asarray(val))
-    try:
-        yield
-    finally:
-        for attr, val in saved.items():
-            setattr(self, attr, val)
-
-
-def _patch_minmax_fit(cls):
-    orig_fit = cls.fit
-
-    @functools.wraps(orig_fit)
-    def fit(self, X, y=None):
-        if not _can_accelerate(X):
-            logger.debug("`MinMaxScaler.fit` not optimized: unsupported input")
-            return orig_fit(self, X, y)
-
-        logger.debug("`MinMaxScaler.fit` input data moved to GPU")
-
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_fit(self, _to_cupy(X), y)
-
-        _minmax_ensure_fitted_on_host(self)
-        return out
-
-    cls.fit = fit
-
-
-def _patch_minmax_partial_fit(cls):
-    orig_partial_fit = cls.partial_fit
-
-    @functools.wraps(orig_partial_fit)
-    def partial_fit(self, X, y=None):
-        if not _can_accelerate(X):
-            logger.debug(
-                "`MinMaxScaler.partial_fit` not optimized: unsupported input"
-            )
-            return orig_partial_fit(self, X, y)
-
-        logger.debug("`MinMaxScaler.partial_fit` input data moved to GPU")
-
-        _minmax_promote_fitted_to_device(self)
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_partial_fit(self, _to_cupy(X), y)
-
-        _minmax_ensure_fitted_on_host(self)
-        return out
-
-    cls.partial_fit = partial_fit
-
-
-def _patch_minmax_transform(cls):
-    orig_transform = cls.transform
-
-    @functools.wraps(orig_transform)
-    def transform(self, X):
-        if not _can_accelerate(X):
-            logger.debug(
-                "`MinMaxScaler.transform` not optimized: unsupported input"
-            )
-            return orig_transform(self, X)
-
-        logger.debug("`MinMaxScaler.transform` input data moved to GPU")
-
-        with (
-            _minmax_fitted_attrs_on_device(self),
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_transform(self, _to_cupy(X))
-
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.transform = transform
-
-
-def _patch_minmax_fit_transform(cls):
-    orig_fit_transform = cls.fit_transform
-
-    @functools.wraps(orig_fit_transform)
-    def fit_transform(self, X, y=None, **fit_params):
-        if not _can_accelerate(X):
-            logger.debug(
-                "`MinMaxScaler.fit_transform` not optimized: unsupported input"
-            )
-            return orig_fit_transform(self, X, y, **fit_params)
-
-        logger.debug("`MinMaxScaler.fit_transform` input data moved to GPU")
-
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_fit_transform(self, _to_cupy(X), y, **fit_params)
-
-        _minmax_ensure_fitted_on_host(self)
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.fit_transform = fit_transform
-
-
-def _patch_minmax_inverse_transform(cls):
-    orig_inverse_transform = cls.inverse_transform
-
-    @functools.wraps(orig_inverse_transform)
-    def inverse_transform(self, X):
-        if not _can_accelerate(X):
-            logger.debug(
-                "`MinMaxScaler.inverse_transform` not optimized: "
-                "unsupported input"
-            )
-            return orig_inverse_transform(self, X)
-
-        logger.debug(
-            "`MinMaxScaler.inverse_transform` input data moved to GPU"
-        )
-
-        with (
-            _minmax_fitted_attrs_on_device(self),
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_inverse_transform(self, _to_cupy(X))
-
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.inverse_transform = inverse_transform
-
-
-_patch_minmax_fit(MinMaxScaler)
-_patch_minmax_partial_fit(MinMaxScaler)
-_patch_minmax_transform(MinMaxScaler)
-_patch_minmax_fit_transform(MinMaxScaler)
-_patch_minmax_inverse_transform(MinMaxScaler)
-
-MinMaxScaler._cuml_accel_patched = True
-
-# ---------------------------------------------------------------------------
-# LabelEncoder patches
-# ---------------------------------------------------------------------------
-
-_LABEL_FITTED_ATTRS = ("classes_",)
-
-
-def _label_ensure_fitted_on_host(self):
-    if GlobalSettings().output_type in (None, "numpy"):
-        for attr in _LABEL_FITTED_ATTRS:
-            val = getattr(self, attr, None)
-            if val is not None:
-                setattr(self, attr, ensure_host(val))
-
-
-def _label_promote_fitted_to_device(self):
-    for attr in _LABEL_FITTED_ATTRS:
-        val = getattr(self, attr, None)
-        if val is not None and isinstance(val, np.ndarray):
-            setattr(self, attr, cp.asarray(val))
-
-
-@contextlib.contextmanager
-def _label_fitted_attrs_on_device(self):
-    saved = {}
-    for attr in _LABEL_FITTED_ATTRS:
-        val = getattr(self, attr, None)
-        if val is not None and isinstance(val, np.ndarray):
-            saved[attr] = val
-            setattr(self, attr, cp.asarray(val))
-    try:
-        yield
-    finally:
-        for attr, val in saved.items():
-            setattr(self, attr, val)
-
-
-def _patch_label_fit(cls):
-    orig_fit = cls.fit
-
-    @functools.wraps(orig_fit)
-    def fit(self, y):
-        if not _can_accelerate(y):
-            logger.debug("`LabelEncoder.fit` not optimized: unsupported input")
-            return orig_fit(self, y)
-
-        logger.debug("`LabelEncoder.fit` input data moved to GPU")
-
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_fit(self, _to_cupy(y))
-
-        _label_ensure_fitted_on_host(self)
-        return out
-
-    cls.fit = fit
-
-
-def _patch_label_fit_transform(cls):
-    orig_fit_transform = cls.fit_transform
-
-    @functools.wraps(orig_fit_transform)
-    def fit_transform(self, y):
-        if not _can_accelerate(y):
-            logger.debug(
-                "`LabelEncoder.fit_transform` not optimized: unsupported input"
-            )
-            return orig_fit_transform(self, y)
-
-        logger.debug("`LabelEncoder.fit_transform` input data moved to GPU")
-
-        with (
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_fit_transform(self, _to_cupy(y))
-
-        _label_ensure_fitted_on_host(self)
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.fit_transform = fit_transform
-
-
-def _patch_label_transform(cls):
-    orig_transform = cls.transform
-
-    @functools.wraps(orig_transform)
-    def transform(self, y):
-        if not _can_accelerate(y):
-            logger.debug(
-                "`LabelEncoder.transform` not optimized: unsupported input"
-            )
-            return orig_transform(self, y)
-
-        logger.debug("`LabelEncoder.transform` input data moved to GPU")
-
-        with (
-            _label_fitted_attrs_on_device(self),
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_transform(self, _to_cupy(y))
-
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.transform = transform
-
-
-def _patch_label_inverse_transform(cls):
-    orig_inverse_transform = cls.inverse_transform
-
-    @functools.wraps(orig_inverse_transform)
-    def inverse_transform(self, y):
-        if not _can_accelerate(y):
-            logger.debug(
-                "`LabelEncoder.inverse_transform` not optimized: "
-                "unsupported input"
-            )
-            return orig_inverse_transform(self, y)
-
-        logger.debug(
-            "`LabelEncoder.inverse_transform` input data moved to GPU"
-        )
-
-        with (
-            _label_fitted_attrs_on_device(self),
-            enable_scipy_array_api(),
-            sklearn.config_context(array_api_dispatch=True),
-            using_output_type("cupy"),
-        ):
-            out = orig_inverse_transform(self, _to_cupy(y))
-
-        if GlobalSettings().output_type in (None, "numpy"):
-            out = ensure_host(out)
-
-        return out
-
-    cls.inverse_transform = inverse_transform
-
-
-_patch_label_fit(LabelEncoder)
-_patch_label_fit_transform(LabelEncoder)
-_patch_label_transform(LabelEncoder)
-_patch_label_inverse_transform(LabelEncoder)
-
-LabelEncoder._cuml_accel_patched = True
+patch_estimator(
+    MinMaxScaler,
+    fitted_attrs=(
+        "scale_",
+        "min_",
+        "data_min_",
+        "data_max_",
+        "data_range_",
+        "n_samples_seen_",
+    ),
+    methods={
+        "fit": dict(is_fitting=True),
+        "partial_fit": dict(is_fitting=True, promotes_fitted=True),
+        "transform": dict(uses_fitted_ctx=True, returns_output=True),
+        "fit_transform": dict(is_fitting=True, returns_output=True),
+        "inverse_transform": dict(uses_fitted_ctx=True, returns_output=True),
+    },
+)
+
+patch_estimator(
+    LabelEncoder,
+    fitted_attrs=("classes_",),
+    methods={
+        "fit": dict(is_fitting=True),
+        "fit_transform": dict(is_fitting=True, returns_output=True),
+        "transform": dict(uses_fitted_ctx=True, returns_output=True),
+        "inverse_transform": dict(uses_fitted_ctx=True, returns_output=True),
+    },
+)

--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -92,6 +92,7 @@ _OVERRIDES = {
 
 _PATCHES = {
     "sklearn.pipeline",
+    "sklearn.preprocessing",
     "sklearn.utils",
 }
 

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -37,6 +37,22 @@ def is_proxy(instance_or_class) -> bool:
     return issubclass(cls, ProxyBase)
 
 
+def supports_device_data(instance_or_class) -> bool:
+    """Check if an estimator can produce and consume device (cupy) arrays.
+
+    Returns True for ProxyBase estimators and for sklearn classes whose
+    methods have been patched to use array-API dispatch on the GPU
+    (marked with ``_cuml_accel_patched = True``).
+    """
+    if isinstance(instance_or_class, type):
+        cls = instance_or_class
+    else:
+        cls = type(instance_or_class)
+    return issubclass(cls, ProxyBase) or getattr(
+        cls, "_cuml_accel_patched", False
+    )
+
+
 def ensure_host(x):
     """Convert any cupy/cupyx.scipy.sparse inputs to their host equivalents"""
     return x.get() if (isinstance(x, cp.ndarray) or is_cp_sparse(x)) else x

--- a/python/cuml/cuml/preprocessing/__init__.py
+++ b/python/cuml/cuml/preprocessing/__init__.py
@@ -16,7 +16,6 @@ from cuml._thirdparty.sklearn.preprocessing import (
     QuantileTransformer,
     RobustScaler,
     SimpleImputer,
-    StandardScaler,
     add_dummy_feature,
     binarize,
     maxabs_scale,
@@ -30,6 +29,7 @@ from cuml._thirdparty.sklearn.preprocessing import (
 from cuml.model_selection import train_test_split
 from cuml.preprocessing import text
 from cuml.preprocessing._label import LabelEncoder
+from cuml.preprocessing._standard_scaler import StandardScaler
 from cuml.preprocessing._target_encoder import TargetEncoder
 from cuml.preprocessing.encoders import OneHotEncoder, OrdinalEncoder
 from cuml.preprocessing.label import LabelBinarizer, label_binarize

--- a/python/cuml/cuml/preprocessing/_standard_scaler.py
+++ b/python/cuml/cuml/preprocessing/_standard_scaler.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Thin StandardScaler that delegates to scikit-learn with GPU acceleration.
+
+Subclasses :class:`sklearn.preprocessing.StandardScaler` and transparently
+moves data to CuPy so that sklearn's array-API dispatch path runs on the GPU.
+"""
+
+import contextlib
+
+import cupy as cp
+import numpy as np
+import scipy.sparse
+import sklearn
+from sklearn.preprocessing import StandardScaler as SklearnStandardScaler
+
+from cuml.accel._patches.sklearn._utils import enable_scipy_array_api
+from cuml.internals.global_settings import GlobalSettings
+from cuml.internals.outputs import using_output_type
+
+__all__ = ("StandardScaler",)
+
+_FITTED_ATTRS = ("mean_", "var_", "scale_", "n_samples_seen_")
+
+
+def _can_accelerate(X):
+    """Check if X is suitable for GPU acceleration."""
+    if scipy.sparse.issparse(X):
+        return False
+    if hasattr(X, "dtype"):
+        if np.issubdtype(X.dtype, np.complexfloating):
+            return False
+        if X.dtype == np.object_:
+            return False
+        if X.dtype == np.float16:
+            return False
+    return True
+
+
+def _to_cupy(X):
+    return X if isinstance(X, cp.ndarray) else cp.asarray(X)
+
+
+def _ensure_host(x):
+    return x.get() if isinstance(x, cp.ndarray) else x
+
+
+def _ensure_fitted_on_host(self):
+    """Convert fitted attributes to host arrays when output_type is numpy."""
+    if GlobalSettings().output_type in (None, "numpy"):
+        for attr in _FITTED_ATTRS:
+            val = getattr(self, attr, None)
+            if val is not None:
+                setattr(self, attr, _ensure_host(val))
+
+
+def _promote_fitted_to_device(self):
+    """Convert any numpy fitted attributes to cupy in-place.
+
+    After fit, fitted attrs are stored as numpy (for user convenience).
+    sklearn's array-API code path needs them in the same namespace as
+    the cupy input.
+    """
+    for attr in _FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            setattr(self, attr, cp.asarray(val))
+
+
+@contextlib.contextmanager
+def _fitted_attrs_on_device(self):
+    """Temporarily move fitted attributes to cupy for a computation.
+
+    Use this for read-only methods (transform, inverse_transform) that
+    should not permanently alter the stored attributes.  For methods
+    that update attributes (partial_fit) call ``_promote_fitted_to_device``
+    directly and let ``_ensure_fitted_on_host`` convert back afterward.
+    """
+    saved = {}
+    for attr in _FITTED_ATTRS:
+        val = getattr(self, attr, None)
+        if val is not None and isinstance(val, np.ndarray):
+            saved[attr] = val
+            setattr(self, attr, cp.asarray(val))
+    try:
+        yield
+    finally:
+        for attr, val in saved.items():
+            setattr(self, attr, val)
+
+
+class StandardScaler(SklearnStandardScaler):
+    def fit(self, X, y=None, sample_weight=None):
+        if sample_weight is not None or not _can_accelerate(X):
+            return super().fit(X, y, sample_weight=sample_weight)
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = super().fit(_to_cupy(X), y)
+
+        _ensure_fitted_on_host(self)
+        return out
+
+    def partial_fit(self, X, y=None, sample_weight=None):
+        if sample_weight is not None or not _can_accelerate(X):
+            return super().partial_fit(X, y, sample_weight=sample_weight)
+
+        _promote_fitted_to_device(self)
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = super().partial_fit(_to_cupy(X), y)
+
+        _ensure_fitted_on_host(self)
+        return out
+
+    def transform(self, X, copy=None):
+        if not _can_accelerate(X):
+            return super().transform(X, copy=copy)
+
+        with (
+            _fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = super().transform(_to_cupy(X), copy=copy)
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = _ensure_host(out)
+
+        return out
+
+    def fit_transform(self, X, y=None, **fit_params):
+        if fit_params.get("sample_weight") is not None or not _can_accelerate(
+            X
+        ):
+            return super().fit_transform(X, y, **fit_params)
+
+        with (
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = super().fit_transform(_to_cupy(X), y, **fit_params)
+
+        _ensure_fitted_on_host(self)
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = _ensure_host(out)
+
+        return out
+
+    def inverse_transform(self, X, copy=None):
+        if not _can_accelerate(X):
+            return super().inverse_transform(X, copy=copy)
+
+        with (
+            _fitted_attrs_on_device(self),
+            enable_scipy_array_api(),
+            sklearn.config_context(array_api_dispatch=True),
+            using_output_type("cupy"),
+        ):
+            out = super().inverse_transform(_to_cupy(X), copy=copy)
+
+        if GlobalSettings().output_type in (None, "numpy"):
+            out = _ensure_host(out)
+
+        return out

--- a/python/cuml/cuml_accel_tests/test_preprocessing.py
+++ b/python/cuml/cuml_accel_tests/test_preprocessing.py
@@ -1,0 +1,427 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse
+from sklearn.datasets import make_blobs
+from sklearn.preprocessing import (
+    LabelEncoder,
+    MinMaxScaler,
+    StandardScaler,
+    TargetEncoder,
+)
+
+from cuml.accel.core import logger
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_log_level():
+    """Reset logger back to warn after every test."""
+    yield
+    logger.set_level("warn")
+
+
+@pytest.fixture
+def get_logs(capsys):
+    """Return a callable that yields the cuml.accel debug lines captured so far."""
+
+    def _get_logs():
+        out, _ = capsys.readouterr()
+        return [
+            line for line in out.split("\n") if line.startswith("[cuml.accel]")
+        ]
+
+    return _get_logs
+
+
+@pytest.fixture
+def X_float64():
+    X, _ = make_blobs(n_samples=200, n_features=5, random_state=42)
+    return X.astype(np.float64)
+
+
+# ---------------------------------------------------------------------------
+# StandardScaler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_standard_scaler_fit_transform(dtype, get_logs):
+    logger.set_level("debug")
+    X, _ = make_blobs(n_samples=200, n_features=5, random_state=42)
+    X = X.astype(dtype)
+
+    scaler = StandardScaler()
+    X_tr = scaler.fit(X).transform(X)
+
+    assert X_tr.shape == X.shape
+    assert isinstance(X_tr, np.ndarray)
+    np.testing.assert_allclose(X_tr.mean(axis=0), 0, atol=1e-5)
+    np.testing.assert_allclose(X_tr.std(axis=0), 1, atol=1e-5)
+
+    logs = get_logs()
+    assert any(
+        "StandardScaler.fit` input data moved to GPU" in line for line in logs
+    )
+
+
+def test_standard_scaler_inverse_transform(X_float64):
+    scaler = StandardScaler().fit(X_float64)
+    X_tr = scaler.transform(X_float64)
+    X_back = scaler.inverse_transform(X_tr)
+    np.testing.assert_allclose(X_back, X_float64, atol=1e-6)
+
+
+def test_standard_scaler_fit_transform_matches_fit_then_transform(X_float64):
+    X = X_float64
+    scaler1 = StandardScaler()
+    X_ft = scaler1.fit_transform(X)
+
+    scaler2 = StandardScaler()
+    X_expected = scaler2.fit(X).transform(X)
+
+    np.testing.assert_allclose(X_ft, X_expected, atol=1e-10)
+
+
+def test_standard_scaler_partial_fit(X_float64):
+    X = X_float64
+    half = len(X) // 2
+
+    scaler_full = StandardScaler().fit(X)
+
+    scaler_partial = StandardScaler()
+    scaler_partial.partial_fit(X[:half])
+    scaler_partial.partial_fit(X[half:])
+
+    np.testing.assert_allclose(
+        scaler_partial.mean_, scaler_full.mean_, atol=1e-6
+    )
+    np.testing.assert_allclose(
+        scaler_partial.var_, scaler_full.var_, atol=1e-6
+    )
+
+
+def test_standard_scaler_fallback_sample_weight(X_float64, get_logs):
+    logger.set_level("debug")
+    X = X_float64
+    w = np.ones(len(X))
+    scaler = StandardScaler()
+    scaler.fit(X, sample_weight=w)
+    X_tr = scaler.transform(X)
+
+    assert X_tr.shape == X.shape
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+def test_standard_scaler_fallback_dataframe(X_float64, get_logs):
+    logger.set_level("debug")
+    df = pd.DataFrame(X_float64)
+
+    scaler_cpu = StandardScaler().fit(X_float64)
+    X_expected = scaler_cpu.transform(X_float64)
+
+    scaler = StandardScaler()
+    scaler.fit(df)
+    X_tr = scaler.transform(df)
+
+    assert X_tr.shape == X_float64.shape
+    np.testing.assert_allclose(X_tr, X_expected, atol=1e-10)
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+def test_standard_scaler_fallback_sparse(X_float64, get_logs):
+    logger.set_level("debug")
+    X_sparse = scipy.sparse.csr_matrix(X_float64)
+
+    scaler = StandardScaler(with_mean=False)
+    scaler.fit(X_sparse)
+    X_tr = scaler.transform(X_sparse)
+
+    assert X_tr.shape == X_float64.shape
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+def test_standard_scaler_fallback_float16(get_logs):
+    logger.set_level("debug")
+    X, _ = make_blobs(n_samples=100, n_features=4, random_state=42)
+    X = X.astype(np.float16)
+
+    scaler = StandardScaler()
+    scaler.fit(X)
+    X_tr = scaler.transform(X)
+
+    assert X_tr.shape == X.shape
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+def test_standard_scaler_fallback_set_output_pandas(X_float64, get_logs):
+    logger.set_level("debug")
+    scaler = StandardScaler().set_output(transform="pandas")
+    scaler.fit(X_float64)
+    X_tr = scaler.transform(X_float64)
+
+    assert isinstance(X_tr, pd.DataFrame)
+    logs = get_logs()
+    assert any(
+        "not optimized: non-default output container" in line for line in logs
+    )
+
+
+# ---------------------------------------------------------------------------
+# MinMaxScaler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("feature_range", [(0, 1), (-1, 1)])
+def test_min_max_scaler_fit_transform(feature_range, X_float64, get_logs):
+    logger.set_level("debug")
+    X = X_float64
+
+    scaler = MinMaxScaler(feature_range=feature_range)
+    X_tr = scaler.fit(X).transform(X)
+
+    assert X_tr.shape == X.shape
+    assert isinstance(X_tr, np.ndarray)
+    # Fitted data should reach the range boundaries
+    np.testing.assert_allclose(X_tr.min(axis=0), feature_range[0], atol=1e-6)
+    np.testing.assert_allclose(X_tr.max(axis=0), feature_range[1], atol=1e-6)
+
+    logs = get_logs()
+    assert any(
+        "MinMaxScaler.fit` input data moved to GPU" in line for line in logs
+    )
+
+
+def test_min_max_scaler_inverse_transform(X_float64):
+    X = X_float64
+    scaler = MinMaxScaler().fit(X)
+    X_tr = scaler.transform(X)
+    X_back = scaler.inverse_transform(X_tr)
+    np.testing.assert_allclose(X_back, X, atol=1e-6)
+
+
+def test_min_max_scaler_fit_transform_method(X_float64):
+    X = X_float64
+    scaler1 = MinMaxScaler()
+    X_ft = scaler1.fit_transform(X)
+
+    scaler2 = MinMaxScaler()
+    X_expected = scaler2.fit(X).transform(X)
+
+    np.testing.assert_allclose(X_ft, X_expected, atol=1e-10)
+
+
+def test_min_max_scaler_partial_fit(X_float64):
+    X = X_float64
+    half = len(X) // 2
+
+    scaler_full = MinMaxScaler().fit(X)
+
+    scaler_partial = MinMaxScaler()
+    scaler_partial.partial_fit(X[:half])
+    scaler_partial.partial_fit(X[half:])
+
+    np.testing.assert_allclose(
+        scaler_partial.data_min_, scaler_full.data_min_, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        scaler_partial.data_max_, scaler_full.data_max_, atol=1e-10
+    )
+
+
+def test_min_max_scaler_fallback_dataframe(X_float64, get_logs):
+    logger.set_level("debug")
+    df = pd.DataFrame(X_float64)
+
+    scaler_cpu = MinMaxScaler().fit(X_float64)
+    X_expected = scaler_cpu.transform(X_float64)
+
+    scaler = MinMaxScaler()
+    scaler.fit(df)
+    X_tr = scaler.transform(df)
+
+    assert X_tr.shape == X_float64.shape
+    np.testing.assert_allclose(X_tr, X_expected, atol=1e-10)
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+def test_min_max_scaler_fallback_set_output_pandas(X_float64, get_logs):
+    logger.set_level("debug")
+    scaler = MinMaxScaler().set_output(transform="pandas")
+    scaler.fit(X_float64)
+    X_tr = scaler.transform(X_float64)
+
+    assert isinstance(X_tr, pd.DataFrame)
+    logs = get_logs()
+    assert any(
+        "not optimized: non-default output container" in line for line in logs
+    )
+
+
+# ---------------------------------------------------------------------------
+# LabelEncoder
+# ---------------------------------------------------------------------------
+
+
+def test_label_encoder_fit_transform(get_logs):
+    logger.set_level("debug")
+    y = np.array([3, 1, 2, 1, 3, 2, 0, 0])
+
+    enc = LabelEncoder()
+    y_enc = enc.fit_transform(y)
+
+    assert y_enc.shape == y.shape
+    assert isinstance(y_enc, np.ndarray)
+    np.testing.assert_array_equal(enc.classes_, np.array([0, 1, 2, 3]))
+
+    logs = get_logs()
+    assert any(
+        "LabelEncoder.fit_transform` input data moved to GPU" in line
+        for line in logs
+    )
+
+
+def test_label_encoder_fit_then_transform(get_logs):
+    logger.set_level("debug")
+    y = np.array([10, 20, 30, 10, 20])
+
+    enc = LabelEncoder()
+    enc.fit(y)
+    y_enc = enc.transform(y)
+
+    assert y_enc.shape == y.shape
+    np.testing.assert_array_equal(np.sort(np.unique(y_enc)), [0, 1, 2])
+    logs = get_logs()
+    assert any(
+        "LabelEncoder.transform` input data moved to GPU" in line
+        for line in logs
+    )
+
+
+def test_label_encoder_inverse_transform():
+    y = np.array([0, 1, 2, 1, 0, 2])
+    enc = LabelEncoder().fit(y)
+    y_enc = enc.transform(y)
+    y_back = enc.inverse_transform(y_enc)
+    np.testing.assert_array_equal(y_back, y)
+
+
+def test_label_encoder_fallback_string_y(get_logs):
+    logger.set_level("debug")
+    y = np.array(["cat", "dog", "cat", "fish", "dog"])
+
+    enc = LabelEncoder()
+    y_enc = enc.fit_transform(y)
+
+    assert y_enc.shape == y.shape
+    np.testing.assert_array_equal(enc.classes_, ["cat", "dog", "fish"])
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+def test_label_encoder_fallback_string_fitted_transform(get_logs):
+    """Encoder fit on strings falls back for any transform because classes_.dtype is non-numeric."""
+    logger.set_level("debug")
+    y_strings = np.array(["a", "b", "c", "a", "b"])
+    enc = LabelEncoder().fit(y_strings)
+
+    # classes_ has string dtype — GPU path rejects the call
+    y_enc = enc.transform(y_strings)
+    assert y_enc.shape == y_strings.shape
+
+    logs = get_logs()
+    assert any("not optimized: unsupported input" in line for line in logs)
+
+
+# ---------------------------------------------------------------------------
+# TargetEncoder (ProxyBase / override path)
+# ---------------------------------------------------------------------------
+
+
+def _make_target_encoder_data():
+    """Return a float64 X (n, 2) and continuous y for TargetEncoder."""
+    rng = np.random.default_rng(0)
+    X = rng.integers(0, 5, size=(100, 2)).astype(float)
+    y = rng.standard_normal(100)
+    return X, y
+
+
+def test_target_encoder_fit_transform():
+    X, y = _make_target_encoder_data()
+
+    enc = TargetEncoder(random_state=0)
+    X_enc = enc.fit_transform(X, y)
+
+    assert X_enc.shape == X.shape
+    assert isinstance(X_enc, np.ndarray)
+    # GPU path was taken: GPU model exists, CPU has no fitted attrs yet
+    assert enc._gpu is not None
+    assert not hasattr(enc._cpu, "n_features_in_")
+
+
+def test_target_encoder_transform_after_fit():
+    X, y = _make_target_encoder_data()
+    X_new = X[:10]
+
+    enc = TargetEncoder(random_state=0).fit(X, y)
+    X_enc = enc.transform(X_new)
+
+    assert X_enc.shape == X_new.shape
+    assert isinstance(X_enc, np.ndarray)
+
+
+def test_target_encoder_fallback_multiclass_y():
+    X, y = _make_target_encoder_data()
+    y_class = (y > 0).astype(int)
+    # Make it a 3-class problem — triggers UnsupportedOnGPU
+    y_class[0] = 2
+
+    enc = TargetEncoder(random_state=0)
+    X_enc = enc.fit_transform(X, y_class)
+
+    # sklearn expands to n_features * n_classes columns for multiclass targets
+    assert X_enc.shape[0] == X.shape[0]
+    # CPU fallback
+    assert enc._gpu is None
+
+
+def test_target_encoder_fallback_random_state_object():
+    X, y = _make_target_encoder_data()
+
+    enc = TargetEncoder(random_state=np.random.RandomState(0))
+    enc.fit_transform(X, y)
+
+    # RandomState object triggers CPU fallback
+    assert enc._gpu is None
+
+
+def test_target_encoder_fallback_custom_categories():
+    X, y = _make_target_encoder_data()
+    # Provide explicit category lists — cuML doesn't support this
+    categories = [list(range(5)), list(range(5))]
+
+    enc = TargetEncoder(random_state=0, categories=categories)
+    enc.fit_transform(X, y)
+
+    assert enc._gpu is None
+
+
+def test_target_encoder_fallback_object_dtype_X():
+    X, y = _make_target_encoder_data()
+    X_obj = X.astype(object)
+
+    enc = TargetEncoder(random_state=0)
+    enc.fit_transform(X_obj, y)
+
+    assert enc._gpu is None

--- a/python/cuml/cuml_accel_tests/test_profilers.py
+++ b/python/cuml/cuml_accel_tests/test_profilers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -198,3 +198,60 @@ def test_profile_fallback_in_gpu_method():
     assert fit_stats.cpu_calls == 1
     assert fit_stats.cpu_time > 0
     assert len(fit_stats.fallback_reasons) == 1
+
+
+def test_profile_preprocessing_patch():
+    import numpy as np
+    import scipy.sparse
+    from sklearn.preprocessing import MinMaxScaler, StandardScaler
+
+    rng = np.random.default_rng(0)
+    X = rng.random((500, 10)).astype(np.float32)
+
+    # Accelerated path: dense numeric array
+    with profile(quiet=True) as results:
+        scaler = MinMaxScaler()
+        scaler.fit(X)
+        scaler.transform(X)
+
+    assert "MinMaxScaler.fit" in results.method_calls
+    assert "MinMaxScaler.transform" in results.method_calls
+
+    fit_stats = results.method_calls["MinMaxScaler.fit"]
+    assert fit_stats.gpu_calls == 1
+    assert fit_stats.gpu_time > 0
+    assert fit_stats.cpu_calls == 0
+
+    transform_stats = results.method_calls["MinMaxScaler.transform"]
+    assert transform_stats.gpu_calls == 1
+    assert transform_stats.gpu_time > 0
+    assert transform_stats.cpu_calls == 0
+
+    # CPU-fallback path: sparse input is unsupported by MinMaxScaler patch
+    X_sparse = scipy.sparse.csr_matrix(X)
+    with profile(quiet=True) as results_fallback:
+        scaler2 = MinMaxScaler()
+        try:
+            scaler2.fit(X_sparse)
+        except TypeError:
+            # sklearn itself raises TypeError for sparse input to MinMaxScaler;
+            # what matters is that the fallback was recorded before the error.
+            pass
+
+    fit_fallback = results_fallback.method_calls.get("MinMaxScaler.fit")
+    assert fit_fallback is not None
+    assert fit_fallback.cpu_calls == 1
+    assert fit_fallback.gpu_calls == 0
+    assert "unsupported input" in fit_fallback.fallback_reasons
+
+    # CPU-fallback path: sample_weight triggers StandardScaler fallback
+    y_weight = rng.random(500).astype(np.float32)
+    with profile(quiet=True) as results_weight:
+        ss = StandardScaler()
+        ss.fit(X, sample_weight=y_weight)
+
+    fit_weight = results_weight.method_calls.get("StandardScaler.fit")
+    assert fit_weight is not None
+    assert fit_weight.cpu_calls == 1
+    assert fit_weight.gpu_calls == 0
+    assert "unsupported input" in fit_weight.fallback_reasons


### PR DESCRIPTION
Adds GPU acceleration for `sklearn.preprocessing.StandardScaler`, `MinMaxScaler`, and `LabelEncoder` in `cuml.accel` by routing their `fit`, `transform`, `fit_transform`, `inverse_transform`, and `partial_fit` methods through sklearn's built-in array API dispatch path with CuPy arrays.

Rather than using `ProxyBase` (which requires a separate cuML GPU implementation), these estimators are monkey-patched in place. When the input is accelerable (numeric dtype, non-sparse, non-DataFrame), the patch converts the input to a CuPy array, temporarily promotes fitted attributes to the device, enables `array_api_dispatch=True`, and calls the original sklearn method. Fitted attributes are stored as NumPy after fit for user-visible consistency; they are promoted to CuPy only during accelerated calls.

I decided to not support dataframe-input for now since it made the patch path significantly more complex.

Modeled partially after #7843 
Closes https://github.com/rapidsai/cuml/issues/8014 https://github.com/rapidsai/cuml/issues/8015