### PR TITLE
Use the PTDS for (most) cupy operations

### DIFF
--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 
 import numpy as np
+from cupy.cuda import Stream
 
 # TODO: Try to resolve circular import that makes this necessary:
 from cuml.internals import input_utils as iu
@@ -212,7 +213,8 @@ def enter_internal_context():
         gs._external_output_type = gs.output_type
         gs.output_type = "mirror"
         try:
-            yield True
+            with Stream.ptds:
+                yield True
         finally:
             gs.output_type = gs._external_output_type
             gs._external_output_type = False
@@ -451,6 +453,7 @@ def reflect(
             # We're internal, return as cuml
             output_type = "cuml"
 
-        return coerce_arrays(res, output_type)
+        with enter_internal_context():
+            return coerce_arrays(res, output_type)
 
     return inner

--- a/python/cuml/cuml/preprocessing/label.py
+++ b/python/cuml/cuml/preprocessing/label.py
@@ -49,8 +49,6 @@ def label_binarize(
         dtype=cp.float32,
     )
 
-    cp.cuda.Stream.null.synchronize()
-
     is_binary = classes.shape[0] == 2
 
     if sparse_output:
@@ -184,8 +182,6 @@ class LabelBinarizer(Base):
             self.classes_ = cp.arange(0, y.shape[1])
         else:
             self.classes_ = cp.unique(y).astype(y.dtype)
-
-        cp.cuda.Stream.null.synchronize()
 
         return self
 

--- a/python/cuml/tests/test_prims.py
+++ b/python/cuml/tests/test_prims.py
@@ -24,8 +24,6 @@ def test_monotonic_without_classes(arr_type, dtype, copy):
 
     monotonic, returned_classes = make_monotonic(arr, copy=copy)
 
-    cp.cuda.Stream.null.synchronize()
-
     # Verify monotonic mapping: [0, 15, 10, 50, 20, 50] -> [0, 2, 1, 4, 3, 4]
     # (sorted unique: 0->0, 10->1, 15->2, 20->3, 50->4)
     expected_monotonic = cp.array([0, 2, 1, 4, 3, 4], dtype=dtype)
@@ -56,8 +54,6 @@ def test_monotonic_inversion(dtype):
     # Invert: use classes array to map indices back to original values
     inverted = classes[monotonic]
 
-    cp.cuda.Stream.null.synchronize()
-
     assert array_equal(inverted, original)
 
 
@@ -73,8 +69,6 @@ def test_monotonic_with_explicit_classes(dtype, copy):
     monotonic, returned_classes = make_monotonic(
         labels, classes=classes, copy=copy
     )
-
-    cp.cuda.Stream.null.synchronize()
 
     # Labels should map to their position in the original classes array
     # 5 -> 0, 2 -> 1, 8 -> 2
@@ -99,8 +93,6 @@ def test_monotonic_unknown_labels(dtype):
     labels = cp.array([1, 999, 2, 3, -1], dtype=dtype)
 
     monotonic, _ = make_monotonic(labels, classes=classes, copy=True)
-
-    cp.cuda.Stream.null.synchronize()
 
     # Unknown labels (999, -1) should map to len(classes) = 3
     # 1 -> 0, 999 -> 3, 2 -> 1, 3 -> 2, -1 -> 3

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -418,9 +418,19 @@ def test_decorators_set_cupy_ptds():
             assert cp.cuda.get_current_stream() is cp.cuda.Stream.ptds
             return cp.zeros(3)
 
-    model = MyEstimator()
     X = cp.ones(3)
+
+    # Check that ptds is used instead of the default stream
+    model = MyEstimator()
     model.fit(X)
     model.direct_call(X)
     model.nested_call(X)
     model.no_reflection(X)
+
+    # Check that ptds is used instead of a custom stream
+    with cp.cuda.Stream():
+        model = MyEstimator()
+        model.fit(X)
+        model.direct_call(X)
+        model.nested_call(X)
+        model.no_reflection(X)

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -394,3 +394,33 @@ def test_array_descriptor_cache_behavior():
     assert b"pandas" not in msg
     assert_output_type(model2.X_, "cupy")
     assert len(model2.__dict__["X_"].values) == 2  # cuml + cupy
+
+
+def test_decorators_set_cupy_ptds():
+    class MyEstimator(Base):
+        @reflect(reset="type")
+        def fit(self, X, y=None):
+            assert cp.cuda.get_current_stream() is cp.cuda.Stream.ptds
+            return self
+
+        @reflect
+        def direct_call(self, X):
+            assert cp.cuda.get_current_stream() is cp.cuda.Stream.ptds
+            return cp.zeros(3)
+
+        @reflect
+        def nested_call(self, X):
+            assert cp.cuda.get_current_stream() is cp.cuda.Stream.ptds
+            return self.direct_call(X)
+
+        @run_in_internal_context
+        def no_reflection(self, X):
+            assert cp.cuda.get_current_stream() is cp.cuda.Stream.ptds
+            return cp.zeros(3)
+
+    model = MyEstimator()
+    X = cp.ones(3)
+    model.fit(X)
+    model.direct_call(X)
+    model.nested_call(X)
+    model.no_reflection(X)


### PR DESCRIPTION
This configures cupy to use the per-thread default stream (PTDS) for _most_ operations. This avoids usage of the default legacy stream in more of the codebase, allowing for improved parallelism when running across multiple threads.

**This is a breaking change.**

Previously any cupy operations in `cuml` ran in cupy's default stream (the legacy stream). We didn't synchronize the stream before returning, but that didn't matter due to the synchronization behavior of the legacy stream.

With this PR we've moved to running (most) cupy operations in the PTDS. Depending on the operation, we may not synchronize the PTDS before returning.

**Most users shouldn't notice a difference and should have no issues.**

Users not using threads, custom streams, or only working with host memory (e.g. numpy in/numpy out) should see no difference. Likewise any users that only use cupy's default stream (the legacy stream) in their code should see no issues.

Users doing tricky things with custom streams or threads may run into issues and require a manual sync of the PTDS (can be done with `cupy.cuda.Stream.ptds.synchronize()`. For example, the following workflow _may_ run into issues:

- Run a cuml operation based on cupy in thread A, returning a cupy array
- Consume that output in thread B as a cupy array using a stream other than the legacy stream (e.g. a different PTDS or a custom stream)

For safety, you probably want to add a call to `cupy.cuda.Stream.ptds.synchronize()` in thread A before returning to ensure the output array is fully populated before consuming it in thread B.

Fixes #7909.