### PR TITLE
Handle sklearn example OpenML network failures

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/example_collector.py
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/example_collector.py
@@ -31,12 +31,28 @@ class ExampleNetworkError(UserWarning):
 _NETWORK_ERROR_PATTERNS = (
     "urllib.error.HTTPError",
     "urllib.error.URLError",
+    "http.client.RemoteDisconnected",
     "http.client.IncompleteRead",
+    "http.client.BadStatusLine",
     "ConnectionError",
+    "ConnectionAbortedError",
+    "ConnectionRefusedError",
     "ConnectionResetError",
+    "RemoteDisconnected",
     "TimeoutError",
+    "requests.exceptions.ConnectionError",
+    "requests.exceptions.Timeout",
+    "socket.gaierror",
     "socket.timeout",
+    "ssl.SSLError",
 )
+
+
+def _network_error_pattern(output):
+    for pattern in _NETWORK_ERROR_PATTERNS:
+        if pattern in output:
+            return pattern
+    return None
 
 
 class _FakeModule:
@@ -97,14 +113,14 @@ class ExampleItem(pytest.Item):
             pytest.xfail(reason=f"Timeout: example exceeded {timeout}s")
         if result.returncode != 0:
             stderr = result.stderr
-            for pattern in _NETWORK_ERROR_PATTERNS:
-                if pattern in stderr:
-                    warnings.warn(
-                        f"Example {self.path.name} failed due to network error"
-                        f" ({pattern})",
-                        ExampleNetworkError,
-                    )
-                    pytest.xfail(reason=f"Network error: {pattern}")
+            pattern = _network_error_pattern(result.stderr + result.stdout)
+            if pattern:
+                warnings.warn(
+                    f"Example {self.path.name} failed due to network error"
+                    f" ({pattern})",
+                    ExampleNetworkError,
+                )
+                pytest.xfail(reason=f"Network error: {pattern}")
             if len(stderr) > 4000:
                 stderr = "...\n" + stderr[-4000:]
             raise ExampleFailed(stderr)


### PR DESCRIPTION
Treat additional connection, HTTP, requests, socket, and SSL failures from sklearn example runs as network xfails, and scan stdout as well as stderr so OpenML fetch failures do not fail the examples job.

Closes https://github.com/rapidsai/cuml/issues/8204
