### PR TITLE
Apply new validation to metrics.pairwise_kernels

### DIFF
--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 import inspect
@@ -9,7 +9,7 @@ import numpy as np
 from numba import cuda
 
 import cuml.internals
-from cuml.internals.input_utils import input_to_cupy_array
+from cuml.internals.validation import check_array
 from cuml.metrics import pairwise_distances
 
 
@@ -275,11 +275,11 @@ def pairwise_kernels(
             [5.04347663e-07, 2.03468369e-04],
             [4.24835426e-18, 2.54366565e-13]])
     """
-    X = input_to_cupy_array(X).array
+    X = check_array(X, input_name="X")
     if Y is None:
         Y = X
     else:
-        Y = input_to_cupy_array(Y).array
+        Y = check_array(Y, input_name="Y")
     if X.shape[1] != Y.shape[1]:
         raise ValueError("X and Y have different dimensions.")
 


### PR DESCRIPTION
Apply new input validation to `cuml.metrics.pairwise_kernels`.

Part of #7998
