### PR TITLE
DOC Add note about onnxruntime bug

### DIFF
--- a/docs/source/cuml-accel/examples/onnx_export.ipynb
+++ b/docs/source/cuml-accel/examples/onnx_export.ipynb
@@ -79,7 +79,7 @@
         "\n",
         "Convert the fitted model to ONNX using `skl2onnx.convert_sklearn()`. The proxy object is passed directly — no `as_sklearn()` call needed.\n",
         "\n",
-        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
+        "> Note: due to a known upstream incompatibility in `onnxruntime` version 1.26.0, predictions from a serialized `RandomForestClassifier` will be incorrect (see [microsoft/onnxruntime#28557](https://github.com/microsoft/onnxruntime/issues/28557)). We recommend using version 1.25.1 until the issue is resolved."
       ]
     },
     {
@@ -113,7 +113,7 @@
         "\n",
         "The saved `.onnx` file can be loaded on any machine with `onnxruntime` installed — no cuML or `sklearn-onnx` needed. Use `onnxruntime` for CPU inference, or `onnxruntime-gpu` for GPU inference.\n",
         "\n",
-        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
+        "> Note: due to a known upstream incompatibility in `onnxruntime` version 1.26.0, predictions from a serialized `RandomForestClassifier` will be incorrect (see [microsoft/onnxruntime#28557](https://github.com/microsoft/onnxruntime/issues/28557)). We recommend using version 1.25.1 until the issue is resolved."
       ]
     },
     {

--- a/docs/source/cuml-accel/examples/onnx_export.ipynb
+++ b/docs/source/cuml-accel/examples/onnx_export.ipynb
@@ -77,7 +77,9 @@
       "source": [
         "## Exporting to ONNX\n",
         "\n",
-        "Convert the fitted model to ONNX using `skl2onnx.convert_sklearn()`. The proxy object is passed directly — no `as_sklearn()` call needed."
+        "Convert the fitted model to ONNX using `skl2onnx.convert_sklearn()`. The proxy object is passed directly — no `as_sklearn()` call needed.\n",
+        "\n",
+        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
       ]
     },
     {
@@ -109,7 +111,9 @@
       "source": [
         "## Inference with ONNX Runtime\n",
         "\n",
-        "The saved `.onnx` file can be loaded on any machine with `onnxruntime` installed — no cuML or `sklearn-onnx` needed. Use `onnxruntime` for CPU inference, or `onnxruntime-gpu` for GPU inference."
+        "The saved `.onnx` file can be loaded on any machine with `onnxruntime` installed — no cuML or `sklearn-onnx` needed. Use `onnxruntime` for CPU inference, or `onnxruntime-gpu` for GPU inference.\n",
+        "\n",
+        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
       ]
     },
     {

--- a/docs/source/pickling_cuml_models.ipynb
+++ b/docs/source/pickling_cuml_models.ipynb
@@ -456,7 +456,9 @@
         "\n",
         "Not all estimators are supported by `sklearn-onnx` — see the [supported model list](https://onnx.ai/sklearn-onnx/supported.html) for details. UMAP, HDBSCAN, and some other estimators are not supported.\n",
         "\n",
-        "Under `cuml.accel`, proxy objects are recognized by `sklearn-onnx` directly without needing `as_sklearn()`. See the [cuml.accel ONNX example](cuml-accel/examples/onnx_export.ipynb) for details."
+        "Under `cuml.accel`, proxy objects are recognized by `sklearn-onnx` directly without needing `as_sklearn()`. See the [cuml.accel ONNX example](cuml-accel/examples/onnx_export.ipynb) for details.\n",
+        "\n",
+        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
       ]
     },
     {
@@ -511,7 +513,9 @@
       "source": [
         "### Inference with ONNX Runtime\n",
         "\n",
-        "The saved `.onnx` file can be loaded on any machine with `onnxruntime` installed — no cuML or `sklearn-onnx` needed. Use `onnxruntime` for CPU inference, or `onnxruntime-gpu` for GPU inference."
+        "The saved `.onnx` file can be loaded on any machine with `onnxruntime` installed — no cuML or `sklearn-onnx` needed. Use `onnxruntime` for CPU inference, or `onnxruntime-gpu` for GPU inference.\n",
+        "\n",
+        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
       ]
     },
     {

--- a/docs/source/pickling_cuml_models.ipynb
+++ b/docs/source/pickling_cuml_models.ipynb
@@ -458,7 +458,7 @@
         "\n",
         "Under `cuml.accel`, proxy objects are recognized by `sklearn-onnx` directly without needing `as_sklearn()`. See the [cuml.accel ONNX example](cuml-accel/examples/onnx_export.ipynb) for details.\n",
         "\n",
-        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
+        "> Note: due to a known upstream incompatibility in `onnxruntime` version 1.26.0, predictions from a serialized `RandomForestClassifier` will be incorrect (see [microsoft/onnxruntime#28557](https://github.com/microsoft/onnxruntime/issues/28557)). We recommend using version 1.25.1 until the issue is resolved."
       ]
     },
     {
@@ -515,7 +515,7 @@
         "\n",
         "The saved `.onnx` file can be loaded on any machine with `onnxruntime` installed — no cuML or `sklearn-onnx` needed. Use `onnxruntime` for CPU inference, or `onnxruntime-gpu` for GPU inference.\n",
         "\n",
-        "> Note: with `onnxruntime` version 1.26.0 predictions from a serialised `RandomForestClassifier` will be incorrect. Please use 1.25.1 instead. [More details](https://github.com/microsoft/onnxruntime/issues/28557)"
+        "> Note: due to a known upstream incompatibility in `onnxruntime` version 1.26.0, predictions from a serialized `RandomForestClassifier` will be incorrect (see [microsoft/onnxruntime#28557](https://github.com/microsoft/onnxruntime/issues/28557)). We recommend using version 1.25.1 until the issue is resolved."
       ]
     },
     {


### PR DESCRIPTION
This adds a note to the two example notebooks that use onnx to serialise models. 

In both I added it to both the "exporting to onnx" and the "using it" sections, assuming that people might only read one of them.

I pondered making it so that the xfail in `test_onnx.py` only applies to 1.26.0, but I think with the current setup we will notice once 1.26.1 is released as the test will start passing again. So I think leaving it "as is" is the thing to do.

xref https://github.com/rapidsai/cuml/issues/8125

cc @csadorf 