### PR TITLE
Further relax `test_nearest_neighbors_pickle` tolerance

### DIFF
--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -479,7 +479,7 @@ def test_nearest_neighbors_pickle(algorithm):
         # just to ensure things are wired together properly.
         accuracy = (i1 == i2).sum() / i1.size
         assert accuracy >= 0.9
-        np.testing.assert_allclose(d1, d2, atol=1e-3)
+        np.testing.assert_allclose(d1, d2, atol=1e-2)
     else:
         np.testing.assert_allclose(i1, i2)
         np.testing.assert_allclose(d1, d2)


### PR DESCRIPTION
This failure started after the recent CCCL upgrade and appears only on rtxpro6000 test runs. We relaxed the tolerance once already, but have still seen a rare periodic failure. From looking at recent failures, an atol of 5e-3 would be sufficient, but bumping to 1e-2 to be sure. We're only checking plumbing here, so some slop in tolerance is fine.

