### PR TITLE
Use cudf to_cupy dtype conversions

### DIFF
--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -683,14 +683,21 @@ def check_array(
                     array = array.to_numpy(dtype="object")
                 array = np.asarray(array, dtype=dtype, order=order)
             else:
-                # XXX: the dtype keyword to `to_cupy` is buggy, and also
-                # doesn't support all dtype coercions. For now we do a
-                # manual cast to handle any coercions.
-                # See https://github.com/rapidsai/cudf/issues/22136.
-                if dtype is not None:
-                    array = array.astype(dtype, copy=False)
+                try:
+                    array = array.to_cupy(dtype=dtype, copy=copy)
+                except TypeError as exc:
+                    needs_precopy_cast = (
+                        dtype is not None
+                        and "cupy does not support" in str(exc)
+                    )
+                    if not needs_precopy_cast:
+                        raise
+                    array = array.astype(dtype, copy=False).to_cupy(copy=copy)
+
                 array = cp.asarray(
-                    array.to_cupy(copy=copy), dtype=dtype, order=order
+                    array,
+                    dtype=dtype,
+                    order=order,
                 )
         elif isinstance(array, (pd.DataFrame, pd.Series)):
             # Handle pandas inputs

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -553,7 +553,7 @@ def _get_output(
     if output_type == "cudf":
         return out
     elif output_type == "cupy":
-        return out.astype(dtype).to_cupy(na_value=np.nan)
+        return out.to_cupy(na_value=np.nan, dtype=dtype)
     elif output_type == "numpy":
         return cp.asnumpy(out.to_cupy(na_value=np.nan, dtype=dtype))
     elif output_type == "pandas":

--- a/python/cuml/tests/test_ordinal_encoder.py
+++ b/python/cuml/tests/test_ordinal_encoder.py
@@ -92,6 +92,14 @@ def test_output_type(test_sample) -> None:
     assert isinstance(enc.transform(X), DataFrame)
 
 
+def test_output_type_cupy_respects_dtype(test_sample) -> None:
+    enc = OrdinalEncoder(output_type="cupy", dtype=np.float32).fit(test_sample)
+    out = enc.transform(test_sample)
+
+    assert isinstance(out, cp.ndarray)
+    assert out.dtype == np.dtype("float32")
+
+
 def test_feature_names(test_sample) -> None:
     enc = OrdinalEncoder().fit(test_sample)
     assert (enc.feature_names_in_ == ["cat", "num"]).all()

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -736,6 +736,18 @@ def test_check_array_dtype(array, mem_type):
     assert out.dtype == "float32"
 
 
+@pytest.mark.parametrize("in_dtype", ["int32", "int64", "float32", "float64"])
+@pytest.mark.parametrize("out_dtype", ["int32", "int64", "float32", "float64"])
+def test_check_array_cudf_dataframe_to_cupy_dtype(in_dtype, out_dtype):
+    data = cp.arange(12, dtype=in_dtype).reshape(3, 4)
+    df = cudf.DataFrame(data)
+
+    out = check_array(df, dtype=out_dtype, mem_type="device")
+
+    assert out.dtype == np.dtype(out_dtype)
+    cp.testing.assert_allclose(out, data.astype(out_dtype))
+
+
 @example(mem_type="device", dtype="int32", order="C", shape=(3, 4))
 @example(mem_type="host", dtype="float32", order="F", shape=(3,))
 @given(


### PR DESCRIPTION
Updates cuML cudf-to-cupy conversion paths to pass `dtype` directly through `to_cupy`, now that cuDF handles dtype coercion for numeric and non-numeric columns. Adds focused validation and encoder coverage for dtype-preserving CuPy output.

Follow-up to https://github.com/rapidsai/cudf/issues/22136
