### PR TITLE
RF: add sample_weight to RandomForestRegressor

### DIFF
--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -18,9 +18,7 @@ if(BUILD_CUML_BENCH)
     sg/linkage.cu
     sg/main.cpp
     sg/rf_classifier.cu
-    # FIXME: RF Regressor is having an issue where the tests now seem to take
-    # forever to finish, as opposed to the classifier counterparts!
-    # sg/rf_regressor.cu
+    sg/rf_regressor.cu
     sg/svc.cu
     sg/svr.cu
     sg/umap.cu

--- a/cpp/bench/sg/rf_regressor.cu
+++ b/cpp/bench/sg/rf_regressor.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -52,12 +52,12 @@ class RFRegressor : public RegressionFixture<D> {
       auto* mPtr = &model.model;
       fit(*this->handle,
           mPtr,
-          this->data.X,
+          this->data.X.data(),
           this->params.nrows,
           this->params.ncols,
-          this->data.y,
+          this->data.y.data(),
           rfParams);
-      handle->sync_stream(this->stream);
+      this->handle->sync_stream(this->stream);
     });
   }
 
@@ -75,14 +75,14 @@ std::vector<RegParams> getInputs()
   struct std::vector<RegParams> out;
   RegParams p;
   p.data.rowMajor = false;
