### PR TITLE
Add early validation for n_clusters > n_samples in dask KMeans

### DIFF
--- a/python/cuml/cuml/dask/cluster/kmeans.py
+++ b/python/cuml/cuml/dask/cluster/kmeans.py
@@ -143,6 +143,24 @@ class KMeans(BaseEstimator, DelayedPredictionMixin, DelayedTransformMixin):
         kwargs = self.kwargs.copy()
         kwargs["random_state"] = check_random_seed(kwargs.get("random_state"))
 
+        # Validate total sample count before submitting distributed work.
+        # Each rank requests `n_clusters` centroids, but partitions may not
+        # have enough data points. The dask layer should surface a clear
+        # error when n_clusters > total data points across all workers.
+        n_clusters = self.kwargs.get("n_clusters")
+        if n_clusters is not None:
+            data._fetch_worker_sizes()
+            total_rows = sum(
+                total for (_, total) in data._worker_sizes.values()
+            )
+            if total_rows < n_clusters:
+                raise ValueError(
+                    f"n_samples={total_rows} should be >= n_clusters={n_clusters}. "
+                    f"There are fewer data points across all workers than the "
+                    f"number of requested clusters. Please reduce n_clusters or "
+                    f"increase the number of data points."
+                )
+
         # This needs to happen on the scheduler
         comms = Comms(comms_p2p=False, client=self.client)
         comms.init(workers=data.workers)

--- a/python/cuml/tests/dask/test_dask_kmeans.py
+++ b/python/cuml/tests/dask/test_dask_kmeans.py
@@ -312,3 +312,32 @@ def test_score(nrows, ncols, nclusters, n_parts, input_type, client):
     # The score is -1 * inertia. Scoring the training data should result in
     # -1 * model.inertia_
     np.testing.assert_allclose(actual_score, -cumlModel.inertia_, atol=9e-3)
+
+
+@pytest.mark.mg
+def test_nclusters_exceeds_n_samples(client):
+    """Test that n_clusters > n_samples raises a clear ValueError."""
+    from cuml.dask.cluster import KMeans
+    from cuml.dask.datasets import make_blobs
+
+    # Use fewer data points than clusters
+    n_clusters = 11
+    n_samples = 10
+
+    X, _ = make_blobs(
+        n_samples=n_samples,
+        n_features=5,
+        centers=5,
+        n_parts=2,
+        random_state=10,
+    )
+
+    model = KMeans(
+        n_clusters=n_clusters,
+        random_state=10,
+    )
+
+    with pytest.raises(
+        ValueError, match="n_samples=10 should be >= n_clusters=11"
+    ):
+        model.fit(X)


### PR DESCRIPTION
Adds pre-validation in dask KMeans `fit()` that checks `n_clusters <= total_rows` across all workers before submitting distributed work. Previously `fit()` would proceed to the GPU layer and produce a confusing CUDA error; now it raises a clear `ValueError` upfront.

Closes #6643
