### PR TITLE
Test cuml.accel upstream test suite with sklearn 1.9

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -651,10 +651,10 @@ dependencies:
         matrices:
           - matrix: {dependencies: "latest"}
             packages:
-              - scikit-learn==1.8.0
+              - scikit-learn==1.9.0
           - matrix: {dependencies: "intermediate"}
             packages:
-              - scikit-learn==1.7.2
+              - scikit-learn==1.8.0
           - matrix: {dependencies: "oldest"}
             packages:
               - scikit-learn==1.6.0

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -368,9 +368,6 @@
   - "sklearn.ensemble.tests.test_forest::test_warm_start[RandomForestClassifier]"
   - "sklearn.ensemble.tests.test_forest::test_warm_start[RandomForestRegressor]"
   - "sklearn.ensemble.tests.test_forest::test_warm_start_oob[RandomForestRegressor]"
-  - "sklearn.ensemble.tests.test_voting::test_predict_on_toy_problem[42]"
-  - "sklearn.ensemble.tests.test_voting::test_sample_weight[42]"
-  - "sklearn.ensemble.tests.test_voting::test_set_estimator_drop"
   - "sklearn.feature_selection.tests.test_from_model::test_feature_importances"
   - "sklearn.feature_selection.tests.test_from_model::test_prefit_get_feature_names_out"
   - "sklearn.feature_selection.tests.test_from_model::test_threshold_string"
@@ -584,6 +581,13 @@
   - "sklearn.svm.tests.test_bounds::test_l1_min_c[no-intercept-multi-class-log-array]"
   - "sklearn.svm.tests.test_bounds::test_l1_min_c[no-intercept-multi-class-log-csr_array]"
   - "sklearn.svm.tests.test_bounds::test_l1_min_c[no-intercept-multi-class-log-csr_matrix]"
+- reason: Test should fail with cuml.accel (scikit-learn <1.9)
+  marker: cuml_accel_bugs
+  condition: scikit-learn<1.9
+  tests:
+  - "sklearn.ensemble.tests.test_voting::test_predict_on_toy_problem[42]"
+  - "sklearn.ensemble.tests.test_voting::test_sample_weight[42]"
+  - "sklearn.ensemble.tests.test_voting::test_set_estimator_drop"
 - reason: Test should fail with cuml.accel (scikit-learn<1.7)
   marker: cuml_accel_bugs
   condition: scikit-learn<1.7
@@ -668,8 +672,6 @@
   - "sklearn.ensemble.tests.test_forest::test_max_samples_boundary_regressors[RandomForestRegressor]"
   - "sklearn.ensemble.tests.test_forest::test_warm_start_oob[RandomForestClassifier]"
   - "sklearn.ensemble.tests.test_stacking::test_stacking_cv_influence[StackingClassifier]"
-  - "sklearn.ensemble.tests.test_voting::test_parallel_fit[42]"
-  - "sklearn.ensemble.tests.test_voting::test_tie_situation"
   - "sklearn.feature_selection.tests.test_sequential::test_unsupervised_model_fit[2]"
   - "sklearn.feature_selection.tests.test_sequential::test_unsupervised_model_fit[3]"
   - "sklearn.manifold.tests.test_spectral_embedding::test_pipeline_spectral_clustering"
@@ -694,6 +696,13 @@
   - "sklearn.tests.test_common::test_estimators[SVR()-check_regressor_data_not_an_array]"
   - "sklearn.tests.test_multioutput::test_base_chain_fit_and_predict_with_sparse_data_and_cv[csr_array]"
   - "sklearn.tests.test_multioutput::test_classifier_chain_fit_and_predict_with_sparse_data[csr_array]"
