### PR TITLE
Fallback on `ensure_all_finite` in `UMAP` on `cuml.accel`

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -560,6 +560,7 @@ umap
   ``"l2"``, ``"euclidean"``).
 - If ``unique=True``.
 - If ``densmap=True``.
+- If ``ensure_all_finite`` is not ``True``.
 
 Additional notes:
 

--- a/python/cuml/cuml/accel/_overrides/umap.py
+++ b/python/cuml/cuml/accel/_overrides/umap.py
@@ -7,6 +7,7 @@ from packaging.version import Version
 
 import cuml.manifold
 from cuml.accel.estimator_proxy import ProxyBase
+from cuml.internals.interop import UnsupportedOnGPU
 
 try:
     import umap as _umap_module
@@ -22,7 +23,8 @@ class UMAP(ProxyBase):
     _gpu_class = cuml.manifold.UMAP
 
     if _UMAP_LT_058:
-        # We support the old signature for backwards compatibility prior to umap-learn 0.5.8
+        # We support the old signature for backwards compatibility prior to
+        # umap-learn 0.5.8
 
         def _gpu_fit(self, X, y=None, force_all_finite=True, **kwargs):
             return self._gpu.fit(X, y=y)
@@ -40,9 +42,10 @@ class UMAP(ProxyBase):
         def _gpu_fit(self, X, y=None, ensure_all_finite=True, **kwargs):
             # **kwargs is here for signature compatibility - umap.UMAP has them,
             # but ignores all but the ones named here.
-            # TODO: cuml.UMAP currently doesn't handle non-finite inputs.
-            # ensure_all_finite is in here for _signature_ compatibility
-            # with umap.UMAP, but we don't properly implement it (yet).
+            if ensure_all_finite is not True:
+                raise UnsupportedOnGPU(
+                    f"{ensure_all_finite=!r} is not supported"
+                )
             return self._gpu.fit(X, y=y)
 
         def _gpu_fit_transform(
@@ -50,9 +53,17 @@ class UMAP(ProxyBase):
         ):
             # **kwargs is here for signature compatibility - umap.UMAP has them,
             # but ignores all but the ones named here.
+            if ensure_all_finite is not True:
+                raise UnsupportedOnGPU(
+                    f"{ensure_all_finite=!r} is not supported"
+                )
             return self._gpu.fit_transform(X, y=y)
 
         def _gpu_transform(self, X, ensure_all_finite=True):
+            if ensure_all_finite is not True:
+                raise UnsupportedOnGPU(
+                    f"{ensure_all_finite=!r} is not supported"
+                )
             return self._gpu.transform(X)
 
     def _gpu_inverse_transform(self, X):


### PR DESCRIPTION
The implementation in cuml only supports finite values, while the use case in `umap.UMAP` to not error on them is for custom metrics. We don't want to disable the check in `cuml` (since that would lead to errors or crashes), so instead we fallback in that case.

For users that want to disable the check for performance reasons, they can use `sklearn.set_config(assume_finite)` or define `SKLEARN_ASSUME_FINITE=1`, which is the documented way to disable this check. Note that in general the finite check runs very fast on GPU (600 GiBs on my machine), so it's unlikely to be a perf issue.

Supersedes #7837.