### PR TITLE
Cleanup `LabelEncoder`

### DIFF
--- a/python/cuml/cuml/common/classification.py
+++ b/python/cuml/cuml/common/classification.py
@@ -93,8 +93,9 @@ def decode_labels(y_encoded, classes, output_type="cupy", index=None):
         return cudf_to_pandas(out)
     elif output_type in ("numpy", "array"):
         # XXX: dtype coercion not needed for object, and when specified
-        # cudf will sometimes coerce `None -> <NA>` erroneously. Better
-        # to leave unspecified.
+        # cudf will sometimes coerce `None -> <NA>` erroneously.
+        # See https://github.com/rapidsai/cudf/issues/22419
+        # Better to leave unspecified in this case.
         return out.to_numpy(dtype=None if dtype == "object" else dtype)
     else:
         raise TypeError(

--- a/python/cuml/cuml/common/classification.py
+++ b/python/cuml/cuml/common/classification.py
@@ -92,7 +92,10 @@ def decode_labels(y_encoded, classes, output_type="cupy", index=None):
     elif output_type == "pandas":
         return cudf_to_pandas(out)
     elif output_type in ("numpy", "array"):
-        return out.to_numpy(dtype=dtype)
+        # XXX: dtype coercion not needed for object, and when specified
+        # cudf will sometimes coerce `None -> <NA>` erroneously. Better
+        # to leave unspecified.
+        return out.to_numpy(dtype=None if dtype == "object" else dtype)
     else:
         raise TypeError(
             f"{output_type=!r} doesn't support outputs of dtype "

--- a/python/cuml/cuml/dask/preprocessing/_label.py
+++ b/python/cuml/cuml/dask/preprocessing/_label.py
@@ -1,12 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-from collections.abc import Sequence
-
-from dask_cudf import DataFrame as dcDataFrame
-from dask_cudf import Series as dcSeries
 from sklearn.exceptions import NotFittedError
-from toolz import first
 
 from cuml.dask.common.base import (
     BaseEstimator,
@@ -134,12 +129,10 @@ class LabelEncoder(
         Number of unique classes will be collected at the client. It'll
         consume memory proportional to the number of unique classes.
         """
-        classes = y.unique().compute().sort_values(ignore_index=True)
-        el = first(y) if isinstance(y, Sequence) else y
-        self.datatype = (
-            "cudf" if isinstance(el, (dcDataFrame, dcSeries)) else "cupy"
-        )
-        self._set_internal_model(LE(**self.kwargs)._fit(y, classes=classes))
+        y_unique = y.unique().compute()
+        self.datatype = "cudf"
+        internal_model = LE(output_type="cudf", **self.kwargs).fit(y_unique)
+        self._set_internal_model(internal_model)
         return self
 
     def fit_transform(self, y, delayed=True):

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -801,8 +801,8 @@ def check_cudf(
     array : array-like
         The input to validate.
     ensure_ndim : {1, 2, None}, default=2
-        The number dimensions to enforce. Set to 1 return a ``cudf.Series``, 2
-        to ensure a cudf.DataFrame, or ``None`` to return either.
+        The number dimensions to enforce. Set to 1 to return a ``cudf.Series``,
+        2 to return a cudf.DataFrame, or ``None`` to return either.
     coerce_ndim : bool or "warn", default=False
         Whether to allow coercing between 1d and 2d inputs. May also set to
         "warn" to warn the user to reshape their input.

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -54,7 +54,7 @@ class LabelEncoder(Base):
     >>> le.fit_transform(y)
     array([0, 0, 1, 2], dtype=uint8)
     >>> le.classes_
-    array(['apple', 'banana', 'grape', dtype='<U6')
+    array(['apple', 'banana', 'grape'], dtype='<U6')
     """
 
     def __init__(

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -191,7 +191,7 @@ class LabelEncoder(Base):
         classes = self.classes_
         n_classes = len(self.classes_)
 
-        if codes.min() < 0 or codes.max() >= n_classes:
+        if len(codes) and (codes.min() < 0 or codes.max() >= n_classes):
             if self.handle_unknown == "error":
                 diff = cp.setdiff1d(
                     codes, cp.arange(n_classes, dtype=codes.dtype)

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -2,43 +2,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+import cupy as cp
+import numpy as np
 
-from typing import TYPE_CHECKING
-
+from cuml.common.classification import decode_labels
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.validation import check_is_fitted
-
-if TYPE_CHECKING:
-    import cudf
-    import cupy as cp
-    import numpy as np
-else:
-    import cudf
-    import cupy as cp
-    import numpy as np
-    import pandas as pd
-
-
-def _to_cudf_series(y, **kwargs):
-    if isinstance(y, (pd.DataFrame, cudf.DataFrame)):
-        if len(y.columns) != 1:
-            raise ValueError(f"`y` must be 1 dimensional, got {y.shape}")
-        y = y.iloc[:, 0]
-    elif isinstance(y, (np.ndarray, cp.ndarray)):
-        if y.ndim == 2 and y.shape[-1] == 1:
-            y = y.flatten()
-        if not y.dtype.isnative:
-            # cudf doesn't support byte-swapped arrays as inputs, coerce to native
-            y = y.astype(y.dtype.newbyteorder("="))
-    if getattr(y, "dtype", None) == "float16":
-        # Upcast float16 since cudf cannot handle them yet
-        y = y.astype("float32")
-    return cudf.Series(y, **kwargs)
+from cuml.internals.outputs import (
+    exit_internal_context,
+    reflect,
+    run_in_internal_context,
+)
+from cuml.internals.validation import check_cudf, check_is_fitted, check_y
 
 
 class LabelEncoder(Base):
-    """
-    An nvcategory based implementation of ordinal label encoding
+    """Encode target labels with values between 0 and n_classes - 1.
+
+    This transformer should be used to encode target values (`y`) and not the
+    input `X`.
 
     Parameters
     ----------
@@ -57,68 +40,21 @@ class LabelEncoder(Base):
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
 
+    Attributes
+    ----------
+    classes_ : numpy.ndarray of shape (n_classes,)
+        Holds the label for each class.
+
     Examples
     --------
-
-    Converting a categorical implementation to a numerical one
-
-    >>> from cudf import DataFrame, Series
+    >>> import numpy as np
     >>> from cuml.preprocessing import LabelEncoder
-    >>> data = DataFrame({'category': ['a', 'b', 'c', 'd']})
-
-    >>> # There are two functionally equivalent ways to do this
+    >>> y = np.array(["apple", "apple", "banana", "grape"])
     >>> le = LabelEncoder()
-    >>> le.fit(data.category)  # le = le.fit(data.category) also works
-    LabelEncoder()
-    >>> encoded = le.transform(data.category)
-
-    >>> print(encoded)
-    0    0
-    1    1
-    2    2
-    3    3
-    dtype: uint8
-
-    >>> # This method is preferred
-    >>> le = LabelEncoder()
-    >>> encoded = le.fit_transform(data.category)
-
-    >>> print(encoded)
-    0    0
-    1    1
-    2    2
-    3    3
-    dtype: uint8
-
-    >>> # We can assign this to a new column
-    >>> data = data.assign(encoded=encoded)
-    >>> print(data.head())
-    category  encoded
-    0         a        0
-    1         b        1
-    2         c        2
-    3         d        3
-
-    >>> # We can also encode more data
-    >>> test_data = Series(['c', 'a'])
-    >>> encoded = le.transform(test_data)
-    >>> print(encoded)
-    0    2
-    1    0
-    dtype: uint8
-
-    >>> # After train, ordinal label can be inverse_transform() back to
-    >>> # string labels
-    >>> ord_label = cudf.Series([0, 0, 1, 2, 1])
-    >>> str_label = le.inverse_transform(ord_label)
-    >>> print(str_label)
-    0    a
-    1    a
-    2    b
-    3    c
-    4    b
-    dtype: object
-
+    >>> le.fit_transform(y)
+    array([0, 0, 1, 2], dtype=uint8)
+    >>> le.classes_
+    array(['apple', 'banana', 'grape', dtype='<U6')
     """
 
     def __init__(
@@ -129,13 +65,18 @@ class LabelEncoder(Base):
         output_type=None,
     ) -> None:
         super().__init__(verbose=verbose, output_type=output_type)
-        self.classes_ = None
-        self.dtype = None
-        self._fitted: bool = False
         self.handle_unknown = handle_unknown
 
+    @classmethod
+    def _get_param_names(cls):
+        return ["handle_unknown", *super()._get_param_names()]
+
     def __sklearn_is_fitted__(self) -> bool:
-        return self.classes_ is not None
+        return hasattr(self, "classes_")
+
+    @staticmethod
+    def _more_static_tags():
+        return {"X_types": ["1dlabels"]}
 
     def _validate_keywords(self):
         if self.handle_unknown not in ("error", "ignore"):
@@ -145,53 +86,61 @@ class LabelEncoder(Base):
             )
             raise ValueError(msg)
 
-    def _fit(self, y, classes=None):
+    @reflect(reset="type")
+    @generate_docstring(
+        y="dense_anydtype",
+        y_shape="n_samples",
+        return_values={
+            "name": "y",
+            "type": "dense",
+            "shape": "n_samples",
+            "description": "Encoded labels.",
+        },
+    )
+    def fit_transform(self, y):
         """
-        Fit a LabelEncoder instance to a set of categories.
+        Simultaneously fit and transform an input.
 
-        Parameters
-        ----------
-        y : cudf.Series, pandas.Series, cupy.ndarray or numpy.ndarray
-            The target values to encode.
-
-        classes: cudf.Series or None
-            The unique classes. If not provided, will be computed.
-
-        Returns
-        -------
-        self : LabelEncoder
+        This is functionally equivalent to (but faster than)
+        ``LabelEncoder().fit(y).transform(y)``.
         """
         self._validate_keywords()
 
-        if classes is None:
-            # dedupe and sort
-            y = (
-                _to_cudf_series(y)
-                .drop_duplicates()
-                .sort_values(ignore_index=True)
-            )
-            self.classes_ = y
-        else:
-            self.classes_ = classes
+        y, classes, index = check_y(
+            y,
+            ensure_discrete_classes=False,
+            return_classes=True,
+            return_index=True,
+        )
+        self.classes_ = classes
+        return CumlArray(data=y, index=index)
 
-        self.dtype = y.dtype if y.dtype != cp.dtype("O") else str
+    @reflect(reset="type")
+    @generate_docstring(
+        y="dense_anydtype",
+        y_shape="n_samples",
+        return_values={
+            "name": "self",
+            "type": "LabelEncoder",
+            "description": "Fitted label encoder.",
+        },
+    )
+    def fit(self, y):
+        """Fit a LabelEncoder instance to a set of categories."""
+        self.fit_transform(y)
         return self
 
-    def fit(self, y):
-        """
-        Fit a LabelEncoder instance to a set of categories.
-
-        Parameters
-        ----------
-        y : cudf.Series, pandas.Series, cupy.ndarray or numpy.ndarray
-            The target values to encode.
-
-        Returns
-        -------
-        self : LabelEncoder
-        """
-        return self._fit(y)
-
+    @reflect
+    @generate_docstring(
+        y="dense_anydtype",
+        y_shape="n_samples",
+        return_values={
+            "name": "y",
+            "type": "dense",
+            "shape": "n_samples",
+            "description": "Encoded labels.",
+        },
+    )
     def transform(self, y):
         """
         Transform an input into its categorical keys.
@@ -199,91 +148,66 @@ class LabelEncoder(Base):
         This is intended for use with small inputs relative to the size of the
         dataset. For fitting and transforming an entire dataset, prefer
         `fit_transform`.
-
-        Parameters
-        ----------
-        y : cudf.Series, pandas.Series, cupy.ndarray or numpy.ndarray
-            Input keys to be transformed. Its values should match the
-            categories given to `fit`
-
-        Returns
-        -------
-        encoded : cudf.Series
-            The ordinally encoded input series
-
-        Raises
-        ------
-        KeyError
-            if a category appears that was not seen in `fit`
         """
         check_is_fitted(self)
 
-        y = _to_cudf_series(y, dtype="category")
-
+        y = check_cudf(
+            y,
+            ensure_ndim=1,
+            coerce_ndim="warn",
+            ensure_min_samples=0,
+            input_name="y",
+        )
+        y = y.astype("category")
         encoded = y.cat.set_categories(self.classes_).cat.codes
 
-        if encoded.hasnans and self.handle_unknown == "error":
-            raise KeyError("Attempted to encode unseen key")
+        if (
+            encoded.hasnans or encoded.has_nulls
+        ) and self.handle_unknown == "error":
+            y = y.unique()
+            diff = y[~y.isin(self.classes_)].to_numpy(dtype=object)
+            raise ValueError(f"y contains previously unseen labels: {diff!s}")
 
-        return encoded
+        return CumlArray(data=encoded.to_cupy(), index=y.index)
 
-    def fit_transform(self, y):
-        """
-        Simultaneously fit and transform an input
-
-        This is functionally equivalent to (but faster than)
-        `LabelEncoder().fit(y).transform(y)`
-        """
-
-        y = _to_cudf_series(y)
-        self.dtype = y.dtype if y.dtype != cp.dtype("O") else str
-
-        y = y.astype("category")
-        self.classes_ = y.cat.categories
-
-        return y.cat.codes
-
-    def inverse_transform(self, y: "cudf.Series"):
-        """
-        Revert ordinal label to original label
-
-        Parameters
-        ----------
-        y : cudf.Series, pandas.Series, cupy.ndarray or numpy.ndarray
-            dtype=int32
-            Ordinal labels to be reverted
-
-        Returns
-        -------
-        reverted : the same type as y
-            Reverted labels
-        """
-        # check LabelEncoder is fitted
+    @run_in_internal_context
+    @generate_docstring(
+        y="dense_anydtype",
+        y_shape="n_samples",
+        return_values={
+            "name": "y_original",
+            "type": "dense",
+            "shape": "n_samples",
+            "description": "Original encoding.",
+        },
+    )
+    def inverse_transform(self, y):
+        """Transform labels back to original encoding."""
         check_is_fitted(self)
 
-        y = _to_cudf_series(y)
+        codes, index = check_y(
+            y, dtype=("i2", "i4", "i8", "u2", "u4", "u8"), return_index=True
+        )
+        classes = self.classes_
+        n_classes = len(self.classes_)
 
-        # check if ord_label out of bound
-        ord_label = y.unique()
-        category_num = len(self.classes_)
-        if self.handle_unknown == "error":
-            if not isinstance(ord_label, (cp.ndarray, np.ndarray)):
-                ord_label = ord_label.to_numpy()
-            for ordi in ord_label:
-                if ordi < 0 or ordi >= category_num:
-                    raise ValueError(
-                        "y contains previously unseen label {}".format(ordi)
-                    )
+        if codes.min() < 0 or codes.max() >= n_classes:
+            if self.handle_unknown == "error":
+                diff = cp.setdiff1d(
+                    codes, cp.arange(n_classes, dtype=codes.dtype)
+                )
+                raise ValueError(
+                    f"y contains previously unseen labels: {diff!s}"
+                )
+            else:
+                codes = cp.where(
+                    (codes < 0) | (codes >= n_classes),
+                    -1,
+                    codes,
+                )
+                classes = np.concat([classes, [None]])
 
-        y = y.astype(self.dtype)
+        with exit_internal_context():
+            output_type = self._get_output_type(y)
 
-        ran_idx = cudf.Index(cp.arange(len(self.classes_))).astype(self.dtype)
-        res = y.replace(ran_idx, self.classes_)
-
-        return res
-
-    @classmethod
-    def _get_param_names(cls):
-        return super()._get_param_names() + [
-            "handle_unknown",
-        ]
+        return decode_labels(codes, classes, output_type=output_type)

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -210,4 +210,6 @@ class LabelEncoder(Base):
         with exit_internal_context():
             output_type = self._get_output_type(y)
 
-        return decode_labels(codes, classes, output_type=output_type)
+        return decode_labels(
+            codes, classes, output_type=output_type, index=index
+        )

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -205,7 +205,7 @@ class LabelEncoder(Base):
                     -1,
                     codes,
                 )
-                classes = np.concat([classes, [None]])
+                classes = np.concatenate([classes, [None]])
 
         with exit_internal_context():
             output_type = self._get_output_type(y)

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -164,7 +164,7 @@ class LabelEncoder(Base):
         if (
             encoded.hasnans or encoded.has_nulls
         ) and self.handle_unknown == "error":
-            y = y.unique()
+            y = y.cat.categories
             diff = y[~y.isin(self.classes_)].to_numpy(dtype=object)
             raise ValueError(f"y contains previously unseen labels: {diff!s}")
 

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -10,9 +10,11 @@ import cupyx
 import numpy as np
 from cudf import Index
 
+import cuml
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.base import Base
 from cuml.internals.output_utils import cudf_to_pandas
+from cuml.internals.outputs import run_in_internal_context
 from cuml.internals.validation import check_features, check_is_fitted
 from cuml.preprocessing._label import LabelEncoder
 
@@ -325,6 +327,7 @@ class OneHotEncoder(BaseEncoder):
             "type": "sparse matrix if sparse_output=True else a 2-d array",
         }
     )
+    @run_in_internal_context
     def transform(self, X):
         """Transform X using one-hot encoding."""
         check_is_fitted(self)
@@ -339,7 +342,7 @@ class OneHotEncoder(BaseEncoder):
         try:
             for feature in X.columns:
                 encoder = self._encoders[feature]
-                col_idx = encoder.transform(X[feature])
+                col_idx = encoder.transform(X[feature]).to_output("cudf")
                 idx_to_keep = col_idx.notnull().to_cupy()
                 col_idx = col_idx.dropna().to_cupy()
 
@@ -401,6 +404,7 @@ class OneHotEncoder(BaseEncoder):
                 "Internal Error: {}".format(input_types_str, repr(e))
             )
 
+    @run_in_internal_context
     def inverse_transform(self, X):
         """Convert the data back to the original representation. In case unknown
         categories are encountered (all zeros in the one-hot encoding), ``None`` is used
@@ -457,9 +461,10 @@ class OneHotEncoder(BaseEncoder):
                 # the nulls in each column are the dropped value
                 dropped_mask = cp.asarray(x_feature.sum(axis=1) == 0).flatten()
                 if dropped_mask.any():
-                    inv[dropped_mask] = feature_enc.inverse_transform(
-                        cudf.Series(self.drop_idx_[feature])
-                    )[0]
+                    with cuml.using_output_type("cudf"):
+                        inv[dropped_mask] = feature_enc.inverse_transform(
+                            cudf.Series(self.drop_idx_[feature])
+                        )[0]
 
             result[feature] = inv
             j += enc_size
@@ -617,6 +622,7 @@ class OrdinalEncoder(BaseEncoder):
             "type": "Type is specified by the `output_type` parameter.",
         }
     )
+    @run_in_internal_context
     def transform(self, X):
         """Transform X using ordinal encoding."""
         check_is_fitted(self)
@@ -625,7 +631,7 @@ class OrdinalEncoder(BaseEncoder):
         result = {}
         for feature in self._features:
             Xi = _slice_feat(X, feature)
-            col_idx = self._encoders[feature].transform(Xi)
+            col_idx = self._encoders[feature].transform(Xi).to_output("cudf")
             result[feature] = col_idx
 
         r = cudf.DataFrame(result)
@@ -644,6 +650,7 @@ class OrdinalEncoder(BaseEncoder):
         X = self._check_input(X)
         return self.fit(X).transform(X)
 
+    @run_in_internal_context
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
 
@@ -662,7 +669,8 @@ class OrdinalEncoder(BaseEncoder):
         result = {}
         for feature in self._features:
             Xi = _slice_feat(X, feature)
-            inv = self._encoders[feature].inverse_transform(Xi)
+            with cuml.using_output_type("cudf"):
+                inv = self._encoders[feature].inverse_transform(Xi)
             result[feature] = inv
 
         r = cudf.DataFrame(result)

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -10,7 +10,6 @@ import cupyx
 import numpy as np
 from cudf import Index
 
-import cuml.internals.logger as logger
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.base import Base
 from cuml.internals.output_utils import cudf_to_pandas
@@ -69,7 +68,7 @@ class BaseEncoder(Base):
             self._encoders = {
                 feature: LabelEncoder(
                     verbose=self.verbose,
-                    output_type=self.output_type,
+                    output_type="cudf",
                     handle_unknown=self.handle_unknown,
                 ).fit(self._unique(X[feature]))
                 for feature in self._features
@@ -86,7 +85,7 @@ class BaseEncoder(Base):
             for feature in self._features:
                 le = LabelEncoder(
                     verbose=self.verbose,
-                    output_type=self.output_type,
+                    output_type="cudf",
                     handle_unknown=self.handle_unknown,
                 )
 
@@ -94,7 +93,8 @@ class BaseEncoder(Base):
 
                 if self.handle_unknown == "error":
                     if self._has_unknown(
-                        X[feature], self._encoders[feature].classes_
+                        X[feature],
+                        cudf.Series(self._encoders[feature].classes_),
                     ):
                         msg = (
                             "Found unknown categories in column {0}"
@@ -348,16 +348,8 @@ class OneHotEncoder(BaseEncoder):
                 # monotonically increasing up to len(encoder.classes_)
                 # Ensure we dont go negative by clamping to 0
                 max_value = int(max(len(encoder.classes_) - 1, 0) + j)
-
-                # If we exceed the max value, upconvert
-                if max_value > np.iinfo(col_idx.dtype).max:
-                    col_idx = col_idx.astype(np.min_scalar_type(max_value))
-                    logger.debug(
-                        "Upconverting column: '{}', to dtype: '{}', "
-                        "to support up to {} classes".format(
-                            feature, np.min_scalar_type(max_value), max_value
-                        )
-                    )
+                min_dtype = np.min_scalar_type(max_value)
+                col_idx = col_idx.astype(min_dtype, copy=False)
 
                 # increase indices to take previous features into account
                 col_idx += j
@@ -439,14 +431,12 @@ class OneHotEncoder(BaseEncoder):
         j = 0
         for feature in self._encoders.keys():
             feature_enc = self._encoders[feature]
-            cats = feature_enc.classes_
+            cats = cudf.Series(feature_enc.classes_)
 
             if self.drop is not None:
                 # Remove dropped categories
                 dropped_class_idx = cudf.Series(self.drop_idx_[feature])
-                dropped_class_mask = cudf.Series(cats).isin(
-                    cats[dropped_class_idx]
-                )
+                dropped_class_mask = cats.isin(cats[dropped_class_idx])
                 if len(cats) == 1:
                     inv = cudf.Series(Index([cats[0]]).repeat(X.shape[0]))
                     result[feature] = inv
@@ -515,9 +505,7 @@ class OneHotEncoder(BaseEncoder):
 
         feature_names = []
         for i in range(len(cats)):
-            names = [
-                input_features[i] + "_" + str(t) for t in cats[i].to_numpy()
-            ]
+            names = [input_features[i] + "_" + str(t) for t in cats[i]]
             if self.drop_idx_ is not None and self.drop_idx_[i] is not None:
                 names.pop(self.drop_idx_[i])
             feature_names.extend(names)

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -342,7 +342,8 @@ class OneHotEncoder(BaseEncoder):
         try:
             for feature in X.columns:
                 encoder = self._encoders[feature]
-                col_idx = encoder.transform(X[feature]).to_output("cudf")
+                with cuml.using_output_type("cudf"):
+                    col_idx = encoder.transform(X[feature])
                 idx_to_keep = col_idx.notnull().to_cupy()
                 col_idx = col_idx.dropna().to_cupy()
 
@@ -631,7 +632,8 @@ class OrdinalEncoder(BaseEncoder):
         result = {}
         for feature in self._features:
             Xi = _slice_feat(X, feature)
-            col_idx = self._encoders[feature].transform(Xi).to_output("cudf")
+            with cuml.using_output_type("cudf"):
+                col_idx = self._encoders[feature].transform(Xi)
             result[feature] = col_idx
 
         r = cudf.DataFrame(result)

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -857,22 +857,6 @@
   condition: scikit-learn<1.7
   tests:
   - "sklearn.cluster.tests.test_spectral::test_precomputed_nearest_neighbors_filtering"
-- reason: cuml.accel deviates in repeated predict output for KMeans
-  marker: cuml_accel_kmeans_repeated_predict_output_deviation
-  condition: scikit-learn<1.6
-  tests:
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[float64-42-100-KMeans-elkan-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[float64-42-100-KMeans-lloyd-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[float64-42-2-KMeans-elkan-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[float64-42-2-KMeans-lloyd-dense]"
-- reason: cuml.accel deviates in repeated predict output for KMeans scikit-learn 1.6
-  marker: cuml_accel_kmeans_repeated_predict_output_deviation
-  condition: scikit-learn>=1.6
-  tests:
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[42-float64-100-KMeans-elkan-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[42-float64-100-KMeans-lloyd-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[42-float64-2-KMeans-elkan-dense]"
-  - "sklearn.cluster.tests.test_k_means::test_kmeans_predict[42-float64-2-KMeans-lloyd-dense]"
 - reason: cuml.accel deviates in log output for KMeans
   marker: cuml_accel_kmeans_verbose_logging_message_deviation
   tests:
@@ -1022,10 +1006,11 @@
   condition: scikit-learn>=1.8
   tests:
   - "sklearn.linear_model.tests.test_logistic::test_scores_attribute_layout_elasticnet"
-- reason: Flaky deviations in n_iter_ values in cuml.accel
+- reason: Flaky deviations in values in cuml.accel
   strict: false
   tests:
   - "sklearn.cluster.tests.test_k_means::test_kmeans_elkan_results[42-1e-100-dense-blobs]"
+  - "sklearn.cluster.tests.test_k_means::test_kmeans_elkan_results[42-1e-100-dense-normal]"
 - reason: Linear SVM sample weight handling differs with cuml.accel in sklearn 1.8
   condition: scikit-learn>=1.8
   tests:

--- a/python/cuml/tests/dask/test_dask_label_encoder.py
+++ b/python/cuml/tests/dask/test_dask_label_encoder.py
@@ -59,7 +59,9 @@ def test_labelencoder_unseen(client):
     le = LabelEncoder().fit(df)
     check_is_fitted(le)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        ValueError, match="y contains previously unseen labels"
+    ):
         tmp = dask_cudf.from_cudf(
             cudf.Series([-100, -120]), npartitions=len(client.has_what())
         )

--- a/python/cuml/tests/dask/test_dask_one_hot_encoder.py
+++ b/python/cuml/tests/dask/test_dask_one_hot_encoder.py
@@ -87,7 +87,9 @@ def test_onehot_transform_handle_unknown(client):
 
     enc = OneHotEncoder(handle_unknown="error", sparse_output=False)
     enc = enc.fit(X)
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        ValueError, match="y contains previously unseen labels"
+    ):
         enc.transform(Y).compute()
 
     enc = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
@@ -215,4 +217,4 @@ def test_onehot_get_categories(client):
     cats = enc.categories_
 
     for i in range(len(ref)):
-        np.testing.assert_array_equal(ref[i], cats[i].to_pandas().to_numpy())
+        np.testing.assert_array_equal(ref[i], cats[i])

--- a/python/cuml/tests/dask/test_dask_ordinal_encoder.py
+++ b/python/cuml/tests/dask/test_dask_ordinal_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -95,7 +95,9 @@ def test_handle_unknown(client, as_array: bool) -> None:
 
     enc = OrdinalEncoder(handle_unknown="error")
     enc = enc.fit(X)
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        ValueError, match="y contains previously unseen labels"
+    ):
         enc.transform(Y).compute()
 
     enc = OrdinalEncoder(handle_unknown="ignore")

--- a/python/cuml/tests/test_label_encoder.py
+++ b/python/cuml/tests/test_label_encoder.py
@@ -134,24 +134,29 @@ def test_unfitted_inverse_transform():
         le.transform(df)
 
 
-@pytest.mark.parametrize(
-    "empty, ord_label", [(cudf.Series([]), cudf.Series([2, 1]))]
-)
-def test_empty_input(empty, ord_label):
-    # prepare LabelEncoder
+def test_empty_input():
+    X = cudf.Series([], dtype="object")
+
+    # fit works on empty data
     le = LabelEncoder()
-    le.fit(empty)
+    le.fit(X)
     check_is_fitted(le)
 
-    # test if correctly raies ValueError
-    with pytest.raises(ValueError, match="y contains previously unseen label"):
-        le.inverse_transform(ord_label)
-
-    # check fit_transform()
+    # fit_transform works on empty data
     le = LabelEncoder()
-    transformed = le.fit_transform(empty)
+    transformed = le.fit_transform(X)
     check_is_fitted(le)
     assert len(transformed) == 0
+
+    # inverse_transform raises on unseen labels
+    encoded = cudf.Series([2, 1])
+    with pytest.raises(ValueError, match="y contains previously unseen label"):
+        le.inverse_transform(encoded)
+
+    # inverse_transform works on empty data
+    out = le.inverse_transform(pd.Series([], dtype="int32"))
+    assert len(out) == 0
+    assert out.dtype == X.dtype
 
 
 def test_masked_encode():

--- a/python/cuml/tests/test_label_encoder.py
+++ b/python/cuml/tests/test_label_encoder.py
@@ -60,7 +60,7 @@ def test_labelencoder_unseen():
     le = LabelEncoder().fit(df)
     check_is_fitted(le)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         le.transform(cudf.Series([-1]))
 
 
@@ -108,7 +108,7 @@ def test_inverse_transform(
     orig_label, ord_label, expected_reverted, bad_ord_label, use_fit_transform
 ):
     # prepare LabelEncoder
-    le = LabelEncoder()
+    le = LabelEncoder(output_type="cudf")
     if use_fit_transform:
         le.fit_transform(orig_label)
     else:
@@ -212,12 +212,14 @@ def test_labelencoder_fit_transform_input_types(length, cardinality, kind):
         if kind == "cudf.DataFrame":
             x = x.to_frame()
 
-    encoder = LabelEncoder()
+    encoder = LabelEncoder(output_type="cudf")
     res = encoder.fit_transform(x)
     sol = cudf.Series(raw).astype("category")
 
-    cudf.testing.assert_series_equal(res, sol.cat.codes)
-    cudf.testing.assert_index_equal(encoder.classes_, sol.cat.categories)
+    cudf.testing.assert_series_equal(res, sol.cat.codes, check_dtype=False)
+    np.testing.assert_array_equal(
+        encoder.classes_, sol.cat.categories.to_numpy()
+    )
 
 
 @pytest.mark.parametrize("kind", ["cupy", "numpy", "pandas"])
@@ -230,12 +232,32 @@ def test_labelencoder_fit_transform_byteswapped(kind):
     elif kind == "pandas":
         x = pd.Series(x)
 
-    encoder = LabelEncoder()
+    encoder = LabelEncoder(output_type="cudf")
     res = encoder.fit_transform(x)
     sol = cudf.Series(native).astype("category")
 
-    cudf.testing.assert_series_equal(res, sol.cat.codes)
-    cudf.testing.assert_index_equal(encoder.classes_, sol.cat.categories)
+    cudf.testing.assert_series_equal(res, sol.cat.codes, check_dtype=False)
+    np.testing.assert_array_equal(
+        encoder.classes_, sol.cat.categories.to_numpy()
+    )
+
+
+@pytest.mark.parametrize("kind", ["pandas", "cudf"])
+@pytest.mark.parametrize("fit_transform", [True, False])
+def test_labelencoder_string_dtype(kind, fit_transform):
+    xdf = pd if kind == "pandas" else cudf
+    x = xdf.Series(["a", "b", "a", "a"], dtype="string")
+    enc = LabelEncoder()
+    if fit_transform:
+        res = enc.fit_transform(x)
+    else:
+        res = enc.fit(x).transform(x)
+    sol = xdf.Series([0, 1, 0, 0])
+
+    xdf.testing.assert_series_equal(res, sol, check_dtype=False)
+    np.testing.assert_array_equal(
+        enc.classes_, np.array(["a", "b"], dtype="object")
+    )
 
 
 @pytest.mark.parametrize("use_fit_transform", [False, True])
@@ -251,7 +273,7 @@ def test_labelencoder_fit_transform_byteswapped(kind):
         (
             np.array([1.09, 0.09, 0.09, 0.09]),
             np.array([1, 1, 0, 0, 1]),
-            cp.array([1.09, 1.09, 0.09, 0.09, 1.09]),
+            np.array([1.09, 1.09, 0.09, 0.09, 1.09]),
             np.array([0, 1, 1, 1, 2]),
         ),
     ],

--- a/python/cuml/tests/test_label_encoder.py
+++ b/python/cuml/tests/test_label_encoder.py
@@ -80,8 +80,8 @@ def test_labelencoder_unfitted():
     [
         (
             cudf.Series(["a", "b", "c"]),
-            cudf.Series([2, 1, 2, 0]),
-            cudf.Series(["c", "b", "c", "a"]),
+            cudf.Series([2, 1, 2, 0], index=[5, 10, 15, 20]),
+            cudf.Series(["c", "b", "c", "a"], index=[5, 10, 15, 20]),
             cudf.Series([-1, 1, 2, 0]),
         ),
         (

--- a/python/cuml/tests/test_one_hot_encoder.py
+++ b/python/cuml/tests/test_one_hot_encoder.py
@@ -114,7 +114,9 @@ def test_onehot_transform_handle_unknown(as_array):
 
     enc = OneHotEncoder(handle_unknown="error", sparse_output=False)
     enc = enc.fit(X)
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        ValueError, match="y contains previously unseen labels"
+    ):
         enc.transform(Y)
 
     enc = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
@@ -255,7 +257,7 @@ def test_onehot_get_categories(as_array):
     cats = enc.categories_
 
     for i in range(len(ref)):
-        np.testing.assert_array_equal(ref[i], cats[i].to_numpy())
+        np.testing.assert_array_equal(ref[i], cats[i])
 
 
 @pytest.mark.parametrize("as_array", [True, False], ids=["cupy", "cudf"])

--- a/python/cuml/tests/test_ordinal_encoder.py
+++ b/python/cuml/tests/test_ordinal_encoder.py
@@ -108,7 +108,9 @@ def test_handle_unknown(as_array: bool) -> None:
 
     enc = OrdinalEncoder(handle_unknown="error")
     enc = enc.fit(X)
-    with pytest.raises(KeyError):
+    with pytest.raises(
+        ValueError, match="y contains previously unseen labels"
+    ):
         enc.transform(Y)
 
     enc = OrdinalEncoder(handle_unknown="ignore")


### PR DESCRIPTION
This cleans up our `LabelEncoder` implementation, preparing for exposing it through `cuml.accel`. This one needed a lot of work, and there are _several breaking changes_.

- The type of `LabelEncoder.classes_` is now a `numpy.ndarray` instead of a `cudf.Series`. Note that `classes_` was undocumented. This mirrors the `classes_` attribute in all our other classifiers (all of which also made this as a breaking change many releases ago). I view this in the same vein.
- Likewise, since `OneHotEncoder` and `OrdinalEncoder` make use of `LabelEncoder` internally, the type of `categories_` has changed there from `list[cudf.Series]` to `list[numpy.ndarray]`. This now better matches with sklearn, and makes sense IMO in the same way that changing `classes_` above did.
- `LabelEncoder` now follows our type-reflection standards, previously it always returned `cudf` objects (even though the docstrings implied type-reflection was followed). I view this as a bugfix.
- `LabelEncoder.inverse_transform` now handles `handle_unknown="ignore"` _as documented_. Previously this would return incorrect values in the presence of missing values. Note that `handle_unknown` is _not_ an argument to `sklearn.preprocessing.LabelEncoder`. I view this as a bugfix.

This required munging in our tests and the implementations of `OrdinalEncoder`/`OneHotEncoder` (and their dask counterparts), but beyond the changes listed above should have no other user-facing ramifications.

Stacked on top of #8038.
Part of #7317.
Precursor for #8015.