### PR TITLE
Remove deprecated `probability` argument to `SVC`

### DIFF
--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -1,14 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-import warnings
-
 import cupy as cp
 import numpy as np
-import sklearn
-from packaging.version import Version
-from sklearn.exceptions import NotFittedError
-from sklearn.utils.metaestimators import available_if
 
 from cuml.common.classification import decode_labels, process_class_weight
 from cuml.common.doc_utils import generate_docstring
@@ -22,15 +16,9 @@ from cuml.internals.outputs import (
     reflect,
     run_in_internal_context,
 )
-from cuml.internals.validation import (
-    check_inputs,
-    check_is_fitted,
-    check_random_seed,
-)
+from cuml.internals.validation import check_inputs, check_is_fitted
 from cuml.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from cuml.svm.svm_base import SVMBase
-
-SKLEARN_19 = Version(sklearn.__version__) >= Version("1.9.0.dev0")
 
 
 class SVC(SVMBase, ClassifierMixin):
@@ -110,16 +98,6 @@ class SVC(SVMBase, ClassifierMixin):
         type. If None, the output type set at the module level
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
-    probability : bool (default = False)
-        .. deprecated:: 26.06
-            ``probability`` is deprecated and will be removed in version
-            26.08. Use ``CalibratedClassifierCV(SVC(), ensemble=False)``
-            from ``sklearn.calibration`` for probability estimates instead.
-
-        Set to ``True`` to enable probability estimates
-        (``predict_proba``/``predict_log_proba``). Note that
-        ``probability=True`` requires your training data have at least 5
-        samples per class.
     random_state: int (default = None)
         Seed for random number generator (used only when ``probability=True``).
     verbose : int or boolean, default=False
@@ -184,31 +162,22 @@ class SVC(SVMBase, ClassifierMixin):
     @classmethod
     def _get_param_names(cls):
         params = super()._get_param_names()
-        params.remove(
-            "epsilon"
-        )  # SVC doesn't expose `epsilon` in the constructor
+        # SVC doesn't expose `epsilon` in the constructor
+        params.remove("epsilon")
         params.extend(
-            [
-                "probability",
-                "random_state",
-                "class_weight",
-                "decision_function_shape",
-            ]
+            ["random_state", "class_weight", "decision_function_shape"]
         )
         return params
 
     @classmethod
     def _params_from_cpu(cls, model):
-        if model.probability is True:
-            # probability=True is deprecated; cuml.accel falls back to
-            # native sklearn's own CalibratedClassifierCV.
+        # TODO: remove when we only support sklearn >= 1.9
+        if getattr(model, "probability", None) is True:
             raise UnsupportedOnGPU("`probability=True` is not supported")
 
         params = super()._params_from_cpu(model)
