### PR TITLE
Fix BERTopic integration tests

### DIFF
--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -29,8 +29,9 @@ rapids-pip-retry install \
   "${CUML_WHEELHOUSE}"/cuml*.whl
 
 # Step 2: Install BERTopic
-# XXX: torch implicitly relies on a cupy feature that depends on pytest in
+# XXX: torch tries to import a cupy feature that depends on pytest in
 # cupy >= 14.1.0. For now we add an explicit dependency on pytest here.
+# See https://github.com/cupy/cupy/issues/9963
 rapids-logger "Installing BERTopic"
 rapids-pip-retry install --prefer-binary bertopic pytest
 

--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -29,8 +29,10 @@ rapids-pip-retry install \
   "${CUML_WHEELHOUSE}"/cuml*.whl
 
 # Step 2: Install BERTopic
+# XXX: torch implicitly relies on a cupy feature that depends on pytest in
+# cupy >= 14.1.0. For now we add an explicit dependency on pytest here.
 rapids-logger "Installing BERTopic"
-rapids-pip-retry install --prefer-binary bertopic
+rapids-pip-retry install --prefer-binary bertopic pytest
 
 # Test 1: Verify imports
 rapids-logger "Testing imports"


### PR DESCRIPTION
This should fix our `bertopic` integration tests. The recent `cupy 14.1.0` release added an implicit dependency on `pytest` to some functionality that `torch` is trying to import. That import failing leads `torch` to not initialize properly, eventually leading to failure.

It's not clear to met yet who's doing the wrong thing here, but for now we add an explicit `pytest` dependency to resolve the issue.