-  p.regression    = {.shuffle        = true,  // Better to shuffle when n_informative < ncols
-                     .effective_rank = -1,    // dataset generation will be faster
+  p.regression    = {.effective_rank = -1,  // dataset generation will be faster
                      .bias           = 4.5,
                      .tail_strength  = 0.5,  // unused when effective_rank = -1
                      .noise          = 1.0,
+                     .shuffle        = true,  // Better to shuffle when n_informative < ncols
                      .seed           = 12345ULL};
 
-  p.rf                          = set_rf_params(10,                 /*max_depth */
+  p.rf = set_rf_params(8,                  /*max_depth */
                        (1 << 20),          /* max_leaves */
                        0.3,                /* max_features */
                        32,                 /* max_n_bins */
@@ -90,25 +90,23 @@ std::vector<RegParams> getInputs()
                        3,                  /* min_samples_split */
                        0.0f,               /* min_impurity_decrease */
                        true,               /* bootstrap */
-                       500,                /* n_trees */
+                       100,                /* n_trees */
                        1.f,                /* max_samples */
                        1234ULL,            /* seed */
                        ML::CRITERION::MSE, /* split_criterion */
                        8,                  /* n_streams */
                        128                 /* max_batch_size */
   );
-  std::vector<DimInfo> dim_info = {{500000, 500, 400}};
+  // Scaled down from {500000, 500, 400} so the bench finishes in minutes;
+  // restore on a follow-up that addresses the FIXME.
+  std::vector<DimInfo> dim_info = {{100000, 100, 80}};
   for (auto& di : dim_info) {
-    // Let's run Bosch only for float type
-    if (!std::is_same<D, float>::value && di.ncols == 968) continue;
     p.data.nrows                  = di.nrows;
     p.data.ncols                  = di.ncols;
     p.regression.n_informative    = di.n_informative;
     p.rf.tree_params.max_features = 1.f;
-    for (auto max_depth : std::vector<int>({7, 11, 15})) {
-      p.rf.tree_params.max_depth = max_depth;
-      out.push_back(p);
-    }
+    p.rf.tree_params.max_depth    = 8;
+    out.push_back(p);
   }
   return out;
 }

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -151,7 +151,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         float* sample_weight                = nullptr);
 void fit(const raft::handle_t& user_handle,
          RandomForestClassifierD* forest,
          double* input,
@@ -161,7 +162,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         double* sample_weight               = nullptr);
 
 template <typename T, typename L>
 void fit_treelite(const raft::handle_t& user_handle,
@@ -174,7 +176,8 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   T* feature_importances,
-                  rapids_logger::level_enum verbosity);
+                  rapids_logger::level_enum verbosity,
+                  T* sample_weight = nullptr);
 
 void predict(const raft::handle_t& user_handle,
              const RandomForestClassifierF* forest,
@@ -232,7 +235,8 @@ void fit(const raft::handle_t& user_handle,
          float* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         float* sample_weight                = nullptr);
 void fit(const raft::handle_t& user_handle,
          RandomForestRegressorD* forest,
          double* input,
@@ -241,7 +245,8 @@ void fit(const raft::handle_t& user_handle,
          double* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         double* sample_weight               = nullptr);
 
 template <typename T, typename L>
 void fit_treelite(const raft::handle_t& user_handle,
@@ -253,7 +258,8 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   T* feature_importances,
-                  rapids_logger::level_enum verbosity);
+                  rapids_logger::level_enum verbosity,
+                  T* sample_weight = nullptr);
 
 void predict(const raft::handle_t& user_handle,
              const RandomForestRegressorF* forest,

--- a/cpp/src/decisiontree/batched-levelalgo/bins.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/bins.cuh
@@ -9,17 +9,17 @@ namespace ML {
 namespace DT {
 
 struct CountBin {
-  // double covers both the unweighted count path and the future weighted-count
-  // path with one bin type; 32-bit int would overflow on large weighted counts.
+  // double covers both the unweighted count path (weight=1.0) and the
+  // per-sample-weighted path; 32-bit int would overflow on large weighted counts.
   double x;
   CountBin(CountBin const&) = default;
   HDI CountBin(double x_) : x(x_) {}
   HDI CountBin() : x(0.0) {}
 
-  DI static void IncrementHistogram(CountBin* hist, int n_bins, int b, int label)
+  DI static void IncrementHistogram(CountBin* hist, int n_bins, int b, int label, double weight)
   {
     auto offset = label * n_bins + b;
-    CountBin::AtomicAdd(hist + offset, {1.0});
+    CountBin::AtomicAdd(hist + offset, {weight});
   }
   DI static void AtomicAdd(CountBin* address, CountBin val) { atomicAdd(&address->x, val.x); }
   HDI CountBin& operator+=(const CountBin& b)
@@ -35,6 +35,8 @@ struct CountBin {
 };
 
 struct AggregateBin {
+  // `label_sum` carries `label * weight`; `count` stays unweighted so
+  // `min_samples_leaf` checks operate on the integer sample count.
   double label_sum;
   int count;
 
@@ -42,9 +44,10 @@ struct AggregateBin {
   HDI AggregateBin() : label_sum(0.0), count(0) {}
   HDI AggregateBin(double label_sum, int count) : label_sum(label_sum), count(count) {}
 
-  DI static void IncrementHistogram(AggregateBin* hist, int n_bins, int b, double label)
+  DI static void IncrementHistogram(
+    AggregateBin* hist, int n_bins, int b, double label, double weight)
   {
-    AggregateBin::AtomicAdd(hist + b, {label, 1});
+    AggregateBin::AtomicAdd(hist + b, {label * weight, 1});
   }
   DI static void AtomicAdd(AggregateBin* address, AggregateBin val)
   {
@@ -63,5 +66,6 @@ struct AggregateBin {
     return b;
   }
 };
+static_assert(sizeof(AggregateBin) == 16, "AggregateBin layout drift");
 }  // namespace DT
 }  // namespace ML

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -162,6 +162,17 @@ struct Builder {
   IdxT* n_nodes;
   /** buffer of segmented histograms*/
   BinT* histograms;
+  /** Classifier companion: per-bin unweighted sample counts for
+   *  `min_samples_leaf` + `Split::nLeft` under fractional weights. */
+  int* unweighted_histograms = nullptr;
+  /** Regressor companion: per-bin sum-of-weights totals for the weighted
+   *  gain denominator and leaf mean. */
+  double* weighted_count_histograms = nullptr;
+  // Compile-time gates on the builder's BinT type; mutually exclusive.
+  static constexpr bool kIsClassifier = std::is_same<typename ObjectiveT::BinT, CountBin>::value;
+  static constexpr bool kIsRegressor = std::is_same<typename ObjectiveT::BinT, AggregateBin>::value;
+  static_assert(kIsClassifier || kIsRegressor,
+                "Builder<ObjectiveT>::BinT must be CountBin or AggregateBin");
   /** threadblock arrival count */
   int* done_count;
   /** mutex array used for atomically updating best split */
@@ -199,7 +210,8 @@ struct Builder {
           IdxT n_cols,
           rmm::device_uvector<IdxT>* row_ids,
           IdxT n_classes,
-          const QuantilesT& q)
+          const QuantilesT& q,
+          const DataT* sample_weight = nullptr)
     : handle(handle),
       builder_stream(s),
       treeid(treeid),
@@ -212,7 +224,8 @@ struct Builder {
               int(row_ids->size()),
               max(1, IdxT(params.max_features * n_cols)),
               row_ids->data(),
-              n_classes},
+              n_classes,
+              sample_weight},
       quantiles(q),
       d_buff(0, builder_stream)
   {
@@ -266,8 +279,15 @@ struct Builder {
     size_t max_len_histograms =
       max_batch * params.max_n_bins * n_blks_for_cols * dataset.num_outputs;
 
-    d_wsize += calculateAlignedBytes(sizeof(IdxT));                               // n_nodes
-    d_wsize += calculateAlignedBytes(sizeof(BinT) * max_len_histograms);          // histograms
+    d_wsize += calculateAlignedBytes(sizeof(IdxT));                       // n_nodes
+    d_wsize += calculateAlignedBytes(sizeof(BinT) * max_len_histograms);  // histograms
+    size_t max_len_companion = max_batch * params.max_n_bins * n_blks_for_cols;
+    if constexpr (kIsClassifier) {
+      d_wsize += calculateAlignedBytes(sizeof(int) * max_len_companion);  // unweighted_histograms
+    } else if constexpr (kIsRegressor) {
+      d_wsize +=
+        calculateAlignedBytes(sizeof(double) * max_len_companion);  // weighted_count_histograms
+    }
     d_wsize += calculateAlignedBytes(sizeof(int) * max_batch * n_blks_for_cols);  // done_count
     d_wsize += calculateAlignedBytes(sizeof(int) * max_batch);                    // mutex
     d_wsize += calculateAlignedBytes(sizeof(SplitT) * max_batch);                 // splits
@@ -304,6 +324,14 @@ struct Builder {
     d_wspace += calculateAlignedBytes(sizeof(IdxT));
     histograms = reinterpret_cast<BinT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(BinT) * max_len_histograms);
+    size_t max_len_companion = max_batch * (params.max_n_bins) * n_blks_for_cols;
+    if constexpr (kIsClassifier) {
+      unweighted_histograms = reinterpret_cast<int*>(d_wspace);
+      d_wspace += calculateAlignedBytes(sizeof(int) * max_len_companion);
+    } else if constexpr (kIsRegressor) {
+      weighted_count_histograms = reinterpret_cast<double*>(d_wspace);
+      d_wspace += calculateAlignedBytes(sizeof(double) * max_len_companion);
+    }
     done_count = reinterpret_cast<int*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(int) * max_batch * n_col_blks);
     mutex = reinterpret_cast<int*>(d_wspace);
@@ -487,12 +515,20 @@ struct Builder {
   auto computeSplitSmemSize()
   {
     size_t smem_size_1 =
-      params.max_n_bins * dataset.num_outputs * sizeof(BinT) +  // shared_histogram size
-      params.max_n_bins * sizeof(DataT) +                       // shared_quantiles size
-      sizeof(int);                                              // shared_done size
-    // Extra room for alignment (see alignPointer in
-    // computeSplitKernel)
-    smem_size_1 += sizeof(DataT) + 3 * sizeof(int);
+      params.max_n_bins * dataset.num_outputs * sizeof(BinT) +  // shared_histogram
+      params.max_n_bins * sizeof(DataT) +                       // shared_quantiles
+      sizeof(int);                                              // shared_done
+    int n_align_slots = 3;  // shared_histogram, shared_quantiles, shared_done
+    if constexpr (kIsClassifier) {
+      smem_size_1 += params.max_n_bins * sizeof(int);  // shared_unweighted
+      n_align_slots = 4;
+    } else if constexpr (kIsRegressor) {
+      smem_size_1 += params.max_n_bins * sizeof(double);  // shared_weighted_count
+      n_align_slots = 4;
+    }
+    // Worst-case alignPointer slack per slot is sizeof(largest-following-type)-1.
+    // The regressor companion is double-aligned, so use 8 bytes per slot.
+    smem_size_1 += n_align_slots * sizeof(double);
     // Calculate the shared memory needed for evalBestSplit
     size_t smem_size_2 = raft::ceildiv(TPB_DEFAULT, raft::WarpSize) * sizeof(SplitT);
     // Pick the max of two
@@ -517,12 +553,22 @@ struct Builder {
     // required total length (in bins) of the global segmented histograms over all
     // classes, features and (large)nodes.
     int len_histograms = n_bins * n_classes * n_blocks_dimy * n_large_nodes;
+    int len_companion  = n_bins * n_blocks_dimy * n_large_nodes;
     RAFT_CUDA_TRY(cudaMemsetAsync(histograms, 0, sizeof(BinT) * len_histograms, builder_stream));
+    if constexpr (kIsClassifier) {
+      RAFT_CUDA_TRY(
+        cudaMemsetAsync(unweighted_histograms, 0, sizeof(int) * len_companion, builder_stream));
+    } else if constexpr (kIsRegressor) {
+      RAFT_CUDA_TRY(cudaMemsetAsync(
+        weighted_count_histograms, 0, sizeof(double) * len_companion, builder_stream));
+    }
     // create the objective function object
     ObjectiveT objective(dataset.num_outputs, params.min_samples_leaf);
     // call the computeSplitKernel
     raft::common::nvtx::range kernel_scope("computeSplitKernel @builder.cuh [batched-levelalgo]");
     launchComputeSplitKernel<DataT, LabelT, IdxT, TPB_DEFAULT>(histograms,
+                                                               unweighted_histograms,
+                                                               weighted_count_histograms,
                                                                params.max_n_bins,
                                                                params.min_samples_split,
                                                                params.max_leaves,

--- a/cpp/src/decisiontree/batched-levelalgo/dataset.h
+++ b/cpp/src/decisiontree/batched-levelalgo/dataset.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,6 +26,8 @@ struct Dataset {
   IdxT* row_ids;
   /** Number of classes or regression outputs*/
   IdxT num_outputs;
+  /** per-row sample weights (length M); nullptr when no per-sample weighting */
+  const DataT* sample_weight = nullptr;
 };
 
 }  // namespace DT

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -365,6 +365,8 @@ CUML_KERNEL void adaptive_sample_kernel(int* colids,
   }
 }
 
+// Exactly one of the two companion pointers is non-null per builder; reads
+// are gated on `kIsClassifier` / `kIsRegressor`.
 template <typename DataT,
           typename LabelT,
           typename IdxT,
@@ -372,6 +374,8 @@ template <typename DataT,
           typename ObjectiveT,
           typename BinT>
 void launchComputeSplitKernel(BinT* histograms,
+                              int* unweighted_histograms,
+                              double* weighted_count_histograms,
                               IdxT n_bins,
                               IdxT min_samples_split,
                               IdxT max_leaves,

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -132,19 +132,35 @@ static __global__ void leafKernel(ObjectiveT objective,
   auto& node     = tree[node_id];
   auto range     = instance_ranges[node_id];
   if (!node.IsLeaf()) return;
-  auto tid = threadIdx.x;
+  auto tid                     = threadIdx.x;
+  constexpr bool kIsClassifier = std::is_same<BinT, CountBin>::value;
+  constexpr bool kIsRegressor  = std::is_same<BinT, AggregateBin>::value;
+  static_assert(kIsClassifier || kIsRegressor, "unknown BinT in leafKernel");
+  // Regressor leaf mean is sum(label*weight) / sum(weight); accumulate the
+  // weighted denominator once in shared memory and hand it to SetLeafVector.
+  // Classifier ignores the value.
+  __shared__ double shared_weight_at_leaf;
+  if constexpr (kIsRegressor) {
+    if (tid == 0) shared_weight_at_leaf = 0.0;
+  }
   for (int i = tid; i < dataset.num_outputs; i += blockDim.x) {
     histogram[i] = BinT();
   }
   __syncthreads();
+  bool has_weight = (dataset.sample_weight != nullptr);
   for (auto i = range.begin + tid; i < range.begin + range.count; i += blockDim.x) {
-    auto label = dataset.labels[dataset.row_ids[i]];
-    BinT::IncrementHistogram(histogram, 1, 0, label);
+    auto row      = dataset.row_ids[i];
+    auto label    = dataset.labels[row];
+    double weight = has_weight ? static_cast<double>(dataset.sample_weight[row]) : 1.0;
+    BinT::IncrementHistogram(histogram, 1, 0, label, weight);
+    if constexpr (kIsRegressor) { atomicAdd(&shared_weight_at_leaf, weight); }
   }
   __syncthreads();
   if (tid == 0) {
+    double weighted_total = 0.0;
+    if constexpr (kIsRegressor) { weighted_total = shared_weight_at_leaf; }
     ObjectiveT::SetLeafVector(
-      histogram, dataset.num_outputs, leaves + dataset.num_outputs * node_id);
+      histogram, dataset.num_outputs, leaves + dataset.num_outputs * node_id, weighted_total);
   }
 }
 
@@ -200,6 +216,8 @@ template <typename DataT,
           typename ObjectiveT,
           typename BinT>
 static __global__ void computeSplitKernel(BinT* histograms,
+                                          int* unweighted_histograms,
+                                          double* weighted_count_histograms,
                                           IdxT max_n_bins,
                                           IdxT min_samples_split,
                                           IdxT max_leaves,
@@ -242,37 +260,57 @@ static __global__ void computeSplitKernel(BinT* histograms,
   // getting the n_bins for that feature
   int n_bins = quantiles.n_bins_array[col];
 
-  auto end                  = range_start + range_len;
-  auto shared_histogram_len = n_bins * objective.NumClasses();
-  auto* shared_histogram    = alignPointer<BinT>(smem);
-  auto* shared_quantiles    = alignPointer<DataT>(shared_histogram + shared_histogram_len);
-  auto* shared_done         = alignPointer<int>(shared_quantiles + n_bins);
-  IdxT stride               = blockDim.x * num_blocks;
-  IdxT tid                  = threadIdx.x + offset_blockid * blockDim.x;
+  constexpr bool kIsClassifier = std::is_same<BinT, CountBin>::value;
+  constexpr bool kIsRegressor  = std::is_same<BinT, AggregateBin>::value;
+  static_assert(kIsClassifier || kIsRegressor, "unknown BinT in computeSplitKernel");
+
+  auto end                      = range_start + range_len;
+  auto shared_histogram_len     = n_bins * objective.NumClasses();
+  auto* shared_histogram        = alignPointer<BinT>(smem);
+  int* shared_unweighted        = nullptr;
+  double* shared_weighted_count = nullptr;
+  DataT* shared_quantiles;
+  int* shared_done;
+  if constexpr (kIsClassifier) {
+    shared_unweighted = alignPointer<int>(shared_histogram + shared_histogram_len);
+    shared_quantiles  = alignPointer<DataT>(shared_unweighted + n_bins);
+  } else if constexpr (kIsRegressor) {
+    shared_weighted_count = alignPointer<double>(shared_histogram + shared_histogram_len);
+    shared_quantiles      = alignPointer<DataT>(shared_weighted_count + n_bins);
+  } else {
+    shared_quantiles = alignPointer<DataT>(shared_histogram + shared_histogram_len);
+  }
+  shared_done = alignPointer<int>(shared_quantiles + n_bins);
+  IdxT stride = blockDim.x * num_blocks;
+  IdxT tid    = threadIdx.x + offset_blockid * blockDim.x;
 
   // populating shared memory with initial values
   for (IdxT i = threadIdx.x; i < shared_histogram_len; i += blockDim.x)
     shared_histogram[i] = BinT();
-  for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x)
+  for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x) {
+    if constexpr (kIsClassifier) shared_unweighted[b] = 0;
+    if constexpr (kIsRegressor) shared_weighted_count[b] = 0.0;
     shared_quantiles[b] = quantiles.quantiles_array[max_n_bins * col + b];
+  }
 
   // synchronizing above changes across block
   __syncthreads();
 
-  // compute pdf shared histogram for all bins for all classes in shared mem
-
+  bool has_weight = (dataset.sample_weight != nullptr);
   // Must be 64 bit - can easily grow larger than a 32 bit int
   std::size_t col_offset = std::size_t(col) * dataset.M;
   for (auto i = range_start + tid; i < end; i += stride) {
     // each thread works over a data point and strides to the next
-    auto row   = dataset.row_ids[i];
-    auto data  = dataset.data[row + col_offset];
-    auto label = dataset.labels[row];
+    auto row      = dataset.row_ids[i];
+    auto data     = dataset.data[row + col_offset];
+    auto label    = dataset.labels[row];
+    double weight = has_weight ? static_cast<double>(dataset.sample_weight[row]) : 1.0;
 
     // `start` is lowest index such that data <= shared_quantiles[start]
     IdxT start = lower_bound(shared_quantiles, n_bins, data);
-    // ++shared_histogram[start]
-    BinT::IncrementHistogram(shared_histogram, n_bins, start, label);
+    BinT::IncrementHistogram(shared_histogram, n_bins, start, label, weight);
+    if constexpr (kIsClassifier) atomicAdd(&shared_unweighted[start], 1);
+    if constexpr (kIsRegressor) atomicAdd(&shared_weighted_count[start], weight);
   }
 
   // synchronizing above changes across block
@@ -281,8 +319,18 @@ static __global__ void computeSplitKernel(BinT* histograms,
     // update the corresponding global location
     auto histograms_offset =
       ((large_nid * gridDim.y) + blockIdx.y) * max_n_bins * objective.NumClasses();
+    auto companion_offset = ((large_nid * gridDim.y) + blockIdx.y) * max_n_bins;
     for (IdxT i = threadIdx.x; i < shared_histogram_len; i += blockDim.x) {
       BinT::AtomicAdd(histograms + histograms_offset + i, shared_histogram[i]);
+    }
+    if constexpr (kIsClassifier) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x) {
+        atomicAdd(&unweighted_histograms[companion_offset + b], shared_unweighted[b]);
+      }
+    } else if constexpr (kIsRegressor) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x) {
+        atomicAdd(&weighted_count_histograms[companion_offset + b], shared_weighted_count[b]);
+      }
     }
 
     __threadfence();  // for commit guarantee
@@ -297,6 +345,13 @@ static __global__ void computeSplitKernel(BinT* histograms,
     // store the complete global histogram in shared memory of last block
     for (IdxT i = threadIdx.x; i < shared_histogram_len; i += blockDim.x)
       shared_histogram[i] = histograms[histograms_offset + i];
+    if constexpr (kIsClassifier) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x)
+        shared_unweighted[b] = unweighted_histograms[companion_offset + b];
+    } else if constexpr (kIsRegressor) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x)
+        shared_weighted_count[b] = weighted_count_histograms[companion_offset + b];
+    }
 
     __syncthreads();
   }
