### PR TITLE
Remove deprecated `probability` argument to `LinearSVC`

### DIFF
--- a/cpp/include/cuml/svm/linear.hpp
+++ b/cpp/include/cuml/svm/linear.hpp
@@ -86,8 +86,6 @@ struct Params {
  * @param [out] w: the fitted weights, shape=(nCoefs, nCols) or (nCoefs + 1, nCols + 1)
  * if `fit_intercept=true`, where nCoefs = 1 for regression or if nClasses = 2, and
  * nClasses otherwise. F-contiguous.
- * @param [out] probScale: the fitted probability scales, shape=(nClasses, 2),
- * F-contiguous. Pass nullptr to not fit probability scales.
  * @return n_iter: the maximum number of iterations run across all classes.
  */
 template <typename T>
@@ -100,28 +98,7 @@ int fit(const raft::handle_t& handle,
         const T* X,
         const T* y,
         const T* sampleWeight,
-        T* w,
-        T* probScale);
-
-/**
- * @brief Compute probabilities from decision function scores.
- *
- * @param [in] handle: the cuML handle.
- * @param [in] nRows: the number of input samples.
- * @param [in] nClasses: the number of input classes.
- * @param [in] probScale: the probability scales, shape=(nClasses, 2), F-contiguous.
- * @param [inout] scores: the decision function scores, shape=(nRows, nClasses),
- * C-contiguous. Note that this array will be mutated in-place during the calculation.
- * @param [out] out: the computed probabilities, shape=(nRows, nClasses), C-contiguous.
- */
-template <typename T>
-void computeProbabilities(const raft::handle_t& handle,
-                          const std::size_t nRows,
-                          const int nClasses,
-                          const T* probScale,
-                          T* scores,
-                          T* out);
-
+        T* w);
 }  // namespace linear
 }  // namespace SVM
 }  // namespace CUML_EXPORT ML

