### PR TITLE
Deprecate `probability` parameter on `SVC` and `LinearSVC`

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -507,9 +507,11 @@ SVC
 
 - If ``kernel="precomputed"`` or is a callable.
 - If ``y`` is multiclass.
-- If ``probability=True``. The ``probability`` parameter is being deprecated
-  in cuML; use ``CalibratedClassifierCV(SVC(), ensemble=False)`` from
-  ``sklearn.calibration`` for probability estimates instead.
+- If ``probability=True``. ``cuml.accel`` does not accelerate ``SVC`` with
+  probability estimates; the fit falls back to native scikit-learn. For
+  GPU-accelerated probability estimates, use
+  ``CalibratedClassifierCV(SVC(), ensemble=False)`` from
+  ``sklearn.calibration`` instead.
 
 Additional notes:
 

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -509,7 +509,7 @@ SVC
 - If ``y`` is multiclass.
 - If ``probability=True``. The ``probability`` parameter is deprecated in
   ``scikit-learn>=1.9``, as well as in ``cuml>=26.06``. We recommend using
-  wrapping ``SVC`` with ``sklearn.calibration.CalibratedClassifier`` like
+  wrapping ``SVC`` with ``sklearn.calibration.CalibratedClassifierCV`` like
   ``CalibratedClassifierCV(SVC(), ensemble=False)`` instead. This will be
   supported across ``scikit-learn`` versions, and won't require CPU fallback.
 

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -507,11 +507,11 @@ SVC
 
 - If ``kernel="precomputed"`` or is a callable.
 - If ``y`` is multiclass.
-- If ``probability=True``. ``cuml.accel`` does not accelerate ``SVC`` with
-  probability estimates; the fit falls back to native scikit-learn. For
-  GPU-accelerated probability estimates, use
-  ``CalibratedClassifierCV(SVC(), ensemble=False)`` from
-  ``sklearn.calibration`` instead.
+- If ``probability=True``. The ``probability`` parameter is deprecated in
+  ``scikit-learn>=1.9``, as well as in ``cuml>=26.06``. We recommend using
+  wrapping ``SVC`` with ``sklearn.calibration.CalibratedClassifier`` like
+  ``CalibratedClassifierCV(SVC(), ensemble=False)`` instead. This will be
+  supported across ``scikit-learn`` versions, and won't require CPU fallback.
 
 Additional notes:
 

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -507,7 +507,9 @@ SVC
 
 - If ``kernel="precomputed"`` or is a callable.
 - If ``y`` is multiclass.
-- If ``probability=True`` and ``y`` doesn't have at least 5 samples per class.
+- If ``probability=True``. The ``probability`` parameter is being deprecated
+  in cuML; use ``CalibratedClassifierCV(SVC(), ensemble=False)`` from
+  ``sklearn.calibration`` for probability estimates instead.
 
 Additional notes:
 

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -39,26 +39,18 @@ class SVC(ProxyBase):
     )
 
     def _gpu_fit(self, X, y, sample_weight=None):
-        classes, counts = np.unique(np.asanyarray(y), return_counts=True)
+        classes = np.unique(np.asanyarray(y))
         if len(classes) > 2:
             raise UnsupportedOnGPU("Multiclass `y` is not supported")
-
-        # CalibratedClassifierCV doesn't like working with cases where any
-        # classes have less than 5 examples.
-        if self.probability and counts.min() < 5:
-            raise UnsupportedOnGPU(
-                "`probability=True` requires >= 5 samples per class"
-            )
-
         return self._gpu.fit(X, y, sample_weight=sample_weight)
 
     def _gpu_decision_function(self, X):
         # Fixup returned dtype
         return self._gpu.decision_function(X).astype("float64", copy=False)
 
