### PR TITLE
RF: add class_weight to RandomForestClassifier

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -460,7 +460,9 @@ if(BUILD_CUML_CPP_LIBRARY)
   endif()
 
   if(all_algo OR randomforest_algo)
-    target_sources(cuml_objs PRIVATE src/randomforest/randomforest.cu)
+    target_sources(
+      cuml_objs PRIVATE src/randomforest/randomforest.cu src/randomforest/per_tree_weights.cu
+    )
   endif()
 
   # todo: separate solvers better

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -18,9 +18,7 @@ if(BUILD_CUML_BENCH)
     sg/linkage.cu
     sg/main.cpp
     sg/rf_classifier.cu
-    # FIXME: RF Regressor is having an issue where the tests now seem to take
-    # forever to finish, as opposed to the classifier counterparts!
-    # sg/rf_regressor.cu
+    sg/rf_regressor.cu
     sg/svc.cu
     sg/svr.cu
     sg/umap.cu

--- a/cpp/bench/sg/rf_regressor.cu
+++ b/cpp/bench/sg/rf_regressor.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -52,12 +52,12 @@ class RFRegressor : public RegressionFixture<D> {
       auto* mPtr = &model.model;
       fit(*this->handle,
           mPtr,
-          this->data.X,
+          this->data.X.data(),
           this->params.nrows,
           this->params.ncols,
-          this->data.y,
+          this->data.y.data(),
           rfParams);
-      handle->sync_stream(this->stream);
+      this->handle->sync_stream(this->stream);
     });
   }
 
@@ -75,14 +75,14 @@ std::vector<RegParams> getInputs()
   struct std::vector<RegParams> out;
   RegParams p;
   p.data.rowMajor = false;