+- reason: Test is flaky with cuml.accel (scikit-learn <1.9)
+  marker: cuml_accel_flaky
+  condition: scikit-learn<1.9
+  strict: false
+  tests:
+  - "sklearn.ensemble.tests.test_voting::test_parallel_fit[42]"
+  - "sklearn.ensemble.tests.test_voting::test_tie_situation"
 - reason: Tests that fail due to poking at sklearn internals, failures don't indicate bugs in cuml.accel
   marker: cuml_accel_invalid_sklearn_tests
   tests:

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -26,11 +26,160 @@
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_from_cv_results_legend_label[None-curve_kwargs1]"
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_from_cv_results_legend_label[single-None]"
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_from_cv_results_legend_label[single-curve_kwargs1]"
+- reason: Coordinate descent sample-weight behavior differs with cuml.accel in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_alpha_max[sample_weight0-False-False-csc_array-ElasticNetCV-ElasticNet]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_alpha_max[sample_weight0-False-False-csc_matrix-ElasticNetCV-ElasticNet]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_array-False-0.01-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_array-False-0.01-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_random_descent[csr_array]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_random_descent[csr_matrix]"
+- reason: HTML representation differs with cuml.accel under sklearn 1.9 ASCII-locale CI
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.model_selection.tests.test_search::test_search_html_repr"
+  - "sklearn.tests.test_base::test_get_fitted_attr_html"
+  - "sklearn.tests.test_base::test_repr_html_wraps"
+  - "sklearn.tests.test_base::test_repr_mimebundle_"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_birch_duck_typing_meta"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_duck_typing_nested_estimator"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_get_params_return_cls"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_an_empty_pipeline"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_fitted_icon[estimator0]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_fitted_icon[estimator1]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_fitted_icon[estimator2]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_pipeline"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_table"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_estimator_html_repr_unfitted_vs_fitted"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_fallback_exists"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_function_transformer_show_caption[<lambda>-&lt;lambda&gt;]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_function_transformer_show_caption[dummy_function-dummy_function]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_function_transformer_show_caption[func2-dummy_function]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_function_transformer_show_caption[func3-vectorize\\\\(\\\\.\\\\.\\\\.\\\\)]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_invalid_parameters_in_stacking"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_one_estimator_print_change_only[False]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_one_estimator_print_change_only[True]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_ovo_classifier_duck_typing_meta"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_show_arrow_pipeline"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_stacking_classifier[None]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_stacking_classifier[final_estimator1]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_stacking_regressor[None]"
+  - "sklearn.utils._repr_html.tests.test_estimator::test_stacking_regressor[final_estimator1]"
+  - "sklearn.utils._repr_html.tests.test_features::test_countvectorizer_output_features"
+  - "sklearn.utils._repr_html.tests.test_features::test_estimator_html_col_names_featureunion"
+  - "sklearn.utils._repr_html.tests.test_features::test_estimator_html_repr_col_names[False-feature_cols1]"
+  - "sklearn.utils._repr_html.tests.test_features::test_estimator_html_repr_col_names[True-feature_cols0]"
+  - "sklearn.utils._repr_html.tests.test_features::test_estimator_html_repr_total_feature_names[False-total_output_features1]"
+  - "sklearn.utils._repr_html.tests.test_features::test_estimator_html_repr_total_feature_names[True-total_output_features0]"
+  - "sklearn.utils._repr_html.tests.test_features::test_features_html_with_pipeline"
+  - "sklearn.utils._repr_html.tests.test_features::test_get_feature_names_out_exception"
+  - "sklearn.utils._repr_html.tests.test_features::test_meta_estimator_output_features"
+  - "sklearn.utils._repr_html.tests.test_features::test_n_features_not_fitted"
+  - "sklearn.utils._repr_html.tests.test_features::test_single_estimator_get_feature_names_out_exception"
+  - "sklearn.utils._repr_html.tests.test_features::test_with_MinimalTransformer"
+- reason: LogisticRegression behavior differs with cuml.accel in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_callback_fitted_estimator[False-2]"
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_callback_fitted_estimator[False-3]"
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_callback_fitted_estimator[True-2]"
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_callback_fitted_estimator[True-3]"
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_cv_refit[42-1]"
+- reason: Missing-value validation message differs with cuml.accel in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.utils.tests.test_validation::test_check_array_links_to_imputer_doc_only_for_X[csr_array-X]"
+- reason: Numerical tolerance issue with sparse/dense coordinate descent equality in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-0.5-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-0.5-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-0.5-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-0.5-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-0.5-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-0.5-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-24-6-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-24-6-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-24-6-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-24-6-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-0.5-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-0.5-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-0.5-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-0.5-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-0.5-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-0-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-0-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-0.5-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-0.5-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-0.5-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-0.5-True-Lasso]"
+- reason: RandomForest estimators_samples_ fitted attribute is not exposed under cuml.accel in sklearn 1.9 (#6966)
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[RandomForestClassifier-RandomForestClassifier]"
+  - "sklearn.tests.test_docstring_parameters::test_fit_docstring_attributes[RandomForestRegressor-RandomForestRegressor]"
+- reason: RandomForest max_samples validation differs with cuml.accel in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.ensemble.tests.test_forest::test_max_samples_geq_one[RandomForestClassifier]"
+  - "sklearn.ensemble.tests.test_forest::test_max_samples_geq_one[RandomForestRegressor]"
+- reason: RandomForest private class/sample-weight helper state differs under cuml.accel in sklearn 1.9 (#8093)
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.ensemble.tests.test_forest::test_class_weights_forest[42-False-RandomForestClassifier]"
+  - "sklearn.ensemble.tests.test_forest::test_class_weights_forest[42-True-RandomForestClassifier]"
+  - "sklearn.ensemble.tests.test_forest::test_validate_y_class_weight[42-2-RandomForestClassifier]"
+  - "sklearn.ensemble.tests.test_forest::test_validate_y_class_weight[42-3-RandomForestClassifier]"
+  - "sklearn.ensemble.tests.test_forest::test_validate_y_class_weight[42-4-RandomForestClassifier]"
+- reason: SVC probability warning behavior differs with cuml.accel in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.svm.tests.test_svm::test_probability_raises_futurewarning[False-SVC-SVC]"
 - reason: Search CV sample weight equivalence differs with cuml.accel in sklearn 1.7.2
   marker: cuml_accel_bugs
   condition: scikit-learn>=1.7.2
   tests:
   - "sklearn.model_selection.tests.test_search::test_search_cv_sample_weight_equivalence[estimator0]"
+- reason: TargetEncoder warning behavior differs with cuml.accel in sklearn 1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.preprocessing.tests.test_target_encoder::test_target_encoder_shuffle_random_state_deprecated"
 - reason: Test should fail with cuml.accel
   marker: cuml_accel_bugs
   condition: scikit-learn<1.8
@@ -581,21 +730,25 @@
   - "sklearn.svm.tests.test_bounds::test_l1_min_c[no-intercept-multi-class-log-array]"
   - "sklearn.svm.tests.test_bounds::test_l1_min_c[no-intercept-multi-class-log-csr_array]"
   - "sklearn.svm.tests.test_bounds::test_l1_min_c[no-intercept-multi-class-log-csr_matrix]"
-- reason: Test should fail with cuml.accel (scikit-learn <1.9)
-  marker: cuml_accel_bugs
-  condition: scikit-learn<1.9
-  tests:
-  - "sklearn.ensemble.tests.test_voting::test_predict_on_toy_problem[42]"
-  - "sklearn.ensemble.tests.test_voting::test_sample_weight[42]"
-  - "sklearn.ensemble.tests.test_voting::test_set_estimator_drop"
 - reason: Test should fail with cuml.accel (scikit-learn<1.7)
   marker: cuml_accel_bugs
   condition: scikit-learn<1.7
   tests:
   - "sklearn.manifold.tests.test_t_sne::test_tnse_n_iter_deprecated"
   - "sklearn.manifold.tests.test_t_sne::test_tnse_n_iter_max_iter_both_set"
+- reason: Test should fail with cuml.accel on scikit-learn <1.9
+  marker: cuml_accel_bugs
+  condition: scikit-learn<1.9
+  tests:
+  - "sklearn.ensemble.tests.test_voting::test_sample_weight[42]"
+- reason: Voting estimator behavior differs with cuml.accel
+  marker: cuml_accel_bugs
+  tests:
+  - "sklearn.ensemble.tests.test_voting::test_predict_on_toy_problem[42]"
+  - "sklearn.ensemble.tests.test_voting::test_set_estimator_drop"
 - reason: cuML TargetEncoder uses different CV fold assignment algorithm (interleaved vs sklearn's sequential)
   marker: cuml_accel_bugs
+  condition: scikit-learn<1.9
   tests:
   - "sklearn.preprocessing.tests.test_target_encoder::test_encoding[42-binary-5.0-auto-3]"
   - "sklearn.preprocessing.tests.test_target_encoder::test_encoding[42-binary-auto-auto-3]"
@@ -609,6 +762,7 @@
   - "sklearn.preprocessing.tests.test_target_encoder::test_smooth_zero"
 - reason: cuML TargetEncoder uses different cross-validation approach producing different encodings
   marker: cuml_accel_bugs
+  condition: scikit-learn<1.9
   tests:
   - "sklearn.preprocessing.tests.test_target_encoder::test_multiple_features_quick[binary-ints-1.0-False]"
   - "sklearn.preprocessing.tests.test_target_encoder::test_multiple_features_quick[binary-ints-1.0-True]"
@@ -696,7 +850,7 @@
   - "sklearn.tests.test_common::test_estimators[SVR()-check_regressor_data_not_an_array]"
   - "sklearn.tests.test_multioutput::test_base_chain_fit_and_predict_with_sparse_data_and_cv[csr_array]"
   - "sklearn.tests.test_multioutput::test_classifier_chain_fit_and_predict_with_sparse_data[csr_array]"
-- reason: Test is flaky with cuml.accel (scikit-learn <1.9)
+- reason: Test is flaky with cuml.accel on scikit-learn <1.9
   marker: cuml_accel_flaky
   condition: scikit-learn<1.9
   strict: false
@@ -912,7 +1066,7 @@
   tests:
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_alpha_max[sample_weight0-False-True]"
 - reason: Elasticnet scores attribute layout differs with cuml.accel in sklearn 1.8
-  condition: scikit-learn>=1.8
+  condition: scikit-learn>=1.8,<1.9
   tests:
   - "sklearn.linear_model.tests.test_logistic::test_scores_attribute_layout_elasticnet"
 - reason: Flaky deviations in values in cuml.accel
@@ -1034,7 +1188,7 @@
   tests:
   - "sklearn.linear_model.tests.test_logistic::test_logistic_cv_multinomial_score[neg_log_loss-multiclass_agg_list3]"
 - reason: Numerical tolerance issue with Lasso sparse/dense equality in sklearn 1.8
-  condition: scikit-learn>=1.8,<1.9
+  condition: scikit-learn>=1.6,<1.9
   tests:
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-False-Lasso]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-True-Lasso]"

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -18,6 +18,10 @@
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_display_plotting_from_cv_results[True-False-predict_proba-False-curve_kwargs1]"
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_display_plotting_from_cv_results[True-False-predict_proba-True-None]"
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_display_plotting_from_cv_results[True-False-predict_proba-True-curve_kwargs1]"
+- reason: AUC standard deviation differs slightly with cuml.accel in sklearn >= 1.7.2
+  marker: cuml_accel_bugs
+  condition: scikit-learn>=1.7.2,<1.9
+  tests:
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_from_cv_results_legend_label[None-None]"
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_from_cv_results_legend_label[None-curve_kwargs1]"
   - "sklearn.metrics._plot.tests.test_roc_curve_display::test_roc_curve_from_cv_results_legend_label[single-None]"
@@ -33,18 +37,48 @@
   tests:
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_coordinate_descent[Lasso-1-kwargs1]"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_warm_start_convergence"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-24-6-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-24-6-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-True-ElasticNet]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_enet_coordinate_descent[csc_array]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_enet_coordinate_descent[csc_matrix]"
   - "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_sparse_input[csr_array]"
   - "sklearn.manifold.tests.test_t_sne::test_pca_initialization_not_compatible_with_sparse_input[csr_matrix]"