-    # XXX: sklearn wants these methods to only exist if probability=True.
-    # ProxyBase lacks a builtin mechanism to do that, since this is the only
-    # use case so far we manually define them for now.
+    # `probability=True` falls back to native sklearn (_params_from_cpu raises
+    # UnsupportedOnGPU); the @available_if gate preserves sklearn's
+    # `hasattr(svc, "predict_proba")` semantics on the proxy.
     @available_if(_has_probability)
     @functools.wraps(_SVC.predict_proba)
     def predict_proba(self, X):

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -20,8 +20,8 @@ __all__ = (
 
 
 def _has_probability(model):
-    # sklearn >= 1.9 defaults `probability` to the sentinel string "deprecated",
-    # which is truthy. Treat it the same as False (no calibration requested).
+    # sklearn >= 1.9 defaults `probability` to the "deprecated" sentinel,
+    # which is truthy. Treat it like False (no calibration requested).
     if model.probability == "deprecated" or not model.probability:
         raise AttributeError(
             "predict_proba is not available when probability=False"

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -48,7 +48,7 @@ class SVC(ProxyBase):
         # Fixup returned dtype
         return self._gpu.decision_function(X).astype("float64", copy=False)
 
-    # Mirror sklearn: predict_proba only exists when probability is enabled.
+    # Manual gate: ProxyBase has no built-in conditional-method support.
     @available_if(_has_probability)
     @functools.wraps(_SVC.predict_proba)
     def predict_proba(self, X):

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -48,9 +48,7 @@ class SVC(ProxyBase):
         # Fixup returned dtype
         return self._gpu.decision_function(X).astype("float64", copy=False)
 
-    # `probability=True` falls back to native sklearn (_params_from_cpu raises
-    # UnsupportedOnGPU); the @available_if gate preserves sklearn's
-    # `hasattr(svc, "predict_proba")` semantics on the proxy.
+    # Mirror sklearn: predict_proba only exists when probability is enabled.
     @available_if(_has_probability)
     @functools.wraps(_SVC.predict_proba)
     def predict_proba(self, X):

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -56,9 +56,9 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         The string 'balanced' is also accepted, in which case
         ``class_weight[i] = n_samples / (n_classes * n_samples_of_class[i])``
     probability: bool, default=False
-        .. deprecated:: 26.08
+        .. deprecated:: 26.06
             ``probability`` is deprecated and will be removed in version
-            26.10. Use ``CalibratedClassifierCV(LinearSVC(), ensemble=False)``
+            26.08. Use ``CalibratedClassifierCV(LinearSVC(), ensemble=False)``
             from ``sklearn.calibration`` for probability estimates instead.
 
         Set to True to enable probability estimate methods (``predict_proba``,
@@ -257,7 +257,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         if self.probability != "deprecated":
             warnings.warn(
                 "The `probability` parameter is deprecated and will be "
-                "removed in cuML version 26.10. Use "
+                "removed in cuML version 26.08. Use "
                 "`CalibratedClassifierCV(LinearSVC(), ensemble=False)` from "
                 "`sklearn.calibration` instead.",
                 FutureWarning,

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+import warnings
+
 import cupy as cp
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.metaestimators import available_if
@@ -54,6 +56,11 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         The string 'balanced' is also accepted, in which case
         ``class_weight[i] = n_samples / (n_classes * n_samples_of_class[i])``
     probability: bool, default=False
+        .. deprecated:: 26.08
+            ``probability`` is deprecated and will be removed in version
+            26.10. Use ``CalibratedClassifierCV(LinearSVC(), ensemble=False)``
+            from ``sklearn.calibration`` for probability estimates instead.
+
         Set to True to enable probability estimate methods (``predict_proba``,
         ``predict_log_proba``).
     tol : float, default=1e-4
@@ -155,6 +162,9 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
                 f"`multi_class={model.multi_class}` is not supported"
             )
 
+        # `probability` is intentionally omitted: sklearn.LinearSVC has no such
+        # parameter, so the cuml-side default `"deprecated"` is restored by
+        # `__init__`.
         return {
             "penalty": model.penalty,
             "loss": model.loss,
@@ -208,7 +218,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         fit_intercept=True,
         penalized_intercept=False,
         class_weight=None,
-        probability=False,
+        probability="deprecated",
         tol=1e-4,
         max_iter=1000,
         linesearch_max_iter=100,
@@ -234,12 +244,26 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         self.n_streams = n_streams
         self.multi_class = multi_class
 
+    @property
+    def _effective_probability(self):
+        return False if self.probability == "deprecated" else self.probability
+
     @generate_docstring()
     @reflect(reset="type")
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "LinearSVC":
         """Fit the model according to the given training data."""
+        if self.probability != "deprecated":
+            warnings.warn(
+                "The `probability` parameter is deprecated and will be "
+                "removed in cuML version 26.10. Use "
+                "`CalibratedClassifierCV(LinearSVC(), ensemble=False)` from "
+                "`sklearn.calibration` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         coef, intercept, n_iter, prob_scale, classes = cuml.svm.linear.fit(
             self,
             X,
@@ -248,7 +272,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             convert_dtype=convert_dtype,
             is_classifier=True,
             n_streams=self.n_streams,
-            probability=self.probability,
+            probability=self._effective_probability,
             class_weight=self.class_weight,
             loss=self.loss,
             penalty=self.penalty,
@@ -284,7 +308,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
     @run_in_internal_context
     def predict(self, X, *, convert_dtype=True):
         """Predict class labels for samples in X."""
-        if self.probability:
+        if self._effective_probability:
             scores = self.predict_proba(X, convert_dtype=convert_dtype)
         else:
             scores = self.decision_function(X, convert_dtype=convert_dtype)
@@ -301,7 +325,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             inds, self.classes_, output_type=output_type, index=index
         )
 
-    @available_if(lambda self: self.probability)
+    @available_if(lambda self: self._effective_probability)
     @generate_docstring(
         return_values={
             "name": "probs",
@@ -329,7 +353,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             n_streams=self.n_streams,
         )
 
-    @available_if(lambda self: self.probability)
+    @available_if(lambda self: self._effective_probability)
     @generate_docstring(
         return_values={
             "name": "probs",

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -162,9 +162,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
                 f"`multi_class={model.multi_class}` is not supported"
             )
 
-        # `probability` is intentionally omitted: sklearn.LinearSVC has no such
-        # parameter, so the cuml-side default `"deprecated"` is restored by
-        # `__init__`.
+        # probability omitted: sklearn.LinearSVC has no such param.
         return {
             "penalty": model.penalty,
             "loss": model.loss,

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -208,9 +208,7 @@ class SVC(SVMBase, ClassifierMixin):
         params.pop(
             "epsilon"
         )  # SVC doesn't expose `epsilon` in the constructor
-        # `probability` is intentionally omitted: True is rejected above;
-        # False and the sklearn-1.9 `"deprecated"` sentinel both restore to
-        # the cuml default via `__init__`.
+        # probability omitted; True rejected above, default restores it.
         params.update(
             {
                 "random_state": model.random_state,

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -111,9 +111,9 @@ class SVC(SVMBase, ClassifierMixin):
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
     probability : bool (default = False)
-        .. deprecated:: 26.08
+        .. deprecated:: 26.06
             ``probability`` is deprecated and will be removed in version
-            26.10. Use ``CalibratedClassifierCV(SVC(), ensemble=False)``
+            26.08. Use ``CalibratedClassifierCV(SVC(), ensemble=False)``
             from ``sklearn.calibration`` for probability estimates instead.
 
         Set to ``True`` to enable probability estimates
@@ -465,7 +465,7 @@ class SVC(SVMBase, ClassifierMixin):
         if self.probability != "deprecated":
             warnings.warn(
                 "The `probability` parameter is deprecated and will be "
-                "removed in cuML version 26.10. Use "
+                "removed in cuML version 26.08. Use "
                 "`CalibratedClassifierCV(SVC(), ensemble=False)` from "
                 "`sklearn.calibration` instead.",
                 FutureWarning,

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -225,9 +225,7 @@ class SVC(SVMBase, ClassifierMixin):
         params.pop(
             "epsilon"
         )  # SVC doesn't expose `epsilon` in the constructor
-        # sklearn 1.9+ uses the same ``"deprecated"`` sentinel; forward
-        # verbatim there so round-trip preserves identity. Older sklearn
-        # rejects the sentinel, so resolve to the effective value.
+        # sklearn <1.9 rejects the ``"deprecated"`` sentinel; resolve it there.
         if SKLEARN_19:
             probability = self.probability
         else:

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -200,8 +200,8 @@ class SVC(SVMBase, ClassifierMixin):
     @classmethod
     def _params_from_cpu(cls, model):
         if model.probability is True:
-            # `probability=True` is being deprecated; cuml.accel falls back
-            # to native sklearn, which uses sklearn's own CalibratedClassifierCV.
+            # probability=True is deprecated; cuml.accel falls back to
+            # native sklearn's own CalibratedClassifierCV.
             raise UnsupportedOnGPU("`probability=True` is not supported")
 
         params = super()._params_from_cpu(model)
@@ -400,8 +400,7 @@ class SVC(SVMBase, ClassifierMixin):
 
         params = {
             **self.get_params(),
-            # Pin the sentinel so inner CalibratedClassifierCV folds don't
-            # re-fire the deprecation warning the outer fit already emitted.
+            # Pin the sentinel (see _fit_multiclass) for the inner folds.
             "probability": "deprecated",
             "output_type": "numpy",
             "class_weight": None,

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -1,8 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+import warnings
+
 import cupy as cp
 import numpy as np
+import sklearn
+from packaging.version import Version
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.metaestimators import available_if
 
@@ -25,6 +29,8 @@ from cuml.internals.validation import (
 )
 from cuml.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from cuml.svm.svm_base import SVMBase
+
+SKLEARN_19 = Version(sklearn.__version__) >= Version("1.9.0.dev0")
 
 
 class SVC(SVMBase, ClassifierMixin):
@@ -105,6 +111,11 @@ class SVC(SVMBase, ClassifierMixin):
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
     probability : bool (default = False)
+        .. deprecated:: 26.08
+            ``probability`` is deprecated and will be removed in version
+            26.10. Use ``CalibratedClassifierCV(SVC(), ensemble=False)``
+            from ``sklearn.calibration`` for probability estimates instead.
+
         Set to ``True`` to enable probability estimates
         (``predict_proba``/``predict_log_proba``). Note that
         ``probability=True`` requires your training data have at least 5
@@ -188,18 +199,20 @@ class SVC(SVMBase, ClassifierMixin):
 
     @classmethod
     def _params_from_cpu(cls, model):
+        if model.probability is True:
+            # `probability=True` is being deprecated; cuml.accel falls back
+            # to native sklearn, which uses sklearn's own CalibratedClassifierCV.
+            raise UnsupportedOnGPU("`probability=True` is not supported")
+
         params = super()._params_from_cpu(model)
         params.pop(
             "epsilon"
         )  # SVC doesn't expose `epsilon` in the constructor
-        # sklearn 1.9 changed the default of `probability` from False to the
-        # sentinel string "deprecated"; coerce to the bool cuml uses.
-        probability = model.probability
-        if probability == "deprecated":
-            probability = False
+        # `probability` is intentionally omitted: True is rejected above;
+        # False and the sklearn-1.9 `"deprecated"` sentinel both restore to
+        # the cuml default via `__init__`.
         params.update(
             {
-                "probability": probability,
                 "random_state": model.random_state,
                 "class_weight": model.class_weight,
                 "decision_function_shape": model.decision_function_shape,
@@ -212,9 +225,16 @@ class SVC(SVMBase, ClassifierMixin):
         params.pop(
             "epsilon"
         )  # SVC doesn't expose `epsilon` in the constructor
+        # sklearn 1.9+ uses the same ``"deprecated"`` sentinel; forward
+        # verbatim there so round-trip preserves identity. Older sklearn
+        # rejects the sentinel, so resolve to the effective value.
+        if SKLEARN_19:
+            probability = self.probability
+        else:
+            probability = self._effective_probability
         params.update(
             {
-                "probability": self.probability,
+                "probability": probability,
                 "random_state": self.random_state,
                 "class_weight": self.class_weight,
                 "decision_function_shape": self.decision_function_shape,
@@ -265,7 +285,7 @@ class SVC(SVMBase, ClassifierMixin):
         nochange_steps=1000,
         verbose=False,
         output_type=None,
-        probability=False,
+        probability="deprecated",
         random_state=None,
         class_weight=None,
         decision_function_shape="ovo",
@@ -287,6 +307,10 @@ class SVC(SVMBase, ClassifierMixin):
         self.random_state = random_state
         self.class_weight = class_weight
         self.decision_function_shape = decision_function_shape
+
+    @property
+    def _effective_probability(self):
+        return False if self.probability == "deprecated" else self.probability
 
     @property
     @reflect
@@ -326,6 +350,9 @@ class SVC(SVMBase, ClassifierMixin):
 
         params = self.get_params()
         decision_function_shape = params.pop("decision_function_shape")
+        # Pin the sentinel on inner clones so they don't re-fire the
+        # deprecation warning the outer fit already emitted.
+        params["probability"] = "deprecated"
         wrappers = {"ovo": OneVsOneClassifier, "ovr": OneVsRestClassifier}
         if (multiclass_cls := wrappers.get(decision_function_shape)) is None:
             raise ValueError(
@@ -375,7 +402,9 @@ class SVC(SVMBase, ClassifierMixin):
 
         params = {
             **self.get_params(),
-            "probability": False,
+            # Pin the sentinel so inner CalibratedClassifierCV folds don't
+            # re-fire the deprecation warning the outer fit already emitted.
+            "probability": "deprecated",
             "output_type": "numpy",
             "class_weight": None,
         }
@@ -433,6 +462,16 @@ class SVC(SVMBase, ClassifierMixin):
         Fit the model with X and y.
 
         """
+        if self.probability != "deprecated":
+            warnings.warn(
+                "The `probability` parameter is deprecated and will be "
+                "removed in cuML version 26.10. Use "
+                "`CalibratedClassifierCV(SVC(), ensemble=False)` from "
+                "`sklearn.calibration` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         if hasattr(self, "_multiclass"):
             del self._multiclass
 
@@ -476,7 +515,7 @@ class SVC(SVMBase, ClassifierMixin):
             balanced_with_sample_weight=False,
         )
 
-        if self.probability:
+        if self._effective_probability:
             return self._fit_proba(X, y, sample_weight)
 
         if len(classes) > 2:
@@ -507,7 +546,7 @@ class SVC(SVMBase, ClassifierMixin):
             inds = self._multiclass.predict(X)
             index = inds.index
             inds = inds.to_output("cupy")
-        elif self.probability:
+        elif self._effective_probability:
             probs = self.predict_proba(X)
             index = probs.index
             inds = cp.argmax(probs.to_output("cupy"), axis=1)
@@ -522,7 +561,7 @@ class SVC(SVMBase, ClassifierMixin):
             inds, self.classes_, output_type=output_type, index=index
         )
 
-    @available_if(lambda self: self.probability)
+    @available_if(lambda self: self._effective_probability)
     @generate_docstring(
         skip_parameters_heading=True,
         return_values={
@@ -584,7 +623,7 @@ class SVC(SVMBase, ClassifierMixin):
 
         return CumlArray(data=proba, index=index)
 
-    @available_if(lambda self: self.probability)
+    @available_if(lambda self: self._effective_probability)
     @generate_docstring(
         return_values={
             "name": "preds",

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -398,7 +398,6 @@ class SVC(SVMBase, ClassifierMixin):
 
         params = {
             **self.get_params(),
-            # Pin the sentinel (see _fit_multiclass) for the inner folds.
             "probability": "deprecated",
             "output_type": "numpy",
             "class_weight": None,

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -267,12 +267,10 @@ class SVMBase(Base,
             "_probA": self._probA,
             "_probB": self._probB,
             "_sparse": self._sparse,
-            # sklearn >= 1.9 added a private fitted attribute that libsvm-facing
-            # code reads during predict (see sklearn PR #32050). It is set during
-            # fit(), so we have to set it ourselves. Harmless on older sklearn
-            # (no code reads it). cuml.SVR has no `probability` attribute;
-            # default to False to match sklearn.
-            "_effective_probability": getattr(self, "probability", False),
+            # sklearn >= 1.9 reads this private attribute during predict
+            # (sklearn PR #32050); harmless on older sklearn (no code reads it).
+            # SVR has no `probability`, so default to False.
+            "_effective_probability": getattr(self, "_effective_probability", False),
             **super()._attrs_to_cpu(model),
         }
 

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -268,8 +268,7 @@ class SVMBase(Base,
             "_probB": self._probB,
             "_sparse": self._sparse,
             # sklearn >= 1.9 reads this private attribute during predict
-            # (sklearn PR #32050); harmless on older sklearn (no code reads it).
-            # SVR has no `probability`, so default to False.
+            # (sklearn PR #32050); harmless on older sklearn.
             "_effective_probability": getattr(self, "_effective_probability", False),
             **super()._attrs_to_cpu(model),
         }

--- a/python/cuml/cuml_accel_tests/integration/test_svc.py
+++ b/python/cuml/cuml_accel_tests/integration/test_svc.py
@@ -42,7 +42,7 @@ def test_svc(binary):
     "ignore:Attribute `prob[AB]_` was deprecated:FutureWarning"
 )
 @pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
+    "ignore:The `probability` parameter (is|was) deprecated:FutureWarning"
 )
 def test_svc_probability(binary):
     X, y = binary

--- a/python/cuml/cuml_accel_tests/integration/test_svc.py
+++ b/python/cuml/cuml_accel_tests/integration/test_svc.py
@@ -38,13 +38,16 @@ def test_svc(binary):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter was deprecated:FutureWarning"
-)
-@pytest.mark.filterwarnings(
     "ignore:Attribute `prob[AB]_` was deprecated:FutureWarning"
+# TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC.
+@pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
 )
 def test_svc_probability(binary):
     X, y = binary
+    # cuml.accel no longer accelerates `probability=True`; this fit falls
+    # back to native sklearn `SVC(probability=True)`. predict_proba still
+    # works through the native path.
     svc = SVC(probability=True).fit(X, y)
     # Inference and score works
     assert svc.score(X, y) > 0.5

--- a/python/cuml/cuml_accel_tests/integration/test_svc.py
+++ b/python/cuml/cuml_accel_tests/integration/test_svc.py
@@ -37,9 +37,10 @@ def test_svc(binary):
     assert svc.score(X, y) > 0.5
 
 
+# TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(
     "ignore:Attribute `prob[AB]_` was deprecated:FutureWarning"
-# TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC.
+)
 @pytest.mark.filterwarnings(
     "ignore:The `probability` parameter is deprecated:FutureWarning"
 )

--- a/python/cuml/cuml_accel_tests/upstream/pytest.ini
+++ b/python/cuml/cuml_accel_tests/upstream/pytest.ini
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # pytest config to be used when running the upstream test suites.

--- a/python/cuml/cuml_accel_tests/upstream/pytest.ini
+++ b/python/cuml/cuml_accel_tests/upstream/pytest.ini
@@ -14,5 +14,9 @@ filterwarnings =
     error::cuml.accel.pytest_plugin.UnmatchedXfailTests
     # Error for FutureWarnings raised by cuml
     error::FutureWarning:cuml
+    # Suppress cuml's deprecation warning for sklearn upstream tests that
+    # legitimately use `probability=True`. Must come after the generic error
+    # rule (later filterwarnings entries take precedence). TODO(26.10): drop.
+    ignore:The `probability` parameter is deprecated:FutureWarning
     # Ignore unknown pytest marks, the xfail-list currently adds a bunch of these
     ignore::pytest.PytestUnknownMarkWarning

--- a/python/cuml/cuml_accel_tests/upstream/pytest.ini
+++ b/python/cuml/cuml_accel_tests/upstream/pytest.ini
@@ -16,7 +16,7 @@ filterwarnings =
     error::FutureWarning:cuml
     # Suppress cuml's deprecation warning for sklearn upstream tests that
     # legitimately use `probability=True`. Must come after the generic error
-    # rule (later filterwarnings entries take precedence). TODO(26.10): drop.
+    # rule (later filterwarnings entries take precedence). TODO(26.08): drop.
     ignore:The `probability` parameter is deprecated:FutureWarning
     # Ignore unknown pytest marks, the xfail-list currently adds a bunch of these
     ignore::pytest.PytestUnknownMarkWarning

--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -84,7 +84,7 @@ def test_exact_regression_datasets(exact_shap_regression_dataset, model):
             )
 
 
-# TODO(26.10): Remove this filter once `probability` is removed from cuml.svm.SVC.
+# TODO(26.08): Remove this filter once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(
     "ignore:The `probability` parameter is deprecated:FutureWarning"
 )

--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -84,6 +84,10 @@ def test_exact_regression_datasets(exact_shap_regression_dataset, model):
             )
 
 
+# TODO(26.10): Remove this filter once `probability` is removed from cuml.svm.SVC.
+@pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
+)
 def test_exact_classification_datasets(exact_shap_classification_dataset):
     X_train, X_test, y_train, y_test = exact_shap_classification_dataset
 

--- a/python/cuml/tests/explainer/test_explainer_permutation_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_permutation_shap.py
@@ -54,6 +54,10 @@ def test_regression_datasets(exact_shap_regression_dataset, model):
             ) <= 1e-5
 
 
+# TODO(26.10): Remove this filter once `probability` is removed from cuml.svm.SVC.
+@pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
+)
 def test_exact_classification_datasets(exact_shap_classification_dataset):
     X_train, X_test, y_train, y_test = exact_shap_classification_dataset
 

--- a/python/cuml/tests/explainer/test_explainer_permutation_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_permutation_shap.py
@@ -54,7 +54,7 @@ def test_regression_datasets(exact_shap_regression_dataset, model):
             ) <= 1e-5
 
 
-# TODO(26.10): Remove this filter once `probability` is removed from cuml.svm.SVC.
+# TODO(26.08): Remove this filter once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(
     "ignore:The `probability` parameter is deprecated:FutureWarning"
 )

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -343,6 +343,10 @@ def test_regressor_predict_dtype(cls):
 )
 # TODO(26.08) Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
+# TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC.
+@pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
+)
 @pytest.mark.parametrize(
     "target_kind", ["binary", "multiclass", "multitarget"]
 )

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -343,7 +343,7 @@ def test_regressor_predict_dtype(cls):
 )
 # TODO(26.08) Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
-# TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC.
+# TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(
     "ignore:The `probability` parameter is deprecated:FutureWarning"
 )

--- a/python/cuml/tests/test_linear_svm.py
+++ b/python/cuml/tests/test_linear_svm.py
@@ -214,6 +214,10 @@ def test_linear_svc_decision_function(
 
 @pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.parametrize("n_classes", [2, 3, 5])
+# TODO(26.10): Remove once `probability` is removed from cuml.svm.LinearSVC.
+@pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
+)
 def test_linear_svc_predict_proba(fit_intercept, n_classes):
     n_rows, n_cols = 500, 20
     X_train, X_test, y_train, y_test = make_classification_dataset(

--- a/python/cuml/tests/test_linear_svm.py
+++ b/python/cuml/tests/test_linear_svm.py
@@ -214,7 +214,7 @@ def test_linear_svc_decision_function(
 
 @pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.parametrize("n_classes", [2, 3, 5])
-# TODO(26.10): Remove once `probability` is removed from cuml.svm.LinearSVC.
+# TODO(26.08): Remove once `probability` is removed from cuml.svm.LinearSVC.
 @pytest.mark.filterwarnings(
     "ignore:The `probability` parameter is deprecated:FutureWarning"
 )

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -30,7 +30,7 @@ from cuml.testing.utils import (
 from cuml.tsa.arima import ARIMA
 
 pytestmark = [
-    # TODO(26.08) Remove this filter
+    # TODO(26.08): Remove this filter
     pytest.mark.filterwarnings(
         "ignore:The default value of 'max_depth':FutureWarning"
     ),

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -29,10 +29,16 @@ from cuml.testing.utils import (
 )
 from cuml.tsa.arima import ARIMA
 
-# TODO(26.08) Remove this filter
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of 'max_depth':FutureWarning"
-)
+pytestmark = [
+    # TODO(26.08) Remove this filter
+    pytest.mark.filterwarnings(
+        "ignore:The default value of 'max_depth':FutureWarning"
+    ),
+    # TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
+    pytest.mark.filterwarnings(
+        "ignore:The `probability` parameter is deprecated:FutureWarning"
+    ),
+]
 regression_config = ClassEnumerator(module=cuml.linear_model)
 regression_models = regression_config.get_models()
 

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -34,7 +34,7 @@ pytestmark = [
     pytest.mark.filterwarnings(
         "ignore:The default value of 'max_depth':FutureWarning"
     ),
-    # TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
+    # TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
     pytest.mark.filterwarnings(
         "ignore:The `probability` parameter is deprecated:FutureWarning"
     ),

--- a/python/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/tests/test_sklearn_import_export.py
@@ -376,8 +376,9 @@ def test_svr(random_state, sparse, kernel):
         )
 
 
+# TODO(26.10): Remove this filter once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter was deprecated:FutureWarning"
+    "ignore:The `probability` parameter (is|was) deprecated:FutureWarning"
 )
 @pytest.mark.filterwarnings(
     "ignore:Attribute `prob[AB]_` was deprecated:FutureWarning"
@@ -396,47 +397,62 @@ def test_svc(random_state, sparse, probability, kernel):
             )
         K = X @ X.T  # Linear kernel matrix
         original = cuml.SVC(kernel="precomputed")
-        assert_estimator_roundtrip(original, sklearn.svm.SVC, K, y)
+        assert_estimator_roundtrip(
+            original,
+            sklearn.svm.SVC,
+            K,
+            y,
+            exclude_params=["probability"],
+        )
     else:
         if sparse:
             X = scipy.sparse.coo_matrix(X)
         original = cuml.SVC()
-        assert_estimator_roundtrip(original, sklearn.svm.SVC, X, y)
+        assert_estimator_roundtrip(
+            original,
+            sklearn.svm.SVC,
+            X,
+            y,
+            exclude_params=["probability"],
+        )
 
         # Check inference works after conversion. sklearn 1.9 deprecated the
         # `probability` parameter; avoid passing it on the sklearn side when
         # False (the default) to avoid the FutureWarning.
         cu_model = cuml.SVC(probability=probability).fit(X, y)
-        if probability:
-            sk_model = sklearn.svm.SVC(probability=True).fit(X, y)
-        else:
-            sk_model = sklearn.svm.SVC().fit(X, y)
-
-        cu_model2 = cuml.SVC.from_sklearn(sk_model)
         sk_model2 = cu_model.as_sklearn()
-
-        cu_score = cu_model2.score(X, y)
-        assert cu_score > 0.7
-
         sk_score = sk_model2.score(X, y)
         assert sk_score > 0.7
 
         if probability:
-            # Check that predict_proba works
-            cu_pred_prob = cu_model2.predict_proba(X).argmax(axis=1)
-            assert accuracy_score(cu_pred_prob, y) > 0.7
+            # `cuml.SVC.from_sklearn` rejects probability=True so cuml.accel
+            # falls back to native sklearn for calibrated SVC.
+            sk_model = sklearn.svm.SVC(probability=True).fit(X, y)
+            with pytest.raises(
+                UnsupportedOnGPU,
+                match=r"`probability=True` is not supported",
+            ):
+                cuml.SVC.from_sklearn(sk_model)
+
+            # The cuml-direct path (used here via cu_model.as_sklearn()) still
+            # wires up probA_ / probB_ for predict_proba on the sklearn side.
             sk_pred_prob = sk_model2.predict_proba(X).argmax(axis=1)
             assert accuracy_score(sk_pred_prob, y) > 0.7
 
-            # Check that probA_, probB_ are wired up properly
             for attr in ["probA_", "probB_"]:
                 val = getattr(sk_model2, attr)
                 assert isinstance(val, np.ndarray)
                 assert val.dtype == "float64"
                 assert val.shape == (1,)
+        else:
+            sk_model = sklearn.svm.SVC().fit(X, y)
+            cu_model2 = cuml.SVC.from_sklearn(sk_model)
 
-        # Check n_support_ is correctly set
-        assert cu_model2.n_support_ == cu_model2.support_vectors_.shape[0]
+            cu_score = cu_model2.score(X, y)
+            assert cu_score > 0.7
+
+            # Check n_support_ is correctly set
+            assert cu_model2.n_support_ == cu_model2.support_vectors_.shape[0]
 
 
 @pytest.mark.parametrize("kind", ["SVC", "SVR"])

--- a/python/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/tests/test_sklearn_import_export.py
@@ -376,7 +376,7 @@ def test_svr(random_state, sparse, kernel):
         )
 
 
-# TODO(26.10): Remove this filter once `probability` is removed from cuml.svm.SVC.
+# TODO(26.08): Remove this filter once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(
     "ignore:The `probability` parameter (is|was) deprecated:FutureWarning"
 )

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -40,7 +40,7 @@ from cuml.testing.utils import (
 
 # Many tests below pass `probability=` to cuml SVC/LinearSVC on purpose;
 # silence the FutureWarning module-wide.
-# TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
+# TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The `probability` parameter is deprecated:FutureWarning"
 )

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import platform
+import warnings
 
 import cudf
 import cupy as cp
@@ -35,6 +36,13 @@ from cuml.testing.utils import (
     stress_param,
     svm_array_equal,
     unit_param,
+)
+
+# Many tests below pass `probability=` to cuml SVC/LinearSVC on purpose;
+# silence the FutureWarning module-wide.
+# TODO(26.10): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
 )
 
 IS_ARM = platform.processor() == "aarch64"
@@ -643,6 +651,122 @@ def test_svc_probability_n_iter():
     model = cuml.SVC(probability=True).fit(X, y)
     assert model.n_iter_.dtype == np.int32
     assert model.n_iter_.shape == (1,)
+
+
+@pytest.mark.parametrize("explicit_value", [True, False])
+def test_svc_probability_emits_future_warning(explicit_value):
+    # cuml-side half of #7982.
+    X, y = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with pytest.warns(
+        FutureWarning,
+        match=r"The `probability` parameter is deprecated",
+    ):
+        cu_svm.SVC(probability=explicit_value).fit(X, y)
+
+
+def test_svc_default_does_not_emit_probability_warning():
+    # If the user does not pass `probability=`, no FutureWarning should fire.
+    # The default sentinel string `"deprecated"` is treated as `probability=False`.
+    X, y = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r"The `probability` parameter is deprecated",
+            category=FutureWarning,
+        )
+        cu_svm.SVC().fit(X, y)
+
+
+@pytest.mark.parametrize("explicit_value", [True, False])
+def test_linear_svc_probability_emits_future_warning(explicit_value):
+    X, y = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with pytest.warns(
+        FutureWarning,
+        match=r"The `probability` parameter is deprecated",
+    ):
+        cu_svm.LinearSVC(probability=explicit_value).fit(X, y)
+
+
+def test_linear_svc_default_does_not_emit_probability_warning():
+    X, y = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r"The `probability` parameter is deprecated",
+            category=FutureWarning,
+        )
+        cu_svm.LinearSVC().fit(X, y)
+
+
+def test_svc_probability_warning_fires_once():
+    # Inner clones (CalibratedClassifierCV folds, multiclass binaries) pin
+    # the sentinel so the FutureWarning fires only on the outer fit, not
+    # per inner fit.
+    X_bin, y_bin = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cu_svm.SVC(probability=True).fit(X_bin, y_bin)
+    matched = [
+        w
+        for w in caught
+        if issubclass(w.category, FutureWarning)
+        and "The `probability` parameter is deprecated" in str(w.message)
+    ]
+    assert len(matched) == 1
+
+    X_mc, y_mc = make_classification(
+        n_samples=60,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=3,
+        random_state=0,
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cu_svm.SVC(probability=False).fit(X_mc, y_mc)
+    matched = [
+        w
+        for w in caught
+        if issubclass(w.category, FutureWarning)
+        and "The `probability` parameter is deprecated" in str(w.message)
+    ]
+    assert len(matched) == 1
 
 
 # Tests for kernel='precomputed'

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -666,7 +666,10 @@ def test_svc_probability_emits_future_warning(explicit_value):
     )
     with pytest.warns(
         FutureWarning,
-        match=r"The `probability` parameter is deprecated",
+        match=(
+            r"The `probability` parameter is deprecated and will be "
+            r"removed in cuML"
+        ),
     ):
         cu_svm.SVC(probability=explicit_value).fit(X, y)
 
@@ -685,7 +688,10 @@ def test_svc_default_does_not_emit_probability_warning():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "error",
-            message=r"The `probability` parameter is deprecated",
+            message=(
+                r"The `probability` parameter is deprecated and will "
+                r"be removed in cuML"
+            ),
             category=FutureWarning,
         )
         cu_svm.SVC().fit(X, y)
@@ -703,7 +709,10 @@ def test_linear_svc_probability_emits_future_warning(explicit_value):
     )
     with pytest.warns(
         FutureWarning,
-        match=r"The `probability` parameter is deprecated",
+        match=(
+            r"The `probability` parameter is deprecated and will be "
+            r"removed in cuML"
+        ),
     ):
         cu_svm.LinearSVC(probability=explicit_value).fit(X, y)
 
@@ -720,7 +729,10 @@ def test_linear_svc_default_does_not_emit_probability_warning():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "error",
-            message=r"The `probability` parameter is deprecated",
+            message=(
+                r"The `probability` parameter is deprecated and will "
+                r"be removed in cuML"
+            ),
             category=FutureWarning,
         )
         cu_svm.LinearSVC().fit(X, y)
@@ -745,7 +757,7 @@ def test_svc_probability_warning_fires_once():
         w
         for w in caught
         if issubclass(w.category, FutureWarning)
-        and "The `probability` parameter is deprecated" in str(w.message)
+        and "is deprecated and will be removed in cuML" in str(w.message)
     ]
     assert len(matched) == 1
 
@@ -764,7 +776,7 @@ def test_svc_probability_warning_fires_once():
         w
         for w in caught
         if issubclass(w.category, FutureWarning)
-        and "The `probability` parameter is deprecated" in str(w.message)
+        and "is deprecated and will be removed in cuML" in str(w.message)
     ]
     assert len(matched) == 1
 


### PR DESCRIPTION
Closes #7982

Mirrors sklearn PR #32050 on cuml.SVC and cuml.LinearSVC. Sentinel + _effective_X property pattern, same as PR #7958. FutureWarning fires from fit when the user passes an explicit value.

Also fixes a latent bug in the accel proxy where _gpu_fit was reading self.probability truthily. Default SVC() on small data would have routed through the probability code path since the sentinel string is truthy.