### PR TITLE
RF: narrow `CountBin` to `double` for weighted-training prep

### DIFF
--- a/cpp/bench/sg/rf_classifier.cu
+++ b/cpp/bench/sg/rf_classifier.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -70,9 +70,6 @@ class RFClassifier : public BlobsFixture<D> {
 template <typename D>
 std::vector<Params> getInputs()
 {
-  struct Triplets {
-    int nrows, ncols, nclasses;
-  };
   std::vector<Params> out;
   Params p;
   p.data.rowMajor = false;
@@ -98,16 +95,28 @@ std::vector<Params> getInputs()
                        128                  /* max_batch_size */
   );
 
-  std::vector<Triplets> rowcols = {
-    {160000, 64, 2}, {640000, 64, 8}, {1184000, 968, 2},  // Mimicking Bosch dataset
+  struct Config {
+    int nrows, ncols, nclasses, max_n_bins;
+    ML::CRITERION criterion;
   };
-  for (auto& rc : rowcols) {
+  std::vector<Config> configs = {
+    {160000, 64, 2, 32, ML::CRITERION::GINI},
+    {640000, 64, 8, 32, ML::CRITERION::GINI},
+    {1184000, 968, 2, 32, ML::CRITERION::GINI},  // Mimicking Bosch dataset
+    // High class count (44) + large bins (128) stress the shared-memory histogram path.
+    {160000, 64, 44, 128, ML::CRITERION::GINI},
+    // Entropy variant exercises the entropy-{float,double}.cu instantiations.
+    {640000, 64, 8, 32, ML::CRITERION::ENTROPY},
+  };
+  for (auto& cfg : configs) {
     // Let's run Bosch only for float type
-    if (!std::is_same<D, float>::value && rc.ncols == 968) continue;
-    p.data.nrows                  = rc.nrows;
-    p.data.ncols                  = rc.ncols;
-    p.data.nclasses               = rc.nclasses;
-    p.rf.tree_params.max_features = 1.f / std::sqrt(float(rc.ncols));
+    if (!std::is_same<D, float>::value && cfg.ncols == 968) continue;
+    p.data.nrows                     = cfg.nrows;
+    p.data.ncols                     = cfg.ncols;
+    p.data.nclasses                  = cfg.nclasses;
+    p.rf.tree_params.max_n_bins      = cfg.max_n_bins;
+    p.rf.tree_params.split_criterion = cfg.criterion;
+    p.rf.tree_params.max_features    = 1.f / std::sqrt(float(cfg.ncols));
     for (auto max_depth : std::vector<int>({7, 9})) {
       p.rf.tree_params.max_depth = max_depth;
       out.push_back(p);

--- a/cpp/src/decisiontree/batched-levelalgo/bins.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/bins.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/src/decisiontree/batched-levelalgo/bins.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/bins.cuh
@@ -9,15 +9,17 @@ namespace ML {
 namespace DT {
 
 struct CountBin {
-  int x;
+  // double covers both the unweighted count path and the future weighted-count
+  // path with one bin type; 32-bit int would overflow on large weighted counts.
+  double x;
   CountBin(CountBin const&) = default;
-  HDI CountBin(int x_) : x(x_) {}
-  HDI CountBin() : x(0) {}
+  HDI CountBin(double x_) : x(x_) {}
+  HDI CountBin() : x(0.0) {}
 
   DI static void IncrementHistogram(CountBin* hist, int n_bins, int b, int label)
   {
     auto offset = label * n_bins + b;
-    CountBin::AtomicAdd(hist + offset, {1});
+    CountBin::AtomicAdd(hist + offset, {1.0});
   }
   DI static void AtomicAdd(CountBin* address, CountBin val) { atomicAdd(&address->x, val.x); }
   HDI CountBin& operator+=(const CountBin& b)

--- a/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -53,8 +53,8 @@ class GiniObjectiveFunction {
 
     for (IdxT j = 0; j < nclasses; ++j) {
       double val_i = 0.0;
-      auto lval_i = hist[n_bins * j + i].x;
-      auto lval   = DataT(lval_i);
+      auto lval_i  = hist[n_bins * j + i].x;
+      auto lval    = DataT(lval_i);
       gain += lval * invLeft * lval * invLen;
 
       val_i += lval_i;
@@ -131,7 +131,7 @@ class EntropyObjectiveFunction {
       auto invLen{DataT(1.0) / len};
       for (IdxT c = 0; c < nclasses; ++c) {
         double val_i = 0.0;
-        auto lval_i = hist[n_bins * c + i].x;
+        auto lval_i  = hist[n_bins * c + i].x;
         if (lval_i != 0) {
           auto lval = DataT(lval_i);
           gain += raft::log(lval * invLeft) / raft::log(DataT(2)) * lval * invLen;

--- a/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
@@ -52,7 +52,7 @@ class GiniObjectiveFunction {
       return -std::numeric_limits<DataT>::max();
 
     for (IdxT j = 0; j < nclasses; ++j) {
-      int val_i   = 0;
+      double val_i = 0.0;
       auto lval_i = hist[n_bins * j + i].x;
       auto lval   = DataT(lval_i);
       gain += lval * invLeft * lval * invLen;
@@ -86,7 +86,7 @@ class GiniObjectiveFunction {
   static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
   {
     // Output probability
-    int total = 0;
+    double total = 0.0;
     for (int i = 0; i < nclasses; i++) {
       total += shist[i].x;
     }
@@ -130,7 +130,7 @@ class EntropyObjectiveFunction {
       auto invRight{DataT(1.0) / nRight};
       auto invLen{DataT(1.0) / len};
       for (IdxT c = 0; c < nclasses; ++c) {
-        int val_i   = 0;
+        double val_i = 0.0;
         auto lval_i = hist[n_bins * c + i].x;
         if (lval_i != 0) {
           auto lval = DataT(lval_i);
@@ -171,7 +171,7 @@ class EntropyObjectiveFunction {
   static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
   {
     // Output probability
-    int total = 0;
+    double total = 0.0;
     for (int i = 0; i < nclasses; i++) {
       total += shist[i].x;
     }

--- a/cpp/tests/sg/rf_test.cu
+++ b/cpp/tests/sg/rf_test.cu
@@ -1297,7 +1297,7 @@ class ObjectiveTest : public ::testing::TestWithParam<ObjectiveTestParameters> {
     for (auto c = 0; c < params.n_classes; ++c) {
       if constexpr (std::is_same<BinT, CountBin>::value)  // countbin
       {
-        count += cdf_hist[params.max_n_bins * c + idx].x;
+        count += static_cast<IdxT>(cdf_hist[params.max_n_bins * c + idx].x);
       } else  // aggregatebin
       {
         count += cdf_hist[params.max_n_bins * c + idx].count;

--- a/python/cuml/cuml_accel_tests/test_onnx.py
+++ b/python/cuml/cuml_accel_tests/test_onnx.py
@@ -82,6 +82,7 @@ def regression_data():
 classifiers = [
     pytest.param(
         RandomForestClassifier(n_estimators=20, max_depth=8, random_state=42),
+        marks=xfail_skl2onnx_bug,
         id="RandomForestClassifier",
     ),
     pytest.param(KNeighborsClassifier(), id="KNeighborsClassifier"),

--- a/python/cuml/cuml_accel_tests/test_onnx.py
+++ b/python/cuml/cuml_accel_tests/test_onnx.py
@@ -82,7 +82,6 @@ def regression_data():
 classifiers = [
     pytest.param(
         RandomForestClassifier(n_estimators=20, max_depth=8, random_state=42),
-        marks=xfail_skl2onnx_bug,
         id="RandomForestClassifier",
     ),
     pytest.param(KNeighborsClassifier(), id="KNeighborsClassifier"),


### PR DESCRIPTION
Refs #8093. First of three PRs in the RF weighted-training series, force-pushed to replace the prior Design D float-bin commit per RAMitchell's review direction to use double rather than float (the original int32 had overflow concerns).

Widens `CountBin::x` from `int` to `double` so the remaining PRs (sample_weight, balanced_subsample, ExtraTrees) can share one unified bin type without a parallel weighted code path. Accumulators in `GainPerSplit` and `SetLeafVector` promoted to `double` to match. No CUB fast-path tricks; the unified `BlockScan<BinT>` path handles both `CountBin` and `AggregateBin`.

Bench data on Blackwell sm_120 across 18 RFClassifier configs (5-rep median):

```
double bin vs int baseline:   min +10.8%, median +22.7%, max +70.5%
```

For reference, the int64 comparison RAMitchell suggested in the review thread: min +2.7%, median +8.4%, max +50.3%. The gap between int64 and double (~12% median) is the residual cost of double-precision math vs 64-bit integer math on top of the shared 8-byte storage cost. Worst case is the high-class-count config (n_bins=128, n_classes=44) at +70.5%; bandwidth doubles at high class count, which is the structural cost.

Several optimization candidates were explored (CUB algorithm variants, hand-rolled warp-shuffle scan, per-warp histograms, fused scan+gain). The top-ranked candidate (a `reinterpret_cast<double*>` to route CUB through its primitive-scalar code path) was prototyped and showed no measurable gain. The rest are documented in case a real perf concern surfaces later.

Includes two adjacent cleanups: a `static_cast<IdxT>` in the `ObjectiveTest` fixture in `rf_test.cu` for the int-to-IdxT narrowing the bin-type change surfaces, and removal of a stale `xfail_skl2onnx_bug` on RandomForestClassifier in `test_onnx.py`. The xfail was XPASSing under strict mode after the bin-type change unblocked the skl2onnx round-trip path for the classifier; the un-xfail keeps the test green going forward.

Verification: 180/180 `SG_RF_TEST` gtests pass on the minimal-double binary (Blackwell sm_120), including the `PropertyBasedTest` determinism checks across 100 parameterized configs.
