### PR TITLE
Ensure output of classifier `predict` has aligned index

### DIFF
--- a/python/cuml/cuml/common/classification.py
+++ b/python/cuml/cuml/common/classification.py
@@ -8,7 +8,7 @@ from cuml.internals.array import CumlArray
 from cuml.internals.output_utils import cudf_to_pandas
 
 
-def decode_labels(y_encoded, classes, output_type="cupy"):
+def decode_labels(y_encoded, classes, output_type="cupy", index=None):
     """Convert encoded labels back into their original classes.
 
     Parameters
@@ -19,6 +19,9 @@ def decode_labels(y_encoded, classes, output_type="cupy"):
         The array of classes, or a list of arrays if multi-target.
     output_type : str, optional
         The type to output. May be any of the output types cuml supports.
+    index : cudf.Index or None, optional
+        An optional index to attach to the output when returning a pandas or
+        cudf output.
 
     Returns
     -------
@@ -43,7 +46,7 @@ def decode_labels(y_encoded, classes, output_type="cupy"):
                 for i, c in enumerate(classes):
                     labels[:, i] = cp.asarray(c).take(y_encoded[:, i])
 
-            out = CumlArray(labels)
+            out = CumlArray(labels, index=index)
         else:
             # At least one class is non-numeric, we need to use cudf
             out = cudf.DataFrame(
@@ -52,7 +55,8 @@ def decode_labels(y_encoded, classes, output_type="cupy"):
                     .take(y_encoded[:, i])
                     .reset_index(drop=True)
                     for i, c in enumerate(classes)
-                }
+                },
+                index=index,
             )
     else:
         # Single-target output
@@ -66,12 +70,14 @@ def decode_labels(y_encoded, classes, output_type="cupy"):
                 # Need to transform y_encoded back to classes
                 labels = cp.asarray(classes).take(y_encoded)
 
-            out = CumlArray(labels)
+            out = CumlArray(labels, index=index)
         else:
             # Non-numeric classes. We use cudf since it supports all types, and will
             # error appropriately later on when converting to outputs like `cupy`
             # that don't support strings.
             out = cudf.Series(classes).take(y_encoded).reset_index(drop=True)
+            if index is not None:
+                out.index = index
 
     # Coerce result to requested output_type
     if isinstance(out, CumlArray):

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -287,10 +287,14 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             align_bytes=align_bytes,
         )
         check_features(self, X)
-        inds = fil.predict(X, threshold=threshold).to_output("cupy")
+        inds = fil.predict(X, threshold=threshold)
+        index = inds.index
+        inds = inds.to_output("cupy")
         with cuml.internals.exit_internal_context():
             output_type = self._get_output_type(X)
-        return decode_labels(inds, self.classes_, output_type=output_type)
+        return decode_labels(
+            inds, self.classes_, output_type=output_type, index=index
+        )
 
     @insert_into_docstring(
         parameters=[("dense", "(n_samples, n_features)")],

--- a/python/cuml/cuml/fil/fil.pyx
+++ b/python/cuml/cuml/fil/fil.pyx
@@ -1115,7 +1115,7 @@ class ForestInference(Base, CMajorInputTagMixin):
                     proba.to_output(output_type='array'), axis=1
                 )
             if preds is None:
-                return result
+                return CumlArray(data=result, index=proba.index)
             else:
                 preds[:] = result
                 return preds

--- a/python/cuml/cuml/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/linear_model/logistic_regression.py
@@ -346,9 +346,9 @@ class LogisticRegression(
         Predicts the y for X.
 
         """
-        scores = self.decision_function(
-            X, convert_dtype=convert_dtype
-        ).to_output("cupy")
+        scores = self.decision_function(X, convert_dtype=convert_dtype)
+        index = scores.index
+        scores = scores.to_output("cupy")
 
         if scores.ndim == 1:
             indices = (scores > 0).view(cp.int8)
