### PR TITLE
Numpy 1.x compatibility fixes

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -47,7 +47,7 @@ dependencies:
 - nltk
 - numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23,<3.0
+- numpy>=1.26,<3.0
 - numpydoc
 - numpydoc<1.9
 - nvidia-ml-py>=12

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - nltk
 - numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23,<3.0
+- numpy>=1.26,<3.0
 - numpydoc
 - numpydoc<1.9
 - nvidia-ml-py>=12

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -47,7 +47,7 @@ dependencies:
 - nltk
 - numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23,<3.0
+- numpy>=1.26,<3.0
 - numpydoc
 - numpydoc<1.9
 - nvidia-ml-py>=12

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -46,7 +46,7 @@ dependencies:
 - nltk
 - numba-cuda>=0.22.2,<0.29.0
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23,<3.0
+- numpy>=1.26,<3.0
 - numpydoc
 - numpydoc<1.9
 - nvidia-ml-py>=12

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -100,7 +100,7 @@ requirements:
     - libcuml =${{ version }}
     - numba >=0.60.0,<0.65.0
     - numba-cuda >=0.22.2,<0.29.0
-    - numpy >=1.23,<3.0
+    - numpy >=1.26,<3.0
     - scikit-learn >=1.4
     - scipy >=1.14.0
     - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -538,7 +538,6 @@ dependencies:
               - umap-learn==0.5.8
               - ipython==8.10.0
               - hdbscan==0.8.41
-              - numpy==2.0
           - matrix: {dependencies: "nightly"}
             packages:
               # Pre-release specifier tells pip to accept dev/alpha/beta versions

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -323,7 +323,7 @@ dependencies:
         packages:
           - joblib>=0.11
           - numba>=0.60.0,<0.65.0
-          - &numpy numpy>=1.23,<3.0
+          - &numpy numpy>=1.26,<3.0
           - scipy>=1.14.0
           - packaging
           - rich
@@ -530,12 +530,15 @@ dependencies:
               - scikit-learn==1.5.0
               - umap-learn==0.5.7
               - hdbscan==0.8.39
+              - numpy==1.26
+              - cupy==13.6
           - matrix: {dependencies: "intermediate"}
             packages:
               - scikit-learn==1.7.2
               - umap-learn==0.5.8
               - ipython==8.10.0
               - hdbscan==0.8.41
+              - numpy==2.0
           - matrix: {dependencies: "nightly"}
             packages:
               # Pre-release specifier tells pip to accept dev/alpha/beta versions

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -531,7 +531,6 @@ dependencies:
               - umap-learn==0.5.7
               - hdbscan==0.8.39
               - numpy==1.26
