### PR TITLE
Apply new input validation to metrics.trustworthiness

### DIFF
--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -64,7 +64,7 @@ def trustworthiness(
             Metric used to compute the trustworthiness. For the moment only
             'euclidean' is supported.
 
-        convert_dtype : bool, optional (default=False)
+        convert_dtype : bool, optional (default=True)
             When set to True, the trustworthiness method will automatically
             convert the inputs to np.float32.
 

--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -80,6 +80,12 @@ def trustworthiness(
     cdef uintptr_t d_X_ptr
     cdef uintptr_t d_X_embedded_ptr
 
+    if metric != 'euclidean':
+        raise ValueError(
+            "Unsupported metric {!r}. Supported metrics are: "
+            "'euclidean'.".format(metric)
+        )
+
     X_m = check_array(
         X,
         order='C',
@@ -108,18 +114,14 @@ def trustworthiness(
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
-    if metric == 'euclidean':
-        ret = trustworthiness_score[float, euclidean](handle_[0],
-                                                      <float*>d_X_ptr,
-                                                      <float*>d_X_embedded_ptr,
-                                                      n_samples,
-                                                      n_features,
-                                                      n_components,
-                                                      n_neighbors,
-                                                      batch_size)
-        handle.sync()
-
-    else:
-        raise Exception("Unknown metric")
+    ret = trustworthiness_score[float, euclidean](handle_[0],
+                                                  <float*>d_X_ptr,
+                                                  <float*>d_X_embedded_ptr,
+                                                  n_samples,
+                                                  n_features,
+                                                  n_components,
+                                                  n_neighbors,
+                                                  batch_size)
+    handle.sync()
 
     return ret

--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -5,7 +5,7 @@
 import numpy as np
 
 from cuml.internals import get_handle
-from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.validation import check_array, check_consistent_length
 
 from libc.stdint cimport uintptr_t
 from pylibraft.common.handle cimport handle_t
@@ -77,27 +77,33 @@ def trustworthiness(
             Trustworthiness of the low-dimensional embedding
     """
 
-    if n_neighbors > X.shape[0]:
-        raise ValueError("n_neighbors must be <= the number of rows.")
-
-    if n_neighbors > X.shape[0]:
-        raise ValueError("n_neighbors must be <= the number of rows.")
-
     cdef uintptr_t d_X_ptr
     cdef uintptr_t d_X_embedded_ptr
 
-    X_m, n_samples, n_features, _ = \
-        input_to_cuml_array(X, order='C', check_dtype=np.float32,
-                            convert_to_dtype=(np.float32 if convert_dtype
-                                              else None))
-    d_X_ptr = X_m.ptr
+    X_m = check_array(
+        X,
+        order='C',
+        dtype=np.float32,
+        convert_dtype=convert_dtype,
+        input_name='X',
+    )
+    cdef int n_samples = X_m.shape[0]
+    cdef int n_features = X_m.shape[1]
+    d_X_ptr = X_m.data.ptr
 
-    X_m2, _, n_components, _ = \
-        input_to_cuml_array(X_embedded, order='C',
-                            check_dtype=np.float32,
-                            convert_to_dtype=(np.float32 if convert_dtype
-                                              else None))
-    d_X_embedded_ptr = X_m2.ptr
+    X_m2 = check_array(
+        X_embedded,
+        order='C',
+        dtype=np.float32,
+        convert_dtype=convert_dtype,
+        input_name='X_embedded',
+    )
+    check_consistent_length(X_m, X_m2)
+    cdef int n_components = X_m2.shape[1]
+    d_X_embedded_ptr = X_m2.data.ptr
+
+    if n_neighbors > n_samples:
+        raise ValueError("n_neighbors must be <= the number of rows.")
 
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()

--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -108,8 +108,11 @@ def trustworthiness(
     cdef int n_components = X_m2.shape[1]
     d_X_embedded_ptr = X_m2.data.ptr
 
-    if n_neighbors > n_samples:
-        raise ValueError("n_neighbors must be <= the number of rows.")
+    if n_neighbors < 1 or 2 * n_neighbors >= n_samples:
+        raise ValueError(
+            "n_neighbors ({}) must be >= 1 and < n_samples / 2; "
+            "n_samples is {}.".format(n_neighbors, n_samples)
+        )
 
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()

--- a/python/cuml/tests/test_trustworthiness.py
+++ b/python/cuml/tests/test_trustworthiness.py
@@ -50,5 +50,36 @@ def test_trustworthiness(
 def test_trustworthiness_invalid_input():
     X, y = make_blobs(n_samples=10, centers=1, n_features=2, random_state=32)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="n_neighbors"):
         cuml_trustworthiness(X, X, n_neighbors=50)
+
+
+def test_trustworthiness_mismatched_rows():
+    X, _ = make_blobs(n_samples=10, n_features=4, random_state=0)
+    X_embedded, _ = make_blobs(n_samples=12, n_features=2, random_state=0)
+    with pytest.raises(ValueError, match="inconsistent number of samples"):
+        cuml_trustworthiness(
+            X.astype(np.float32), X_embedded.astype(np.float32)
+        )
+
+
+def test_trustworthiness_convert_dtype_false_rejects_float64():
+    X, _ = make_blobs(n_samples=20, n_features=4, random_state=0)  # float64
+    X_embedded, _ = make_blobs(n_samples=20, n_features=2, random_state=0)
+    with pytest.raises(ValueError, match="dtype"):
+        cuml_trustworthiness(X, X_embedded, convert_dtype=False)
+
+
+def test_trustworthiness_rejects_1d_input():
+    X = np.arange(20, dtype=np.float32)
+    X_embedded = np.arange(20, dtype=np.float32)
+    with pytest.raises(ValueError):
+        cuml_trustworthiness(X, X_embedded)
+
+
+def test_trustworthiness_unknown_metric():
+    rng = np.random.RandomState(0)
+    X = rng.rand(20, 4).astype(np.float32)
+    X_embedded = rng.rand(20, 2).astype(np.float32)
+    with pytest.raises(Exception, match="Unknown metric"):
+        cuml_trustworthiness(X, X_embedded, metric="manhattan")

--- a/python/cuml/tests/test_trustworthiness.py
+++ b/python/cuml/tests/test_trustworthiness.py
@@ -47,11 +47,12 @@ def test_trustworthiness(
     assert abs(cu_score - sk_score) <= 1e-3
 
 
-def test_trustworthiness_invalid_input():
+@pytest.mark.parametrize("n_neighbors", [0, 5, 50])
+def test_trustworthiness_invalid_n_neighbors(n_neighbors):
     X, y = make_blobs(n_samples=10, centers=1, n_features=2, random_state=32)
 
-    with pytest.raises(ValueError, match="n_neighbors"):
-        cuml_trustworthiness(X, X, n_neighbors=50)
+    with pytest.raises(ValueError, match="n_neighbors.*n_samples"):
+        cuml_trustworthiness(X, X, n_neighbors=n_neighbors)
 
 
 def test_trustworthiness_mismatched_rows():

--- a/python/cuml/tests/test_trustworthiness.py
+++ b/python/cuml/tests/test_trustworthiness.py
@@ -78,8 +78,6 @@ def test_trustworthiness_rejects_1d_input():
 
 
 def test_trustworthiness_unknown_metric():
-    rng = np.random.RandomState(0)
-    X = rng.rand(20, 4).astype(np.float32)
-    X_embedded = rng.rand(20, 2).astype(np.float32)
-    with pytest.raises(Exception, match="Unknown metric"):
-        cuml_trustworthiness(X, X_embedded, metric="manhattan")
+    X = np.arange(20, dtype=np.float32)
+    with pytest.raises(ValueError, match="Unsupported metric 'manhattan'"):
+        cuml_trustworthiness(X, X, metric="manhattan")


### PR DESCRIPTION
Applies new input validation system to `metrics.trustworthiness`.

Part of #7998