### PR TITLE
Suppress intentional hardcoded version references

### DIFF
--- a/python/cuml/cuml/dask/ensemble/base.py
+++ b/python/cuml/cuml/dask/ensemble/base.py
@@ -46,6 +46,7 @@ class BaseRandomForestModel(object):
             )
         self.workers = workers
         self._set_internal_model(None)
+        # rapids-pre-commit-hooks: disable-next-line
         # TODO(26.08): Drop along with the single-GPU deprecation in
         # cuml.ensemble.randomforest_common.
         # Record whether the user explicitly set `max_depth`; the warning is
@@ -100,11 +101,13 @@ class BaseRandomForestModel(object):
         return n_estimators_per_worker
 
     def _fit(self, model, dataset, convert_dtype, broadcast_data):
+        # rapids-pre-commit-hooks: disable-next-line
         # TODO(26.08): Drop along with the single-GPU deprecation in
         # cuml.ensemble.randomforest_common.
         if not getattr(self, "_max_depth_user_set", True):
             warnings.warn(
                 "The default value of 'max_depth' will change from 16 to "
+                # rapids-pre-commit-hooks: disable-next-line
                 "None (unlimited depth) in release 26.08. To suppress this "
                 "warning, set 'max_depth' explicitly.",
                 FutureWarning,
@@ -252,6 +255,7 @@ class BaseRandomForestModel(object):
         return params_of_each_model
 
     def _set_params(self, **params):
+        # rapids-pre-commit-hooks: disable-next-line
         # TODO(26.08): Drop along with the single-GPU deprecation in
         # cuml.ensemble.randomforest_common.
         if "max_depth" in params:

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -75,6 +75,7 @@ class RandomForestClassifier(
         .. note:: This default differs from scikit-learn's
           random forest, which defaults to unlimited depth.
 
+        .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
           The default of `max_depth` will change from `16` to `None`.
     max_leaves : int (default = -1)

--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -65,6 +65,7 @@ class RandomForestRegressor(
         .. note:: This default differs from scikit-learn's
           random forest, which defaults to unlimited depth.
 
+        .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
           The default of `max_depth` will change from `16` to `None`.
     max_leaves : int (default = -1)

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -428,6 +428,7 @@ class BaseRandomForestModel(Base, InteropMixin):
         if max_depth == _DEPRECATED_MAX_DEPTH_DEFAULT:
             warnings.warn(
                 "The default value of 'max_depth' will change from 16 to "
+                # rapids-pre-commit-hooks: disable-next-line
                 "None (unlimited depth) in release 26.08. To suppress this "
                 "warning, set 'max_depth' explicitly.",
                 FutureWarning, stacklevel=3)

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -74,6 +74,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         .. note:: This default differs from scikit-learn's random forest,
           which defaults to unlimited depth.
 
+        .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
           The default of `max_depth` will change from `16` to `None`.
     max_leaves : int (default = -1)

--- a/python/cuml/cuml/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/ensemble/randomforestregressor.py
@@ -69,6 +69,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         .. note:: This default differs from scikit-learn's random forest,
           which defaults to unlimited depth.
 
+        .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
           The default of `max_depth` will change from `16` to `None`.
     max_leaves : int (default = -1)

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -24,6 +24,7 @@ from cuml.dask.ensemble import RandomForestRegressor as cuRFR_mg
 from cuml.ensemble import RandomForestClassifier as cuRFC_sg
 from cuml.ensemble import RandomForestRegressor as cuRFR_sg
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/explainer/test_explainer_common.py
+++ b/python/cuml/tests/explainer/test_explainer_common.py
@@ -21,6 +21,7 @@ from cuml.explainer.common import (
 )
 from cuml.testing.utils import ClassEnumerator
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08) Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -20,6 +20,7 @@ from cuml import KernelExplainer, Lasso
 from cuml.testing.datasets import with_dtype
 from cuml.testing.utils import ClassEnumerator, get_shap_values
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -28,6 +28,7 @@ from cuml.testing.utils import as_type
 shap = pytest.importorskip("shap")
 
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"
@@ -929,6 +930,7 @@ def check_efficiency_interactions(expected_value, pred, shap_values):
             )
 
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Can inline this back within the `example` call
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore")

--- a/python/cuml/tests/test_api.py
+++ b/python/cuml/tests/test_api.py
@@ -197,6 +197,7 @@ def test_mro(model):
 @pytest.mark.parametrize("model_name", list(models.keys()))
 # ignore random forest float64 warnings and max_depth deprecation
 @pytest.mark.filterwarnings("ignore:To use pickling or GPU-based")
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_fit_function(dataset, model_name):

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -110,6 +110,7 @@ def test_base_subclass_init_matches_docs(child_class: str):
 @pytest.mark.parametrize("child_class", list(all_base_children.keys()))
 # ignore ColumnTransformer init warning and max_depth deprecation
 @pytest.mark.filterwarnings("ignore:Transformers are required")
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08) Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 @pytest.mark.filterwarnings("ignore::FutureWarning")
@@ -231,6 +232,7 @@ def test_common_signatures(cls, method):
             first = ["self", "X", "y"]
         if "sample_weight" in sig.parameters:
             first.append("sample_weight")
+            # rapids-pre-commit-hooks: disable-next-line
             # TODO(26.08): remove "deprecated"
             assert sig.parameters["sample_weight"].default in (
                 None,
@@ -300,6 +302,7 @@ def test_get_handle_device_ids():
         and hasattr(cls, "predict")
     ],
 )
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08) Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_regressor_predict_dtype(cls):
@@ -341,6 +344,7 @@ def test_regressor_predict_dtype(cls):
         (cuml.naive_bayes.MultinomialNB, None),
     ],
 )
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08) Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 @pytest.mark.parametrize(

--- a/python/cuml/tests/test_common.py
+++ b/python/cuml/tests/test_common.py
@@ -20,6 +20,7 @@ from cuml.datasets import make_blobs
     ],
 )
 @pytest.mark.filterwarnings("ignore:The number of bins.*:UserWarning")
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08) Remove this filter
 @pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_random_state_argument(Estimator):

--- a/python/cuml/tests/test_fil.py
+++ b/python/cuml/tests/test_fil.py
@@ -42,6 +42,7 @@ from cuml.testing.utils import (  # noqa: E402
     unit_param,
 )
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/test_meta_estimators.py
+++ b/python/cuml/tests/test_meta_estimators.py
@@ -15,6 +15,7 @@ from cuml.preprocessing import StandardScaler
 from cuml.svm import SVC
 from cuml.testing.utils import ClassEnumerator
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -29,6 +29,7 @@ from cuml.testing.utils import (
 )
 from cuml.tsa.arima import ARIMA
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08) Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -36,6 +36,7 @@ from cuml.ensemble.randomforest_common import compute_max_features
 from cuml.metrics import r2_score
 from cuml.testing.utils import quality_param, stress_param, unit_param
 
+# rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove this filter
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value of 'max_depth':FutureWarning"

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -80,6 +80,7 @@ ESTIMATORS = [
     ElasticNet(),
     Lasso(),
     LinearRegression(),
+    # rapids-pre-commit-hooks: disable-next-line
     # TODO(26.08): Remove explicit default
     RandomForestClassifier(max_depth=None),
     RandomForestRegressor(max_depth=None),


### PR DESCRIPTION
Adds explicit `verify-hardcoded-version` suppressions for intentional `26.08` deprecation, docstring, and TODO references so the all-files pre-commit check passes after the version update.
