### PR TITLE
Remove inertia_check Param from KMeans

### DIFF
--- a/cpp/bench/sg/kmeans.cu
+++ b/cpp/bench/sg/kmeans.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/bench/sg/kmeans.cu
+++ b/cpp/bench/sg/kmeans.cu
@@ -95,7 +95,6 @@ std::vector<Params> getInputs()
   p.kmeans.verbosity                       = rapids_logger::level_enum::info;
   p.kmeans.metric                          = ML::distance::DistanceType::L2Expanded;
   p.kmeans.rng_state                       = raft::random::RngState(p.blobs.seed);
-  p.kmeans.inertia_check                   = true;
   std::vector<std::pair<int, int>> rowcols = {
     {160000, 64},
     {320000, 64},

--- a/cpp/include/cuml/cluster/kmeans_params.hpp
+++ b/cpp/include/cuml/cluster/kmeans_params.hpp
@@ -32,7 +32,6 @@ struct KMeansParams {
   double oversampling_factor = 2.0;
   int batch_samples          = 1 << 15;
   int batch_centroids        = 0;
-  bool inertia_check         = false;
 
   cuvs::cluster::kmeans::params to_cuvs() const;
 };

--- a/cpp/src/kmeans/kmeans_params.cpp
+++ b/cpp/src/kmeans/kmeans_params.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/kmeans/kmeans_params.cpp
+++ b/cpp/src/kmeans/kmeans_params.cpp
@@ -25,7 +25,6 @@ cuvs::cluster::kmeans::params KMeansParams::to_cuvs() const
   params.oversampling_factor = this->oversampling_factor;
   params.batch_samples       = this->batch_samples;
   params.batch_centroids     = this->batch_centroids;
-  params.inertia_check       = this->inertia_check;
 
   return params;
 }

--- a/python/cuml/cuml/cluster/cpp/kmeans.pxd
+++ b/python/cuml/cuml/cluster/cpp/kmeans.pxd
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/python/cuml/cuml/cluster/cpp/kmeans.pxd
+++ b/python/cuml/cuml/cluster/cpp/kmeans.pxd
@@ -29,8 +29,7 @@ cdef extern from "cuml/cluster/kmeans_params.hpp" namespace "ML::kmeans" nogil:
         int n_init,
         double oversampling_factor,
         int batch_samples,
-        int batch_centroids,
-        bool inertia_check
+        int batch_centroids
 
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans" nogil:


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cuvs/pull/2015. Inertia checking is being made mandatory and https://github.com/rapidsai/cuvs/pull/2015 is a breaking change. This PR is needed to prevent compilation failures.