### PR TITLE
Add `check_cudf`, and a few other validation changes

### DIFF
--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -790,6 +790,8 @@ def check_cudf(
         raise ValueError(f"Unsupported {ensure_ndim=!r}")
     if coerce_ndim not in (True, False, "warn"):
         raise ValueError(f"Unsupported {coerce_ndim=!r}")
+    if ensure_min_features > 1 and ensure_ndim != 2:
+        raise ValueError(f"{ensure_min_features=!r} requires ensure_ndim=2")
 
     array_type = type(array)
 
@@ -885,7 +887,8 @@ _cupy_any_inf_or_nan_or_real = cp.ReductionKernel(
 def _check_classification_targets(y, ensure_discrete_classes=True):
     """Check if `y` is composed of valid class labels.
 
-    Catches NaN, infinity, and non-integral inputs.
+    Catches NaN, infinity, and non-integral inputs when
+    `ensure_discrete_classes=True`.
 
     Parameters
     ----------
@@ -967,6 +970,10 @@ def check_y(
     classes : numpy.ndarray or list[numpy.ndarray]
         The collected classes for a classifier input. Only returned if
         ``return_classes=True``.
+    index : pandas.Index, cudf.Index, or None
+        The index of the input if a dataframe-like, or None if no index. The
+        index will be converted to match ``mem_type``. Only returned if
+        ``return_index=True``.
     """
     if y is None:
         raise ValueError(

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -24,6 +24,7 @@ __all__ = (
     "check_all_finite",
     "check_non_negative",
     "check_array",
+    "check_cudf",
     "check_y",
     "check_sample_weight",
     "check_inputs",
@@ -464,6 +465,19 @@ def _ensure_int32_sparse(array):
         return array
 
 
+def _index_as_mem_type(index, mem_type=None):
+    """Coerce `index` to a specified `mem_type` (if needed)."""
+    if isinstance(index, cudf.Index) and mem_type == "host":
+        index = (
+            cudf.pandas.as_proxy_object(index)
+            if cudf.pandas.LOADED
+            else index.to_pandas()
+        )
+    elif isinstance(index, pd.Index) and mem_type == "device":
+        index = cudf.Index(index)
+    return index
+
+
 def check_array(
     array,
     *,
@@ -645,9 +659,13 @@ def check_array(
             # Handle cudf inputs
             index = array.index
             if mem_type == "host":
-                array = np.asarray(
-                    array.to_numpy(dtype=dtype), dtype=dtype, order=order
-                )
+                # XXX: cudf's to_numpy doesn't support conversions for all
+                # dtypes. Roundtrip through object dtype when necessary.
+                try:
+                    array = array.to_numpy(dtype=dtype)
+                except NotImplementedError:
+                    array = array.to_numpy(dtype="object")
+                array = np.asarray(array, dtype=dtype, order=order)
             else:
                 # XXX: the dtype keyword to `to_cupy` is buggy, and also
                 # doesn't support all dtype coercions. For now we do a
@@ -729,17 +747,120 @@ def check_array(
 
     # Process index if requested, then return
     if return_index:
-        if isinstance(index, cudf.Index) and mem_type == "host":
-            index = (
-                cudf.pandas.as_proxy_object(index)
-                if cudf.pandas.LOADED
-                else index.to_pandas()
-            )
-        elif isinstance(index, pd.Index) and mem_type == "device":
-            index = cudf.Index(index)
-        return array, index
+        return array, _index_as_mem_type(index, mem_type)
     else:
         return array
+
+
+def check_cudf(
+    array,
+    *,
+    ensure_ndim=2,
+    coerce_ndim=False,
+    ensure_min_samples=1,
+    ensure_min_features=1,
+    input_name=None,
+):
+    """Validate and coerce the input to a ``cudf.Series`` or ``cudf.DataFrame``.
+
+    Parameters
+    ----------
+    array : array-like
+        The input to validate.
+    ensure_ndim : {1, 2, None}, default=2
+        The number dimensions to enforce. Set to 1 return a ``cudf.Series``, 2
+        to ensure a cudf.DataFrame, or ``None`` to return either.
+    coerce_ndim : bool or "warn", default=False
+        Whether to allow coercing between 1d and 2d inputs. May also set to
+        "warn" to warn the user to reshape their input.
+    ensure_min_samples : int, default=1
+        A minimum number of samples to require. Set to 0 for no minimum.
+    ensure_min_features : int, default=1
+        A minimum number of features to require for 2D inputs. Set to 0 for no
+        minimum.
+    input_name : str or None, default=None
+        The input parameter name to use in error messages.
+
+    Returns
+    -------
+    array : cudf.Series or cudf.DataFrame
+        The converted and validated data.
+    """
+    if ensure_ndim not in (1, 2, None):
+        raise ValueError(f"Unsupported {ensure_ndim=!r}")
+    if coerce_ndim not in (True, False, "warn"):
+        raise ValueError(f"Unsupported {coerce_ndim=!r}")
+
+    array_type = type(array)
+
+    # Coerce input to a cudf type.
+    # XXX: cudf currently doesn't support float16, any float16 input is
+    # automatically upcast here to float32.
+    if isinstance(array, pd.Series):
+        if array.dtype == "float16":
+            array = array.astype("float32")
+        array = cudf.Series(array)
+    elif isinstance(array, pd.DataFrame):
+        f16_cols = array.select_dtypes("float16").columns.tolist()
+        if f16_cols:
+            array = array.astype({c: "float32" for c in f16_cols}, copy=False)
+        array = cudf.DataFrame(array)
+    elif not isinstance(array, (cudf.DataFrame, cudf.Series)):
+        # Remaining array-like inputs go through check_array first (without
+        # device transfer) to normalize on cupy/numpy before coercion to cudf
+        array = check_array(
+            array,
+            mem_type=None,
+            ensure_2d=False,
+            ensure_min_samples=0,
+            ensure_min_features=0,
+            ensure_all_finite=False,
+            input_name=input_name,
+        )
+        if array.dtype == "float16":
+            array = array.astype("float32")
+        array = (cudf.DataFrame if array.ndim == 2 else cudf.Series)(
+            array, dtype=(np.dtype("O") if array.dtype.kind in "U" else None)
+        )
+
+    # Validate shape and coerce dimensionality
+    _check_shape(
+        array.shape,
+        ensure_2d=(ensure_ndim == 2 and coerce_ndim is False),
+        ensure_min_samples=ensure_min_samples,
+        ensure_min_features=ensure_min_features,
+        array_type=array_type,
+    )
+    if ensure_ndim == 1:
+        # Warn/error appropriately for 2D inputs
+        if array.ndim == 2:
+            if not coerce_ndim or array.shape[1] != 1:
+                raise ValueError(
+                    f"{input_name or 'Input'} should be a 1d array, got an array "
+                    f"of shape {array.shape} instead."
+                )
+            if coerce_ndim == "warn":
+                name = input_name or "input"
+                warnings.warn(
+                    f"A column-vector {name} was passed when a 1d array was "
+                    f"expected. Please change the shape of {name} to "
+                    f"(n_samples,), for example using ravel().",
+                    DataConversionWarning,
+                )
+            array = array.iloc[:, 0]
+    elif ensure_ndim == 2 and array.ndim == 1:
+        # coerce_ndim == False is handled above in _check_shape
+        if coerce_ndim == "warn":
+            name = input_name or "input"
+            warnings.warn(
+                f"A 1d array {name} was passed when a 2d array was "
+                f"expected. Please change the shape of {name} to "
+                f"(n_samples, 1), for example using reshape(-1, 1).",
+                DataConversionWarning,
+            )
+        array = array.to_frame()
+
+    return array
 
 
 # Returns status in a bitfield:
@@ -761,7 +882,7 @@ _cupy_any_inf_or_nan_or_real = cp.ReductionKernel(
 )
 
 
-def _check_classification_targets(y):
+def _check_classification_targets(y, ensure_discrete_classes=True):
     """Check if `y` is composed of valid class labels.
 
     Catches NaN, infinity, and non-integral inputs.
@@ -770,8 +891,10 @@ def _check_classification_targets(y):
     ----------
     y : cupy.ndarray
         The ``y`` input to check.
+    ensure_discrete_classes : bool, default=True
+        Whether to ensure class labels are discrete, non-continuous values.
     """
-    if y.dtype.kind == "f":
+    if y.dtype.kind == "f" and ensure_discrete_classes:
         status = _cupy_any_inf_or_nan_or_real(y)
         if status & 0b001:
             raise ValueError("Input y contains NaN.")
@@ -795,7 +918,9 @@ def check_y(
     mem_type="device",
     order="A",
     accept_multi_output=False,
+    ensure_discrete_classes=True,
     return_classes=False,
+    return_index=False,
 ):
     """Validate and coerce ``y`` to a supported type.
 
@@ -826,8 +951,14 @@ def check_y(
         Whether multi-output y is accepted. By default only 1D inputs (or 2D
         inputs with a single column) are accepted. Set to True to accept
         multi-column inputs as well.
+    ensure_discrete_classes : bool, default=True
+        Whether to ensure class labels are discrete, non-continuous values.
     return_classes : bool, default=False
         Set to True to also label encode ``y`` and return the ``classes``.
+    return_index : bool, default=False
+        Whether to return the index of ``y`` (if a dataframe-like value).
+        This is useful for functions that need to return an output with a
+        dataframe index aligned with the input.
 
     Returns
     -------
@@ -847,6 +978,12 @@ def check_y(
         if not isinstance(dtype, (list, tuple)):
             dtype = [dtype]
         dtype = [np.dtype(i) for i in dtype]
+
+    # Extract the index from `y` (if available)
+    if isinstance(y, (pd.DataFrame, pd.Series, cudf.DataFrame, cudf.Series)):
+        index = y.index
+    else:
+        index = None
 
     # Coerce `y` to a supported array type
     if return_classes:
@@ -898,6 +1035,7 @@ def check_y(
             ensure_min_samples=0,
             input_name="y",
         )
+        mem_type = "device" if isinstance(y, cp.ndarray) else "host"
 
     # Warn/error appropriately for 2D inputs
     if y.ndim == 2:
@@ -919,18 +1057,27 @@ def check_y(
                 f"y should be a 1d array, got an array of shape {y.shape} instead."
             )
 
+    if return_index:
+        index = _index_as_mem_type(index, mem_type)
+
     if not return_classes:
-        return y
+        return (y, index) if return_index else y
 
     # For classifiers, we label encode y and return the integral labels as well
     # as the classes.
     def _encode(y):
         """Encode `y` to codes and classes"""
-        _check_classification_targets(y)
+        _check_classification_targets(y, ensure_discrete_classes)
         if isinstance(y, cudf.Series):
             y = y.astype("category")
             codes = cp.asarray(y.cat.codes)
-            classes = y.cat.categories.to_numpy()
+            classes = y.cat.categories
+            # XXX: cudf's to_numpy doesn't support conversions for all
+            # dtypes. Roundtrip through object dtype when necessary.
+            try:
+                classes = classes.to_numpy(dtype=input_dtype)
+            except NotImplementedError:
+                classes = classes.to_numpy(dtype="object")
             # cudf will sometimes translate non-numeric dtypes. Coerce back to
             # the input dtype if the input was originally a numpy array.
             if input_dtype is not None:
@@ -968,6 +1115,8 @@ def check_y(
         # convert back to host if needed
         y = y.get(order=order)
 
+    if return_index:
+        return y, classes, index
     return y, classes
 
 

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -22,6 +22,7 @@ from cuml.internals.validation import (
     check_all_finite,
     check_array,
     check_consistent_length,
+    check_cudf,
     check_features,
     check_inputs,
     check_non_negative,
@@ -1162,6 +1163,14 @@ def test_check_y_accept_multi_output(kind):
     order="F",
 )
 @example(
+    kind="cudf",
+    label_dtype="string",
+    n_classes=3,
+    mem_type="device",
+    dtype=None,
+    order=None,
+)
+@example(
     kind="list",
     label_dtype="O",
     n_classes=2,
@@ -1171,7 +1180,9 @@ def test_check_y_accept_multi_output(kind):
 )
 @given(
     kind=st.sampled_from(["cupy", "numpy", "pandas", "cudf", "list"]),
-    label_dtype=st.sampled_from(["int32", "int64", "bool", "O", "U"]),
+    label_dtype=st.sampled_from(
+        ["int32", "int64", "bool", "O", "U", "string"]
+    ),
     n_classes=st.sampled_from([2, 4, (3,), (2, 4)]),
     mem_type=st.sampled_from(["device", "host", None]),
     dtype=st.sampled_from([None, "int32", "int64", "float32"]),
@@ -1187,6 +1198,10 @@ def test_check_y_return_classes(
         labels = np.array(["a", "b", "c", "d"], dtype=label_dtype)
     elif label_dtype == "bool":
         labels = np.array([True, False])
+    elif label_dtype == "string":
+        # only pandas and cudf support this type
+        assume(kind in ("pandas", "cudf"))
+        labels = np.array(["a", "b", "c", "d"], dtype="object")
     else:
         labels = np.array([5, 10, 15, 20], dtype=label_dtype)
 
@@ -1203,8 +1218,12 @@ def test_check_y_return_classes(
         y = cp.asarray(y)
     elif kind == "pandas":
         y = pd.DataFrame(y) if inds.ndim == 2 else pd.Series(y)
+        if label_dtype == "string":
+            y = y.astype("string")
     elif kind == "cudf":
         y = cudf.DataFrame(y) if inds.ndim == 2 else cudf.Series(y)
+        if label_dtype == "string":
+            y = y.astype("string")
     elif kind == "list":
         y = y.tolist()
 
@@ -1307,12 +1326,39 @@ def test_check_y_classifier_floating_input_errors():
         check_y(has_inf, return_classes=True)
     with pytest.raises(ValueError, match="Unknown label type: continuous"):
         check_y(non_integral, return_classes=True)
+    # No issue if ensure_discrete_classes=False
+    check_y(has_nan, return_classes=True, ensure_discrete_classes=False)
+    check_y(has_inf, return_classes=True, ensure_discrete_classes=False)
+    check_y(non_integral, return_classes=True, ensure_discrete_classes=False)
 
 
 def test_check_y_classifier_on_non_str_object():
     bad = np.array([1, 2, 0], dtype=object)
     with pytest.raises(ValueError, match="Unknown label type: unknown"):
         check_y(bad, return_classes=True)
+
+
+@pytest.mark.parametrize("return_classes", [False, True])
+@pytest.mark.parametrize("mem_type", ["device", "host"])
+def test_check_y_return_index(return_classes, mem_type):
+    y = pd.Series([1, 2, 1, 3], index=[10, 20, 30, 40])
+
+    out = check_y(
+        y, return_index=True, return_classes=return_classes, mem_type=mem_type
+    )
+
+    if return_classes:
+        y, classes, index = out
+        np.testing.assert_array_equal(classes, np.array([1, 2, 3]))
+    else:
+        y, index = out
+
+    if mem_type == "host":
+        assert isinstance(index, pd.Index)
+    else:
+        assert isinstance(index, cudf.Index)
+
+    assert (cudf.Index(index) == cudf.Index([10, 20, 30, 40])).all()
 
 
 @pytest.mark.parametrize(
@@ -1580,3 +1626,116 @@ def test_check_inputs_return_index():
     )
     assert isinstance(index, cudf.Index)
     assert (index == cudf.Index([10, 20, 30])).all()
+
+
+@example(kind="numpy", dtype="U", shape=10)
+@example(kind="numpy", dtype="f2", shape=(10, 1))
+@example(kind="numpy", dtype="U", shape=(10, 2))
+@example(kind="list", dtype="i8", shape=10)
+@example(kind="cupy", dtype="i4", shape=(10, 1))
+@example(kind="cupy", dtype="f2", shape=(10, 2))
+@example(kind="cudf", dtype="f4", shape=10)
+@example(kind="cudf", dtype="i4", shape=(10, 1))
+@example(kind="cudf", dtype="i4", shape=(10, 2))
+@example(kind="pandas", dtype="O", shape=(10, 1))
+@example(kind="pandas", dtype="O", shape=(10, 2))
+@example(kind="pandas", dtype="f2", shape=10)
+@example(kind="pandas", dtype="f2", shape=(10, 2))
+@given(
+    kind=st.sampled_from(["cudf", "pandas", "numpy", "cupy", "list"]),
+    dtype=st.sampled_from(["i4", "i8", "f2", "f4", "f8", "U", "O"]),
+    shape=st.sampled_from([10, (10, 1), (10, 2)]),
+)
+@pytest.mark.parametrize("ensure_ndim", [1, 2, None])
+@pytest.mark.parametrize("coerce_ndim", [True, False, "warn"])
+def test_check_cudf(kind, ensure_ndim, coerce_ndim, dtype, shape):
+    rng = np.random.default_rng(42)
+    dtype = np.dtype(dtype)
+
+    # Construct input data
+    if dtype in ("O", "U"):
+        # cupy doesn't support these types
+        assume(kind != "cupy")
+        data = rng.choice(["a", "b", "c", "d"], size=shape).astype(dtype)
+    elif dtype.kind == "i":
+        data = rng.integers(0, 100, size=shape, dtype=dtype)
+    else:
+        # cudf doesn't support float16
+        assume(not (kind == "cudf" and dtype == "float16"))
+        data = rng.random(shape).astype(dtype)
+
+    if kind == "cupy":
+        array = cp.asarray(data)
+    elif kind == "numpy":
+        array = data
+    elif kind == "list":
+        array = data.tolist()
+    elif kind == "pandas":
+        array = pd.Series(data) if data.ndim == 1 else pd.DataFrame(data)
+    elif kind == "cudf":
+        array = cudf.Series(data) if data.ndim == 1 else cudf.DataFrame(data)
+
+    should_error = False
+    ctx = assert_no_warnings()
+    if ensure_ndim == 1 and data.ndim == 2:
+        if not coerce_ndim or data.shape[1] != 1:
+            ctx = pytest.raises(ValueError, match="y should be a 1d array")
+            should_error = True
+        elif coerce_ndim == "warn":
+            ctx = pytest.warns(
+                DataConversionWarning, match="A column-vector myarray"
+            )
+    elif ensure_ndim == 2 and data.ndim == 1:
+        if not coerce_ndim:
+            if isinstance(array, (cudf.Series, pd.Series)):
+                ctx = pytest.raises(
+                    ValueError, match="Expected a 2-dimensional container"
+                )
+            else:
+                ctx = pytest.raises(ValueError, match="Expected 2D array")
+            should_error = True
+        elif coerce_ndim == "warn":
+            ctx = pytest.warns(
+                DataConversionWarning, match="A 1d array myarray"
+            )
+
+    with ctx:
+        out = check_cudf(
+            array,
+            ensure_ndim=ensure_ndim,
+            coerce_ndim=coerce_ndim,
+            input_name="myarray",
+        )
+    if not should_error:
+        if ensure_ndim == 2:
+            assert isinstance(out, cudf.DataFrame)
+            if data.ndim != 2:
+                data = data.reshape(-1, 1)
+        elif ensure_ndim == 1:
+            assert isinstance(out, cudf.Series)
+            if data.ndim != 1:
+                data = data.ravel()
+        else:
+            assert isinstance(out, (cudf.Series, cudf.DataFrame))
+        res = out.to_numpy(dtype=data.dtype)
+        np.testing.assert_array_equal(res, data)
+
+
+def test_check_cudf_bad_args():
+    with pytest.raises(ValueError, match="Unsupported ensure_ndim='bad'"):
+        check_cudf([1, 2, 3], ensure_ndim="bad")
+
+    with pytest.raises(ValueError, match="Unsupported coerce_ndim='bad'"):
+        check_cudf([1, 2, 3], coerce_ndim="bad")
+
+
+@pytest.mark.parametrize(
+    "xdf", [pytest.param(pd, id="pandas"), pytest.param(cudf, id="cudf")]
+)
+@pytest.mark.parametrize("ensure_ndim", [1, 2, None])
+def test_check_cudf_persists_index(xdf, ensure_ndim):
+    index = xdf.Index([20, 10, 30])
+    df = xdf.DataFrame({"x": [1, 2, 3]}, index=index)
+
+    out = check_cudf(df, ensure_ndim=ensure_ndim, coerce_ndim=True)
+    assert (out.index == cudf.Index(index)).all()

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -1679,7 +1679,9 @@ def test_check_cudf(kind, ensure_ndim, coerce_ndim, dtype, shape):
     ctx = assert_no_warnings()
     if ensure_ndim == 1 and data.ndim == 2:
         if not coerce_ndim or data.shape[1] != 1:
-            ctx = pytest.raises(ValueError, match="y should be a 1d array")
+            ctx = pytest.raises(
+                ValueError, match="myarray should be a 1d array"
+            )
             should_error = True
         elif coerce_ndim == "warn":
             ctx = pytest.warns(
@@ -1727,6 +1729,11 @@ def test_check_cudf_bad_args():
 
     with pytest.raises(ValueError, match="Unsupported coerce_ndim='bad'"):
         check_cudf([1, 2, 3], coerce_ndim="bad")
+
+    with pytest.raises(
+        ValueError, match="ensure_min_features=2 requires ensure_ndim=2"
+    ):
+        check_cudf([1, 2, 3], ensure_ndim=1, ensure_min_features=2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is staging some validation functionality needed to cleanup and improve our preprocessing encoders. I've split out the validation changes into a separate PR (with tests) to ease review.

The main changes here are:

- Addition of a new `check_cudf` function. This validates and coerces user input into a `cudf` object (a `DataFrame`, `Series`, or either depending on dimensionality), following the same general validation flow as `check_array`. This is useful for estimators that make use of `cudf` functionality, or those that need to work with non-numeric types (like our encoders). The checks and knobs are pared down to just what is needed for these estimators, but all error messages and checks are compatible with what sklearn expects.
- Addition of a `return_index` option to `check_y`. In rare occasions we sometimes want to return an output that aligns with the index of `y`, and having a way to strip that off in `check_y` is useful.
- Addition of `ensure_discrete_classes` to `check_y`. Setting this to `False` disables the continuous value check used when encoding class labels.

These will be used in follow-up PRs to simplify several preprocessing estimators, as well as metrics and other label-handling code.