### PR TITLE
Fix Validate FIL output dtype and memory order

### DIFF
--- a/python/cuml/cuml/fil/fil.pyx
+++ b/python/cuml/cuml/fil/fil.pyx
@@ -255,6 +255,7 @@ cdef class ForestInference_impl():
 
     def _predict(self, X, *, predict_type="default", preds=None, chunk_size=None):
         model_dtype = self.get_dtype()
+        expected_dtype = np.dtype(model_dtype)
         mem_type = GlobalSettings().fil_memory_type
 
         X, index = check_array(
@@ -298,9 +299,22 @@ cdef class ForestInference_impl():
                 mem_type=mem_type,
             )
         else:
-            # TODO(wphicks): Handle incorrect dtype/device/layout in C++
+            preds = CumlArray.from_input(
+                preds,
+                order="K",
+                convert_to_mem_type=False,
+                force_contiguous=False,
+            )
+            if preds.dtype != expected_dtype:
+                raise TypeError(
+                    f"preds dtype must be {expected_dtype}, got {preds.dtype}"
+                )
+            if preds.order != "C":
+                raise ValueError("preds must be C-contiguous")
+            if preds.mem_type is not mem_type:
+                raise TypeError(f"preds must use {mem_type.name} memory")
             if preds.shape != output_shape:
-                raise ValueError(f"If supplied, preds argument must have shape {output_shape}")
+                raise ValueError(f"preds shape must be {output_shape}, got {preds.shape}")
             preds.index = index
         cdef raft_proto_device_t out_dev
         out_dev = get_fil_raft_proto_device_type(preds)

--- a/python/cuml/tests/test_fil.py
+++ b/python/cuml/tests/test_fil.py
@@ -563,6 +563,33 @@ def test_output_args(train_device, infer_device, small_classifier_and_preds):
     np.testing.assert_almost_equal(fil_preds, xgb_preds)
 
 
+def test_invalid_preds_dtype_raises(small_classifier_and_preds):
+    with set_fil_device_type("cpu"):
+        model_path, model_type, X, _ = small_classifier_and_preds
+        fm = ForestInference.load(
+            model_path, is_classifier=True, model_type=model_type
+        )
+        expected_preds = np.asarray(fm.predict_proba(X))
+        wrong_dtype = np.float64 if expected_preds.dtype == np.float32 else np.float32
+        preds = np.empty(expected_preds.shape, dtype=wrong_dtype, order="C")
+
+        with pytest.raises(TypeError, match="preds dtype must be"):
+            fm.predict_proba(X, preds=preds)
+
+
+def test_invalid_preds_order_raises(small_classifier_and_preds):
+    with set_fil_device_type("cpu"):
+        model_path, model_type, X, _ = small_classifier_and_preds
+        fm = ForestInference.load(
+            model_path, is_classifier=True, model_type=model_type
+        )
+        expected_preds = np.asarray(fm.predict_per_tree(X))
+        preds = np.empty(expected_preds.shape, dtype=expected_preds.dtype, order="F")
+
+        with pytest.raises(ValueError, match="preds must be C-contiguous"):
+            fm.predict_per_tree(X, preds=preds)
+
+
 def to_categorical(features, n_categorical, invalid_frac, random_state):
     """returns data in two formats: pandas (for LightGBM) and numpy (for FIL)
     LightGBM needs a DataFrame to recognize and fit on categorical columns.


### PR DESCRIPTION
## Motivation

ForestInference allows callers to pass a buffer for outputs. Before this change, validation only enforced shape, so incompatible inputs (dtype, layout, or memory placement) could fail later with less actionable errors.

This PR adds explicit validation so that they fail early with clear
messages.

## What changed

**- python/cuml/cuml/fil/fil.pyx:**
  - validate user provided preds dtype against model dtype
  - validate preds is C contiguous
  - validate preds  memory type matches FIL mode
  - retain shape validation with clearer message

**- python/cuml/tests/test_fil.py:**
  - add: **test_invalid_preds_dtype_raises**
  - add: **test_invalid_preds_order_raises**

## Validation

- py -m pytest python/cuml/tests/test_fil.py -k "invalid_preds_dtype or invalid_preds_order" -q -rs`:
  - 4 passed
- py -m pytest python/cuml/tests/test_fil.py -k "output_args" -q:
  - 8 passed

## Breaking change

No. / N/A. This is a bug fix that improves error handling. 