+- reason: Test should fail with cuml.accel
+  marker: cuml_accel_bugs
+  condition: scikit-learn<1.9
+  tests:
+  - "sklearn.ensemble.tests.test_forest::test_class_weights[RandomForestClassifier]"
+  - "sklearn.linear_model.tests.test_base::test_linear_regression_pd_sparse_dataframe_warning"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_array-False-0.01-False]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_array-False-0.01-True]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-False]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-True]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_sparse_input_convergence_warning[csr_array]"
+  - "sklearn.linear_model.tests.test_coordinate_descent::test_sparse_input_convergence_warning[csr_matrix]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-True-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-False-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-False-Lasso]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-True-ElasticNet]"
+  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-True-Lasso]"
+  - "sklearn.utils.tests.test_estimator_checks::test_check_estimator"
+  - "sklearn.utils.tests.test_estimator_checks::test_check_estimator_clones"
 - reason: Test should fail with cuml.accel
   marker: cuml_accel_bugs
   tests:
@@ -304,7 +338,6 @@
   - "sklearn.decomposition.tests.test_pca::test_sparse_pca_solver_error[42-csr_matrix-full]"
   - "sklearn.decomposition.tests.test_pca::test_sparse_pca_solver_error[42-csr_matrix-randomized]"
   - "sklearn.ensemble.tests.test_forest::test_backend_respected"
