### PR TITLE
Switch RandomForest max_depth default to None

### DIFF
--- a/python/cuml/cuml/dask/ensemble/base.py
+++ b/python/cuml/cuml/dask/ensemble/base.py
@@ -46,18 +46,6 @@ class BaseRandomForestModel(object):
             )
         self.workers = workers
         self._set_internal_model(None)
-        # rapids-pre-commit-hooks: disable-next-line
-        # TODO(26.08): Drop along with the single-GPU deprecation in
-        # cuml.ensemble.randomforest_common.
-        # Record whether the user explicitly set `max_depth`; the warning is
-        # emitted from `_fit` so it fires at fit time (matching the single-GPU
-        # path) rather than at construction. We still forward an explicit
-        # `max_depth=16` to the per-worker single-GPU estimators so they don't
-        # each emit their own FutureWarning.
-        self._max_depth_user_set = "max_depth" in kwargs
-        if not self._max_depth_user_set:
-            kwargs["max_depth"] = 16
-
         self.active_workers = list()
         self.ignore_empty_partitions = ignore_empty_partitions
         self.n_estimators = n_estimators
@@ -101,19 +89,6 @@ class BaseRandomForestModel(object):
         return n_estimators_per_worker
 
     def _fit(self, model, dataset, convert_dtype, broadcast_data):
-        # rapids-pre-commit-hooks: disable-next-line
-        # TODO(26.08): Drop along with the single-GPU deprecation in
-        # cuml.ensemble.randomforest_common.
-        if not getattr(self, "_max_depth_user_set", True):
-            warnings.warn(
-                "The default value of 'max_depth' will change from 16 to "
-                # rapids-pre-commit-hooks: disable-next-line
-                "None (unlimited depth) in release 26.08. To suppress this "
-                "warning, set 'max_depth' explicitly.",
-                FutureWarning,
-                stacklevel=3,
-            )
-
         data = DistributedDataHandler.create(dataset, client=self.client)
         self.active_workers = data.workers
         self.datatype = data.datatype
@@ -255,11 +230,6 @@ class BaseRandomForestModel(object):
         return params_of_each_model
 
     def _set_params(self, **params):