@@ -309,13 +364,21 @@ static __global__ void computeSplitKernel(BinT* histograms,
     // now, `shared_histogram[n_bins * c + i]` will have count of datapoints of class `c`
     // that are less than or equal to `shared_quantiles[i]`.
   }
+  if constexpr (kIsClassifier) { pdf_to_cdf<int, IdxT, TPB>(shared_unweighted, n_bins); }
+  if constexpr (kIsRegressor) { pdf_to_cdf<double, IdxT, TPB>(shared_weighted_count, n_bins); }
 
   __syncthreads();
 
   // calculate the best candidate bins (one for each thread in the block) in current feature and
   // corresponding information gain for splitting
-  Split<DataT, IdxT> sp =
-    objective.Gain(shared_histogram, shared_quantiles, col, range_len, n_bins);
+  Split<DataT, IdxT> sp;
+  if constexpr (kIsClassifier) {
+    sp =
+      objective.Gain(shared_histogram, shared_quantiles, col, range_len, n_bins, shared_unweighted);
+  } else {
+    sp = objective.Gain(
+      shared_histogram, shared_quantiles, col, range_len, n_bins, shared_weighted_count);
+  }
 
   __syncthreads();
 
@@ -332,6 +395,8 @@ template <typename DataT,
           typename ObjectiveT,
           typename BinT>
 void launchComputeSplitKernel(BinT* histograms,
+                              int* unweighted_histograms,
+                              double* weighted_count_histograms,
                               IdxT max_n_bins,
                               IdxT min_samples_split,
                               IdxT max_leaves,
@@ -353,6 +418,8 @@ void launchComputeSplitKernel(BinT* histograms,
 {
   computeSplitKernel<DataT, LabelT, IdxT, TPB_DEFAULT>
     <<<grid, TPB_DEFAULT, smem_size, builder_stream>>>(histograms,
+                                                       unweighted_histograms,
+                                                       weighted_count_histograms,
                                                        max_n_bins,
                                                        min_samples_split,
                                                        max_leaves,
@@ -393,6 +460,8 @@ template void launchLeafKernel<_DatasetT, _NodeT, _ObjectiveT, _DataT>(
 
 template void launchComputeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT, _ObjectiveT, _BinT>(
   _BinT* histograms,
+  int* unweighted_histograms,
+  double* weighted_count_histograms,
   _IdxT n_bins,
   _IdxT min_samples_split,
   _IdxT max_leaves,

--- a/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
@@ -38,57 +38,85 @@ class GiniObjectiveFunction {
   /**
    * @brief compute the gini impurity reduction for each split
    */
-  HDI DataT GainPerSplit(BinT* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft)
+  HDI DataT
+  GainPerSplit(BinT* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft, double W_total, double W_left)
   {
-    IdxT nRight         = len - nLeft;
-    constexpr DataT One = DataT(1.0);
-    auto invLen         = One / len;
-    auto invLeft        = One / nLeft;
-    auto invRight       = One / nRight;
-    auto gain           = DataT(0.0);
-
-    // if there aren't enough samples in this split, don't bother!
+    IdxT nRight = len - nLeft;
+    // min_samples_leaf gate stays on the unweighted counts: sklearn enforces
+    // min_samples_leaf against the integer left/right sample counts.
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
 
+    // Skip splits where one side has all-zero weights but nonzero sample count.
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
+
+    // Weighted Gini proxy: argmax of sum_c w_left_c^2/W_left + w_right_c^2/W_right.
+    // The leading 1/W_total scaling drops a constant term that's identical
+    // across split candidates within a node.
+    auto invW      = DataT(1.0) / DataT(W_total);
+    auto invWLeft  = DataT(1.0) / DataT(W_left);
+    auto invWRight = DataT(1.0) / DataT(W_right);
+    auto gain      = DataT(0.0);
+
     for (IdxT j = 0; j < nclasses; ++j) {
-      double val_i = 0.0;
-      auto lval_i  = hist[n_bins * j + i].x;
-      auto lval    = DataT(lval_i);
-      gain += lval * invLeft * lval * invLen;
+      auto lval      = DataT(hist[n_bins * j + i].x);
+      auto total_sum = DataT(hist[n_bins * j + n_bins - 1].x);
+      auto rval      = total_sum - lval;
 
-      val_i += lval_i;
-      auto total_sum = hist[n_bins * j + n_bins - 1].x;
-      auto rval_i    = total_sum - lval_i;
-      auto rval      = DataT(rval_i);
-      gain += rval * invRight * rval * invLen;
+      gain += lval * invWLeft * lval * invW;
+      gain += rval * invWRight * rval * invW;
 
-      val_i += rval_i;
-      auto val = DataT(val_i) * invLen;
+      auto val = total_sum * invW;
       gain -= val * val;
     }
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(BinT* shist, DataT* squantiles, IdxT col, IdxT len, IdxT n_bins)
+  DI Split<DataT, IdxT> Gain(
+    BinT* shist, DataT* squantiles, IdxT col, IdxT len, IdxT n_bins, int const* unweighted_cdf)
   {
+    // Hoist W_total out of the per-bin loop. The total weighted node sample
+    // count is the last-bin CDF value summed over classes.
+    double W_total = 0.0;
+    for (IdxT j = 0; j < nclasses; ++j)
+      W_total += shist[n_bins * j + n_bins - 1].x;
+
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      IdxT nLeft = 0;
-      for (IdxT j = 0; j < nclasses; ++j) {
-        nLeft += shist[n_bins * j + i].x;
-      }
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      // Read the unweighted prefix-count directly: under fractional
+      // sample_weight the per-class weighted CDF can't carry the integer
+      // sample count that min_samples_leaf and Split::nLeft need.
+      IdxT nLeft = unweighted_cdf[i];
+
+      // Weighted left-side total at bin i, summed over classes.
+      double W_left = 0.0;
+      for (IdxT j = 0; j < nclasses; ++j)
+        W_left += shist[n_bins * j + i].x;
+
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist,
+                               int nclasses,
+                               DataT* out,
+                               double /* weighted_total, unused for classifier */)
   {
     // Output probability
     double total = 0.0;
     for (int i = 0; i < nclasses; i++) {
       total += shist[i].x;
+    }
+    if (total <= 0.0) {
+      // All zero-weight leaf: emit a uniform distribution so downstream consumers
+      // see a finite vector and so argmax stays deterministic across builds.
+      DataT uniform = DataT(1.0) / DataT(nclasses);
+      for (int i = 0; i < nclasses; i++)
+        out[i] = uniform;
+      return;
     }
     for (int i = 0; i < nclasses; i++) {
       out[i] = DataT(shist[i].x) / total;
@@ -118,62 +146,86 @@ class EntropyObjectiveFunction {
   /**
    * @brief compute the Entropy (or information gain) for each split
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft)
+  HDI DataT GainPerSplit(
+    BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft, double W_total, double W_left)
   {
-    IdxT nRight{len - nLeft};
-    auto gain{DataT(0.0)};
-    // if there aren't enough samples in this split, don't bother!
-    if (nLeft < min_samples_leaf || nRight < min_samples_leaf) {
+    IdxT nRight = len - nLeft;
+    if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
-    } else {
-      auto invLeft{DataT(1.0) / nLeft};
-      auto invRight{DataT(1.0) / nRight};
-      auto invLen{DataT(1.0) / len};
-      for (IdxT c = 0; c < nclasses; ++c) {
-        double val_i = 0.0;
-        auto lval_i  = hist[n_bins * c + i].x;
-        if (lval_i != 0) {
-          auto lval = DataT(lval_i);
-          gain += raft::log(lval * invLeft) / raft::log(DataT(2)) * lval * invLen;
-        }
 
-        val_i += lval_i;
-        auto total_sum = hist[n_bins * c + n_bins - 1].x;
-        auto rval_i    = total_sum - lval_i;
-        if (rval_i != 0) {
-          auto rval = DataT(rval_i);
-          gain += raft::log(rval * invRight) / raft::log(DataT(2)) * rval * invLen;
-        }
+    // Skip splits where one side has all-zero weights but nonzero sample count.
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
-        val_i += rval_i;
-        if (val_i != 0) {
-          auto val = DataT(val_i) * invLen;
-          gain -= val * raft::log(val) / raft::log(DataT(2));
-        }
+    auto invWLeft  = DataT(1.0) / DataT(W_left);
+    auto invWRight = DataT(1.0) / DataT(W_right);
+    auto invW      = DataT(1.0) / DataT(W_total);
+    auto gain      = DataT(0.0);
+
+    for (IdxT c = 0; c < nclasses; ++c) {
+      auto lval_i = hist[n_bins * c + i].x;
+      if (lval_i != 0) {
+        auto lval = DataT(lval_i);
+        gain += raft::log(lval * invWLeft) / raft::log(DataT(2)) * lval * invW;
       }
 
-      return gain;
+      auto total_sum = hist[n_bins * c + n_bins - 1].x;
+      auto rval_i    = total_sum - lval_i;
+      if (rval_i != 0) {
+        auto rval = DataT(rval_i);
+        gain += raft::log(rval * invWRight) / raft::log(DataT(2)) * rval * invW;
+      }
+
+      if (total_sum != 0) {
+        auto val = DataT(total_sum) * invW;
+        gain -= val * raft::log(val) / raft::log(DataT(2));
+      }
     }
+
+    return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(BinT* scdf_labels, DataT* squantiles, IdxT col, IdxT len, IdxT n_bins)
+  DI Split<DataT, IdxT> Gain(BinT* scdf_labels,
+                             DataT* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             int const* unweighted_cdf)
   {
+    double W_total = 0.0;
+    for (IdxT c = 0; c < nclasses; ++c)
+      W_total += scdf_labels[n_bins * c + n_bins - 1].x;
+
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      IdxT nLeft = 0;
-      for (IdxT j = 0; j < nclasses; ++j) {
-        nLeft += scdf_labels[n_bins * j + i].x;
-      }
-      sp.update({squantiles[i], col, GainPerSplit(scdf_labels, i, n_bins, len, nLeft), nLeft});
+      IdxT nLeft = unweighted_cdf[i];
+
+      double W_left = 0.0;
+      for (IdxT c = 0; c < nclasses; ++c)
+        W_left += scdf_labels[n_bins * c + i].x;
+
+      sp.update({squantiles[i],
+                 col,
+                 GainPerSplit(scdf_labels, i, n_bins, len, nLeft, W_total, W_left),
+                 nLeft});
     }
     return sp;
   }
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist,
+                               int nclasses,
+                               DataT* out,
+                               double /* weighted_total, unused for classifier */)
   {
     // Output probability
     double total = 0.0;
     for (int i = 0; i < nclasses; i++) {
       total += shist[i].x;
+    }
+    if (total <= 0.0) {
+      DataT uniform = DataT(1.0) / DataT(nclasses);
+      for (int i = 0; i < nclasses; i++)
+        out[i] = uniform;
+      return;
     }
     for (int i = 0; i < nclasses; i++) {
       out[i] = DataT(shist[i].x) / total;
@@ -211,44 +263,68 @@ class MSEObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       mean-squared errors.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
-    auto gain{DataT(0)};
     IdxT nRight{len - nLeft};
-    auto invLen = DataT(1.0) / len;
-    // if there aren't enough samples in this split, don't bother!
+    // min_samples_leaf gate stays on the unweighted integer count: sklearn
+    // enforces min_samples_leaf against the sample count, not the weight sum.
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf) {
       return -std::numeric_limits<DataT>::max();
-    } else {
-      auto label_sum        = hist[n_bins - 1].label_sum;
-      DataT parent_obj      = -label_sum * label_sum * invLen;
-      DataT left_obj        = -(hist[i].label_sum * hist[i].label_sum) / nLeft;
-      DataT right_label_sum = hist[i].label_sum - label_sum;
-      DataT right_obj       = -(right_label_sum * right_label_sum) / nRight;
-      gain                  = parent_obj - (left_obj + right_obj);
-      gain *= DataT(0.5) * invLen;
-
-      return gain;
     }
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
+
+    // Weighted MSE proxy (sklearn 1.7.2 _criterion.pyx:1089-1118): replace n
+    // with sum(weight) in every denominator so leaf-mean is
+    // sum(label*weight)/sum(weight).
+    auto invW             = DataT(1.0) / DataT(W_total);
+    auto label_sum        = hist[n_bins - 1].label_sum;
+    DataT parent_obj      = -DataT(label_sum) * DataT(label_sum) * invW;
+    DataT left_obj        = -DataT(hist[i].label_sum * hist[i].label_sum) / DataT(W_left);
+    DataT right_label_sum = label_sum - hist[i].label_sum;
+    DataT right_obj       = -(right_label_sum * right_label_sum) / DataT(W_right);
+    DataT gain            = parent_obj - (left_obj + right_obj);
+    gain *= DataT(0.5) * invW;
+    return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    // AggregateBin.count is the unweighted sample count (see bins.cuh); the
+    // weighted CDF lives in the parallel companion buffer.
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
 
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };
@@ -285,15 +361,20 @@ class PoissonObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       poisson half deviances.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
-    // get the lens'
     IdxT nRight = len - nLeft;
-    auto invLen = DataT(1) / len;
-
-    // if there aren't enough samples in this split, don't bother!
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
+
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
     auto label_sum       = hist[n_bins - 1].label_sum;
     auto left_label_sum  = (hist[i].label_sum);
@@ -303,33 +384,48 @@ class PoissonObjectiveFunction {
     if (label_sum < eps_ || left_label_sum < eps_ || right_label_sum < eps_)
       return -std::numeric_limits<DataT>::max();
 
-    // compute the gain to be
-    DataT parent_obj = -label_sum * raft::log(label_sum * invLen);
-    DataT left_obj   = -left_label_sum * raft::log(left_label_sum / nLeft);
-    DataT right_obj  = -right_label_sum * raft::log(right_label_sum / nRight);
+    // Weighted Poisson half-deviance (sklearn 1.7.2 _criterion.pyx:1597-1642):
+    // swap sample-count denominators for sum(weight) so the predicted-mean per
+    // leaf is sum(label*weight)/sum(weight).
+    auto invW        = DataT(1.0) / DataT(W_total);
+    DataT parent_obj = -label_sum * raft::log(label_sum * invW);
+    DataT left_obj   = -left_label_sum * raft::log(left_label_sum / DataT(W_left));
+    DataT right_obj  = -right_label_sum * raft::log(right_label_sum / DataT(W_right));
     DataT gain       = parent_obj - (left_obj + right_obj);
-    gain             = gain * invLen;
+    gain             = gain * invW;
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
 
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };
@@ -365,14 +461,20 @@ class GammaObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       gamma half deviances.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
     IdxT nRight = len - nLeft;
-    auto invLen = DataT(1) / len;
-
-    // if there aren't enough samples in this split, don't bother!
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
+
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
     DataT label_sum       = hist[n_bins - 1].label_sum;
     DataT left_label_sum  = (hist[i].label_sum);
@@ -382,32 +484,46 @@ class GammaObjectiveFunction {
     if (label_sum < eps_ || left_label_sum < eps_ || right_label_sum < eps_)
       return -std::numeric_limits<DataT>::max();
 
-    // compute the gain to be
-    DataT parent_obj = len * raft::log(label_sum * invLen);
-    DataT left_obj   = nLeft * raft::log(left_label_sum / nLeft);
-    DataT right_obj  = nRight * raft::log(right_label_sum / nRight);
+    // Weighted Gamma half-deviance: the n coefficients become sum(weight) so
+    // the formula stays scale-equivariant under sample reweighting.
+    auto invW        = DataT(1.0) / DataT(W_total);
+    DataT parent_obj = DataT(W_total) * raft::log(label_sum * invW);
+    DataT left_obj   = DataT(W_left) * raft::log(left_label_sum / DataT(W_left));
+    DataT right_obj  = DataT(W_right) * raft::log(right_label_sum / DataT(W_right));
     DataT gain       = parent_obj - (left_obj + right_obj);
-    gain             = gain * invLen;
+    gain             = gain * invW;
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };
@@ -443,14 +559,20 @@ class InverseGaussianObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       inverse gaussian deviances.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
-    // get the lens'
     IdxT nRight = len - nLeft;
-
-    // if there aren't enough samples in this split, don't bother!
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
+
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
     auto label_sum       = hist[n_bins - 1].label_sum;
     auto left_label_sum  = (hist[i].label_sum);
@@ -460,32 +582,45 @@ class InverseGaussianObjectiveFunction {
     if (label_sum < eps_ || left_label_sum < eps_ || right_label_sum < eps_)
       return -std::numeric_limits<DataT>::max();
 
-    // compute the gain to be
-    DataT parent_obj = -DataT(len) * DataT(len) / label_sum;
-    DataT left_obj   = -DataT(nLeft) * DataT(nLeft) / left_label_sum;
-    DataT right_obj  = -DataT(nRight) * DataT(nRight) / right_label_sum;
+    // Weighted Inverse Gaussian half-deviance: substitute n with sum(weight)
+    // so the formula stays scale-equivariant under sample reweighting.
+    DataT parent_obj = -DataT(W_total) * DataT(W_total) / label_sum;
+    DataT left_obj   = -DataT(W_left) * DataT(W_left) / left_label_sum;
+    DataT right_obj  = -DataT(W_right) * DataT(W_right) / right_label_sum;
     DataT gain       = parent_obj - (left_obj + right_obj);
-    gain             = gain / (2 * len);
+    gain             = gain / (DataT(2.0) * DataT(W_total));
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };

--- a/cpp/src/decisiontree/decisiontree.cuh
+++ b/cpp/src/decisiontree/decisiontree.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -243,7 +243,8 @@ class DecisionTree {
     DecisionTreeParams params,
     uint64_t seed,
     const Quantiles<DataT, int>& quantiles,
-    int treeid)
+    int treeid,
+    const DataT* sample_weight = nullptr)
   {
     if (params.split_criterion ==
         CRITERION::CRITERION_END) {  // Set default to GINI (classification) or MSE (regression)
@@ -265,7 +266,8 @@ class DecisionTree {
                                                                  ncols,
                                                                  row_ids,
                                                                  unique_labels,
-                                                                 quantiles)
+                                                                 quantiles,
+                                                                 sample_weight)
         .train();
     } else if (not std::is_same<DataT, LabelT>::value and
                params.split_criterion == CRITERION::ENTROPY) {
@@ -280,7 +282,8 @@ class DecisionTree {
                                                                     ncols,
                                                                     row_ids,
                                                                     unique_labels,
-                                                                    quantiles)
+                                                                    quantiles,
+                                                                    sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and params.split_criterion == CRITERION::MSE) {
       return Builder<MSEObjectiveFunction<DataT, LabelT, IdxT>>(handle,
@@ -294,7 +297,8 @@ class DecisionTree {
                                                                 ncols,
                                                                 row_ids,
                                                                 unique_labels,
-                                                                quantiles)
+                                                                quantiles,
+                                                                sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and
                params.split_criterion == CRITERION::POISSON) {
@@ -309,7 +313,8 @@ class DecisionTree {
                                                                     ncols,
                                                                     row_ids,
                                                                     unique_labels,
-                                                                    quantiles)
+                                                                    quantiles,
+                                                                    sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and params.split_criterion == CRITERION::GAMMA) {
       return Builder<GammaObjectiveFunction<DataT, LabelT, IdxT>>(handle,
@@ -323,7 +328,8 @@ class DecisionTree {
                                                                   ncols,
                                                                   row_ids,
                                                                   unique_labels,
-                                                                  quantiles)
+                                                                  quantiles,
+                                                                  sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and
                params.split_criterion == CRITERION::INVERSE_GAUSSIAN) {
@@ -338,7 +344,8 @@ class DecisionTree {
                                                                             ncols,
                                                                             row_ids,
                                                                             unique_labels,
-                                                                            quantiles)
+                                                                            quantiles,
+                                                                            sample_weight)
         .train();
     } else {
       ASSERT(false, "Unknown split criterion.");

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -356,7 +356,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         float* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -366,8 +367,15 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<float, int>> rf_classifier =
     std::make_shared<RandomForest<float, int>>(rf_params, RF_type::CLASSIFICATION);
-  rf_classifier->fit(
-    user_handle, input, n_rows, n_cols, labels, n_unique_labels, forest, bootstrap_masks);
+  rf_classifier->fit(user_handle,
+                     input,
+                     n_rows,
+                     n_cols,
+                     labels,
+                     n_unique_labels,
+                     forest,
+                     bootstrap_masks,
+                     sample_weight);
 }
 
 void fit(const raft::handle_t& user_handle,
@@ -379,7 +387,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         double* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -389,8 +398,15 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<double, int>> rf_classifier =
     std::make_shared<RandomForest<double, int>>(rf_params, RF_type::CLASSIFICATION);
-  rf_classifier->fit(
-    user_handle, input, n_rows, n_cols, labels, n_unique_labels, forest, bootstrap_masks);
+  rf_classifier->fit(user_handle,
+                     input,
+                     n_rows,
+                     n_cols,
+                     labels,
+                     n_unique_labels,
+                     forest,
+                     bootstrap_masks,
+                     sample_weight);
 }
 
 template <typename value_t, typename label_t>
@@ -404,7 +420,8 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   value_t* feature_importances,
-                  rapids_logger::level_enum verbosity)
+                  rapids_logger::level_enum verbosity,
+                  value_t* sample_weight)
 {
   RandomForestMetaData<value_t, label_t> metadata;
   fit(user_handle,
@@ -416,7 +433,8 @@ void fit_treelite(const raft::handle_t& user_handle,
       n_unique_labels,
       rf_params,
       verbosity,
-      bootstrap_masks);
+      bootstrap_masks,
+      sample_weight);
 
   // Compute feature importances if requested
   if (feature_importances != nullptr) {
@@ -584,7 +602,8 @@ void fit(const raft::handle_t& user_handle,
          float* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         float* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -594,7 +613,8 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<float, float>> rf_regressor =
     std::make_shared<RandomForest<float, float>>(rf_params, RF_type::REGRESSION);
-  rf_regressor->fit(user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks);
+  rf_regressor->fit(
+    user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks, sample_weight);
 }
 
 void fit(const raft::handle_t& user_handle,
@@ -605,7 +625,8 @@ void fit(const raft::handle_t& user_handle,
          double* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         double* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -615,7 +636,8 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<double, double>> rf_regressor =
     std::make_shared<RandomForest<double, double>>(rf_params, RF_type::REGRESSION);
-  rf_regressor->fit(user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks);
+  rf_regressor->fit(
+    user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks, sample_weight);
 }
 
 template <typename value_t, typename label_t>
@@ -628,10 +650,20 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   value_t* feature_importances,
-                  rapids_logger::level_enum verbosity)
+                  rapids_logger::level_enum verbosity,
+                  value_t* sample_weight)
 {
   RandomForestMetaData<value_t, label_t> metadata;
-  fit(user_handle, &metadata, input, n_rows, n_cols, labels, rf_params, verbosity, bootstrap_masks);
+  fit(user_handle,
+      &metadata,
+      input,
+      n_rows,
+      n_cols,
+      labels,
+      rf_params,
+      verbosity,
+      bootstrap_masks,
+      sample_weight);
 
   // Compute feature importances if requested
   if (feature_importances != nullptr) {
@@ -838,7 +870,8 @@ template CUML_EXPORT void fit_treelite<float, int>(const raft::handle_t& user_ha
                                                    RF_params rf_params,
                                                    bool* bootstrap_masks,
                                                    float* feature_importances,
-                                                   rapids_logger::level_enum verbosity);
+                                                   rapids_logger::level_enum verbosity,
+                                                   float* sample_weight);
 template CUML_EXPORT void fit_treelite<double, int>(const raft::handle_t& user_handle,
                                                     TreeliteModelHandle* model,
                                                     double* input,
@@ -849,7 +882,8 @@ template CUML_EXPORT void fit_treelite<double, int>(const raft::handle_t& user_h
                                                     RF_params rf_params,
                                                     bool* bootstrap_masks,
                                                     double* feature_importances,
-                                                    rapids_logger::level_enum verbosity);
+                                                    rapids_logger::level_enum verbosity,
+                                                    double* sample_weight);
 template CUML_EXPORT void fit_treelite<float, float>(const raft::handle_t& user_handle,
                                                      TreeliteModelHandle* model,
                                                      float* input,
@@ -859,7 +893,8 @@ template CUML_EXPORT void fit_treelite<float, float>(const raft::handle_t& user_
                                                      RF_params rf_params,
                                                      bool* bootstrap_masks,
                                                      float* feature_importances,
-                                                     rapids_logger::level_enum verbosity);
+                                                     rapids_logger::level_enum verbosity,
+                                                     float* sample_weight);
 template CUML_EXPORT void fit_treelite<double, double>(const raft::handle_t& user_handle,
                                                        TreeliteModelHandle* model,
                                                        double* input,
@@ -869,5 +904,6 @@ template CUML_EXPORT void fit_treelite<double, double>(const raft::handle_t& use
                                                        RF_params rf_params,
                                                        bool* bootstrap_masks,
                                                        double* feature_importances,
-                                                       rapids_logger::level_enum verbosity);
+                                                       rapids_logger::level_enum verbosity,
+                                                       double* sample_weight);
 }  // End namespace ML

--- a/cpp/src/randomforest/randomforest.cuh
+++ b/cpp/src/randomforest/randomforest.cuh
@@ -117,7 +117,8 @@ class RandomForest {
            L* labels,
            int n_unique_labels,
            RandomForestMetaData<T, L>* forest,
-           bool* bootstrap_masks = nullptr)
+           bool* bootstrap_masks  = nullptr,
+           const T* sample_weight = nullptr)
   {
     raft::common::nvtx::range fun_scope("RandomForest::fit @randomforest.cuh");
     this->error_checking(input, labels, n_rows, n_cols, false);
@@ -187,7 +188,8 @@ class RandomForest {
                                                this->rf_params.tree_params,
                                                this->rf_params.seed,
                                                quantiles,
-                                               i);
+                                               i,
+                                               sample_weight);
 
       // Store bootstrap mask if device buffer is provided
       if (bootstrap_masks != nullptr) {

--- a/cpp/tests/sg/rf_test.cu
+++ b/cpp/tests/sg/rf_test.cu
@@ -640,6 +640,299 @@ INSTANTIATE_TEST_CASE_P(RfTests,
                                                                            n_labels,
                                                                            double_precision)));
 
+// Unit-weight invariance: classifier fit with `sample_weight = 1.0` matches
+// the `nullptr` path byte-for-byte.
+TEST(RfTests, ClassifierSampleWeightOnesMatchesNullptr)
+{
+  constexpr int m = 500;
+  constexpr int n = 8;
+  thrust::device_vector<float> X(m * n);
+  thrust::device_vector<float> w(m, 1.0f);
+  raft::random::Rng r(7);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  std::vector<int> h_y(m);
+  std::mt19937 host_rng(7);
+  for (int i = 0; i < m; ++i)
+    h_y[i] = host_rng() & 1;
+  thrust::device_vector<int> y = h_y;
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(4, 32, 1.0, 32, 1, 2, 0.0, false, 5, 1.0, 42, CRITERION::GINI, 1, 128);
+
+  auto forest_null = std::make_shared<RandomForestMetaData<float, int>>();
+  auto forest_ones = std::make_shared<RandomForestMetaData<float, int>>();
+  fit(handle,
+      forest_null.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn);
+  fit(handle,
+      forest_ones.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn,
+      nullptr,
+      w.data().get());
+
+  ASSERT_EQ(forest_null->trees.size(), forest_ones->trees.size());
+  for (size_t t = 0; t < forest_null->trees.size(); ++t) {
+    auto& tn = forest_null->trees[t];
+    auto& to = forest_ones->trees[t];
+    ASSERT_EQ(tn->leaf_counter, to->leaf_counter) << "tree " << t;
+    ASSERT_EQ(tn->depth_counter, to->depth_counter) << "tree " << t;
+    ASSERT_EQ(tn->sparsetree, to->sparsetree) << "tree " << t;
+    ASSERT_EQ(tn->vector_leaf.size(), to->vector_leaf.size()) << "tree " << t;
+    for (size_t i = 0; i < tn->vector_leaf.size(); ++i) {
+      ASSERT_FLOAT_EQ(tn->vector_leaf[i], to->vector_leaf[i])
+        << "tree " << t << " leaf-element " << i;
+    }
+  }
+}
+
+// Unit-weight invariance: regressor fit with `sample_weight = 1.0` matches
+// the `nullptr` path byte-for-byte.
+TEST(RfTests, RegressorSampleWeightOnesMatchesNullptr)
+{
+  constexpr int m = 400;
+  constexpr int n = 6;
+  thrust::device_vector<float> X(m * n);
+  thrust::device_vector<float> y(m);
+  thrust::device_vector<float> w(m, 1.0f);
+  raft::random::Rng r(11);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  r.normal(y.data().get(), y.size(), 0.0f, 1.0f, nullptr);
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(4, 32, 1.0, 32, 1, 2, 0.0, false, 5, 1.0, 42, CRITERION::MSE, 1, 128);
+
+  auto forest_null = std::make_shared<RandomForestMetaData<float, float>>();
+  auto forest_ones = std::make_shared<RandomForestMetaData<float, float>>();
+  fit(handle,
+      forest_null.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      rf_params,
+      rapids_logger::level_enum::warn);
+  fit(handle,
+      forest_ones.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      rf_params,
+      rapids_logger::level_enum::warn,
+      nullptr,
+      w.data().get());
+
+  ASSERT_EQ(forest_null->trees.size(), forest_ones->trees.size());
+  for (size_t t = 0; t < forest_null->trees.size(); ++t) {
+    auto& tn = forest_null->trees[t];
+    auto& to = forest_ones->trees[t];
+    ASSERT_EQ(tn->leaf_counter, to->leaf_counter) << "tree " << t;
+    ASSERT_EQ(tn->depth_counter, to->depth_counter) << "tree " << t;
+    ASSERT_EQ(tn->sparsetree, to->sparsetree) << "tree " << t;
+    ASSERT_EQ(tn->vector_leaf.size(), to->vector_leaf.size()) << "tree " << t;
+    for (size_t i = 0; i < tn->vector_leaf.size(); ++i) {
+      ASSERT_FLOAT_EQ(tn->vector_leaf[i], to->vector_leaf[i])
+        << "tree " << t << " leaf-element " << i;
+    }
+  }
+}
+
+namespace DT {
+
+// Shared two-bin AggregateBin CDF for the four regressor weighted ground-truth
+// tests: hist[0] = LEFT prefix (label_sum=8, count=2), hist[1] = total
+// (label_sum=20, count=4). W_total=6, W_left=4, W_right=2, nLeft=2, len=4.
+static void RegressorWeightedHist(AggregateBin (&hist)[2])
+{
+  hist[0] = AggregateBin{8.0, 2};
+  hist[1] = AggregateBin{20.0, 4};
+}
+
+template <typename ObjectiveT, typename DataT>
+static DataT RegressorWeightedGainAt(DataT W_total, DataT W_left)
+{
+  AggregateBin hist[2];
+  RegressorWeightedHist(hist);
+  ObjectiveT objective(/* nclasses */ 1, /* min_samples_leaf */ 0);
+  return objective.GainPerSplit(hist,
+                                /* i */ 0,
+                                /* n_bins */ 2,
+                                /* len */ 4,
+                                /* nLeft */ 2,
+                                static_cast<double>(W_total),
+                                static_cast<double>(W_left));
+}
+
+// Weighted MSE proxy = 0.5 * (-L^2/W + L_l^2/W_l + L_r^2/W_r) / W; expected 16/9.
+TEST(RfTests, MSEWeightedGainPerSplitGroundTruth)
+{
+  auto g_d = RegressorWeightedGainAt<MSEObjectiveFunction<double, double, int>, double>(6.0, 4.0);
+  ASSERT_NEAR(16.0 / 9.0, g_d, 1e-9);
+  auto g_f = RegressorWeightedGainAt<MSEObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(16.0f / 9.0f, g_f, 1e-5f);
+}
+
+// Weighted Poisson half-deviance proxy: -sum L_k * log(L_k/W_k) / W. Expected
+// computed inline so a sign-flip in the implementation surfaces here.
+TEST(RfTests, PoissonWeightedGainPerSplitGroundTruth)
+{
+  const double parent   = -20.0 * std::log(20.0 / 6.0);
+  const double left     = -8.0 * std::log(8.0 / 4.0);
+  const double right    = -12.0 * std::log(12.0 / 2.0);
+  const double expected = (parent - (left + right)) / 6.0;
+  auto g_d =
+    RegressorWeightedGainAt<PoissonObjectiveFunction<double, double, int>, double>(6.0, 4.0);
+  ASSERT_NEAR(expected, g_d, 1e-9);
+  auto g_f =
+    RegressorWeightedGainAt<PoissonObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(static_cast<float>(expected), g_f, 1e-5f);
+}
+
+// Weighted Gamma half-deviance proxy: sum W_k * log(L_k/W_k) / W (parent term
+// scaled by W, not -L). Expected computed inline.
+TEST(RfTests, GammaWeightedGainPerSplitGroundTruth)
+{
+  const double parent   = 6.0 * std::log(20.0 / 6.0);
+  const double left     = 4.0 * std::log(8.0 / 4.0);
+  const double right    = 2.0 * std::log(12.0 / 2.0);
+  const double expected = (parent - (left + right)) / 6.0;
+  auto g_d = RegressorWeightedGainAt<GammaObjectiveFunction<double, double, int>, double>(6.0, 4.0);
+  ASSERT_NEAR(expected, g_d, 1e-9);
+  auto g_f = RegressorWeightedGainAt<GammaObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(static_cast<float>(expected), g_f, 1e-5f);
+}
+
+// Weighted Inverse Gaussian half-deviance proxy: -W_k^2 / L_k summed, scaled
+// by 1/(2*W). Expected = 2/45 from the shared histogram.
+TEST(RfTests, InverseGaussianWeightedGainPerSplitGroundTruth)
+{
+  const double expected = 2.0 / 45.0;
+  auto g_d = RegressorWeightedGainAt<InverseGaussianObjectiveFunction<double, double, int>, double>(
+    6.0, 4.0);
+  ASSERT_NEAR(expected, g_d, 1e-9);
+  auto g_f =
+    RegressorWeightedGainAt<InverseGaussianObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(static_cast<float>(expected), g_f, 1e-5f);
+}
+
+// GainPerSplit honors its integer nLeft argument for the min_samples_leaf
+// gate, independent of the weighted W_left. Asymmetric class counts so the
+// finite gain is provably nonzero (no per-class cancellation).
+TEST(RfTests, ClassifierGainPerSplitNLeftGateRespectsIntegerCount)
+{
+  const int n_bins                = 2;
+  const int nclass                = 2;
+  CountBin shist[n_bins * nclass] = {
+    CountBin{1.0},
+    CountBin{3.0},  // class 0: bin-0 prefix, bin-1 CDF total
+    CountBin{2.0},
+    CountBin{3.0},  // class 1
+  };
+  GiniObjectiveFunction<float, int, int> gini_strict(nclass, /* min_samples_leaf */ 3);
+  // Same weighted (W_total, W_left) both calls; only integer nLeft differs.
+  // len=10 keeps nRight >= leaf so the assertion isolates the nLeft side.
+  float gain_fail = gini_strict.GainPerSplit(shist,
+                                             /* i */ 0,
+                                             n_bins,
+                                             /* len */ 10,
+                                             /* nLeft */ 2,
+                                             /* W_total */ 6.0,
+                                             /* W_left */ 3.0);
+  float gain_ok   = gini_strict.GainPerSplit(shist,
+                                           /* i */ 0,
+                                           n_bins,
+                                           /* len */ 10,
+                                           /* nLeft */ 5,
+                                           /* W_total */ 6.0,
+                                           /* W_left */ 3.0);
+  ASSERT_EQ(gain_fail, -std::numeric_limits<float>::max());
+  ASSERT_GT(gain_ok, 0.0f);  // non-trivial positive gain proves no cancellation
+}
+
+// SetLeafVector is __device__-only; one-thread kernel wraps it for host gtests.
+template <typename ObjectiveT, typename BinT, typename DataT>
+__global__ void RunSetLeafVectorKernel(BinT const* shist,
+                                       int nclasses,
+                                       DataT* out,
+                                       double weighted_total)
+{
+  ObjectiveT::SetLeafVector(shist, nclasses, out, weighted_total);
+}
+
+template <typename ObjectiveT, typename BinT, typename DataT>
+static void RunSetLeafVectorOnDevice(std::vector<BinT> const& shist_host,
+                                     std::vector<DataT>& out_host,
+                                     double weighted_total)
+{
+  thrust::device_vector<BinT> shist_dev = shist_host;
+  thrust::device_vector<DataT> out_dev  = out_host;
+  RunSetLeafVectorKernel<ObjectiveT, BinT, DataT><<<1, 1>>>(shist_dev.data().get(),
+                                                            static_cast<int>(out_host.size()),
+                                                            out_dev.data().get(),
+                                                            weighted_total);
+  RAFT_CUDA_TRY(cudaDeviceSynchronize());
+  thrust::copy(out_dev.begin(), out_dev.end(), out_host.begin());
+}
+
+// All-zero-weight leaf: classifier SetLeafVector emits a uniform distribution
+// instead of NaN (0/0). Covers Gini and Entropy.
+TEST(RfTests, ClassifierSetLeafVectorAllZeroWeightYieldsUniform)
+{
+  const int nclasses          = 3;
+  std::vector<CountBin> shist = {CountBin{0.0}, CountBin{0.0}, CountBin{0.0}};
+  std::vector<float> out(nclasses, -1.0f);
+  RunSetLeafVectorOnDevice<GiniObjectiveFunction<float, int, int>, CountBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  for (int i = 0; i < nclasses; ++i)
+    ASSERT_FLOAT_EQ(out[i], 1.0f / static_cast<float>(nclasses));
+  std::fill(out.begin(), out.end(), -1.0f);
+  RunSetLeafVectorOnDevice<EntropyObjectiveFunction<float, int, int>, CountBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  for (int i = 0; i < nclasses; ++i)
+    ASSERT_FLOAT_EQ(out[i], 1.0f / static_cast<float>(nclasses));
+}
+
+// All-zero-weight leaf: regressor SetLeafVector emits 0 instead of NaN. Covers
+// all four regressor objectives.
+TEST(RfTests, RegressorSetLeafVectorAllZeroWeightYieldsZero)
+{
+  std::vector<AggregateBin> shist = {AggregateBin{0.0, 0}};
+  std::vector<float> out(1, -1.0f);
+  RunSetLeafVectorOnDevice<MSEObjectiveFunction<float, float, int>, AggregateBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+  out[0] = -1.0f;
+  RunSetLeafVectorOnDevice<PoissonObjectiveFunction<float, float, int>, AggregateBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+  out[0] = -1.0f;
+  RunSetLeafVectorOnDevice<GammaObjectiveFunction<float, float, int>, AggregateBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+  out[0]            = -1.0f;
+  using IGObjective = InverseGaussianObjectiveFunction<float, float, int>;
+  RunSetLeafVectorOnDevice<IGObjective, AggregateBin, float>(shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+}
+
+}  // namespace DT
+
 TEST(RfTests, IntegerOverflow)
 {
   std::size_t m = 1000000;
@@ -1438,11 +1731,19 @@ class ObjectiveTest : public ::testing::TestWithParam<ObjectiveTestParameters> {
     auto split_bin_index      = RandUnder(params.max_n_bins);
     auto ground_truth_gain    = GroundTruthGain(data, split_bin_index);
 
-    auto hypothesis_gain = objective.GainPerSplit(&cdf_hist[0],
-                                                  split_bin_index,
-                                                  params.max_n_bins,
-                                                  NumLeftOfBin(cdf_hist, params.max_n_bins - 1),
-                                                  NumLeftOfBin(cdf_hist, split_bin_index));
+    // Both Gini/Entropy (CountBin) and the regressor objectives (AggregateBin)
+    // now take weighted denominators (W_total, W_left). Tests are unweighted,
+    // so W == n; pass the unweighted sums through the weighted slots.
+    auto W_total = static_cast<double>(NumLeftOfBin(cdf_hist, params.max_n_bins - 1));
+    auto W_left  = static_cast<double>(NumLeftOfBin(cdf_hist, split_bin_index));
+    DataT hypothesis_gain;
+    hypothesis_gain = objective.GainPerSplit(&cdf_hist[0],
+                                             split_bin_index,
+                                             params.max_n_bins,
+                                             NumLeftOfBin(cdf_hist, params.max_n_bins - 1),
+                                             NumLeftOfBin(cdf_hist, split_bin_index),
+                                             W_total,
+                                             W_left);
 
     // The gain may actually be NaN. If so, a comparison between the result and
     // ground truth would yield false, even if they are both (correctly) NaNs.

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -205,7 +205,6 @@ RandomForestClassifier
 - If ``min_weight_fraction_leaf`` is not ``0``.
 - If ``ccp_alpha`` is not ``0``.
 - If ``class_weight`` is not ``None``.
-- If ``sample_weight`` is passed to ``fit`` or ``score``.
 - If ``X`` is sparse.
 - If ``X`` contains missing values (represented as ``NaN``).
 - If ``y`` is a multi-output target.
@@ -222,7 +221,6 @@ RandomForestRegressor
 - If ``max_values`` is an integer.
 - If ``min_weight_fraction_leaf`` is not ``0``.
 - If ``ccp_alpha`` is not ``0``.
-- If ``sample_weight`` is passed to ``fit`` or ``score``.
 - If ``X`` is sparse.
 - If ``X`` contains missing values (represented as ``NaN``).
 - If ``y`` is a multi-output target.

--- a/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
@@ -12,7 +12,7 @@ __all__ = ("RandomForestRegressor", "RandomForestClassifier")
 
 
 class _RandomForestMixin:
-    def _check_inputs(self, X, y=None, sample_weight=None):
+    def _check_inputs(self, X, y=None):
         # Fallback to CPU if NaN in X
         try:
             check_array(
@@ -24,9 +24,6 @@ class _RandomForestMixin:
                     "Missing values are not supported"
                 ) from None
             raise
-
-        if sample_weight is not None:
-            raise UnsupportedOnGPU("`sample_weight` is not supported")
 
         if y is not None:
             y = check_array(
@@ -47,16 +44,16 @@ class _RandomForestMixin:
                 )
 
     def _gpu_fit(self, X, y, sample_weight=None):
-        self._check_inputs(X, y, sample_weight=sample_weight)
-        return self._gpu.fit(X, y)
+        self._check_inputs(X, y)
+        return self._gpu.fit(X, y, sample_weight=sample_weight)
 
     def _gpu_predict(self, X):
         self._check_inputs(X)
         return self._gpu.predict(X)
 
     def _gpu_score(self, X, y, sample_weight=None):
-        self._check_inputs(X, y, sample_weight=sample_weight)
-        return self._gpu.score(X, y)
+        self._check_inputs(X, y)
+        return self._gpu.score(X, y, sample_weight=sample_weight)
 
 
 class RandomForestRegressor(ProxyBase, _RandomForestMixin):

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -158,7 +158,15 @@ class RandomForestClassifier(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(self, X, y, convert_dtype=False, broadcast_data=False):
+    def fit(
+        self,
+        X,
+        y,
+        convert_dtype=False,
+        broadcast_data=False,
+        *,
+        sample_weight=None,
+    ):
         """
         Fit the input data with a Random Forest classifier
 
@@ -207,8 +215,18 @@ class RandomForestClassifier(
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
             is trained on its partition
+        sample_weight : array-like of shape (n_samples,), optional (default = None)
+            Not supported on the distributed estimator; a non-None value raises
+            ``NotImplementedError``.
 
         """
+        if sample_weight is not None:
+            raise NotImplementedError(
+                "sample_weight is not supported for distributed "
+                "RandomForestClassifier; use the single-GPU "
+                "cuml.ensemble.RandomForestClassifier instead "
+                "(tracking issue: #8186)"
+            )
         # Handle both Dask Arrays and Dask Series/DataFrames
         if isinstance(y, dask.array.Array):
             # For Dask Arrays, use dask.array.unique

--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -141,7 +141,15 @@ class RandomForestRegressor(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(self, X, y, convert_dtype=False, broadcast_data=False):
+    def fit(
+        self,
+        X,
+        y,
+        convert_dtype=False,
+        broadcast_data=False,
+        *,
+        sample_weight=None,
+    ):
         """
         Fit the input data with a Random Forest regression model
 
@@ -186,8 +194,18 @@ class RandomForestRegressor(
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
             is trained on its partition
+        sample_weight : array-like of shape (n_samples,), optional (default = None)
+            Not supported on the distributed estimator; a non-None value raises
+            ``NotImplementedError``.
 
         """
+        if sample_weight is not None:
+            raise NotImplementedError(
+                "sample_weight is not supported for distributed "
+                "RandomForestRegressor; use the single-GPU "
+                "cuml.ensemble.RandomForestRegressor instead "
+                "(tracking issue: #8186)"
+            )
         self.internal_model = None
         self._fit(
             model=self.rfs,

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -78,7 +78,8 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
         RF_params params,
         bool* bootstrap_masks,
         T* feature_importances,
-        level_enum verbosity
+        level_enum verbosity,
+        T* sample_weight
     ) except +
 
     cdef void fit_treelite[T, L](
@@ -91,7 +92,8 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
         RF_params params,
         bool* bootstrap_masks,
         T* feature_importances,
-        level_enum verbosity
+        level_enum verbosity,
+        T* sample_weight
     ) except +
 
 
@@ -458,7 +460,7 @@ class BaseRandomForestModel(Base, InteropMixin):
             handle=get_handle(),
         )
 
-    def _fit_forest(self, X, y):
+    def _fit_forest(self, X, y, sample_weight=None):
         cdef bool is_classifier = self._estimator_type == "classifier"
         cdef bool is_float32 = X.dtype == np.float32
 
@@ -466,6 +468,14 @@ class BaseRandomForestModel(Base, InteropMixin):
         cdef uintptr_t y_ptr = y.data.ptr
         cdef int n_rows = X.shape[0]
         cdef int n_cols = X.shape[1]
+
+        # sample_weight is pre-validated by check_inputs; None becomes a NULL
+        # pointer at the C boundary (the kernel treats NULL as weight=1.0).
+        cdef uintptr_t sample_weight_ptr_val = (
+            sample_weight.data.ptr if sample_weight is not None else 0
+        )
+        cdef float* sample_weight_f = <float*> sample_weight_ptr_val
+        cdef double* sample_weight_d = <double*> sample_weight_ptr_val
         cdef level_enum verbose = <level_enum> self._verbose_level
         cdef int n_classes = self.n_classes_ if is_classifier else 0
 
@@ -575,7 +585,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <float*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_f
                     )
                 else:
                     fit_treelite(
@@ -589,7 +600,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <double*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_d
                     )
             else:
                 if is_float32:
@@ -603,7 +615,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <float*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_f
                     )
                 else:
                     fit_treelite(
@@ -616,7 +629,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <double*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_d
                     )
 
         # XXX: Theoretically we could wrap `tl_handle` with `treelite.Model` to

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -238,21 +238,28 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         convert_dtype_cast="np.float32",
     )
     @cuml.internals.reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "RandomForestClassifier":
+    def fit(
+        self, X, y, sample_weight=None, *, convert_dtype=True
+    ) -> "RandomForestClassifier":
         """
         Perform Random Forest Classification on the input data
 
         Parameters
         ----------
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Sample weights. If None, then samples are equally weighted.
+            Quantile-binned split finding means weighting a row is not
+            equivalent to duplicating it.
         convert_dtype : bool, optional (default = True)
             When set to True, the fit method will, when necessary, convert
             y to be of dtype int32. This will increase memory used for
             the method.
         """
-        X, y, classes = check_inputs(
+        X, y, sample_weight, classes = check_inputs(
             self,
             X,
             y,
+            sample_weight=sample_weight,
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
             order="F",
@@ -262,7 +269,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         )
         self.classes_ = classes
         self.n_classes_ = len(classes)
-        return self._fit_forest(X, y)
+        return self._fit_forest(X, y, sample_weight=sample_weight)
 
     @nvtx.annotate(
         message="predict RF-Classifier @randomforestclassifier.pyx",
@@ -451,6 +458,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         self,
         X,
         y,
+        sample_weight=None,
         *,
         threshold=0.5,
         convert_dtype=True,
@@ -465,6 +473,8 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         ----------
         X : {}
         y : {}
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Per-sample weights forwarded to ``accuracy_score``.
         threshold : float (default = 0.5)
             Threshold used for classification predictions
         convert_dtype : bool (default = True)
@@ -496,4 +506,4 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,
         )
-        return accuracy_score(y, y_pred)
+        return accuracy_score(y, y_pred, sample_weight=sample_weight)

--- a/python/cuml/cuml/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/ensemble/randomforestregressor.py
@@ -202,23 +202,32 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         message="fit RF-Regressor @randomforestregressor.pyx",
         domain="cuml_python",
     )
-    @generate_docstring()
+    @generate_docstring(skip_parameters_heading=True)
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "RandomForestRegressor":
+    def fit(
+        self, X, y, sample_weight=None, *, convert_dtype=True
+    ) -> "RandomForestRegressor":
         """
         Perform Random Forest Regression on the input data
 
+        Parameters
+        ----------
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Sample weights. If None, then samples are equally weighted.
+            Quantile-binned split finding means weighting a row is not
+            equivalent to duplicating it.
         """
-        X, y = check_inputs(
+        X, y, sample_weight = check_inputs(
             self,
             X,
             y,
+            sample_weight=sample_weight,
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
             order="F",
             reset=True,
         )
-        return self._fit_forest(X, y)
+        return self._fit_forest(X, y, sample_weight=sample_weight)
 
     @nvtx.annotate(
         message="predict RF-Regressor @randomforestclassifier.pyx",
@@ -302,6 +311,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         self,
         X,
         y,
+        sample_weight=None,
         *,
         convert_dtype=True,
         layout="depth_first",
@@ -315,6 +325,8 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         ----------
         X : {}
         y : {}
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Per-sample weights forwarded to ``r2_score``.
         convert_dtype : bool (default = True)
             When True, automatically convert the input to the data type used
             to train the model. This may increase memory usage.
@@ -342,4 +354,4 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,
         )
-        return r2_score(y, y_pred)
+        return r2_score(y, y_pred, sample_weight=sample_weight)

--- a/python/cuml/cuml_accel_tests/integration/test_rf_classifier.py
+++ b/python/cuml/cuml_accel_tests/integration/test_rf_classifier.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -209,3 +209,19 @@ def test_oob_score(classification_data):
 
     # Check attribute exists and is a float
     assert isinstance(clf.oob_score_, float)
+
+
+def test_rf_sample_weight_runs_on_gpu(classification_data):
+    # cuml.accel proxy forwards sample_weight to the GPU classifier path
+    # for both fit() and score().
+    X, y = classification_data
+    w = np.random.RandomState(0).uniform(0.5, 2.0, len(y)).astype(np.float32)
+    clf = RandomForestClassifier(n_estimators=10, random_state=42)
+    clf.fit(X, y, sample_weight=w)
+    y_pred = clf.predict(X)
+    s_unweighted = clf.score(X, y)
+    s_weighted = clf.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(accuracy_score(y, y_pred))
+    assert s_weighted == pytest.approx(
+        accuracy_score(y, y_pred, sample_weight=w)
+    )

--- a/python/cuml/cuml_accel_tests/integration/test_rf_regressor.py
+++ b/python/cuml/cuml_accel_tests/integration/test_rf_regressor.py
@@ -1,8 +1,9 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import numpy as np
 import pytest
 from sklearn.datasets import make_regression
 from sklearn.ensemble import RandomForestRegressor
@@ -192,3 +193,17 @@ def test_oob_score(regression_data):
 
     # Check attribute exists and is a float
     assert isinstance(reg.oob_score_, float)
+
+
+def test_rf_sample_weight_runs_on_gpu(regression_data):
+    # cuml.accel proxy forwards sample_weight to the GPU regressor path
+    # for both fit() and score().
+    X, y = regression_data
+    w = np.random.RandomState(0).uniform(0.5, 2.0, len(y)).astype(np.float32)
+    reg = RandomForestRegressor(n_estimators=10, random_state=42)
+    reg.fit(X, y, sample_weight=w)
+    y_pred = reg.predict(X)
+    s_unweighted = reg.score(X, y)
+    s_weighted = reg.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(r2_score(y, y_pred))
+    assert s_weighted == pytest.approx(r2_score(y, y_pred, sample_weight=w))

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -929,6 +929,10 @@
   tests:
   - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_sparse_data]"
+- reason: Quantile-binned splits mean sample_weight is not equivalent to row duplication
+  marker: cuml_accel_test_estimators
+  condition: scikit-learn>=1.6
+  tests:
   - "sklearn.tests.test_common::test_estimators[RandomForestClassifier()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[RandomForestClassifier()-check_sample_weight_equivalence_on_sparse_data]"
   - "sklearn.tests.test_common::test_estimators[RandomForestRegressor()-check_sample_weight_equivalence_on_dense_data]"

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -518,3 +518,58 @@ def test_rf_broadcast(model_type, fit_broadcast, transform_broadcast, client):
 
     if transform_broadcast:
         assert cuml_mod.internal_model is None
+
+
+def _tiny_dataset():
+    # Single-chunk so the helper is topology-agnostic across worker counts.
+    X = cp.asarray(np.random.RandomState(0).rand(10, 3), dtype=cp.float32)
+    y = cp.asarray(np.array([0, 1] * 5), dtype=cp.int32)
+    w = cp.ones(len(y), dtype=cp.float32)
+    return from_array(X, chunks=(len(y), -1)), from_array(y, chunks=len(y)), w
+
+
+# The raises_not_implemented tests omit ignore_empty_partitions=True on
+# purpose: the NotImplementedError fires inside the subclass fit() before
+# control reaches base._fit where the empty-partition check lives.
+def test_dask_rfc_sample_weight_raises_not_implemented(client):
+    X, y, w = _tiny_dataset()
+    with pytest.raises(
+        NotImplementedError,
+        match=r"sample_weight is not supported for distributed RandomForest",
+    ):
+        cuRFC_mg(client=client, n_estimators=2, max_depth=2).fit(
+            X, y, sample_weight=w
+        )
+
+
+def test_dask_rfr_sample_weight_raises_not_implemented(client):
+    X, y, w = _tiny_dataset()
+    y = y.astype(cp.float32)
+    with pytest.raises(
+        NotImplementedError,
+        match=r"sample_weight is not supported for distributed RandomForest",
+    ):
+        cuRFR_mg(client=client, n_estimators=2, max_depth=2).fit(
+            X, y, sample_weight=w
+        )
+
+
+def test_dask_rfc_sample_weight_none_does_not_raise(client):
+    X, y, _ = _tiny_dataset()
+    cuRFC_mg(
+        client=client,
+        n_estimators=2,
+        max_depth=2,
+        ignore_empty_partitions=True,
+    ).fit(X, y, sample_weight=None)
+
+
+def test_dask_rfr_sample_weight_none_does_not_raise(client):
+    X, y, _ = _tiny_dataset()
+    y = y.astype(cp.float32)
+    cuRFR_mg(
+        client=client,
+        n_estimators=2,
+        max_depth=2,
+        ignore_empty_partitions=True,
+    ).fit(X, y, sample_weight=None)

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -34,6 +34,7 @@ import cuml
 from cuml.ensemble import RandomForestClassifier as curfc
 from cuml.ensemble import RandomForestRegressor as curfr
 from cuml.ensemble.randomforest_common import compute_max_features
+from cuml.metrics import accuracy_score as cuml_accuracy_score
 from cuml.metrics import r2_score
 from cuml.testing.utils import quality_param, stress_param, unit_param
 
@@ -1427,3 +1428,248 @@ def test_rf_feature_zero_bias(datatype, n_features):
     # If feature 0 is severely under-sampled, accuracy will be much lower
     # Observed: mean=0.003, range=[0.001, 0.005], stderr=0.000
     assert cuml_acc >= (sk_acc - 0.10)
+
+
+@pytest.fixture
+def sample_weight_clf_data():
+    X, y = make_classification(
+        n_samples=500,
+        n_features=10,
+        n_classes=3,
+        n_informative=5,
+        random_state=42,
+    )
+    return cp.asarray(X, dtype=cp.float32), cp.asarray(y, dtype=cp.int32)
+
+
+@pytest.fixture
+def sample_weight_reg_data():
+    X, y = make_regression(
+        n_samples=300, n_features=8, n_informative=4, random_state=42
+    )
+    return cp.asarray(X, dtype=cp.float32), cp.asarray(y, dtype=cp.float32)
+
+
+def test_rfc_sample_weight_ones_matches_none(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    base = curfc(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    weighted = curfc(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    base.fit(X, y)
+    weighted.fit(X, y, sample_weight=cp.ones(len(y), dtype=cp.float32))
+    p_base = cp.asnumpy(base.predict(X))
+    p_weighted = cp.asnumpy(weighted.predict(X))
+    assert np.array_equal(p_base, p_weighted)
+
+
+def test_rfc_sample_weight_none_does_not_raise(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    p_no_arg = cp.asnumpy(
+        curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y)
+        .predict(X)
+    )
+    p_none = cp.asnumpy(
+        curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=None)
+        .predict(X)
+    )
+    assert np.array_equal(p_no_arg, p_none)
+
+
+def test_rfc_sample_weight_biases_minority_class():
+    X, y = make_classification(
+        n_samples=200, n_features=5, n_classes=2, random_state=42
+    )
+    X = cp.asarray(X, dtype=cp.float32)
+    y = cp.asarray(y, dtype=cp.int32)
+    weights = cp.where(y == 0, 10.0, 0.1).astype(cp.float32)
+
+    uniform = curfc(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    biased = curfc(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    uniform.fit(X, y)
+    biased.fit(X, y, sample_weight=weights)
+
+    n_class0_uniform = int((cp.asnumpy(uniform.predict(X)) == 0).sum())
+    n_class0_biased = int((cp.asnumpy(biased.predict(X)) == 0).sum())
+    # Observed: uniform=90, heavily-weighted-class-0=178 out of 200 rows.
+    assert n_class0_biased > n_class0_uniform
+
+
+def test_rfc_sample_weight_sklearn_parity_nonuniform(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    rng = np.random.default_rng(7)
+    w = rng.uniform(0.5, 2.0, len(y)).astype(np.float32)
+    w_cp = cp.asarray(w)
+
+    cu = curfc(n_estimators=20, max_depth=6, random_state=0, n_streams=1)
+    sk = skrfc(n_estimators=20, max_depth=6, random_state=0)
+    cu.fit(X, y, sample_weight=w_cp)
+    sk.fit(cp.asnumpy(X), cp.asnumpy(y), sample_weight=w)
+
+    cu_acc = accuracy_score(cp.asnumpy(y), cp.asnumpy(cu.predict(X)))
+    sk_acc = accuracy_score(cp.asnumpy(y), sk.predict(cp.asnumpy(X)))
+    # Observed: cu=0.95, sk=0.94, gap=0.01. Tolerance covers quantile-binning
+    # divergence + RNG drift across CUDA versions.
+    assert abs(cu_acc - sk_acc) < 0.07
+
+
+def test_rfc_sample_weight_positional_or_keyword(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    w = cp.ones(len(y), dtype=cp.float32)
+    p_pos = cp.asnumpy(
+        curfc(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, w)
+        .predict(X)
+    )
+    p_kw = cp.asnumpy(
+        curfc(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=w)
+        .predict(X)
+    )
+    assert np.array_equal(p_pos, p_kw)
+
+
+def test_rfc_score_with_sample_weight(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    rng = np.random.default_rng(1)
+    w = cp.asarray(rng.uniform(0.5, 2.0, len(y)).astype(np.float32))
+
+    clf = curfc(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+    s_unweighted = clf.score(X, y)
+    s_weighted = clf.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(float(cuml_accuracy_score(y, y_pred)))
+    assert s_weighted == pytest.approx(
+        float(cuml_accuracy_score(y, y_pred, sample_weight=w))
+    )
+
+
+def test_rfc_sample_weight_wrong_length_raises(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(ValueError, match=r"inconsistent number"):
+        clf.fit(X, y, sample_weight=cp.ones(len(y) + 5, dtype=cp.float32))
+
+
+def test_rfc_sample_weight_all_zero_raises(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(
+        ValueError, match=r"Sample weights must contain at least one non-zero"
+    ):
+        clf.fit(X, y, sample_weight=cp.zeros(len(y), dtype=cp.float32))
+
+
+def test_rfr_sample_weight_ones_matches_none(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    base = curfr(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    weighted = curfr(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    base.fit(X, y)
+    weighted.fit(X, y, sample_weight=cp.ones(len(y), dtype=cp.float32))
+    p_base = cp.asnumpy(base.predict(X))
+    p_weighted = cp.asnumpy(weighted.predict(X))
+    assert np.array_equal(p_base, p_weighted)
+
+
+def test_rfr_sample_weight_none_does_not_raise(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    p_no_arg = cp.asnumpy(
+        curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y)
+        .predict(X)
+    )
+    p_none = cp.asnumpy(
+        curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=None)
+        .predict(X)
+    )
+    assert np.array_equal(p_no_arg, p_none)
+
+
+def test_rfr_score_with_sample_weight(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    rng = np.random.default_rng(1)
+    w = cp.asarray(rng.uniform(0.5, 2.0, len(y)).astype(np.float32))
+
+    reg = curfr(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+    reg.fit(X, y)
+    y_pred = reg.predict(X)
+    s_unweighted = reg.score(X, y)
+    s_weighted = reg.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(float(r2_score(y, y_pred)))
+    assert s_weighted == pytest.approx(
+        float(r2_score(y, y_pred, sample_weight=w))
+    )
+
+
+def test_rfr_sample_weight_biases_prediction():
+    # Heavily upweight the top-half of the target; weighted-fit MAE on those
+    # rows should be lower than unweighted-fit MAE (which averages globally).
+    X, y = make_regression(
+        n_samples=200, n_features=5, n_informative=3, random_state=42
+    )
+    X = cp.asarray(X, dtype=cp.float32)
+    y = cp.asarray(y, dtype=cp.float32)
+    high = y > cp.median(y)
+    weights = cp.where(high, 10.0, 0.1).astype(cp.float32)
+
+    uniform = curfr(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    biased = curfr(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    uniform.fit(X, y)
+    biased.fit(X, y, sample_weight=weights)
+
+    err_uniform = float(cp.mean(cp.abs(uniform.predict(X)[high] - y[high])))
+    err_biased = float(cp.mean(cp.abs(biased.predict(X)[high] - y[high])))
+    # Observed: err_uniform ~ 87, err_biased ~ 41 on the upweighted half.
+    assert err_biased < err_uniform
+
+
+def test_rfr_sample_weight_sklearn_parity_nonuniform(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    rng = np.random.default_rng(7)
+    w = rng.uniform(0.5, 2.0, len(y)).astype(np.float32)
+    w_cp = cp.asarray(w)
+
+    cu = curfr(n_estimators=20, max_depth=6, random_state=0, n_streams=1)
+    sk = skrfr(n_estimators=20, max_depth=6, random_state=0)
+    cu.fit(X, y, sample_weight=w_cp)
+    sk.fit(cp.asnumpy(X), cp.asnumpy(y), sample_weight=w)
+
+    cu_r2 = r2_score(y, cu.predict(X))
+    sk_r2 = float(sk.score(cp.asnumpy(X), cp.asnumpy(y)))
+    # Observed: cu r2 ~ 0.91, sk r2 ~ 0.93, gap ~ 0.02. Tolerance covers
+    # quantile-binning divergence + RNG drift across CUDA versions.
+    assert abs(float(cu_r2) - sk_r2) < 0.10
+
+
+def test_rfr_sample_weight_wrong_length_raises(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    reg = curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(ValueError, match=r"inconsistent number"):
+        reg.fit(X, y, sample_weight=cp.ones(len(y) + 5, dtype=cp.float32))
+
+
+def test_rfr_sample_weight_all_zero_raises(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    reg = curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(
+        ValueError, match=r"Sample weights must contain at least one non-zero"
+    ):
+        reg.fit(X, y, sample_weight=cp.zeros(len(y), dtype=cp.float32))
+
+
+def test_rfr_sample_weight_positional_or_keyword(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    w = cp.ones(len(y), dtype=cp.float32)
+    p_pos = cp.asnumpy(
+        curfr(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, w)
+        .predict(X)
+    )
+    p_kw = cp.asnumpy(
+        curfr(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=w)
+        .predict(X)
+    )
+    assert np.array_equal(p_pos, p_kw)

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -119,10 +119,14 @@ XFAILS = {
     RandomForestRegressor: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",
         "check_regressor_data_not_an_array": "RandomForestRegressor does not handle non-array data",
+        "check_sample_weight_equivalence_on_dense_data": "Quantile binning means sample_weight is not equivalent to row duplication",
+        "check_sample_weight_equivalence_on_sparse_data": "RandomForestRegressor does not handle sparse data",
     },
     RandomForestClassifier: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",
         "check_classifier_data_not_an_array": "RandomForestClassifier does not handle non-array data",
+        "check_sample_weight_equivalence_on_dense_data": "Quantile binning means sample_weight is not equivalent to row duplication",
+        "check_sample_weight_equivalence_on_sparse_data": "RandomForestClassifier does not handle sparse data",
     },
     KNeighborsClassifier: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",


### PR DESCRIPTION
Towards #8093. Adds sample_weight to `RandomForestRegressor.fit`, building on the classifier work in #8132. Single-GPU only; distributed (Dask) raises `NotImplementedError` (tracking #8186).

The regressor follows the companion-buffer approach the classifier already uses: a per-bin weighted-count buffer feeds the weighted gain and leaf mean, while the unweighted sample count still drives `min_samples_leaf`. Weighted MSE and Poisson match sklearn; Gamma and InverseGaussian apply the same substitution to cuml's existing formulas. Leaf vectors NaN-guard the all-zero-weight case.

Adds per-objective ground-truth gtests plus Python tests mirrored across RFC and RFR. The accel proxy now forwards sample_weight to the GPU path. xfail entries for sklearn's `check_sample_weight_equivalence` checks stay because cuml's quantile-binned splits don't satisfy the row-duplication assumption.

On the regressor bench, double-precision MSE runs ~11% slower than the pre-PR baseline (cost of the per-sample weight accumulator); float is flat and classifier is within noise. `libcuml.so` grows by 36 KB. Adjacent fix: re-enabled `cpp/bench/sg/rf_regressor.cu` (was disabled with a stale FIXME); fixed a couple of compile errors and scaled the workload down so it finishes in minutes.