-  - "sklearn.ensemble.tests.test_forest::test_class_weights[RandomForestClassifier]"
   - "sklearn.ensemble.tests.test_forest::test_estimators_samples[RandomForestClassifier-False-1]"
   - "sklearn.ensemble.tests.test_forest::test_estimators_samples[RandomForestClassifier-False-None]"
   - "sklearn.ensemble.tests.test_forest::test_estimators_samples[RandomForestClassifier-True-1]"
@@ -351,25 +384,18 @@
   - "sklearn.linear_model.tests.test_base::test_inplace_data_preprocessing[42-False-None]"
   - "sklearn.linear_model.tests.test_base::test_inplace_data_preprocessing[42-True-None]"
   - "sklearn.linear_model.tests.test_base::test_linear_regression"
-  - "sklearn.linear_model.tests.test_base::test_linear_regression_pd_sparse_dataframe_warning"
   - "sklearn.linear_model.tests.test_common::test_balance_property[42-True-LogisticRegression]"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_elasticnet_precompute_gram_weighted_samples"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_copy_X_False_check_input_False"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_float_precision"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_multitarget"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_nonfinite_params"
-  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_array-False-0.01-False]"
-  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_array-False-0.01-True]"
-  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-False]"
-  - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_sample_weight_consistency[42-csr_matrix-False-0.01-True]"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_toy"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_lasso_alpha_warning"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_lasso_dual_gap"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_lasso_readonly_data"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_lasso_toy"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_lasso_zero"
-  - "sklearn.linear_model.tests.test_coordinate_descent::test_sparse_input_convergence_warning[csr_array]"
-  - "sklearn.linear_model.tests.test_coordinate_descent::test_sparse_input_convergence_warning[csr_matrix]"
   - "sklearn.linear_model.tests.test_coordinate_descent::test_warm_start_convergence_with_regularizer_decrement"
   - "sklearn.linear_model.tests.test_ransac::test_perfect_horizontal_line"
   - "sklearn.linear_model.tests.test_ransac::test_ransac_exceed_max_skips"
