### PR TITLE
fix(ci): add explicit `actions: write` permission for `telemetry-summarize`


### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,9 +6,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 permissions: {}
-
 jobs:
   # Please keep pr-builder as the top job here
   pr-builder:
@@ -558,7 +556,7 @@ jobs:
     if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
     continue-on-error: true
     permissions:
-      actions: read
+      actions: write
     steps:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main


### PR DESCRIPTION
## Description
As part of https://github.com/rapidsai/build-planning/issues/275 we removed the default set of permissions from all workflow jobs.

The shared-action that handles telemetry cleanup is now failing because it is trying to clean up artifacts that shouldn't remain after a given workflow run.

This PR adds an explicit `actions: write` permission, to allow that action to clean up those artifacts.

xref https://github.com/rapidsai/shared-actions/issues/106
