### PR TITLE
Fix FIL buffer bounds assertions

### DIFF
--- a/cpp/include/cuml/fil/detail/raft_proto/buffer.hpp
+++ b/cpp/include/cuml/fil/detail/raft_proto/buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -321,7 +321,8 @@ const_agnostic_same_t<T, U> copy(buffer<T>& dst,
                                  cuda_stream stream)
 {
   if constexpr (bounds_check) {
-    if (src.size() - src_offset < size || dst.size() - dst_offset < size) {
+    if (src_offset > src.size() || src.size() - src_offset < size || dst_offset > dst.size() ||
+        dst.size() - dst_offset < size) {
       throw out_of_bounds("Attempted copy to or from buffer of inadequate size");
     }
   }
@@ -353,7 +354,8 @@ const_agnostic_same_t<T, U> copy(buffer<T>&& dst,
                                  cuda_stream stream)
 {
   if constexpr (bounds_check) {
-    if (src.size() - src_offset < size || dst.size() - dst_offset < size) {
+    if (src_offset > src.size() || src.size() - src_offset < size || dst_offset > dst.size() ||
+        dst.size() - dst_offset < size) {
       throw out_of_bounds("Attempted copy to or from buffer of inadequate size");
     }
   }

--- a/cpp/tests/sg/fil/raft_proto/buffer.cpp
+++ b/cpp/tests/sg/fil/raft_proto/buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -307,6 +307,22 @@ TEST(Buffer, partial_buffer_copy)
   copy<true>(buf2, buf1, 1, 2, 3, cuda_stream{});
   copy<false>(buf2, buf1, 1, 2, 3, cuda_stream{});
   EXPECT_THROW(copy<true>(buf2, buf1, 1, 2, 4, cuda_stream{}), out_of_bounds);
+  EXPECT_THROW(copy<true>(buf2, buf1, 1, data1.size() + 1, 0, cuda_stream{}), out_of_bounds);
+  EXPECT_THROW(copy<true>(buf2, buf1, data2.size() + 1, 2, 0, cuda_stream{}), out_of_bounds);
+  EXPECT_THROW(copy<true>(buffer<int>{data2.data(), data2.size(), device_type::cpu},
+                          buffer<int>{data1.data(), data1.size(), device_type::cpu},
+                          1,
+                          data1.size() + 1,
+                          0,
+                          cuda_stream{}),
+               out_of_bounds);
+  EXPECT_THROW(copy<true>(buffer<int>{data2.data(), data2.size(), device_type::cpu},
+                          buffer<int>{data1.data(), data1.size(), device_type::cpu},
+                          data2.size() + 1,
+                          2,
+                          0,
+                          cuda_stream{}),
+               out_of_bounds);
 }
 
 TEST(Buffer, buffer_copy_overloads)


### PR DESCRIPTION
Adds explicit source and destination offset checks before computing remaining buffer capacity in FIL `raft_proto::copy`, and covers invalid offsets in the buffer tests.