### PR TITLE
Xfail sklearn example requiring plotly

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -18,6 +18,7 @@
 - reason: 'Missing optional dependency: plotly'
   strict: false
   tests:
+  - "ensemble::plot_forest_hist_grad_boosting_comparison"
   - "model_selection::plot_grid_search_text_feature_extraction"
 - reason: 'Missing optional dependency: polars'
   strict: false


### PR DESCRIPTION
Adds `ensemble::plot_forest_hist_grad_boosting_comparison` to the sklearn example xfail list because it requires the optional `plotly` dependency.

Closes https://github.com/rapidsai/cuml/issues/8191
