### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -29,11 +29,8 @@ rapids-pip-retry install \
   "${CUML_WHEELHOUSE}"/cuml*.whl
 
 # Step 2: Install BERTopic
-# XXX: torch tries to import a cupy feature that depends on pytest in
-# cupy >= 14.1.0. For now we add an explicit dependency on pytest here.
-# See https://github.com/cupy/cupy/issues/9963
 rapids-logger "Installing BERTopic"
-rapids-pip-retry install --prefer-binary bertopic pytest
+rapids-pip-retry install --prefer-binary bertopic
 
 # Test 1: Verify imports
 rapids-logger "Testing imports"

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.6.*,>=0.0.0a0
 - cxx-compiler
 - cython>=3.2.2

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -96,7 +96,7 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - joblib >=0.11
     - libcuml =${{ version }}
     - numba >=0.60.0,<0.65.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -744,7 +744,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -756,25 +756,25 @@ dependencies:
               cuda: "12.*"
               dependencies: "nightly"
             packages:
-              - cupy-cuda12x>=13.6.0a0
+              - cupy-cuda12x>=13.6.0a0,!=14.0.0,!=14.1.0
           - matrix:
               cuda: "13.*"
               dependencies: "nightly"
             packages:
-              - cupy-cuda13x>=13.6.0a0
+              - cupy-cuda13x>=13.6.0a0,!=14.0.0,!=14.1.0
           - matrix:
               dependencies: "nightly"
             packages:
-              - cupy-cuda13x>=13.6.0a0
+              - cupy-cuda13x>=13.6.0a0,!=14.0.0,!=14.1.0
           # Standard dependencies
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
       - output_types: requirements
         matrices:
           - matrix:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "cuda-python>=13.0.1,<14.0",
     "cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==13.*",
     "cudf==26.6.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "joblib>=0.11",
     "libcuml==26.6.*,>=0.0.0a0",
     "numba-cuda>=0.22.2,<0.29.0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.
See the linked issue for details.
