### PR TITLE
Mark `test_precomputed_sparse_transform_on_iris` as flaky

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/umap/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/umap/xfail-list.yaml
@@ -37,6 +37,7 @@
   marker: cuml_accel_flaky
   strict: false
   tests:
+  - "umap.tests.test_umap_on_iris::test_precomputed_sparse_transform_on_iris"
   - "umap.tests.test_umap_on_iris::test_precomputed_transform_on_iris"
   - "umap.tests.test_umap_ops::test_umap_transform_embedding_stability"
 - reason: UMAP using removed numpy function `in1d`


### PR DESCRIPTION
The dense version is already marked as flaky, but I've now seen the sparse version fail twice.