### PR TITLE
Large (int64 indices) sparse input support

### DIFF
--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -34,6 +34,7 @@ __all__ = (
 )
 
 PANDAS_VERSION = Version(pd.__version__)
+_CUPY_SUPPORTS_LARGE_SPARSE = Version(cp.__version__) >= Version("14.1.0")
 
 
 def _as_numpy_dtype(dtype):
@@ -444,13 +445,13 @@ def check_non_negative(array, *, input_name=None) -> None:
         raise ValueError(f"Negative values in data{suffix}")
 
 
-def _ensure_int32_sparse(array):
-    """Convert sparse array to int32 indices if possible, and error otherwise"""
+def _is_int64_sparse(array):
+    """Check if a sparse array requires int64 indices"""
     INT32_MAX = (1 << 31) - 1
-
-    # All sparse arrays must have shapes and nnz that fit in an int32. In addition,
-    # CSR, CSC, and BSR must have indices/indptr that fit in an int32.
-    if (
+    # A sparse array is large if:
+    # - It has shape or nnz that doesn't fit in an int32
+    # - CSR/CSC/BSR have indices/indptr that don't fit in an int32
+    return (
         any(s > INT32_MAX for s in array.shape)
         or array.nnz > INT32_MAX
         or (
@@ -459,7 +460,12 @@ def _ensure_int32_sparse(array):
                 len(array.indices) > INT32_MAX or len(array.indptr) > INT32_MAX
             )
         )
-    ):
+    )
+
+
+def _ensure_int32_sparse(array):
+    """Convert sparse array to int32 indices if possible, and error otherwise"""
+    if _is_int64_sparse(array):
         raise ValueError(
             "Only sparse matrices with int32 indices are currently supported."
         )