@@ -357,7 +357,9 @@ class LogisticRegression(
 
         with cuml.internals.exit_internal_context():
             output_type = self._get_output_type(X)
-        return decode_labels(indices, self.classes_, output_type=output_type)
+        return decode_labels(
+            indices, self.classes_, output_type=output_type, index=index
+        )
 
     @generate_docstring(
         X="dense_sparse",

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -219,12 +219,11 @@ class MBSGDClassifier(
         Predicts the y for X.
 
         """
-        scores = self.decision_function(
-            X, convert_dtype=convert_dtype
-        ).to_output("cupy")
-
+        scores = self.decision_function(X, convert_dtype=convert_dtype)
         thresh = 0 if self.loss == "hinge" else 0.5
-        indices = (scores > thresh).view(cp.int8)
+        indices = (scores.to_output("cupy") > thresh).view(cp.int8)
         with cuml.internals.exit_internal_context():
             output_type = self._get_output_type(X)
-        return decode_labels(indices, self.classes_, output_type=output_type)
+        return decode_labels(
+            indices, self.classes_, output_type=output_type, index=scores.index
+        )

--- a/python/cuml/cuml/multiclass/multiclass.py
+++ b/python/cuml/cuml/multiclass/multiclass.py
@@ -77,16 +77,18 @@ class _BaseMulticlassClassifier(Base, ClassifierMixin):
         """
         Predict using multi class classifier.
         """
-        X = check_inputs(
+        X, index = check_inputs(
             self,
             X,
             dtype=("float32", "float64"),
             accept_sparse=True,
             mem_type="host",
+            return_index=True,
         )
 
         with cuml.internals.exit_internal_context():
-            return self.multiclass_estimator.predict(X)
+            out = self.multiclass_estimator.predict(X)
+        return CumlArray(data=out, index=index)
 
     @generate_docstring(
         return_values={
@@ -101,15 +103,17 @@ class _BaseMulticlassClassifier(Base, ClassifierMixin):
         """
         Calculate the decision function.
         """
-        X = check_inputs(
+        X, index = check_inputs(
             self,
             X,
             dtype=("float32", "float64"),
             accept_sparse=True,
             mem_type="host",
+            return_index=True,
         )
         with cuml.internals.exit_internal_context():
-            return self.multiclass_estimator.decision_function(X)
+            out = self.multiclass_estimator.decision_function(X)
+        return CumlArray(data=out, index=index)
 
 
 class OneVsRestClassifier(_BaseMulticlassClassifier):

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -255,7 +255,13 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
 
         with cuml.internals.exit_internal_context():
             output_type = self._get_output_type(X)
-        return decode_labels(out, self.classes_, output_type=output_type)
+
+        return decode_labels(
+            out,
+            self.classes_,
+            output_type=output_type,
+            index=knn_indices.index,
+        )
 
     @generate_docstring(convert_dtype_cast='np.float32',
                         return_values={'name': 'X_new',

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -285,13 +285,11 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
     def predict(self, X, *, convert_dtype=True):
         """Predict class labels for samples in X."""
         if self.probability:
-            scores = self.predict_proba(
-                X, convert_dtype=convert_dtype
-            ).to_output("cupy")
+            scores = self.predict_proba(X, convert_dtype=convert_dtype)
         else:
-            scores = self.decision_function(
-                X, convert_dtype=convert_dtype
-            ).to_output("cupy")
+            scores = self.decision_function(X, convert_dtype=convert_dtype)
+        index = scores.index
+        scores = scores.to_output("cupy")
         if scores.ndim == 1:
             inds = (scores >= 0).view(cp.int8)
         else:
@@ -299,7 +297,9 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
 
         with cuml.internals.exit_internal_context():
             output_type = self._get_output_type(X)
-        return decode_labels(inds, self.classes_, output_type=output_type)
+        return decode_labels(
+            inds, self.classes_, output_type=output_type, index=index
+        )
 
     @available_if(lambda self: self.probability)
     @generate_docstring(

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -504,17 +504,23 @@ class SVC(SVMBase, ClassifierMixin):
         check_is_fitted(self)
 
         if hasattr(self, "_multiclass"):
-            inds = self._multiclass.predict(X).to_output("cupy")
+            inds = self._multiclass.predict(X)
+            index = inds.index
+            inds = inds.to_output("cupy")
         elif self.probability:
-            probs = self.predict_proba(X).to_output("cupy")
-            inds = cp.argmax(probs, axis=1)
+            probs = self.predict_proba(X)
+            index = probs.index
+            inds = cp.argmax(probs.to_output("cupy"), axis=1)
         else:
             res = self.decision_function(X, convert_dtype=convert_dtype)
+            index = res.index
             inds = (res.to_output("cupy") >= 0).view(cp.int8)
 
         with exit_internal_context():
             output_type = self._get_output_type(X)
-        return decode_labels(inds, self.classes_, output_type=output_type)
+        return decode_labels(
+            inds, self.classes_, output_type=output_type, index=index
+        )
 
     @available_if(lambda self: self.probability)
     @generate_docstring(
@@ -548,7 +554,9 @@ class SVC(SVMBase, ClassifierMixin):
 
         from cupyx.scipy.special import expit
 
-        preds = self.decision_function(X).to_output("cupy")
+        preds = self.decision_function(X)
+        index = preds.index
+        preds = preds.to_output("cupy")
         if preds.ndim == 1:
             preds = preds[:, None]
 
@@ -574,7 +582,7 @@ class SVC(SVMBase, ClassifierMixin):
         if log:
             proba = cp.log(proba)
 
-        return CumlArray(data=proba)
+        return CumlArray(data=proba, index=index)
 
     @available_if(lambda self: self.probability)
     @generate_docstring(

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -387,6 +387,11 @@ def test_classifier_label_types(cls, kwargs, target_kind, dtype_kind):
         preds2 = model.predict(X)
     assert isinstance(preds2, (pd.Series, pd.DataFrame))
 
+    # `predict` attaches the index of `X`
+    df_X = pd.DataFrame(X, index=[10 * i for i in range(X.shape[0])])
+    preds3 = model.predict(df_X)
+    assert (preds3.index == df_X.index).all()
+
     # Unsupported dtype & output type pairs raise nicely
     if dtype_kind == "string" and target_kind == "binary":
         with pytest.raises(


### PR DESCRIPTION
When returning pandas/cudf outputs, we want the index of the output to be aligned with the index of the input. This PR plumbs through `index` in `decode_labels`, adds a test for all classifiers, then applies the necessary fixes and plumbing so the output has an aligned index.

In the long run I hope to move index alignment handling to the `reflect` decorator so method code doesn't need to worry about this, but for now this is the most idiomatic and cleanest solution.

Split out and expanded from #8039.