--- a/cpp/src/svm/linear.cu
+++ b/cpp/src/svm/linear.cu
@@ -180,7 +180,6 @@ int fit(const raft::handle_t& handle,
   T* w1 = w;
   rmm::device_uvector<T> y1Buf(0, stream);
   rmm::device_uvector<T> w1Buf(0, stream);
-  rmm::device_uvector<T> psBuf(0, stream);
   if (nClasses > 1) {
     y1Buf.resize(nRows * coefCols, stream);
     y1 = y1Buf.data();

--- a/cpp/src/svm/linear.cu
+++ b/cpp/src/svm/linear.cu
@@ -2,44 +2,27 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#include <common/nvtx.hpp>
-
 #include <cuml/common/export.hpp>
 #include <cuml/common/utils.hpp>
 #include <cuml/linear_model/glm.hpp>
 #include <cuml/svm/linear.hpp>
-#include <cuml/svm/svm_model.h>
-#include <cuml/svm/svm_parameter.h>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/nvtx.hpp>
-#include <raft/label/classlabels.cuh>
 #include <raft/linalg/gemm.cuh>
-#include <raft/linalg/gemv.cuh>
-#include <raft/linalg/map.cuh>
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/transpose.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 
 #include <rmm/device_uvector.hpp>
-#include <rmm/mr/per_device_resource.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/functional>
-#include <cuda/std/tuple>
-#include <thrust/copy.h>
 #include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
 #include <thrust/fill.h>
-#include <thrust/iterator/counting_iterator.h>
 
-#include <cublas_v2.h>
 #include <omp.h>
-
-#include <random>
-#include <type_traits>
 
 namespace ML {
 namespace SVM {
@@ -52,108 +35,6 @@ inline int narrowDown(std::size_t n)
          n);
   return int(n);
 }
-
-/**  The cuda kernel for classification. Call it via PredictProba::run(..). */
-template <typename T, bool Binary, int BX = 32, int BY = 8>
-CUML_KERNEL void predictProba(T* out, const T* z, const int nRows, const int nClasses)
-{
-  typedef cub::WarpReduce<T, BX> WarpRed;
-  __shared__ typename WarpRed::TempStorage shm[BY];
-  typename WarpRed::TempStorage& warpStore = shm[threadIdx.y];
-
-  const int i = threadIdx.y + blockIdx.y * BY;
-  if (i >= nRows) return;
-  const T* rowIn = z + i * (Binary ? 1 : nClasses);
-  T* rowOut      = out + i * nClasses;
-
-  // the largest 'z' in the row (to subtract it from z for numeric stability).
-  T t      = std::numeric_limits<T>::lowest();
-  T maxVal = t;
-  int j    = threadIdx.x;
-  if constexpr (Binary) {
-    t      = rowIn[0];
-    maxVal = raft::max<T>(t, T{0});
-    t      = T(j) * t;  // set z[0] = 0, z[1] = t
-  } else {
-    for (; j < nClasses; j += BX) {
-      t      = rowIn[j];
-      maxVal = raft::max<T>(maxVal, t);
-    }
-    j -= BX;
-    maxVal = WarpRed(warpStore).Reduce(maxVal, cuda::maximum{});
-    maxVal = cub::ShuffleIndex<BX>(maxVal, 0, 0xFFFFFFFFU);
-  }
-  // At this point, either `j` refers to the last valid column idx worked
-  // by the current thread, or `j` is negative.
-  // We traverse the columns array in the opposite direction in the next
-  // block. This allows us to avoid extra global memory accesses when
-  // BX >= nClasses, which is a very common case.
-
-  T et;         // Numerator of the softmax.
-  T smSum = 0;  // Denominator of the softmax.
-  while (j >= 0) {
-    et = raft::exp<T>(t - maxVal);
-    smSum += et;
-    if (j < BX) break;
-    j -= BX;
-    t = rowIn[j];
-  }
-  smSum = WarpRed(warpStore).Reduce(smSum, cuda::std::plus{});
-  smSum = cub::ShuffleIndex<BX>(smSum, 0, 0xFFFFFFFFU);
-
-  // Now, either `j` refers to the first valid column idx worked by the
-  // current thread, or `j` is negative (no work at all).
-  // Traverse in the forward direction again to save the results.
-  // Note, no extra memory reads when BX >= nClasses!
-  if (j < 0) return;
-  T d = 1 / smSum;
-  while (j < nClasses) {
-    rowOut[j] = et * d;
-    j += BX;
-    if (j >= nClasses) break;
-    t  = rowIn[j];
-    et = raft::exp<T>(t - maxVal);
-  }
-}
-
-/**
- * The wrapper struct on top of predictProba that recursively selects the best BX
- * (largest BX satisfying `BX < coefCols*2`) and then schedules the kernel launch.
- *
- * @tparam T - the data element type (e.g. float/double).
- * @tparam BlockSize - the total size of the cuda thread block (BX * BY).
- * @tparam BX - the size of the block along rows (nClasses dim).
- */
-template <typename T, int BlockSize = 256, int BX = 32>
-struct PredictProba {
-  static_assert(BX <= 32, "BX must be not larger than warpSize");
-  static_assert(BX <= BlockSize, "BX must be not larger than BlockSize");
-  /**
-   * Predict probabilities using the scores.
-   *
-   * @param [out] out - row-major matrix of probabilities (nRows, nClasses).
-   * @param [in] z   - row-major matrix of scores (nRows, Binary ? 1 : nClasses).
-   * @param [in] nRows - number of rows in the data.
-   * @param [in] nClasses - number of classes in the problem.
-   * @param [in] stream - the work stream.
-   */
-  static inline void run(
-    T* out, const T* z, const int nRows, const int nClasses, cudaStream_t stream)
-  {
-    if constexpr (BX > 2) {
-      if (nClasses <= (BX >> 1))
-        return PredictProba<T, BlockSize, std::max<int>(BX >> 1, 2)>::run(
-          out, z, nRows, nClasses, stream);
-    }
-    const int BY      = BlockSize / BX;
-    const bool Binary = BX == 2;
-    const dim3 bs(BX, BY, 1);
-    const dim3 gs(1, raft::ceildiv(nRows, BY), 1);
-    if constexpr (Binary)
-      ASSERT((void*)out != (void*)z, "PredictProba for the binary case cannot be inplace.");
-    predictProba<T, Binary, BX, BY><<<gs, bs, 0, stream>>>(out, z, nRows, nClasses);
-  }
-};
 
 /** The loss function is the main hint for whether we solve classification or regression. */
 inline bool isRegression(Params::Loss loss)
@@ -248,12 +129,10 @@ int fit(const raft::handle_t& handle,
         const T* X,
         const T* y,
         const T* sampleWeight,
-        T* w,
-        T* probScale)
+        T* w)
 {
   if (isRegression(params.loss)) {
     ASSERT(nClasses == 0 && classes == nullptr, "Regression fit takes no classes");
-    ASSERT(probScale == nullptr, "probability scaling not allowed for regressions");
   } else {
     ASSERT(nClasses > 1 && classes != nullptr, "Must have > 1 class for classification");
   }
@@ -297,15 +176,8 @@ int fit(const raft::handle_t& handle,
   qn_pams.lbfgs_memory        = params.lbfgs_memory;
   qn_pams.verbose             = static_cast<int>(params.verbose);
 
-  ML::GLM::qn_params qn_pams_logistic = qn_pams;
-  qn_pams_logistic.loss               = ML::GLM::QN_LOSS_LOGISTIC;
-  qn_pams_logistic.fit_intercept      = true;
-  qn_pams_logistic.penalty_l1         = 0;
-  qn_pams_logistic.penalty_l2 = 1 / T(1 + nRows);  // L2 regularization reflects the flat prior.
-
-  T* y1  = (T*)y;
-  T* w1  = w;
-  T* ps1 = probScale;
+  T* y1 = (T*)y;
+  T* w1 = w;
   rmm::device_uvector<T> y1Buf(0, stream);
   rmm::device_uvector<T> w1Buf(0, stream);
   rmm::device_uvector<T> psBuf(0, stream);
@@ -316,16 +188,8 @@ int fit(const raft::handle_t& handle,
   if (coefCols > 1) {
     w1Buf.resize(coefCols * coefRows, stream);
     w1 = w1Buf.data();
-    if (probScale != nullptr) {
-      psBuf.resize(2 * coefCols, stream);
-      ps1 = psBuf.data();
-    }
   }
   RAFT_CUDA_TRY(cudaMemsetAsync(w1, 0, coefCols * coefRows * sizeof(T), stream));
-  if (probScale != nullptr) {
-    thrust::device_ptr<cuda::std::tuple<T, T>> p((cuda::std::tuple<T, T>*)ps1);
-    thrust::fill(thrust::cuda::par.on(stream), p, p + coefCols, cuda::std::make_tuple(T(1), T(0)));
-  }
 
   // one-vs-rest logic goes over each class
   const int n_streams = coefCols > 1 ? handle.get_stream_pool_size() : 1;
@@ -358,65 +222,12 @@ int fit(const raft::handle_t& handle,
                   (T*)sampleWeight,
                   T(params.epsilon));
     if (n_iter > max_n_iter) { max_n_iter = n_iter; }
-
-    if (probScale == nullptr) continue;
-    // Calibrate probabilities
-    T* psi = ps1 + 2 * class_i;
-    rmm::device_uvector<T> xwBuf(nRows, worker.stream);
-    T* xw = xwBuf.data();
-    predictLinear(worker.handle, X, wi, nRows, nCols, 1, params.fit_intercept, xw, worker.stream);
-
-    GLM::qnFit<T>(worker.handle,
-                  qn_pams_logistic,
-                  xw,
-                  false,
-                  yi,
-                  narrowDown(nRows),
-                  1,
-                  2,
-                  psi,
-                  &target,
-                  &n_iter,
-                  (T*)sampleWeight);
-
-    if (n_iter > max_n_iter) { max_n_iter = n_iter; }
   }
   if (parallel) handle.sync_stream_pool();
 
-  if (coefCols > 1) {
-    raft::linalg::transpose(handle, w1, w, coefRows, coefCols, stream);
-    if (probScale != nullptr) {
-      raft::linalg::transpose(handle, ps1, probScale, 2, coefCols, stream);
-    }
-  }
+  if (coefCols > 1) { raft::linalg::transpose(handle, w1, w, coefRows, coefCols, stream); }
 
   return max_n_iter;
-}
-
-template <typename T>
-void computeProbabilities(const raft::handle_t& handle,
-                          const std::size_t nRows,
-                          const int nClasses,
-                          const T* probScale,
-                          T* scores,
-                          T* out)
-{
-  auto stream                = handle.get_stream();
-  const std::size_t coefCols = nClasses == 2 ? 1 : nClasses;
-
-  // probability calibration
-  raft::linalg::matrixVectorOp<true, true>(
-    scores,
-    scores,
-    probScale,
-    probScale + coefCols,
-    coefCols,
-    nRows,
-    [] __device__(const T x, const T a, const T b) { return a * x + b; },
-    stream);
-
-  // apply sigmoid/softmax
-  PredictProba<T>::run(out, scores, nRows, nClasses, stream);
 }
 
 // Explicit instantiations for library
@@ -429,8 +240,7 @@ template CUML_EXPORT int fit<float>(const raft::handle_t& handle,
                                     const float* X,
                                     const float* y,
                                     const float* sampleWeight,
-                                    float* w,
-                                    float* probScale);
+                                    float* w);
 template CUML_EXPORT int fit<double>(const raft::handle_t& handle,
                                      const Params& params,
                                      const std::size_t nRows,
@@ -440,21 +250,7 @@ template CUML_EXPORT int fit<double>(const raft::handle_t& handle,
                                      const double* X,
                                      const double* y,
                                      const double* sampleWeight,
-                                     double* w,
-                                     double* probScale);
-template CUML_EXPORT void computeProbabilities<float>(const raft::handle_t& handle,
-                                                      const std::size_t nRows,
-                                                      const int nClasses,
-                                                      const float* probScale,
-                                                      float* scores,
-                                                      float* out);
-template CUML_EXPORT void computeProbabilities<double>(const raft::handle_t& handle,
-                                                       const std::size_t nRows,
-                                                       const int nClasses,
-                                                       const double* probScale,
-                                                       double* scores,
-                                                       double* out);
-
+                                     double* w);
 }  // namespace linear
 }  // namespace SVM
 }  // namespace ML

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -53,7 +53,6 @@ cdef extern from "cuml/svm/linear.hpp" namespace "ML::SVM::linear" nogil:
         const T* y,
         const T* sampleWeight,
         T* w,