@@ -701,7 +707,16 @@ def check_array(
         if array.format not in accept_sparse:
             array = array.asformat(accept_sparse[0])
         if not accept_large_sparse:
+            # Try to coerce to int32 indices, erroring otherwise
             array = _ensure_int32_sparse(array)
+        elif (
+            _is_int64_sparse(array)
+            and mem_type == "device"
+            and not _CUPY_SUPPORTS_LARGE_SPARSE
+        ):
+            raise ValueError(
+                "Sparse matrices with int64 indices require cupy >= 14.1.0"
+            )
 
         # Validate dimensions and shape are as expected. We do this here
         # _before_ host/device conversion, since cupyx doesn't have a sparse
@@ -716,7 +731,7 @@ def check_array(
 
         # Coerce to proper dtype and mem_type if needed
         if mem_type == "host" and not sp.issparse(array):
-            # Coerce to device, then coerce dtype. We do this to save device
+            # Coerce to host, then coerce dtype. We do this to save device
             # memory, and since scipy supports more dtypes.
             array = array.get()
             if dtype is not None and array.dtype != dtype:

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -33,7 +33,6 @@ __all__ = (
     "check_classification_targets",
 )
 
-PANDAS_VERSION = Version(pd.__version__)
 _CUPY_SUPPORTS_LARGE_SPARSE = Version(cp.__version__) >= Version("14.1.0")
 
 
@@ -914,12 +913,7 @@ def check_cudf(
     elif isinstance(array, pd.DataFrame):
         f16_cols = array.select_dtypes("float16").columns.tolist()
         if f16_cols:
-            dtype = {c: "float32" for c in f16_cols}
-            # TODO: Drop this pandas 2 branch once pandas 2 support is removed.
-            if PANDAS_VERSION < Version("3.0"):
-                array = array.astype(dtype, copy=False)
-            else:
-                array = array.astype(dtype)
+            array = array.astype({c: "float32" for c in f16_cols})
         array = cudf.DataFrame(array)
     elif not isinstance(array, (cudf.DataFrame, cudf.Series)):
         # Remaining array-like inputs go through check_array first (without

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -444,10 +444,10 @@ def check_non_negative(array, *, input_name=None) -> None:
         raise ValueError(f"Negative values in data{suffix}")
 
 
-def _is_int64_sparse(array):
+def _requires_int64_sparse(array):
     """Check if a sparse array requires int64 indices"""
     INT32_MAX = (1 << 31) - 1
-    # A sparse array is large if:
+    # A sparse array requires int64 indices if:
     # - It has shape or nnz that doesn't fit in an int32
     # - CSR/CSC/BSR have indices/indptr that don't fit in an int32
     return (
@@ -464,7 +464,7 @@ def _is_int64_sparse(array):
 
 def _ensure_int32_sparse(array):
     """Convert sparse array to int32 indices if possible, and error otherwise"""
-    if _is_int64_sparse(array):
+    if _requires_int64_sparse(array):
         raise ValueError(
             "Only sparse matrices with int32 indices are currently supported."
         )
@@ -709,7 +709,7 @@ def check_array(
             # Try to coerce to int32 indices, erroring otherwise
             array = _ensure_int32_sparse(array)
         elif (
-            _is_int64_sparse(array)
+            _requires_int64_sparse(array)
             and mem_type == "device"
             and not _CUPY_SUPPORTS_LARGE_SPARSE
         ):

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -325,6 +325,7 @@ class LinearRegression(Base,
             convert_dtype=convert_dtype,
             ensure_min_samples=2,
             accept_sparse=True,
+            accept_large_sparse=True,
             accept_multi_output=True,
             reset=True,
         )

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -370,6 +370,7 @@ class Ridge(Base,
             convert_dtype=convert_dtype,
             ensure_min_samples=2,
             accept_sparse=True,
+            accept_large_sparse=True,
             accept_multi_output=True,
             reset=True,
         )

--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -94,6 +94,7 @@ class _BaseRandomProjection(Base, SparseInputTagMixin):
             mem_type=None,
             order=None,
             accept_sparse=True,
+            accept_large_sparse=True,
             reset=True,
         )
         n_samples, n_features = X.shape
@@ -133,6 +134,7 @@ class _BaseRandomProjection(Base, SparseInputTagMixin):
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
             accept_sparse=("csr", "csc"),
+            accept_large_sparse=True,
             return_index=True,
         )
         components = self.components_.to_output("cupy")

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -14,6 +14,7 @@ import pytest
 import scipy.sparse as sp
 import sklearn
 from hypothesis import assume, example, given
+from packaging.version import Version
 from sklearn.exceptions import DataConversionWarning
 
 from cuml.internals.validation import (
@@ -30,6 +31,8 @@ from cuml.internals.validation import (
     check_sample_weight,
     check_y,
 )
+
+CUPY_SUPPORTS_LARGE_SPARSE = Version(cp.__version__) >= Version("14.1.0")
 
 DTYPES = ("i1", "i2", "i4", "i8", "u1", "u2", "u4", "u8", "f2", "f4", "f8")
 
@@ -1092,6 +1095,45 @@ def test_check_array_large_sparse_errors():
         array, accept_sparse=True, accept_large_sparse=True, mem_type="host"
     )
     assert out is array
+
+
+@pytest.mark.skipif(
+    not CUPY_SUPPORTS_LARGE_SPARSE, reason="requires cupy >= 14.1.0"
+)
+def test_check_array_large_sparse_cupy_supported():
+    x_host = sp.coo_matrix(
+        (
+            np.array([1.5]),
+            (np.array([0], dtype="int64"), np.array([0], dtype="int64")),
+        ),
+        shape=(2**32, 10),
+    )
+    x_device = cp_sp.coo_matrix(x_host)
+
+    out = check_array(x_host, accept_sparse=True, accept_large_sparse=True)
+    assert isinstance(out, cp_sp.coo_matrix)
+    assert out.shape == x_host.shape
+
+    out = check_array(x_device, accept_sparse=True, accept_large_sparse=True)
+    assert out is x_device
+
+
+@pytest.mark.skipif(
+    CUPY_SUPPORTS_LARGE_SPARSE, reason="requires cupy < 14.1.0"
+)
+def test_check_array_large_sparse_cupy_not_supported():
+    array = sp.coo_matrix(
+        (
+            np.array([1.5]),
+            (np.array([0], dtype="int64"), np.array([0], dtype="int64")),
+        ),
+        shape=(2**32, 10),
+    )
+    with pytest.raises(
+        ValueError,
+        match="Sparse matrices with int64 indices require cupy >= 14.1.0",
+    ):
+        check_array(array, accept_sparse=True, accept_large_sparse=True)
 
 
 @example(array=np.ones((3, 2)))


### PR DESCRIPTION
This:

- Updates some code in `cuml.internals.validation` to provide a better error message if `cupy < 14.1.0` when users pass in large sparse matrices on host, noting the cupy version that's required to support this.
- Adds some tests for our validation routines for large device-side sparse matrices. This is possible to do in low memory.
- Sets `accept_large_sparse=True` for `Ridge`, `LinearRegression`, and `cuml.random_projection`. I've tested that these work locally, but _running these requires more memory than we can feasibly rely on in CI_. The approach used in sklearn (constructing a tiny sparse matrix, but forcing int64 indices) isn't feasible here, since `cupy` rightfully tries to optimistically coerce indices to `int32` values, which would defeat the purpose of testing. Since `int32` indices run much faster, I think this validation check is valid and not something worth working around. FWIW, these estimators are mostly plumbing the inputs -> routines in cupy/cublas/cusparse/cusolver, so I don't think missing tests in CI here should be a release blocker.

Fixes #8150.
Fixes #8151.
Fixes #8152.
Fixes #8157.