-        # rapids-pre-commit-hooks: disable-next-line
-        # TODO(26.08): Drop along with the single-GPU deprecation in
-        # cuml.ensemble.randomforest_common.
-        if "max_depth" in params:
-            self._max_depth_user_set = True
         model_params = list()
         for idx, worker in enumerate(self.workers):
             model_params.append(

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -68,16 +68,13 @@ class RandomForestClassifier(
          * If ``False``, the whole dataset is used to build each tree.
     max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
-    max_depth : int or None (default = 16)
+    max_depth : int or None (default = None)
         Maximum tree depth. Use ``None`` for unlimited depth (trees grow
         until all leaves are pure). Must be a positive integer or ``None``.
 
-        .. note:: This default differs from scikit-learn's
-          random forest, which defaults to unlimited depth.
-
         .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
-          The default of `max_depth` will change from `16` to `None`.
+          The default of `max_depth` changed from `16` to `None`.
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited, If ``-1``.
     max_features : float (default = 'auto')

--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -58,16 +58,13 @@ class RandomForestRegressor(
          * If ``False``, the whole dataset is used to build each tree.
     max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
-    max_depth : int or None (default = 16)
+    max_depth : int or None (default = None)
         Maximum tree depth. Use ``None`` for unlimited depth (trees grow
         until all leaves are pure). Must be a positive integer or ``None``.
 
-        .. note:: This default differs from scikit-learn's
-          random forest, which defaults to unlimited depth.
-
         .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
-          The default of `max_depth` will change from `16` to `None`.
+          The default of `max_depth` changed from `16` to `None`.
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited, If ``-1``.
     max_features : float (default = 'auto')

--- a/python/cuml/cuml/ensemble/randomforest_common.pyx
+++ b/python/cuml/cuml/ensemble/randomforest_common.pyx
@@ -168,9 +168,6 @@ def compute_max_features(
         )
 
 
-_DEPRECATED_MAX_DEPTH_DEFAULT = "deprecated"
-
-
 class BaseRandomForestModel(Base, InteropMixin):
 
     @classmethod
@@ -248,9 +245,7 @@ class BaseRandomForestModel(Base, InteropMixin):
         return {
             "n_estimators": self.n_estimators,
             "criterion": criterion,
-            "max_depth": (
-                16 if self.max_depth == _DEPRECATED_MAX_DEPTH_DEFAULT else self.max_depth
-            ),
+            "max_depth": self.max_depth,
             "min_samples_split": self.min_samples_split,
             "min_samples_leaf": self.min_samples_leaf,
             "max_features": self.max_features,
@@ -313,7 +308,7 @@ class BaseRandomForestModel(Base, InteropMixin):
         n_estimators=100,
         bootstrap=True,
         max_samples=1.0,
-        max_depth=_DEPRECATED_MAX_DEPTH_DEFAULT,
+        max_depth=None,
         max_leaves=-1,
         max_features='sqrt',
         n_bins=128,
@@ -471,15 +466,6 @@ class BaseRandomForestModel(Base, InteropMixin):
 
         cdef int max_depth_c
         max_depth = self.max_depth
-
-        if max_depth == _DEPRECATED_MAX_DEPTH_DEFAULT:
-            warnings.warn(
-                "The default value of 'max_depth' will change from 16 to "
-                # rapids-pre-commit-hooks: disable-next-line
-                "None (unlimited depth) in release 26.08. To suppress this "
-                "warning, set 'max_depth' explicitly.",
-                FutureWarning, stacklevel=3)
-            max_depth = 16
 
         if max_depth is None:
             max_depth_c = np.iinfo(np.int32).max

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -67,16 +67,13 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
             * If ``False``, the whole dataset is used to build each tree.
     max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
-    max_depth : int or None (default = 16)
+    max_depth : int or None (default = None)
         Maximum tree depth. Use ``None`` for unlimited depth (trees grow
         until all leaves are pure). Must be a positive integer or ``None``.
 
-        .. note:: This default differs from scikit-learn's random forest,
-          which defaults to unlimited depth.
-
         .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
-          The default of `max_depth` will change from `16` to `None`.
+          The default of `max_depth` changed from `16` to `None`.
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited,
         If ``-1``.
@@ -194,7 +191,7 @@ class RandomForestClassifier(BaseRandomForestModel, ClassifierMixin):
         split_criterion="gini",
         bootstrap=True,
         max_samples=1.0,
-        max_depth="deprecated",
+        max_depth=None,
         max_leaves=-1,
         max_features="sqrt",
         n_bins=128,

--- a/python/cuml/cuml/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/ensemble/randomforestregressor.py
@@ -62,16 +62,13 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
             * If ``False``, the whole dataset is used to build each tree.
     max_samples : float (default = 1.0)
         Ratio of dataset rows used while fitting each tree.
-    max_depth : int or None (default = 16)
+    max_depth : int or None (default = None)
         Maximum tree depth. Use ``None`` for unlimited depth (trees grow
         until all leaves are pure). Must be a positive integer or ``None``.
 
-        .. note:: This default differs from scikit-learn's random forest,
-          which defaults to unlimited depth.
-
         .. rapids-pre-commit-hooks: disable-next-line
         .. versionchanged:: 26.08
-          The default of `max_depth` will change from `16` to `None`.
+          The default of `max_depth` changed from `16` to `None`.
     max_leaves : int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited,
         If ``-1``.
@@ -164,7 +161,7 @@ class RandomForestRegressor(BaseRandomForestModel, RegressorMixin):
         split_criterion="mse",
         bootstrap=True,
         max_samples=1.0,
-        max_depth="deprecated",
+        max_depth=None,
         max_leaves=-1,
         max_features=1.0,
         n_bins=128,

--- a/python/cuml/tests/dask/test_dask_random_forest.py
+++ b/python/cuml/tests/dask/test_dask_random_forest.py
@@ -24,12 +24,6 @@ from cuml.dask.ensemble import RandomForestRegressor as cuRFR_mg
 from cuml.ensemble import RandomForestClassifier as cuRFC_sg
 from cuml.ensemble import RandomForestRegressor as cuRFR_sg
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of 'max_depth':FutureWarning"
-)
-
 
 def _prep_training_data(c, X_train, y_train, partitions_per_worker):
     workers = c.has_what().keys()

--- a/python/cuml/tests/explainer/test_explainer_common.py
+++ b/python/cuml/tests/explainer/test_explainer_common.py
@@ -26,11 +26,6 @@ pytestmark = [
     pytest.mark.filterwarnings(
         "ignore:cuml.fil.ForestInference.* is deprecated:FutureWarning"
     ),
-    # rapids-pre-commit-hooks: disable-next-line
-    # TODO(26.08) Remove this filter
-    pytest.mark.filterwarnings(
-        "ignore:The default value of 'max_depth':FutureWarning"
-    ),
 ]
 models_config = ClassEnumerator(module=cuml)
 models = models_config.get_models()

--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -20,11 +20,6 @@ from cuml import KernelExplainer, Lasso
 from cuml.testing.datasets import with_dtype
 from cuml.testing.utils import ClassEnumerator, get_shap_values
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of 'max_depth':FutureWarning"
-)
 models_config = ClassEnumerator(module=cuml)
 models = models_config.get_models()
 

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -28,13 +28,6 @@ from cuml.testing.utils import as_type
 shap = pytest.importorskip("shap")
 
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of 'max_depth':FutureWarning"
-)
-
-
 def make_classification_with_categorical(
     *,
     n_samples,

--- a/python/cuml/tests/test_api.py
+++ b/python/cuml/tests/test_api.py
@@ -200,11 +200,8 @@ def test_mro(model):
 
 
 @pytest.mark.parametrize("model_name", list(models.keys()))
-# ignore random forest float64 warnings and max_depth deprecation
+# ignore random forest float64 warnings
 @pytest.mark.filterwarnings("ignore:To use pickling or GPU-based")
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter
-@pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_fit_function(dataset, model_name):
     # This test ensures that our estimators return self after a call to fit
     if model_name in [

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -108,11 +108,8 @@ def test_base_subclass_init_matches_docs(child_class: str):
 
 
 @pytest.mark.parametrize("child_class", list(all_base_children.keys()))
-# ignore ColumnTransformer init warning and max_depth deprecation
+# ignore ColumnTransformer init warning
 @pytest.mark.filterwarnings("ignore:Transformers are required")
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08) Remove this filter
-@pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 @pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_base_children__get_param_names(child_class: str):
     """
@@ -302,9 +299,6 @@ def test_get_handle_device_ids():
         and hasattr(cls, "predict")
     ],
 )
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08) Remove this filter
-@pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_regressor_predict_dtype(cls):
     X, y = make_regression(n_samples=200, random_state=42)
     X32 = X.astype("float32")
@@ -344,9 +338,6 @@ def test_regressor_predict_dtype(cls):
         (cuml.naive_bayes.MultinomialNB, None),
     ],
 )
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08) Remove this filter
-@pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 # rapids-pre-commit-hooks: disable-next-line
 # TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC.
 @pytest.mark.filterwarnings(

--- a/python/cuml/tests/test_common.py
+++ b/python/cuml/tests/test_common.py
@@ -20,9 +20,6 @@ from cuml.datasets import make_blobs
     ],
 )
 @pytest.mark.filterwarnings("ignore:The number of bins.*:UserWarning")
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08) Remove this filter
-@pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_random_state_argument(Estimator):
     X, y = make_blobs(random_state=0)
     # Check that both integer and np.random.RandomState are accepted

--- a/python/cuml/tests/test_fil.py
+++ b/python/cuml/tests/test_fil.py
@@ -52,9 +52,6 @@ pytestmark = [
     pytest.mark.filterwarnings(
         r"ignore:.*as_fil\(\) method is deprecated.*:FutureWarning"
     ),
-    pytest.mark.filterwarnings(
-        "ignore:The default value of 'max_depth':FutureWarning"
-    ),
 ]
 
 

--- a/python/cuml/tests/test_meta_estimators.py
+++ b/python/cuml/tests/test_meta_estimators.py
@@ -15,12 +15,6 @@ from cuml.preprocessing import StandardScaler
 from cuml.svm import SVC
 from cuml.testing.utils import ClassEnumerator
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of 'max_depth':FutureWarning"
-)
-
 
 def test_pipeline():
     X, y = make_classification(random_state=0)

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -31,11 +31,6 @@ from cuml.tsa.arima import ARIMA
 
 pytestmark = [
     # rapids-pre-commit-hooks: disable-next-line
-    # TODO(26.08): Remove this filter
-    pytest.mark.filterwarnings(
-        "ignore:The default value of 'max_depth':FutureWarning"
-    ),
-    # rapids-pre-commit-hooks: disable-next-line
     # TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
     pytest.mark.filterwarnings(
         "ignore:The `probability` parameter is deprecated:FutureWarning"
@@ -381,7 +376,6 @@ def test_umap_pickle(tmpdir, datatype, keys):
 @pytest.mark.filterwarnings(
     "ignore:Transformers((.|\n)*):UserWarning:cuml[.*]"
 )
-@pytest.mark.filterwarnings("ignore:The default value of 'max_depth'")
 def test_unfit_pickle(model_name):
     # Any model xfailed in this test cannot be used for hyperparameter sweeps
     # with dask or sklearn

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -37,12 +37,6 @@ from cuml.ensemble.randomforest_common import compute_max_features
 from cuml.metrics import r2_score
 from cuml.testing.utils import quality_param, stress_param, unit_param
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The default value of 'max_depth':FutureWarning"
-)
-
 
 @pytest.fixture(
     scope="session",
@@ -190,9 +184,6 @@ def special_reg(request):
     return X, y
 
 
-@pytest.mark.filterwarnings(
-    "default:The default value of 'max_depth':FutureWarning"
-)
 def test_default_parameters():
     X = np.array([[1.0, 2.0]], dtype=np.float32)
     y_reg = np.array([1.0], dtype=np.float32)
@@ -200,13 +191,11 @@ def test_default_parameters():
 
     reg = curfr()
     reg_params = reg.get_params()
-    with pytest.warns(FutureWarning, match="The default value of 'max_depth'"):
-        reg.fit(X, y_reg)
+    reg.fit(X, y_reg)
 
     clf = curfc()
     clf_params = clf.get_params()
-    with pytest.warns(FutureWarning, match="The default value of 'max_depth'"):
-        clf.fit(X, y_clf)
+    clf.fit(X, y_clf)
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
@@ -222,6 +211,9 @@ def test_default_parameters():
     # Different default split_criterion
     assert reg_params["split_criterion"] == "mse"
     assert clf_params["split_criterion"] == "gini"
+
+    assert reg_params["max_depth"] is None
+    assert clf_params["max_depth"] is None
 
     # Drop differing params
     for name in ["max_features", "split_criterion"]:

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -80,10 +80,8 @@ ESTIMATORS = [
     ElasticNet(),
     Lasso(),
     LinearRegression(),
-    # rapids-pre-commit-hooks: disable-next-line
-    # TODO(26.08): Remove explicit default
-    RandomForestClassifier(max_depth=None),
-    RandomForestRegressor(max_depth=None),
+    RandomForestClassifier(),
+    RandomForestRegressor(),
     KMeans(),
     SpectralClustering(),
     LogisticRegression(),


### PR DESCRIPTION
Changes `RandomForestClassifier`, `RandomForestRegressor`, and their Dask variants to use `max_depth=None` as the default now that unlimited-depth support is available. Also removes the 26.06 deprecation sentinel and updates tests/docs to expect the new default.

Validation:
- `python -m pytest python/cuml/tests/test_random_forest.py -k "default_parameters or unlimited_max_depth"`
- `python -m pytest python/cuml/tests/dask/test_dask_random_forest.py -k "unlimited_max_depth"`
- `python -m pytest python/cuml/tests/test_sklearn_compatibility.py -k "RandomForest"`

Closes #7946