@@ -408,30 +434,6 @@
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_enet_toy_list_input[csc_matrix-True]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_lasso_zero[csc_array]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_lasso_zero[csc_matrix]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-6-24-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-24-6-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-True-6-24-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-False-6-24-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-24-6-True-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-False-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-False-Lasso]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-True-ElasticNet]"
-  - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_matrix-True-6-24-True-Lasso]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_lasso_not_as_toy_dataset[csc_array]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_lasso_not_as_toy_dataset[csc_matrix]"
   - "sklearn.manifold.tests.test_t_sne::test_accessible_kl_divergence"
@@ -555,8 +557,6 @@
   - "sklearn.tests.test_multioutput::test_multi_target_sparse_regression[lil_matrix]"
   - "sklearn.tests.test_multioutput::test_multiclass_multioutput_estimator_predict_proba"
   - "sklearn.utils.tests.test_estimator_checks::test_check_dataframe_column_names_consistency"
-  - "sklearn.utils.tests.test_estimator_checks::test_check_estimator"
-  - "sklearn.utils.tests.test_estimator_checks::test_check_estimator_clones"
   - "sklearn.utils.tests.test_estimator_checks::test_check_estimator_pairwise"
   - "sklearn.utils.tests.test_validation::test_check_array_links_to_imputer_doc_only_for_X[asarray-X]"
   - "sklearn.utils.tests.test_validation::test_check_array_links_to_imputer_doc_only_for_X[csr_matrix-X]"