-              - cupy==13.6
           - matrix: {dependencies: "intermediate"}
             packages:
               - scikit-learn==1.7.2

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -351,7 +351,7 @@ def check_all_finite(array, *, allow_nan=False, input_name=None) -> None:
     input_name : str or None, default=None
         The input parameter name to use in error messages.
     """
-    if not np.isdtype(array.dtype, "real floating"):
+    if not array.dtype.kind == "f":
         # No-op for non floating inputs
         return
 
@@ -484,6 +484,20 @@ def _index_as_mem_type(index, mem_type=None):
     return index
 
 
+if np.__version__.startswith("1."):
+
+    def np_asarray(x, dtype=None, order=None, copy=None):
+        """A compatibility shim for `np.asarray`.
+
+        numpy 2.0 added the `copy` arg to `np.asarray`, as well as changed the
+        meaning of copy=False to "error if a copy required" rather than "only
+        copy if needed" (which is now `copy=None`)."""
+        return np.array(x, dtype=dtype, order=order, copy=bool(copy))
+
+else:
+    np_asarray = np.asarray
+
+
 def check_array(
     array,
     *,
@@ -600,7 +614,7 @@ def check_array(
     # Infer proper output dtype
     if array_dtype is not None:
         # Check for complex inputs before conversion when possible
-        if np.isdtype(array_dtype, "complex floating"):
+        if array_dtype.kind == "c":
             raise ValueError("Complex data not supported")
         if dtype is None:
             dtype = array_dtype
@@ -703,7 +717,7 @@ def check_array(
             elif (
                 mem_type is None
                 and cudf.pandas.LOADED
-                and np.isdtype(array.dtype, ("numeric", "bool"))
+                and array.dtype.kind in "iufb"
             ):
                 # We treat pandas objects with supported dtypes as device
                 # memory when running under cudf.pandas. Note that the output
@@ -732,8 +746,7 @@ def check_array(
                     array, dtype=dtype, order=order, copy=(copy or None)
                 )
             else:
-                # XXX: using np.array for compat with numpy < 2
-                array = np.array(
+                array = np_asarray(
                     array, dtype=dtype, order=order, copy=(copy or None)
                 )
 
@@ -761,7 +774,7 @@ def check_array(
         )
 
     # Check for complex inputs after conversion for cases when `dtype=None`
-    if np.isdtype(array.dtype, "complex floating"):
+    if array.dtype.kind == "c":
         raise ValueError("Complex data not supported")
 
     # Validate data meets expected value requirements
@@ -1052,10 +1065,7 @@ def check_y(
                 input_dtype = y.dtype
             if mem_type is None:
                 mem_type = "host" if isinstance(y, np.ndarray) else "device"
-            if (
-                np.isdtype(y.dtype, ("numeric", "bool"))
-                and return_classes is True
-            ):
+            if y.dtype.kind in "iufb" and return_classes is True:
                 y = cp.asarray(y)
             elif (
                 y.dtype == "object"

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -494,7 +494,7 @@ else:
         numpy 2.0 added the `copy` arg to `np.asarray`, as well as changed the
         meaning of copy=False to "error if a copy required" rather than "only
         copy if needed" (which is now `copy=None`)."""
-        return np.array(x, dtype=dtype, order=order, copy=bool(copy))
+        return np.array(x, dtype=dtype, order=order or "K", copy=bool(copy))
 
 
 def check_array(

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -484,7 +484,9 @@ def _index_as_mem_type(index, mem_type=None):
     return index
 
 
-if np.__version__.startswith("1."):
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
+    np_asarray = np.asarray
+else:
 
     def np_asarray(x, dtype=None, order=None, copy=None):
         """A compatibility shim for `np.asarray`.
@@ -493,9 +495,6 @@ if np.__version__.startswith("1."):
         meaning of copy=False to "error if a copy required" rather than "only
         copy if needed" (which is now `copy=None`)."""
         return np.array(x, dtype=dtype, order=order, copy=bool(copy))
-
-else:
-    np_asarray = np.asarray
 
 
 def check_array(

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -241,7 +241,7 @@ class LinearRegression(Base,
         )
 
         # All libcuml solvers require F-ordered X, and mutate the inputs.
-        X = cp.asarray(X, order="F", copy=None if may_mutate_X else True)
+        X = cp.array(X, order="F", copy=None if may_mutate_X else True)
         if not may_mutate_y:
             y = y.copy()
         if sample_weight is not None and not may_mutate_sample_weight:

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -285,7 +285,7 @@ class Ridge(Base,
         # The `eig` solver requires X be F-contiguous. Additionally, all inputs
         # are mutated when weighted or `fit_intercept=True`.
         mutates = self.fit_intercept or sample_weight is not None
-        X = cp.asarray(X, order="F", copy=True if mutates and not may_mutate_X else None)
+        X = cp.array(X, order="F", copy=True if mutates and not may_mutate_X else None)
         if mutates and not may_mutate_y:
             y = y.copy()
         if sample_weight is not None and mutates and not may_mutate_sample_weight:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
     "libcuml==26.6.*,>=0.0.0a0",
     "numba-cuda>=0.22.2,<0.29.0",
     "numba>=0.60.0,<0.65.0",
-    "numpy>=1.23,<3.0",
+    "numpy>=1.26,<3.0",
     "nvidia-nvjitlink>=13.0,<14",
     "packaging",
     "pylibraft==26.6.*,>=0.0.0a0",

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -124,6 +124,9 @@ def count_categorical_split(tl_model):
 )
 def test_xgb_regressor(objective):
     xgb = pytest.importorskip("xgboost")
+    pytest.importorskip(
+        "numpy", minversion="2.0", reason="Test fails on numpy < 2"
+    )
 
     n_samples = 100
     X, y = make_regression(
@@ -197,6 +200,9 @@ def test_xgb_regressor(objective):
 )
 def test_xgb_classifier(objective, n_classes):
     xgb = pytest.importorskip("xgboost")
+    pytest.importorskip(
+        "numpy", minversion="2.0", reason="Test fails on numpy < 2"
+    )
 
     n_samples = 100
     X, y = make_classification(

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -841,8 +841,9 @@ def test_check_array_dataframe_mixed_dtypes(kind, mem_type):
     )
     # Non-numeric columns -> object dtype by default
     if is_cuda_output(mem_type, df):
-        # cupy doesn't support object dtypes
-        with pytest.raises((ValueError, TypeError), match="object"):
+        # cupy doesn't support object dtypes. We don't care what the exception
+        # is here, just that one is raised.
+        with pytest.raises(Exception, match="object"):
             check_array(df, mem_type=mem_type)
     else:
         # dtype=None does no conversion by default


### PR DESCRIPTION
This:

- Bumps our minimum supported `numpy` version to 1.26, to match that of `cudf`. Since `cudf` is a required dependency, we were effectively pinned at that already.
- Adds `numpy` to our oldest deps test runs. This also effectively adds `cupy==13.6`, since `cupy==14` requires `numpy>=2.0`. Explicitly specifying `cupy==13.6` in an oldest-deps run is tricky since the pypi packages require cuda suffixes as well. I'm skipping that for now.
- Fixes a few incompatibilities with numpy 1.x