### PR TITLE
Use cudaStream_t instead of cuda_stream_view in cuml Cython

### DIFF
--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -22,6 +22,7 @@ from cython.operator cimport dereference as deref
 from libc.stdint cimport int64_t, uint64_t, uintptr_t
 from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
+from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_uvector cimport device_uvector
 
 cimport cuml.cluster.hdbscan.headers as lib
@@ -197,7 +198,7 @@ cdef class _HDBSCANState:
         cdef int min_samples = model.min_samples or model.min_cluster_size
         cdef device_uvector[int64_t] *temp_buffer = new device_uvector[int64_t](
             0,
-            handle_[0].get_stream(),
+            <cuda_stream_view>handle_[0].get_stream(),
         )
 
         with nogil:

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -22,7 +22,6 @@ from cython.operator cimport dereference as deref
 from libc.stdint cimport int64_t, uint64_t, uintptr_t
 from libcpp cimport bool
 from pylibraft.common.handle cimport handle_t
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_uvector cimport device_uvector
 
 cimport cuml.cluster.hdbscan.headers as lib
@@ -198,7 +197,7 @@ cdef class _HDBSCANState:
         cdef int min_samples = model.min_samples or model.min_cluster_size
         cdef device_uvector[int64_t] *temp_buffer = new device_uvector[int64_t](
             0,
-            <cuda_stream_view>handle_[0].get_stream(),
+            handle_[0].get_stream(),
         )
 
         with nogil:

--- a/python/cuml/cuml/manifold/umap/lib.pxd
+++ b/python/cuml/cuml/manifold/umap/lib.pxd
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+from cuda.bindings.cyruntime cimport cudaStream_t
 from libc.stdint cimport int64_t, uint64_t
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from pylibraft.common.handle cimport handle_t
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
 
 from cuml.internals.logger cimport level_enum
@@ -72,8 +72,8 @@ cdef extern from "cuml/manifold/umapparams.h" namespace "ML" nogil:
 
 cdef extern from "raft/sparse/coo.hpp" nogil:
     cdef cppclass COO "raft::sparse::COO<float, int, uint64_t>":
-        COO(cuda_stream_view stream)
-        void allocate(uint64_t nnz, int size, bool init, cuda_stream_view stream)
+        COO(cudaStream_t stream)
+        void allocate(uint64_t nnz, int size, bool init, cudaStream_t stream)
         uint64_t nnz
         float* vals()
         int* rows()

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -6,6 +6,8 @@ import ctypes
 import warnings
 from collections import deque
 
+from cuda.bindings.cyruntime cimport cudaStream_t
+
 import cupy as cp
 import cupyx.scipy.sparse
 import joblib
@@ -1306,8 +1308,8 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
                     <const void*><uintptr_t>(
                         init.data.ptr if isinstance(init, cp.ndarray) else init.ctypes.data
                     ),
-                    init.nbytes,
-                    handle_.get_stream(),
+                    <size_t> init.nbytes,
+                    <cudaStream_t> handle_.get_stream(),
                     make_any_device_resource(get_current_device_resource().get_mr())
                 )
             )

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -41,6 +41,7 @@ from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 from pylibraft.common.handle cimport handle_t
+from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.memory_resource cimport make_any_device_resource
 from rmm.pylibrmm.device_buffer cimport DeviceBuffer
@@ -1292,7 +1293,7 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
                 new device_buffer(
                     <const void*><uintptr_t>init_m.ptr,
                     init_m.size,
-                    handle_.get_stream(),
+                    <cuda_stream_view>handle_.get_stream(),
                     make_any_device_resource(get_current_device_resource().get_mr())
                 )
             )

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -43,7 +43,6 @@ from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 from pylibraft.common.handle cimport handle_t
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.memory_resource cimport make_any_device_resource
 from rmm.pylibrmm.device_buffer cimport DeviceBuffer
@@ -1308,7 +1307,7 @@ class UMAP(Base, InteropMixin, CMajorInputTagMixin, SparseInputTagMixin):
                         init.data.ptr if isinstance(init, cp.ndarray) else init.ctypes.data
                     ),
                     init.nbytes,
-                    <cuda_stream_view>handle_.get_stream(),
+                    handle_.get_stream(),
                     make_any_device_resource(get_current_device_resource().get_mr())
                 )
             )


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/rmm/issues/2359

Once https://github.com/rapidsai/raft/pull/3011 merges this PR will be necessary to unblock cuml's CI