@@ -809,13 +809,20 @@
   condition: scikit-learn>=1.6
   strict: false
   tests:
+  - "sklearn.linear_model._glm.tests.test_glm::test_linalg_warning_with_newton_solver[42]"
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_path_convergence_fail"
+- reason: These tests sometimes fail due to new deprecation warnings in SciPy 1.16
+  marker: cuml_accel_scipy_1_16
+  condition: scikit-learn>=1.6,<1.9
+  strict: false
+  tests:
   - "sklearn.linear_model.tests.test_logistic::test_newton_cholesky_fallback_to_lbfgs[42]"
 - reason: These tests sometimes fail due to new deprecation warnings in SciPy 1.16
   marker: cuml_accel_scipy_1_16
+  condition: scikit-learn>=1.9
   strict: false
   tests:
-  - "sklearn.linear_model._glm.tests.test_glm::test_linalg_warning_with_newton_solver[42]"
-  - "sklearn.linear_model.tests.test_logistic::test_logistic_regression_path_convergence_fail"
+  - "sklearn.linear_model.tests.test_logistic::test_newton_cholesky_fallback_to_lbfgs"
 - reason: SVC input handling and validation
   marker: cuml_accel_svc_estimator_checks
   condition: scikit-learn<1.8
@@ -892,7 +899,7 @@
   tests:
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_alpha_max_sample_weight[sample_weight0-False-True]"
 - reason: ElasticNet sample_weight handling is a bit off
-  condition: scikit-learn>=1.8
+  condition: scikit-learn>=1.8,<1.9
   tests:
   - "sklearn.linear_model.tests.test_coordinate_descent::test_enet_alpha_max[sample_weight0-False-True]"
 - reason: Elasticnet scores attribute layout differs with cuml.accel in sklearn 1.8
@@ -1007,11 +1014,18 @@
   tests:
   - "sklearn.linear_model.tests.test_logistic::test_logistic_cv[42-False]"
   - "sklearn.linear_model.tests.test_logistic::test_logistic_cv[42-True]"
-  - "sklearn.linear_model.tests.test_logistic::test_logistic_cv_multinomial_score[42-neg_log_loss-multiclass_agg_list3]"
   - "sklearn.linear_model.tests.test_logistic::test_logistic_glmnet[lbfgs]"
   - "sklearn.linear_model.tests.test_logistic::test_logistic_glmnet[newton-cholesky]"