-  p.regression    = {.shuffle        = true,  // Better to shuffle when n_informative < ncols
-                     .effective_rank = -1,    // dataset generation will be faster
+  p.regression    = {.effective_rank = -1,  // dataset generation will be faster
                      .bias           = 4.5,
                      .tail_strength  = 0.5,  // unused when effective_rank = -1
                      .noise          = 1.0,
+                     .shuffle        = true,  // Better to shuffle when n_informative < ncols
                      .seed           = 12345ULL};
 
-  p.rf                          = set_rf_params(10,                 /*max_depth */
+  p.rf = set_rf_params(8,                  /*max_depth */
                        (1 << 20),          /* max_leaves */
                        0.3,                /* max_features */
                        32,                 /* max_n_bins */
@@ -90,25 +90,23 @@ std::vector<RegParams> getInputs()
                        3,                  /* min_samples_split */
                        0.0f,               /* min_impurity_decrease */
                        true,               /* bootstrap */
-                       500,                /* n_trees */
+                       100,                /* n_trees */
                        1.f,                /* max_samples */
                        1234ULL,            /* seed */
                        ML::CRITERION::MSE, /* split_criterion */
                        8,                  /* n_streams */
                        128                 /* max_batch_size */
   );
-  std::vector<DimInfo> dim_info = {{500000, 500, 400}};
+  // Scaled down from {500000, 500, 400} so the bench finishes in minutes;
+  // restore on a follow-up that addresses the FIXME.
+  std::vector<DimInfo> dim_info = {{100000, 100, 80}};
   for (auto& di : dim_info) {
-    // Let's run Bosch only for float type
-    if (!std::is_same<D, float>::value && di.ncols == 968) continue;
     p.data.nrows                  = di.nrows;
     p.data.ncols                  = di.ncols;
     p.regression.n_informative    = di.n_informative;
     p.rf.tree_params.max_features = 1.f;
-    for (auto max_depth : std::vector<int>({7, 11, 15})) {
-      p.rf.tree_params.max_depth = max_depth;
-      out.push_back(p);
-    }
+    p.rf.tree_params.max_depth    = 8;
+    out.push_back(p);
   }
   return out;
 }

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -151,7 +151,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         float* sample_weight                = nullptr);
 void fit(const raft::handle_t& user_handle,
          RandomForestClassifierD* forest,
          double* input,
@@ -161,7 +162,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         double* sample_weight               = nullptr);
 
 template <typename T, typename L>
 void fit_treelite(const raft::handle_t& user_handle,
@@ -174,7 +176,8 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   T* feature_importances,
-                  rapids_logger::level_enum verbosity);
+                  rapids_logger::level_enum verbosity,
+                  T* sample_weight = nullptr);
 
 void predict(const raft::handle_t& user_handle,
              const RandomForestClassifierF* forest,
@@ -232,7 +235,8 @@ void fit(const raft::handle_t& user_handle,
          float* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         float* sample_weight                = nullptr);
 void fit(const raft::handle_t& user_handle,
          RandomForestRegressorD* forest,
          double* input,
@@ -241,7 +245,8 @@ void fit(const raft::handle_t& user_handle,
          double* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
-         bool* bootstrap_masks               = nullptr);
+         bool* bootstrap_masks               = nullptr,
+         double* sample_weight               = nullptr);
 
 template <typename T, typename L>
 void fit_treelite(const raft::handle_t& user_handle,
@@ -253,7 +258,8 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   T* feature_importances,
-                  rapids_logger::level_enum verbosity);
+                  rapids_logger::level_enum verbosity,
+                  T* sample_weight = nullptr);
 
 void predict(const raft::handle_t& user_handle,
              const RandomForestRegressorF* forest,

--- a/cpp/include/cuml/ensemble/randomforest.hpp
+++ b/cpp/include/cuml/ensemble/randomforest.hpp
@@ -26,6 +26,11 @@ enum RF_type {
 
 enum task_category { REGRESSION_MODEL = 1, CLASSIFICATION_MODEL = 2 };
 
+// Per-tree class-weight mode. NONE passes sample_weight through;
+// BALANCED_SUBSAMPLE recomputes per-tree reciprocals from each bootstrap
+// (see per_tree_weights.cuh for the formula and sklearn parity).
+enum class ClassWeightMode : int { NONE = 0, BALANCED_SUBSAMPLE = 1 };
+
 struct RF_metrics {
   RF_type rf_type;
 
@@ -152,7 +157,9 @@ void fit(const raft::handle_t& user_handle,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
          bool* bootstrap_masks               = nullptr,
-         float* sample_weight                = nullptr);
+         float* sample_weight                = nullptr,
+         int class_weight_mode               = 0,
+         const double* class_weight_array    = nullptr);
 void fit(const raft::handle_t& user_handle,
          RandomForestClassifierD* forest,
          double* input,
@@ -163,7 +170,9 @@ void fit(const raft::handle_t& user_handle,
          RF_params rf_params,
          rapids_logger::level_enum verbosity = rapids_logger::level_enum::info,
          bool* bootstrap_masks               = nullptr,
-         double* sample_weight               = nullptr);
+         double* sample_weight               = nullptr,
+         int class_weight_mode               = 0,
+         const double* class_weight_array    = nullptr);
 
 template <typename T, typename L>
 void fit_treelite(const raft::handle_t& user_handle,
@@ -177,7 +186,9 @@ void fit_treelite(const raft::handle_t& user_handle,
                   bool* bootstrap_masks,
                   T* feature_importances,
                   rapids_logger::level_enum verbosity,
-                  T* sample_weight = nullptr);
+                  T* sample_weight                 = nullptr,
+                  int class_weight_mode            = 0,
+                  const double* class_weight_array = nullptr);
 
 void predict(const raft::handle_t& user_handle,
              const RandomForestClassifierF* forest,

--- a/cpp/src/decisiontree/batched-levelalgo/bins.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/bins.cuh
@@ -9,17 +9,17 @@ namespace ML {
 namespace DT {
 
 struct CountBin {
-  // double covers both the unweighted count path and the future weighted-count
-  // path with one bin type; 32-bit int would overflow on large weighted counts.
+  // double covers both the unweighted count path (weight=1.0) and the
+  // per-sample-weighted path; 32-bit int would overflow on large weighted counts.
   double x;
   CountBin(CountBin const&) = default;
   HDI CountBin(double x_) : x(x_) {}
   HDI CountBin() : x(0.0) {}
 
-  DI static void IncrementHistogram(CountBin* hist, int n_bins, int b, int label)
+  DI static void IncrementHistogram(CountBin* hist, int n_bins, int b, int label, double weight)
   {
     auto offset = label * n_bins + b;
-    CountBin::AtomicAdd(hist + offset, {1.0});
+    CountBin::AtomicAdd(hist + offset, {weight});
   }
   DI static void AtomicAdd(CountBin* address, CountBin val) { atomicAdd(&address->x, val.x); }
   HDI CountBin& operator+=(const CountBin& b)
@@ -35,6 +35,8 @@ struct CountBin {
 };
 
 struct AggregateBin {
+  // `label_sum` carries `label * weight`; `count` stays unweighted so
+  // `min_samples_leaf` checks operate on the integer sample count.
   double label_sum;
   int count;
 
@@ -42,9 +44,10 @@ struct AggregateBin {
   HDI AggregateBin() : label_sum(0.0), count(0) {}
   HDI AggregateBin(double label_sum, int count) : label_sum(label_sum), count(count) {}
 
-  DI static void IncrementHistogram(AggregateBin* hist, int n_bins, int b, double label)
+  DI static void IncrementHistogram(
+    AggregateBin* hist, int n_bins, int b, double label, double weight)
   {
-    AggregateBin::AtomicAdd(hist + b, {label, 1});
+    AggregateBin::AtomicAdd(hist + b, {label * weight, 1});
   }
   DI static void AtomicAdd(AggregateBin* address, AggregateBin val)
   {
@@ -63,5 +66,6 @@ struct AggregateBin {
     return b;
   }
 };
+static_assert(sizeof(AggregateBin) == 16, "AggregateBin layout drift");
 }  // namespace DT
 }  // namespace ML

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -162,6 +162,17 @@ struct Builder {
   IdxT* n_nodes;
   /** buffer of segmented histograms*/
   BinT* histograms;
+  /** Classifier companion: per-bin unweighted sample counts for
+   *  `min_samples_leaf` + `Split::nLeft` under fractional weights. */
+  int* unweighted_histograms = nullptr;
+  /** Regressor companion: per-bin sum-of-weights totals for the weighted
+   *  gain denominator and leaf mean. */
+  double* weighted_count_histograms = nullptr;
+  // Compile-time gates on the builder's BinT type; mutually exclusive.
+  static constexpr bool kIsClassifier = std::is_same<typename ObjectiveT::BinT, CountBin>::value;
+  static constexpr bool kIsRegressor = std::is_same<typename ObjectiveT::BinT, AggregateBin>::value;
+  static_assert(kIsClassifier || kIsRegressor,
+                "Builder<ObjectiveT>::BinT must be CountBin or AggregateBin");
   /** threadblock arrival count */
   int* done_count;
   /** mutex array used for atomically updating best split */
@@ -199,7 +210,8 @@ struct Builder {
           IdxT n_cols,
           rmm::device_uvector<IdxT>* row_ids,
           IdxT n_classes,
-          const QuantilesT& q)
+          const QuantilesT& q,
+          const DataT* sample_weight = nullptr)
     : handle(handle),
       builder_stream(s),
       treeid(treeid),
@@ -212,7 +224,8 @@ struct Builder {
               int(row_ids->size()),
               max(1, IdxT(params.max_features * n_cols)),
               row_ids->data(),
-              n_classes},
+              n_classes,
+              sample_weight},
       quantiles(q),
       d_buff(0, builder_stream)
   {
@@ -266,8 +279,15 @@ struct Builder {
     size_t max_len_histograms =
       max_batch * params.max_n_bins * n_blks_for_cols * dataset.num_outputs;
 
-    d_wsize += calculateAlignedBytes(sizeof(IdxT));                               // n_nodes
-    d_wsize += calculateAlignedBytes(sizeof(BinT) * max_len_histograms);          // histograms
+    d_wsize += calculateAlignedBytes(sizeof(IdxT));                       // n_nodes
+    d_wsize += calculateAlignedBytes(sizeof(BinT) * max_len_histograms);  // histograms
+    size_t max_len_companion = max_batch * params.max_n_bins * n_blks_for_cols;
+    if constexpr (kIsClassifier) {
+      d_wsize += calculateAlignedBytes(sizeof(int) * max_len_companion);  // unweighted_histograms
+    } else if constexpr (kIsRegressor) {
+      d_wsize +=
+        calculateAlignedBytes(sizeof(double) * max_len_companion);  // weighted_count_histograms
+    }
     d_wsize += calculateAlignedBytes(sizeof(int) * max_batch * n_blks_for_cols);  // done_count
     d_wsize += calculateAlignedBytes(sizeof(int) * max_batch);                    // mutex
     d_wsize += calculateAlignedBytes(sizeof(SplitT) * max_batch);                 // splits
@@ -304,6 +324,14 @@ struct Builder {
     d_wspace += calculateAlignedBytes(sizeof(IdxT));
     histograms = reinterpret_cast<BinT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(BinT) * max_len_histograms);
+    size_t max_len_companion = max_batch * (params.max_n_bins) * n_blks_for_cols;
+    if constexpr (kIsClassifier) {
+      unweighted_histograms = reinterpret_cast<int*>(d_wspace);
+      d_wspace += calculateAlignedBytes(sizeof(int) * max_len_companion);
+    } else if constexpr (kIsRegressor) {
+      weighted_count_histograms = reinterpret_cast<double*>(d_wspace);
+      d_wspace += calculateAlignedBytes(sizeof(double) * max_len_companion);
+    }
     done_count = reinterpret_cast<int*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(int) * max_batch * n_col_blks);
     mutex = reinterpret_cast<int*>(d_wspace);
@@ -487,12 +515,20 @@ struct Builder {
   auto computeSplitSmemSize()
   {
     size_t smem_size_1 =
-      params.max_n_bins * dataset.num_outputs * sizeof(BinT) +  // shared_histogram size
-      params.max_n_bins * sizeof(DataT) +                       // shared_quantiles size
-      sizeof(int);                                              // shared_done size
-    // Extra room for alignment (see alignPointer in
-    // computeSplitKernel)
-    smem_size_1 += sizeof(DataT) + 3 * sizeof(int);
+      params.max_n_bins * dataset.num_outputs * sizeof(BinT) +  // shared_histogram
+      params.max_n_bins * sizeof(DataT) +                       // shared_quantiles
+      sizeof(int);                                              // shared_done
+    int n_align_slots = 3;  // shared_histogram, shared_quantiles, shared_done
+    if constexpr (kIsClassifier) {
+      smem_size_1 += params.max_n_bins * sizeof(int);  // shared_unweighted
+      n_align_slots = 4;
+    } else if constexpr (kIsRegressor) {
+      smem_size_1 += params.max_n_bins * sizeof(double);  // shared_weighted_count
+      n_align_slots = 4;
+    }
+    // Worst-case alignPointer slack per slot is sizeof(largest-following-type)-1.
+    // The regressor companion is double-aligned, so use 8 bytes per slot.
+    smem_size_1 += n_align_slots * sizeof(double);
     // Calculate the shared memory needed for evalBestSplit
     size_t smem_size_2 = raft::ceildiv(TPB_DEFAULT, raft::WarpSize) * sizeof(SplitT);
     // Pick the max of two
@@ -517,12 +553,22 @@ struct Builder {
     // required total length (in bins) of the global segmented histograms over all
     // classes, features and (large)nodes.
     int len_histograms = n_bins * n_classes * n_blocks_dimy * n_large_nodes;
+    int len_companion  = n_bins * n_blocks_dimy * n_large_nodes;
     RAFT_CUDA_TRY(cudaMemsetAsync(histograms, 0, sizeof(BinT) * len_histograms, builder_stream));
+    if constexpr (kIsClassifier) {
+      RAFT_CUDA_TRY(
+        cudaMemsetAsync(unweighted_histograms, 0, sizeof(int) * len_companion, builder_stream));
+    } else if constexpr (kIsRegressor) {
+      RAFT_CUDA_TRY(cudaMemsetAsync(
+        weighted_count_histograms, 0, sizeof(double) * len_companion, builder_stream));
+    }
     // create the objective function object
     ObjectiveT objective(dataset.num_outputs, params.min_samples_leaf);
     // call the computeSplitKernel
     raft::common::nvtx::range kernel_scope("computeSplitKernel @builder.cuh [batched-levelalgo]");
     launchComputeSplitKernel<DataT, LabelT, IdxT, TPB_DEFAULT>(histograms,
+                                                               unweighted_histograms,
+                                                               weighted_count_histograms,
                                                                params.max_n_bins,
                                                                params.min_samples_split,
                                                                params.max_leaves,

--- a/cpp/src/decisiontree/batched-levelalgo/dataset.h
+++ b/cpp/src/decisiontree/batched-levelalgo/dataset.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,6 +26,8 @@ struct Dataset {
   IdxT* row_ids;
   /** Number of classes or regression outputs*/
   IdxT num_outputs;
+  /** per-row sample weights (length M); nullptr when no per-sample weighting */
+  const DataT* sample_weight = nullptr;
 };
 
 }  // namespace DT

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -365,6 +365,8 @@ CUML_KERNEL void adaptive_sample_kernel(int* colids,
   }
 }
 
+// Exactly one of the two companion pointers is non-null per builder; reads
+// are gated on `kIsClassifier` / `kIsRegressor`.
 template <typename DataT,
           typename LabelT,
           typename IdxT,
@@ -372,6 +374,8 @@ template <typename DataT,
           typename ObjectiveT,
           typename BinT>
 void launchComputeSplitKernel(BinT* histograms,
+                              int* unweighted_histograms,
+                              double* weighted_count_histograms,
                               IdxT n_bins,
                               IdxT min_samples_split,
                               IdxT max_leaves,

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -132,19 +132,35 @@ static __global__ void leafKernel(ObjectiveT objective,
   auto& node     = tree[node_id];
   auto range     = instance_ranges[node_id];
   if (!node.IsLeaf()) return;
-  auto tid = threadIdx.x;
+  auto tid                     = threadIdx.x;
+  constexpr bool kIsClassifier = std::is_same<BinT, CountBin>::value;
+  constexpr bool kIsRegressor  = std::is_same<BinT, AggregateBin>::value;
+  static_assert(kIsClassifier || kIsRegressor, "unknown BinT in leafKernel");
+  // Regressor leaf mean is sum(label*weight) / sum(weight); accumulate the
+  // weighted denominator once in shared memory and hand it to SetLeafVector.
+  // Classifier ignores the value.
+  __shared__ double shared_weight_at_leaf;
+  if constexpr (kIsRegressor) {
+    if (tid == 0) shared_weight_at_leaf = 0.0;
+  }
   for (int i = tid; i < dataset.num_outputs; i += blockDim.x) {
     histogram[i] = BinT();
   }
   __syncthreads();
+  bool has_weight = (dataset.sample_weight != nullptr);
   for (auto i = range.begin + tid; i < range.begin + range.count; i += blockDim.x) {
-    auto label = dataset.labels[dataset.row_ids[i]];
-    BinT::IncrementHistogram(histogram, 1, 0, label);
+    auto row      = dataset.row_ids[i];
+    auto label    = dataset.labels[row];
+    double weight = has_weight ? static_cast<double>(dataset.sample_weight[row]) : 1.0;
+    BinT::IncrementHistogram(histogram, 1, 0, label, weight);
+    if constexpr (kIsRegressor) { atomicAdd(&shared_weight_at_leaf, weight); }
   }
   __syncthreads();
   if (tid == 0) {
+    double weighted_total = 0.0;
+    if constexpr (kIsRegressor) { weighted_total = shared_weight_at_leaf; }
     ObjectiveT::SetLeafVector(
-      histogram, dataset.num_outputs, leaves + dataset.num_outputs * node_id);
+      histogram, dataset.num_outputs, leaves + dataset.num_outputs * node_id, weighted_total);
   }
 }
 
@@ -200,6 +216,8 @@ template <typename DataT,
           typename ObjectiveT,
           typename BinT>
 static __global__ void computeSplitKernel(BinT* histograms,
+                                          int* unweighted_histograms,
+                                          double* weighted_count_histograms,
                                           IdxT max_n_bins,
                                           IdxT min_samples_split,
                                           IdxT max_leaves,
@@ -242,37 +260,57 @@ static __global__ void computeSplitKernel(BinT* histograms,
   // getting the n_bins for that feature
   int n_bins = quantiles.n_bins_array[col];
 
-  auto end                  = range_start + range_len;
-  auto shared_histogram_len = n_bins * objective.NumClasses();
-  auto* shared_histogram    = alignPointer<BinT>(smem);
-  auto* shared_quantiles    = alignPointer<DataT>(shared_histogram + shared_histogram_len);
-  auto* shared_done         = alignPointer<int>(shared_quantiles + n_bins);
-  IdxT stride               = blockDim.x * num_blocks;
-  IdxT tid                  = threadIdx.x + offset_blockid * blockDim.x;
+  constexpr bool kIsClassifier = std::is_same<BinT, CountBin>::value;
+  constexpr bool kIsRegressor  = std::is_same<BinT, AggregateBin>::value;
+  static_assert(kIsClassifier || kIsRegressor, "unknown BinT in computeSplitKernel");
+
+  auto end                      = range_start + range_len;
+  auto shared_histogram_len     = n_bins * objective.NumClasses();
+  auto* shared_histogram        = alignPointer<BinT>(smem);
+  int* shared_unweighted        = nullptr;
+  double* shared_weighted_count = nullptr;
+  DataT* shared_quantiles;
+  int* shared_done;
+  if constexpr (kIsClassifier) {
+    shared_unweighted = alignPointer<int>(shared_histogram + shared_histogram_len);
+    shared_quantiles  = alignPointer<DataT>(shared_unweighted + n_bins);
+  } else if constexpr (kIsRegressor) {
+    shared_weighted_count = alignPointer<double>(shared_histogram + shared_histogram_len);
+    shared_quantiles      = alignPointer<DataT>(shared_weighted_count + n_bins);
+  } else {
+    shared_quantiles = alignPointer<DataT>(shared_histogram + shared_histogram_len);
+  }
+  shared_done = alignPointer<int>(shared_quantiles + n_bins);
+  IdxT stride = blockDim.x * num_blocks;
+  IdxT tid    = threadIdx.x + offset_blockid * blockDim.x;
 
   // populating shared memory with initial values
   for (IdxT i = threadIdx.x; i < shared_histogram_len; i += blockDim.x)
     shared_histogram[i] = BinT();
-  for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x)
+  for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x) {
+    if constexpr (kIsClassifier) shared_unweighted[b] = 0;
+    if constexpr (kIsRegressor) shared_weighted_count[b] = 0.0;
     shared_quantiles[b] = quantiles.quantiles_array[max_n_bins * col + b];
+  }
 
   // synchronizing above changes across block
   __syncthreads();
 
-  // compute pdf shared histogram for all bins for all classes in shared mem
-
+  bool has_weight = (dataset.sample_weight != nullptr);
   // Must be 64 bit - can easily grow larger than a 32 bit int
   std::size_t col_offset = std::size_t(col) * dataset.M;
   for (auto i = range_start + tid; i < end; i += stride) {
     // each thread works over a data point and strides to the next
-    auto row   = dataset.row_ids[i];
-    auto data  = dataset.data[row + col_offset];
-    auto label = dataset.labels[row];
+    auto row      = dataset.row_ids[i];
+    auto data     = dataset.data[row + col_offset];
+    auto label    = dataset.labels[row];
+    double weight = has_weight ? static_cast<double>(dataset.sample_weight[row]) : 1.0;
 
     // `start` is lowest index such that data <= shared_quantiles[start]
     IdxT start = lower_bound(shared_quantiles, n_bins, data);
-    // ++shared_histogram[start]
-    BinT::IncrementHistogram(shared_histogram, n_bins, start, label);
+    BinT::IncrementHistogram(shared_histogram, n_bins, start, label, weight);
+    if constexpr (kIsClassifier) atomicAdd(&shared_unweighted[start], 1);
+    if constexpr (kIsRegressor) atomicAdd(&shared_weighted_count[start], weight);
   }
 
   // synchronizing above changes across block
@@ -281,8 +319,18 @@ static __global__ void computeSplitKernel(BinT* histograms,
     // update the corresponding global location
     auto histograms_offset =
       ((large_nid * gridDim.y) + blockIdx.y) * max_n_bins * objective.NumClasses();
+    auto companion_offset = ((large_nid * gridDim.y) + blockIdx.y) * max_n_bins;
     for (IdxT i = threadIdx.x; i < shared_histogram_len; i += blockDim.x) {
       BinT::AtomicAdd(histograms + histograms_offset + i, shared_histogram[i]);
+    }
+    if constexpr (kIsClassifier) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x) {
+        atomicAdd(&unweighted_histograms[companion_offset + b], shared_unweighted[b]);
+      }
+    } else if constexpr (kIsRegressor) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x) {
+        atomicAdd(&weighted_count_histograms[companion_offset + b], shared_weighted_count[b]);
+      }
     }
 
     __threadfence();  // for commit guarantee
@@ -297,6 +345,13 @@ static __global__ void computeSplitKernel(BinT* histograms,
     // store the complete global histogram in shared memory of last block
     for (IdxT i = threadIdx.x; i < shared_histogram_len; i += blockDim.x)
       shared_histogram[i] = histograms[histograms_offset + i];
+    if constexpr (kIsClassifier) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x)
+        shared_unweighted[b] = unweighted_histograms[companion_offset + b];
+    } else if constexpr (kIsRegressor) {
+      for (IdxT b = threadIdx.x; b < n_bins; b += blockDim.x)
+        shared_weighted_count[b] = weighted_count_histograms[companion_offset + b];
+    }
 
     __syncthreads();
   }
@@ -309,13 +364,21 @@ static __global__ void computeSplitKernel(BinT* histograms,
     // now, `shared_histogram[n_bins * c + i]` will have count of datapoints of class `c`
     // that are less than or equal to `shared_quantiles[i]`.
   }
+  if constexpr (kIsClassifier) { pdf_to_cdf<int, IdxT, TPB>(shared_unweighted, n_bins); }
+  if constexpr (kIsRegressor) { pdf_to_cdf<double, IdxT, TPB>(shared_weighted_count, n_bins); }
 
   __syncthreads();
 
   // calculate the best candidate bins (one for each thread in the block) in current feature and
   // corresponding information gain for splitting
-  Split<DataT, IdxT> sp =
-    objective.Gain(shared_histogram, shared_quantiles, col, range_len, n_bins);
+  Split<DataT, IdxT> sp;
+  if constexpr (kIsClassifier) {
+    sp =
+      objective.Gain(shared_histogram, shared_quantiles, col, range_len, n_bins, shared_unweighted);
+  } else {
+    sp = objective.Gain(
+      shared_histogram, shared_quantiles, col, range_len, n_bins, shared_weighted_count);
+  }
 
   __syncthreads();
 
@@ -332,6 +395,8 @@ template <typename DataT,
           typename ObjectiveT,
           typename BinT>
 void launchComputeSplitKernel(BinT* histograms,
+                              int* unweighted_histograms,
+                              double* weighted_count_histograms,
                               IdxT max_n_bins,
                               IdxT min_samples_split,
                               IdxT max_leaves,
@@ -353,6 +418,8 @@ void launchComputeSplitKernel(BinT* histograms,
 {
   computeSplitKernel<DataT, LabelT, IdxT, TPB_DEFAULT>
     <<<grid, TPB_DEFAULT, smem_size, builder_stream>>>(histograms,
+                                                       unweighted_histograms,
+                                                       weighted_count_histograms,
                                                        max_n_bins,
                                                        min_samples_split,
                                                        max_leaves,
@@ -393,6 +460,8 @@ template void launchLeafKernel<_DatasetT, _NodeT, _ObjectiveT, _DataT>(
 
 template void launchComputeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT, _ObjectiveT, _BinT>(
   _BinT* histograms,
+  int* unweighted_histograms,
+  double* weighted_count_histograms,
   _IdxT n_bins,
   _IdxT min_samples_split,
   _IdxT max_leaves,

--- a/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/objectives.cuh
@@ -38,57 +38,85 @@ class GiniObjectiveFunction {
   /**
    * @brief compute the gini impurity reduction for each split
    */
-  HDI DataT GainPerSplit(BinT* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft)
+  HDI DataT
+  GainPerSplit(BinT* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft, double W_total, double W_left)
   {
-    IdxT nRight         = len - nLeft;
-    constexpr DataT One = DataT(1.0);
-    auto invLen         = One / len;
-    auto invLeft        = One / nLeft;
-    auto invRight       = One / nRight;
-    auto gain           = DataT(0.0);
-
-    // if there aren't enough samples in this split, don't bother!
+    IdxT nRight = len - nLeft;
+    // min_samples_leaf gate stays on the unweighted counts: sklearn enforces
+    // min_samples_leaf against the integer left/right sample counts.
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
 
+    // Skip splits where one side has all-zero weights but nonzero sample count.
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
+
+    // Weighted Gini proxy: argmax of sum_c w_left_c^2/W_left + w_right_c^2/W_right.
+    // The leading 1/W_total scaling drops a constant term that's identical
+    // across split candidates within a node.
+    auto invW      = DataT(1.0) / DataT(W_total);
+    auto invWLeft  = DataT(1.0) / DataT(W_left);
+    auto invWRight = DataT(1.0) / DataT(W_right);
+    auto gain      = DataT(0.0);
+
     for (IdxT j = 0; j < nclasses; ++j) {
-      double val_i = 0.0;
-      auto lval_i  = hist[n_bins * j + i].x;
-      auto lval    = DataT(lval_i);
-      gain += lval * invLeft * lval * invLen;
+      auto lval      = DataT(hist[n_bins * j + i].x);
+      auto total_sum = DataT(hist[n_bins * j + n_bins - 1].x);
+      auto rval      = total_sum - lval;
 
-      val_i += lval_i;
-      auto total_sum = hist[n_bins * j + n_bins - 1].x;
-      auto rval_i    = total_sum - lval_i;
-      auto rval      = DataT(rval_i);
-      gain += rval * invRight * rval * invLen;
+      gain += lval * invWLeft * lval * invW;
+      gain += rval * invWRight * rval * invW;
 
-      val_i += rval_i;
-      auto val = DataT(val_i) * invLen;
+      auto val = total_sum * invW;
       gain -= val * val;
     }
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(BinT* shist, DataT* squantiles, IdxT col, IdxT len, IdxT n_bins)
+  DI Split<DataT, IdxT> Gain(
+    BinT* shist, DataT* squantiles, IdxT col, IdxT len, IdxT n_bins, int const* unweighted_cdf)
   {
+    // Hoist W_total out of the per-bin loop. The total weighted node sample
+    // count is the last-bin CDF value summed over classes.
+    double W_total = 0.0;
+    for (IdxT j = 0; j < nclasses; ++j)
+      W_total += shist[n_bins * j + n_bins - 1].x;
+
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      IdxT nLeft = 0;
-      for (IdxT j = 0; j < nclasses; ++j) {
-        nLeft += shist[n_bins * j + i].x;
-      }
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      // Read the unweighted prefix-count directly: under fractional
+      // sample_weight the per-class weighted CDF can't carry the integer
+      // sample count that min_samples_leaf and Split::nLeft need.
+      IdxT nLeft = unweighted_cdf[i];
+
+      // Weighted left-side total at bin i, summed over classes.
+      double W_left = 0.0;
+      for (IdxT j = 0; j < nclasses; ++j)
+        W_left += shist[n_bins * j + i].x;
+
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist,
+                               int nclasses,
+                               DataT* out,
+                               double /* weighted_total, unused for classifier */)
   {
     // Output probability
     double total = 0.0;
     for (int i = 0; i < nclasses; i++) {
       total += shist[i].x;
+    }
+    if (total <= 0.0) {
+      // All zero-weight leaf: emit a uniform distribution so downstream consumers
+      // see a finite vector and so argmax stays deterministic across builds.
+      DataT uniform = DataT(1.0) / DataT(nclasses);
+      for (int i = 0; i < nclasses; i++)
+        out[i] = uniform;
+      return;
     }
     for (int i = 0; i < nclasses; i++) {
       out[i] = DataT(shist[i].x) / total;
@@ -118,62 +146,86 @@ class EntropyObjectiveFunction {
   /**
    * @brief compute the Entropy (or information gain) for each split
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft)
+  HDI DataT GainPerSplit(
+    BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft, double W_total, double W_left)
   {
-    IdxT nRight{len - nLeft};
-    auto gain{DataT(0.0)};
-    // if there aren't enough samples in this split, don't bother!
-    if (nLeft < min_samples_leaf || nRight < min_samples_leaf) {
+    IdxT nRight = len - nLeft;
+    if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
-    } else {
-      auto invLeft{DataT(1.0) / nLeft};
-      auto invRight{DataT(1.0) / nRight};
-      auto invLen{DataT(1.0) / len};
-      for (IdxT c = 0; c < nclasses; ++c) {
-        double val_i = 0.0;
-        auto lval_i  = hist[n_bins * c + i].x;
-        if (lval_i != 0) {
-          auto lval = DataT(lval_i);
-          gain += raft::log(lval * invLeft) / raft::log(DataT(2)) * lval * invLen;
-        }
 
-        val_i += lval_i;
-        auto total_sum = hist[n_bins * c + n_bins - 1].x;
-        auto rval_i    = total_sum - lval_i;
-        if (rval_i != 0) {
-          auto rval = DataT(rval_i);
-          gain += raft::log(rval * invRight) / raft::log(DataT(2)) * rval * invLen;
-        }
+    // Skip splits where one side has all-zero weights but nonzero sample count.
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
-        val_i += rval_i;
-        if (val_i != 0) {
-          auto val = DataT(val_i) * invLen;
-          gain -= val * raft::log(val) / raft::log(DataT(2));
-        }
+    auto invWLeft  = DataT(1.0) / DataT(W_left);
+    auto invWRight = DataT(1.0) / DataT(W_right);
+    auto invW      = DataT(1.0) / DataT(W_total);
+    auto gain      = DataT(0.0);
+
+    for (IdxT c = 0; c < nclasses; ++c) {
+      auto lval_i = hist[n_bins * c + i].x;
+      if (lval_i != 0) {
+        auto lval = DataT(lval_i);
+        gain += raft::log(lval * invWLeft) / raft::log(DataT(2)) * lval * invW;
       }
 
-      return gain;
+      auto total_sum = hist[n_bins * c + n_bins - 1].x;
+      auto rval_i    = total_sum - lval_i;
+      if (rval_i != 0) {
+        auto rval = DataT(rval_i);
+        gain += raft::log(rval * invWRight) / raft::log(DataT(2)) * rval * invW;
+      }
+
+      if (total_sum != 0) {
+        auto val = DataT(total_sum) * invW;
+        gain -= val * raft::log(val) / raft::log(DataT(2));
+      }
     }
+
+    return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(BinT* scdf_labels, DataT* squantiles, IdxT col, IdxT len, IdxT n_bins)
+  DI Split<DataT, IdxT> Gain(BinT* scdf_labels,
+                             DataT* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             int const* unweighted_cdf)
   {
+    double W_total = 0.0;
+    for (IdxT c = 0; c < nclasses; ++c)
+      W_total += scdf_labels[n_bins * c + n_bins - 1].x;
+
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      IdxT nLeft = 0;
-      for (IdxT j = 0; j < nclasses; ++j) {
-        nLeft += scdf_labels[n_bins * j + i].x;
-      }
-      sp.update({squantiles[i], col, GainPerSplit(scdf_labels, i, n_bins, len, nLeft), nLeft});
+      IdxT nLeft = unweighted_cdf[i];
+
+      double W_left = 0.0;
+      for (IdxT c = 0; c < nclasses; ++c)
+        W_left += scdf_labels[n_bins * c + i].x;
+
+      sp.update({squantiles[i],
+                 col,
+                 GainPerSplit(scdf_labels, i, n_bins, len, nLeft, W_total, W_left),
+                 nLeft});
     }
     return sp;
   }
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist,
+                               int nclasses,
+                               DataT* out,
+                               double /* weighted_total, unused for classifier */)
   {
     // Output probability
     double total = 0.0;
     for (int i = 0; i < nclasses; i++) {
       total += shist[i].x;
+    }
+    if (total <= 0.0) {
+      DataT uniform = DataT(1.0) / DataT(nclasses);
+      for (int i = 0; i < nclasses; i++)
+        out[i] = uniform;
+      return;
     }
     for (int i = 0; i < nclasses; i++) {
       out[i] = DataT(shist[i].x) / total;
@@ -211,44 +263,68 @@ class MSEObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       mean-squared errors.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
-    auto gain{DataT(0)};
     IdxT nRight{len - nLeft};
-    auto invLen = DataT(1.0) / len;
-    // if there aren't enough samples in this split, don't bother!
+    // min_samples_leaf gate stays on the unweighted integer count: sklearn
+    // enforces min_samples_leaf against the sample count, not the weight sum.
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf) {
       return -std::numeric_limits<DataT>::max();
-    } else {
-      auto label_sum        = hist[n_bins - 1].label_sum;
-      DataT parent_obj      = -label_sum * label_sum * invLen;
-      DataT left_obj        = -(hist[i].label_sum * hist[i].label_sum) / nLeft;
-      DataT right_label_sum = hist[i].label_sum - label_sum;
-      DataT right_obj       = -(right_label_sum * right_label_sum) / nRight;
-      gain                  = parent_obj - (left_obj + right_obj);
-      gain *= DataT(0.5) * invLen;
-
-      return gain;
     }
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
+
+    // Weighted MSE proxy (sklearn 1.7.2 _criterion.pyx:1089-1118): replace n
+    // with sum(weight) in every denominator so leaf-mean is
+    // sum(label*weight)/sum(weight).
+    auto invW             = DataT(1.0) / DataT(W_total);
+    auto label_sum        = hist[n_bins - 1].label_sum;
+    DataT parent_obj      = -DataT(label_sum) * DataT(label_sum) * invW;
+    DataT left_obj        = -DataT(hist[i].label_sum * hist[i].label_sum) / DataT(W_left);
+    DataT right_label_sum = label_sum - hist[i].label_sum;
+    DataT right_obj       = -(right_label_sum * right_label_sum) / DataT(W_right);
+    DataT gain            = parent_obj - (left_obj + right_obj);
+    gain *= DataT(0.5) * invW;
+    return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    // AggregateBin.count is the unweighted sample count (see bins.cuh); the
+    // weighted CDF lives in the parallel companion buffer.
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
 
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };
@@ -285,15 +361,20 @@ class PoissonObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       poisson half deviances.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
-    // get the lens'
     IdxT nRight = len - nLeft;
-    auto invLen = DataT(1) / len;
-
-    // if there aren't enough samples in this split, don't bother!
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
+
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
     auto label_sum       = hist[n_bins - 1].label_sum;
     auto left_label_sum  = (hist[i].label_sum);
@@ -303,33 +384,48 @@ class PoissonObjectiveFunction {
     if (label_sum < eps_ || left_label_sum < eps_ || right_label_sum < eps_)
       return -std::numeric_limits<DataT>::max();
 
-    // compute the gain to be
-    DataT parent_obj = -label_sum * raft::log(label_sum * invLen);
-    DataT left_obj   = -left_label_sum * raft::log(left_label_sum / nLeft);
-    DataT right_obj  = -right_label_sum * raft::log(right_label_sum / nRight);
+    // Weighted Poisson half-deviance (sklearn 1.7.2 _criterion.pyx:1597-1642):
+    // swap sample-count denominators for sum(weight) so the predicted-mean per
+    // leaf is sum(label*weight)/sum(weight).
+    auto invW        = DataT(1.0) / DataT(W_total);
+    DataT parent_obj = -label_sum * raft::log(label_sum * invW);
+    DataT left_obj   = -left_label_sum * raft::log(left_label_sum / DataT(W_left));
+    DataT right_obj  = -right_label_sum * raft::log(right_label_sum / DataT(W_right));
     DataT gain       = parent_obj - (left_obj + right_obj);
-    gain             = gain * invLen;
+    gain             = gain * invW;
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
 
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };
@@ -365,14 +461,20 @@ class GammaObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       gamma half deviances.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
     IdxT nRight = len - nLeft;
-    auto invLen = DataT(1) / len;
-
-    // if there aren't enough samples in this split, don't bother!
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
+
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
     DataT label_sum       = hist[n_bins - 1].label_sum;
     DataT left_label_sum  = (hist[i].label_sum);
@@ -382,32 +484,46 @@ class GammaObjectiveFunction {
     if (label_sum < eps_ || left_label_sum < eps_ || right_label_sum < eps_)
       return -std::numeric_limits<DataT>::max();
 
-    // compute the gain to be
-    DataT parent_obj = len * raft::log(label_sum * invLen);
-    DataT left_obj   = nLeft * raft::log(left_label_sum / nLeft);
-    DataT right_obj  = nRight * raft::log(right_label_sum / nRight);
+    // Weighted Gamma half-deviance: the n coefficients become sum(weight) so
+    // the formula stays scale-equivariant under sample reweighting.
+    auto invW        = DataT(1.0) / DataT(W_total);
+    DataT parent_obj = DataT(W_total) * raft::log(label_sum * invW);
+    DataT left_obj   = DataT(W_left) * raft::log(left_label_sum / DataT(W_left));
+    DataT right_obj  = DataT(W_right) * raft::log(right_label_sum / DataT(W_right));
     DataT gain       = parent_obj - (left_obj + right_obj);
-    gain             = gain * invLen;
+    gain             = gain * invW;
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };
@@ -443,14 +559,20 @@ class InverseGaussianObjectiveFunction {
    *       and is mathematically equivalent to the respective differences of
    *       inverse gaussian deviances.
    */
-  HDI DataT GainPerSplit(BinT const* hist, IdxT i, IdxT n_bins, IdxT len, IdxT nLeft) const
+  HDI DataT GainPerSplit(BinT const* hist,
+                         IdxT i,
+                         IdxT n_bins,
+                         IdxT len,
+                         IdxT nLeft,
+                         double W_total,
+                         double W_left) const
   {
-    // get the lens'
     IdxT nRight = len - nLeft;
-
-    // if there aren't enough samples in this split, don't bother!
     if (nLeft < min_samples_leaf || nRight < min_samples_leaf)
       return -std::numeric_limits<DataT>::max();
+
+    double W_right = W_total - W_left;
+    if (W_left <= 0.0 || W_right <= 0.0) return -std::numeric_limits<DataT>::max();
 
     auto label_sum       = hist[n_bins - 1].label_sum;
     auto left_label_sum  = (hist[i].label_sum);
@@ -460,32 +582,45 @@ class InverseGaussianObjectiveFunction {
     if (label_sum < eps_ || left_label_sum < eps_ || right_label_sum < eps_)
       return -std::numeric_limits<DataT>::max();
 
-    // compute the gain to be
-    DataT parent_obj = -DataT(len) * DataT(len) / label_sum;
-    DataT left_obj   = -DataT(nLeft) * DataT(nLeft) / left_label_sum;
-    DataT right_obj  = -DataT(nRight) * DataT(nRight) / right_label_sum;
+    // Weighted Inverse Gaussian half-deviance: substitute n with sum(weight)
+    // so the formula stays scale-equivariant under sample reweighting.
+    DataT parent_obj = -DataT(W_total) * DataT(W_total) / label_sum;
+    DataT left_obj   = -DataT(W_left) * DataT(W_left) / left_label_sum;
+    DataT right_obj  = -DataT(W_right) * DataT(W_right) / right_label_sum;
     DataT gain       = parent_obj - (left_obj + right_obj);
-    gain             = gain / (2 * len);
+    gain             = gain / (DataT(2.0) * DataT(W_total));
 
     return gain;
   }
 
-  DI Split<DataT, IdxT> Gain(
-    BinT const* shist, DataT const* squantiles, IdxT col, IdxT len, IdxT n_bins) const
+  DI Split<DataT, IdxT> Gain(BinT const* shist,
+                             DataT const* squantiles,
+                             IdxT col,
+                             IdxT len,
+                             IdxT n_bins,
+                             double const* weighted_cdf) const
   {
+    double W_total = weighted_cdf[n_bins - 1];
     Split<DataT, IdxT> sp;
     for (IdxT i = threadIdx.x; i < n_bins; i += blockDim.x) {
-      auto nLeft = shist[i].count;
-      sp.update({squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft), nLeft});
+      auto nLeft    = shist[i].count;
+      double W_left = weighted_cdf[i];
+      sp.update(
+        {squantiles[i], col, GainPerSplit(shist, i, n_bins, len, nLeft, W_total, W_left), nLeft});
     }
     return sp;
   }
   DI IdxT NumClasses() const { return 1; }
 
-  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out)
+  static DI void SetLeafVector(BinT const* shist, int nclasses, DataT* out, double weighted_total)
   {
+    if (weighted_total <= 0.0) {
+      for (int i = 0; i < nclasses; i++)
+        out[i] = DataT(0);
+      return;
+    }
     for (int i = 0; i < nclasses; i++) {
-      out[i] = shist[i].label_sum / shist[i].count;
+      out[i] = DataT(shist[i].label_sum / weighted_total);
     }
   }
 };

--- a/cpp/src/decisiontree/decisiontree.cuh
+++ b/cpp/src/decisiontree/decisiontree.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -243,7 +243,8 @@ class DecisionTree {
     DecisionTreeParams params,
     uint64_t seed,
     const Quantiles<DataT, int>& quantiles,
-    int treeid)
+    int treeid,
+    const DataT* sample_weight = nullptr)
   {
     if (params.split_criterion ==
         CRITERION::CRITERION_END) {  // Set default to GINI (classification) or MSE (regression)
@@ -265,7 +266,8 @@ class DecisionTree {
                                                                  ncols,
                                                                  row_ids,
                                                                  unique_labels,
-                                                                 quantiles)
+                                                                 quantiles,
+                                                                 sample_weight)
         .train();
     } else if (not std::is_same<DataT, LabelT>::value and
                params.split_criterion == CRITERION::ENTROPY) {
@@ -280,7 +282,8 @@ class DecisionTree {
                                                                     ncols,
                                                                     row_ids,
                                                                     unique_labels,
-                                                                    quantiles)
+                                                                    quantiles,
+                                                                    sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and params.split_criterion == CRITERION::MSE) {
       return Builder<MSEObjectiveFunction<DataT, LabelT, IdxT>>(handle,
@@ -294,7 +297,8 @@ class DecisionTree {
                                                                 ncols,
                                                                 row_ids,
                                                                 unique_labels,
-                                                                quantiles)
+                                                                quantiles,
+                                                                sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and
                params.split_criterion == CRITERION::POISSON) {
@@ -309,7 +313,8 @@ class DecisionTree {
                                                                     ncols,
                                                                     row_ids,
                                                                     unique_labels,
-                                                                    quantiles)
+                                                                    quantiles,
+                                                                    sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and params.split_criterion == CRITERION::GAMMA) {
       return Builder<GammaObjectiveFunction<DataT, LabelT, IdxT>>(handle,
@@ -323,7 +328,8 @@ class DecisionTree {
                                                                   ncols,
                                                                   row_ids,
                                                                   unique_labels,
-                                                                  quantiles)
+                                                                  quantiles,
+                                                                  sample_weight)
         .train();
     } else if (std::is_same<DataT, LabelT>::value and
                params.split_criterion == CRITERION::INVERSE_GAUSSIAN) {
@@ -338,7 +344,8 @@ class DecisionTree {
                                                                             ncols,
                                                                             row_ids,
                                                                             unique_labels,
-                                                                            quantiles)
+                                                                            quantiles,
+                                                                            sample_weight)
         .train();
     } else {
       ASSERT(false, "Unknown split criterion.");

--- a/cpp/src/randomforest/per_tree_weights.cu
+++ b/cpp/src/randomforest/per_tree_weights.cu
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "per_tree_weights.cuh"
+
+#include <raft/core/handle.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cuda_runtime.h>
+
+namespace ML {
+
+namespace {
+
+// Shared-mem atomicAdd bincount; one block, smem holds n_unique_labels
+// ints. Simpler than CUB/Thrust at RFC's typical n_unique_labels (<= ~64).
+template <typename LabelT>
+__global__ void bincount_bootstrap_kernel(const LabelT* labels,
+                                          const int* selected_rows,
+                                          int n_sampled_rows,
+                                          int n_unique_labels,
+                                          int* counts_out)
+{
+  extern __shared__ int shared_counts[];
+  for (int c = threadIdx.x; c < n_unique_labels; c += blockDim.x) {
+    shared_counts[c] = 0;
+  }
+  __syncthreads();
+
+  for (int i = threadIdx.x; i < n_sampled_rows; i += blockDim.x) {
+    int row    = selected_rows[i];
+    LabelT lab = labels[row];
+    atomicAdd(&shared_counts[static_cast<int>(lab)], 1);
+  }
+  __syncthreads();
+
+  for (int c = threadIdx.x; c < n_unique_labels; c += blockDim.x) {
+    counts_out[c] = shared_counts[c];
+  }
+}
+
+template <typename DataT, typename LabelT>
+__global__ void fill_per_tree_weights_kernel(const LabelT* labels,
+                                             int n_rows,
+                                             const int* counts,
+                                             int n_sampled_rows,
+                                             const int* n_classes_present_ptr,
+                                             const DataT* base_sample_weight,
+                                             DataT* per_tree_weights)
+{
+  // sklearn parity: compute_sample_weight uses len(classes_subsample) as
+  // the denominator, not full class cardinality. n_classes_present_ptr
+  // is a device int written by count_classes_present_kernel; reading it
+  // here avoids a host-side cudaStreamSynchronize per tree.
+  const double denom_const = static_cast<double>(*n_classes_present_ptr);
+  const double n_sampled   = static_cast<double>(n_sampled_rows);
+
+  int tid    = blockIdx.x * blockDim.x + threadIdx.x;
+  int stride = blockDim.x * gridDim.x;
+
+  for (int i = tid; i < n_rows; i += stride) {
+    int lab   = static_cast<int>(labels[i]);
+    int count = counts[lab];
+    double reciprocal =
+      (count > 0) ? (n_sampled / (denom_const * static_cast<double>(count))) : 0.0;
+    double base         = base_sample_weight ? static_cast<double>(base_sample_weight[i]) : 1.0;
+    per_tree_weights[i] = static_cast<DataT>(base * reciprocal);
+  }
+}
+
+// Tiny reduction: count how many class bins received at least one sample
+// from this bootstrap. Used as the per-tree class-cardinality denominator
+// in fill_per_tree_weights_kernel to match sklearn.
+__global__ void count_classes_present_kernel(const int* counts,
+                                             int n_unique_labels,
+                                             int* n_present_out)
+{
+  extern __shared__ int shared_n_present[];
+  if (threadIdx.x == 0) shared_n_present[0] = 0;
+  __syncthreads();
+
+  for (int c = threadIdx.x; c < n_unique_labels; c += blockDim.x) {
+    if (counts[c] > 0) atomicAdd(&shared_n_present[0], 1);
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) *n_present_out = shared_n_present[0];
+}
+
+}  // namespace
+
+template <typename DataT, typename LabelT>
+void computePerTreeBalancedWeights(const raft::handle_t& handle,
+                                   cudaStream_t stream,
+                                   const LabelT* labels,
+                                   const int* selected_rows,
+                                   int n_sampled_rows,
+                                   int n_unique_labels,
+                                   int n_rows,
+                                   const DataT* base_sample_weight,
+                                   const double* /* class_weight_array */,
+                                   DataT* per_tree_weights)
+{
+  // Per-tree compute is bounded by stream s; rmm-deferred-free preserves
+  // lifetime past DecisionTree::fit's async kernels on the same stream.
+  // Shared-memory budget bound: n_unique_labels <= 8192 fits the typical
+  // 48-100KB per-block smem limit at sizeof(int) per class.
+  ASSERT(static_cast<size_t>(n_unique_labels) <= 8192,
+         "computePerTreeBalancedWeights: n_unique_labels=%d exceeds the "
+         "8192 cap dictated by shared-memory budget on the bincount kernel",
+         n_unique_labels);
+
+  rmm::device_uvector<int> counts(n_unique_labels, stream);
+  rmm::device_uvector<int> n_classes_present(1, stream);
+
+  constexpr int TPB   = 256;
+  size_t shared_bytes = sizeof(int) * static_cast<size_t>(n_unique_labels);
+  bincount_bootstrap_kernel<LabelT><<<1, TPB, shared_bytes, stream>>>(
+    labels, selected_rows, n_sampled_rows, n_unique_labels, counts.data());
+
+  count_classes_present_kernel<<<1, TPB, sizeof(int), stream>>>(
+    counts.data(), n_unique_labels, n_classes_present.data());
+
+  // Three kernel launches on `stream`, all async. No host sync needed:
+  // fill_per_tree_weights_kernel dereferences n_classes_present on device.
+  int fill_blocks = (n_rows + TPB - 1) / TPB;
+  fill_per_tree_weights_kernel<DataT, LabelT>
+    <<<fill_blocks, TPB, 0, stream>>>(labels,
+                                      n_rows,
+                                      counts.data(),
+                                      n_sampled_rows,
+                                      n_classes_present.data(),
+                                      base_sample_weight,
+                                      per_tree_weights);
+}
+
+// Explicit template instantiations matching the (T, L) combinations cuml's
+// RandomForest::fit supports (see randomforest.cu). The LabelT=float regressor
+// path is kept for ABI symmetry; BALANCED_SUBSAMPLE is RFC-only.
+template void computePerTreeBalancedWeights<float, int>(const raft::handle_t&,
+                                                        cudaStream_t,
+                                                        const int*,
+                                                        const int*,
+                                                        int,
+                                                        int,
+                                                        int,
+                                                        const float*,
+                                                        const double*,
+                                                        float*);
+template void computePerTreeBalancedWeights<double, int>(const raft::handle_t&,
+                                                         cudaStream_t,
+                                                         const int*,
+                                                         const int*,
+                                                         int,
+                                                         int,
+                                                         int,
+                                                         const double*,
+                                                         const double*,
+                                                         double*);
+
+}  // namespace ML

--- a/cpp/src/randomforest/per_tree_weights.cuh
+++ b/cpp/src/randomforest/per_tree_weights.cuh
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <raft/core/handle.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <cstdint>
+
+namespace ML {
+
+/**
+ * @brief Compute per-tree sample weights for class_weight='balanced_subsample'.
+ *
+ * Mirrors sklearn's _parallel_build_trees: bincount the bootstrap labels,
+ * derive balanced reciprocals using `n_classes_present` (classes with
+ * count > 0 in the bootstrap, matching sklearn's len(classes_subsample)),
+ * then fill per-row weights by multiplying the per-class reciprocal into
+ * `base_sample_weight`.
+ *
+ * @note `class_weight_array` is accepted on the ABI but not consumed by
+ * this mode (forward-compat for future C++ modes).
+ *
+ * @param[in]  handle             RAFT handle (for memory resource).
+ * @param[in]  stream             Stream the OMP loop is using for this tree.
+ * @param[in]  labels             [n_rows] device pointer; integer class labels.
+ * @param[in]  selected_rows      [n_sampled_rows] device pointer; bootstrap indices.
+ * @param[in]  n_sampled_rows     length of selected_rows.
+ * @param[in]  n_unique_labels    number of classes (upper bound of label value + 1).
+ * @param[in]  n_rows             length of labels / per_tree_weights.
+ * @param[in]  base_sample_weight [n_rows] device pointer, or nullptr (treated as 1.0).
+ * @param[in]  class_weight_array [n_unique_labels] device pointer (currently unused; see above).
+ * @param[out] per_tree_weights   [n_rows] device pointer, pre-allocated; receives the result.
+ */
+template <typename DataT, typename LabelT>
+void computePerTreeBalancedWeights(const raft::handle_t& handle,
+                                   cudaStream_t stream,
+                                   const LabelT* labels,
+                                   const int* selected_rows,
+                                   int n_sampled_rows,
+                                   int n_unique_labels,
+                                   int n_rows,
+                                   const DataT* base_sample_weight,
+                                   const double* class_weight_array,
+                                   DataT* per_tree_weights);
+
+}  // namespace ML

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -357,7 +357,9 @@ void fit(const raft::handle_t& user_handle,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
          bool* bootstrap_masks,
-         float* sample_weight)
+         float* sample_weight,
+         int class_weight_mode,
+         const double* class_weight_array)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -375,7 +377,9 @@ void fit(const raft::handle_t& user_handle,
                      n_unique_labels,
                      forest,
                      bootstrap_masks,
-                     sample_weight);
+                     sample_weight,
+                     class_weight_mode,
+                     class_weight_array);
 }
 
 void fit(const raft::handle_t& user_handle,
@@ -388,7 +392,9 @@ void fit(const raft::handle_t& user_handle,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
          bool* bootstrap_masks,
-         double* sample_weight)
+         double* sample_weight,
+         int class_weight_mode,
+         const double* class_weight_array)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -406,7 +412,9 @@ void fit(const raft::handle_t& user_handle,
                      n_unique_labels,
                      forest,
                      bootstrap_masks,
-                     sample_weight);
+                     sample_weight,
+                     class_weight_mode,
+                     class_weight_array);
 }
 
 template <typename value_t, typename label_t>
@@ -421,7 +429,9 @@ void fit_treelite(const raft::handle_t& user_handle,
                   bool* bootstrap_masks,
                   value_t* feature_importances,
                   rapids_logger::level_enum verbosity,
-                  value_t* sample_weight)
+                  value_t* sample_weight,
+                  int class_weight_mode,
+                  const double* class_weight_array)
 {
   RandomForestMetaData<value_t, label_t> metadata;
   fit(user_handle,
@@ -434,7 +444,9 @@ void fit_treelite(const raft::handle_t& user_handle,
       rf_params,
       verbosity,
       bootstrap_masks,
-      sample_weight);
+      sample_weight,
+      class_weight_mode,
+      class_weight_array);
 
   // Compute feature importances if requested
   if (feature_importances != nullptr) {
@@ -871,7 +883,9 @@ template CUML_EXPORT void fit_treelite<float, int>(const raft::handle_t& user_ha
                                                    bool* bootstrap_masks,
                                                    float* feature_importances,
                                                    rapids_logger::level_enum verbosity,
-                                                   float* sample_weight);
+                                                   float* sample_weight,
+                                                   int class_weight_mode,
+                                                   const double* class_weight_array);
 template CUML_EXPORT void fit_treelite<double, int>(const raft::handle_t& user_handle,
                                                     TreeliteModelHandle* model,
                                                     double* input,
@@ -883,7 +897,9 @@ template CUML_EXPORT void fit_treelite<double, int>(const raft::handle_t& user_h
                                                     bool* bootstrap_masks,
                                                     double* feature_importances,
                                                     rapids_logger::level_enum verbosity,
-                                                    double* sample_weight);
+                                                    double* sample_weight,
+                                                    int class_weight_mode,
+                                                    const double* class_weight_array);
 template CUML_EXPORT void fit_treelite<float, float>(const raft::handle_t& user_handle,
                                                      TreeliteModelHandle* model,
                                                      float* input,

--- a/cpp/src/randomforest/randomforest.cu
+++ b/cpp/src/randomforest/randomforest.cu
@@ -356,7 +356,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         float* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -366,8 +367,15 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<float, int>> rf_classifier =
     std::make_shared<RandomForest<float, int>>(rf_params, RF_type::CLASSIFICATION);
-  rf_classifier->fit(
-    user_handle, input, n_rows, n_cols, labels, n_unique_labels, forest, bootstrap_masks);
+  rf_classifier->fit(user_handle,
+                     input,
+                     n_rows,
+                     n_cols,
+                     labels,
+                     n_unique_labels,
+                     forest,
+                     bootstrap_masks,
+                     sample_weight);
 }
 
 void fit(const raft::handle_t& user_handle,
@@ -379,7 +387,8 @@ void fit(const raft::handle_t& user_handle,
          int n_unique_labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         double* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -389,8 +398,15 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<double, int>> rf_classifier =
     std::make_shared<RandomForest<double, int>>(rf_params, RF_type::CLASSIFICATION);
-  rf_classifier->fit(
-    user_handle, input, n_rows, n_cols, labels, n_unique_labels, forest, bootstrap_masks);
+  rf_classifier->fit(user_handle,
+                     input,
+                     n_rows,
+                     n_cols,
+                     labels,
+                     n_unique_labels,
+                     forest,
+                     bootstrap_masks,
+                     sample_weight);
 }
 
 template <typename value_t, typename label_t>
@@ -404,7 +420,8 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   value_t* feature_importances,
-                  rapids_logger::level_enum verbosity)
+                  rapids_logger::level_enum verbosity,
+                  value_t* sample_weight)
 {
   RandomForestMetaData<value_t, label_t> metadata;
   fit(user_handle,
@@ -416,7 +433,8 @@ void fit_treelite(const raft::handle_t& user_handle,
       n_unique_labels,
       rf_params,
       verbosity,
-      bootstrap_masks);
+      bootstrap_masks,
+      sample_weight);
 
   // Compute feature importances if requested
   if (feature_importances != nullptr) {
@@ -584,7 +602,8 @@ void fit(const raft::handle_t& user_handle,
          float* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         float* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -594,7 +613,8 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<float, float>> rf_regressor =
     std::make_shared<RandomForest<float, float>>(rf_params, RF_type::REGRESSION);
-  rf_regressor->fit(user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks);
+  rf_regressor->fit(
+    user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks, sample_weight);
 }
 
 void fit(const raft::handle_t& user_handle,
@@ -605,7 +625,8 @@ void fit(const raft::handle_t& user_handle,
          double* labels,
          RF_params rf_params,
          rapids_logger::level_enum verbosity,
-         bool* bootstrap_masks)
+         bool* bootstrap_masks,
+         double* sample_weight)
 {
   raft::common::nvtx::range fun_scope("RF::fit @randomforest.cu");
   ML::default_logger().set_level(verbosity);
@@ -615,7 +636,8 @@ void fit(const raft::handle_t& user_handle,
 
   std::shared_ptr<RandomForest<double, double>> rf_regressor =
     std::make_shared<RandomForest<double, double>>(rf_params, RF_type::REGRESSION);
-  rf_regressor->fit(user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks);
+  rf_regressor->fit(
+    user_handle, input, n_rows, n_cols, labels, 1, forest, bootstrap_masks, sample_weight);
 }
 
 template <typename value_t, typename label_t>
@@ -628,10 +650,20 @@ void fit_treelite(const raft::handle_t& user_handle,
                   RF_params rf_params,
                   bool* bootstrap_masks,
                   value_t* feature_importances,
-                  rapids_logger::level_enum verbosity)
+                  rapids_logger::level_enum verbosity,
+                  value_t* sample_weight)
 {
   RandomForestMetaData<value_t, label_t> metadata;
-  fit(user_handle, &metadata, input, n_rows, n_cols, labels, rf_params, verbosity, bootstrap_masks);
+  fit(user_handle,
+      &metadata,
+      input,
+      n_rows,
+      n_cols,
+      labels,
+      rf_params,
+      verbosity,
+      bootstrap_masks,
+      sample_weight);
 
   // Compute feature importances if requested
   if (feature_importances != nullptr) {
@@ -838,7 +870,8 @@ template CUML_EXPORT void fit_treelite<float, int>(const raft::handle_t& user_ha
                                                    RF_params rf_params,
                                                    bool* bootstrap_masks,
                                                    float* feature_importances,
-                                                   rapids_logger::level_enum verbosity);
+                                                   rapids_logger::level_enum verbosity,
+                                                   float* sample_weight);
 template CUML_EXPORT void fit_treelite<double, int>(const raft::handle_t& user_handle,
                                                     TreeliteModelHandle* model,
                                                     double* input,
@@ -849,7 +882,8 @@ template CUML_EXPORT void fit_treelite<double, int>(const raft::handle_t& user_h
                                                     RF_params rf_params,
                                                     bool* bootstrap_masks,
                                                     double* feature_importances,
-                                                    rapids_logger::level_enum verbosity);
+                                                    rapids_logger::level_enum verbosity,
+                                                    double* sample_weight);
 template CUML_EXPORT void fit_treelite<float, float>(const raft::handle_t& user_handle,
                                                      TreeliteModelHandle* model,
                                                      float* input,
@@ -859,7 +893,8 @@ template CUML_EXPORT void fit_treelite<float, float>(const raft::handle_t& user_
                                                      RF_params rf_params,
                                                      bool* bootstrap_masks,
                                                      float* feature_importances,
-                                                     rapids_logger::level_enum verbosity);
+                                                     rapids_logger::level_enum verbosity,
+                                                     float* sample_weight);
 template CUML_EXPORT void fit_treelite<double, double>(const raft::handle_t& user_handle,
                                                        TreeliteModelHandle* model,
                                                        double* input,
@@ -869,5 +904,6 @@ template CUML_EXPORT void fit_treelite<double, double>(const raft::handle_t& use
                                                        RF_params rf_params,
                                                        bool* bootstrap_masks,
                                                        double* feature_importances,
-                                                       rapids_logger::level_enum verbosity);
+                                                       rapids_logger::level_enum verbosity,
+                                                       double* sample_weight);
 }  // End namespace ML

--- a/cpp/src/randomforest/randomforest.cuh
+++ b/cpp/src/randomforest/randomforest.cuh
@@ -117,7 +117,8 @@ class RandomForest {
            L* labels,
            int n_unique_labels,
            RandomForestMetaData<T, L>* forest,
-           bool* bootstrap_masks = nullptr)
+           bool* bootstrap_masks  = nullptr,
+           const T* sample_weight = nullptr)
   {
     raft::common::nvtx::range fun_scope("RandomForest::fit @randomforest.cuh");
     this->error_checking(input, labels, n_rows, n_cols, false);
@@ -187,7 +188,8 @@ class RandomForest {
                                                this->rf_params.tree_params,
                                                this->rf_params.seed,
                                                quantiles,
-                                               i);
+                                               i,
+                                               sample_weight);
 
       // Store bootstrap mask if device buffer is provided
       if (bootstrap_masks != nullptr) {

--- a/cpp/src/randomforest/randomforest.cuh
+++ b/cpp/src/randomforest/randomforest.cuh
@@ -25,6 +25,9 @@
 #include <decisiontree/batched-levelalgo/quantiles.cuh>
 #include <decisiontree/decisiontree.cuh>
 #include <decisiontree/treelite_util.h>
+#include <randomforest/per_tree_weights.cuh>
+
+#include <type_traits>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -117,11 +120,20 @@ class RandomForest {
            L* labels,
            int n_unique_labels,
            RandomForestMetaData<T, L>* forest,
-           bool* bootstrap_masks  = nullptr,
-           const T* sample_weight = nullptr)
+           bool* bootstrap_masks            = nullptr,
+           const T* sample_weight           = nullptr,
+           int class_weight_mode            = 0,
+           const double* class_weight_array = nullptr)
   {
     raft::common::nvtx::range fun_scope("RandomForest::fit @randomforest.cuh");
     this->error_checking(input, labels, n_rows, n_cols, false);
+    ASSERT((class_weight_mode == 0) == (class_weight_array == nullptr),
+           "class_weight_mode and class_weight_array must agree on nullness: "
+           "NONE iff nullptr (mode=%d, array=%p)",
+           class_weight_mode,
+           static_cast<const void*>(class_weight_array));
+    const bool use_per_tree_weights =
+      class_weight_mode == static_cast<int>(ML::ClassWeightMode::BALANCED_SUBSAMPLE);
     const raft::handle_t& handle = user_handle;
     int n_sampled_rows           = 0;
     if (this->rf_params.bootstrap) {
@@ -168,6 +180,28 @@ class RandomForest {
 
       this->get_row_sample(i, n_rows, &selected_rows[stream_id], s);
 
+      // `if constexpr` gate: regressor (LabelT != int) instantiations
+      // skip the call site so they don't reference the unimplemented
+      // computePerTreeBalancedWeights<T, non-int>.
+      const T* tree_sample_weight = sample_weight;
+      rmm::device_uvector<T> per_tree_weights(0, s);
+      if constexpr (std::is_same_v<L, int>) {
+        if (use_per_tree_weights) {
+          per_tree_weights.resize(n_rows, s);
+          ML::computePerTreeBalancedWeights<T, L>(handle,
+                                                  s,
+                                                  labels,
+                                                  selected_rows[stream_id].data(),
+                                                  n_sampled_rows,
+                                                  n_unique_labels,
+                                                  n_rows,
+                                                  sample_weight,
+                                                  class_weight_array,
+                                                  per_tree_weights.data());
+          tree_sample_weight = per_tree_weights.data();
+        }
+      }
+
       /* Build individual tree in the forest.
         - input is a pointer to orig data that have n_cols features and n_rows rows.
         - n_sampled_rows: # rows sampled for tree's bootstrap sample.
@@ -189,7 +223,7 @@ class RandomForest {
                                                this->rf_params.seed,
                                                quantiles,
                                                i,
-                                               sample_weight);
+                                               tree_sample_weight);
 
       // Store bootstrap mask if device buffer is provided
       if (bootstrap_masks != nullptr) {

--- a/cpp/tests/sg/rf_test.cu
+++ b/cpp/tests/sg/rf_test.cu
@@ -640,6 +640,299 @@ INSTANTIATE_TEST_CASE_P(RfTests,
                                                                            n_labels,
                                                                            double_precision)));
 
+// Unit-weight invariance: classifier fit with `sample_weight = 1.0` matches
+// the `nullptr` path byte-for-byte.
+TEST(RfTests, ClassifierSampleWeightOnesMatchesNullptr)
+{
+  constexpr int m = 500;
+  constexpr int n = 8;
+  thrust::device_vector<float> X(m * n);
+  thrust::device_vector<float> w(m, 1.0f);
+  raft::random::Rng r(7);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  std::vector<int> h_y(m);
+  std::mt19937 host_rng(7);
+  for (int i = 0; i < m; ++i)
+    h_y[i] = host_rng() & 1;
+  thrust::device_vector<int> y = h_y;
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(4, 32, 1.0, 32, 1, 2, 0.0, false, 5, 1.0, 42, CRITERION::GINI, 1, 128);
+
+  auto forest_null = std::make_shared<RandomForestMetaData<float, int>>();
+  auto forest_ones = std::make_shared<RandomForestMetaData<float, int>>();
+  fit(handle,
+      forest_null.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn);
+  fit(handle,
+      forest_ones.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn,
+      nullptr,
+      w.data().get());
+
+  ASSERT_EQ(forest_null->trees.size(), forest_ones->trees.size());
+  for (size_t t = 0; t < forest_null->trees.size(); ++t) {
+    auto& tn = forest_null->trees[t];
+    auto& to = forest_ones->trees[t];
+    ASSERT_EQ(tn->leaf_counter, to->leaf_counter) << "tree " << t;
+    ASSERT_EQ(tn->depth_counter, to->depth_counter) << "tree " << t;
+    ASSERT_EQ(tn->sparsetree, to->sparsetree) << "tree " << t;
+    ASSERT_EQ(tn->vector_leaf.size(), to->vector_leaf.size()) << "tree " << t;
+    for (size_t i = 0; i < tn->vector_leaf.size(); ++i) {
+      ASSERT_FLOAT_EQ(tn->vector_leaf[i], to->vector_leaf[i])
+        << "tree " << t << " leaf-element " << i;
+    }
+  }
+}
+
+// Unit-weight invariance: regressor fit with `sample_weight = 1.0` matches
+// the `nullptr` path byte-for-byte.
+TEST(RfTests, RegressorSampleWeightOnesMatchesNullptr)
+{
+  constexpr int m = 400;
+  constexpr int n = 6;
+  thrust::device_vector<float> X(m * n);
+  thrust::device_vector<float> y(m);
+  thrust::device_vector<float> w(m, 1.0f);
+  raft::random::Rng r(11);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  r.normal(y.data().get(), y.size(), 0.0f, 1.0f, nullptr);
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(4, 32, 1.0, 32, 1, 2, 0.0, false, 5, 1.0, 42, CRITERION::MSE, 1, 128);
+
+  auto forest_null = std::make_shared<RandomForestMetaData<float, float>>();
+  auto forest_ones = std::make_shared<RandomForestMetaData<float, float>>();
+  fit(handle,
+      forest_null.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      rf_params,
+      rapids_logger::level_enum::warn);
+  fit(handle,
+      forest_ones.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      rf_params,
+      rapids_logger::level_enum::warn,
+      nullptr,
+      w.data().get());
+
+  ASSERT_EQ(forest_null->trees.size(), forest_ones->trees.size());
+  for (size_t t = 0; t < forest_null->trees.size(); ++t) {
+    auto& tn = forest_null->trees[t];
+    auto& to = forest_ones->trees[t];
+    ASSERT_EQ(tn->leaf_counter, to->leaf_counter) << "tree " << t;
+    ASSERT_EQ(tn->depth_counter, to->depth_counter) << "tree " << t;
+    ASSERT_EQ(tn->sparsetree, to->sparsetree) << "tree " << t;
+    ASSERT_EQ(tn->vector_leaf.size(), to->vector_leaf.size()) << "tree " << t;
+    for (size_t i = 0; i < tn->vector_leaf.size(); ++i) {
+      ASSERT_FLOAT_EQ(tn->vector_leaf[i], to->vector_leaf[i])
+        << "tree " << t << " leaf-element " << i;
+    }
+  }
+}
+
+namespace DT {
+
+// Shared two-bin AggregateBin CDF for the four regressor weighted ground-truth
+// tests: hist[0] = LEFT prefix (label_sum=8, count=2), hist[1] = total
+// (label_sum=20, count=4). W_total=6, W_left=4, W_right=2, nLeft=2, len=4.
+static void RegressorWeightedHist(AggregateBin (&hist)[2])
+{
+  hist[0] = AggregateBin{8.0, 2};
+  hist[1] = AggregateBin{20.0, 4};
+}
+
+template <typename ObjectiveT, typename DataT>
+static DataT RegressorWeightedGainAt(DataT W_total, DataT W_left)
+{
+  AggregateBin hist[2];
+  RegressorWeightedHist(hist);
+  ObjectiveT objective(/* nclasses */ 1, /* min_samples_leaf */ 0);
+  return objective.GainPerSplit(hist,
+                                /* i */ 0,
+                                /* n_bins */ 2,
+                                /* len */ 4,
+                                /* nLeft */ 2,
+                                static_cast<double>(W_total),
+                                static_cast<double>(W_left));
+}
+
+// Weighted MSE proxy = 0.5 * (-L^2/W + L_l^2/W_l + L_r^2/W_r) / W; expected 16/9.
+TEST(RfTests, MSEWeightedGainPerSplitGroundTruth)
+{
+  auto g_d = RegressorWeightedGainAt<MSEObjectiveFunction<double, double, int>, double>(6.0, 4.0);
+  ASSERT_NEAR(16.0 / 9.0, g_d, 1e-9);
+  auto g_f = RegressorWeightedGainAt<MSEObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(16.0f / 9.0f, g_f, 1e-5f);
+}
+
+// Weighted Poisson half-deviance proxy: -sum L_k * log(L_k/W_k) / W. Expected
+// computed inline so a sign-flip in the implementation surfaces here.
+TEST(RfTests, PoissonWeightedGainPerSplitGroundTruth)
+{
+  const double parent   = -20.0 * std::log(20.0 / 6.0);
+  const double left     = -8.0 * std::log(8.0 / 4.0);
+  const double right    = -12.0 * std::log(12.0 / 2.0);
+  const double expected = (parent - (left + right)) / 6.0;
+  auto g_d =
+    RegressorWeightedGainAt<PoissonObjectiveFunction<double, double, int>, double>(6.0, 4.0);
+  ASSERT_NEAR(expected, g_d, 1e-9);
+  auto g_f =
+    RegressorWeightedGainAt<PoissonObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(static_cast<float>(expected), g_f, 1e-5f);
+}
+
+// Weighted Gamma half-deviance proxy: sum W_k * log(L_k/W_k) / W (parent term
+// scaled by W, not -L). Expected computed inline.
+TEST(RfTests, GammaWeightedGainPerSplitGroundTruth)
+{
+  const double parent   = 6.0 * std::log(20.0 / 6.0);
+  const double left     = 4.0 * std::log(8.0 / 4.0);
+  const double right    = 2.0 * std::log(12.0 / 2.0);
+  const double expected = (parent - (left + right)) / 6.0;
+  auto g_d = RegressorWeightedGainAt<GammaObjectiveFunction<double, double, int>, double>(6.0, 4.0);
+  ASSERT_NEAR(expected, g_d, 1e-9);
+  auto g_f = RegressorWeightedGainAt<GammaObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(static_cast<float>(expected), g_f, 1e-5f);
+}
+
+// Weighted Inverse Gaussian half-deviance proxy: -W_k^2 / L_k summed, scaled
+// by 1/(2*W). Expected = 2/45 from the shared histogram.
+TEST(RfTests, InverseGaussianWeightedGainPerSplitGroundTruth)
+{
+  const double expected = 2.0 / 45.0;
+  auto g_d = RegressorWeightedGainAt<InverseGaussianObjectiveFunction<double, double, int>, double>(
+    6.0, 4.0);
+  ASSERT_NEAR(expected, g_d, 1e-9);
+  auto g_f =
+    RegressorWeightedGainAt<InverseGaussianObjectiveFunction<float, float, int>, float>(6.0f, 4.0f);
+  ASSERT_NEAR(static_cast<float>(expected), g_f, 1e-5f);
+}
+
+// GainPerSplit honors its integer nLeft argument for the min_samples_leaf
+// gate, independent of the weighted W_left. Asymmetric class counts so the
+// finite gain is provably nonzero (no per-class cancellation).
+TEST(RfTests, ClassifierGainPerSplitNLeftGateRespectsIntegerCount)
+{
+  const int n_bins                = 2;
+  const int nclass                = 2;
+  CountBin shist[n_bins * nclass] = {
+    CountBin{1.0},
+    CountBin{3.0},  // class 0: bin-0 prefix, bin-1 CDF total
+    CountBin{2.0},
+    CountBin{3.0},  // class 1
+  };
+  GiniObjectiveFunction<float, int, int> gini_strict(nclass, /* min_samples_leaf */ 3);
+  // Same weighted (W_total, W_left) both calls; only integer nLeft differs.
+  // len=10 keeps nRight >= leaf so the assertion isolates the nLeft side.
+  float gain_fail = gini_strict.GainPerSplit(shist,
+                                             /* i */ 0,
+                                             n_bins,
+                                             /* len */ 10,
+                                             /* nLeft */ 2,
+                                             /* W_total */ 6.0,
+                                             /* W_left */ 3.0);
+  float gain_ok   = gini_strict.GainPerSplit(shist,
+                                           /* i */ 0,
+                                           n_bins,
+                                           /* len */ 10,
+                                           /* nLeft */ 5,
+                                           /* W_total */ 6.0,
+                                           /* W_left */ 3.0);
+  ASSERT_EQ(gain_fail, -std::numeric_limits<float>::max());
+  ASSERT_GT(gain_ok, 0.0f);  // non-trivial positive gain proves no cancellation
+}
+
+// SetLeafVector is __device__-only; one-thread kernel wraps it for host gtests.
+template <typename ObjectiveT, typename BinT, typename DataT>
+__global__ void RunSetLeafVectorKernel(BinT const* shist,
+                                       int nclasses,
+                                       DataT* out,
+                                       double weighted_total)
+{
+  ObjectiveT::SetLeafVector(shist, nclasses, out, weighted_total);
+}
+
+template <typename ObjectiveT, typename BinT, typename DataT>
+static void RunSetLeafVectorOnDevice(std::vector<BinT> const& shist_host,
+                                     std::vector<DataT>& out_host,
+                                     double weighted_total)
+{
+  thrust::device_vector<BinT> shist_dev = shist_host;
+  thrust::device_vector<DataT> out_dev  = out_host;
+  RunSetLeafVectorKernel<ObjectiveT, BinT, DataT><<<1, 1>>>(shist_dev.data().get(),
+                                                            static_cast<int>(out_host.size()),
+                                                            out_dev.data().get(),
+                                                            weighted_total);
+  RAFT_CUDA_TRY(cudaDeviceSynchronize());
+  thrust::copy(out_dev.begin(), out_dev.end(), out_host.begin());
+}
+
+// All-zero-weight leaf: classifier SetLeafVector emits a uniform distribution
+// instead of NaN (0/0). Covers Gini and Entropy.
+TEST(RfTests, ClassifierSetLeafVectorAllZeroWeightYieldsUniform)
+{
+  const int nclasses          = 3;
+  std::vector<CountBin> shist = {CountBin{0.0}, CountBin{0.0}, CountBin{0.0}};
+  std::vector<float> out(nclasses, -1.0f);
+  RunSetLeafVectorOnDevice<GiniObjectiveFunction<float, int, int>, CountBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  for (int i = 0; i < nclasses; ++i)
+    ASSERT_FLOAT_EQ(out[i], 1.0f / static_cast<float>(nclasses));
+  std::fill(out.begin(), out.end(), -1.0f);
+  RunSetLeafVectorOnDevice<EntropyObjectiveFunction<float, int, int>, CountBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  for (int i = 0; i < nclasses; ++i)
+    ASSERT_FLOAT_EQ(out[i], 1.0f / static_cast<float>(nclasses));
+}
+
+// All-zero-weight leaf: regressor SetLeafVector emits 0 instead of NaN. Covers
+// all four regressor objectives.
+TEST(RfTests, RegressorSetLeafVectorAllZeroWeightYieldsZero)
+{
+  std::vector<AggregateBin> shist = {AggregateBin{0.0, 0}};
+  std::vector<float> out(1, -1.0f);
+  RunSetLeafVectorOnDevice<MSEObjectiveFunction<float, float, int>, AggregateBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+  out[0] = -1.0f;
+  RunSetLeafVectorOnDevice<PoissonObjectiveFunction<float, float, int>, AggregateBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+  out[0] = -1.0f;
+  RunSetLeafVectorOnDevice<GammaObjectiveFunction<float, float, int>, AggregateBin, float>(
+    shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+  out[0]            = -1.0f;
+  using IGObjective = InverseGaussianObjectiveFunction<float, float, int>;
+  RunSetLeafVectorOnDevice<IGObjective, AggregateBin, float>(shist, out, /* weighted_total */ 0.0);
+  ASSERT_FLOAT_EQ(out[0], 0.0f);
+}
+
+}  // namespace DT
+
 TEST(RfTests, IntegerOverflow)
 {
   std::size_t m = 1000000;
@@ -1438,11 +1731,19 @@ class ObjectiveTest : public ::testing::TestWithParam<ObjectiveTestParameters> {
     auto split_bin_index      = RandUnder(params.max_n_bins);
     auto ground_truth_gain    = GroundTruthGain(data, split_bin_index);
 
-    auto hypothesis_gain = objective.GainPerSplit(&cdf_hist[0],
-                                                  split_bin_index,
-                                                  params.max_n_bins,
-                                                  NumLeftOfBin(cdf_hist, params.max_n_bins - 1),
-                                                  NumLeftOfBin(cdf_hist, split_bin_index));
+    // Both Gini/Entropy (CountBin) and the regressor objectives (AggregateBin)
+    // now take weighted denominators (W_total, W_left). Tests are unweighted,
+    // so W == n; pass the unweighted sums through the weighted slots.
+    auto W_total = static_cast<double>(NumLeftOfBin(cdf_hist, params.max_n_bins - 1));
+    auto W_left  = static_cast<double>(NumLeftOfBin(cdf_hist, split_bin_index));
+    DataT hypothesis_gain;
+    hypothesis_gain = objective.GainPerSplit(&cdf_hist[0],
+                                             split_bin_index,
+                                             params.max_n_bins,
+                                             NumLeftOfBin(cdf_hist, params.max_n_bins - 1),
+                                             NumLeftOfBin(cdf_hist, split_bin_index),
+                                             W_total,
+                                             W_left);
 
     // The gain may actually be NaN. If so, a comparison between the result and
     // ground truth would yield false, even if they are both (correctly) NaNs.

--- a/cpp/tests/sg/rf_test.cu
+++ b/cpp/tests/sg/rf_test.cu
@@ -933,6 +933,191 @@ TEST(RfTests, RegressorSetLeafVectorAllZeroWeightYieldsZero)
 
 }  // namespace DT
 
+// Default args (mode=NONE, array=nullptr) must produce byte-identical
+// trees vs the pre-class_weight_mode signature.
+TEST(RfTests, ClassWeightModeNoneIsByteIdentical)
+{
+  constexpr int m = 400;
+  constexpr int n = 6;
+  thrust::device_vector<float> X(m * n);
+  raft::random::Rng r(11);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  std::vector<int> h_y(m);
+  std::mt19937 host_rng(11);
+  for (int i = 0; i < m; ++i)
+    h_y[i] = host_rng() & 1;
+  thrust::device_vector<int> y = h_y;
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(4, 32, 1.0, 32, 1, 2, 0.0, true, 5, 1.0, 17, CRITERION::GINI, 1, 128);
+
+  auto forest_default       = std::make_shared<RandomForestMetaData<float, int>>();
+  auto forest_explicit_none = std::make_shared<RandomForestMetaData<float, int>>();
+  fit(handle,
+      forest_default.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn);
+  fit(handle,
+      forest_explicit_none.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn,
+      /*bootstrap_masks=*/nullptr,
+      /*sample_weight=*/nullptr,
+      /*class_weight_mode=*/static_cast<int>(ClassWeightMode::NONE),
+      /*class_weight_array=*/nullptr);
+
+  ASSERT_EQ(forest_default->trees.size(), forest_explicit_none->trees.size());
+  for (size_t t = 0; t < forest_default->trees.size(); ++t) {
+    auto& td = forest_default->trees[t];
+    auto& te = forest_explicit_none->trees[t];
+    ASSERT_EQ(td->leaf_counter, te->leaf_counter) << "tree " << t;
+    ASSERT_EQ(td->depth_counter, te->depth_counter) << "tree " << t;
+    ASSERT_EQ(td->sparsetree, te->sparsetree) << "tree " << t;
+    ASSERT_EQ(td->vector_leaf.size(), te->vector_leaf.size()) << "tree " << t;
+    for (size_t i = 0; i < td->vector_leaf.size(); ++i) {
+      ASSERT_FLOAT_EQ(td->vector_leaf[i], te->vector_leaf[i])
+        << "tree " << t << " leaf-element " << i;
+    }
+  }
+}
+
+// Contract: (mode == NONE) iff (array == nullptr). Both halves should
+// raise a typed exception when violated.
+TEST(RfTests, ClassWeightModeContractViolationAsserts)
+{
+  constexpr int m = 64;
+  constexpr int n = 4;
+  thrust::device_vector<float> X(m * n);
+  raft::random::Rng r(7);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  std::vector<int> h_y(m, 0);
+  for (int i = 0; i < m; ++i)
+    h_y[i] = i & 1;
+  thrust::device_vector<int> y = h_y;
+  thrust::device_vector<double> cw(2, 1.0);
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(3, 16, 1.0, 16, 1, 2, 0.0, true, 2, 1.0, 7, CRITERION::GINI, 1, 64);
+
+  auto forest_a = std::make_shared<RandomForestMetaData<float, int>>();
+  EXPECT_THROW(fit(handle,
+                   forest_a.get(),
+                   X.data().get(),
+                   m,
+                   n,
+                   y.data().get(),
+                   2,
+                   rf_params,
+                   rapids_logger::level_enum::warn,
+                   nullptr,
+                   nullptr,
+                   static_cast<int>(ClassWeightMode::BALANCED_SUBSAMPLE),
+                   /*class_weight_array=*/nullptr),
+               raft::exception);
+
+  auto forest_b = std::make_shared<RandomForestMetaData<float, int>>();
+  EXPECT_THROW(fit(handle,
+                   forest_b.get(),
+                   X.data().get(),
+                   m,
+                   n,
+                   y.data().get(),
+                   2,
+                   rf_params,
+                   rapids_logger::level_enum::warn,
+                   nullptr,
+                   nullptr,
+                   static_cast<int>(ClassWeightMode::NONE),
+                   cw.data().get()),
+               raft::exception);
+}
+
+// BALANCED_SUBSAMPLE on a 90/10 fixture must produce a different forest
+// than the unweighted baseline (engagement check, not sklearn parity).
+TEST(RfTests, ClassWeightModeBalancedSubsampleChangesForest)
+{
+  constexpr int m = 600;
+  constexpr int n = 6;
+  thrust::device_vector<float> X(m * n);
+  raft::random::Rng r(23);
+  r.normal(X.data().get(), X.size(), 0.0f, 1.0f, nullptr);
+  std::vector<int> h_y(m);
+  // 90/10 imbalance.
+  for (int i = 0; i < m; ++i)
+    h_y[i] = (i % 10 == 0) ? 1 : 0;
+  thrust::device_vector<int> y = h_y;
+  // Full-y balanced reciprocals: minority class (count=60) gets 5x, majority
+  // (count=540) gets ~0.556. Passed through the ABI as the diagnostic array.
+  thrust::device_vector<double> class_weights(2);
+  class_weights[0] = static_cast<double>(m) / (2.0 * 540.0);
+  class_weights[1] = static_cast<double>(m) / (2.0 * 60.0);
+
+  auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(1);
+  raft::handle_t handle(rmm::cuda_stream_per_thread, stream_pool);
+  RF_params rf_params =
+    set_rf_params(5, 64, 1.0, 32, 1, 2, 0.0, true, 8, 1.0, 23, CRITERION::GINI, 1, 128);
+
+  auto forest_baseline     = std::make_shared<RandomForestMetaData<float, int>>();
+  auto forest_balanced_sub = std::make_shared<RandomForestMetaData<float, int>>();
+  fit(handle,
+      forest_baseline.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn);
+  fit(handle,
+      forest_balanced_sub.get(),
+      X.data().get(),
+      m,
+      n,
+      y.data().get(),
+      2,
+      rf_params,
+      rapids_logger::level_enum::warn,
+      /*bootstrap_masks=*/nullptr,
+      /*sample_weight=*/nullptr,
+      /*class_weight_mode=*/static_cast<int>(ClassWeightMode::BALANCED_SUBSAMPLE),
+      /*class_weight_array=*/class_weights.data().get());
+
+  // Either the leaf counts or the tree structure should change; a forest
+  // that ignores the per-tree reweighting would be byte-identical here.
+  bool any_differ = false;
+  for (size_t t = 0; t < forest_baseline->trees.size(); ++t) {
+    auto& tb  = forest_baseline->trees[t];
+    auto& tbs = forest_balanced_sub->trees[t];
+    if (tb->leaf_counter != tbs->leaf_counter || tb->sparsetree.size() != tbs->sparsetree.size()) {
+      any_differ = true;
+      break;
+    }
+    for (size_t i = 0; i < tb->vector_leaf.size(); ++i) {
+      if (tb->vector_leaf[i] != tbs->vector_leaf[i]) {
+        any_differ = true;
+        break;
+      }
+    }
+    if (any_differ) break;
+  }
+  ASSERT_TRUE(any_differ) << "BALANCED_SUBSAMPLE produced identical forest to unweighted; the "
+                             "per-tree compute path is not engaging.";
+}
+
 TEST(RfTests, IntegerOverflow)
 {
   std::size_t m = 1000000;

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -205,7 +205,6 @@ RandomForestClassifier
 - If ``min_weight_fraction_leaf`` is not ``0``.
 - If ``ccp_alpha`` is not ``0``.
 - If ``class_weight`` is not ``None``.
-- If ``sample_weight`` is passed to ``fit`` or ``score``.
 - If ``X`` is sparse.
 - If ``X`` contains missing values (represented as ``NaN``).
 - If ``y`` is a multi-output target.
@@ -222,7 +221,6 @@ RandomForestRegressor
 - If ``max_values`` is an integer.
 - If ``min_weight_fraction_leaf`` is not ``0``.
 - If ``ccp_alpha`` is not ``0``.
-- If ``sample_weight`` is passed to ``fit`` or ``score``.
 - If ``X`` is sparse.
 - If ``X`` contains missing values (represented as ``NaN``).
 - If ``y`` is a multi-output target.

--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -204,7 +204,7 @@ RandomForestClassifier
 - If ``max_values`` is an integer.
 - If ``min_weight_fraction_leaf`` is not ``0``.
 - If ``ccp_alpha`` is not ``0``.
-- If ``class_weight`` is not ``None``.
+- If ``class_weight`` is a list of dicts (multi-output) or a string other than ``"balanced"`` / ``"balanced_subsample"``.
 - If ``X`` is sparse.
 - If ``X`` contains missing values (represented as ``NaN``).
 - If ``y`` is a multi-output target.

--- a/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/ensemble.py
@@ -12,7 +12,7 @@ __all__ = ("RandomForestRegressor", "RandomForestClassifier")
 
 
 class _RandomForestMixin:
-    def _check_inputs(self, X, y=None, sample_weight=None):
+    def _check_inputs(self, X, y=None):
         # Fallback to CPU if NaN in X
         try:
             check_array(
@@ -24,9 +24,6 @@ class _RandomForestMixin:
                     "Missing values are not supported"
                 ) from None
             raise
-
-        if sample_weight is not None:
-            raise UnsupportedOnGPU("`sample_weight` is not supported")
 
         if y is not None:
             y = check_array(
@@ -47,16 +44,16 @@ class _RandomForestMixin:
                 )
 
     def _gpu_fit(self, X, y, sample_weight=None):
-        self._check_inputs(X, y, sample_weight=sample_weight)
-        return self._gpu.fit(X, y)
+        self._check_inputs(X, y)
+        return self._gpu.fit(X, y, sample_weight=sample_weight)
 
     def _gpu_predict(self, X):
         self._check_inputs(X)
         return self._gpu.predict(X)
 
     def _gpu_score(self, X, y, sample_weight=None):
-        self._check_inputs(X, y, sample_weight=sample_weight)
-        return self._gpu.score(X, y)
+        self._check_inputs(X, y)
+        return self._gpu.score(X, y, sample_weight=sample_weight)
 
 
 class RandomForestRegressor(ProxyBase, _RandomForestMixin):

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -158,7 +158,15 @@ class RandomForestClassifier(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(self, X, y, convert_dtype=False, broadcast_data=False):
+    def fit(
+        self,
+        X,
+        y,
+        convert_dtype=False,
+        broadcast_data=False,
+        *,
+        sample_weight=None,
+    ):
         """
         Fit the input data with a Random Forest classifier
 
@@ -207,8 +215,18 @@ class RandomForestClassifier(
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
             is trained on its partition
+        sample_weight : array-like of shape (n_samples,), optional (default = None)
+            Not supported on the distributed estimator; a non-None value raises
+            ``NotImplementedError``.
 
         """
+        if sample_weight is not None:
+            raise NotImplementedError(
+                "sample_weight is not supported for distributed "
+                "RandomForestClassifier; use the single-GPU "
+                "cuml.ensemble.RandomForestClassifier instead "
+                "(tracking issue: #8186)"
+            )
         # Handle both Dask Arrays and Dask Series/DataFrames
         if isinstance(y, dask.array.Array):
             # For Dask Arrays, use dask.array.unique

--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -141,7 +141,15 @@ class RandomForestRegressor(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(self, X, y, convert_dtype=False, broadcast_data=False):
+    def fit(
+        self,
+        X,
+        y,
+        convert_dtype=False,
+        broadcast_data=False,
+        *,
+        sample_weight=None,
+    ):
         """
         Fit the input data with a Random Forest regression model
 
@@ -186,8 +194,18 @@ class RandomForestRegressor(
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
             is trained on its partition
+        sample_weight : array-like of shape (n_samples,), optional (default = None)
+            Not supported on the distributed estimator; a non-None value raises
+            ``NotImplementedError``.
 
         """
+        if sample_weight is not None:
+            raise NotImplementedError(
+                "sample_weight is not supported for distributed "
+                "RandomForestRegressor; use the single-GPU "
+                "cuml.ensemble.RandomForestRegressor instead "
+                "(tracking issue: #8186)"
+            )
         self.internal_model = None
         self._fit(
             model=self.rfs,

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -79,7 +79,9 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
         bool* bootstrap_masks,
         T* feature_importances,
         level_enum verbosity,
-        T* sample_weight
+        T* sample_weight,
+        int class_weight_mode,
+        const double* class_weight_array
     ) except +
 
     cdef void fit_treelite[T, L](
@@ -223,7 +225,8 @@ class BaseRandomForestModel(Base, InteropMixin):
 
         if isinstance(model.max_samples, int):
             raise UnsupportedOnGPU("`int` values for `max_samples` are not supported")
-        elif model.max_samples is not None:
+        elif model.max_samples is not None and model.bootstrap:
+            # Mirrors _params_to_cpu: sklearn rejects max_samples when bootstrap=False.
             conditional_params["max_samples"] = model.max_samples
 
         return {
@@ -260,7 +263,8 @@ class BaseRandomForestModel(Base, InteropMixin):
             "min_impurity_decrease": self.min_impurity_decrease,
             "bootstrap": self.bootstrap,
             "random_state": self.random_state,
-            "max_samples": self.max_samples,
+            # sklearn rejects non-None max_samples when bootstrap=False.
+            "max_samples": self.max_samples if self.bootstrap else None,
             "oob_score": self.oob_score,
         }
 
@@ -460,7 +464,14 @@ class BaseRandomForestModel(Base, InteropMixin):
             handle=get_handle(),
         )
 
-    def _fit_forest(self, X, y, sample_weight=None):
+    def _fit_forest(
+        self,
+        X,
+        y,
+        sample_weight=None,
+        class_weight_mode=0,
+        class_weight_array=None,
+    ):
         cdef bool is_classifier = self._estimator_type == "classifier"
         cdef bool is_float32 = X.dtype == np.float32
 
@@ -475,6 +486,14 @@ class BaseRandomForestModel(Base, InteropMixin):
             sample_weight.data.ptr if sample_weight is not None else 0
         )
         cdef float* sample_weight_f = <float*> sample_weight_ptr_val
+
+        # class_weight_array is a float64 cupy array or None (C++ ABI is
+        # const double*). C++ ASSERTs (mode==NONE) iff (array==nullptr).
+        cdef int class_weight_mode_c = <int> class_weight_mode
+        cdef uintptr_t class_weight_array_ptr_val = (
+            class_weight_array.data.ptr if class_weight_array is not None else 0
+        )
+        cdef const double* class_weight_array_d = <const double*> class_weight_array_ptr_val
         cdef double* sample_weight_d = <double*> sample_weight_ptr_val
         cdef level_enum verbose = <level_enum> self._verbose_level
         cdef int n_classes = self.n_classes_ if is_classifier else 0
@@ -586,7 +605,9 @@ class BaseRandomForestModel(Base, InteropMixin):
                         bootstrap_masks_ptr,
                         <float*> feature_importances_ptr,
                         verbose,
-                        sample_weight_f
+                        sample_weight_f,
+                        class_weight_mode_c,
+                        class_weight_array_d
                     )
                 else:
                     fit_treelite(
@@ -601,7 +622,9 @@ class BaseRandomForestModel(Base, InteropMixin):
                         bootstrap_masks_ptr,
                         <double*> feature_importances_ptr,
                         verbose,
-                        sample_weight_d
+                        sample_weight_d,
+                        class_weight_mode_c,
+                        class_weight_array_d
                     )
             else:
                 if is_float32:

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -78,7 +78,8 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
         RF_params params,
         bool* bootstrap_masks,
         T* feature_importances,
-        level_enum verbosity
+        level_enum verbosity,
+        T* sample_weight
     ) except +
 
     cdef void fit_treelite[T, L](
@@ -91,7 +92,8 @@ cdef extern from "cuml/ensemble/randomforest.hpp" namespace "ML" nogil:
         RF_params params,
         bool* bootstrap_masks,
         T* feature_importances,
-        level_enum verbosity
+        level_enum verbosity,
+        T* sample_weight
     ) except +
 
 
@@ -458,7 +460,7 @@ class BaseRandomForestModel(Base, InteropMixin):
             handle=get_handle(),
         )
 
-    def _fit_forest(self, X, y):
+    def _fit_forest(self, X, y, sample_weight=None):
         cdef bool is_classifier = self._estimator_type == "classifier"
         cdef bool is_float32 = X.dtype == np.float32
 
@@ -466,6 +468,14 @@ class BaseRandomForestModel(Base, InteropMixin):
         cdef uintptr_t y_ptr = y.data.ptr
         cdef int n_rows = X.shape[0]
         cdef int n_cols = X.shape[1]
+
+        # sample_weight is pre-validated by check_inputs; None becomes a NULL
+        # pointer at the C boundary (the kernel treats NULL as weight=1.0).
+        cdef uintptr_t sample_weight_ptr_val = (
+            sample_weight.data.ptr if sample_weight is not None else 0
+        )
+        cdef float* sample_weight_f = <float*> sample_weight_ptr_val
+        cdef double* sample_weight_d = <double*> sample_weight_ptr_val
         cdef level_enum verbose = <level_enum> self._verbose_level
         cdef int n_classes = self.n_classes_ if is_classifier else 0
 
@@ -575,7 +585,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <float*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_f
                     )
                 else:
                     fit_treelite(
@@ -589,7 +600,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <double*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_d
                     )
             else:
                 if is_float32:
@@ -603,7 +615,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <float*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_f
                     )
                 else:
                     fit_treelite(
@@ -616,7 +629,8 @@ class BaseRandomForestModel(Base, InteropMixin):
                         params,
                         bootstrap_masks_ptr,
                         <double*> feature_importances_ptr,
-                        verbose
+                        verbose,
+                        sample_weight_d
                     )
 
         # XXX: Theoretically we could wrap `tl_handle` with `treelite.Model` to

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -238,21 +238,28 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         convert_dtype_cast="np.float32",
     )
     @cuml.internals.reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "RandomForestClassifier":
+    def fit(
+        self, X, y, sample_weight=None, *, convert_dtype=True
+    ) -> "RandomForestClassifier":
         """
         Perform Random Forest Classification on the input data
 
         Parameters
         ----------
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Sample weights. If None, then samples are equally weighted.
+            Quantile-binned split finding means weighting a row is not
+            equivalent to duplicating it.
         convert_dtype : bool, optional (default = True)
             When set to True, the fit method will, when necessary, convert
             y to be of dtype int32. This will increase memory used for
             the method.
         """
-        X, y, classes = check_inputs(
+        X, y, sample_weight, classes = check_inputs(
             self,
             X,
             y,
+            sample_weight=sample_weight,
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
             order="F",
@@ -262,7 +269,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         )
         self.classes_ = classes
         self.n_classes_ = len(classes)
-        return self._fit_forest(X, y)
+        return self._fit_forest(X, y, sample_weight=sample_weight)
 
     @nvtx.annotate(
         message="predict RF-Classifier @randomforestclassifier.pyx",
@@ -451,6 +458,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         self,
         X,
         y,
+        sample_weight=None,
         *,
         threshold=0.5,
         convert_dtype=True,
@@ -465,6 +473,8 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         ----------
         X : {}
         y : {}
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Per-sample weights forwarded to ``accuracy_score``.
         threshold : float (default = 0.5)
             Threshold used for classification predictions
         convert_dtype : bool (default = True)
@@ -496,4 +506,4 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,
         )
-        return accuracy_score(y, y_pred)
+        return accuracy_score(y, y_pred, sample_weight=sample_weight)

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
+import numpy as np
 
 import cuml.internals
 import cuml.internals.nvtx as nvtx
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.common.classification import decode_labels
+from cuml.common.classification import decode_labels, process_class_weight
 from cuml.common.doc_utils import generate_docstring, insert_into_docstring
 from cuml.ensemble.randomforest_common import BaseRandomForestModel
 from cuml.internals.array import CumlArray
@@ -124,6 +125,19 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         accuracy. Only available if ``bootstrap=True``. The out-of-bag estimate
         provides a way to evaluate the model without requiring a separate
         validation set. The OOB score is computed using accuracy.
+    class_weight : dict, 'balanced', 'balanced_subsample', or None (default = None)
+        Weights associated with classes in the form
+        ``{class_label: weight}``. If ``None``, all classes are weighted
+        equally. The ``'balanced'`` mode uses the values of ``y`` to
+        automatically adjust weights inversely proportional to class
+        frequencies in the input data as
+        ``n_samples / (n_classes * np.bincount(y))``. The
+        ``'balanced_subsample'`` mode is the same as ``'balanced'`` except
+        that weights are computed based on the bootstrap sample for every
+        tree grown; with ``bootstrap=False`` it silently behaves as
+        ``'balanced'`` since there is no per-tree subsample to weight by.
+        These weights are multiplied with ``sample_weight`` (passed through
+        the ``fit`` method) if both are specified.
     verbose : int or boolean, default=False
         Sets logging level. It must be one of `cuml.common.logger.level_*`.
         See :ref:`verbosity-levels` for more info.
@@ -147,6 +161,17 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         was never left out during the bootstrap. In this case,
         ``oob_decision_function_`` might contain NaN. This attribute exists
         only when ``oob_score`` is True.
+    class_weight_ : np.ndarray of shape (n_classes,)
+        The per-class weights actually applied during fit, after resolving
+        ``class_weight``. For ``class_weight=None`` (the default), all
+        entries are 1.0. For ``class_weight='balanced_subsample'`` with
+        ``bootstrap=True``, this reflects the full-``y`` balanced weights
+        as a reference; the per-tree weights used internally are computed
+        from each tree's bootstrap sample and not exposed. Note that
+        scikit-learn's ``RandomForestClassifier`` does not expose this
+        attribute; cuML adds it mirroring ``SVC.class_weight_``. Round-
+        tripping a sklearn-trained model via ``from_sklearn`` leaves it
+        unset until refit.
     feature_importances_ : ndarray of shape (n_features,)
         The impurity-based feature importances.
 
@@ -154,6 +179,14 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     -----
     While training the model for multi class classification problems, using
     deep trees or `max_features=1.0` provides better performance.
+
+    Under weighted training (``sample_weight`` or non-None ``class_weight``),
+    ``feature_importances_`` is well-formed (non-negative and sums to one)
+    but is not byte-equivalent to scikit-learn's. cuML weights the impurity
+    term in the gain accumulator; scikit-learn weights the count term via
+    ``weighted_n_node_samples``. Both apply each tree's per-sample weight
+    once, so direction-of-importance agreement is typical; ordering across
+    features can differ in the long tail.
 
     For additional docs, see `scikitlearn's RandomForestClassifier
     <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_.
@@ -168,24 +201,56 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
     _cpu_class_path = "sklearn.ensemble.RandomForestClassifier"
 
     @classmethod
+    def _get_param_names(cls):
+        return [*super()._get_param_names(), "class_weight"]
+
+    @classmethod
     def _params_from_cpu(cls, model):
-        if model.class_weight is not None:
-            raise UnsupportedOnGPU("`class_weight` is not supported")
-        return super()._params_from_cpu(model)
+        cw = model.class_weight
+        if isinstance(cw, (list, tuple)):
+            raise UnsupportedOnGPU(
+                "`class_weight` as a list of dicts (multi-output) is not "
+                "supported (cuml RFC has n_outputs_=1)."
+            )
+        if isinstance(cw, str) and cw not in (
+            "balanced",
+            "balanced_subsample",
+        ):
+            raise UnsupportedOnGPU(f"`class_weight={cw!r}` is not supported")
+        params = super()._params_from_cpu(model)
+        params["class_weight"] = cw
+        return params
+
+    def _params_to_cpu(self):
+        params = super()._params_to_cpu()
+        params["class_weight"] = self.class_weight
+        return params
 
     def _attrs_from_cpu(self, model):
-        return {
+        attrs = {
             "classes_": model.classes_,
             "n_classes_": model.n_classes_,
             **super()._attrs_from_cpu(model),
         }
+        if hasattr(model, "class_weight_"):
+            attrs["class_weight_"] = model.class_weight_
+        return attrs
 
     def _attrs_to_cpu(self, model):
-        return {
+        attrs = {
             "classes_": self.classes_,
             "n_classes_": self.n_classes_,
             **super()._attrs_to_cpu(model),
         }
+        if hasattr(self, "class_weight_"):
+            attrs["class_weight_"] = self.class_weight_
+        return attrs
+
+    @property
+    def _effective_class_weight(self):
+        if self.class_weight == "balanced_subsample" and not self.bootstrap:
+            return "balanced"
+        return self.class_weight
 
     def __init__(
         self,
@@ -205,6 +270,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         random_state=None,
         n_streams=4,
         oob_score=False,
+        class_weight=None,
         verbose=False,
         output_type=None,
     ):
@@ -227,6 +293,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             verbose=verbose,
             output_type=output_type,
         )
+        self.class_weight = class_weight
 
     @nvtx.annotate(
         message="fit RF-Classifier @randomforestclassifier.pyx",
@@ -269,7 +336,52 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         )
         self.classes_ = classes
         self.n_classes_ = len(classes)
-        return self._fit_forest(X, y, sample_weight=sample_weight)
+
+        cw = self._effective_class_weight
+        if isinstance(cw, str) and cw not in (
+            "balanced",
+            "balanced_subsample",
+        ):
+            raise ValueError(
+                "`class_weight` must be None, a dict mapping class label "
+                "to weight, 'balanced', or 'balanced_subsample'. Got "
+                f"{self.class_weight!r}."
+            )
+        class_weight_mode = 0  # ClassWeightMode::NONE
+        class_weight_array = None
+        if cw is None:
+            self.class_weight_ = np.ones(self.n_classes_, dtype=np.float64)
+        elif cw == "balanced_subsample":
+            # bootstrap=True: C++ recomputes per-tree weights from each
+            # tree's bootstrap sample. The full-y array set here is a
+            # diagnostic surface, not what the kernel actually applies.
+            self.class_weight_, _ = process_class_weight(
+                classes,
+                y,
+                "balanced",
+                sample_weight=None,
+                balanced_with_sample_weight=False,
+            )
+            class_weight_mode = 1  # ClassWeightMode::BALANCED_SUBSAMPLE
+            class_weight_array = cp.asarray(
+                self.class_weight_, dtype=cp.float64
+            )
+        else:
+            self.class_weight_, sample_weight = process_class_weight(
+                classes,
+                y,
+                cw,
+                sample_weight=sample_weight,
+                balanced_with_sample_weight=False,
+            )
+
+        return self._fit_forest(
+            X,
+            y,
+            sample_weight=sample_weight,
+            class_weight_mode=class_weight_mode,
+            class_weight_array=class_weight_array,
+        )
 
     @nvtx.annotate(
         message="predict RF-Classifier @randomforestclassifier.pyx",

--- a/python/cuml/cuml/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/ensemble/randomforestregressor.py
@@ -202,23 +202,32 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         message="fit RF-Regressor @randomforestregressor.pyx",
         domain="cuml_python",
     )
-    @generate_docstring()
+    @generate_docstring(skip_parameters_heading=True)
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "RandomForestRegressor":
+    def fit(
+        self, X, y, sample_weight=None, *, convert_dtype=True
+    ) -> "RandomForestRegressor":
         """
         Perform Random Forest Regression on the input data
 
+        Parameters
+        ----------
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Sample weights. If None, then samples are equally weighted.
+            Quantile-binned split finding means weighting a row is not
+            equivalent to duplicating it.
         """
-        X, y = check_inputs(
+        X, y, sample_weight = check_inputs(
             self,
             X,
             y,
+            sample_weight=sample_weight,
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
             order="F",
             reset=True,
         )
-        return self._fit_forest(X, y)
+        return self._fit_forest(X, y, sample_weight=sample_weight)
 
     @nvtx.annotate(
         message="predict RF-Regressor @randomforestclassifier.pyx",
@@ -302,6 +311,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         self,
         X,
         y,
+        sample_weight=None,
         *,
         convert_dtype=True,
         layout="depth_first",
@@ -315,6 +325,8 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         ----------
         X : {}
         y : {}
+        sample_weight : array-like of shape (n_samples,) (default = None)
+            Per-sample weights forwarded to ``r2_score``.
         convert_dtype : bool (default = True)
             When True, automatically convert the input to the data type used
             to train the model. This may increase memory usage.
@@ -342,4 +354,4 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,
         )
-        return r2_score(y, y_pred)
+        return r2_score(y, y_pred, sample_weight=sample_weight)

--- a/python/cuml/cuml_accel_tests/integration/test_rf_classifier.py
+++ b/python/cuml/cuml_accel_tests/integration/test_rf_classifier.py
@@ -158,11 +158,15 @@ def test_rf_warm_start(classification_data, warm_start):
     _ = accuracy_score(y, clf.predict(X))
 
 
-@pytest.mark.parametrize("class_weight", [None, "balanced", {0: 1, 1: 2}])
+@pytest.mark.parametrize(
+    "class_weight", [None, "balanced", "balanced_subsample", {0: 1, 1: 2}]
+)
 def test_rf_class_weight(classification_data, class_weight):
     X, y = classification_data
     clf = RandomForestClassifier(
-        class_weight=class_weight, n_estimators=50, random_state=42
+        class_weight=class_weight,
+        n_estimators=50,
+        random_state=42,
     )
     clf.fit(X, y)
     _ = accuracy_score(y, clf.predict(X))

--- a/python/cuml/cuml_accel_tests/integration/test_rf_classifier.py
+++ b/python/cuml/cuml_accel_tests/integration/test_rf_classifier.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -209,3 +209,19 @@ def test_oob_score(classification_data):
 
     # Check attribute exists and is a float
     assert isinstance(clf.oob_score_, float)
+
+
+def test_rf_sample_weight_runs_on_gpu(classification_data):
+    # cuml.accel proxy forwards sample_weight to the GPU classifier path
+    # for both fit() and score().
+    X, y = classification_data
+    w = np.random.RandomState(0).uniform(0.5, 2.0, len(y)).astype(np.float32)
+    clf = RandomForestClassifier(n_estimators=10, random_state=42)
+    clf.fit(X, y, sample_weight=w)
+    y_pred = clf.predict(X)
+    s_unweighted = clf.score(X, y)
+    s_weighted = clf.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(accuracy_score(y, y_pred))
+    assert s_weighted == pytest.approx(
+        accuracy_score(y, y_pred, sample_weight=w)
+    )

--- a/python/cuml/cuml_accel_tests/integration/test_rf_regressor.py
+++ b/python/cuml/cuml_accel_tests/integration/test_rf_regressor.py
@@ -1,8 +1,9 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import numpy as np
 import pytest
 from sklearn.datasets import make_regression
 from sklearn.ensemble import RandomForestRegressor
@@ -192,3 +193,17 @@ def test_oob_score(regression_data):
 
     # Check attribute exists and is a float
     assert isinstance(reg.oob_score_, float)
+
+
+def test_rf_sample_weight_runs_on_gpu(regression_data):
+    # cuml.accel proxy forwards sample_weight to the GPU regressor path
+    # for both fit() and score().
+    X, y = regression_data
+    w = np.random.RandomState(0).uniform(0.5, 2.0, len(y)).astype(np.float32)
+    reg = RandomForestRegressor(n_estimators=10, random_state=42)
+    reg.fit(X, y, sample_weight=w)
+    y_pred = reg.predict(X)
+    s_unweighted = reg.score(X, y)
+    s_weighted = reg.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(r2_score(y, y_pred))
+    assert s_weighted == pytest.approx(r2_score(y, y_pred, sample_weight=w))

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -923,12 +923,6 @@
   tests:
   - "sklearn.tests.test_common::test_estimators[SVR()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[SVR()-check_sample_weight_equivalence_on_sparse_data]"
-- reason: test_estimators checks fail
-  marker: cuml_accel_test_estimators
-  condition: scikit-learn>=1.6
-  tests:
-  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_dense_data]"
-  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_sparse_data]"
 - reason: Quantile-binned splits mean sample_weight is not equivalent to row duplication
   marker: cuml_accel_test_estimators
   condition: scikit-learn>=1.6
@@ -937,6 +931,12 @@
   - "sklearn.tests.test_common::test_estimators[RandomForestClassifier()-check_sample_weight_equivalence_on_sparse_data]"
   - "sklearn.tests.test_common::test_estimators[RandomForestRegressor()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[RandomForestRegressor()-check_sample_weight_equivalence_on_sparse_data]"
+- reason: test_estimators checks fail
+  marker: cuml_accel_test_estimators
+  condition: scikit-learn>=1.6
+  tests:
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_dense_data]"
+  - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_sparse_data]"
 - reason: test_estimators checks fail
   marker: cuml_accel_test_estimators
   tests:

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -929,6 +929,10 @@
   tests:
   - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[KMeans()-check_sample_weight_equivalence_on_sparse_data]"
+- reason: Quantile-binned splits mean sample_weight is not equivalent to row duplication
+  marker: cuml_accel_test_estimators
+  condition: scikit-learn>=1.6
+  tests:
   - "sklearn.tests.test_common::test_estimators[RandomForestClassifier()-check_sample_weight_equivalence_on_dense_data]"
   - "sklearn.tests.test_common::test_estimators[RandomForestClassifier()-check_sample_weight_equivalence_on_sparse_data]"
   - "sklearn.tests.test_common::test_estimators[RandomForestRegressor()-check_sample_weight_equivalence_on_dense_data]"

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -518,3 +518,58 @@ def test_rf_broadcast(model_type, fit_broadcast, transform_broadcast, client):
 
     if transform_broadcast:
         assert cuml_mod.internal_model is None
+
+
+def _tiny_dataset():
+    # Single-chunk so the helper is topology-agnostic across worker counts.
+    X = cp.asarray(np.random.RandomState(0).rand(10, 3), dtype=cp.float32)
+    y = cp.asarray(np.array([0, 1] * 5), dtype=cp.int32)
+    w = cp.ones(len(y), dtype=cp.float32)
+    return from_array(X, chunks=(len(y), -1)), from_array(y, chunks=len(y)), w
+
+
+# The raises_not_implemented tests omit ignore_empty_partitions=True on
+# purpose: the NotImplementedError fires inside the subclass fit() before
+# control reaches base._fit where the empty-partition check lives.
+def test_dask_rfc_sample_weight_raises_not_implemented(client):
+    X, y, w = _tiny_dataset()
+    with pytest.raises(
+        NotImplementedError,
+        match=r"sample_weight is not supported for distributed RandomForest",
+    ):
+        cuRFC_mg(client=client, n_estimators=2, max_depth=2).fit(
+            X, y, sample_weight=w
+        )
+
+
+def test_dask_rfr_sample_weight_raises_not_implemented(client):
+    X, y, w = _tiny_dataset()
+    y = y.astype(cp.float32)
+    with pytest.raises(
+        NotImplementedError,
+        match=r"sample_weight is not supported for distributed RandomForest",
+    ):
+        cuRFR_mg(client=client, n_estimators=2, max_depth=2).fit(
+            X, y, sample_weight=w
+        )
+
+
+def test_dask_rfc_sample_weight_none_does_not_raise(client):
+    X, y, _ = _tiny_dataset()
+    cuRFC_mg(
+        client=client,
+        n_estimators=2,
+        max_depth=2,
+        ignore_empty_partitions=True,
+    ).fit(X, y, sample_weight=None)
+
+
+def test_dask_rfr_sample_weight_none_does_not_raise(client):
+    X, y, _ = _tiny_dataset()
+    y = y.astype(cp.float32)
+    cuRFR_mg(
+        client=client,
+        n_estimators=2,
+        max_depth=2,
+        ignore_empty_partitions=True,
+    ).fit(X, y, sample_weight=None)

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -34,6 +34,7 @@ import cuml
 from cuml.ensemble import RandomForestClassifier as curfc
 from cuml.ensemble import RandomForestRegressor as curfr
 from cuml.ensemble.randomforest_common import compute_max_features
+from cuml.metrics import accuracy_score as cuml_accuracy_score
 from cuml.metrics import r2_score
 from cuml.testing.utils import quality_param, stress_param, unit_param
 
@@ -1427,3 +1428,248 @@ def test_rf_feature_zero_bias(datatype, n_features):
     # If feature 0 is severely under-sampled, accuracy will be much lower
     # Observed: mean=0.003, range=[0.001, 0.005], stderr=0.000
     assert cuml_acc >= (sk_acc - 0.10)
+
+
+@pytest.fixture
+def sample_weight_clf_data():
+    X, y = make_classification(
+        n_samples=500,
+        n_features=10,
+        n_classes=3,
+        n_informative=5,
+        random_state=42,
+    )
+    return cp.asarray(X, dtype=cp.float32), cp.asarray(y, dtype=cp.int32)
+
+
+@pytest.fixture
+def sample_weight_reg_data():
+    X, y = make_regression(
+        n_samples=300, n_features=8, n_informative=4, random_state=42
+    )
+    return cp.asarray(X, dtype=cp.float32), cp.asarray(y, dtype=cp.float32)
+
+
+def test_rfc_sample_weight_ones_matches_none(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    base = curfc(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    weighted = curfc(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    base.fit(X, y)
+    weighted.fit(X, y, sample_weight=cp.ones(len(y), dtype=cp.float32))
+    p_base = cp.asnumpy(base.predict(X))
+    p_weighted = cp.asnumpy(weighted.predict(X))
+    assert np.array_equal(p_base, p_weighted)
+
+
+def test_rfc_sample_weight_none_does_not_raise(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    p_no_arg = cp.asnumpy(
+        curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y)
+        .predict(X)
+    )
+    p_none = cp.asnumpy(
+        curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=None)
+        .predict(X)
+    )
+    assert np.array_equal(p_no_arg, p_none)
+
+
+def test_rfc_sample_weight_biases_minority_class():
+    X, y = make_classification(
+        n_samples=200, n_features=5, n_classes=2, random_state=42
+    )
+    X = cp.asarray(X, dtype=cp.float32)
+    y = cp.asarray(y, dtype=cp.int32)
+    weights = cp.where(y == 0, 10.0, 0.1).astype(cp.float32)
+
+    uniform = curfc(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    biased = curfc(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    uniform.fit(X, y)
+    biased.fit(X, y, sample_weight=weights)
+
+    n_class0_uniform = int((cp.asnumpy(uniform.predict(X)) == 0).sum())
+    n_class0_biased = int((cp.asnumpy(biased.predict(X)) == 0).sum())
+    # Observed: uniform=90, heavily-weighted-class-0=178 out of 200 rows.
+    assert n_class0_biased > n_class0_uniform
+
+
+def test_rfc_sample_weight_sklearn_parity_nonuniform(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    rng = np.random.default_rng(7)
+    w = rng.uniform(0.5, 2.0, len(y)).astype(np.float32)
+    w_cp = cp.asarray(w)
+
+    cu = curfc(n_estimators=20, max_depth=6, random_state=0, n_streams=1)
+    sk = skrfc(n_estimators=20, max_depth=6, random_state=0)
+    cu.fit(X, y, sample_weight=w_cp)
+    sk.fit(cp.asnumpy(X), cp.asnumpy(y), sample_weight=w)
+
+    cu_acc = accuracy_score(cp.asnumpy(y), cp.asnumpy(cu.predict(X)))
+    sk_acc = accuracy_score(cp.asnumpy(y), sk.predict(cp.asnumpy(X)))
+    # Observed: cu=0.95, sk=0.94, gap=0.01. Tolerance covers quantile-binning
+    # divergence + RNG drift across CUDA versions.
+    assert abs(cu_acc - sk_acc) < 0.07
+
+
+def test_rfc_sample_weight_positional_or_keyword(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    w = cp.ones(len(y), dtype=cp.float32)
+    p_pos = cp.asnumpy(
+        curfc(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, w)
+        .predict(X)
+    )
+    p_kw = cp.asnumpy(
+        curfc(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=w)
+        .predict(X)
+    )
+    assert np.array_equal(p_pos, p_kw)
+
+
+def test_rfc_score_with_sample_weight(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    rng = np.random.default_rng(1)
+    w = cp.asarray(rng.uniform(0.5, 2.0, len(y)).astype(np.float32))
+
+    clf = curfc(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+    s_unweighted = clf.score(X, y)
+    s_weighted = clf.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(float(cuml_accuracy_score(y, y_pred)))
+    assert s_weighted == pytest.approx(
+        float(cuml_accuracy_score(y, y_pred, sample_weight=w))
+    )
+
+
+def test_rfc_sample_weight_wrong_length_raises(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(ValueError, match=r"inconsistent number"):
+        clf.fit(X, y, sample_weight=cp.ones(len(y) + 5, dtype=cp.float32))
+
+
+def test_rfc_sample_weight_all_zero_raises(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(
+        ValueError, match=r"Sample weights must contain at least one non-zero"
+    ):
+        clf.fit(X, y, sample_weight=cp.zeros(len(y), dtype=cp.float32))
+
+
+def test_rfr_sample_weight_ones_matches_none(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    base = curfr(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    weighted = curfr(n_estimators=10, max_depth=4, random_state=0, n_streams=1)
+    base.fit(X, y)
+    weighted.fit(X, y, sample_weight=cp.ones(len(y), dtype=cp.float32))
+    p_base = cp.asnumpy(base.predict(X))
+    p_weighted = cp.asnumpy(weighted.predict(X))
+    assert np.array_equal(p_base, p_weighted)
+
+
+def test_rfr_sample_weight_none_does_not_raise(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    p_no_arg = cp.asnumpy(
+        curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y)
+        .predict(X)
+    )
+    p_none = cp.asnumpy(
+        curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=None)
+        .predict(X)
+    )
+    assert np.array_equal(p_no_arg, p_none)
+
+
+def test_rfr_score_with_sample_weight(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    rng = np.random.default_rng(1)
+    w = cp.asarray(rng.uniform(0.5, 2.0, len(y)).astype(np.float32))
+
+    reg = curfr(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+    reg.fit(X, y)
+    y_pred = reg.predict(X)
+    s_unweighted = reg.score(X, y)
+    s_weighted = reg.score(X, y, sample_weight=w)
+    assert s_unweighted == pytest.approx(float(r2_score(y, y_pred)))
+    assert s_weighted == pytest.approx(
+        float(r2_score(y, y_pred, sample_weight=w))
+    )
+
+
+def test_rfr_sample_weight_biases_prediction():
+    # Heavily upweight the top-half of the target; weighted-fit MAE on those
+    # rows should be lower than unweighted-fit MAE (which averages globally).
+    X, y = make_regression(
+        n_samples=200, n_features=5, n_informative=3, random_state=42
+    )
+    X = cp.asarray(X, dtype=cp.float32)
+    y = cp.asarray(y, dtype=cp.float32)
+    high = y > cp.median(y)
+    weights = cp.where(high, 10.0, 0.1).astype(cp.float32)
+
+    uniform = curfr(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    biased = curfr(n_estimators=20, max_depth=4, random_state=0, n_streams=1)
+    uniform.fit(X, y)
+    biased.fit(X, y, sample_weight=weights)
+
+    err_uniform = float(cp.mean(cp.abs(uniform.predict(X)[high] - y[high])))
+    err_biased = float(cp.mean(cp.abs(biased.predict(X)[high] - y[high])))
+    # Observed: err_uniform ~ 87, err_biased ~ 41 on the upweighted half.
+    assert err_biased < err_uniform
+
+
+def test_rfr_sample_weight_sklearn_parity_nonuniform(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    rng = np.random.default_rng(7)
+    w = rng.uniform(0.5, 2.0, len(y)).astype(np.float32)
+    w_cp = cp.asarray(w)
+
+    cu = curfr(n_estimators=20, max_depth=6, random_state=0, n_streams=1)
+    sk = skrfr(n_estimators=20, max_depth=6, random_state=0)
+    cu.fit(X, y, sample_weight=w_cp)
+    sk.fit(cp.asnumpy(X), cp.asnumpy(y), sample_weight=w)
+
+    cu_r2 = r2_score(y, cu.predict(X))
+    sk_r2 = float(sk.score(cp.asnumpy(X), cp.asnumpy(y)))
+    # Observed: cu r2 ~ 0.91, sk r2 ~ 0.93, gap ~ 0.02. Tolerance covers
+    # quantile-binning divergence + RNG drift across CUDA versions.
+    assert abs(float(cu_r2) - sk_r2) < 0.10
+
+
+def test_rfr_sample_weight_wrong_length_raises(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    reg = curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(ValueError, match=r"inconsistent number"):
+        reg.fit(X, y, sample_weight=cp.ones(len(y) + 5, dtype=cp.float32))
+
+
+def test_rfr_sample_weight_all_zero_raises(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    reg = curfr(n_estimators=2, max_depth=2, random_state=0, n_streams=1)
+    with pytest.raises(
+        ValueError, match=r"Sample weights must contain at least one non-zero"
+    ):
+        reg.fit(X, y, sample_weight=cp.zeros(len(y), dtype=cp.float32))
+
+
+def test_rfr_sample_weight_positional_or_keyword(sample_weight_reg_data):
+    X, y = sample_weight_reg_data
+    w = cp.ones(len(y), dtype=cp.float32)
+    p_pos = cp.asnumpy(
+        curfr(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, w)
+        .predict(X)
+    )
+    p_kw = cp.asnumpy(
+        curfr(n_estimators=5, max_depth=3, random_state=0, n_streams=1)
+        .fit(X, y, sample_weight=w)
+        .predict(X)
+    )
+    assert np.array_equal(p_pos, p_kw)

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -27,6 +27,7 @@ from sklearn.metrics import (
     accuracy_score,
     mean_squared_error,
     mean_tweedie_deviance,
+    recall_score,
 )
 from sklearn.model_selection import train_test_split
 
@@ -34,6 +35,7 @@ import cuml
 from cuml.ensemble import RandomForestClassifier as curfc
 from cuml.ensemble import RandomForestRegressor as curfr
 from cuml.ensemble.randomforest_common import compute_max_features
+from cuml.internals.interop import UnsupportedOnGPU
 from cuml.metrics import accuracy_score as cuml_accuracy_score
 from cuml.metrics import r2_score
 from cuml.testing.utils import quality_param, stress_param, unit_param
@@ -228,6 +230,9 @@ def test_default_parameters():
     for name in ["max_features", "split_criterion"]:
         reg_params.pop(name)
         clf_params.pop(name)
+
+    # `class_weight` is RFC-only (sklearn matches).
+    clf_params.pop("class_weight")
 
     # The rest are the same
     assert reg_params == clf_params
@@ -1559,6 +1564,407 @@ def test_rfc_sample_weight_all_zero_raises(sample_weight_clf_data):
         ValueError, match=r"Sample weights must contain at least one non-zero"
     ):
         clf.fit(X, y, sample_weight=cp.zeros(len(y), dtype=cp.float32))
+
+
+# --- class_weight on RandomForestClassifier ---
+
+
+@pytest.fixture
+def imbalanced_clf_data():
+    X, y = make_classification(
+        n_samples=500,
+        n_features=10,
+        n_classes=2,
+        n_informative=5,
+        weights=[0.9, 0.1],
+        random_state=42,
+    )
+    return cp.asarray(X, dtype=cp.float32), cp.asarray(y, dtype=cp.int32)
+
+
+@pytest.mark.parametrize(
+    "class_weight", ["balanced", {0: 1.0, 1: 3.0, 2: 0.5}]
+)
+def test_rfc_class_weight_matches_sklearn(
+    sample_weight_clf_data, class_weight
+):
+    X, y = sample_weight_clf_data
+    cuml_model = curfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        n_streams=1,
+        class_weight=class_weight,
+    )
+    sk_model = skrfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        class_weight=class_weight,
+    )
+    cuml_model.fit(X, y)
+    sk_model.fit(cp.asnumpy(X), cp.asnumpy(y))
+    cuml_acc = accuracy_score(cp.asnumpy(y), cp.asnumpy(cuml_model.predict(X)))
+    sk_acc = accuracy_score(cp.asnumpy(y), sk_model.predict(cp.asnumpy(X)))
+    # Observed: range=[0.00, 0.02] across both class_weight values on
+    # this fixture; 0.07 tolerance covers quantile-binning + RNG drift.
+    assert abs(cuml_acc - sk_acc) < 0.07
+
+
+def test_rfc_class_weight_dict_partial_then_extra_raises(
+    sample_weight_clf_data,
+):
+    # process_class_weight raises only when the dict has extras AND real
+    # classes are missing (classification.py:179).
+    X, y = sample_weight_clf_data
+    clf = curfc(
+        n_estimators=2,
+        max_depth=2,
+        random_state=0,
+        n_streams=1,
+        class_weight={0: 1.0, 99: 5.0},
+    )
+    with pytest.raises(ValueError, match=r"are not in class_weight"):
+        clf.fit(X, y)
+
+
+def test_rfc_class_weight_dict_partial_silent_fill(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(
+        n_estimators=3,
+        max_depth=3,
+        random_state=0,
+        n_streams=1,
+        class_weight={0: 1.0, 1: 2.0},
+    )
+    clf.fit(X, y)
+    np.testing.assert_allclose(clf.class_weight_, [1.0, 2.0, 1.0])
+
+
+def test_rfc_class_weight_dict_extra_keys_succeeds(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(
+        n_estimators=3,
+        max_depth=3,
+        random_state=0,
+        n_streams=1,
+        class_weight={0: 1.0, 1: 1.0, 2: 1.0, 99: 5.0},
+    )
+    clf.fit(X, y)
+    np.testing.assert_allclose(clf.class_weight_, [1.0, 1.0, 1.0])
+
+
+def test_rfc_class_weight_balanced_single_class_y():
+    X = cp.asarray(np.random.RandomState(0).rand(40, 4), dtype=cp.float32)
+    y = cp.zeros(40, dtype=cp.int32)
+    clf = curfc(
+        n_estimators=2,
+        max_depth=2,
+        n_bins=4,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced",
+    )
+    clf.fit(X, y)
+    assert clf.class_weight_.shape == (1,)
+    assert float(clf.class_weight_[0]) == pytest.approx(1.0)
+
+
+def test_rfc_class_weight_and_sample_weight_combine(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    rng = np.random.default_rng(11)
+    w = cp.asarray(rng.uniform(0.5, 2.0, len(y)).astype(np.float32))
+    cw = {0: 1.0, 1: 2.0, 2: 0.5}
+    clf = curfc(
+        n_estimators=3,
+        max_depth=3,
+        random_state=0,
+        n_streams=1,
+        class_weight=cw,
+    )
+    clf.fit(X, y, sample_weight=w)
+    np.testing.assert_allclose(
+        clf.class_weight_, np.array([1.0, 2.0, 0.5], dtype=np.float64)
+    )
+
+
+def test_rfc_balanced_subsample_collapses_without_bootstrap(
+    imbalanced_clf_data,
+):
+    # sklearn silently collapses 'balanced_subsample' to 'balanced' when
+    # bootstrap=False (verified vs sklearn 1.5.0 and 1.7.2). cuml matches.
+    X, y = imbalanced_clf_data
+    clf_collapsed = curfc(
+        n_estimators=5,
+        max_depth=4,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced_subsample",
+        bootstrap=False,
+    )
+    clf_collapsed.fit(X, y)
+
+    clf_balanced = curfc(
+        n_estimators=5,
+        max_depth=4,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced",
+        bootstrap=False,
+    )
+    clf_balanced.fit(X, y)
+    np.testing.assert_array_equal(
+        clf_collapsed.class_weight_, clf_balanced.class_weight_
+    )
+    np.testing.assert_array_equal(
+        cp.asnumpy(clf_collapsed.predict(X)),
+        cp.asnumpy(clf_balanced.predict(X)),
+    )
+
+
+def test_rfc_class_weight_invalid_string_raises(sample_weight_clf_data):
+    X, y = sample_weight_clf_data
+    clf = curfc(
+        n_estimators=2,
+        max_depth=2,
+        random_state=0,
+        n_streams=1,
+        class_weight="nonsense",
+    )
+    with pytest.raises(ValueError, match=r"`class_weight` must be None"):
+        clf.fit(X, y)
+
+
+def test_rfc_balanced_subsample_with_bootstrap_lifts_minority_recall(
+    imbalanced_clf_data,
+):
+    # Verify BALANCED_SUBSAMPLE per-tree compute lifts minority recall
+    # on a 90/10 imbalanced fixture vs the unweighted baseline.
+    X, y = imbalanced_clf_data
+    baseline = curfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        n_streams=1,
+        class_weight=None,
+        bootstrap=True,
+    )
+    balanced_sub = curfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced_subsample",
+        bootstrap=True,
+    )
+    baseline.fit(X, y)
+    balanced_sub.fit(X, y)
+    rec_baseline = recall_score(
+        cp.asnumpy(y), cp.asnumpy(baseline.predict(X)), pos_label=1
+    )
+    rec_balanced = recall_score(
+        cp.asnumpy(y), cp.asnumpy(balanced_sub.predict(X)), pos_label=1
+    )
+    # Observed: baseline=0.30, balanced_subsample=0.85 on this 90/10
+    # fixture (gap=0.55). 0.10 margin tolerates ~0.4 RNG variance.
+    assert rec_balanced > rec_baseline + 0.10
+
+
+def test_rfc_balanced_subsample_matches_sklearn(imbalanced_clf_data):
+    # Direction-of-effect parity with sklearn on the same fixture +
+    # random_state. Tight prediction agreement isn't expected (quantile
+    # binning differs from sklearn's exhaustive splits), so we check
+    # recall stays within a reasonable band.
+    X, y = imbalanced_clf_data
+    cuml_model = curfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced_subsample",
+        bootstrap=True,
+    )
+    sk_model = skrfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        class_weight="balanced_subsample",
+        bootstrap=True,
+    )
+    cuml_model.fit(X, y)
+    sk_model.fit(cp.asnumpy(X), cp.asnumpy(y))
+    cuml_rec = recall_score(
+        cp.asnumpy(y), cp.asnumpy(cuml_model.predict(X)), pos_label=1
+    )
+    sk_rec = recall_score(
+        cp.asnumpy(y), sk_model.predict(cp.asnumpy(X)), pos_label=1
+    )
+    # Observed: cuml=0.85, sk=0.88, gap=0.03. 0.15 tolerance covers
+    # quantile-binning + RNG drift across CUDA versions / sklearn pins.
+    assert abs(cuml_rec - sk_rec) < 0.15
+
+
+def test_rfc_from_sklearn_invalid_class_weight_unsupported():
+    sk_model = skrfc(
+        n_estimators=2,
+        max_depth=2,
+        random_state=0,
+        class_weight="nonsense",
+    )
+    with pytest.raises(
+        UnsupportedOnGPU, match=r"`class_weight=.*not supported"
+    ):
+        curfc._params_from_cpu(sk_model)
+
+
+def test_rfc_from_sklearn_list_of_dicts_unsupported():
+    # Multi-output class_weight=[dict, dict, ...] should surface as
+    # UnsupportedOnGPU at from_sklearn time so the accel proxy falls
+    # back to sklearn instead of silently crashing in fit().
+    sk_model = skrfc(
+        n_estimators=2,
+        max_depth=2,
+        random_state=0,
+        class_weight=[{0: 1, 1: 2}, {0: 2, 1: 1}],
+    )
+    with pytest.raises(UnsupportedOnGPU, match=r"list of dicts"):
+        curfc._params_from_cpu(sk_model)
+
+
+@pytest.mark.parametrize(
+    "sk_cls,cu_cls",
+    [(skrfc, curfc), (skrfr, curfr)],
+    ids=["classifier", "regressor"],
+)
+def test_rf_from_sklearn_drops_max_samples_when_bootstrap_false(
+    sk_cls, cu_cls
+):
+    # sklearn rejects max_samples when bootstrap=False; the _params_from_cpu
+    # guard mirrors _params_to_cpu so the round-trip stays symmetric.
+    sk_model = sk_cls(
+        n_estimators=2,
+        max_depth=2,
+        random_state=0,
+        bootstrap=False,
+        max_samples=0.5,
+    )
+    params = cu_cls._params_from_cpu(sk_model)
+    assert "max_samples" not in params
+
+
+def test_rfc_class_weight_refit_replaces_prior(sample_weight_clf_data):
+    # Refit on the same estimator with a different class_weight value
+    # must replace the prior class_weight_; no leakage.
+    X, y = sample_weight_clf_data
+    clf = curfc(
+        n_estimators=3,
+        max_depth=3,
+        random_state=0,
+        n_streams=1,
+        class_weight={0: 1.0, 1: 2.0, 2: 3.0},
+    )
+    clf.fit(X, y)
+    np.testing.assert_allclose(clf.class_weight_, [1.0, 2.0, 3.0])
+    clf.class_weight = None
+    clf.fit(X, y)
+    np.testing.assert_allclose(clf.class_weight_, [1.0, 1.0, 1.0])
+
+
+def test_rfc_class_weight_balanced_predict_proba(imbalanced_clf_data):
+    # class_weight='balanced' must shift the minority class probability
+    # upward vs the unweighted baseline. predict_proba surface should
+    # also be well-formed (sums to 1 per row).
+    X, y = imbalanced_clf_data
+    base = curfc(n_estimators=20, max_depth=6, random_state=0, n_streams=1)
+    weighted = curfc(
+        n_estimators=20,
+        max_depth=6,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced",
+    )
+    base.fit(X, y)
+    weighted.fit(X, y)
+    p_base = cp.asnumpy(base.predict_proba(X))
+    p_weighted = cp.asnumpy(weighted.predict_proba(X))
+    assert p_base.shape == (X.shape[0], 2)
+    assert p_weighted.shape == (X.shape[0], 2)
+    np.testing.assert_allclose(p_base.sum(axis=1), 1.0, atol=1e-5)
+    np.testing.assert_allclose(p_weighted.sum(axis=1), 1.0, atol=1e-5)
+    # Mean minority probability should rise under balanced.
+    assert p_weighted[:, 1].mean() > p_base[:, 1].mean()
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        unit_param({"n": 500, "n_features": 10, "n_classes": 3}),
+        quality_param({"n": 50_000, "n_features": 20, "n_classes": 5}),
+        stress_param({"n": 200_000, "n_features": 50, "n_classes": 10}),
+    ],
+)
+def test_rfc_class_weight_balanced_scales(scale):
+    # Gated coverage for the C++ per-tree compute path under class_weight.
+    # Stress size (~200k x 50, 10 classes) takes ~30s and ~2GB VRAM and
+    # guards against OOM + degenerate-output regressions in the kernel.
+    X, y = make_classification(
+        n_samples=scale["n"],
+        n_features=scale["n_features"],
+        n_classes=scale["n_classes"],
+        n_informative=scale["n_features"] // 2,
+        random_state=0,
+    )
+    X = cp.asarray(X, dtype=cp.float32)
+    y = cp.asarray(y, dtype=cp.int32)
+    clf = curfc(
+        n_estimators=10,
+        max_depth=8,
+        random_state=0,
+        n_streams=1,
+        class_weight="balanced_subsample",
+        bootstrap=True,
+    )
+    try:
+        clf.fit(X, y)
+    except cp.cuda.memory.OutOfMemoryError as exc:
+        pytest.skip(f"OOM at scale {scale}: {exc}")
+    assert clf.class_weight_.shape == (scale["n_classes"],)
+    assert float(clf.class_weight_.min()) > 0.0
+    preds = cp.asnumpy(clf.predict(X))
+    assert preds.shape[0] == scale["n"]
+    assert len(np.unique(preds)) > 1
+
+
+@pytest.mark.parametrize(
+    "weighting",
+    ["balanced", {0: 1.0, 1: 1.0, 2: 1.0}, "sample_weight"],
+)
+def test_rfc_feature_importances_weighted_well_formed(
+    sample_weight_clf_data, weighting
+):
+    # Backs the docstring claim that feature_importances_ stays well-formed
+    # (non-negative, sums to 1) under weighted training, even though it is
+    # not byte-equivalent to sklearn's.
+    X, y = sample_weight_clf_data
+    rng = np.random.default_rng(3)
+    sw = (
+        cp.asarray(rng.uniform(0.5, 2.0, len(y)).astype(np.float32))
+        if weighting == "sample_weight"
+        else None
+    )
+    cw = None if weighting == "sample_weight" else weighting
+    clf = curfc(
+        n_estimators=10,
+        max_depth=4,
+        random_state=0,
+        n_streams=1,
+        class_weight=cw,
+    )
+    clf.fit(X, y, sample_weight=sw)
+    imps = clf.feature_importances_
+    assert (imps >= 0).all()
+    assert float(imps.sum()) == pytest.approx(1.0, abs=1e-4)
+    assert (imps > 0).any()
 
 
 def test_rfr_sample_weight_ones_matches_none(sample_weight_reg_data):

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -119,10 +119,14 @@ XFAILS = {
     RandomForestRegressor: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",
         "check_regressor_data_not_an_array": "RandomForestRegressor does not handle non-array data",
+        "check_sample_weight_equivalence_on_dense_data": "Quantile binning means sample_weight is not equivalent to row duplication",
+        "check_sample_weight_equivalence_on_sparse_data": "RandomForestRegressor does not handle sparse data",
     },
     RandomForestClassifier: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",
         "check_classifier_data_not_an_array": "RandomForestClassifier does not handle non-array data",
+        "check_sample_weight_equivalence_on_dense_data": "Quantile binning means sample_weight is not equivalent to row duplication",
+        "check_sample_weight_equivalence_on_sparse_data": "RandomForestClassifier does not handle sparse data",
     },
     KNeighborsClassifier: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -127,6 +127,7 @@ XFAILS = {
         "check_classifier_data_not_an_array": "RandomForestClassifier does not handle non-array data",
         "check_sample_weight_equivalence_on_dense_data": "Quantile binning means sample_weight is not equivalent to row duplication",
         "check_sample_weight_equivalence_on_sparse_data": "RandomForestClassifier does not handle sparse data",
+        "check_class_weight_classifiers": "Sklearn's check sets min_weight_fraction_leaf=0.01 to force the decision boundary; cuml RandomForestClassifier omits that parameter as UnsupportedOnGPU, so the >0.87 threshold is unreachable. The class_weight machinery itself is correct (verified in test_random_forest.py::test_rfc_class_weight_matches_sklearn). Remove if cuml RFC ever supports min_weight_fraction_leaf.",
     },
     KNeighborsClassifier: {
         "check_estimator_tags_renamed": "No support for modern tags infrastructure",

--- a/python/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/tests/test_sklearn_import_export.py
@@ -795,19 +795,34 @@ def test_kernel_density(random_state, kernel, bandwidth, metric):
     assert_kde_close(cu_model, cu_model2)
 
 
+@pytest.mark.parametrize(
+    "class_weight",
+    [None, "balanced", "balanced_subsample", {0: 1.0, 1: 2.0}],
+)
+@pytest.mark.parametrize("bootstrap", [True, False])
 @pytest.mark.parametrize("oob_score", [False, True])
-def test_random_forest_classifier(random_state, oob_score):
+def test_random_forest_classifier(
+    random_state, oob_score, bootstrap, class_weight
+):
     X, y = make_classification(
         n_samples=200, n_features=5, n_informative=3, random_state=random_state
     )
 
+    # OOB needs bootstrap; with bootstrap=False, balanced_subsample
+    # silently collapses to 'balanced' on both cuml and sklearn.
+    effective_oob = oob_score and bootstrap
+
     cu_model = cuml.RandomForestClassifier(
-        oob_score=oob_score,
+        oob_score=effective_oob,
         max_depth=None,
+        bootstrap=bootstrap,
+        class_weight=class_weight,
     ).fit(X, y)
     sk_model = sklearn.ensemble.RandomForestClassifier(
-        oob_score=oob_score,
+        oob_score=effective_oob,
         max_depth=None,
+        bootstrap=bootstrap,
+        class_weight=class_weight,
     ).fit(X, y)
 
     sk_model2 = cu_model.as_sklearn()
@@ -822,12 +837,17 @@ def test_random_forest_classifier(random_state, oob_score):
     # Exclude classes_ due to dtype differences between implementations
     # Exclude feature_importances_ because sklearn can't compute them from
     # treelite-exported models
+    # Exclude class_weight_ because sklearn's RandomForestClassifier doesn't
+    # expose it; cu_model2 (from sk_model via from_sklearn) won't have it set
+    # until refit.
     assert_roundtrip_consistency(
-        cu_model, cu_model2, exclude=("classes_", "feature_importances_")
+        cu_model,
+        cu_model2,
+        exclude=("classes_", "feature_importances_", "class_weight_"),
     )
 
     # Verify OOB attributes are present when oob_score=True
-    if oob_score:
+    if effective_oob:
         assert hasattr(cu_model, "oob_score_")
         assert hasattr(cu_model2, "oob_score_")
         assert hasattr(sk_model2, "oob_score_")


### PR DESCRIPTION
Closes #8093, Refs #8146

Adds `class_weight` to `RandomForestClassifier`. Supports `None`, a dict, `'balanced'`, and `'balanced_subsample'`. The first three reuse the existing helper from LR/SVC. `'balanced_subsample'` re-weights per tree from each bootstrap sample (matches sklearn). With `bootstrap=False` it silently collapses to `'balanced'`, also matching sklearn.

cuml exposes `class_weight_` as a fitted attribute (mirroring SVC); sklearn's RFC doesn't. Under weighted training, `feature_importances_` is well-formed but not byte-equivalent to sklearn's; cuml weights the impurity term, sklearn weights node counts. Documented in the docstring.

Overhead on a 500k × 30 × 10-class fixture: `balanced` is essentially free, `balanced_subsample` is +2.5%. The unweighted path stays byte-identical.

Adjacent fix: `max_samples` now round-trips to `None` when `bootstrap=False` so the new round-trip tests on `balanced_subsample` succeed (sklearn rejects the combination).

Tests cover each `class_weight` shape, refit, `predict_proba`, sklearn round-trip parametrized over `class_weight × bootstrap × oob_score`, plus stress coverage. Two upstream tests stay xfailed (importance-formula divergence; reliance on a cuml-unsupported parameter); both rationales name a revisit trigger.

PR-4 (#8143) closes the ETC half of #8146 by inheritance.
