### PR TITLE
Drop `__firstlineno__` on `ProxyBase` instances

### DIFF
--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -243,6 +243,19 @@ class ProxyBase(BaseEstimator, metaclass=ProxyBaseMeta):
         # be pickled properly.
         cls.__module__ = cls._gpu_class._cpu_class_path.rsplit(".", 1)[0]
 
+        # Drop `__firstlineno__`, since we can't give a good option for that.
+        # We don't want to expose the original value, since we've changed the
+        # defining `__module__`. And we don't want to use our `__firstlineno__`
+        # since it would map to the definitions in the overrides (which don't
+        # have the same `__module__` either). We use a `try-except` here since
+        # the __firstlineno__ may be stored in `cls.__dict__` (the one we want
+        # to drop) or `type(cls).__dict__` (which will error), depending on
+        # cPython version.
+        try:
+            del cls.__firstlineno__
+        except AttributeError:
+            pass
+
         # Forward _estimator_type as a class attribute if available
         _estimator_type = getattr(cls._cpu_class, "_estimator_type", None)
         if isinstance(_estimator_type, str):


### PR DESCRIPTION
We don't want to define `__firstlineno__` on instances of `ProxyBase`.

- We don't want to proxy through the original `__firstlineno__`, since we've updated `__module__`, so the line numbers would no longer be accurate.
- We don't want to use our `__firstlineno__` for the same reason - they map to a different file than `__module__`.

Dropping this attribute causes tools like `inspect.getsourcelines` to error appropriately, saying the source code cannot be found. Note that any _methods_ inspected on our proxy classes will still report the original sklearn code (as intended), it's just grabbing the whole class that won't work.

The main place this shows up is some docstring tests in the sklearn repo - previously these were implicitly skipped because `getsourcelines` would error. The recent metaclass changes led to this not erroring in _all_ python versions, leading to failures in our nightlies.

This PR fixes things so that we drop `__firstlineno__` uniformly, leading to the tests to pass/skip in all python versions, reverting to the previous behavior.