+- reason: 'Numerical precision difference: cuML uses float32, test expects float64 precision'
+  condition: scikit-learn>=1.8,<1.9
+  tests:
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_cv_multinomial_score[42-neg_log_loss-multiclass_agg_list3]"
+- reason: 'Numerical precision difference: cuML uses float32, test expects float64 precision'
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.linear_model.tests.test_logistic::test_logistic_cv_multinomial_score[neg_log_loss-multiclass_agg_list3]"
 - reason: Numerical tolerance issue with Lasso sparse/dense equality in sklearn 1.8
-  condition: scikit-learn>=1.8
+  condition: scikit-learn>=1.8,<1.9
   tests:
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-False-Lasso]"
   - "sklearn.linear_model.tests.test_sparse_coordinate_descent::test_sparse_dense_equality[csc_array-False-24-6-True-Lasso]"
@@ -1124,7 +1138,7 @@
   - "sklearn.linear_model.tests.test_logistic::test_max_iter[42-saga-The max_iter was reached which means the coef_ did not converge-max_iter3]"
   - "sklearn.svm.tests.test_svm::test_linear_svm_convergence_warnings[42]"
 - reason: cuML doesn't enforce sparse matrix int64 indices restriction
-  condition: scikit-learn>=1.8
+  condition: scikit-learn>=1.8,<1.9
   tests:
   - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[42-csr_array-liblinear]"
   - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[42-csr_array-sag]"
@@ -1132,8 +1146,17 @@
   - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[42-csr_matrix-liblinear]"
   - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[42-csr_matrix-sag]"
   - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[42-csr_matrix-saga]"
+- reason: cuML doesn't enforce sparse matrix int64 indices restriction
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[csr_array-liblinear]"
+  - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[csr_array-sag]"
+  - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[csr_array-saga]"
+  - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[csr_matrix-liblinear]"
+  - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[csr_matrix-sag]"
+  - "sklearn.linear_model.tests.test_logistic::test_large_sparse_matrix[csr_matrix-saga]"
 - reason: cuML doesn't support warm_start with newton solvers
-  condition: scikit-learn>=1.8
+  condition: scikit-learn>=1.8,<1.9
   tests:
   - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[42-1-False-newton-cg]"
   - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[42-1-False-newton-cholesky]"
@@ -1143,6 +1166,17 @@
   - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[42-inf-False-newton-cholesky]"
   - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[42-inf-True-newton-cg]"
   - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[42-inf-True-newton-cholesky]"
+- reason: cuML doesn't support warm_start with newton solvers
+  condition: scikit-learn>=1.9
+  tests:
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[1-False-newton-cg]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[1-False-newton-cholesky]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[1-True-newton-cg]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[1-True-newton-cholesky]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[inf-False-newton-cg]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[inf-False-newton-cholesky]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[inf-True-newton-cg]"
+  - "sklearn.linear_model.tests.test_logistic::test_warm_start_newton_solver[inf-True-newton-cholesky]"
 - reason: cuML proxy doesn't replicate sklearn warnings in sklearn 1.8
   condition: scikit-learn>=1.8
   tests:


### PR DESCRIPTION
Updates the `cuml.accel` upstream scikit-learn test target matrix to cover `scikit-learn` `1.9.0`, and updates the xfail list for test IDs and behavior changes across the supported `1.6`, `1.8`, and `1.9` targets.

## Summary

- Bumps the latest upstream scikit-learn accel test target from `1.8.0` to `1.9.0`.
- Moves the intermediate target from `1.7.2` to `1.8.0`.
- Keeps the oldest target pinned at `1.6.0`.
- Scopes existing xfails to the scikit-learn versions where they still apply, avoiding stale xfails on newer targets.
- Adds new `scikit-learn>=1.9` xfail groups for renamed tests and behavior differences observed in the updated upstream test suite.