-        T* probScale,
     ) except +
 
 
@@ -212,7 +211,6 @@ def fit(
     cdef uintptr_t classes_ptr = 0 if class_codes is None else class_codes.data.ptr
     cdef uintptr_t w_ptr = w.data.ptr
     # TODO
-    cdef uintptr_t prob_scale_ptr = 0
     cdef int n_iter
 
     # Perform fit
@@ -229,7 +227,6 @@ def fit(
                 <const float*>y_ptr,
                 <const float*>sample_weight_ptr,
                 <float*>w_ptr,
-                <float*>prob_scale_ptr,
             )
         else:
             n_iter = cpp_fit[double](
@@ -243,7 +240,6 @@ def fit(
                 <const double*>y_ptr,
                 <const double*>sample_weight_ptr,
                 <double*>w_ptr,
-                <double*>prob_scale_ptr,
             )
     handle.sync()
 

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -210,7 +210,6 @@ def fit(
     cdef uintptr_t sample_weight_ptr = 0 if sample_weight is None else sample_weight.data.ptr
     cdef uintptr_t classes_ptr = 0 if class_codes is None else class_codes.data.ptr
     cdef uintptr_t w_ptr = w.data.ptr
-    # TODO
     cdef int n_iter
 
     # Perform fit

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -13,7 +13,7 @@ from pylibraft.common.handle cimport handle_t
 
 from cuml.internals.logger cimport level_enum
 
-__all__ = ("fit", "compute_probabilities")
+__all__ = ("fit",)
 
 
 cdef extern from "cuml/svm/linear.hpp" namespace "ML::SVM::linear" nogil:
@@ -56,14 +56,6 @@ cdef extern from "cuml/svm/linear.hpp" namespace "ML::SVM::linear" nogil:
         T* probScale,
     ) except +
 
-    cdef void computeProbabilities[T](
-        const handle_t& handle,
-        const size_t nRows,
-        const int nClasses,
-        const T* probScale,
-        T* scores,
-        T* out) except +
-
 
 def fit(
     estimator,
@@ -73,7 +65,6 @@ def fit(
     *,
     convert_dtype=True,
     is_classifier=False,
-    probability=False,
     class_weight=None,
     n_streams=0,
     penalty,
@@ -102,9 +93,6 @@ def fit(
         The sample weights
     is_classifier : bool, default=False
         Whether this is a classifier model. Defaults to False.
-    probability : bool, default=False
-        When fitting a classifier, whether to also fit probability scales to enable
-        `predict_proba`.
     class_weight : dict or 'balanced', default=None
         When fitting a classifier, weights associated per-classes, or None for
         uniform weights. If 'balanced', weights inversely proportional to the
@@ -128,8 +116,6 @@ def fit(
         classification.
     n_iter_ : int
         The maximum number of iterations run across all classes.
-    prob_scale_ : None or cp.ndarray, shape = (n_classes, 2)
-        The probability scales (if `probability=True`), `None` otherwise.
     classes_ : numpy.ndarray, shape=(n_classes,)
         The classes (if ``is_classifier=True``), `None` otherwise.
     """
@@ -216,10 +202,6 @@ def fit(
 
     # Allocate output arrays
     w = cp.empty(shape=w_shape, dtype=X.dtype, order="F")
-    if probability and is_classifier:
-        prob_scale = cp.empty((n_classes, 2), dtype=X.dtype, order="F")
-    else:
-        prob_scale = None
 
     handle = get_handle(n_streams=n_streams)
     cdef handle_t *handle_ = <handle_t*><size_t>handle.getHandle()
@@ -229,7 +211,8 @@ def fit(
     cdef uintptr_t sample_weight_ptr = 0 if sample_weight is None else sample_weight.data.ptr
     cdef uintptr_t classes_ptr = 0 if class_codes is None else class_codes.data.ptr
     cdef uintptr_t w_ptr = w.data.ptr
-    cdef uintptr_t prob_scale_ptr = 0 if prob_scale is None else prob_scale.data.ptr
+    # TODO
+    cdef uintptr_t prob_scale_ptr = 0
     cdef int n_iter
 
     # Perform fit
@@ -276,63 +259,4 @@ def fit(
         coef = w
         intercept = 0.0
 
-    return coef, intercept, n_iter, prob_scale, classes
-
-
-def compute_probabilities(scores, prob_scale, n_streams):
-    """Compute probabilities from decision function scores.
-
-    Parameters
-    ----------
-    scores : cp.ndarray, shape = (n_samples, n_classes)
-        The decision function scores.
-    prob_scale : cp.ndarray, shape = (n_classes, 2)
-        The probability scaling factors.
-    n_streams : int
-        The number of streams to use.
-
-    Returns
-    -------
-    probabilities : cp.ndarray, shape = (n_samples, n_classes)
-        The computed probabilities.
-    """
-    # Ensure proper ordering
-    prob_scale = cp.asarray(prob_scale, order="F")
-    scores = cp.asarray(scores, order="C", dtype=prob_scale.dtype)
-
-    # Extract dimensions
-    cdef size_t n_rows = scores.shape[0]
-    cdef int n_classes = prob_scale.shape[0]
-
-    # Allocate outputs
-    out = cp.empty((n_rows, n_classes), dtype=scores.dtype, order="C")
-
-    handle = get_handle(n_streams=n_streams)
-    cdef handle_t *handle_ = <handle_t*><size_t>handle.getHandle()
-    cdef bool is_float32 = scores.dtype == cp.float32
-    cdef uintptr_t scores_ptr = scores.data.ptr
-    cdef uintptr_t prob_scale_ptr = prob_scale.data.ptr
-    cdef uintptr_t out_ptr = out.data.ptr
-
-    # Compute probabilities
-    with nogil:
-        if is_float32:
-            computeProbabilities[float](
-                handle_[0],
-                n_rows,
-                n_classes,
-                <const float*>prob_scale_ptr,
-                <float*>scores_ptr,
-                <float*>out_ptr
-            )
-        else:
-            computeProbabilities[double](
-                handle_[0],
-                n_rows,
-                n_classes,
-                <const double*>prob_scale_ptr,
-                <double*>scores_ptr,
-                <double*>out_ptr
-            )
-    handle.sync()
-    return out
+    return coef, intercept, n_iter, classes

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -1,11 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-import warnings
-
 import cupy as cp
-from sklearn.exceptions import NotFittedError
-from sklearn.utils.metaestimators import available_if
 
 import cuml.svm.linear
 from cuml.common.array_descriptor import CumlArrayDescriptor
@@ -21,7 +17,6 @@ from cuml.internals.interop import (
 )
 from cuml.internals.mixins import ClassifierMixin
 from cuml.internals.outputs import reflect, run_in_internal_context
-from cuml.internals.validation import check_is_fitted
 from cuml.linear_model.base import LinearClassifierMixin
 
 __all__ = ("LinearSVC",)
@@ -55,14 +50,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         Weights to modify the parameter C for class i to ``class_weight[i]*C``.
         The string 'balanced' is also accepted, in which case
         ``class_weight[i] = n_samples / (n_classes * n_samples_of_class[i])``
-    probability: bool, default=False
-        .. deprecated:: 26.06
-            ``probability`` is deprecated and will be removed in version
-            26.08. Use ``CalibratedClassifierCV(LinearSVC(), ensemble=False)``
-            from ``sklearn.calibration`` for probability estimates instead.
-
-        Set to True to enable probability estimate methods (``predict_proba``,
-        ``predict_log_proba``).
     tol : float, default=1e-4
         Tolerance for the stopping criterion.
     max_iter : int, default=1000
@@ -98,9 +85,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         A sorted array of the class labels.
     n_iter_ : int
         The maximum number of iterations run across all classes during the fit.
-    prob_scale_ : array or None, shape (`n_classes_`, 2)
-        The probability calibration constants if ``probability=True``,
-        otherwise ``None``.
 
     Notes
     -----
@@ -128,7 +112,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
 
     coef_ = CumlArrayDescriptor(order="F")
     intercept_ = CumlArrayDescriptor(order="F")
-    prob_scale_ = CumlArrayDescriptor(order="F")
 
     _cpu_class_path = "sklearn.svm.LinearSVC"
 
@@ -142,7 +125,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             "fit_intercept",
             "penalized_intercept",
             "class_weight",
-            "probability",
             "tol",
             "max_iter",
             "linesearch_max_iter",
@@ -162,7 +144,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
                 f"`multi_class={model.multi_class}` is not supported"
             )
 
-        # probability omitted: sklearn.LinearSVC has no such param.
         return {
             "penalty": model.penalty,
             "loss": model.loss,
@@ -193,7 +174,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
                 model.intercept_, order="F", dtype=cp.float64
             ),
             "classes_": model.classes_,
-            "prob_scale_": None,
             "n_iter_": model.n_iter_,
             **super()._attrs_from_cpu(model),
         }
@@ -216,7 +196,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         fit_intercept=True,
         penalized_intercept=False,
         class_weight=None,
-        probability="deprecated",
         tol=1e-4,
         max_iter=1000,
         linesearch_max_iter=100,
@@ -234,7 +213,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         self.fit_intercept = fit_intercept
         self.penalized_intercept = penalized_intercept
         self.class_weight = class_weight
-        self.probability = probability
         self.tol = tol
         self.max_iter = max_iter
         self.linesearch_max_iter = linesearch_max_iter
@@ -242,28 +220,13 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         self.n_streams = n_streams
         self.multi_class = multi_class
 
-    @property
-    def _effective_probability(self):
-        return False if self.probability == "deprecated" else self.probability
-
     @generate_docstring()
     @reflect(reset="type")
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "LinearSVC":
         """Fit the model according to the given training data."""
-        if self.probability != "deprecated":
-            warnings.warn(
-                "The `probability` parameter is deprecated and will be "
-                # rapids-pre-commit-hooks: disable-next-line
-                "removed in cuML version 26.08. Use "
-                "`CalibratedClassifierCV(LinearSVC(), ensemble=False)` from "
-                "`sklearn.calibration` instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-
-        coef, intercept, n_iter, prob_scale, classes = cuml.svm.linear.fit(
+        coef, intercept, n_iter, classes = cuml.svm.linear.fit(
             self,
             X,
             y,
@@ -271,7 +234,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             convert_dtype=convert_dtype,
             is_classifier=True,
             n_streams=self.n_streams,
-            probability=self._effective_probability,
             class_weight=self.class_weight,
             loss=self.loss,
             penalty=self.penalty,
@@ -290,9 +252,6 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
             intercept if cp.isscalar(intercept) else CumlArray(data=intercept)
         )
         self.n_iter_ = n_iter
-        self.prob_scale_ = (
-            None if prob_scale is None else CumlArray(data=prob_scale)
-        )
         self.classes_ = classes
         return self
 
@@ -307,10 +266,7 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
     @run_in_internal_context
     def predict(self, X, *, convert_dtype=True):
         """Predict class labels for samples in X."""
-        if self._effective_probability:
-            scores = self.predict_proba(X, convert_dtype=convert_dtype)
-        else:
-            scores = self.decision_function(X, convert_dtype=convert_dtype)
+        scores = self.decision_function(X, convert_dtype=convert_dtype)
         index = scores.index
         scores = scores.to_output("cupy")
         if scores.ndim == 1:
@@ -323,53 +279,3 @@ class LinearSVC(Base, InteropMixin, LinearClassifierMixin, ClassifierMixin):
         return decode_labels(
             inds, self.classes_, output_type=output_type, index=index
         )
-
-    @available_if(lambda self: self._effective_probability)
-    @generate_docstring(
-        return_values={
-            "name": "probs",
-            "type": "dense",
-            "description": "Probabilities per class for each sample.",
-            "shape": "(n_samples, n_classes)",
-        },
-    )
-    @reflect
-    def predict_proba(self, X, *, convert_dtype=True) -> CumlArray:
-        """Compute probabilities of possible outcomes for samples in X.
-
-        The model must have been fit with ``probability=True`` for this method
-        to be available.
-        """
-        check_is_fitted(self)
-        if self.prob_scale_ is None:
-            raise NotFittedError(
-                "predict_proba is not available when fitted with probability=False"
-            )
-        scores = self.decision_function(X, convert_dtype=convert_dtype)
-        return cuml.svm.linear.compute_probabilities(
-            scores,
-            self.prob_scale_.to_output("cupy"),
-            n_streams=self.n_streams,
-        )
-
-    @available_if(lambda self: self._effective_probability)
-    @generate_docstring(
-        return_values={
-            "name": "probs",
-            "type": "dense",
-            "description": "Log probabilities per class for each sample.",
-            "shape": "(n_samples, n_classes)",
-        },
-    )
-    @reflect
-    def predict_log_proba(self, X, *, convert_dtype=True) -> CumlArray:
-        """Compute log probabilities of possible outcomes for samples in X.
-
-        The model must have been fit with ``probability=True`` for this method
-        to be available.
-        """
-        probs = self.predict_proba(X, convert_dtype=convert_dtype).to_output(
-            "cupy"
-        )
-        cp.log(probs, out=probs)
-        return CumlArray(data=probs)

--- a/python/cuml/cuml/svm/linear_svr.py
+++ b/python/cuml/cuml/svm/linear_svr.py
@@ -205,7 +205,7 @@ class LinearSVR(Base, InteropMixin, LinearPredictMixin, RegressorMixin):
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "LinearSVR":
         """Fit the model according to the given training data."""
-        coef, intercept, n_iter, _, _ = cuml.svm.linear.fit(
+        coef, intercept, n_iter, _ = cuml.svm.linear.fit(
             self,
             X,
             y,

--- a/python/cuml/cuml_accel_tests/upstream/pytest.ini
+++ b/python/cuml/cuml_accel_tests/upstream/pytest.ini
@@ -14,11 +14,6 @@ filterwarnings =
     error::cuml.accel.pytest_plugin.UnmatchedXfailTests
     # Error for FutureWarnings raised by cuml
     error::FutureWarning:cuml
-    # Suppress cuml's deprecation warning for sklearn upstream tests that
-    # legitimately use `probability=True`. Must come after the generic error
-    # rapids-pre-commit-hooks: disable-next-line
-    # rule (later filterwarnings entries take precedence). TODO(26.08): drop.
-    ignore:The `probability` parameter is deprecated:FutureWarning
     # sklearn 1.6 tag API transition; remove once cuML avoids the legacy tag provider path
     ignore:The `_get_tags` method is deprecated in 1.6 and will be removed in 1.7.*:FutureWarning
     ignore:The `_get_tags` method is deprecated in 1.6 and will be removed in 1.7.*:DeprecationWarning

--- a/python/cuml/tests/explainer/test_gpu_treeshap.py
+++ b/python/cuml/tests/explainer/test_gpu_treeshap.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import json
-import warnings
 
 import cudf
 import cupy as cp
@@ -929,15 +928,6 @@ def check_efficiency_interactions(expected_value, pred, shap_values):
             )
 
 
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Can inline this back within the `example` call
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore")
-    example_random_forest = curfr(
-        max_features=1.0, random_state=0, n_streams=1, n_bins=10
-    ).fit(np.ones((10, 5), dtype=np.float32), np.ones(10, dtype=np.float32))
-
-
 # Generating input data/models can be time consuming and triggers
 # hypothesis HealthCheck
 @settings(
@@ -949,7 +939,9 @@ with warnings.catch_warnings():
     params=(
         pd.DataFrame(np.ones((10, 5), dtype=np.float32)),
         np.ones(10, dtype=np.float32),
-        example_random_forest,
+        curfr(max_features=1.0, random_state=0, n_streams=1, n_bins=10).fit(
+            np.ones((10, 5), dtype=np.float32), np.ones(10, dtype=np.float32)
+        ),
         np.ones(10, dtype=np.float32),
     ),
     interactions_method="shapley-interactions",

--- a/python/cuml/tests/test_base.py
+++ b/python/cuml/tests/test_base.py
@@ -229,12 +229,7 @@ def test_common_signatures(cls, method):
             first = ["self", "X", "y"]
         if "sample_weight" in sig.parameters:
             first.append("sample_weight")
-            # rapids-pre-commit-hooks: disable-next-line
-            # TODO(26.08): remove "deprecated"
-            assert sig.parameters["sample_weight"].default in (
-                None,
-                "deprecated",
-            )
+            assert sig.parameters["sample_weight"].default is None
         if "copy" in sig.parameters:
             first.append("copy")
             assert (

--- a/python/cuml/tests/test_linear_svm.py
+++ b/python/cuml/tests/test_linear_svm.py
@@ -2,13 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import math
-import warnings
 
 import numpy as np
 import pytest
 import sklearn.svm
 from sklearn.datasets import make_classification, make_regression
-from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
 
 import cuml
@@ -213,62 +211,6 @@ def test_linear_svc_decision_function(
     np.testing.assert_allclose(res, sol, atol=1e-4)
 
 
-@pytest.mark.parametrize("fit_intercept", [True, False])
-@pytest.mark.parametrize("n_classes", [2, 3, 5])
-# rapids-pre-commit-hooks: disable-next-line
-# TODO(26.08): Remove once `probability` is removed from cuml.svm.LinearSVC.
-@pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
-)
-def test_linear_svc_predict_proba(fit_intercept, n_classes):
-    n_rows, n_cols = 500, 20
-    X_train, X_test, y_train, y_test = make_classification_dataset(
-        n_rows, n_cols, n_classes
-    )
-
-    cu_model = cuml.LinearSVC(fit_intercept=fit_intercept, probability=True)
-    cu_model.fit(X_train, y_train)
-    cu_score = cu_model.score(X_test, y_test)
-
-    sk_model = sklearn.svm.LinearSVC(fit_intercept=fit_intercept)
-    sk_model.fit(X_train, y_train)
-    sk_score = sk_model.score(X_test, y_test)
-
-    assert cu_score >= sk_score - 0.05
-
-    proba = cu_model.predict_proba(X_test)
-    log_proba = cu_model.predict_log_proba(X_test)
-
-    # log_proba is log(proba)
-    np.testing.assert_allclose(np.log(proba), log_proba, rtol=1e-4)
-
-    # Probabilities sum to 1
-    np.testing.assert_allclose(
-        proba.sum(axis=1), np.ones(len(proba)), rtol=1e-4
-    )
-
-    # Predictions are argmax(proba)
-    y_pred = cu_model.predict(X_test)
-    y_pred_proba = cu_model.classes_.take(proba.argmax(axis=1).astype("int32"))
-    np.testing.assert_array_equal(y_pred, y_pred_proba)
-
-
-def test_linear_svc_predict_proba_not_available():
-    X, y = make_classification()
-    model = cuml.LinearSVC().fit(X, y)
-
-    assert not hasattr(model, "predict_proba")
-    assert not hasattr(model, "predict_log_proba")
-
-    # Setting `probability=True` makes the attribute available, but
-    # calling it raises a NotFittedError until refit
-    model.probability = True
-    assert hasattr(model, "predict_proba")
-
-    with pytest.raises(NotFittedError, match="fitted with probability=False"):
-        model.predict_proba(X)
-
-
 @pytest.mark.parametrize("kind", ["numpy", "pandas", "cupy", "cudf"])
 @pytest.mark.parametrize("weighted", [False, True])
 def test_linear_svc_input_types(kind, weighted):
@@ -309,44 +251,3 @@ def test_linear_svc_n_iter_max_iter(penalty, n_streams):
         penalty=penalty, n_streams=n_streams, max_iter=10
     ).fit(X, y)
     assert model.n_iter_ == 10
-
-
-@pytest.mark.parametrize("explicit_value", [True, False])
-def test_linear_svc_probability_emits_future_warning(explicit_value):
-    X, y = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            r"The `probability` parameter is deprecated and will be "
-            r"removed in cuML"
-        ),
-    ):
-        cuml.LinearSVC(probability=explicit_value).fit(X, y)
-
-
-def test_linear_svc_default_does_not_emit_probability_warning():
-    X, y = make_classification(
-        n_samples=40,
-        n_features=4,
-        n_informative=3,
-        n_redundant=0,
-        n_classes=2,
-        random_state=0,
-    )
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message=(
-                r"The `probability` parameter is deprecated and will "
-                r"be removed in cuML"
-            ),
-            category=FutureWarning,
-        )
-        cuml.LinearSVC().fit(X, y)

--- a/python/cuml/tests/test_pickle.py
+++ b/python/cuml/tests/test_pickle.py
@@ -754,19 +754,13 @@ def test_svc_pickle(tmpdir, datatype, multiclass, sparse):
     pickle_save_load(tmpdir, create_mod, assert_model)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The `probability` parameter is deprecated:FutureWarning"
-)
 @pytest.mark.parametrize("datatype", [np.float32, np.float64])
-@pytest.mark.parametrize(
-    "params", [{"probability": True}, {"probability": False}]
-)
 @pytest.mark.parametrize("multiclass", [True, False])
-def test_linear_svc_pickle(tmpdir, datatype, params, multiclass):
+def test_linear_svc_pickle(tmpdir, datatype, multiclass):
     result = {}
 
     def create_mod():
-        model = cuml.svm.LinearSVC(**params)
+        model = cuml.svm.LinearSVC()
         iris = load_iris()
         iris_selection = np.random.RandomState(42).choice(
             [True, False], 150, replace=True, p=[0.75, 0.25]
@@ -780,12 +774,8 @@ def test_linear_svc_pickle(tmpdir, datatype, params, multiclass):
         return model, data
 
     def assert_model(pickled_model, data):
-        if result["model"].probability:
-            pred_before = result["model"].predict_proba(data[0])
-            pred_after = pickled_model.predict_proba(data[0])
-        else:
-            pred_before = result["model"].predict(data[0])
-            pred_after = pickled_model.predict(data[0])
+        pred_before = result["model"].predict(data[0])
+        pred_after = pickled_model.predict(data[0])
         assert array_equal(pred_before, pred_after)
 
     pickle_save_load(tmpdir, create_mod, assert_model)


### PR DESCRIPTION
This removes the deprecated `probability` argument to `LinearSVC`, along with all supporting code (python and C++).

Currently stacked on #8223.

Last part of #8220. Fixes #8220.