-        params.pop(
-            "epsilon"
-        )  # SVC doesn't expose `epsilon` in the constructor
-        # probability omitted; True rejected above, default restores it.
+        # SVC doesn't expose `epsilon` in the constructor
+        params.pop("epsilon")
         params.update(
             {
                 "random_state": model.random_state,
@@ -220,17 +189,10 @@ class SVC(SVMBase, ClassifierMixin):
 
     def _params_to_cpu(self):
         params = super()._params_to_cpu()
-        params.pop(
-            "epsilon"
-        )  # SVC doesn't expose `epsilon` in the constructor
-        # sklearn <1.9 rejects the ``"deprecated"`` sentinel; resolve it there.
-        if SKLEARN_19:
-            probability = self.probability
-        else:
-            probability = self._effective_probability
+        # SVC doesn't expose `epsilon` in the constructor
+        params.pop("epsilon")
         params.update(
             {
-                "probability": probability,
                 "random_state": self.random_state,
                 "class_weight": self.class_weight,
                 "decision_function_shape": self.decision_function_shape,
@@ -281,7 +243,6 @@ class SVC(SVMBase, ClassifierMixin):
         nochange_steps=1000,
         verbose=False,
         output_type=None,
-        probability="deprecated",
         random_state=None,
         class_weight=None,
         decision_function_shape="ovo",
@@ -299,14 +260,9 @@ class SVC(SVMBase, ClassifierMixin):
             verbose=verbose,
             output_type=output_type,
         )
-        self.probability = probability
         self.random_state = random_state
         self.class_weight = class_weight
         self.decision_function_shape = decision_function_shape
-
-    @property
-    def _effective_probability(self):
-        return False if self.probability == "deprecated" else self.probability
 
     @property
     @reflect
@@ -346,9 +302,6 @@ class SVC(SVMBase, ClassifierMixin):
 
         params = self.get_params()
         decision_function_shape = params.pop("decision_function_shape")
-        # Pin the sentinel on inner clones so they don't re-fire the
-        # deprecation warning the outer fit already emitted.
-        params["probability"] = "deprecated"
         wrappers = {"ovo": OneVsOneClassifier, "ovr": OneVsRestClassifier}
         if (multiclass_cls := wrappers.get(decision_function_shape)) is None:
             raise ValueError(
@@ -392,63 +345,6 @@ class SVC(SVMBase, ClassifierMixin):
         )
         return self
 
-    def _fit_proba(self, X, y, sample_weight):
-        from sklearn.calibration import CalibratedClassifierCV
-        from sklearn.model_selection import StratifiedKFold
-
-        params = {
-            **self.get_params(),
-            "probability": "deprecated",
-            "output_type": "numpy",
-            "class_weight": None,
-        }
-
-        # Currently CalibratedClassifierCV expects data on the host, see
-        # https://github.com/rapidsai/cuml/issues/2608
-        X = X.get()
-        y = y.get()
-
-        if sample_weight is not None:
-            sample_weight = sample_weight.get()
-
-        cv = StratifiedKFold(
-            n_splits=5,
-            random_state=check_random_seed(self.random_state),
-            shuffle=True,
-        )
-        cccv = CalibratedClassifierCV(SVC(**params), cv=cv, ensemble=False)
-
-        with exit_internal_context():
-            cccv.fit(X, y, sample_weight=sample_weight)
-
-        cal_clf = cccv.calibrated_classifiers_[0]
-        svc = cal_clf.estimator
-
-        self._probA = np.array([cal.a_ for cal in cal_clf.calibrators])
-        self._probB = np.array([cal.b_ for cal in cal_clf.calibrators])
-
-        if hasattr(svc, "_multiclass"):
-            attrs = ["_multiclass", "fit_status_", "shape_fit_"]
-        else:
-            attrs = [
-                "support_",
-                "support_vectors_",
-                "dual_coef_",
-                "intercept_",
-                "n_support_",
-                "fit_status_",
-                "shape_fit_",
-                "n_iter_",
-                "_gamma",
-                "_sparse",
-            ]
-
-        # Forward on inner attributes
-        for attr in attrs:
-            setattr(self, attr, getattr(svc, attr))
-
-        return self
-
     @generate_docstring(y="dense_anydtype")
     @reflect(reset="type")
     def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "SVC":
@@ -456,17 +352,6 @@ class SVC(SVMBase, ClassifierMixin):
         Fit the model with X and y.
 
         """
-        if self.probability != "deprecated":
-            warnings.warn(
-                "The `probability` parameter is deprecated and will be "
-                # rapids-pre-commit-hooks: disable-next-line
-                "removed in cuML version 26.08. Use "
-                "`CalibratedClassifierCV(SVC(), ensemble=False)` from "
-                "`sklearn.calibration` instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-
         if hasattr(self, "_multiclass"):
             del self._multiclass
 
@@ -510,9 +395,6 @@ class SVC(SVMBase, ClassifierMixin):
             balanced_with_sample_weight=False,
         )
 
-        if self._effective_probability:
-            return self._fit_proba(X, y, sample_weight)
-
         if len(classes) > 2:
             return self._fit_multiclass(X, y, sample_weight)
 
@@ -541,10 +423,6 @@ class SVC(SVMBase, ClassifierMixin):
             inds = self._multiclass.predict(X)
             index = inds.index
             inds = inds.to_output("cupy")
-        elif self._effective_probability:
-            probs = self.predict_proba(X)
-            index = probs.index
-            inds = cp.argmax(probs.to_output("cupy"), axis=1)
         else:
             res = self.decision_function(X, convert_dtype=convert_dtype)
             index = res.index
@@ -555,87 +433,6 @@ class SVC(SVMBase, ClassifierMixin):
         return decode_labels(
             inds, self.classes_, output_type=output_type, index=index
         )
-
-    @available_if(lambda self: self._effective_probability)
-    @generate_docstring(
-        skip_parameters_heading=True,
-        return_values={
-            "name": "preds",
-            "type": "dense",
-            "description": "Predicted probabilities",
-            "shape": "(n_samples, n_classes)",
-        },
-    )
-    @reflect
-    def predict_proba(self, X, *, log=False) -> CumlArray:
-        """
-        Predicts the class probabilities for X.
-
-        The model has to be trained with probability=True to use this method.
-
-        Parameters
-        ----------
-        log: boolean (default = False)
-             Whether to return log probabilities.
-
-        """
-        check_is_fitted(self)
-
-        if self._probA.size == 0 or self._probB.size == 0:
-            raise NotFittedError(
-                "predict_proba is not available when fitted with probability=False"
-            )
-
-        from cupyx.scipy.special import expit
-
-        preds = self.decision_function(X)
-        index = preds.index
-        preds = preds.to_output("cupy")
-        if preds.ndim == 1:
-            preds = preds[:, None]
-
-        n_classes = len(self.classes_)
-
-        proba = cp.zeros((preds.shape[0], n_classes))
-        for i in range(preds.shape[1]):
-            a = self._probA[i]
-            b = self._probB[i]
-            ind = i + 1 if n_classes == 2 else i
-            proba[:, ind] = expit(-(a * preds[:, i] + b))
-
-        if n_classes == 2:
-            proba[:, 0] = 1.0 - proba[:, 1]
-        else:
-            den = cp.sum(proba, axis=1)
-            cp.divide(proba, den[:, None], out=proba)
-            # If all probabilities are 0, use a uniform distribution
-            proba[den == 0] = 1 / n_classes
-            # Clip to between 0 and 1 to handle rounding error
-            cp.clip(proba, 0, 1, out=proba)
-
-        if log:
-            proba = cp.log(proba)
-
-        return CumlArray(data=proba, index=index)
-
-    @available_if(lambda self: self._effective_probability)
-    @generate_docstring(
-        return_values={
-            "name": "preds",
-            "type": "dense",
-            "description": "Log of predicted probabilities",
-            "shape": "(n_samples, n_classes)",
-        }
-    )
-    @reflect
-    def predict_log_proba(self, X) -> CumlArray:
-        """
-        Predicts the log probabilities for X (returns log(predict_proba(x)).
-
-        The model has to be trained with probability=True to use this method.
-
-        """
-        return self.predict_proba(X, log=True)
 
     @generate_docstring(
         return_values={

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -227,8 +227,6 @@ class SVMBase(Base,
             "fit_status_": model.fit_status_,
             "shape_fit_": model.shape_fit_,
             "n_iter_": model.n_iter_,
-            "_probA": model._probA,
-            "_probB": model._probB,
             **super()._attrs_from_cpu(model),
         }
 
@@ -264,12 +262,12 @@ class SVMBase(Base,
             "support_": to_cpu(self.support_, order="C", dtype=np.int32),
             "support_vectors_": support_vectors_,
             "_gamma": self._gamma,
-            "_probA": self._probA,
-            "_probB": self._probB,
+            "_probA": np.empty(0, dtype=np.float64),
+            "_probB": np.empty(0, dtype=np.float64),
             "_sparse": self._sparse,
             # sklearn >= 1.9 reads this private attribute during predict
             # (sklearn PR #32050); harmless on older sklearn.
-            "_effective_probability": getattr(self, "_effective_probability", False),
+            "_effective_probability": False,
             **super()._attrs_to_cpu(model),
         }
 
@@ -479,8 +477,6 @@ class SVMBase(Base,
         self.n_iter_ = np.array([n_iter], dtype=np.int32) if is_classifier else n_iter
         self._gamma = gamma
         self._sparse = sparse_X
-        self._probA = np.empty(0, dtype=np.float64)
-        self._probB = np.empty(0, dtype=np.float64)
 
     def _predict(self, X, *, convert_dtype=True) -> CumlArray:
         """Perform `predict`."""

--- a/python/cuml/cuml/testing/utils.py
+++ b/python/cuml/cuml/testing/utils.py
@@ -14,7 +14,6 @@ import pytest
 from cudf.pandas import LOADED as cudf_pandas_active
 from numba import cuda
 from numba.cuda.cudadrv.devicearray import DeviceNDArray
-from sklearn.metrics import brier_score_loss, mean_squared_error
 
 from cuml.internals.base import Base
 from cuml.internals.input_utils import input_to_cuml_array, is_array_like
@@ -612,22 +611,6 @@ def compare_svm(
     intersection_len = len(support1.intersection(support2))
     average_len = (len(support1) + len(support2)) / 2
     assert intersection_len > average_len / 8
-
-
-def compare_probabilistic_svm(
-    svc1, svc2, X_test, y_test, tol=1e-3, brier_tol=1e-3
-):
-    """Compare the probability output from two support vector classifiers."""
-
-    prob1 = svc1.predict_proba(X_test)
-    prob2 = svc2.predict_proba(X_test)
-    assert mean_squared_error(prob1, prob2) <= tol
-
-    if svc1.n_classes_ == 2:
-        brier1 = brier_score_loss(y_test, prob1[:, 1])
-        brier2 = brier_score_loss(y_test, prob2[:, 1])
-        # Brier score - smaller is better
-        assert brier1 - brier2 <= brier_tol
 
 
 def svm_array_equal(a, b, tol=1e-6, relative_diff=True, report_summary=False):

--- a/python/cuml/cuml_accel_tests/integration/test_svc.py
+++ b/python/cuml/cuml_accel_tests/integration/test_svc.py
@@ -37,8 +37,7 @@ def test_svc(binary):
     assert svc.score(X, y) > 0.5
 
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC.
+# TODO: remove once we only support sklearn >= 1.9
 @pytest.mark.filterwarnings(
     "ignore:Attribute `prob[AB]_` was deprecated:FutureWarning"
 )
@@ -46,10 +45,9 @@ def test_svc(binary):
     "ignore:The `probability` parameter (is|was) deprecated:FutureWarning"
 )
 def test_svc_probability(binary):
+    """This runs fully unaccelerated. Just checking that the gated methods
+    and attributes still work properly."""
     X, y = binary
-    # cuml.accel no longer accelerates `probability=True`; this fit falls
-    # back to native sklearn `SVC(probability=True)`. predict_proba still
-    # works through the native path.
     svc = SVC(probability=True).fit(X, y)
     # Inference and score works
     assert svc.score(X, y) > 0.5

--- a/python/cuml/tests/explainer/test_explainer_kernel_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_kernel_shap.py
@@ -80,42 +80,32 @@ def test_exact_regression_datasets(exact_shap_regression_dataset, model):
             )
 
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter once `probability` is removed from cuml.svm.SVC.
-@pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
-)
-def test_exact_classification_datasets(exact_shap_classification_dataset):
+@pytest.mark.parametrize("cls", [cuml.SVC, sklearn.svm.SVC])
+def test_exact_classification_datasets(exact_shap_classification_dataset, cls):
     X_train, X_test, y_train, y_test = exact_shap_classification_dataset
 
-    models = []
-    models.append(cuml.SVC(probability=True).fit(X_train, y_train))
-    models.append(
-        CalibratedClassifierCV(sklearn.svm.SVC(), ensemble=False).fit(
-            X_train, y_train
-        )
+    model = CalibratedClassifierCV(cls(), ensemble=False)
+    model.fit(X_train, y_train)
+
+    explainer, shap_values = get_shap_values(
+        model=model.predict_proba,
+        background_dataset=X_train,
+        explained_dataset=X_test,
+        explainer=KernelExplainer,
     )
 
-    for mod in models:
-        explainer, shap_values = get_shap_values(
-            model=mod.predict_proba,
-            background_dataset=X_train,
-            explained_dataset=X_test,
-            explainer=KernelExplainer,
+    # Some values are very small, which mean our tolerance here needs to be
+    # a little looser to avoid false positives from comparisons like
+    # 0.00348627 - 0.00247397. The loose tolerance still tests that the
+    # distribution of the values matches.
+    for idx, svs in enumerate(shap_values):
+        assert_and_log(
+            svs[0],
+            golden_classification_result[idx],
+            float(model.predict_proba(X_test)[0][idx]),
+            explainer.expected_value[idx],
+            tolerance=1e-01,
         )
-
-        # Some values are very small, which mean our tolerance here needs to be
-        # a little looser to avoid false positives from comparisons like
-        # 0.00348627 - 0.00247397. The loose tolerance still tests that the
-        # distribution of the values matches.
-        for idx, svs in enumerate(shap_values):
-            assert_and_log(
-                svs[0],
-                golden_classification_result[idx],
-                float(mod.predict_proba(X_test)[0][idx]),
-                explainer.expected_value[idx],
-                tolerance=1e-01,
-            )
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])

--- a/python/cuml/tests/explainer/test_explainer_permutation_shap.py
+++ b/python/cuml/tests/explainer/test_explainer_permutation_shap.py
@@ -54,43 +54,31 @@ def test_regression_datasets(exact_shap_regression_dataset, model):
             ) <= 1e-5
 
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter once `probability` is removed from cuml.svm.SVC.
-@pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
-)
-def test_exact_classification_datasets(exact_shap_classification_dataset):
+@pytest.mark.parametrize("cls", [cuml.SVC, sklearn.svm.SVC])
+def test_exact_classification_datasets(exact_shap_classification_dataset, cls):
     X_train, X_test, y_train, y_test = exact_shap_classification_dataset
 
-    models = []
-    models.append(cuml.SVC(probability=True).fit(X_train, y_train))
-    models.append(
-        CalibratedClassifierCV(sklearn.svm.SVC(), ensemble=False).fit(
-            X_train, y_train
-        )
+    model = CalibratedClassifierCV(cls(), ensemble=False)
+    model.fit(X_train, y_train)
+
+    explainer, shap_values = get_shap_values(
+        model=model.predict_proba,
+        background_dataset=X_train,
+        explained_dataset=X_test,
+        explainer=PermutationExplainer,
     )
 
-    for mod in models:
-        explainer, shap_values = get_shap_values(
-            model=mod.predict_proba,
-            background_dataset=X_train,
-            explained_dataset=X_test,
-            explainer=PermutationExplainer,
-        )
+    fx = model.predict_proba(X_test)
+    exp_v = explainer.expected_value
 
-        fx = mod.predict_proba(X_test)
-        exp_v = explainer.expected_value
-
-        for i in range(3):
-            print(i, fx[i][1], shap_values[1][i])
-            assert (
-                np.sum(cp.asnumpy(shap_values[0][i]))
-                - abs(fx[i][0] - exp_v[0])
-            ) <= 1e-5
-            assert (
-                np.sum(cp.asnumpy(shap_values[1][i]))
-                - abs(fx[i][1] - exp_v[1])
-            ) <= 1e-5
+    for i in range(3):
+        print(i, fx[i][1], shap_values[1][i])
+        assert (
+            np.sum(cp.asnumpy(shap_values[0][i])) - abs(fx[i][0] - exp_v[0])
+        ) <= 1e-5
+        assert (
+            np.sum(cp.asnumpy(shap_values[1][i])) - abs(fx[i][1] - exp_v[1])
+        ) <= 1e-5
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -322,33 +322,27 @@ def test_regressor_predict_dtype(cls):
 
 
 @pytest.mark.parametrize(
-    "cls, kwargs",
+    "cls",
     [
-        (cuml.LogisticRegression, None),
-        (cuml.RandomForestClassifier, None),
-        (cuml.SVC, None),
-        (cuml.SVC, {"probability": True}),
-        (cuml.LinearSVC, None),
-        (cuml.KNeighborsClassifier, None),
-        (cuml.MBSGDClassifier, None),
-        (cuml.naive_bayes.GaussianNB, None),
-        (cuml.naive_bayes.BernoulliNB, None),
-        (cuml.naive_bayes.ComplementNB, None),
-        (cuml.naive_bayes.CategoricalNB, None),
-        (cuml.naive_bayes.MultinomialNB, None),
+        cuml.LogisticRegression,
+        cuml.RandomForestClassifier,
+        cuml.SVC,
+        cuml.LinearSVC,
+        cuml.KNeighborsClassifier,
+        cuml.MBSGDClassifier,
+        cuml.naive_bayes.GaussianNB,
+        cuml.naive_bayes.BernoulliNB,
+        cuml.naive_bayes.ComplementNB,
+        cuml.naive_bayes.CategoricalNB,
+        cuml.naive_bayes.MultinomialNB,
     ],
-)
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC.
-@pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
 )
 @pytest.mark.parametrize(
     "target_kind", ["binary", "multiclass", "multitarget"]
 )
 @pytest.mark.parametrize("dtype_kind", ["int-monotonic", "int", "string"])
-def test_classifier_label_types(cls, kwargs, target_kind, dtype_kind):
-    model = cls(**(kwargs or {}))
+def test_classifier_label_types(cls, target_kind, dtype_kind):
+    model = cls()
     tags = model.__sklearn_tags__()
 
     supports_multitarget = [cuml.KNeighborsClassifier]

--- a/python/cuml/tests/test_linear_svm.py
+++ b/python/cuml/tests/test_linear_svm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import math
+import warnings
 
 import numpy as np
 import pytest
@@ -308,3 +309,44 @@ def test_linear_svc_n_iter_max_iter(penalty, n_streams):
         penalty=penalty, n_streams=n_streams, max_iter=10
     ).fit(X, y)
     assert model.n_iter_ == 10
+
+
+@pytest.mark.parametrize("explicit_value", [True, False])
+def test_linear_svc_probability_emits_future_warning(explicit_value):
+    X, y = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            r"The `probability` parameter is deprecated and will be "
+            r"removed in cuML"
+        ),
+    ):
+        cuml.LinearSVC(probability=explicit_value).fit(X, y)
+
+
+def test_linear_svc_default_does_not_emit_probability_warning():
+    X, y = make_classification(
+        n_samples=40,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        n_classes=2,
+        random_state=0,
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=(
+                r"The `probability` parameter is deprecated and will "
+                r"be removed in cuML"
+            ),
+            category=FutureWarning,
+        )
+        cuml.LinearSVC().fit(X, y)

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -21,7 +21,6 @@ import cuml
 from cuml.testing.utils import (
     ClassEnumerator,
     array_equal,
-    compare_probabilistic_svm,
     compare_svm,
     get_all_base_subclasses,
     stress_param,
@@ -29,13 +28,6 @@ from cuml.testing.utils import (
 )
 from cuml.tsa.arima import ARIMA
 
-pytestmark = [
-    # rapids-pre-commit-hooks: disable-next-line
-    # TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
-    pytest.mark.filterwarnings(
-        "ignore:The `probability` parameter is deprecated:FutureWarning"
-    ),
-]
 regression_config = ClassEnumerator(module=cuml.linear_model)
 regression_models = regression_config.get_models()
 
@@ -735,19 +727,13 @@ def test_tsne_pickle(tmpdir):
 # Probabilistic SVM is tested separately because it is a meta estimator that
 # owns a set of base SV classifiers.
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
-@pytest.mark.parametrize(
-    "params", [{"probability": True}, {"probability": False}]
-)
 @pytest.mark.parametrize("multiclass", [True, False])
 @pytest.mark.parametrize("sparse", [False, True])
-def test_svc_pickle(tmpdir, datatype, params, multiclass, sparse):
+def test_svc_pickle(tmpdir, datatype, multiclass, sparse):
     result = {}
 
-    if sparse and params["probability"]:
-        pytest.skip("Probabilistic SVC does not support sparse input")
-
     def create_mod():
-        model = cuml.svm.SVC(**params)
+        model = cuml.svm.SVC()
         iris = load_iris()
         iris_selection = np.random.RandomState(42).choice(
             [True, False], 150, replace=True, p=[0.75, 0.25]
@@ -763,18 +749,14 @@ def test_svc_pickle(tmpdir, datatype, params, multiclass, sparse):
         return model, data
 
     def assert_model(pickled_model, data):
-        if result["model"].probability:
-            print("Comparing probabilistic svc")
-            compare_probabilistic_svm(
-                result["model"], pickled_model, data[0], data[1], 0, 0
-            )
-        else:
-            print("comparing base svc")
-            compare_svm(result["model"], pickled_model, data[0], data[1])
+        compare_svm(result["model"], pickled_model, data[0], data[1])
 
     pickle_save_load(tmpdir, create_mod, assert_model)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The `probability` parameter is deprecated:FutureWarning"
+)
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
 @pytest.mark.parametrize(
     "params", [{"probability": True}, {"probability": False}]
@@ -897,15 +879,12 @@ def test_sparse_svr_pickle(tmpdir, datatype, nrows, ncols, n_info):
 @pytest.mark.parametrize("nrows", [unit_param(500)])
 @pytest.mark.parametrize("ncols", [unit_param(16)])
 @pytest.mark.parametrize("n_info", [unit_param(7)])
-@pytest.mark.parametrize(
-    "params", [{"probability": True}, {"probability": False}]
-)
-def test_svc_pickle_nofit(tmpdir, datatype, nrows, ncols, n_info, params):
+def test_svc_pickle_nofit(tmpdir, datatype, nrows, ncols, n_info):
     def create_mod():
         X_train, y_train, X_test = make_classification_dataset(
             datatype, nrows, ncols, n_info, n_classes=2
         )
-        model = cuml.svm.SVC(**params)
+        model = cuml.svm.SVC()
         return model, [X_train, y_train, X_test]
 
     def assert_model(pickled_model, X):

--- a/python/cuml/tests/test_sklearn_import_export.py
+++ b/python/cuml/tests/test_sklearn_import_export.py
@@ -376,84 +376,39 @@ def test_svr(random_state, sparse, kernel):
         )
 
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove this filter once `probability` is removed from cuml.svm.SVC.
-@pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter (is|was) deprecated:FutureWarning"
-)
-@pytest.mark.filterwarnings(
-    "ignore:Attribute `prob[AB]_` was deprecated:FutureWarning"
-)
 @pytest.mark.parametrize("sparse", [False, True])
-@pytest.mark.parametrize("probability", [False, True])
-@pytest.mark.parametrize("kernel", ["rbf", "precomputed"])
-def test_svc(random_state, sparse, probability, kernel):
+def test_svc(random_state, sparse):
     X, y = make_classification(
         n_samples=100, n_features=5, n_informative=3, random_state=random_state
     )
-    if kernel == "precomputed":
-        if sparse or probability:
-            pytest.skip(
-                "precomputed kernel not supported with sparse or probability"
-            )
-        K = X @ X.T  # Linear kernel matrix
-        original = cuml.SVC(kernel="precomputed")
-        assert_estimator_roundtrip(
-            original,
-            sklearn.svm.SVC,
-            K,
-            y,
-            exclude_params=["probability"],
-        )
-    else:
-        if sparse:
-            X = scipy.sparse.coo_matrix(X)
-        original = cuml.SVC()
-        assert_estimator_roundtrip(
-            original,
-            sklearn.svm.SVC,
-            X,
-            y,
-            exclude_params=["probability"],
-        )
+    if sparse:
+        X = scipy.sparse.coo_matrix(X)
+    original = cuml.SVC()
+    assert_estimator_roundtrip(original, sklearn.svm.SVC, X, y)
 
-        # Check inference works after conversion. sklearn 1.9 deprecated the
-        # `probability` parameter; avoid passing it on the sklearn side when
-        # False (the default) to avoid the FutureWarning.
-        cu_model = cuml.SVC(probability=probability).fit(X, y)
-        sk_model2 = cu_model.as_sklearn()
-        sk_score = sk_model2.score(X, y)
-        assert sk_score > 0.7
+    # Check inference works after conversion.
+    cu_model = cuml.SVC().fit(X, y)
+    sk_model2 = cu_model.as_sklearn()
+    sk_score = sk_model2.score(X, y)
+    assert sk_score > 0.7
 
-        if probability:
-            # `cuml.SVC.from_sklearn` rejects probability=True so cuml.accel
-            # falls back to native sklearn for calibrated SVC.
-            sk_model = sklearn.svm.SVC(probability=True).fit(X, y)
-            with pytest.raises(
-                UnsupportedOnGPU,
-                match=r"`probability=True` is not supported",
-            ):
-                cuml.SVC.from_sklearn(sk_model)
+    sk_model = sklearn.svm.SVC().fit(X, y)
+    cu_model2 = cuml.SVC.from_sklearn(sk_model)
 
-            # The cuml-direct path (used here via cu_model.as_sklearn()) still
-            # wires up probA_ / probB_ for predict_proba on the sklearn side.
-            sk_pred_prob = sk_model2.predict_proba(X).argmax(axis=1)
-            assert accuracy_score(sk_pred_prob, y) > 0.7
+    cu_score = cu_model2.score(X, y)
+    assert cu_score > 0.7
 
-            for attr in ["probA_", "probB_"]:
-                val = getattr(sk_model2, attr)
-                assert isinstance(val, np.ndarray)
-                assert val.dtype == "float64"
-                assert val.shape == (1,)
-        else:
-            sk_model = sklearn.svm.SVC().fit(X, y)
-            cu_model2 = cuml.SVC.from_sklearn(sk_model)
+    # Check n_support_ is correctly set
+    assert cu_model2.n_support_ == cu_model2.support_vectors_.shape[0]
 
-            cu_score = cu_model2.score(X, y)
-            assert cu_score > 0.7
 
-            # Check n_support_ is correctly set
-            assert cu_model2.n_support_ == cu_model2.support_vectors_.shape[0]
+def test_svc_precomputed(random_state):
+    X, y = make_classification(
+        n_samples=100, n_features=5, n_informative=3, random_state=random_state
+    )
+    K = X @ X.T  # Linear kernel matrix
+    original = cuml.SVC(kernel="precomputed")
+    assert_estimator_roundtrip(original, sklearn.svm.SVC, K, y)
 
 
 @pytest.mark.parametrize("kind", ["SVC", "SVR"])

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import platform
-import warnings
 
 import cudf
 import cupy as cp
@@ -12,7 +11,6 @@ import scipy.sparse as scipy_sparse
 from cudf.pandas import LOADED as cudf_pandas_active
 from numba import cuda
 from sklearn import svm
-from sklearn.calibration import CalibratedClassifierCV
 from sklearn.datasets import (
     load_iris,
     make_blobs,
@@ -21,29 +19,18 @@ from sklearn.datasets import (
     make_gaussian_quantiles,
     make_regression,
 )
-from sklearn.exceptions import NotFittedError
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 
 import cuml
 import cuml.svm as cu_svm
-from cuml.common import input_to_cuml_array
 from cuml.testing.utils import (
-    compare_probabilistic_svm,
     compare_svm,
     quality_param,
     stress_param,
     svm_array_equal,
     unit_param,
-)
-
-# Many tests below pass `probability=` to cuml SVC/LinearSVC on purpose;
-# silence the FutureWarning module-wide.
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove once `probability` is removed from cuml.svm.SVC/LinearSVC.
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
 )
 
 IS_ARM = platform.processor() == "aarch64"
@@ -202,40 +189,18 @@ def test_svm_skl_cmp_multiclass(
         )
 
 
-@pytest.mark.parametrize(
-    "params",
-    [
-        {"kernel": "rbf", "C": 5, "gamma": 0.005, "probability": False},
-        {"kernel": "rbf", "C": 5, "gamma": 0.005, "probability": True},
-    ],
-)
-def test_svm_skl_cmp_decision_function(params, n_rows=4000, n_cols=20):
-    X_train, X_test, y_train, y_test = make_dataset(
-        "classification1", n_rows, n_cols
-    )
-    y_train = y_train.astype(np.int32)
-    y_test = y_test.astype(np.int32)
+def test_svm_skl_cmp_decision_function():
+    X_train, X_test, y_train, _ = make_dataset("classification1", 4000, 20)
+    y_train = y_train.astype("int32")
 
-    cuSVC = cu_svm.SVC(**params)
-    cuSVC.fit(X_train, y_train)
+    params = {"kernel": "rbf", "C": 5, "gamma": 0.005}
+    cu_model = cu_svm.SVC(**params).fit(X_train, y_train)
+    sk_model = svm.SVC(**params).fit(X_train, y_train)
 
-    pred = cuSVC.predict(X_test)
-    assert pred.dtype == y_train.dtype
-
-    df1 = cuSVC.decision_function(X_test)
-    assert df1.dtype == X_train.dtype
-
-    # sklearn here is just a reference value for decision_function, which does
-    # not depend on calibration (the value of `probability`). The `probability`
-    # parametrization of the test exists to verify that cuml's probability=True
-    # path doesn't break decision_function on our side, so we drop probability
-    # from the sklearn kwargs (sklearn 1.9 warns on any explicit value, and
-    # 1.11 will remove the parameter entirely).
-    sklSVC = svm.SVC(**{k: v for k, v in params.items() if k != "probability"})
-    sklSVC.fit(X_train, y_train)
-    df2 = sklSVC.decision_function(X_test)
-
-    assert mean_squared_error(df1, df2) < 1e-5
+    cu_res = cu_model.decision_function(X_test)
+    assert cu_res.dtype == X_train.dtype
+    sk_res = sk_model.decision_function(X_test)
+    assert mean_squared_error(cu_res, sk_res) < 1e-5
 
 
 @pytest.mark.parametrize(
@@ -269,67 +234,9 @@ def test_svm_predict(params, n_pred):
     assert accuracy > 99
 
 
-def test_svc_predict_proba_not_available():
-    X, y = make_classification()
-    model = cuml.SVC().fit(X, y)
-
-    assert not hasattr(model, "predict_proba")
-    assert not hasattr(model, "predict_log_proba")
-
-    # Setting `probability=True` makes the attribute available, but
-    # calling it raises a NotFittedError until refit
-    model.probability = True
-    assert hasattr(model, "predict_proba")
-
-    with pytest.raises(NotFittedError, match="fitted with probability=False"):
-        model.predict_proba(X)
-
-
-# Probabilisic SVM uses scikit-learn's CalibratedClassifierCV, and therefore
-# the input array is converted to numpy under the hood. We explicitly test for
-# all supported input types, to avoid errors like
-# https://github.com/rapidsai/cuml/issues/3090
-@pytest.mark.parametrize("in_type", ["numpy", "cudf", "cupy", "pandas"])
-@pytest.mark.parametrize("n_classes", [2, 4])
-def test_svc_predict_proba(in_type, n_classes):
-    params = {
-        "kernel": "rbf",
-        "C": 1,
-        "tol": 1e-3,
-        "gamma": "scale",
-        "probability": True,
-    }
-    X, y = make_classification(
-        n_samples=1000,
-        n_features=20,
-        n_informative=5,
-        n_classes=n_classes,
-        n_redundant=10,
-        random_state=137,
-    )
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.8, random_state=42
-    )
-
-    X_m = input_to_cuml_array(X_train).array
-    y_m = input_to_cuml_array(y_train).array
-
-    cuSVC = cu_svm.SVC(**params)
-    cuSVC.fit(X_m.to_output(in_type), y_m.to_output(in_type))
-    sk_params = {k: v for k, v in params.items() if k != "probability"}
-    sklSVC = CalibratedClassifierCV(svm.SVC(**sk_params), ensemble=False)
-    sklSVC.fit(X_train, y_train)
-
-    tol = 1e-2 if n_classes == 2 else 1e-1
-    compare_probabilistic_svm(
-        cuSVC, sklSVC, X_test, y_test, tol=tol, brier_tol=tol
-    )
-
-
 @pytest.mark.parametrize("class_weight", [None, {1: 10}, "balanced"])
 @pytest.mark.parametrize("sample_weight", [None, True])
-@pytest.mark.parametrize("probability", [False, True])
-def test_svc_weights(class_weight, sample_weight, probability):
+def test_svc_weights(class_weight, sample_weight):
     # We are using the following example as a test case
     # https://scikit-learn.org/stable/auto_examples/svm/plot_separating_hyperplane_unbalanced.html
     X, y = make_blobs(
@@ -347,33 +254,20 @@ def test_svc_weights(class_weight, sample_weight, probability):
         "kernel": "linear",
         "C": 1,
         "gamma": "scale",
-        "probability": probability,
+        "class_weight": class_weight,
     }
-    params["class_weight"] = class_weight
-    cuSVC = cu_svm.SVC(**params)
-    cuSVC.fit(X, y, sample_weight)
+    cu_model = cu_svm.SVC(**params).fit(X, y, sample_weight=sample_weight)
 
     if class_weight is not None or sample_weight is not None:
         # Standalone test: check if smaller blob is correctly classified in the
         # presence of class weights
         X_1 = X[y == 1, :]
         y_1 = np.ones(X_1.shape[0])
-        cu_score = cuSVC.score(X_1, y_1)
+        cu_score = cu_model.score(X_1, y_1)
         assert cu_score > 0.9
 
-    sk_params = {k: v for k, v in params.items() if k != "probability"}
-    if probability:
-        sklSVC = CalibratedClassifierCV(svm.SVC(**sk_params), ensemble=False)
-    else:
-        sklSVC = svm.SVC(**sk_params)
-    sklSVC.fit(X, y, sample_weight)
-    if not probability:
-        # TODO: SVC estimators with probability=True don't expose all the fitted
-        # attributes properly on the cuml side. This will be best resolved by
-        # changing our internal representation rather than cludging on more
-        # @property definitions. Skipping the attribute equivalence check here
-        # for now.
-        compare_svm(cuSVC, sklSVC, X, y, coef_tol=1e-5, report_summary=True)
+    sk_model = svm.SVC(**params).fit(X, y, sample_weight=sample_weight)
+    compare_svm(cu_model, sk_model, X, y, coef_tol=1e-5, report_summary=True)
 
 
 @pytest.mark.parametrize(
@@ -645,141 +539,6 @@ def test_svc_multiclass_n_iter():
     model = cuml.SVC().fit(X, y)
     assert model.n_iter_.dtype == np.int32
     assert model.n_iter_.shape == (3,)
-
-
-def test_svc_probability_n_iter():
-    X, y = make_classification(random_state=42)
-    model = cuml.SVC(probability=True).fit(X, y)
-    assert model.n_iter_.dtype == np.int32
-    assert model.n_iter_.shape == (1,)
-
-
-@pytest.mark.parametrize("explicit_value", [True, False])
-def test_svc_probability_emits_future_warning(explicit_value):
-    # cuml-side half of #7982.
-    X, y = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            r"The `probability` parameter is deprecated and will be "
-            r"removed in cuML"
-        ),
-    ):
-        cu_svm.SVC(probability=explicit_value).fit(X, y)
-
-
-def test_svc_default_does_not_emit_probability_warning():
-    # If the user does not pass `probability=`, no FutureWarning should fire.
-    # The default sentinel string `"deprecated"` is treated as `probability=False`.
-    X, y = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message=(
-                r"The `probability` parameter is deprecated and will "
-                r"be removed in cuML"
-            ),
-            category=FutureWarning,
-        )
-        cu_svm.SVC().fit(X, y)
-
-
-@pytest.mark.parametrize("explicit_value", [True, False])
-def test_linear_svc_probability_emits_future_warning(explicit_value):
-    X, y = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            r"The `probability` parameter is deprecated and will be "
-            r"removed in cuML"
-        ),
-    ):
-        cu_svm.LinearSVC(probability=explicit_value).fit(X, y)
-
-
-def test_linear_svc_default_does_not_emit_probability_warning():
-    X, y = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message=(
-                r"The `probability` parameter is deprecated and will "
-                r"be removed in cuML"
-            ),
-            category=FutureWarning,
-        )
-        cu_svm.LinearSVC().fit(X, y)
-
-
-def test_svc_probability_warning_fires_once():
-    # Inner clones (CalibratedClassifierCV folds, multiclass binaries) pin
-    # the sentinel so the FutureWarning fires only on the outer fit, not
-    # per inner fit.
-    X_bin, y_bin = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        cu_svm.SVC(probability=True).fit(X_bin, y_bin)
-    matched = [
-        w
-        for w in caught
-        if issubclass(w.category, FutureWarning)
-        and "is deprecated and will be removed in cuML" in str(w.message)
-    ]
-    assert len(matched) == 1
-
-    X_mc, y_mc = make_classification(
-        n_samples=60,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=3,
-        random_state=0,
-    )
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        cu_svm.SVC(probability=False).fit(X_mc, y_mc)
-    matched = [
-        w
-        for w in caught
-        if issubclass(w.category, FutureWarning)
-        and "is deprecated and will be removed in cuML" in str(w.message)
-    ]
-    assert len(matched) == 1
 
 
 # Tests for kernel='precomputed'


### PR DESCRIPTION
This removes the deprecated `probability` argument to `SVC`.

Part of #8220.