### PR TITLE
Isolation Forest Implementation 

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -460,7 +460,10 @@ if(BUILD_CUML_CPP_LIBRARY)
     target_sources(cuml_objs PRIVATE src/randomforest/randomforest.cu)
   endif()
 
-  if(all_algo OR isolationforest_algo OR randomforest_algo)
+  if(all_algo
+     OR isolationforest_algo
+     OR randomforest_algo
+  )
     target_sources(cuml_objs PRIVATE src/isolation_forest/isolation_forest.cu)
   endif()
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -460,6 +460,10 @@ if(BUILD_CUML_CPP_LIBRARY)
     target_sources(cuml_objs PRIVATE src/randomforest/randomforest.cu)
   endif()
 
+  if(all_algo OR isolationforest_algo OR randomforest_algo)
+    target_sources(cuml_objs PRIVATE src/isolation_forest/isolation_forest.cu)
+  endif()
+
   # todo: separate solvers better
   if(all_algo OR solvers_algo)
     target_sources(cuml_objs PRIVATE src/solver/lars.cu src/solver/solver.cu)

--- a/cpp/cmake/modules/ConfigureAlgorithms.cmake
+++ b/cpp/cmake/modules/ConfigureAlgorithms.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cpp/cmake/modules/ConfigureAlgorithms.cmake
+++ b/cpp/cmake/modules/ConfigureAlgorithms.cmake
@@ -44,6 +44,7 @@ else()
 
   if(ensemble_algo)
     set(randomforest_algo ON)
+    set(isolationforest_algo ON)
   endif()
 
   # todo: organize linear model headers better
@@ -104,6 +105,11 @@ else()
     set(decisiontree_algo ON)
     set(LINK_TREELITE ON)
     set(LINK_NVFOREST ON)
+  endif()
+
+  if(isolationforest_algo)
+    set(decisiontree_algo ON)
+    set(LINK_TREELITE ON)
   endif()
 
   if(hierarchicalclustering_algo OR kmeans_algo)

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -37,7 +37,11 @@ struct IsolationForestModel {
   int n_features = 0;          ///< Number of features in training data
   int n_samples_per_tree = 0;  ///< Samples used per tree (for c(n) calculation)
   T c_normalization = 0;       ///< Precomputed c(n) normalization constant
-  rmm::device_buffer fast_trees;  ///< Device memory for trees (IFTree<T>*)
+  int max_nodes_per_tree = 0;  ///< Allocated node capacity per tree
+  rmm::device_buffer global_nodes;  ///< Device memory for global-memory IFNode array
+  rmm::device_buffer global_tree_offsets;  ///< Per-tree base offset in global_nodes
+  rmm::device_buffer global_tree_n_nodes;  ///< Per-tree used node counts
+  rmm::device_buffer global_tree_max_depth;  ///< Per-tree max depth metadata
 };
 
 typedef IsolationForestModel<float> IsolationForestF;

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -5,16 +5,20 @@
 
 #pragma once
 
+#include <cuml/common/export.hpp>
 #include <cuml/common/logger.hpp>
+#include <cuml/ensemble/treelite_defs.hpp>
 #include <rmm/device_buffer.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace raft {
 class handle_t;
 }
 
-namespace ML {
+namespace CUML_EXPORT ML {
 
 /**
  * @brief Isolation Forest hyperparameters
@@ -76,6 +80,23 @@ CompactIFForest get_compact_trees(const raft::handle_t& handle,
 /** @brief Compute c(n) = 2H(n-1) - 2(n-1)/n normalization constant. */
 template <typename T>
 T compute_c_normalization(int n);
+
+/**
+ * @brief Build a Treelite regression forest from a trained Isolation Forest model.
+ *
+ * The exported Treelite model predicts average path length across trees. The
+ * Isolation Forest anomaly score transform, s(x) = 2^(-E[h(x)] / c(n)), is
+ * intentionally applied by callers so exported tree structure stays faithful
+ * to the trained isolation trees.
+ *
+ * @param[out] model_handle Treelite model handle owned by the caller
+ * @param[in]  handle       RAFT handle for GPU resources
+ * @param[in]  forest       Trained Isolation Forest model
+ */
+template <typename T>
+void build_treelite_isolation_forest(TreeliteModelHandle* model_handle,
+                                     const raft::handle_t& handle,
+                                     const IsolationForestModel<T>* forest);
 
 /**
  * @brief Fit an Isolation Forest model.

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -27,6 +27,7 @@ struct IF_params {
   int n_estimators = 100;   ///< Number of isolation trees
   int max_samples = 256;    ///< Samples per tree (default 256)
   int max_depth = -1;       ///< Max depth (-1 = auto: ceil(log2(max_samples)))
+  int max_features = -1;    ///< Features sampled per tree (-1 = all features)
   bool bootstrap = false;   ///< If true, sample rows with replacement
   uint64_t seed = 0;        ///< Random seed
 };
@@ -36,9 +37,11 @@ template <class T>
 struct IsolationForestModel {
   IF_params params;            ///< Hyperparameters used for training
   int n_features = 0;          ///< Number of features in training data
+  int n_features_per_tree = 0; ///< Features sampled per tree
   int n_samples_per_tree = 0;  ///< Samples used per tree (for c(n) calculation)
   T c_normalization = 0;       ///< Precomputed c(n) normalization constant
   int max_nodes_per_tree = 0;  ///< Allocated node capacity per tree
+  rmm::device_buffer global_feature_indices;  ///< Optional per-tree sampled feature ids
   rmm::device_buffer global_nodes;  ///< Device memory for global-memory IFNode array
   rmm::device_buffer global_tree_offsets;  ///< Per-tree base offset in global_nodes
   rmm::device_buffer global_tree_n_nodes;  ///< Per-tree used node counts

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -8,6 +8,8 @@
 #include <cuml/common/logger.hpp>
 #include <rmm/device_buffer.hpp>
 
+#include <vector>
+
 namespace raft {
 class handle_t;
 }
@@ -36,6 +38,40 @@ struct IsolationForestModel {
 
 typedef IsolationForestModel<float> IsolationForestF;
 typedef IsolationForestModel<double> IsolationForestD;
+
+/**
+ * @brief Compact node representation (matches internal IFNode layout).
+ *
+ * Internal nodes: feature_idx >= 0, threshold is split value
+ * Leaf nodes: feature_idx = -1, threshold stores pre-computed path length
+ */
+struct IFNodeCompact {
+  int feature_idx;
+  float threshold;
+  int left_child;
+  int right_child;
+};
+
+/**
+ * @brief Compact tree data returned by get_compact_trees().
+ * Contains all used nodes concatenated, with per-tree metadata.
+ */
+struct CompactIFForest {
+  std::vector<IFNodeCompact> nodes;   ///< All used nodes, trees concatenated
+  std::vector<int> tree_offsets;      ///< Start index in nodes[] for each tree
+  std::vector<int> tree_n_nodes;      ///< Number of nodes per tree
+  std::vector<int> tree_max_depth;    ///< Max depth per tree
+};
+
+/**
+ * @brief Extract compact tree data from a trained model for export.
+ *
+ * Efficiently copies only the used nodes (~400 KB for 100 trees)
+ * instead of the full padded storage (~200 MB).
+ */
+template <typename T>
+CompactIFForest get_compact_trees(const raft::handle_t& handle,
+                                  const IsolationForestModel<T>* model);
 
 /** @brief Compute c(n) = 2H(n-1) - 2(n-1)/n normalization constant. */
 template <typename T>

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -47,7 +47,7 @@ T compute_c_normalization(int n);
  * @param[in]  handle    RAFT handle for GPU resources
  * @param[out] forest    Model to populate with trained trees
  * @param[in]  input     Training data, column-major [n_rows × n_cols], device pointer
- * @param[in]  n_rows    Number of training samples (supports >2B rows via size_t)
+ * @param[in]  n_rows    Number of training samples 
  * @param[in]  n_cols    Number of features
  * @param[in]  params    Hyperparameters (n_estimators, max_samples, max_depth, seed)
  * @param[in]  verbosity Logging level
@@ -79,7 +79,7 @@ void fit(const raft::handle_t& handle,
  * @param[in]  handle    RAFT handle for GPU resources
  * @param[in]  forest    Trained Isolation Forest model
  * @param[in]  input     Test data, row-major [n_rows × n_cols], device pointer
- * @param[in]  n_rows    Number of test samples (supports >2B rows via size_t)
+ * @param[in]  n_rows    Number of test samples 
  * @param[in]  n_cols    Number of features (must match training)
  * @param[out] scores    Anomaly scores [n_rows], device pointer
  * @param[in]  verbosity Logging level

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cuml/common/logger.hpp>
+#include <rmm/device_buffer.hpp>
+
+namespace raft {
+class handle_t;
+}
+
+namespace ML {
+
+/**
+ * @brief Isolation Forest hyperparameters
+ */
+struct IF_params {
+  int n_estimators = 100;   ///< Number of isolation trees
+  int max_samples = 256;    ///< Samples per tree (default 256)
+  int max_depth = -1;       ///< Max depth (-1 = auto: ceil(log2(max_samples)))
+  uint64_t seed = 0;        ///< Random seed
+};
+
+/** @brief Trained Isolation Forest model */
+template <class T>
+struct IsolationForestModel {
+  IF_params params;            ///< Hyperparameters used for training
+  int n_features = 0;          ///< Number of features in training data
+  int n_samples_per_tree = 0;  ///< Samples used per tree (for c(n) calculation)
+  T c_normalization = 0;       ///< Precomputed c(n) normalization constant
+  rmm::device_buffer fast_trees;  ///< Device memory for trees (IFTree<T>*)
+};
+
+typedef IsolationForestModel<float> IsolationForestF;
+typedef IsolationForestModel<double> IsolationForestD;
+
+/** @brief Compute c(n) = 2H(n-1) - 2(n-1)/n normalization constant. */
+template <typename T>
+T compute_c_normalization(int n);
+
+/**
+ * @brief Fit an Isolation Forest model.
+ *
+ * @param[in]  handle    RAFT handle for GPU resources
+ * @param[out] forest    Model to populate with trained trees
+ * @param[in]  input     Training data, column-major [n_rows × n_cols], device pointer
+ * @param[in]  n_rows    Number of training samples (supports >2B rows via size_t)
+ * @param[in]  n_cols    Number of features
+ * @param[in]  params    Hyperparameters (n_estimators, max_samples, max_depth, seed)
+ * @param[in]  verbosity Logging level
+ */
+void fit(const raft::handle_t& handle,
+         IsolationForestF* forest,
+         const float* input,
+         size_t n_rows,
+         int n_cols,
+         const IF_params& params,
+         rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
+
+void fit(const raft::handle_t& handle,
+         IsolationForestD* forest,
+         const double* input,
+         size_t n_rows,
+         int n_cols,
+         const IF_params& params,
+         rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
+
+/**
+ * @brief Compute anomaly scores.
+ *
+ * Returns scores following the original paper convention (Liu et al. 2008):
+ * - Score ≈ 1.0: anomaly (isolated quickly)
+ * - Score ≈ 0.5: normal (average isolation depth)
+ * - Score ≈ 0.0: very normal (hard to isolate)
+ *
+ * @param[in]  handle    RAFT handle for GPU resources
+ * @param[in]  forest    Trained Isolation Forest model
+ * @param[in]  input     Test data, row-major [n_rows × n_cols], device pointer
+ * @param[in]  n_rows    Number of test samples (supports >2B rows via size_t)
+ * @param[in]  n_cols    Number of features (must match training)
+ * @param[out] scores    Anomaly scores [n_rows], device pointer
+ * @param[in]  verbosity Logging level
+ */
+void score_samples(const raft::handle_t& handle,
+                   const IsolationForestF* forest,
+                   const float* input,
+                   size_t n_rows,
+                   int n_cols,
+                   float* scores,
+                   rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
+
+void score_samples(const raft::handle_t& handle,
+                   const IsolationForestD* forest,
+                   const double* input,
+                   size_t n_rows,
+                   int n_cols,
+                   double* scores,
+                   rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
+
+/**
+ * @brief Predict anomaly labels.
+ *
+ * @param[in]  handle      RAFT handle for GPU resources
+ * @param[in]  forest      Trained Isolation Forest model
+ * @param[in]  input       Test data, row-major [n_rows × n_cols], device pointer
+ * @param[in]  n_rows      Number of test samples
+ * @param[in]  n_cols      Number of features (must match training)
+ * @param[out] predictions Labels [n_rows]: 1 = anomaly, -1 = normal, device pointer
+ * @param[in]  threshold   Score threshold (default 0.5, higher = more anomalies)
+ * @param[in]  verbosity   Logging level
+ */
+void predict(const raft::handle_t& handle,
+             const IsolationForestF* forest,
+             const float* input,
+             size_t n_rows,
+             int n_cols,
+             int* predictions,
+             float threshold = 0.5f,
+             rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
+
+void predict(const raft::handle_t& handle,
+             const IsolationForestD* forest,
+             const double* input,
+             size_t n_rows,
+             int n_cols,
+             int* predictions,
+             double threshold = 0.5,
+             rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
+
+}  // namespace ML

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -8,6 +8,7 @@
 #include <cuml/common/export.hpp>
 #include <cuml/common/logger.hpp>
 #include <cuml/ensemble/treelite_defs.hpp>
+
 #include <rmm/device_buffer.hpp>
 
 #include <cstddef>
@@ -24,28 +25,28 @@ namespace CUML_EXPORT ML {
  * @brief Isolation Forest hyperparameters
  */
 struct IF_params {
-  int n_estimators = 100;   ///< Number of isolation trees
-  int max_samples = 256;    ///< Samples per tree (default 256)
-  int max_depth = -1;       ///< Max depth (-1 = auto: ceil(log2(max_samples)))
-  int max_features = -1;    ///< Features sampled per tree (-1 = all features)
-  bool bootstrap = false;   ///< If true, sample rows with replacement
-  uint64_t seed = 0;        ///< Random seed
+  int n_estimators = 100;    ///< Number of isolation trees
+  int max_samples  = 256;    ///< Samples per tree (default 256)
+  int max_depth    = -1;     ///< Max depth (-1 = auto: ceil(log2(max_samples)))
+  int max_features = -1;     ///< Features sampled per tree (-1 = all features)
+  bool bootstrap   = false;  ///< If true, sample rows with replacement
+  uint64_t seed    = 0;      ///< Random seed
 };
 
 /** @brief Trained Isolation Forest model */
 template <class T>
 struct IsolationForestModel {
-  IF_params params;            ///< Hyperparameters used for training
-  int n_features = 0;          ///< Number of features in training data
-  int n_features_per_tree = 0; ///< Features sampled per tree
-  int n_samples_per_tree = 0;  ///< Samples used per tree (for c(n) calculation)
-  T c_normalization = 0;       ///< Precomputed c(n) normalization constant
-  int max_nodes_per_tree = 0;  ///< Allocated node capacity per tree
+  IF_params params;                           ///< Hyperparameters used for training
+  int n_features          = 0;                ///< Number of features in training data
+  int n_features_per_tree = 0;                ///< Features sampled per tree
+  int n_samples_per_tree  = 0;                ///< Samples used per tree (for c(n) calculation)
+  T c_normalization       = 0;                ///< Precomputed c(n) normalization constant
+  int max_nodes_per_tree  = 0;                ///< Allocated node capacity per tree
   rmm::device_buffer global_feature_indices;  ///< Optional per-tree sampled feature ids
-  rmm::device_buffer global_nodes;  ///< Device memory for global-memory IFNode array
-  rmm::device_buffer global_tree_offsets;  ///< Per-tree base offset in global_nodes
-  rmm::device_buffer global_tree_n_nodes;  ///< Per-tree used node counts
-  rmm::device_buffer global_tree_max_depth;  ///< Per-tree max depth metadata
+  rmm::device_buffer global_nodes;            ///< Device memory for global-memory IFNode array
+  rmm::device_buffer global_tree_offsets;     ///< Per-tree base offset in global_nodes
+  rmm::device_buffer global_tree_n_nodes;     ///< Per-tree used node counts
+  rmm::device_buffer global_tree_max_depth;   ///< Per-tree max depth metadata
 };
 
 typedef IsolationForestModel<float> IsolationForestF;
@@ -69,10 +70,10 @@ struct IFNodeCompact {
  * Contains all used nodes concatenated, with per-tree metadata.
  */
 struct CompactIFForest {
-  std::vector<IFNodeCompact> nodes;   ///< All used nodes, trees concatenated
-  std::vector<int> tree_offsets;      ///< Start index in nodes[] for each tree
-  std::vector<int> tree_n_nodes;      ///< Number of nodes per tree
-  std::vector<int> tree_max_depth;    ///< Max depth per tree
+  std::vector<IFNodeCompact> nodes;  ///< All used nodes, trees concatenated
+  std::vector<int> tree_offsets;     ///< Start index in nodes[] for each tree
+  std::vector<int> tree_n_nodes;     ///< Number of nodes per tree
+  std::vector<int> tree_max_depth;   ///< Max depth per tree
 };
 
 /**
@@ -112,7 +113,7 @@ void build_treelite_isolation_forest(TreeliteModelHandle* model_handle,
  * @param[in]  handle    RAFT handle for GPU resources
  * @param[out] forest    Model to populate with trained trees
  * @param[in]  input     Training data, column-major [n_rows × n_cols], device pointer
- * @param[in]  n_rows    Number of training samples 
+ * @param[in]  n_rows    Number of training samples
  * @param[in]  n_cols    Number of features
  * @param[in]  params    Hyperparameters (n_estimators, max_samples, max_depth, seed)
  * @param[in]  verbosity Logging level
@@ -144,7 +145,7 @@ void fit(const raft::handle_t& handle,
  * @param[in]  handle    RAFT handle for GPU resources
  * @param[in]  forest    Trained Isolation Forest model
  * @param[in]  input     Test data, row-major [n_rows × n_cols], device pointer
- * @param[in]  n_rows    Number of test samples 
+ * @param[in]  n_rows    Number of test samples
  * @param[in]  n_cols    Number of features (must match training)
  * @param[out] scores    Anomaly scores [n_rows], device pointer
  * @param[in]  verbosity Logging level
@@ -183,7 +184,7 @@ void predict(const raft::handle_t& handle,
              size_t n_rows,
              int n_cols,
              int* predictions,
-             float threshold = 0.5f,
+             float threshold                     = 0.5f,
              rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
 
 void predict(const raft::handle_t& handle,
@@ -192,7 +193,7 @@ void predict(const raft::handle_t& handle,
              size_t n_rows,
              int n_cols,
              int* predictions,
-             double threshold = 0.5,
+             double threshold                    = 0.5,
              rapids_logger::level_enum verbosity = rapids_logger::level_enum::info);
 
-}  // namespace ML
+}  // namespace CUML_EXPORT ML

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -27,6 +27,7 @@ struct IF_params {
   int n_estimators = 100;   ///< Number of isolation trees
   int max_samples = 256;    ///< Samples per tree (default 256)
   int max_depth = -1;       ///< Max depth (-1 = auto: ceil(log2(max_samples)))
+  bool bootstrap = false;   ///< If true, sample rows with replacement
   uint64_t seed = 0;        ///< Random seed
 };
 

--- a/cpp/include/cuml/ensemble/isolation_forest.hpp
+++ b/cpp/include/cuml/ensemble/isolation_forest.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -40,7 +40,7 @@ struct IsolationForestModel {
   int n_features          = 0;                ///< Number of features in training data
   int n_features_per_tree = 0;                ///< Features sampled per tree
   int n_samples_per_tree  = 0;                ///< Samples used per tree (for c(n) calculation)
-  T c_normalization       = 0;                ///< Precomputed c(n) normalization constant
+  double c_normalization  = 0;                ///< Precomputed c(n) normalization constant
   int max_nodes_per_tree  = 0;                ///< Allocated node capacity per tree
   rmm::device_buffer global_feature_indices;  ///< Optional per-tree sampled feature ids
   rmm::device_buffer global_nodes;            ///< Device memory for global-memory IFNode array
@@ -58,9 +58,10 @@ typedef IsolationForestModel<double> IsolationForestD;
  * Internal nodes: feature_idx >= 0, threshold is split value
  * Leaf nodes: feature_idx = -1, threshold stores pre-computed path length
  */
+template <typename T>
 struct IFNodeCompact {
   int feature_idx;
-  float threshold;
+  T threshold;
   int left_child;
   int right_child;
 };
@@ -69,11 +70,12 @@ struct IFNodeCompact {
  * @brief Compact tree data returned by get_compact_trees().
  * Contains all used nodes concatenated, with per-tree metadata.
  */
+template <typename T>
 struct CompactIFForest {
-  std::vector<IFNodeCompact> nodes;  ///< All used nodes, trees concatenated
-  std::vector<int> tree_offsets;     ///< Start index in nodes[] for each tree
-  std::vector<int> tree_n_nodes;     ///< Number of nodes per tree
-  std::vector<int> tree_max_depth;   ///< Max depth per tree
+  std::vector<IFNodeCompact<T>> nodes;  ///< All used nodes, trees concatenated
+  std::vector<int> tree_offsets;        ///< Start index in nodes[] for each tree
+  std::vector<int> tree_n_nodes;        ///< Number of nodes per tree
+  std::vector<int> tree_max_depth;      ///< Max depth per tree
 };
 
 /**
@@ -83,12 +85,11 @@ struct CompactIFForest {
  * instead of the full padded storage (~200 MB).
  */
 template <typename T>
-CompactIFForest get_compact_trees(const raft::handle_t& handle,
-                                  const IsolationForestModel<T>* model);
+CompactIFForest<T> get_compact_trees(const raft::handle_t& handle,
+                                     const IsolationForestModel<T>* model);
 
 /** @brief Compute c(n) = 2H(n-1) - 2(n-1)/n normalization constant. */
-template <typename T>
-T compute_c_normalization(int n);
+double compute_c_normalization(int n);
 
 /**
  * @brief Build a Treelite regression forest from a trained Isolation Forest model.
@@ -175,7 +176,7 @@ void score_samples(const raft::handle_t& handle,
  * @param[in]  n_rows      Number of test samples
  * @param[in]  n_cols      Number of features (must match training)
  * @param[out] predictions Labels [n_rows]: 1 = anomaly, -1 = normal, device pointer
- * @param[in]  threshold   Score threshold (default 0.5, higher = more anomalies)
+ * @param[in]  threshold   Score threshold (default 0.5); scores strictly above it are anomalies
  * @param[in]  verbosity   Logging level
  */
 void predict(const raft::handle_t& handle,

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "isolation_forest.cuh"
+
+#include <cuml/ensemble/isolation_forest.hpp>
+
+#include <raft/core/handle.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/transform.h>
+
+namespace ML {
+
+// Explicit instantiation of compute_c_normalization
+template float compute_c_normalization<float>(int n);
+template double compute_c_normalization<double>(int n);
+
+void fit(const raft::handle_t& handle,
+         IsolationForestF* forest,
+         const float* input,
+         size_t n_rows,
+         int n_cols,
+         const IF_params& params,
+         rapids_logger::level_enum verbosity)
+{
+  ML::default_logger().set_level(verbosity);
+  IsolationForest<float> if_model(params);
+  if_model.fit(handle, input, n_rows, n_cols, forest);
+}
+
+void fit(const raft::handle_t& handle,
+         IsolationForestD* forest,
+         const double* input,
+         size_t n_rows,
+         int n_cols,
+         const IF_params& params,
+         rapids_logger::level_enum verbosity)
+{
+  ML::default_logger().set_level(verbosity);
+  IsolationForest<double> if_model(params);
+  if_model.fit(handle, input, n_rows, n_cols, forest);
+}
+
+void score_samples(const raft::handle_t& handle,
+                   const IsolationForestF* forest,
+                   const float* input,
+                   size_t n_rows,
+                   int n_cols,
+                   float* scores,
+                   rapids_logger::level_enum verbosity)
+{
+  ML::default_logger().set_level(verbosity);
+  IsolationForest<float> if_model(forest->params);
+
+  // Compute average path lengths
+  rmm::device_uvector<float> avg_path_lengths(n_rows, handle.get_stream());
+  if_model.compute_path_lengths(handle, forest, input, n_rows, n_cols, avg_path_lengths.data());
+
+  // Convert to anomaly scores
+  if_model.compute_anomaly_scores(handle, forest, avg_path_lengths.data(), n_rows, scores);
+}
+
+void score_samples(const raft::handle_t& handle,
+                   const IsolationForestD* forest,
+                   const double* input,
+                   size_t n_rows,
+                   int n_cols,
+                   double* scores,
+                   rapids_logger::level_enum verbosity)
+{
+  ML::default_logger().set_level(verbosity);
+  IsolationForest<double> if_model(forest->params);
+
+  // Compute average path lengths
+  rmm::device_uvector<double> avg_path_lengths(n_rows, handle.get_stream());
+  if_model.compute_path_lengths(handle, forest, input, n_rows, n_cols, avg_path_lengths.data());
+
+  // Convert to anomaly scores
+  if_model.compute_anomaly_scores(handle, forest, avg_path_lengths.data(), n_rows, scores);
+}
+
+void predict(const raft::handle_t& handle,
+             const IsolationForestF* forest,
+             const float* input,
+             size_t n_rows,
+             int n_cols,
+             int* predictions,
+             float threshold,
+             rapids_logger::level_enum verbosity)
+{
+  ML::default_logger().set_level(verbosity);
+  cudaStream_t stream = handle.get_stream();
+
+  // First compute anomaly scores
+  rmm::device_uvector<float> scores(n_rows, stream);
+  score_samples(handle, forest, input, n_rows, n_cols, scores.data(), verbosity);
+
+  // Convert scores to predictions: 1 for anomaly (score >= threshold), -1 for normal
+  thrust::transform(rmm::exec_policy(stream),
+                    scores.data(),
+                    scores.data() + n_rows,
+                    predictions,
+                    [threshold] __device__(float score) { return score >= threshold ? 1 : -1; });
+
+  handle.sync_stream(stream);
+}
+
+void predict(const raft::handle_t& handle,
+             const IsolationForestD* forest,
+             const double* input,
+             size_t n_rows,
+             int n_cols,
+             int* predictions,
+             double threshold,
+             rapids_logger::level_enum verbosity)
+{
+  ML::default_logger().set_level(verbosity);
+  cudaStream_t stream = handle.get_stream();
+
+  // First compute anomaly scores
+  rmm::device_uvector<double> scores(n_rows, stream);
+  score_samples(handle, forest, input, n_rows, n_cols, scores.data(), verbosity);
+
+  // Convert scores to predictions: 1 for anomaly (score >= threshold), -1 for normal
+  thrust::transform(rmm::exec_policy(stream),
+                    scores.data(),
+                    scores.data() + n_rows,
+                    predictions,
+                    [threshold] __device__(double score) { return score >= threshold ? 1 : -1; });
+
+  handle.sync_stream(stream);
+}
+
+}  // namespace ML

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -8,17 +8,118 @@
 #include <cuml/ensemble/isolation_forest.hpp>
 
 #include <raft/core/handle.hpp>
+#include <raft/core/error.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
 
+#include <treelite/enum/task_type.h>
+#include <treelite/tree.h>
+
+#include <cstdint>
+#include <vector>
+
 namespace ML {
+namespace tl = treelite;
 
 // Explicit instantiation of compute_c_normalization
-template float compute_c_normalization<float>(int n);
-template double compute_c_normalization<double>(int n);
+template CUML_EXPORT float compute_c_normalization<float>(int n);
+template CUML_EXPORT double compute_c_normalization<double>(int n);
+
+template <typename T>
+tl::Tree<T, T> build_treelite_if_tree(const CompactIFForest& compact, int tree_id)
+{
+  ASSERT(tree_id >= 0 && tree_id < static_cast<int>(compact.tree_offsets.size()),
+         "Invalid isolation forest tree id.");
+
+  int tree_offset = compact.tree_offsets[tree_id];
+  int n_nodes     = compact.tree_n_nodes[tree_id];
+  ASSERT(n_nodes > 0, "Cannot export an empty isolation tree.");
+
+  tl::Tree<T, T> tl_tree;
+  tl_tree.Init();
+
+  std::vector<int> tl_node_ids(n_nodes, -1);
+  tl_node_ids[0] = tl_tree.AllocNode();
+
+  std::vector<int> stack{0};
+  while (!stack.empty()) {
+    int if_node_id = stack.back();
+    stack.pop_back();
+
+    const auto& if_node = compact.nodes[tree_offset + if_node_id];
+    int tl_node_id      = tl_node_ids[if_node_id];
+
+    if (if_node.feature_idx < 0) {
+      tl_tree.SetLeaf(tl_node_id, static_cast<T>(if_node.threshold));
+    } else {
+      ASSERT(if_node.left_child >= 0 && if_node.left_child < n_nodes,
+             "Invalid left child in isolation tree.");
+      ASSERT(if_node.right_child >= 0 && if_node.right_child < n_nodes,
+             "Invalid right child in isolation tree.");
+
+      int tl_left_child  = tl_tree.AllocNode();
+      int tl_right_child = tl_tree.AllocNode();
+      tl_node_ids[if_node.left_child]  = tl_left_child;
+      tl_node_ids[if_node.right_child] = tl_right_child;
+
+      tl_tree.SetChildren(tl_node_id, tl_left_child, tl_right_child);
+      tl_tree.SetNumericalTest(tl_node_id,
+                               if_node.feature_idx,
+                               static_cast<T>(if_node.threshold),
+                               true,
+                               tl::Operator::kLT);
+
+      stack.push_back(if_node.right_child);
+      stack.push_back(if_node.left_child);
+    }
+
+    tl_tree.SetDataCount(tl_node_id, 0);
+  }
+
+  return tl_tree;
+}
+
+template <typename T>
+void build_treelite_isolation_forest(TreeliteModelHandle* model_handle,
+                                     const raft::handle_t& handle,
+                                     const IsolationForestModel<T>* forest)
+{
+  ASSERT(model_handle != nullptr, "Treelite output handle cannot be null.");
+  ASSERT(forest != nullptr, "Isolation Forest model cannot be null.");
+  ASSERT(forest->params.n_estimators > 0, "Cannot export an empty Isolation Forest.");
+  ASSERT(forest->n_features > 0, "Cannot export Isolation Forest with no features.");
+
+  auto compact = get_compact_trees(handle, forest);
+  ASSERT(static_cast<int>(compact.tree_offsets.size()) == forest->params.n_estimators,
+         "Inconsistent compact Isolation Forest tree offsets.");
+  ASSERT(static_cast<int>(compact.tree_n_nodes.size()) == forest->params.n_estimators,
+         "Inconsistent compact Isolation Forest tree sizes.");
+
+  auto model                          = tl::Model::Create<T, T>();
+  tl::ModelPreset<T, T>& model_preset = std::get<tl::ModelPreset<T, T>>(model->variant_);
+
+  model->task_type           = tl::TaskType::kRegressor;
+  model->postprocessor       = "identity";
+  model->num_target          = 1;
+  model->num_class           = std::vector<std::int32_t>{1};
+  model->leaf_vector_shape   = std::vector<std::int32_t>{1, 1};
+  model->target_id           = std::vector<std::int32_t>(forest->params.n_estimators, 0);
+  model->class_id            = std::vector<std::int32_t>(forest->params.n_estimators, 0);
+  model->num_feature         = forest->n_features;
+  model->average_tree_output = true;
+  model->base_scores         = std::vector<double>{0.0};
+  model->SetTreeLimit(forest->params.n_estimators);
+
+#pragma omp parallel for
+  for (int i = 0; i < forest->params.n_estimators; ++i) {
+    model_preset.trees[i] = build_treelite_if_tree<T>(compact, i);
+  }
+
+  *model_handle = static_cast<TreeliteModelHandle>(model.release());
+}
 
 void fit(const raft::handle_t& handle,
          IsolationForestF* forest,
@@ -135,5 +236,10 @@ void predict(const raft::handle_t& handle,
 
   handle.sync_stream(stream);
 }
+
+template CUML_EXPORT void build_treelite_isolation_forest<float>(
+  TreeliteModelHandle*, const raft::handle_t&, const IsolationForestModel<float>*);
+template CUML_EXPORT void build_treelite_isolation_forest<double>(
+  TreeliteModelHandle*, const raft::handle_t&, const IsolationForestModel<double>*);
 
 }  // namespace ML

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -7,8 +7,8 @@
 
 #include <cuml/ensemble/isolation_forest.hpp>
 
-#include <raft/core/handle.hpp>
 #include <raft/core/error.hpp>
+#include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -60,8 +60,8 @@ tl::Tree<T, T> build_treelite_if_tree(const CompactIFForest& compact, int tree_i
       ASSERT(if_node.right_child >= 0 && if_node.right_child < n_nodes,
              "Invalid right child in isolation tree.");
 
-      int tl_left_child  = tl_tree.AllocNode();
-      int tl_right_child = tl_tree.AllocNode();
+      int tl_left_child                = tl_tree.AllocNode();
+      int tl_right_child               = tl_tree.AllocNode();
       tl_node_ids[if_node.left_child]  = tl_left_child;
       tl_node_ids[if_node.right_child] = tl_right_child;
 

--- a/cpp/src/isolation_forest/isolation_forest.cu
+++ b/cpp/src/isolation_forest/isolation_forest.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,12 +24,18 @@
 namespace ML {
 namespace tl = treelite;
 
-// Explicit instantiation of compute_c_normalization
-template CUML_EXPORT float compute_c_normalization<float>(int n);
-template CUML_EXPORT double compute_c_normalization<double>(int n);
+double compute_c_normalization(int n)
+{
+  if (n <= 1) return 0.0;
+  if (n == 2) return 1.0;
+
+  constexpr double euler_mascheroni = 0.5772156649015329;
+  double harmonic_n_minus_1         = std::log(static_cast<double>(n - 1)) + euler_mascheroni;
+  return 2.0 * harmonic_n_minus_1 - 2.0 * static_cast<double>(n - 1) / static_cast<double>(n);
+}
 
 template <typename T>
-tl::Tree<T, T> build_treelite_if_tree(const CompactIFForest& compact, int tree_id)
+tl::Tree<T, T> build_treelite_if_tree(const CompactIFForest<T>& compact, int tree_id)
 {
   ASSERT(tree_id >= 0 && tree_id < static_cast<int>(compact.tree_offsets.size()),
          "Invalid isolation forest tree id.");
@@ -201,12 +207,12 @@ void predict(const raft::handle_t& handle,
   rmm::device_uvector<float> scores(n_rows, stream);
   score_samples(handle, forest, input, n_rows, n_cols, scores.data(), verbosity);
 
-  // Convert scores to predictions: 1 for anomaly (score >= threshold), -1 for normal
+  // Convert scores to predictions: 1 for anomaly (score > threshold), -1 for normal
   thrust::transform(rmm::exec_policy(stream),
                     scores.data(),
                     scores.data() + n_rows,
                     predictions,
-                    [threshold] __device__(float score) { return score >= threshold ? 1 : -1; });
+                    [threshold] __device__(float score) { return score > threshold ? 1 : -1; });
 
   handle.sync_stream(stream);
 }
@@ -227,12 +233,12 @@ void predict(const raft::handle_t& handle,
   rmm::device_uvector<double> scores(n_rows, stream);
   score_samples(handle, forest, input, n_rows, n_cols, scores.data(), verbosity);
 
-  // Convert scores to predictions: 1 for anomaly (score >= threshold), -1 for normal
+  // Convert scores to predictions: 1 for anomaly (score > threshold), -1 for normal
   thrust::transform(rmm::exec_policy(stream),
                     scores.data(),
                     scores.data() + n_rows,
                     predictions,
-                    [threshold] __device__(double score) { return score >= threshold ? 1 : -1; });
+                    [threshold] __device__(double score) { return score > threshold ? 1 : -1; });
 
   handle.sync_stream(stream);
 }

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -18,9 +18,11 @@
 
 #include "isolation_tree_builder.cuh"
 
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <cstring>
+#include <limits>
 
 namespace ML {
 
@@ -34,6 +36,23 @@ T compute_c_normalization(int n)
   constexpr T euler_mascheroni = T(0.5772156649015329);
   T harmonic_n_minus_1         = std::log(T(n - 1)) + euler_mascheroni;
   return T(2) * harmonic_n_minus_1 - T(2) * T(n - 1) / T(n);
+}
+
+inline int compute_global_max_nodes_per_tree(int max_depth, int max_samples)
+{
+  ASSERT(max_depth >= 0, "max_depth must be non-negative, got %d", max_depth);
+  ASSERT(max_samples > 0, "max_samples must be positive, got %d", max_samples);
+
+  int64_t sample_bound = 2LL * static_cast<int64_t>(max_samples) - 1LL;
+  int64_t depth_bound = sample_bound;
+  if (max_depth < 30) {
+    depth_bound = (1LL << (max_depth + 1)) - 1LL;
+  }
+
+  int64_t bounded = std::min(sample_bound, depth_bound);
+  ASSERT(bounded <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+         "Global-memory Isolation Forest node capacity exceeds int range.");
+  return static_cast<int>(bounded);
 }
 
 template <class T>
@@ -83,14 +102,27 @@ class IsolationForest {
     model->c_normalization    = compute_c_normalization<T>(n_sampled_rows);
     
     auto stream = handle.get_stream();
-    size_t trees_size = params.n_estimators * sizeof(IsolationTree::IFTree<T>);
-    model->fast_trees = rmm::device_buffer(trees_size, stream);
-    
-    IsolationTree::build_isolation_forest(
+    model->max_nodes_per_tree = compute_global_max_nodes_per_tree(max_depth, n_sampled_rows);
+    size_t total_nodes =
+      static_cast<size_t>(params.n_estimators) * model->max_nodes_per_tree;
+    model->global_nodes =
+      rmm::device_buffer(total_nodes * sizeof(IsolationTree::IFNode), stream);
+    model->global_tree_offsets =
+      rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+    model->global_tree_n_nodes =
+      rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+    model->global_tree_max_depth =
+      rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+
+    IsolationTree::build_isolation_forest_global(
         handle, input, n_rows, n_cols,
         params.n_estimators, n_sampled_rows, max_depth,
+        model->max_nodes_per_tree,
         params.seed,
-        static_cast<IsolationTree::IFTree<T>*>(model->fast_trees.data()));
+        static_cast<IsolationTree::IFNode*>(model->global_nodes.data()),
+        static_cast<int*>(model->global_tree_offsets.data()),
+        static_cast<int*>(model->global_tree_n_nodes.data()),
+        static_cast<int*>(model->global_tree_max_depth.data()));
     
     handle.sync_stream();
   }
@@ -106,12 +138,13 @@ class IsolationForest {
     raft::common::nvtx::range fun_scope("IF::compute_path_lengths @isolation_forest.cuh");
     cudaStream_t stream = handle.get_stream();
 
-    auto* fast_trees = static_cast<const IsolationTree::IFTree<T>*>(model->fast_trees.data());
     int threads = 256;
     size_t blocks = (n_rows + threads - 1) / threads;
-    
-    IsolationTree::compute_path_lengths_kernel<T><<<blocks, threads, 0, stream>>>(
-        input, n_rows, n_cols, fast_trees, params.n_estimators, avg_path_lengths);
+
+    auto* nodes = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
+    auto* tree_offsets = static_cast<const int*>(model->global_tree_offsets.data());
+    IsolationTree::compute_path_lengths_global_kernel<T><<<blocks, threads, 0, stream>>>(
+        input, n_rows, n_cols, nodes, tree_offsets, params.n_estimators, avg_path_lengths);
     
     RAFT_CUDA_TRY(cudaGetLastError());
     handle.sync_stream(stream);
@@ -148,14 +181,16 @@ template <typename T>
 CompactIFForest get_compact_trees(const raft::handle_t& handle,
                                   const IsolationForestModel<T>* model)
 {
-  auto* d_trees = static_cast<const IsolationTree::IFTree<T>*>(model->fast_trees.data());
-  int n_trees   = model->params.n_estimators;
+  int n_trees = model->params.n_estimators;
 
   CompactIFForest result;
   std::vector<IsolationTree::IFNode> raw_nodes;
 
-  IsolationTree::compact_isolation_forest<T>(
-      handle, d_trees, n_trees,
+  auto* d_nodes = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
+  auto* d_tree_n_nodes = static_cast<const int*>(model->global_tree_n_nodes.data());
+  auto* d_tree_max_depth = static_cast<const int*>(model->global_tree_max_depth.data());
+  IsolationTree::compact_global_isolation_forest<T>(
+      handle, d_nodes, d_tree_n_nodes, d_tree_max_depth, n_trees, model->max_nodes_per_tree,
       raw_nodes, result.tree_offsets, result.tree_n_nodes, result.tree_max_depth);
 
   result.nodes.resize(raw_nodes.size());

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -20,6 +20,7 @@
 
 #include <climits>
 #include <cmath>
+#include <cstring>
 
 namespace ML {
 
@@ -142,5 +143,33 @@ class IsolationForest {
 
 template class IsolationForest<float>;
 template class IsolationForest<double>;
+
+template <typename T>
+CompactIFForest get_compact_trees(const raft::handle_t& handle,
+                                  const IsolationForestModel<T>* model)
+{
+  auto* d_trees = static_cast<const IsolationTree::IFTree<T>*>(model->fast_trees.data());
+  int n_trees   = model->params.n_estimators;
+
+  CompactIFForest result;
+  std::vector<IsolationTree::IFNode> raw_nodes;
+
+  IsolationTree::compact_isolation_forest<T>(
+      handle, d_trees, n_trees,
+      raw_nodes, result.tree_offsets, result.tree_n_nodes, result.tree_max_depth);
+
+  result.nodes.resize(raw_nodes.size());
+  static_assert(sizeof(IFNodeCompact) == sizeof(IsolationTree::IFNode),
+                "IFNodeCompact and IFNode must have identical layout");
+  std::memcpy(result.nodes.data(), raw_nodes.data(),
+              raw_nodes.size() * sizeof(IFNodeCompact));
+
+  return result;
+}
+
+template CompactIFForest get_compact_trees<float>(const raft::handle_t&,
+                                                  const IsolationForestModel<float>*);
+template CompactIFForest get_compact_trees<double>(const raft::handle_t&,
+                                                   const IsolationForestModel<double>*);
 
 }  // namespace ML

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "isolation_tree_builder.cuh"
+
 #include <cuml/ensemble/isolation_forest.hpp>
 
 #include <raft/core/handle.hpp>
@@ -15,8 +17,6 @@
 
 #include <thrust/fill.h>
 #include <thrust/transform.h>
-
-#include "isolation_tree_builder.cuh"
 
 #include <algorithm>
 #include <climits>
@@ -44,10 +44,8 @@ inline int compute_global_max_nodes_per_tree(int max_depth, int max_samples)
   ASSERT(max_samples > 0, "max_samples must be positive, got %d", max_samples);
 
   int64_t sample_bound = 2LL * static_cast<int64_t>(max_samples) - 1LL;
-  int64_t depth_bound = sample_bound;
-  if (max_depth < 30) {
-    depth_bound = (1LL << (max_depth + 1)) - 1LL;
-  }
+  int64_t depth_bound  = sample_bound;
+  if (max_depth < 30) { depth_bound = (1LL << (max_depth + 1)) - 1LL; }
 
   int64_t bounded = std::min(sample_bound, depth_bound);
   ASSERT(bounded <= static_cast<int64_t>(std::numeric_limits<int>::max()),
@@ -88,56 +86,54 @@ class IsolationForest {
   {
     raft::common::nvtx::range fun_scope("IsolationForest::fit @isolation_forest.cuh");
     this->error_checking(input, n_rows, n_cols);
-    
-    int n_sampled_rows = std::min(params.max_samples, static_cast<int>(std::min(n_rows, static_cast<size_t>(INT_MAX))));
-    int max_depth = params.max_depth;
+
+    int n_sampled_rows = std::min(params.max_samples,
+                                  static_cast<int>(std::min(n_rows, static_cast<size_t>(INT_MAX))));
+    int max_depth      = params.max_depth;
     if (max_depth <= 0) {
       max_depth = static_cast<int>(std::ceil(std::log2(static_cast<double>(n_sampled_rows))));
       max_depth = std::max(max_depth, 1);
     }
-    
+
     int n_sampled_features = params.max_features;
-    if (n_sampled_features <= 0 || n_sampled_features > n_cols) {
-      n_sampled_features = n_cols;
-    }
+    if (n_sampled_features <= 0 || n_sampled_features > n_cols) { n_sampled_features = n_cols; }
 
     model->params              = params;
     model->n_features          = n_cols;
     model->n_features_per_tree = n_sampled_features;
     model->n_samples_per_tree  = n_sampled_rows;
     model->c_normalization     = compute_c_normalization<T>(n_sampled_rows);
-    
-    auto stream = handle.get_stream();
+
+    auto stream               = handle.get_stream();
     model->max_nodes_per_tree = compute_global_max_nodes_per_tree(max_depth, n_sampled_rows);
-    size_t total_nodes =
-      static_cast<size_t>(params.n_estimators) * model->max_nodes_per_tree;
-    model->global_nodes =
-      rmm::device_buffer(total_nodes * sizeof(IsolationTree::IFNode), stream);
-    model->global_tree_offsets =
-      rmm::device_buffer(params.n_estimators * sizeof(int), stream);
-    model->global_tree_n_nodes =
-      rmm::device_buffer(params.n_estimators * sizeof(int), stream);
-    model->global_tree_max_depth =
-      rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+    size_t total_nodes  = static_cast<size_t>(params.n_estimators) * model->max_nodes_per_tree;
+    model->global_nodes = rmm::device_buffer(total_nodes * sizeof(IsolationTree::IFNode), stream);
+    model->global_tree_offsets   = rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+    model->global_tree_n_nodes   = rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+    model->global_tree_max_depth = rmm::device_buffer(params.n_estimators * sizeof(int), stream);
     if (n_sampled_features < n_cols) {
-      model->global_feature_indices =
-        rmm::device_buffer(static_cast<size_t>(params.n_estimators) *
-                           n_sampled_features * sizeof(int),
-                           stream);
+      model->global_feature_indices = rmm::device_buffer(
+        static_cast<size_t>(params.n_estimators) * n_sampled_features * sizeof(int), stream);
     }
 
     IsolationTree::build_isolation_forest_global(
-        handle, input, n_rows, n_cols,
-        params.n_estimators, n_sampled_rows, n_sampled_features, max_depth,
-        model->max_nodes_per_tree,
-        params.bootstrap,
-        params.seed,
-        static_cast<int*>(model->global_feature_indices.data()),
-        static_cast<IsolationTree::IFNode*>(model->global_nodes.data()),
-        static_cast<int*>(model->global_tree_offsets.data()),
-        static_cast<int*>(model->global_tree_n_nodes.data()),
-        static_cast<int*>(model->global_tree_max_depth.data()));
-    
+      handle,
+      input,
+      n_rows,
+      n_cols,
+      params.n_estimators,
+      n_sampled_rows,
+      n_sampled_features,
+      max_depth,
+      model->max_nodes_per_tree,
+      params.bootstrap,
+      params.seed,
+      static_cast<int*>(model->global_feature_indices.data()),
+      static_cast<IsolationTree::IFNode*>(model->global_nodes.data()),
+      static_cast<int*>(model->global_tree_offsets.data()),
+      static_cast<int*>(model->global_tree_n_nodes.data()),
+      static_cast<int*>(model->global_tree_max_depth.data()));
+
     handle.sync_stream();
   }
 
@@ -152,14 +148,14 @@ class IsolationForest {
     raft::common::nvtx::range fun_scope("IF::compute_path_lengths @isolation_forest.cuh");
     cudaStream_t stream = handle.get_stream();
 
-    int threads = 256;
+    int threads   = 256;
     size_t blocks = (n_rows + threads - 1) / threads;
 
-    auto* nodes = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
+    auto* nodes        = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
     auto* tree_offsets = static_cast<const int*>(model->global_tree_offsets.data());
     IsolationTree::compute_path_lengths_global_kernel<T><<<blocks, threads, 0, stream>>>(
-        input, n_rows, n_cols, nodes, tree_offsets, params.n_estimators, avg_path_lengths);
-    
+      input, n_rows, n_cols, nodes, tree_offsets, params.n_estimators, avg_path_lengths);
+
     RAFT_CUDA_TRY(cudaGetLastError());
     handle.sync_stream(stream);
   }
@@ -200,18 +196,24 @@ CompactIFForest get_compact_trees(const raft::handle_t& handle,
   CompactIFForest result;
   std::vector<IsolationTree::IFNode> raw_nodes;
 
-  auto* d_nodes = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
-  auto* d_tree_n_nodes = static_cast<const int*>(model->global_tree_n_nodes.data());
+  auto* d_nodes          = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
+  auto* d_tree_n_nodes   = static_cast<const int*>(model->global_tree_n_nodes.data());
   auto* d_tree_max_depth = static_cast<const int*>(model->global_tree_max_depth.data());
-  IsolationTree::compact_global_isolation_forest<T>(
-      handle, d_nodes, d_tree_n_nodes, d_tree_max_depth, n_trees, model->max_nodes_per_tree,
-      raw_nodes, result.tree_offsets, result.tree_n_nodes, result.tree_max_depth);
+  IsolationTree::compact_global_isolation_forest<T>(handle,
+                                                    d_nodes,
+                                                    d_tree_n_nodes,
+                                                    d_tree_max_depth,
+                                                    n_trees,
+                                                    model->max_nodes_per_tree,
+                                                    raw_nodes,
+                                                    result.tree_offsets,
+                                                    result.tree_n_nodes,
+                                                    result.tree_max_depth);
 
   result.nodes.resize(raw_nodes.size());
   static_assert(sizeof(IFNodeCompact) == sizeof(IsolationTree::IFNode),
                 "IFNodeCompact and IFNode must have identical layout");
-  std::memcpy(result.nodes.data(), raw_nodes.data(),
-              raw_nodes.size() * sizeof(IFNodeCompact));
+  std::memcpy(result.nodes.data(), raw_nodes.data(), raw_nodes.size() * sizeof(IFNodeCompact));
 
   return result;
 }

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -96,10 +96,16 @@ class IsolationForest {
       max_depth = std::max(max_depth, 1);
     }
     
-    model->params             = params;
-    model->n_features         = n_cols;
-    model->n_samples_per_tree = n_sampled_rows;
-    model->c_normalization    = compute_c_normalization<T>(n_sampled_rows);
+    int n_sampled_features = params.max_features;
+    if (n_sampled_features <= 0 || n_sampled_features > n_cols) {
+      n_sampled_features = n_cols;
+    }
+
+    model->params              = params;
+    model->n_features          = n_cols;
+    model->n_features_per_tree = n_sampled_features;
+    model->n_samples_per_tree  = n_sampled_rows;
+    model->c_normalization     = compute_c_normalization<T>(n_sampled_rows);
     
     auto stream = handle.get_stream();
     model->max_nodes_per_tree = compute_global_max_nodes_per_tree(max_depth, n_sampled_rows);
@@ -113,13 +119,20 @@ class IsolationForest {
       rmm::device_buffer(params.n_estimators * sizeof(int), stream);
     model->global_tree_max_depth =
       rmm::device_buffer(params.n_estimators * sizeof(int), stream);
+    if (n_sampled_features < n_cols) {
+      model->global_feature_indices =
+        rmm::device_buffer(static_cast<size_t>(params.n_estimators) *
+                           n_sampled_features * sizeof(int),
+                           stream);
+    }
 
     IsolationTree::build_isolation_forest_global(
         handle, input, n_rows, n_cols,
-        params.n_estimators, n_sampled_rows, max_depth,
+        params.n_estimators, n_sampled_rows, n_sampled_features, max_depth,
         model->max_nodes_per_tree,
         params.bootstrap,
         params.seed,
+        static_cast<int*>(model->global_feature_indices.data()),
         static_cast<IsolationTree::IFNode*>(model->global_nodes.data()),
         static_cast<int*>(model->global_tree_offsets.data()),
         static_cast<int*>(model->global_tree_n_nodes.data()),

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cuml/ensemble/isolation_forest.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/core/nvtx.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/fill.h>
+#include <thrust/transform.h>
+
+#include "isolation_tree_builder.cuh"
+
+#include <climits>
+#include <cmath>
+
+namespace ML {
+
+/** @brief Compute average path length c(n) = 2H(n-1) - 2(n-1)/n for normalization. */
+template <typename T>
+T compute_c_normalization(int n)
+{
+  if (n <= 1) return T(0);
+  if (n == 2) return T(1);
+
+  constexpr T euler_mascheroni = T(0.5772156649015329);
+  T harmonic_n_minus_1         = std::log(T(n - 1)) + euler_mascheroni;
+  return T(2) * harmonic_n_minus_1 - T(2) * T(n - 1) / T(n);
+}
+
+template <class T>
+class IsolationForest {
+ private:
+  IF_params params;
+
+  void error_checking(const T* input, size_t n_rows, int n_cols) const
+  {
+    ASSERT((n_rows > 0), "Invalid n_rows %zu", n_rows);
+    ASSERT((n_cols > 0), "Invalid n_cols %d", n_cols);
+    ASSERT((params.n_estimators > 0), "n_estimators must be > 0, got %d", params.n_estimators);
+    ASSERT(IsolationTree::is_dev_ptr(input), "IF Error: Expected input to be a GPU pointer");
+  }
+
+ public:
+  IsolationForest(const IF_params& cfg_params) : params(cfg_params) {}
+
+  /**
+   * @brief Fit the Isolation Forest model.
+   *
+   * @param[in] handle raft::handle_t
+   * @param[in] input Training data (n_rows x n_cols) in column-major format. Device pointer.
+   * @param[in] n_rows Number of training samples
+   * @param[in] n_cols Number of features
+   * @param[out] model IsolationForestModel to populate
+   */
+  void fit(const raft::handle_t& handle,
+           const T* input,
+           size_t n_rows,
+           int n_cols,
+           IsolationForestModel<T>* model)
+  {
+    raft::common::nvtx::range fun_scope("IsolationForest::fit @isolation_forest.cuh");
+    this->error_checking(input, n_rows, n_cols);
+    
+    int n_sampled_rows = std::min(params.max_samples, static_cast<int>(std::min(n_rows, static_cast<size_t>(INT_MAX))));
+    int max_depth = params.max_depth;
+    if (max_depth <= 0) {
+      max_depth = static_cast<int>(std::ceil(std::log2(static_cast<double>(n_sampled_rows))));
+      max_depth = std::max(max_depth, 1);
+    }
+    
+    model->params             = params;
+    model->n_features         = n_cols;
+    model->n_samples_per_tree = n_sampled_rows;
+    model->c_normalization    = compute_c_normalization<T>(n_sampled_rows);
+    
+    auto stream = handle.get_stream();
+    size_t trees_size = params.n_estimators * sizeof(IsolationTree::IFTree<T>);
+    model->fast_trees = rmm::device_buffer(trees_size, stream);
+    
+    IsolationTree::build_isolation_forest(
+        handle, input, n_rows, n_cols,
+        params.n_estimators, n_sampled_rows, max_depth,
+        params.seed,
+        static_cast<IsolationTree::IFTree<T>*>(model->fast_trees.data()));
+    
+    handle.sync_stream();
+  }
+
+  /** @brief Compute average path lengths for each sample. Input must be row-major. */
+  void compute_path_lengths(const raft::handle_t& handle,
+                            const IsolationForestModel<T>* model,
+                            const T* input,
+                            size_t n_rows,
+                            int n_cols,
+                            T* avg_path_lengths) const
+  {
+    raft::common::nvtx::range fun_scope("IF::compute_path_lengths @isolation_forest.cuh");
+    cudaStream_t stream = handle.get_stream();
+
+    auto* fast_trees = static_cast<const IsolationTree::IFTree<T>*>(model->fast_trees.data());
+    int threads = 256;
+    size_t blocks = (n_rows + threads - 1) / threads;
+    
+    IsolationTree::compute_path_lengths_kernel<T><<<blocks, threads, 0, stream>>>(
+        input, n_rows, n_cols, fast_trees, params.n_estimators, avg_path_lengths);
+    
+    RAFT_CUDA_TRY(cudaGetLastError());
+    handle.sync_stream(stream);
+  }
+
+  /** @brief Compute anomaly scores: score = 2^(-avg_path_length / c(n)). */
+  void compute_anomaly_scores(const raft::handle_t& handle,
+                              const IsolationForestModel<T>* model,
+                              const T* avg_path_lengths,
+                              size_t n_rows,
+                              T* scores) const
+  {
+    cudaStream_t stream = handle.get_stream();
+    T c_n               = model->c_normalization;
+
+    if (c_n <= T(0)) {
+      thrust::fill(rmm::exec_policy(stream), scores, scores + n_rows, T(0.5));
+    } else {
+      thrust::transform(
+        rmm::exec_policy(stream),
+        avg_path_lengths,
+        avg_path_lengths + n_rows,
+        scores,
+        [c_n] __device__(T path_length) { return std::pow(T(2), -path_length / c_n); });
+    }
+    handle.sync_stream(stream);
+  }
+};
+
+template class IsolationForest<float>;
+template class IsolationForest<double>;
+
+}  // namespace ML

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -118,6 +118,7 @@ class IsolationForest {
         handle, input, n_rows, n_cols,
         params.n_estimators, n_sampled_rows, max_depth,
         model->max_nodes_per_tree,
+        params.bootstrap,
         params.seed,
         static_cast<IsolationTree::IFNode*>(model->global_nodes.data()),
         static_cast<int*>(model->global_tree_offsets.data()),

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -212,9 +212,9 @@ CompactIFForest<T> get_compact_trees(const raft::handle_t& handle,
   return result;
 }
 
-template CompactIFForest<float> get_compact_trees<float>(const raft::handle_t&,
-                                                         const IsolationForestModel<float>*);
-template CompactIFForest<double> get_compact_trees<double>(const raft::handle_t&,
-                                                           const IsolationForestModel<double>*);
+template CUML_EXPORT CompactIFForest<float> get_compact_trees<float>(
+  const raft::handle_t&, const IsolationForestModel<float>*);
+template CUML_EXPORT CompactIFForest<double> get_compact_trees<double>(
+  const raft::handle_t&, const IsolationForestModel<double>*);
 
 }  // namespace ML

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -95,6 +95,8 @@ class IsolationForest {
     auto stream               = handle.get_stream();
     model->max_nodes_per_tree = compute_global_max_nodes_per_tree(max_depth, n_sampled_rows);
     size_t total_nodes = static_cast<size_t>(params.n_estimators) * model->max_nodes_per_tree;
+    ASSERT(total_nodes <= static_cast<size_t>(std::numeric_limits<int>::max()),
+           "Isolation Forest node offsets exceed int range.");
     model->global_nodes =
       rmm::device_buffer(total_nodes * sizeof(IsolationTree::IFNode<T>), stream);
     model->global_tree_offsets   = rmm::device_buffer(params.n_estimators * sizeof(int), stream);

--- a/cpp/src/isolation_forest/isolation_forest.cuh
+++ b/cpp/src/isolation_forest/isolation_forest.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,18 +25,6 @@
 #include <limits>
 
 namespace ML {
-
-/** @brief Compute average path length c(n) = 2H(n-1) - 2(n-1)/n for normalization. */
-template <typename T>
-T compute_c_normalization(int n)
-{
-  if (n <= 1) return T(0);
-  if (n == 2) return T(1);
-
-  constexpr T euler_mascheroni = T(0.5772156649015329);
-  T harmonic_n_minus_1         = std::log(T(n - 1)) + euler_mascheroni;
-  return T(2) * harmonic_n_minus_1 - T(2) * T(n - 1) / T(n);
-}
 
 inline int compute_global_max_nodes_per_tree(int max_depth, int max_samples)
 {
@@ -102,18 +90,21 @@ class IsolationForest {
     model->n_features          = n_cols;
     model->n_features_per_tree = n_sampled_features;
     model->n_samples_per_tree  = n_sampled_rows;
-    model->c_normalization     = compute_c_normalization<T>(n_sampled_rows);
+    model->c_normalization     = compute_c_normalization(n_sampled_rows);
 
     auto stream               = handle.get_stream();
     model->max_nodes_per_tree = compute_global_max_nodes_per_tree(max_depth, n_sampled_rows);
-    size_t total_nodes  = static_cast<size_t>(params.n_estimators) * model->max_nodes_per_tree;
-    model->global_nodes = rmm::device_buffer(total_nodes * sizeof(IsolationTree::IFNode), stream);
+    size_t total_nodes = static_cast<size_t>(params.n_estimators) * model->max_nodes_per_tree;
+    model->global_nodes =
+      rmm::device_buffer(total_nodes * sizeof(IsolationTree::IFNode<T>), stream);
     model->global_tree_offsets   = rmm::device_buffer(params.n_estimators * sizeof(int), stream);
     model->global_tree_n_nodes   = rmm::device_buffer(params.n_estimators * sizeof(int), stream);
     model->global_tree_max_depth = rmm::device_buffer(params.n_estimators * sizeof(int), stream);
     if (n_sampled_features < n_cols) {
       model->global_feature_indices = rmm::device_buffer(
         static_cast<size_t>(params.n_estimators) * n_sampled_features * sizeof(int), stream);
+    } else {
+      model->global_feature_indices = rmm::device_buffer{};
     }
 
     IsolationTree::build_isolation_forest_global(
@@ -128,8 +119,9 @@ class IsolationForest {
       model->max_nodes_per_tree,
       params.bootstrap,
       params.seed,
-      static_cast<int*>(model->global_feature_indices.data()),
-      static_cast<IsolationTree::IFNode*>(model->global_nodes.data()),
+      n_sampled_features < n_cols ? static_cast<int*>(model->global_feature_indices.data())
+                                  : nullptr,
+      static_cast<IsolationTree::IFNode<T>*>(model->global_nodes.data()),
       static_cast<int*>(model->global_tree_offsets.data()),
       static_cast<int*>(model->global_tree_n_nodes.data()),
       static_cast<int*>(model->global_tree_max_depth.data()));
@@ -151,7 +143,7 @@ class IsolationForest {
     int threads   = 256;
     size_t blocks = (n_rows + threads - 1) / threads;
 
-    auto* nodes        = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
+    auto* nodes        = static_cast<const IsolationTree::IFNode<T>*>(model->global_nodes.data());
     auto* tree_offsets = static_cast<const int*>(model->global_tree_offsets.data());
     IsolationTree::compute_path_lengths_global_kernel<T><<<blocks, threads, 0, stream>>>(
       input, n_rows, n_cols, nodes, tree_offsets, params.n_estimators, avg_path_lengths);
@@ -168,7 +160,7 @@ class IsolationForest {
                               T* scores) const
   {
     cudaStream_t stream = handle.get_stream();
-    T c_n               = model->c_normalization;
+    T c_n               = static_cast<T>(model->c_normalization);
 
     if (c_n <= T(0)) {
       thrust::fill(rmm::exec_policy(stream), scores, scores + n_rows, T(0.5));
@@ -188,15 +180,15 @@ template class IsolationForest<float>;
 template class IsolationForest<double>;
 
 template <typename T>
-CompactIFForest get_compact_trees(const raft::handle_t& handle,
-                                  const IsolationForestModel<T>* model)
+CompactIFForest<T> get_compact_trees(const raft::handle_t& handle,
+                                     const IsolationForestModel<T>* model)
 {
   int n_trees = model->params.n_estimators;
 
-  CompactIFForest result;
-  std::vector<IsolationTree::IFNode> raw_nodes;
+  CompactIFForest<T> result;
+  std::vector<IsolationTree::IFNode<T>> raw_nodes;
 
-  auto* d_nodes          = static_cast<const IsolationTree::IFNode*>(model->global_nodes.data());
+  auto* d_nodes          = static_cast<const IsolationTree::IFNode<T>*>(model->global_nodes.data());
   auto* d_tree_n_nodes   = static_cast<const int*>(model->global_tree_n_nodes.data());
   auto* d_tree_max_depth = static_cast<const int*>(model->global_tree_max_depth.data());
   IsolationTree::compact_global_isolation_forest<T>(handle,
@@ -211,16 +203,16 @@ CompactIFForest get_compact_trees(const raft::handle_t& handle,
                                                     result.tree_max_depth);
 
   result.nodes.resize(raw_nodes.size());
-  static_assert(sizeof(IFNodeCompact) == sizeof(IsolationTree::IFNode),
+  static_assert(sizeof(IFNodeCompact<T>) == sizeof(IsolationTree::IFNode<T>),
                 "IFNodeCompact and IFNode must have identical layout");
-  std::memcpy(result.nodes.data(), raw_nodes.data(), raw_nodes.size() * sizeof(IFNodeCompact));
+  std::memcpy(result.nodes.data(), raw_nodes.data(), raw_nodes.size() * sizeof(IFNodeCompact<T>));
 
   return result;
 }
 
-template CompactIFForest get_compact_trees<float>(const raft::handle_t&,
-                                                  const IsolationForestModel<float>*);
-template CompactIFForest get_compact_trees<double>(const raft::handle_t&,
-                                                   const IsolationForestModel<double>*);
+template CompactIFForest<float> get_compact_trees<float>(const raft::handle_t&,
+                                                         const IsolationForestModel<float>*);
+template CompactIFForest<double> get_compact_trees<double>(const raft::handle_t&,
+                                                           const IsolationForestModel<double>*);
 
 }  // namespace ML

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Shared device types and helpers for the batched Isolation Forest tree builder.
- * 
+ *
  * Key design decisions:
  * - All trees built in a single kernel launch (1 block per tree)
  * - Subsamples gathered into contiguous buffer to avoid scattered reads
@@ -15,18 +15,20 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
-#include <curand_kernel.h>
-
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
+
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cuda_runtime.h>
 #include <thrust/transform.h>
 
+#include <curand_kernel.h>
+
 #include <algorithm>
-#include <cstdint>
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 namespace ML {
@@ -86,8 +88,8 @@ __device__ __forceinline__ size_t sample_bounded(curandState* rng_state, size_t 
   if (bound <= 1) return 0;
 
   constexpr uint64_t max_uint64 = 0xffffffffffffffffULL;
-  uint64_t limit = max_uint64 - (max_uint64 % static_cast<uint64_t>(bound));
-  uint64_t value = curand_u64(rng_state);
+  uint64_t limit                = max_uint64 - (max_uint64 % static_cast<uint64_t>(bound));
+  uint64_t value                = curand_u64(rng_state);
   while (value >= limit) {
     value = curand_u64(rng_state);
   }
@@ -137,17 +139,17 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
   __syncthreads();
 
   if (tid == 0) {
-    int n_nodes           = 1;
+    int n_nodes            = 1;
     int observed_max_depth = 0;
-    int stack_top         = 0;
-    stack[stack_top++]    = {0, 0, n_samples, 0};
+    int stack_top          = 0;
+    stack[stack_top++]     = {0, 0, n_samples, 0};
 
     while (stack_top > 0) {
-      StackEntry entry = stack[--stack_top];
-      int node_idx     = entry.node_idx;
-      int start        = entry.start_idx;
-      int end          = entry.end_idx;
-      int depth        = entry.depth;
+      StackEntry entry   = stack[--stack_top];
+      int node_idx       = entry.node_idx;
+      int start          = entry.start_idx;
+      int end            = entry.end_idx;
+      int depth          = entry.depth;
       int n_node_samples = end - start;
       observed_max_depth = observed_max_depth > depth ? observed_max_depth : depth;
 
@@ -160,8 +162,7 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
         continue;
       }
 
-      int local_feature =
-        static_cast<int>(sample_bounded(rng_state, static_cast<size_t>(n_cols)));
+      int local_feature = static_cast<int>(sample_bounded(rng_state, static_cast<size_t>(n_cols)));
       int original_feature =
         feature_indices == nullptr ? local_feature : feature_indices[local_feature];
 
@@ -242,12 +243,12 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
 
   T* local_data = subsample_buffer + static_cast<size_t>(tree_id) * max_samples * max_features;
   size_t* tree_sample_indices = sample_indices + static_cast<size_t>(tree_id) * max_samples;
-  int* tree_feature_indices = feature_indices == nullptr ?
-                                nullptr :
-                                feature_indices + static_cast<size_t>(tree_id) * max_features;
-  int* tree_work_indices = work_indices + static_cast<size_t>(tree_id) * max_samples;
-  StackEntry* tree_stack = stack + static_cast<size_t>(tree_id) * max_nodes_per_tree;
-  IFNode* tree_nodes     = nodes + tree_offset;
+  int* tree_feature_indices   = feature_indices == nullptr
+                                  ? nullptr
+                                  : feature_indices + static_cast<size_t>(tree_id) * max_features;
+  int* tree_work_indices      = work_indices + static_cast<size_t>(tree_id) * max_samples;
+  StackEntry* tree_stack      = stack + static_cast<size_t>(tree_id) * max_nodes_per_tree;
+  IFNode* tree_nodes          = nodes + tree_offset;
 
   // Thread 0 samples source rows using sklearn IsolationForest semantics:
   // bootstrap=True samples with replacement; bootstrap=False samples without
@@ -260,8 +261,8 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
     } else {
       size_t start = n_rows - static_cast<size_t>(max_samples);
       for (int i = 0; i < max_samples; i++) {
-        size_t j = start + static_cast<size_t>(i);
-        size_t t = sample_bounded(&rng_state, j + 1);
+        size_t j               = start + static_cast<size_t>(i);
+        size_t t               = sample_bounded(&rng_state, j + 1);
         tree_sample_indices[i] = contains_sample(tree_sample_indices, i, t) ? j : t;
       }
     }
@@ -270,7 +271,7 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
       size_t start = static_cast<size_t>(n_cols - max_features);
       for (int i = 0; i < max_features; i++) {
         size_t j = start + static_cast<size_t>(i);
-        int t = static_cast<int>(sample_bounded(&rng_state, j + 1));
+        int t    = static_cast<int>(sample_bounded(&rng_state, j + 1));
         tree_feature_indices[i] =
           contains_int_sample(tree_feature_indices, i, t) ? static_cast<int>(j) : t;
       }
@@ -422,11 +423,8 @@ void compact_global_isolation_forest(const raft::handle_t& handle,
 
   h_tree_n_nodes.resize(n_trees);
   h_tree_max_depth.resize(n_trees);
-  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_n_nodes.data(),
-                                d_tree_n_nodes,
-                                n_trees * sizeof(int),
-                                cudaMemcpyDeviceToHost,
-                                stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(
+    h_tree_n_nodes.data(), d_tree_n_nodes, n_trees * sizeof(int), cudaMemcpyDeviceToHost, stream));
   RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_max_depth.data(),
                                 d_tree_max_depth,
                                 n_trees * sizeof(int),
@@ -449,8 +447,12 @@ void compact_global_isolation_forest(const raft::handle_t& handle,
                                 stream));
 
   rmm::device_uvector<IFNode> d_compact(total_nodes, stream);
-  compact_global_trees_kernel<T><<<n_trees, 128, 0, stream>>>(
-    d_nodes, n_trees, max_nodes_per_tree, d_tree_n_nodes, d_compact_offsets.data(), d_compact.data());
+  compact_global_trees_kernel<T><<<n_trees, 128, 0, stream>>>(d_nodes,
+                                                              n_trees,
+                                                              max_nodes_per_tree,
+                                                              d_tree_n_nodes,
+                                                              d_compact_offsets.data(),
+                                                              d_compact.data());
   RAFT_CUDA_TRY(cudaGetLastError());
 
   h_nodes.resize(total_nodes);

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -25,6 +25,7 @@
 #include <thrust/transform.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cmath>
 #include <vector>
 
@@ -73,6 +74,32 @@ inline bool is_dev_ptr(const void* ptr)
     return false;
   }
   return attr.type == cudaMemoryTypeDevice || attr.type == cudaMemoryTypeManaged;
+}
+
+__device__ __forceinline__ uint64_t curand_u64(curandState* rng_state)
+{
+  return (static_cast<uint64_t>(curand(rng_state)) << 32) | curand(rng_state);
+}
+
+__device__ __forceinline__ size_t sample_bounded(curandState* rng_state, size_t bound)
+{
+  if (bound <= 1) return 0;
+
+  constexpr uint64_t max_uint64 = 0xffffffffffffffffULL;
+  uint64_t limit = max_uint64 - (max_uint64 % static_cast<uint64_t>(bound));
+  uint64_t value = curand_u64(rng_state);
+  while (value >= limit) {
+    value = curand_u64(rng_state);
+  }
+  return static_cast<size_t>(value % static_cast<uint64_t>(bound));
+}
+
+__device__ bool contains_sample(const size_t* samples, int n_samples, size_t candidate)
+{
+  for (int i = 0; i < n_samples; ++i) {
+    if (samples[i] == candidate) return true;
+  }
+  return false;
 }
 
 /**
@@ -179,6 +206,7 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
                                                     int max_samples,
                                                     int max_depth,
                                                     int max_nodes_per_tree,
+                                                    bool bootstrap,
                                                     uint64_t seed,
                                                     IFNode* __restrict__ nodes,
                                                     int* __restrict__ tree_offsets,
@@ -204,12 +232,21 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
   StackEntry* tree_stack = stack + static_cast<size_t>(tree_id) * max_nodes_per_tree;
   IFNode* tree_nodes     = nodes + tree_offset;
 
-  // Thread 0 samples source rows with replacement. The broader sampling PR will
-  // replace this with sklearn's bootstrap-aware without/with-replacement modes.
+  // Thread 0 samples source rows using sklearn IsolationForest semantics:
+  // bootstrap=True samples with replacement; bootstrap=False samples without
+  // replacement. Bounded rejection sampling avoids modulo bias.
   if (threadIdx.x == 0) {
-    for (int i = 0; i < max_samples; i++) {
-      uint64_t rand64 = (static_cast<uint64_t>(curand(&rng_state)) << 32) | curand(&rng_state);
-      tree_sample_indices[i] = rand64 % n_rows;
+    if (bootstrap) {
+      for (int i = 0; i < max_samples; i++) {
+        tree_sample_indices[i] = sample_bounded(&rng_state, n_rows);
+      }
+    } else {
+      size_t start = n_rows - static_cast<size_t>(max_samples);
+      for (int i = 0; i < max_samples; i++) {
+        size_t j = start + static_cast<size_t>(i);
+        size_t t = sample_bounded(&rng_state, j + 1);
+        tree_sample_indices[i] = contains_sample(tree_sample_indices, i, t) ? j : t;
+      }
     }
   }
   __syncthreads();
@@ -282,6 +319,7 @@ void build_isolation_forest_global(const raft::handle_t& handle,
                                    int max_samples,
                                    int max_depth,
                                    int max_nodes_per_tree,
+                                   bool bootstrap,
                                    uint64_t seed,
                                    IFNode* nodes,
                                    int* tree_offsets,
@@ -303,6 +341,7 @@ void build_isolation_forest_global(const raft::handle_t& handle,
                                                                       max_samples,
                                                                       max_depth,
                                                                       max_nodes_per_tree,
+                                                                      bootstrap,
                                                                       seed,
                                                                       nodes,
                                                                       tree_offsets,

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -329,5 +329,114 @@ void build_isolation_forest(
   RAFT_CUDA_TRY(cudaGetLastError());
 }
 
+// ── Tree compaction: extract only used nodes for efficient D2H transfer ──────
+
+/**
+ * @brief Extract per-tree metadata (n_nodes, max_depth) from the padded
+ * IFTree structs. One thread per tree.
+ */
+template <typename T>
+__global__ void extract_tree_metadata_kernel(
+    const IFTree<T>* __restrict__ trees,
+    int n_trees,
+    int* __restrict__ n_nodes_out,
+    int* __restrict__ max_depth_out)
+{
+  int t = blockIdx.x * blockDim.x + threadIdx.x;
+  if (t >= n_trees) return;
+  n_nodes_out[t]  = trees[t].n_nodes;
+  max_depth_out[t] = trees[t].max_depth;
+}
+
+/**
+ * @brief Copy each tree's used nodes into a contiguous output buffer.
+ * One block per tree, threads cooperate on the copy.
+ */
+template <typename T>
+__global__ void compact_trees_kernel(
+    const IFTree<T>* __restrict__ trees,
+    int n_trees,
+    const int* __restrict__ offsets,
+    IFNode* __restrict__ compact_nodes)
+{
+  int tree_id = blockIdx.x;
+  if (tree_id >= n_trees) return;
+  int n = trees[tree_id].n_nodes;
+  int off = offsets[tree_id];
+  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+    compact_nodes[off + i] = trees[tree_id].nodes[i];
+  }
+}
+
+/**
+ * @brief Compact an isolation forest from padded IFTree structs into
+ * host-side vectors, minimizing the device-to-host transfer.
+ *
+ * Typical transfer: ~400 KB (100 trees × 255 nodes × 16B) instead of
+ * ~200 MB (100 trees × 131K nodes × 16B).
+ *
+ * @param[in]  handle          RAFT handle
+ * @param[in]  d_trees         Device pointer to padded IFTree<T> array
+ * @param[in]  n_trees         Number of trees
+ * @param[out] h_nodes         All used nodes concatenated (host)
+ * @param[out] h_tree_offsets  Start offset in h_nodes for each tree (host)
+ * @param[out] h_tree_n_nodes  Node count per tree (host)
+ * @param[out] h_tree_max_depth Max depth per tree (host)
+ */
+template <typename T>
+void compact_isolation_forest(
+    const raft::handle_t& handle,
+    const IFTree<T>* d_trees,
+    int n_trees,
+    std::vector<IFNode>& h_nodes,
+    std::vector<int>& h_tree_offsets,
+    std::vector<int>& h_tree_n_nodes,
+    std::vector<int>& h_tree_max_depth)
+{
+  auto stream = handle.get_stream();
+
+  // 1. Extract metadata from padded structs
+  rmm::device_uvector<int> d_n_nodes(n_trees, stream);
+  rmm::device_uvector<int> d_max_depth(n_trees, stream);
+
+  int threads = 128;
+  int blocks  = (n_trees + threads - 1) / threads;
+  extract_tree_metadata_kernel<T><<<blocks, threads, 0, stream>>>(
+      d_trees, n_trees, d_n_nodes.data(), d_max_depth.data());
+  RAFT_CUDA_TRY(cudaGetLastError());
+
+  // 2. Copy metadata to host and compute prefix-sum offsets
+  h_tree_n_nodes.resize(n_trees);
+  h_tree_max_depth.resize(n_trees);
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_n_nodes.data(), d_n_nodes.data(),
+                                  n_trees * sizeof(int), cudaMemcpyDeviceToHost, stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_max_depth.data(), d_max_depth.data(),
+                                  n_trees * sizeof(int), cudaMemcpyDeviceToHost, stream));
+  handle.sync_stream(stream);
+
+  h_tree_offsets.resize(n_trees);
+  int total_nodes = 0;
+  for (int t = 0; t < n_trees; ++t) {
+    h_tree_offsets[t] = total_nodes;
+    total_nodes += h_tree_n_nodes[t];
+  }
+
+  // 3. Compact nodes on device using the offsets
+  rmm::device_uvector<int> d_offsets(n_trees, stream);
+  RAFT_CUDA_TRY(cudaMemcpyAsync(d_offsets.data(), h_tree_offsets.data(),
+                                  n_trees * sizeof(int), cudaMemcpyHostToDevice, stream));
+
+  rmm::device_uvector<IFNode> d_compact(total_nodes, stream);
+  compact_trees_kernel<T><<<n_trees, 128, 0, stream>>>(
+      d_trees, n_trees, d_offsets.data(), d_compact.data());
+  RAFT_CUDA_TRY(cudaGetLastError());
+
+  // 4. Single compact D2H copy
+  h_nodes.resize(total_nodes);
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(), d_compact.data(),
+                                  total_nodes * sizeof(IFNode), cudaMemcpyDeviceToHost, stream));
+  handle.sync_stream(stream);
+}
+
 }  // namespace IsolationTree
 }  // namespace ML

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Lightweight batched Isolation Forest tree builder.
+ * Shared device types and helpers for the batched Isolation Forest tree builder.
  * 
  * Key design decisions:
  * - All trees built in a single kernel launch (1 block per tree)
@@ -24,13 +24,19 @@
 #include <rmm/exec_policy.hpp>
 #include <thrust/transform.h>
 
+#include <algorithm>
 #include <cmath>
+#include <vector>
 
 namespace ML {
 namespace IsolationTree {
 
-constexpr int MAX_DEPTH = 16;  // Supports up to 2^16 = 65536 samples per tree
-constexpr int MAX_NODES = (1 << (MAX_DEPTH + 1)) - 1;  // Complete binary tree nodes
+struct StackEntry {
+  int node_idx;
+  int start_idx;
+  int end_idx;
+  int depth;
+};
 
 /**
  * @brief Compute c(n) = 2H(n-1) - 2(n-1)/n, the expected path length in an
@@ -57,13 +63,6 @@ struct IFNode {
   int right_child;
 };
 
-template <typename T>
-struct IFTree {
-  IFNode nodes[MAX_NODES];
-  int n_nodes;
-  int max_depth;
-};
-
 /** @brief Check if pointer is on GPU (for input validation). */
 inline bool is_dev_ptr(const void* ptr)
 {
@@ -77,67 +76,56 @@ inline bool is_dev_ptr(const void* ptr)
 }
 
 /**
- * @brief Build one isolation tree from pre-gathered subsample data.
- * 
- * Uses iterative DFS with explicit stack 
- * Only thread 0 builds the tree; other threads help with initialization.
- * 
- * @param local_data Subsample data in row-major [max_samples x n_cols]
+ * @brief Build one isolation tree into global-memory node storage.
+ *
+ * Stack and partition indices are supplied by global RMM buffers so depth and
+ * max_samples are not constrained by fixed per-block shared-memory storage.
  */
 template <typename T>
-__device__ void build_tree_iterative_local(
-    const T* __restrict__ local_data,
-    int n_samples,
-    int n_cols,
-    int max_samples,
-    int max_depth,
-    curandState* rng_state,
-    IFTree<T>* tree)
+__device__ void build_tree_iterative_global(const T* __restrict__ local_data,
+                                            int n_samples,
+                                            int n_cols,
+                                            int max_depth,
+                                            int max_nodes_per_tree,
+                                            curandState* rng_state,
+                                            IFNode* nodes,
+                                            int* n_nodes_out,
+                                            int* max_depth_out,
+                                            int* work_indices,
+                                            StackEntry* stack)
 {
-  struct StackEntry { int node_idx, start_idx, end_idx, depth; };
-  
-  // Shared memory layout: [stack for DFS] [work_indices for partitioning]
-  extern __shared__ char shared_mem[];
-  StackEntry* stack = reinterpret_cast<StackEntry*>(shared_mem);
-  int* work_indices = reinterpret_cast<int*>(shared_mem + sizeof(int) * 4 * MAX_DEPTH * 2);
-  
-  // Initialize work_indices = [0, 1, 2, ..., n_samples-1]
   int tid = threadIdx.x;
   for (int i = tid; i < n_samples; i += blockDim.x) {
     work_indices[i] = i;
   }
   __syncthreads();
-  
+
   if (tid == 0) {
-    tree->n_nodes = 0;
-    tree->max_depth = max_depth;
-  }
-  __syncthreads();
-  
-  // Single-threaded tree construction (tree building is inherently sequential)
-  if (tid == 0) {
-    int stack_top = 0;
-    stack[stack_top++] = {0, 0, n_samples, 0};
-    tree->n_nodes = 1;
-    
+    int n_nodes           = 1;
+    int observed_max_depth = 0;
+    int stack_top         = 0;
+    stack[stack_top++]    = {0, 0, n_samples, 0};
+
     while (stack_top > 0) {
       StackEntry entry = stack[--stack_top];
-      int node_idx = entry.node_idx;
-      int start = entry.start_idx;
-      int end = entry.end_idx;
-      int depth = entry.depth;
+      int node_idx     = entry.node_idx;
+      int start        = entry.start_idx;
+      int end          = entry.end_idx;
+      int depth        = entry.depth;
       int n_node_samples = end - start;
-      
-      // Stopping condition: max depth or isolated sample
-      if (depth >= max_depth || n_node_samples <= 1) {
+      observed_max_depth = observed_max_depth > depth ? observed_max_depth : depth;
+
+      if (node_idx >= max_nodes_per_tree) { continue; }
+
+      // Stopping condition: max depth, isolated sample, or exhausted capacity.
+      if (depth >= max_depth || n_node_samples <= 1 || n_nodes + 2 > max_nodes_per_tree) {
         float path_length = static_cast<float>(depth) + compute_c_n(n_node_samples);
-        tree->nodes[node_idx] = {-1, path_length, -1, -1};
+        nodes[node_idx]   = {-1, path_length, -1, -1};
         continue;
       }
-      
+
       int feature = curand(rng_state) % n_cols;
-      
-      // Find min/max of selected feature in current partition
+
       T min_val = local_data[work_indices[start] * n_cols + feature];
       T max_val = min_val;
       for (int i = start + 1; i < end; i++) {
@@ -145,273 +133,233 @@ __device__ void build_tree_iterative_local(
         if (val < min_val) min_val = val;
         if (val > max_val) max_val = val;
       }
-      
-      // All values identical -> can't split, make leaf
+
       if (min_val >= max_val) {
         float path_length = static_cast<float>(depth) + compute_c_n(n_node_samples);
-        tree->nodes[node_idx] = {-1, path_length, -1, -1};
+        nodes[node_idx]   = {-1, path_length, -1, -1};
         continue;
       }
-      
-      // Random threshold in (min, max) - core of Isolation Forest
+
       float rand_frac = curand_uniform(rng_state);
-      T threshold = min_val + static_cast<T>(rand_frac) * (max_val - min_val);
-      
-      // Partition: move samples < threshold to left side (in-place swap)
+      T threshold     = min_val + static_cast<T>(rand_frac) * (max_val - min_val);
+
       int left_end = start;
       for (int i = start; i < end; i++) {
         T val = local_data[work_indices[i] * n_cols + feature];
         if (val < threshold) {
-          int tmp = work_indices[left_end];
+          int tmp                = work_indices[left_end];
           work_indices[left_end] = work_indices[i];
-          work_indices[i] = tmp;
+          work_indices[i]        = tmp;
           left_end++;
         }
       }
-      
-      // Edge case: all samples went to one side (shouldn't happen)
-      if (left_end == start || left_end == end) {
-        left_end = start + n_node_samples / 2;
-      }
-      
-      int left_child = tree->n_nodes;
-      int right_child = tree->n_nodes + 1;
-      tree->n_nodes += 2;
-      
-      tree->nodes[node_idx] = {feature, static_cast<float>(threshold), left_child, right_child};
-      
-      // Push children (right first so left is processed first - DFS order)
+
+      if (left_end == start || left_end == end) { left_end = start + n_node_samples / 2; }
+
+      int left_child  = n_nodes;
+      int right_child = n_nodes + 1;
+      n_nodes += 2;
+
+      nodes[node_idx] = {feature, static_cast<float>(threshold), left_child, right_child};
+
       stack[stack_top++] = {right_child, left_end, end, depth + 1};
       stack[stack_top++] = {left_child, start, left_end, depth + 1};
     }
+
+    *n_nodes_out   = n_nodes;
+    *max_depth_out = observed_max_depth;
   }
-  __syncthreads();
 }
 
-/**
- * @brief Main kernel: each block builds one complete isolation tree.
- * 
- * Phase 1: Generate random sample indices and gather data into contiguous buffer
- * Phase 2: Build tree from gathered data (avoids scattered global memory reads)
- */
 template <typename T>
-__global__ void build_isolation_trees_kernel(
-    const T* __restrict__ data,         // Full dataset [n_rows x n_cols] column-major
-    size_t n_rows,                       // Use size_t to support large datasets (>2B elements)
-    int n_cols,
-    int n_trees,
-    int max_samples,
-    int max_depth,
-    uint64_t seed,
-    IFTree<T>* trees,
-    T* __restrict__ subsample_buffer)   // [n_trees x max_samples x n_cols] row-major
+__global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
+                                                    size_t n_rows,
+                                                    int n_cols,
+                                                    int n_trees,
+                                                    int max_samples,
+                                                    int max_depth,
+                                                    int max_nodes_per_tree,
+                                                    uint64_t seed,
+                                                    IFNode* __restrict__ nodes,
+                                                    int* __restrict__ tree_offsets,
+                                                    int* __restrict__ tree_n_nodes,
+                                                    int* __restrict__ tree_max_depth,
+                                                    T* __restrict__ subsample_buffer,
+                                                    size_t* __restrict__ sample_indices,
+                                                    int* __restrict__ work_indices,
+                                                    StackEntry* __restrict__ stack)
 {
   int tree_id = blockIdx.x;
   if (tree_id >= n_trees) return;
-  
-  // Each tree gets unique RNG state (seed + tree_id)
+
   curandState rng_state;
   curand_init(seed, tree_id, 0, &rng_state);
-  
-  T* local_data = subsample_buffer + tree_id * max_samples * n_cols;
-  
-  extern __shared__ char shared_mem[];
-  size_t* sample_indices = reinterpret_cast<size_t*>(shared_mem + sizeof(int) * 4 * MAX_DEPTH * 2);
-  
-  // Thread 0 generates random sample indices
+
+  int tree_offset = tree_id * max_nodes_per_tree;
+  if (threadIdx.x == 0) { tree_offsets[tree_id] = tree_offset; }
+
+  T* local_data = subsample_buffer + static_cast<size_t>(tree_id) * max_samples * n_cols;
+  size_t* tree_sample_indices = sample_indices + static_cast<size_t>(tree_id) * max_samples;
+  int* tree_work_indices = work_indices + static_cast<size_t>(tree_id) * max_samples;
+  StackEntry* tree_stack = stack + static_cast<size_t>(tree_id) * max_nodes_per_tree;
+  IFNode* tree_nodes     = nodes + tree_offset;
+
+  // Thread 0 samples source rows with replacement. The broader sampling PR will
+  // replace this with sklearn's bootstrap-aware without/with-replacement modes.
   if (threadIdx.x == 0) {
     for (int i = 0; i < max_samples; i++) {
-      // Use 64-bit random for proper sampling from large datasets (>2B rows)
       uint64_t rand64 = (static_cast<uint64_t>(curand(&rng_state)) << 32) | curand(&rng_state);
-      sample_indices[i] = rand64 % n_rows;
+      tree_sample_indices[i] = rand64 % n_rows;
     }
   }
   __syncthreads();
-  
-  // All threads gather subsample data (coalesced writes to local_data).
-  // We copy regardless of input layout to get 256 samples into a contiguous
-  // buffer for cache-friendly tree building. The col-major→row-major conversion
-  // is just different index math during this already-required copy.
+
   int tid = threadIdx.x;
   for (int s = 0; s < max_samples; s++) {
-    size_t src_row = sample_indices[s];
+    size_t src_row = tree_sample_indices[s];
     for (int f = tid; f < n_cols; f += blockDim.x) {
       local_data[s * n_cols + f] = data[src_row + static_cast<size_t>(f) * n_rows];
     }
   }
   __syncthreads();
-  
-  build_tree_iterative_local(local_data, max_samples, n_cols, max_samples, max_depth, &rng_state, &trees[tree_id]);
+
+  build_tree_iterative_global(local_data,
+                              max_samples,
+                              n_cols,
+                              max_depth,
+                              max_nodes_per_tree,
+                              &rng_state,
+                              tree_nodes,
+                              tree_n_nodes + tree_id,
+                              tree_max_depth + tree_id,
+                              tree_work_indices,
+                              tree_stack);
 }
 
-/**
- * @brief Traverse tree to get path length for one sample.
- *
- * Leaf nodes store pre-computed path lengths (depth + c(n)), so traversal
- * simply walks to the leaf and returns the stored value.
- */
 template <typename T>
-__device__ T traverse_tree(const IFTree<T>* tree, const T* sample, int n_cols)
+__device__ T traverse_global_tree(const IFNode* tree_nodes, const T* sample, int n_cols)
 {
   int node_idx = 0;
-  
+
   while (true) {
-    const IFNode& node = tree->nodes[node_idx];
-    
-    if (node.feature_idx < 0) {
-      return static_cast<T>(node.threshold);
-    }
-    
-    T val = sample[node.feature_idx];
+    const IFNode& node = tree_nodes[node_idx];
+
+    if (node.feature_idx < 0) { return static_cast<T>(node.threshold); }
+
+    T val    = sample[node.feature_idx];
     node_idx = (val < static_cast<T>(node.threshold)) ? node.left_child : node.right_child;
   }
 }
 
-/**
- * @brief Compute average path length across all trees for each sample.
- * Each thread handles one sample.
- */
 template <typename T>
-__global__ void compute_path_lengths_kernel(
-    const T* __restrict__ data,     // [n_samples x n_cols] row-major
-    size_t n_samples,
-    int n_cols,
-    const IFTree<T>* __restrict__ trees,
-    int n_trees,
-    T* __restrict__ path_lengths)   // Output: [n_samples]
+__global__ void compute_path_lengths_global_kernel(const T* __restrict__ data,
+                                                   size_t n_samples,
+                                                   int n_cols,
+                                                   const IFNode* __restrict__ nodes,
+                                                   const int* __restrict__ tree_offsets,
+                                                   int n_trees,
+                                                   T* __restrict__ path_lengths)
 {
   size_t sample_idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (sample_idx >= n_samples) return;
-  
+
   const T* sample = data + sample_idx * n_cols;
-  
+
   T total_path = T(0);
   for (int t = 0; t < n_trees; t++) {
-    total_path += traverse_tree(&trees[t], sample, n_cols);
+    total_path += traverse_global_tree(nodes + tree_offsets[t], sample, n_cols);
   }
-  
+
   path_lengths[sample_idx] = (n_trees > 0) ? total_path / static_cast<T>(n_trees) : T(0);
 }
 
-/**
- * @brief Host function to build all isolation trees.
- * 
- * Allocates temporary buffer for gathered subsamples, launches kernel,
- * then buffer is freed automatically when function returns.
- */
 template <typename T>
-void build_isolation_forest(
-    const raft::handle_t& handle,
-    const T* data,              // [n_rows x n_cols] column-major
-    size_t n_rows,              // Use size_t to support large datasets
-    int n_cols,
-    int n_trees,
-    int max_samples,
-    int max_depth,
-    uint64_t seed,
-    IFTree<T>* d_trees)         // Output: device array [n_trees]
+void build_isolation_forest_global(const raft::handle_t& handle,
+                                   const T* data,
+                                   size_t n_rows,
+                                   int n_cols,
+                                   int n_trees,
+                                   int max_samples,
+                                   int max_depth,
+                                   int max_nodes_per_tree,
+                                   uint64_t seed,
+                                   IFNode* nodes,
+                                   int* tree_offsets,
+                                   int* tree_n_nodes,
+                                   int* tree_max_depth)
 {
   auto stream = handle.get_stream();
-  
-  // Temp buffer: [n_trees x max_samples x n_cols] for gathered subsamples
-  // ~10MB for typical 100 trees x 256 samples x 100 features x float
+
   size_t subsample_buffer_size = static_cast<size_t>(n_trees) * max_samples * n_cols;
   rmm::device_uvector<T> subsample_buffer(subsample_buffer_size, stream);
-  
-  // Shared memory: stack for DFS + sample indices (size_t for >2B row support)
-  int stack_size = MAX_DEPTH * 2 * 4 * sizeof(int);
-  int indices_size = max_samples * sizeof(size_t);
-  int shared_mem_size = stack_size + indices_size;
-  
-  build_isolation_trees_kernel<T><<<n_trees, 128, shared_mem_size, stream>>>(
-      data, n_rows, n_cols, n_trees, max_samples, max_depth, seed, d_trees, subsample_buffer.data());
-  
+  rmm::device_uvector<size_t> sample_indices(static_cast<size_t>(n_trees) * max_samples, stream);
+  rmm::device_uvector<int> work_indices(static_cast<size_t>(n_trees) * max_samples, stream);
+  rmm::device_uvector<StackEntry> stack(static_cast<size_t>(n_trees) * max_nodes_per_tree, stream);
+
+  build_isolation_trees_global_kernel<T><<<n_trees, 128, 0, stream>>>(data,
+                                                                      n_rows,
+                                                                      n_cols,
+                                                                      n_trees,
+                                                                      max_samples,
+                                                                      max_depth,
+                                                                      max_nodes_per_tree,
+                                                                      seed,
+                                                                      nodes,
+                                                                      tree_offsets,
+                                                                      tree_n_nodes,
+                                                                      tree_max_depth,
+                                                                      subsample_buffer.data(),
+                                                                      sample_indices.data(),
+                                                                      work_indices.data(),
+                                                                      stack.data());
+
   RAFT_CUDA_TRY(cudaGetLastError());
 }
 
-// ── Tree compaction: extract only used nodes for efficient D2H transfer ──────
-
-/**
- * @brief Extract per-tree metadata (n_nodes, max_depth) from the padded
- * IFTree structs. One thread per tree.
- */
 template <typename T>
-__global__ void extract_tree_metadata_kernel(
-    const IFTree<T>* __restrict__ trees,
-    int n_trees,
-    int* __restrict__ n_nodes_out,
-    int* __restrict__ max_depth_out)
-{
-  int t = blockIdx.x * blockDim.x + threadIdx.x;
-  if (t >= n_trees) return;
-  n_nodes_out[t]  = trees[t].n_nodes;
-  max_depth_out[t] = trees[t].max_depth;
-}
-
-/**
- * @brief Copy each tree's used nodes into a contiguous output buffer.
- * One block per tree, threads cooperate on the copy.
- */
-template <typename T>
-__global__ void compact_trees_kernel(
-    const IFTree<T>* __restrict__ trees,
-    int n_trees,
-    const int* __restrict__ offsets,
-    IFNode* __restrict__ compact_nodes)
+__global__ void compact_global_trees_kernel(const IFNode* __restrict__ nodes,
+                                            int n_trees,
+                                            int max_nodes_per_tree,
+                                            const int* __restrict__ tree_n_nodes,
+                                            const int* __restrict__ compact_offsets,
+                                            IFNode* __restrict__ compact_nodes)
 {
   int tree_id = blockIdx.x;
   if (tree_id >= n_trees) return;
-  int n = trees[tree_id].n_nodes;
-  int off = offsets[tree_id];
+  int n       = tree_n_nodes[tree_id];
+  int src_off = tree_id * max_nodes_per_tree;
+  int dst_off = compact_offsets[tree_id];
   for (int i = threadIdx.x; i < n; i += blockDim.x) {
-    compact_nodes[off + i] = trees[tree_id].nodes[i];
+    compact_nodes[dst_off + i] = nodes[src_off + i];
   }
 }
 
-/**
- * @brief Compact an isolation forest from padded IFTree structs into
- * host-side vectors, minimizing the device-to-host transfer.
- *
- * Typical transfer: ~400 KB (100 trees × 255 nodes × 16B) instead of
- * ~200 MB (100 trees × 131K nodes × 16B).
- *
- * @param[in]  handle          RAFT handle
- * @param[in]  d_trees         Device pointer to padded IFTree<T> array
- * @param[in]  n_trees         Number of trees
- * @param[out] h_nodes         All used nodes concatenated (host)
- * @param[out] h_tree_offsets  Start offset in h_nodes for each tree (host)
- * @param[out] h_tree_n_nodes  Node count per tree (host)
- * @param[out] h_tree_max_depth Max depth per tree (host)
- */
 template <typename T>
-void compact_isolation_forest(
-    const raft::handle_t& handle,
-    const IFTree<T>* d_trees,
-    int n_trees,
-    std::vector<IFNode>& h_nodes,
-    std::vector<int>& h_tree_offsets,
-    std::vector<int>& h_tree_n_nodes,
-    std::vector<int>& h_tree_max_depth)
+void compact_global_isolation_forest(const raft::handle_t& handle,
+                                     const IFNode* d_nodes,
+                                     const int* d_tree_n_nodes,
+                                     const int* d_tree_max_depth,
+                                     int n_trees,
+                                     int max_nodes_per_tree,
+                                     std::vector<IFNode>& h_nodes,
+                                     std::vector<int>& h_tree_offsets,
+                                     std::vector<int>& h_tree_n_nodes,
+                                     std::vector<int>& h_tree_max_depth)
 {
   auto stream = handle.get_stream();
 
-  // 1. Extract metadata from padded structs
-  rmm::device_uvector<int> d_n_nodes(n_trees, stream);
-  rmm::device_uvector<int> d_max_depth(n_trees, stream);
-
-  int threads = 128;
-  int blocks  = (n_trees + threads - 1) / threads;
-  extract_tree_metadata_kernel<T><<<blocks, threads, 0, stream>>>(
-      d_trees, n_trees, d_n_nodes.data(), d_max_depth.data());
-  RAFT_CUDA_TRY(cudaGetLastError());
-
-  // 2. Copy metadata to host and compute prefix-sum offsets
   h_tree_n_nodes.resize(n_trees);
   h_tree_max_depth.resize(n_trees);
-  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_n_nodes.data(), d_n_nodes.data(),
-                                  n_trees * sizeof(int), cudaMemcpyDeviceToHost, stream));
-  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_max_depth.data(), d_max_depth.data(),
-                                  n_trees * sizeof(int), cudaMemcpyDeviceToHost, stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_n_nodes.data(),
+                                d_tree_n_nodes,
+                                n_trees * sizeof(int),
+                                cudaMemcpyDeviceToHost,
+                                stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_max_depth.data(),
+                                d_tree_max_depth,
+                                n_trees * sizeof(int),
+                                cudaMemcpyDeviceToHost,
+                                stream));
   handle.sync_stream(stream);
 
   h_tree_offsets.resize(n_trees);
@@ -421,20 +369,24 @@ void compact_isolation_forest(
     total_nodes += h_tree_n_nodes[t];
   }
 
-  // 3. Compact nodes on device using the offsets
-  rmm::device_uvector<int> d_offsets(n_trees, stream);
-  RAFT_CUDA_TRY(cudaMemcpyAsync(d_offsets.data(), h_tree_offsets.data(),
-                                  n_trees * sizeof(int), cudaMemcpyHostToDevice, stream));
+  rmm::device_uvector<int> d_compact_offsets(n_trees, stream);
+  RAFT_CUDA_TRY(cudaMemcpyAsync(d_compact_offsets.data(),
+                                h_tree_offsets.data(),
+                                n_trees * sizeof(int),
+                                cudaMemcpyHostToDevice,
+                                stream));
 
   rmm::device_uvector<IFNode> d_compact(total_nodes, stream);
-  compact_trees_kernel<T><<<n_trees, 128, 0, stream>>>(
-      d_trees, n_trees, d_offsets.data(), d_compact.data());
+  compact_global_trees_kernel<T><<<n_trees, 128, 0, stream>>>(
+    d_nodes, n_trees, max_nodes_per_tree, d_tree_n_nodes, d_compact_offsets.data(), d_compact.data());
   RAFT_CUDA_TRY(cudaGetLastError());
 
-  // 4. Single compact D2H copy
   h_nodes.resize(total_nodes);
-  RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(), d_compact.data(),
-                                  total_nodes * sizeof(IFNode), cudaMemcpyDeviceToHost, stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(),
+                                d_compact.data(),
+                                total_nodes * sizeof(IFNode),
+                                cudaMemcpyDeviceToHost,
+                                stream));
   handle.sync_stream(stream);
 }
 

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -102,6 +102,14 @@ __device__ bool contains_sample(const size_t* samples, int n_samples, size_t can
   return false;
 }
 
+__device__ bool contains_int_sample(const int* samples, int n_samples, int candidate)
+{
+  for (int i = 0; i < n_samples; ++i) {
+    if (samples[i] == candidate) return true;
+  }
+  return false;
+}
+
 /**
  * @brief Build one isolation tree into global-memory node storage.
  *
@@ -112,6 +120,7 @@ template <typename T>
 __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
                                             int n_samples,
                                             int n_cols,
+                                            const int* feature_indices,
                                             int max_depth,
                                             int max_nodes_per_tree,
                                             curandState* rng_state,
@@ -151,12 +160,15 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
         continue;
       }
 
-      int feature = curand(rng_state) % n_cols;
+      int local_feature =
+        static_cast<int>(sample_bounded(rng_state, static_cast<size_t>(n_cols)));
+      int original_feature =
+        feature_indices == nullptr ? local_feature : feature_indices[local_feature];
 
-      T min_val = local_data[work_indices[start] * n_cols + feature];
+      T min_val = local_data[work_indices[start] * n_cols + local_feature];
       T max_val = min_val;
       for (int i = start + 1; i < end; i++) {
-        T val = local_data[work_indices[i] * n_cols + feature];
+        T val = local_data[work_indices[i] * n_cols + local_feature];
         if (val < min_val) min_val = val;
         if (val > max_val) max_val = val;
       }
@@ -172,7 +184,7 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
 
       int left_end = start;
       for (int i = start; i < end; i++) {
-        T val = local_data[work_indices[i] * n_cols + feature];
+        T val = local_data[work_indices[i] * n_cols + local_feature];
         if (val < threshold) {
           int tmp                = work_indices[left_end];
           work_indices[left_end] = work_indices[i];
@@ -187,7 +199,7 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
       int right_child = n_nodes + 1;
       n_nodes += 2;
 
-      nodes[node_idx] = {feature, static_cast<float>(threshold), left_child, right_child};
+      nodes[node_idx] = {original_feature, static_cast<float>(threshold), left_child, right_child};
 
       stack[stack_top++] = {right_child, left_end, end, depth + 1};
       stack[stack_top++] = {left_child, start, left_end, depth + 1};
@@ -204,10 +216,12 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
                                                     int n_cols,
                                                     int n_trees,
                                                     int max_samples,
+                                                    int max_features,
                                                     int max_depth,
                                                     int max_nodes_per_tree,
                                                     bool bootstrap,
                                                     uint64_t seed,
+                                                    int* __restrict__ feature_indices,
                                                     IFNode* __restrict__ nodes,
                                                     int* __restrict__ tree_offsets,
                                                     int* __restrict__ tree_n_nodes,
@@ -226,8 +240,11 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
   int tree_offset = tree_id * max_nodes_per_tree;
   if (threadIdx.x == 0) { tree_offsets[tree_id] = tree_offset; }
 
-  T* local_data = subsample_buffer + static_cast<size_t>(tree_id) * max_samples * n_cols;
+  T* local_data = subsample_buffer + static_cast<size_t>(tree_id) * max_samples * max_features;
   size_t* tree_sample_indices = sample_indices + static_cast<size_t>(tree_id) * max_samples;
+  int* tree_feature_indices = feature_indices == nullptr ?
+                                nullptr :
+                                feature_indices + static_cast<size_t>(tree_id) * max_features;
   int* tree_work_indices = work_indices + static_cast<size_t>(tree_id) * max_samples;
   StackEntry* tree_stack = stack + static_cast<size_t>(tree_id) * max_nodes_per_tree;
   IFNode* tree_nodes     = nodes + tree_offset;
@@ -248,21 +265,33 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
         tree_sample_indices[i] = contains_sample(tree_sample_indices, i, t) ? j : t;
       }
     }
+
+    if (tree_feature_indices != nullptr) {
+      size_t start = static_cast<size_t>(n_cols - max_features);
+      for (int i = 0; i < max_features; i++) {
+        size_t j = start + static_cast<size_t>(i);
+        int t = static_cast<int>(sample_bounded(&rng_state, j + 1));
+        tree_feature_indices[i] =
+          contains_int_sample(tree_feature_indices, i, t) ? static_cast<int>(j) : t;
+      }
+    }
   }
   __syncthreads();
 
   int tid = threadIdx.x;
   for (int s = 0; s < max_samples; s++) {
     size_t src_row = tree_sample_indices[s];
-    for (int f = tid; f < n_cols; f += blockDim.x) {
-      local_data[s * n_cols + f] = data[src_row + static_cast<size_t>(f) * n_rows];
+    for (int f = tid; f < max_features; f += blockDim.x) {
+      int src_col = tree_feature_indices == nullptr ? f : tree_feature_indices[f];
+      local_data[s * max_features + f] = data[src_row + static_cast<size_t>(src_col) * n_rows];
     }
   }
   __syncthreads();
 
   build_tree_iterative_global(local_data,
                               max_samples,
-                              n_cols,
+                              max_features,
+                              tree_feature_indices,
                               max_depth,
                               max_nodes_per_tree,
                               &rng_state,
@@ -317,10 +346,12 @@ void build_isolation_forest_global(const raft::handle_t& handle,
                                    int n_cols,
                                    int n_trees,
                                    int max_samples,
+                                   int max_features,
                                    int max_depth,
                                    int max_nodes_per_tree,
                                    bool bootstrap,
                                    uint64_t seed,
+                                   int* feature_indices,
                                    IFNode* nodes,
                                    int* tree_offsets,
                                    int* tree_n_nodes,
@@ -328,7 +359,7 @@ void build_isolation_forest_global(const raft::handle_t& handle,
 {
   auto stream = handle.get_stream();
 
-  size_t subsample_buffer_size = static_cast<size_t>(n_trees) * max_samples * n_cols;
+  size_t subsample_buffer_size = static_cast<size_t>(n_trees) * max_samples * max_features;
   rmm::device_uvector<T> subsample_buffer(subsample_buffer_size, stream);
   rmm::device_uvector<size_t> sample_indices(static_cast<size_t>(n_trees) * max_samples, stream);
   rmm::device_uvector<int> work_indices(static_cast<size_t>(n_trees) * max_samples, stream);
@@ -339,10 +370,12 @@ void build_isolation_forest_global(const raft::handle_t& handle,
                                                                       n_cols,
                                                                       n_trees,
                                                                       max_samples,
+                                                                      max_features,
                                                                       max_depth,
                                                                       max_nodes_per_tree,
                                                                       bootstrap,
                                                                       seed,
+                                                                      feature_indices,
                                                                       nodes,
                                                                       tree_offsets,
                                                                       tree_n_nodes,

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -9,6 +9,8 @@
  * - Subsamples gathered into contiguous buffer to avoid scattered reads
  * - Tree built iteratively using a stack (no recursion in CUDA)
  * - Random splits: pick random feature, then random threshold in [min, max]
+ * - Leaf nodes store pre-computed path lengths (depth + c(n)) so that
+ *   inference is a simple tree traversal with no per-leaf computation
  */
 
 #pragma once
@@ -31,9 +33,22 @@ constexpr int MAX_DEPTH = 16;  // Supports up to 2^16 = 65536 samples per tree
 constexpr int MAX_NODES = (1 << (MAX_DEPTH + 1)) - 1;  // Complete binary tree nodes
 
 /**
+ * @brief Compute c(n) = 2H(n-1) - 2(n-1)/n, the expected path length in an
+ * unsuccessful BST search (used for adjusting isolation depth at leaves).
+ */
+__device__ __forceinline__ float compute_c_n(int n_samples)
+{
+  if (n_samples <= 1) return 0.0f;
+  if (n_samples == 2) return 1.0f;
+  float n = static_cast<float>(n_samples);
+  return 2.0f * (logf(n - 1.0f) + 0.5772156649f) - 2.0f * (n - 1.0f) / n;
+}
+
+/**
  * @brief Tree node structure.
  * Internal nodes: feature_idx >= 0, threshold is split value
- * Leaf nodes: feature_idx = -1, threshold stores sample count (for c(n) adjustment)
+ * Leaf nodes: feature_idx = -1, threshold stores pre-computed path length
+ *             (depth + c(n_samples)) for direct use by inference
  */
 struct IFNode {
   int feature_idx;
@@ -115,7 +130,8 @@ __device__ void build_tree_iterative_local(
       
       // Stopping condition: max depth or isolated sample
       if (depth >= max_depth || n_node_samples <= 1) {
-        tree->nodes[node_idx] = {-1, static_cast<float>(n_node_samples), -1, -1};
+        float path_length = static_cast<float>(depth) + compute_c_n(n_node_samples);
+        tree->nodes[node_idx] = {-1, path_length, -1, -1};
         continue;
       }
       
@@ -132,7 +148,8 @@ __device__ void build_tree_iterative_local(
       
       // All values identical -> can't split, make leaf
       if (min_val >= max_val) {
-        tree->nodes[node_idx] = {-1, static_cast<float>(n_node_samples), -1, -1};
+        float path_length = static_cast<float>(depth) + compute_c_n(n_node_samples);
+        tree->nodes[node_idx] = {-1, path_length, -1, -1};
         continue;
       }
       
@@ -228,35 +245,25 @@ __global__ void build_isolation_trees_kernel(
 }
 
 /**
- * @brief Traverse tree to compute path length for one sample.
- * 
- * Path length = depth + c(n) adjustment for leaf's remaining samples.
- * c(n) accounts for expected additional depth if tree were fully grown.
+ * @brief Traverse tree to get path length for one sample.
+ *
+ * Leaf nodes store pre-computed path lengths (depth + c(n)), so traversal
+ * simply walks to the leaf and returns the stored value.
  */
 template <typename T>
 __device__ T traverse_tree(const IFTree<T>* tree, const T* sample, int n_cols)
 {
   int node_idx = 0;
-  int depth = 0;
   
   while (true) {
     const IFNode& node = tree->nodes[node_idx];
     
     if (node.feature_idx < 0) {
-      // Leaf: add c(n) for unbuilt subtree
-      int n_samples = static_cast<int>(node.threshold);
-      T c_n = T(0);
-      if (n_samples > 1) {
-        // c(n) = 2*H(n-1) - 2*(n-1)/n, H(k) ≈ ln(k) + γ
-        T n = static_cast<T>(n_samples);
-        c_n = T(2) * (log(n - T(1)) + T(0.5772156649)) - T(2) * (n - T(1)) / n;
-      }
-      return static_cast<T>(depth) + c_n;
+      return static_cast<T>(node.threshold);
     }
     
     T val = sample[node.feature_idx];
     node_idx = (val < static_cast<T>(node.threshold)) ? node.left_child : node.right_child;
-    depth++;
   }
 }
 

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -1,0 +1,326 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Lightweight batched Isolation Forest tree builder.
+ * 
+ * Key design decisions:
+ * - All trees built in a single kernel launch (1 block per tree)
+ * - Subsamples gathered into contiguous buffer to avoid scattered reads
+ * - Tree built iteratively using a stack (no recursion in CUDA)
+ * - Random splits: pick random feature, then random threshold in [min, max]
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+
+#include <raft/core/handle.hpp>
+#include <raft/util/cudart_utils.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+#include <thrust/transform.h>
+
+#include <cmath>
+
+namespace ML {
+namespace IsolationTree {
+
+constexpr int MAX_DEPTH = 16;  // Supports up to 2^16 = 65536 samples per tree
+constexpr int MAX_NODES = (1 << (MAX_DEPTH + 1)) - 1;  // Complete binary tree nodes
+
+/**
+ * @brief Tree node structure.
+ * Internal nodes: feature_idx >= 0, threshold is split value
+ * Leaf nodes: feature_idx = -1, threshold stores sample count (for c(n) adjustment)
+ */
+struct IFNode {
+  int feature_idx;
+  float threshold;
+  int left_child;
+  int right_child;
+};
+
+template <typename T>
+struct IFTree {
+  IFNode nodes[MAX_NODES];
+  int n_nodes;
+  int max_depth;
+};
+
+/** @brief Check if pointer is on GPU (for input validation). */
+inline bool is_dev_ptr(const void* ptr)
+{
+  cudaPointerAttributes attr;
+  auto err = cudaPointerGetAttributes(&attr, ptr);
+  if (err != cudaSuccess) {
+    cudaGetLastError();
+    return false;
+  }
+  return attr.type == cudaMemoryTypeDevice || attr.type == cudaMemoryTypeManaged;
+}
+
+/**
+ * @brief Build one isolation tree from pre-gathered subsample data.
+ * 
+ * Uses iterative DFS with explicit stack 
+ * Only thread 0 builds the tree; other threads help with initialization.
+ * 
+ * @param local_data Subsample data in row-major [max_samples x n_cols]
+ */
+template <typename T>
+__device__ void build_tree_iterative_local(
+    const T* __restrict__ local_data,
+    int n_samples,
+    int n_cols,
+    int max_samples,
+    int max_depth,
+    curandState* rng_state,
+    IFTree<T>* tree)
+{
+  struct StackEntry { int node_idx, start_idx, end_idx, depth; };
+  
+  // Shared memory layout: [stack for DFS] [work_indices for partitioning]
+  extern __shared__ char shared_mem[];
+  StackEntry* stack = reinterpret_cast<StackEntry*>(shared_mem);
+  int* work_indices = reinterpret_cast<int*>(shared_mem + sizeof(int) * 4 * MAX_DEPTH * 2);
+  
+  // Initialize work_indices = [0, 1, 2, ..., n_samples-1]
+  int tid = threadIdx.x;
+  for (int i = tid; i < n_samples; i += blockDim.x) {
+    work_indices[i] = i;
+  }
+  __syncthreads();
+  
+  if (tid == 0) {
+    tree->n_nodes = 0;
+    tree->max_depth = max_depth;
+  }
+  __syncthreads();
+  
+  // Single-threaded tree construction (tree building is inherently sequential)
+  if (tid == 0) {
+    int stack_top = 0;
+    stack[stack_top++] = {0, 0, n_samples, 0};
+    tree->n_nodes = 1;
+    
+    while (stack_top > 0) {
+      StackEntry entry = stack[--stack_top];
+      int node_idx = entry.node_idx;
+      int start = entry.start_idx;
+      int end = entry.end_idx;
+      int depth = entry.depth;
+      int n_node_samples = end - start;
+      
+      // Stopping condition: max depth or isolated sample
+      if (depth >= max_depth || n_node_samples <= 1) {
+        tree->nodes[node_idx] = {-1, static_cast<float>(n_node_samples), -1, -1};
+        continue;
+      }
+      
+      int feature = curand(rng_state) % n_cols;
+      
+      // Find min/max of selected feature in current partition
+      T min_val = local_data[work_indices[start] * n_cols + feature];
+      T max_val = min_val;
+      for (int i = start + 1; i < end; i++) {
+        T val = local_data[work_indices[i] * n_cols + feature];
+        if (val < min_val) min_val = val;
+        if (val > max_val) max_val = val;
+      }
+      
+      // All values identical -> can't split, make leaf
+      if (min_val >= max_val) {
+        tree->nodes[node_idx] = {-1, static_cast<float>(n_node_samples), -1, -1};
+        continue;
+      }
+      
+      // Random threshold in (min, max) - core of Isolation Forest
+      float rand_frac = curand_uniform(rng_state);
+      T threshold = min_val + static_cast<T>(rand_frac) * (max_val - min_val);
+      
+      // Partition: move samples < threshold to left side (in-place swap)
+      int left_end = start;
+      for (int i = start; i < end; i++) {
+        T val = local_data[work_indices[i] * n_cols + feature];
+        if (val < threshold) {
+          int tmp = work_indices[left_end];
+          work_indices[left_end] = work_indices[i];
+          work_indices[i] = tmp;
+          left_end++;
+        }
+      }
+      
+      // Edge case: all samples went to one side (shouldn't happen)
+      if (left_end == start || left_end == end) {
+        left_end = start + n_node_samples / 2;
+      }
+      
+      int left_child = tree->n_nodes;
+      int right_child = tree->n_nodes + 1;
+      tree->n_nodes += 2;
+      
+      tree->nodes[node_idx] = {feature, static_cast<float>(threshold), left_child, right_child};
+      
+      // Push children (right first so left is processed first - DFS order)
+      stack[stack_top++] = {right_child, left_end, end, depth + 1};
+      stack[stack_top++] = {left_child, start, left_end, depth + 1};
+    }
+  }
+  __syncthreads();
+}
+
+/**
+ * @brief Main kernel: each block builds one complete isolation tree.
+ * 
+ * Phase 1: Generate random sample indices and gather data into contiguous buffer
+ * Phase 2: Build tree from gathered data (avoids scattered global memory reads)
+ */
+template <typename T>
+__global__ void build_isolation_trees_kernel(
+    const T* __restrict__ data,         // Full dataset [n_rows x n_cols] column-major
+    size_t n_rows,                       // Use size_t to support large datasets (>2B elements)
+    int n_cols,
+    int n_trees,
+    int max_samples,
+    int max_depth,
+    uint64_t seed,
+    IFTree<T>* trees,
+    T* __restrict__ subsample_buffer)   // [n_trees x max_samples x n_cols] row-major
+{
+  int tree_id = blockIdx.x;
+  if (tree_id >= n_trees) return;
+  
+  // Each tree gets unique RNG state (seed + tree_id)
+  curandState rng_state;
+  curand_init(seed, tree_id, 0, &rng_state);
+  
+  T* local_data = subsample_buffer + tree_id * max_samples * n_cols;
+  
+  extern __shared__ char shared_mem[];
+  size_t* sample_indices = reinterpret_cast<size_t*>(shared_mem + sizeof(int) * 4 * MAX_DEPTH * 2);
+  
+  // Thread 0 generates random sample indices
+  if (threadIdx.x == 0) {
+    for (int i = 0; i < max_samples; i++) {
+      // Use 64-bit random for proper sampling from large datasets (>2B rows)
+      uint64_t rand64 = (static_cast<uint64_t>(curand(&rng_state)) << 32) | curand(&rng_state);
+      sample_indices[i] = rand64 % n_rows;
+    }
+  }
+  __syncthreads();
+  
+  // All threads gather subsample data (coalesced writes to local_data).
+  // We copy regardless of input layout to get 256 samples into a contiguous
+  // buffer for cache-friendly tree building. The col-major→row-major conversion
+  // is just different index math during this already-required copy.
+  int tid = threadIdx.x;
+  for (int s = 0; s < max_samples; s++) {
+    size_t src_row = sample_indices[s];
+    for (int f = tid; f < n_cols; f += blockDim.x) {
+      local_data[s * n_cols + f] = data[src_row + static_cast<size_t>(f) * n_rows];
+    }
+  }
+  __syncthreads();
+  
+  build_tree_iterative_local(local_data, max_samples, n_cols, max_samples, max_depth, &rng_state, &trees[tree_id]);
+}
+
+/**
+ * @brief Traverse tree to compute path length for one sample.
+ * 
+ * Path length = depth + c(n) adjustment for leaf's remaining samples.
+ * c(n) accounts for expected additional depth if tree were fully grown.
+ */
+template <typename T>
+__device__ T traverse_tree(const IFTree<T>* tree, const T* sample, int n_cols)
+{
+  int node_idx = 0;
+  int depth = 0;
+  
+  while (true) {
+    const IFNode& node = tree->nodes[node_idx];
+    
+    if (node.feature_idx < 0) {
+      // Leaf: add c(n) for unbuilt subtree
+      int n_samples = static_cast<int>(node.threshold);
+      T c_n = T(0);
+      if (n_samples > 1) {
+        // c(n) = 2*H(n-1) - 2*(n-1)/n, H(k) ≈ ln(k) + γ
+        T n = static_cast<T>(n_samples);
+        c_n = T(2) * (log(n - T(1)) + T(0.5772156649)) - T(2) * (n - T(1)) / n;
+      }
+      return static_cast<T>(depth) + c_n;
+    }
+    
+    T val = sample[node.feature_idx];
+    node_idx = (val < static_cast<T>(node.threshold)) ? node.left_child : node.right_child;
+    depth++;
+  }
+}
+
+/**
+ * @brief Compute average path length across all trees for each sample.
+ * Each thread handles one sample.
+ */
+template <typename T>
+__global__ void compute_path_lengths_kernel(
+    const T* __restrict__ data,     // [n_samples x n_cols] row-major
+    size_t n_samples,
+    int n_cols,
+    const IFTree<T>* __restrict__ trees,
+    int n_trees,
+    T* __restrict__ path_lengths)   // Output: [n_samples]
+{
+  size_t sample_idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (sample_idx >= n_samples) return;
+  
+  const T* sample = data + sample_idx * n_cols;
+  
+  T total_path = T(0);
+  for (int t = 0; t < n_trees; t++) {
+    total_path += traverse_tree(&trees[t], sample, n_cols);
+  }
+  
+  path_lengths[sample_idx] = (n_trees > 0) ? total_path / static_cast<T>(n_trees) : T(0);
+}
+
+/**
+ * @brief Host function to build all isolation trees.
+ * 
+ * Allocates temporary buffer for gathered subsamples, launches kernel,
+ * then buffer is freed automatically when function returns.
+ */
+template <typename T>
+void build_isolation_forest(
+    const raft::handle_t& handle,
+    const T* data,              // [n_rows x n_cols] column-major
+    size_t n_rows,              // Use size_t to support large datasets
+    int n_cols,
+    int n_trees,
+    int max_samples,
+    int max_depth,
+    uint64_t seed,
+    IFTree<T>* d_trees)         // Output: device array [n_trees]
+{
+  auto stream = handle.get_stream();
+  
+  // Temp buffer: [n_trees x max_samples x n_cols] for gathered subsamples
+  // ~10MB for typical 100 trees x 256 samples x 100 features x float
+  size_t subsample_buffer_size = static_cast<size_t>(n_trees) * max_samples * n_cols;
+  rmm::device_uvector<T> subsample_buffer(subsample_buffer_size, stream);
+  
+  // Shared memory: stack for DFS + sample indices (size_t for >2B row support)
+  int stack_size = MAX_DEPTH * 2 * 4 * sizeof(int);
+  int indices_size = max_samples * sizeof(size_t);
+  int shared_mem_size = stack_size + indices_size;
+  
+  build_isolation_trees_kernel<T><<<n_trees, 128, shared_mem_size, stream>>>(
+      data, n_rows, n_cols, n_trees, max_samples, max_depth, seed, d_trees, subsample_buffer.data());
+  
+  RAFT_CUDA_TRY(cudaGetLastError());
+}
+
+}  // namespace IsolationTree
+}  // namespace ML

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -164,24 +164,38 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
         continue;
       }
 
-      int local_feature = static_cast<int>(sample_bounded(rng_state, static_cast<size_t>(n_cols)));
-      int original_feature =
-        feature_indices == nullptr ? local_feature : feature_indices[local_feature];
-
-      T min_val = local_data[work_indices[start] * n_cols + local_feature];
-      T max_val = min_val;
-      for (int i = start + 1; i < end; i++) {
-        T val = local_data[work_indices[i] * n_cols + local_feature];
-        if (val < min_val) min_val = val;
-        if (val > max_val) max_val = val;
+      // Try every feature, starting from a random offset, before concluding
+      // that this node cannot be split. This avoids prematurely stopping on
+      // sparse or one-hot data when the first random feature is constant.
+      int local_feature = -1;
+      T min_val         = T(0);
+      T max_val         = T(0);
+      int feature_start = static_cast<int>(sample_bounded(rng_state, static_cast<size_t>(n_cols)));
+      for (int attempt = 0; attempt < n_cols; ++attempt) {
+        int candidate   = (feature_start + attempt) % n_cols;
+        T candidate_min = local_data[work_indices[start] * n_cols + candidate];
+        T candidate_max = candidate_min;
+        for (int i = start + 1; i < end; ++i) {
+          T val = local_data[work_indices[i] * n_cols + candidate];
+          if (val < candidate_min) candidate_min = val;
+          if (val > candidate_max) candidate_max = val;
+        }
+        if (candidate_min < candidate_max) {
+          local_feature = candidate;
+          min_val       = candidate_min;
+          max_val       = candidate_max;
+          break;
+        }
       }
 
-      if (min_val >= max_val) {
+      if (local_feature < 0) {
         T path_length   = static_cast<T>(depth) + compute_c_n<T>(n_node_samples);
         nodes[node_idx] = {-1, path_length, -1, -1};
         continue;
       }
 
+      int original_feature =
+        feature_indices == nullptr ? local_feature : feature_indices[local_feature];
       float rand_frac = curand_uniform(rng_state);
       T threshold     = min_val + static_cast<T>(rand_frac) * (max_val - min_val);
 
@@ -196,7 +210,22 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
         }
       }
 
-      if (left_end == start || left_end == end) { left_end = start + n_node_samples / 2; }
+      if (left_end == start || left_end == end) {
+        // Numerical rounding can move the random threshold onto an endpoint.
+        // Repartition with max_val so the stored split and training partition
+        // remain consistent. Since min_val < max_val, both children are nonempty.
+        threshold = max_val;
+        left_end  = start;
+        for (int i = start; i < end; ++i) {
+          T val = local_data[work_indices[i] * n_cols + local_feature];
+          if (val < threshold) {
+            int tmp                = work_indices[left_end];
+            work_indices[left_end] = work_indices[i];
+            work_indices[i]        = tmp;
+            ++left_end;
+          }
+        }
+      }
 
       int left_child  = n_nodes;
       int right_child = n_nodes + 1;
@@ -243,8 +272,8 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
   curandState rng_state;
   curand_init(seed, tree_id, 0, &rng_state);
 
-  int tree_offset = tree_id * max_nodes_per_tree;
-  if (threadIdx.x == 0) { tree_offsets[tree_id] = tree_offset; }
+  size_t tree_offset = static_cast<size_t>(tree_id) * max_nodes_per_tree;
+  if (threadIdx.x == 0) { tree_offsets[tree_id] = static_cast<int>(tree_offset); }
 
   T* local_data = subsample_buffer + static_cast<size_t>(tree_id) * max_samples * max_features;
   size_t* tree_sample_indices = sample_indices + static_cast<size_t>(tree_id) * max_samples;
@@ -404,9 +433,9 @@ __global__ void compact_global_trees_kernel(const IFNode<T>* __restrict__ nodes,
 {
   int tree_id = blockIdx.x;
   if (tree_id >= n_trees) return;
-  int n       = tree_n_nodes[tree_id];
-  int src_off = tree_id * max_nodes_per_tree;
-  int dst_off = compact_offsets[tree_id];
+  int n          = tree_n_nodes[tree_id];
+  size_t src_off = static_cast<size_t>(tree_id) * max_nodes_per_tree;
+  int dst_off    = compact_offsets[tree_id];
   for (int i = threadIdx.x; i < n; i += blockDim.x) {
     compact_nodes[dst_off + i] = nodes[src_off + i];
   }

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -202,7 +202,10 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
       int right_child = n_nodes + 1;
       n_nodes += 2;
 
-      nodes[node_idx] = {original_feature, threshold, left_child, right_child};
+      nodes[node_idx].feature_idx = original_feature;
+      nodes[node_idx].threshold   = threshold;
+      nodes[node_idx].left_child  = left_child;
+      nodes[node_idx].right_child = right_child;
 
       stack[stack_top++] = {right_child, left_end, end, depth + 1};
       stack[stack_top++] = {left_child, start, left_end, depth + 1};

--- a/cpp/src/isolation_forest/isolation_tree_builder.cuh
+++ b/cpp/src/isolation_forest/isolation_tree_builder.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Shared device types and helpers for the batched Isolation Forest tree builder.
@@ -45,12 +45,13 @@ struct StackEntry {
  * @brief Compute c(n) = 2H(n-1) - 2(n-1)/n, the expected path length in an
  * unsuccessful BST search (used for adjusting isolation depth at leaves).
  */
-__device__ __forceinline__ float compute_c_n(int n_samples)
+template <typename T>
+__device__ __forceinline__ T compute_c_n(int n_samples)
 {
-  if (n_samples <= 1) return 0.0f;
-  if (n_samples == 2) return 1.0f;
-  float n = static_cast<float>(n_samples);
-  return 2.0f * (logf(n - 1.0f) + 0.5772156649f) - 2.0f * (n - 1.0f) / n;
+  if (n_samples <= 1) return T(0);
+  if (n_samples == 2) return T(1);
+  T n = static_cast<T>(n_samples);
+  return T(2) * (log(n - T(1)) + T(0.5772156649015329)) - T(2) * (n - T(1)) / n;
 }
 
 /**
@@ -59,9 +60,10 @@ __device__ __forceinline__ float compute_c_n(int n_samples)
  * Leaf nodes: feature_idx = -1, threshold stores pre-computed path length
  *             (depth + c(n_samples)) for direct use by inference
  */
+template <typename T>
 struct IFNode {
   int feature_idx;
-  float threshold;
+  T threshold;
   int left_child;
   int right_child;
 };
@@ -126,7 +128,7 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
                                             int max_depth,
                                             int max_nodes_per_tree,
                                             curandState* rng_state,
-                                            IFNode* nodes,
+                                            IFNode<T>* nodes,
                                             int* n_nodes_out,
                                             int* max_depth_out,
                                             int* work_indices,
@@ -157,8 +159,8 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
 
       // Stopping condition: max depth, isolated sample, or exhausted capacity.
       if (depth >= max_depth || n_node_samples <= 1 || n_nodes + 2 > max_nodes_per_tree) {
-        float path_length = static_cast<float>(depth) + compute_c_n(n_node_samples);
-        nodes[node_idx]   = {-1, path_length, -1, -1};
+        T path_length   = static_cast<T>(depth) + compute_c_n<T>(n_node_samples);
+        nodes[node_idx] = {-1, path_length, -1, -1};
         continue;
       }
 
@@ -175,8 +177,8 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
       }
 
       if (min_val >= max_val) {
-        float path_length = static_cast<float>(depth) + compute_c_n(n_node_samples);
-        nodes[node_idx]   = {-1, path_length, -1, -1};
+        T path_length   = static_cast<T>(depth) + compute_c_n<T>(n_node_samples);
+        nodes[node_idx] = {-1, path_length, -1, -1};
         continue;
       }
 
@@ -200,7 +202,7 @@ __device__ void build_tree_iterative_global(const T* __restrict__ local_data,
       int right_child = n_nodes + 1;
       n_nodes += 2;
 
-      nodes[node_idx] = {original_feature, static_cast<float>(threshold), left_child, right_child};
+      nodes[node_idx] = {original_feature, threshold, left_child, right_child};
 
       stack[stack_top++] = {right_child, left_end, end, depth + 1};
       stack[stack_top++] = {left_child, start, left_end, depth + 1};
@@ -223,7 +225,7 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
                                                     bool bootstrap,
                                                     uint64_t seed,
                                                     int* __restrict__ feature_indices,
-                                                    IFNode* __restrict__ nodes,
+                                                    IFNode<T>* __restrict__ nodes,
                                                     int* __restrict__ tree_offsets,
                                                     int* __restrict__ tree_n_nodes,
                                                     int* __restrict__ tree_max_depth,
@@ -248,7 +250,7 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
                                   : feature_indices + static_cast<size_t>(tree_id) * max_features;
   int* tree_work_indices      = work_indices + static_cast<size_t>(tree_id) * max_samples;
   StackEntry* tree_stack      = stack + static_cast<size_t>(tree_id) * max_nodes_per_tree;
-  IFNode* tree_nodes          = nodes + tree_offset;
+  IFNode<T>* tree_nodes       = nodes + tree_offset;
 
   // Thread 0 samples source rows using sklearn IsolationForest semantics:
   // bootstrap=True samples with replacement; bootstrap=False samples without
@@ -304,17 +306,17 @@ __global__ void build_isolation_trees_global_kernel(const T* __restrict__ data,
 }
 
 template <typename T>
-__device__ T traverse_global_tree(const IFNode* tree_nodes, const T* sample, int n_cols)
+__device__ T traverse_global_tree(const IFNode<T>* tree_nodes, const T* sample, int n_cols)
 {
   int node_idx = 0;
 
   while (true) {
-    const IFNode& node = tree_nodes[node_idx];
+    const IFNode<T>& node = tree_nodes[node_idx];
 
-    if (node.feature_idx < 0) { return static_cast<T>(node.threshold); }
+    if (node.feature_idx < 0) { return node.threshold; }
 
     T val    = sample[node.feature_idx];
-    node_idx = (val < static_cast<T>(node.threshold)) ? node.left_child : node.right_child;
+    node_idx = (val < node.threshold) ? node.left_child : node.right_child;
   }
 }
 
@@ -322,7 +324,7 @@ template <typename T>
 __global__ void compute_path_lengths_global_kernel(const T* __restrict__ data,
                                                    size_t n_samples,
                                                    int n_cols,
-                                                   const IFNode* __restrict__ nodes,
+                                                   const IFNode<T>* __restrict__ nodes,
                                                    const int* __restrict__ tree_offsets,
                                                    int n_trees,
                                                    T* __restrict__ path_lengths)
@@ -353,7 +355,7 @@ void build_isolation_forest_global(const raft::handle_t& handle,
                                    bool bootstrap,
                                    uint64_t seed,
                                    int* feature_indices,
-                                   IFNode* nodes,
+                                   IFNode<T>* nodes,
                                    int* tree_offsets,
                                    int* tree_n_nodes,
                                    int* tree_max_depth)
@@ -390,12 +392,12 @@ void build_isolation_forest_global(const raft::handle_t& handle,
 }
 
 template <typename T>
-__global__ void compact_global_trees_kernel(const IFNode* __restrict__ nodes,
+__global__ void compact_global_trees_kernel(const IFNode<T>* __restrict__ nodes,
                                             int n_trees,
                                             int max_nodes_per_tree,
                                             const int* __restrict__ tree_n_nodes,
                                             const int* __restrict__ compact_offsets,
-                                            IFNode* __restrict__ compact_nodes)
+                                            IFNode<T>* __restrict__ compact_nodes)
 {
   int tree_id = blockIdx.x;
   if (tree_id >= n_trees) return;
@@ -409,12 +411,12 @@ __global__ void compact_global_trees_kernel(const IFNode* __restrict__ nodes,
 
 template <typename T>
 void compact_global_isolation_forest(const raft::handle_t& handle,
-                                     const IFNode* d_nodes,
+                                     const IFNode<T>* d_nodes,
                                      const int* d_tree_n_nodes,
                                      const int* d_tree_max_depth,
                                      int n_trees,
                                      int max_nodes_per_tree,
-                                     std::vector<IFNode>& h_nodes,
+                                     std::vector<IFNode<T>>& h_nodes,
                                      std::vector<int>& h_tree_offsets,
                                      std::vector<int>& h_tree_n_nodes,
                                      std::vector<int>& h_tree_max_depth)
@@ -446,7 +448,7 @@ void compact_global_isolation_forest(const raft::handle_t& handle,
                                 cudaMemcpyHostToDevice,
                                 stream));
 
-  rmm::device_uvector<IFNode> d_compact(total_nodes, stream);
+  rmm::device_uvector<IFNode<T>> d_compact(total_nodes, stream);
   compact_global_trees_kernel<T><<<n_trees, 128, 0, stream>>>(d_nodes,
                                                               n_trees,
                                                               max_nodes_per_tree,
@@ -458,7 +460,7 @@ void compact_global_isolation_forest(const raft::handle_t& handle,
   h_nodes.resize(total_nodes);
   RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(),
                                 d_compact.data(),
-                                total_nodes * sizeof(IFNode),
+                                total_nodes * sizeof(IFNode<T>),
                                 cudaMemcpyDeviceToHost,
                                 stream));
   handle.sync_stream(stream);

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -157,6 +157,15 @@ if(all_algo OR randomforest_algo)
   )
 endif()
 
+if(all_algo OR isolationforest_algo)
+  ConfigureTest(
+    PREFIX SG
+    NAME ISOLATION_FOREST_TEST sg/isolation_forest_test.cu ML_INCLUDE
+    GPUS 1
+    PERCENT 100
+  )
+endif()
+
 # todo: separate solvers better
 if(all_algo OR solvers_algo)
   ConfigureTest(PREFIX SG NAME CD_TEST sg/cd_test.cu ML_INCLUDE)

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -14,9 +14,9 @@
  * - Edge cases and parameter validation
  */
 
-#include <cuml/ensemble/isolation_forest.hpp>
-
 #include "../../src/isolation_forest/isolation_tree_builder.cuh"
+
+#include <cuml/ensemble/isolation_forest.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/linalg/transpose.cuh>
@@ -51,11 +51,8 @@
 namespace ML {
 namespace tl = treelite;
 
-__global__ void sample_rows_for_test(size_t n_rows,
-                                     int max_samples,
-                                     bool bootstrap,
-                                     uint64_t seed,
-                                     size_t* sample_indices)
+__global__ void sample_rows_for_test(
+  size_t n_rows, int max_samples, bool bootstrap, uint64_t seed, size_t* sample_indices)
 {
   if (threadIdx.x != 0 || blockIdx.x != 0) return;
 
@@ -69,10 +66,9 @@ __global__ void sample_rows_for_test(size_t n_rows,
   } else {
     size_t start = n_rows - static_cast<size_t>(max_samples);
     for (int i = 0; i < max_samples; ++i) {
-      size_t j = start + static_cast<size_t>(i);
-      size_t t = IsolationTree::sample_bounded(&rng_state, j + 1);
-      sample_indices[i] =
-        IsolationTree::contains_sample(sample_indices, i, t) ? j : t;
+      size_t j          = start + static_cast<size_t>(i);
+      size_t t          = IsolationTree::sample_bounded(&rng_state, j + 1);
+      sample_indices[i] = IsolationTree::contains_sample(sample_indices, i, t) ? j : t;
     }
   }
 }
@@ -90,7 +86,7 @@ __global__ void sample_features_for_test(int n_cols,
   size_t start = static_cast<size_t>(n_cols - max_features);
   for (int i = 0; i < max_features; ++i) {
     size_t j = start + static_cast<size_t>(i);
-    int t = static_cast<int>(IsolationTree::sample_bounded(&rng_state, j + 1));
+    int t    = static_cast<int>(IsolationTree::sample_bounded(&rng_state, j + 1));
     feature_indices[i] =
       IsolationTree::contains_int_sample(feature_indices, i, t) ? static_cast<int>(j) : t;
   }
@@ -166,7 +162,11 @@ class IsolationForestTest : public ::testing::Test {
     // Generate outliers: far from origin (row-major)
     if (n_outliers > 0) {
       thrust::device_vector<float> outliers(n_outliers * n_features);
-      rng.normal(outliers.data().get(), n_outliers * n_features, outlier_distance, inlier_std * 0.5f, stream);
+      rng.normal(outliers.data().get(),
+                 n_outliers * n_features,
+                 outlier_distance,
+                 inlier_std * 0.5f,
+                 stream);
       thrust::copy(outliers.begin(), outliers.end(), X_rowmajor.begin() + n_inliers * n_features);
     }
 
@@ -283,7 +283,8 @@ TEST_F(IsolationForestTest, DeepTreesFitWithGlobalMemoryStorage)
   EXPECT_GT(model.global_nodes.size(), 0);
 
   thrust::device_vector<float> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   thrust::host_vector<float> h_scores = scores;
   for (int i = 0; i < n_samples; i++) {
@@ -362,7 +363,7 @@ TEST_F(IsolationForestTest, SubsamplingWorks)
 
 TEST_F(IsolationForestTest, BootstrapFalseSamplesWithoutReplacement)
 {
-  const size_t n_rows  = 64;
+  const size_t n_rows   = 64;
   const int max_samples = 64;
   thrust::device_vector<size_t> sampled(max_samples);
 
@@ -381,7 +382,7 @@ TEST_F(IsolationForestTest, BootstrapFalseSamplesWithoutReplacement)
 
 TEST_F(IsolationForestTest, BootstrapTrueSamplesWithReplacement)
 {
-  const size_t n_rows  = 4;
+  const size_t n_rows   = 4;
   const int max_samples = 64;
   thrust::device_vector<size_t> sampled(max_samples);
 
@@ -452,8 +453,8 @@ TEST_F(IsolationForestTest, MaxFeaturesFitStoresOriginalFeatureIds)
                                 n_estimators * sizeof(int),
                                 cudaMemcpyDeviceToHost,
                                 stream));
-  std::vector<IsolationTree::IFNode> h_nodes(
-    static_cast<size_t>(n_estimators) * model.max_nodes_per_tree);
+  std::vector<IsolationTree::IFNode> h_nodes(static_cast<size_t>(n_estimators) *
+                                             model.max_nodes_per_tree);
   RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(),
                                 model.global_nodes.data(),
                                 h_nodes.size() * sizeof(IsolationTree::IFNode),
@@ -505,7 +506,8 @@ TEST_F(IsolationForestTest, AnomalyScoresInRange)
 
   // Compute anomaly scores (row-major input)
   thrust::device_vector<float> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   // Copy to host and verify range
   thrust::host_vector<float> h_scores = scores;
@@ -532,8 +534,8 @@ TEST_F(IsolationForestTest, OutliersScoreHigher)
   thrust::device_vector<float> X_colmajor;
   thrust::device_vector<float> X_rowmajor;
   thrust::device_vector<int> labels;
-  generate_data_with_outliers(n_inliers, n_outliers, n_features, 1.0f, 10.0f,
-                              X_colmajor, X_rowmajor, labels);
+  generate_data_with_outliers(
+    n_inliers, n_outliers, n_features, 1.0f, 10.0f, X_colmajor, X_rowmajor, labels);
 
   IF_params params;
   params.n_estimators = n_estimators;
@@ -546,7 +548,8 @@ TEST_F(IsolationForestTest, OutliersScoreHigher)
 
   // Compute anomaly scores (row-major input)
   thrust::device_vector<float> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   // Copy to host
   thrust::host_vector<float> h_scores = scores;
@@ -606,7 +609,8 @@ TEST_F(IsolationForestTest, PredictReturnsValidLabels)
 
   // Get predictions (row-major input)
   thrust::device_vector<int> predictions(n_samples);
-  predict(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, predictions.data().get());
+  predict(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, predictions.data().get());
 
   // Verify all predictions are either 1 or -1
   thrust::host_vector<int> h_predictions = predictions;
@@ -652,8 +656,10 @@ TEST_F(IsolationForestTest, DeterministicWithRandomState)
   thrust::device_vector<float> scores1(n_samples);
   thrust::device_vector<float> scores2(n_samples);
 
-  score_samples(*handle, &model1, X_rowmajor.data().get(), n_samples, n_features, scores1.data().get());
-  score_samples(*handle, &model2, X_rowmajor.data().get(), n_samples, n_features, scores2.data().get());
+  score_samples(
+    *handle, &model1, X_rowmajor.data().get(), n_samples, n_features, scores1.data().get());
+  score_samples(
+    *handle, &model2, X_rowmajor.data().get(), n_samples, n_features, scores2.data().get());
 
   // Scores should be identical
   thrust::host_vector<float> h_scores1 = scores1;
@@ -723,7 +729,8 @@ TEST_F(IsolationForestTest, DoublePrecisionSupport)
 
   // Compute scores (row-major)
   thrust::device_vector<double> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   // Verify scores are in range
   thrust::host_vector<double> h_scores = scores;
@@ -765,7 +772,8 @@ TEST_F(IsolationForestTest, SmallDataset)
 
   // Should still produce valid scores (row-major)
   thrust::device_vector<float> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   thrust::host_vector<float> h_scores = scores;
   for (int i = 0; i < n_samples; i++) {
@@ -804,7 +812,8 @@ TEST_F(IsolationForestTest, UniformData)
 
   // Compute scores - all should be similar for uniform data (row-major)
   thrust::device_vector<float> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   thrust::host_vector<float> h_scores = scores;
 
@@ -858,7 +867,8 @@ TEST_F(IsolationForestTest, ManyEstimators)
 
   // Verify scoring works with many trees (row-major)
   thrust::device_vector<float> scores(n_samples);
-  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
 
   thrust::host_vector<float> h_scores = scores;
   for (int i = 0; i < n_samples; i++) {
@@ -895,17 +905,17 @@ TEST_F(IsolationForestTest, PredictThreshold)
 
   // Predictions with low threshold (more anomalies) - row-major input
   thrust::device_vector<int> pred_low(n_samples);
-  predict(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, pred_low.data().get(), 0.3f);
+  predict(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, pred_low.data().get(), 0.3f);
 
   // Predictions with high threshold (fewer anomalies) - row-major input
   thrust::device_vector<int> pred_high(n_samples);
-  predict(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, pred_high.data().get(), 0.7f);
+  predict(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, pred_high.data().get(), 0.7f);
 
   // Count anomalies in each
-  int anomalies_low =
-    thrust::count(thrust::device, pred_low.begin(), pred_low.end(), 1);
-  int anomalies_high =
-    thrust::count(thrust::device, pred_high.begin(), pred_high.end(), 1);
+  int anomalies_low  = thrust::count(thrust::device, pred_low.begin(), pred_low.end(), 1);
+  int anomalies_high = thrust::count(thrust::device, pred_high.begin(), pred_high.end(), 1);
 
   // Lower threshold should produce more anomaly predictions
   EXPECT_GE(anomalies_low, anomalies_high)

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -35,6 +35,8 @@
 
 #include <gtest/gtest.h>
 #include <test_utils.h>
+#include <treelite/enum/task_type.h>
+#include <treelite/tree.h>
 
 #include <cmath>
 #include <memory>
@@ -43,6 +45,7 @@
 #include <vector>
 
 namespace ML {
+namespace tl = treelite;
 
 /**
  * @brief Base test fixture for Isolation Forest tests.
@@ -705,6 +708,57 @@ TEST_F(IsolationForestTest, PredictThreshold)
   // Lower threshold should produce more anomaly predictions
   EXPECT_GE(anomalies_low, anomalies_high)
     << "Lower threshold should produce at least as many anomalies";
+}
+
+/**
+ * @brief Test: Export trained Isolation Forest model to Treelite.
+ *
+ * The exported Treelite model is a regressor whose prediction is the average
+ * path length across isolation trees. The anomaly-score transform is applied
+ * outside Treelite by higher-level callers.
+ */
+TEST_F(IsolationForestTest, TreeliteExportMetadata)
+{
+  const int n_samples    = 128;
+  const int n_features   = 6;
+  const int n_estimators = 7;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  TreeliteModelHandle tl_handle = nullptr;
+  build_treelite_isolation_forest(&tl_handle, *handle, &model);
+  ASSERT_NE(tl_handle, nullptr);
+
+  std::unique_ptr<tl::Model> tl_model(static_cast<tl::Model*>(tl_handle));
+  auto& model_preset = std::get<tl::ModelPreset<float, float>>(tl_model->variant_);
+
+  EXPECT_EQ(tl_model->task_type, tl::TaskType::kRegressor);
+  EXPECT_EQ(tl_model->postprocessor, "identity");
+  EXPECT_EQ(tl_model->num_target, 1);
+  ASSERT_EQ(tl_model->num_class.Size(), 1);
+  EXPECT_EQ(tl_model->num_class[0], 1);
+  ASSERT_EQ(tl_model->leaf_vector_shape.Size(), 2);
+  EXPECT_EQ(tl_model->leaf_vector_shape[0], 1);
+  EXPECT_EQ(tl_model->leaf_vector_shape[1], 1);
+  EXPECT_EQ(tl_model->num_feature, n_features);
+  EXPECT_TRUE(tl_model->average_tree_output);
+  ASSERT_EQ(model_preset.trees.size(), static_cast<std::size_t>(n_estimators));
+  for (const auto& tree : model_preset.trees) {
+    EXPECT_GT(tree.num_nodes, 0);
+  }
 }
 
 }  // namespace ML

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -168,7 +168,7 @@ TEST_F(IsolationForestTest, FitProducesExpectedTreeCount)
   // Verify model was created correctly
   EXPECT_EQ(model.params.n_estimators, n_estimators);
   EXPECT_EQ(model.n_features, n_features);
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
 }
 
 /**
@@ -201,8 +201,46 @@ TEST_F(IsolationForestTest, TreeDepthRespected)
   fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
 
   // Verify model was created (we can't inspect individual trees with new API)
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
   EXPECT_EQ(model.params.max_depth, max_depth);
+}
+
+/**
+ * @brief Test: max_depth above the previous fixed-storage cap fits successfully.
+ */
+TEST_F(IsolationForestTest, DeepTreesFitWithGlobalMemoryStorage)
+{
+  const int n_samples    = 128;
+  const int n_features   = 4;
+  const int n_estimators = 5;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.max_depth    = 17;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  EXPECT_EQ(model.max_nodes_per_tree, 2 * params.max_samples - 1);
+  EXPECT_GT(model.global_nodes.size(), 0);
+
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  thrust::host_vector<float> h_scores = scores;
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_GE(h_scores[i], 0.0f);
+    EXPECT_LE(h_scores[i], 1.0f);
+  }
 }
 
 /**
@@ -235,7 +273,7 @@ TEST_F(IsolationForestTest, AutoMaxDepthCalculation)
   fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
 
   // Verify model was created with auto max_depth
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
   // Auto depth should be calculated from max_samples
   EXPECT_EQ(model.params.max_samples, max_samples);
 }
@@ -270,7 +308,7 @@ TEST_F(IsolationForestTest, SubsamplingWorks)
 
   // Verify stored max_samples
   EXPECT_EQ(model.n_samples_per_tree, max_samples);
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
 }
 
 /**
@@ -517,7 +555,7 @@ TEST_F(IsolationForestTest, DoublePrecisionSupport)
 
   // Verify model was created
   EXPECT_EQ(model.params.n_estimators, n_estimators);
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
 
   // Compute scores (row-major)
   thrust::device_vector<double> scores(n_samples);
@@ -598,7 +636,7 @@ TEST_F(IsolationForestTest, UniformData)
 
   // Model should fit without error
   EXPECT_EQ(model.params.n_estimators, n_estimators);
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
 
   // Compute scores - all should be similar for uniform data (row-major)
   thrust::device_vector<float> scores(n_samples);
@@ -652,7 +690,7 @@ TEST_F(IsolationForestTest, ManyEstimators)
 
   // Model should be created with all trees
   EXPECT_EQ(model.params.n_estimators, n_estimators);
-  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_GT(model.global_nodes.size(), 0);
 
   // Verify scoring works with many trees (row-major)
   thrust::device_vector<float> scores(n_samples);
@@ -753,6 +791,48 @@ TEST_F(IsolationForestTest, TreeliteExportMetadata)
   ASSERT_EQ(tl_model->leaf_vector_shape.Size(), 2);
   EXPECT_EQ(tl_model->leaf_vector_shape[0], 1);
   EXPECT_EQ(tl_model->leaf_vector_shape[1], 1);
+  EXPECT_EQ(tl_model->num_feature, n_features);
+  EXPECT_TRUE(tl_model->average_tree_output);
+  ASSERT_EQ(model_preset.trees.size(), static_cast<std::size_t>(n_estimators));
+  for (const auto& tree : model_preset.trees) {
+    EXPECT_GT(tree.num_nodes, 0);
+  }
+}
+
+/**
+ * @brief Test: Treelite export works for deep global-memory tree storage.
+ */
+TEST_F(IsolationForestTest, TreeliteExportGlobalMemoryStorage)
+{
+  const int n_samples    = 128;
+  const int n_features   = 6;
+  const int n_estimators = 7;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.max_depth    = 17;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+  ASSERT_GT(model.global_nodes.size(), 0);
+
+  TreeliteModelHandle tl_handle = nullptr;
+  build_treelite_isolation_forest(&tl_handle, *handle, &model);
+  ASSERT_NE(tl_handle, nullptr);
+
+  std::unique_ptr<tl::Model> tl_model(static_cast<tl::Model*>(tl_handle));
+  auto& model_preset = std::get<tl::ModelPreset<float, float>>(tl_model->variant_);
+
+  EXPECT_EQ(tl_model->task_type, tl::TaskType::kRegressor);
   EXPECT_EQ(tl_model->num_feature, n_features);
   EXPECT_TRUE(tl_model->average_tree_output);
   ASSERT_EQ(model_preset.trees.size(), static_cast<std::size_t>(n_estimators));

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -1,0 +1,710 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file isolation_forest_test.cu
+ * @brief Unit tests for Isolation Forest based on sklearn's test_iforest.py patterns.
+ *
+ * Test cases adapted from sklearn's Isolation Forest test suite:
+ * - Basic fit/predict functionality
+ * - Anomaly score computation
+ * - Outlier detection performance
+ * - Edge cases and parameter validation
+ */
+
+#include <cuml/ensemble/isolation_forest.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/linalg/transpose.cuh>
+#include <raft/random/rng.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/extrema.h>
+#include <thrust/host_vector.h>
+#include <thrust/reduce.h>
+#include <thrust/transform.h>
+
+#include <gtest/gtest.h>
+#include <test_utils.h>
+
+#include <cmath>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <vector>
+
+namespace ML {
+
+/**
+ * @brief Base test fixture for Isolation Forest tests.
+ *
+ * Provides common setup with raft handle and stream management.
+ */
+class IsolationForestTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    stream_pool = std::make_shared<rmm::cuda_stream_pool>(4);
+    handle      = std::make_unique<raft::handle_t>(rmm::cuda_stream_per_thread, stream_pool);
+    stream      = handle->get_stream();
+  }
+
+  void TearDown() override
+  {
+    handle.reset();
+    stream_pool.reset();
+  }
+
+  /**
+   * @brief Transpose data between row-major and column-major formats.
+   *
+   * @param[in] src Source data
+   * @param[out] dst Destination data (must be pre-allocated)
+   * @param[in] n_rows Number of rows
+   * @param[in] n_cols Number of columns
+   */
+  template <typename T>
+  void transpose_data(thrust::device_vector<T>& src,
+                      thrust::device_vector<T>& dst,
+                      int n_rows,
+                      int n_cols)
+  {
+    // Note: raft::linalg::transpose takes non-const input even though it doesn't modify it
+    raft::linalg::transpose(*handle, src.data().get(), dst.data().get(), n_rows, n_cols, stream);
+    handle->sync_stream(stream);
+  }
+
+  /**
+   * @brief Generate synthetic normal data with optional outliers.
+   *
+   * Creates a dataset with normally distributed inliers and optional
+   * outliers placed far from the main cluster.
+   *
+   * @param[out] X_colmajor Column-major data for fit() (n_cols x n_rows layout)
+   * @param[out] X_rowmajor Row-major data for score_samples() (n_rows x n_cols layout)
+   * @param[out] labels Ground truth labels (0=inlier, 1=outlier)
+   */
+  void generate_data_with_outliers(int n_inliers,
+                                   int n_outliers,
+                                   int n_features,
+                                   float inlier_std,
+                                   float outlier_distance,
+                                   thrust::device_vector<float>& X_colmajor,
+                                   thrust::device_vector<float>& X_rowmajor,
+                                   thrust::device_vector<int>& labels)
+  {
+    int n_samples = n_inliers + n_outliers;
+    X_rowmajor.resize(n_samples * n_features);
+    X_colmajor.resize(n_samples * n_features);
+    labels.resize(n_samples);
+
+    // Generate inliers: centered at origin with small std (row-major)
+    raft::random::Rng rng(42);
+    rng.normal(X_rowmajor.data().get(), n_inliers * n_features, 0.0f, inlier_std, stream);
+
+    // Generate outliers: far from origin (row-major)
+    if (n_outliers > 0) {
+      thrust::device_vector<float> outliers(n_outliers * n_features);
+      rng.normal(outliers.data().get(), n_outliers * n_features, outlier_distance, inlier_std * 0.5f, stream);
+      thrust::copy(outliers.begin(), outliers.end(), X_rowmajor.begin() + n_inliers * n_features);
+    }
+
+    // Labels: 0 for inliers, 1 for outliers
+    thrust::fill(labels.begin(), labels.begin() + n_inliers, 0);
+    thrust::fill(labels.begin() + n_inliers, labels.end(), 1);
+
+    handle->sync_stream(stream);
+
+    // Transpose to column-major for fit()
+    transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+  }
+
+  std::shared_ptr<rmm::cuda_stream_pool> stream_pool;
+  std::unique_ptr<raft::handle_t> handle;
+  cudaStream_t stream;
+};
+
+/**
+ * @brief Test: Basic fit produces expected number of trees.
+ *
+ * Corresponds to sklearn test: test_iforest (partial)
+ * Verifies that fit() creates the correct number of isolation trees.
+ */
+TEST_F(IsolationForestTest, FitProducesExpectedTreeCount)
+{
+  const int n_samples    = 100;
+  const int n_features   = 5;
+  const int n_estimators = 10;
+
+  // Generate random data in row-major, then transpose to column-major for fit
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  // Configure and fit (column-major)
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Verify model was created correctly
+  EXPECT_EQ(model.params.n_estimators, n_estimators);
+  EXPECT_EQ(model.n_features, n_features);
+  EXPECT_GT(model.fast_trees.size(), 0);
+}
+
+/**
+ * @brief Test: Tree depth respects max_depth parameter.
+ *
+ * Corresponds to sklearn test: test_recalculate_max_depth (partial)
+ * Verifies that no tree exceeds the specified maximum depth.
+ */
+TEST_F(IsolationForestTest, TreeDepthRespected)
+{
+  const int n_samples    = 256;
+  const int n_features   = 4;
+  const int n_estimators = 5;
+  const int max_depth    = 4;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 128;
+  params.max_depth    = max_depth;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Verify model was created (we can't inspect individual trees with new API)
+  EXPECT_GT(model.fast_trees.size(), 0);
+  EXPECT_EQ(model.params.max_depth, max_depth);
+}
+
+/**
+ * @brief Test: Auto max_depth calculation.
+ *
+ * Corresponds to sklearn test: test_recalculate_max_depth
+ * When max_depth=-1, it should be set to ceil(log2(max_samples)).
+ */
+TEST_F(IsolationForestTest, AutoMaxDepthCalculation)
+{
+  const int n_samples    = 1000;
+  const int n_features   = 4;
+  const int n_estimators = 3;
+  const int max_samples  = 256;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = max_samples;
+  params.max_depth    = -1;  // Auto
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Verify model was created with auto max_depth
+  EXPECT_GT(model.fast_trees.size(), 0);
+  // Auto depth should be calculated from max_samples
+  EXPECT_EQ(model.params.max_samples, max_samples);
+}
+
+/**
+ * @brief Test: Subsampling works correctly.
+ *
+ * Corresponds to sklearn test: test_iforest_subsampled_features (partial)
+ * Verifies that each tree is trained on max_samples points.
+ */
+TEST_F(IsolationForestTest, SubsamplingWorks)
+{
+  const int n_samples    = 500;
+  const int n_features   = 4;
+  const int n_estimators = 5;
+  const int max_samples  = 100;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = max_samples;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Verify stored max_samples
+  EXPECT_EQ(model.n_samples_per_tree, max_samples);
+  EXPECT_GT(model.fast_trees.size(), 0);
+}
+
+/**
+ * @brief Test: Anomaly scores are in valid range [0, 1].
+ *
+ * Corresponds to sklearn test: test_score_samples
+ * All anomaly scores should be between 0 and 1.
+ */
+TEST_F(IsolationForestTest, AnomalyScoresInRange)
+{
+  const int n_samples    = 200;
+  const int n_features   = 4;
+  const int n_estimators = 10;
+
+  // Generate data: row-major for score_samples, column-major for fit
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 128;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Compute anomaly scores (row-major input)
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  // Copy to host and verify range
+  thrust::host_vector<float> h_scores = scores;
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_GE(h_scores[i], 0.0f) << "Score at index " << i << " is below 0";
+    EXPECT_LE(h_scores[i], 1.0f) << "Score at index " << i << " is above 1";
+  }
+}
+
+/**
+ * @brief Test: Outliers score higher than inliers.
+ *
+ * Corresponds to sklearn test: test_iforest_performance
+ * Synthetic outliers should have higher anomaly scores than inliers.
+ */
+TEST_F(IsolationForestTest, OutliersScoreHigher)
+{
+  const int n_inliers    = 200;
+  const int n_outliers   = 20;
+  const int n_features   = 4;
+  const int n_estimators = 20;
+
+  // Generate data with proper column-major (fit) and row-major (score) formats
+  thrust::device_vector<float> X_colmajor;
+  thrust::device_vector<float> X_rowmajor;
+  thrust::device_vector<int> labels;
+  generate_data_with_outliers(n_inliers, n_outliers, n_features, 1.0f, 10.0f,
+                              X_colmajor, X_rowmajor, labels);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 128;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  int n_samples = n_inliers + n_outliers;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Compute anomaly scores (row-major input)
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  // Copy to host
+  thrust::host_vector<float> h_scores = scores;
+  thrust::host_vector<int> h_labels   = labels;
+
+  // Calculate mean scores for inliers and outliers
+  float inlier_sum  = 0.0f;
+  float outlier_sum = 0.0f;
+  int inlier_count  = 0;
+  int outlier_count = 0;
+
+  for (int i = 0; i < n_samples; i++) {
+    if (h_labels[i] == 0) {
+      inlier_sum += h_scores[i];
+      inlier_count++;
+    } else {
+      outlier_sum += h_scores[i];
+      outlier_count++;
+    }
+  }
+
+  float mean_inlier_score  = inlier_sum / inlier_count;
+  float mean_outlier_score = outlier_sum / outlier_count;
+
+  // Outliers should have higher average score (closer to 1)
+  EXPECT_GT(mean_outlier_score, mean_inlier_score)
+    << "Mean outlier score (" << mean_outlier_score << ") should be higher than mean inlier score ("
+    << mean_inlier_score << ")";
+}
+
+/**
+ * @brief Test: Predict returns correct labels.
+ *
+ * Corresponds to sklearn test: test_iforest (partial)
+ * Predictions should be 1 (anomaly) or -1 (normal).
+ */
+TEST_F(IsolationForestTest, PredictReturnsValidLabels)
+{
+  const int n_samples    = 100;
+  const int n_features   = 4;
+  const int n_estimators = 10;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Get predictions (row-major input)
+  thrust::device_vector<int> predictions(n_samples);
+  predict(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, predictions.data().get());
+
+  // Verify all predictions are either 1 or -1
+  thrust::host_vector<int> h_predictions = predictions;
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_TRUE(h_predictions[i] == 1 || h_predictions[i] == -1)
+      << "Prediction at index " << i << " is " << h_predictions[i] << ", expected 1 or -1";
+  }
+}
+
+/**
+ * @brief Test: Deterministic results with same seed.
+ *
+ * Corresponds to sklearn test: reproducibility checks
+ * Same seed should produce identical results.
+ */
+TEST_F(IsolationForestTest, DeterministicWithRandomState)
+{
+  const int n_samples    = 100;
+  const int n_features   = 4;
+  const int n_estimators = 5;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 12345;
+
+  // First fit (column-major)
+  IsolationForestF model1;
+  fit(*handle, &model1, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Second fit with same seed (column-major)
+  IsolationForestF model2;
+  fit(*handle, &model2, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Compute scores from both models (row-major)
+  thrust::device_vector<float> scores1(n_samples);
+  thrust::device_vector<float> scores2(n_samples);
+
+  score_samples(*handle, &model1, X_rowmajor.data().get(), n_samples, n_features, scores1.data().get());
+  score_samples(*handle, &model2, X_rowmajor.data().get(), n_samples, n_features, scores2.data().get());
+
+  // Scores should be identical
+  thrust::host_vector<float> h_scores1 = scores1;
+  thrust::host_vector<float> h_scores2 = scores2;
+
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_FLOAT_EQ(h_scores1[i], h_scores2[i])
+      << "Scores differ at index " << i << " despite same seed";
+  }
+}
+
+/**
+ * @brief Test: c(n) normalization constant computation.
+ *
+ * Verifies the average path length normalization constant is computed correctly.
+ */
+TEST_F(IsolationForestTest, CNormalizationConstant)
+{
+  // c(n) = 2*H(n-1) - 2(n-1)/n where H(i) ≈ ln(i) + 0.5772...
+  // For n=256:
+  //   H(255) ≈ ln(255) + 0.5772 ≈ 5.541 + 0.577 ≈ 6.118
+  //   c(256) = 2 * 6.118 - 2 * 255/256 ≈ 12.236 - 1.992 ≈ 10.24
+
+  float c_256 = compute_c_normalization<float>(256);
+  EXPECT_NEAR(c_256, 10.24f, 0.1f);
+
+  float c_2 = compute_c_normalization<float>(2);
+  EXPECT_FLOAT_EQ(c_2, 1.0f);
+
+  float c_1 = compute_c_normalization<float>(1);
+  EXPECT_FLOAT_EQ(c_1, 0.0f);
+
+  // Double precision
+  double c_256_d = compute_c_normalization<double>(256);
+  EXPECT_NEAR(c_256_d, 10.24, 0.1);
+}
+
+/**
+ * @brief Test: Double precision support.
+ *
+ * Verifies that double precision fits and scores correctly.
+ */
+TEST_F(IsolationForestTest, DoublePrecisionSupport)
+{
+  const int n_samples    = 100;
+  const int n_features   = 4;
+  const int n_estimators = 5;
+
+  thrust::device_vector<double> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<double> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0, 1.0, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestD model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Verify model was created
+  EXPECT_EQ(model.params.n_estimators, n_estimators);
+  EXPECT_GT(model.fast_trees.size(), 0);
+
+  // Compute scores (row-major)
+  thrust::device_vector<double> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  // Verify scores are in range
+  thrust::host_vector<double> h_scores = scores;
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_GE(h_scores[i], 0.0);
+    EXPECT_LE(h_scores[i], 1.0);
+  }
+}
+
+/**
+ * @brief Test: Edge case with small dataset.
+ *
+ * Corresponds to sklearn test: edge cases
+ * Handles datasets smaller than max_samples correctly.
+ */
+TEST_F(IsolationForestTest, SmallDataset)
+{
+  const int n_samples    = 32;  // Smaller than typical max_samples (256)
+  const int n_features   = 4;
+  const int n_estimators = 3;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 256;  // Larger than n_samples
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // max_samples should be capped at n_samples
+  EXPECT_EQ(model.n_samples_per_tree, n_samples);
+
+  // Should still produce valid scores (row-major)
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  thrust::host_vector<float> h_scores = scores;
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_GE(h_scores[i], 0.0f);
+    EXPECT_LE(h_scores[i], 1.0f);
+  }
+}
+
+/**
+ * @brief Test: Handle uniform data (all same values).
+ *
+ * Corresponds to sklearn test: test_iforest_with_uniform_data
+ * Edge case where all feature values are identical.
+ */
+TEST_F(IsolationForestTest, UniformData)
+{
+  const int n_samples    = 100;
+  const int n_features   = 4;
+  const int n_estimators = 5;
+
+  // Create uniform data (all zeros) - same in both layouts
+  thrust::device_vector<float> X_colmajor(n_samples * n_features, 0.0f);
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features, 0.0f);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Model should fit without error
+  EXPECT_EQ(model.params.n_estimators, n_estimators);
+  EXPECT_GT(model.fast_trees.size(), 0);
+
+  // Compute scores - all should be similar for uniform data (row-major)
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  thrust::host_vector<float> h_scores = scores;
+
+  // All scores should be in valid range
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_GE(h_scores[i], 0.0f);
+    EXPECT_LE(h_scores[i], 1.0f);
+  }
+
+  // For uniform data, scores should be very similar (low variance)
+  float mean_score = thrust::reduce(h_scores.begin(), h_scores.end(), 0.0f) / n_samples;
+  float variance   = 0.0f;
+  for (const auto& s : h_scores) {
+    variance += (s - mean_score) * (s - mean_score);
+  }
+  variance /= n_samples;
+
+  // Variance should be small for uniform data
+  EXPECT_LT(variance, 0.1f) << "Uniform data should produce similar scores, but variance is high";
+}
+
+/**
+ * @brief Test: Large number of estimators.
+ *
+ * Verifies that training many trees works correctly.
+ */
+TEST_F(IsolationForestTest, ManyEstimators)
+{
+  const int n_samples    = 200;
+  const int n_features   = 4;
+  const int n_estimators = 50;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Model should be created with all trees
+  EXPECT_EQ(model.params.n_estimators, n_estimators);
+  EXPECT_GT(model.fast_trees.size(), 0);
+
+  // Verify scoring works with many trees (row-major)
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+
+  thrust::host_vector<float> h_scores = scores;
+  for (int i = 0; i < n_samples; i++) {
+    EXPECT_GE(h_scores[i], 0.0f);
+    EXPECT_LE(h_scores[i], 1.0f);
+  }
+}
+
+/**
+ * @brief Test: Predict threshold parameter.
+ *
+ * Verifies that the threshold parameter affects predictions correctly.
+ */
+TEST_F(IsolationForestTest, PredictThreshold)
+{
+  const int n_samples    = 200;
+  const int n_features   = 4;
+  const int n_estimators = 10;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  // Predictions with low threshold (more anomalies) - row-major input
+  thrust::device_vector<int> pred_low(n_samples);
+  predict(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, pred_low.data().get(), 0.3f);
+
+  // Predictions with high threshold (fewer anomalies) - row-major input
+  thrust::device_vector<int> pred_high(n_samples);
+  predict(*handle, &model, X_rowmajor.data().get(), n_samples, n_features, pred_high.data().get(), 0.7f);
+
+  // Count anomalies in each
+  int anomalies_low =
+    thrust::count(thrust::device, pred_low.begin(), pred_low.end(), 1);
+  int anomalies_high =
+    thrust::count(thrust::device, pred_high.begin(), pred_high.end(), 1);
+
+  // Lower threshold should produce more anomaly predictions
+  EXPECT_GE(anomalies_low, anomalies_high)
+    << "Lower threshold should produce at least as many anomalies";
+}
+
+}  // namespace ML

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -77,6 +77,25 @@ __global__ void sample_rows_for_test(size_t n_rows,
   }
 }
 
+__global__ void sample_features_for_test(int n_cols,
+                                         int max_features,
+                                         uint64_t seed,
+                                         int* feature_indices)
+{
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+
+  curandState rng_state;
+  curand_init(seed, 0, 0, &rng_state);
+
+  size_t start = static_cast<size_t>(n_cols - max_features);
+  for (int i = 0; i < max_features; ++i) {
+    size_t j = start + static_cast<size_t>(i);
+    int t = static_cast<int>(IsolationTree::sample_bounded(&rng_state, j + 1));
+    feature_indices[i] =
+      IsolationTree::contains_int_sample(feature_indices, i, t) ? static_cast<int>(j) : t;
+  }
+}
+
 /**
  * @brief Base test fixture for Isolation Forest tests.
  *
@@ -378,6 +397,82 @@ TEST_F(IsolationForestTest, BootstrapTrueSamplesWithReplacement)
   std::sort(h_sampled.begin(), h_sampled.end());
   auto last = std::unique(h_sampled.begin(), h_sampled.end());
   EXPECT_LT(std::distance(h_sampled.begin(), last), max_samples);
+}
+
+TEST_F(IsolationForestTest, MaxFeaturesSamplesUniqueFeatureIds)
+{
+  const int n_cols       = 16;
+  const int max_features = 5;
+  thrust::device_vector<int> sampled(max_features);
+
+  sample_features_for_test<<<1, 1, 0, stream>>>(n_cols, max_features, 42, sampled.data().get());
+  RAFT_CUDA_TRY(cudaGetLastError());
+  handle->sync_stream(stream);
+
+  thrust::host_vector<int> h_sampled = sampled;
+  for (int feature : h_sampled) {
+    EXPECT_GE(feature, 0);
+    EXPECT_LT(feature, n_cols);
+  }
+
+  std::sort(h_sampled.begin(), h_sampled.end());
+  auto last = std::unique(h_sampled.begin(), h_sampled.end());
+  EXPECT_EQ(std::distance(h_sampled.begin(), last), max_features);
+}
+
+TEST_F(IsolationForestTest, MaxFeaturesFitStoresOriginalFeatureIds)
+{
+  const int n_samples    = 128;
+  const int n_features   = 8;
+  const int n_estimators = 5;
+  const int max_features = 3;
+
+  thrust::device_vector<float> X_rowmajor(n_samples * n_features);
+  thrust::device_vector<float> X_colmajor(n_samples * n_features);
+  raft::random::Rng rng(42);
+  rng.normal(X_rowmajor.data().get(), X_rowmajor.size(), 0.0f, 1.0f, stream);
+  handle->sync_stream(stream);
+  transpose_data(X_rowmajor, X_colmajor, n_samples, n_features);
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = 64;
+  params.max_features = max_features;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+
+  EXPECT_EQ(model.n_features_per_tree, max_features);
+  EXPECT_GT(model.global_feature_indices.size(), 0);
+
+  std::vector<int> h_tree_n_nodes(n_estimators);
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_tree_n_nodes.data(),
+                                model.global_tree_n_nodes.data(),
+                                n_estimators * sizeof(int),
+                                cudaMemcpyDeviceToHost,
+                                stream));
+  std::vector<IsolationTree::IFNode> h_nodes(
+    static_cast<size_t>(n_estimators) * model.max_nodes_per_tree);
+  RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(),
+                                model.global_nodes.data(),
+                                h_nodes.size() * sizeof(IsolationTree::IFNode),
+                                cudaMemcpyDeviceToHost,
+                                stream));
+  handle->sync_stream(stream);
+
+  bool saw_split = false;
+  for (int tree = 0; tree < n_estimators; ++tree) {
+    auto tree_offset = static_cast<size_t>(tree) * model.max_nodes_per_tree;
+    for (int node_idx = 0; node_idx < h_tree_n_nodes[tree]; ++node_idx) {
+      const auto& node = h_nodes[tree_offset + node_idx];
+      if (node.feature_idx >= 0) {
+        saw_split = true;
+        EXPECT_LT(node.feature_idx, n_features);
+      }
+    }
+  }
+  EXPECT_TRUE(saw_split);
 }
 
 /**

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -16,6 +16,8 @@
 
 #include <cuml/ensemble/isolation_forest.hpp>
 
+#include "../../src/isolation_forest/isolation_tree_builder.cuh"
+
 #include <raft/core/handle.hpp>
 #include <raft/linalg/transpose.cuh>
 #include <raft/random/rng.cuh>
@@ -38,7 +40,9 @@
 #include <treelite/enum/task_type.h>
 #include <treelite/tree.h>
 
+#include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <memory>
 #include <numeric>
 #include <random>
@@ -46,6 +50,32 @@
 
 namespace ML {
 namespace tl = treelite;
+
+__global__ void sample_rows_for_test(size_t n_rows,
+                                     int max_samples,
+                                     bool bootstrap,
+                                     uint64_t seed,
+                                     size_t* sample_indices)
+{
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+
+  curandState rng_state;
+  curand_init(seed, 0, 0, &rng_state);
+
+  if (bootstrap) {
+    for (int i = 0; i < max_samples; ++i) {
+      sample_indices[i] = IsolationTree::sample_bounded(&rng_state, n_rows);
+    }
+  } else {
+    size_t start = n_rows - static_cast<size_t>(max_samples);
+    for (int i = 0; i < max_samples; ++i) {
+      size_t j = start + static_cast<size_t>(i);
+      size_t t = IsolationTree::sample_bounded(&rng_state, j + 1);
+      sample_indices[i] =
+        IsolationTree::contains_sample(sample_indices, i, t) ? j : t;
+    }
+  }
+}
 
 /**
  * @brief Base test fixture for Isolation Forest tests.
@@ -309,6 +339,45 @@ TEST_F(IsolationForestTest, SubsamplingWorks)
   // Verify stored max_samples
   EXPECT_EQ(model.n_samples_per_tree, max_samples);
   EXPECT_GT(model.global_nodes.size(), 0);
+}
+
+TEST_F(IsolationForestTest, BootstrapFalseSamplesWithoutReplacement)
+{
+  const size_t n_rows  = 64;
+  const int max_samples = 64;
+  thrust::device_vector<size_t> sampled(max_samples);
+
+  sample_rows_for_test<<<1, 1, 0, stream>>>(n_rows, max_samples, false, 42, sampled.data().get());
+  RAFT_CUDA_TRY(cudaGetLastError());
+  handle->sync_stream(stream);
+
+  thrust::host_vector<size_t> h_sampled = sampled;
+  std::sort(h_sampled.begin(), h_sampled.end());
+  auto last = std::unique(h_sampled.begin(), h_sampled.end());
+
+  EXPECT_EQ(std::distance(h_sampled.begin(), last), max_samples);
+  EXPECT_EQ(h_sampled.front(), 0);
+  EXPECT_EQ(h_sampled.back(), n_rows - 1);
+}
+
+TEST_F(IsolationForestTest, BootstrapTrueSamplesWithReplacement)
+{
+  const size_t n_rows  = 4;
+  const int max_samples = 64;
+  thrust::device_vector<size_t> sampled(max_samples);
+
+  sample_rows_for_test<<<1, 1, 0, stream>>>(n_rows, max_samples, true, 42, sampled.data().get());
+  RAFT_CUDA_TRY(cudaGetLastError());
+  handle->sync_stream(stream);
+
+  thrust::host_vector<size_t> h_sampled = sampled;
+  for (size_t row : h_sampled) {
+    EXPECT_LT(row, n_rows);
+  }
+
+  std::sort(h_sampled.begin(), h_sampled.end());
+  auto last = std::unique(h_sampled.begin(), h_sampled.end());
+  EXPECT_LT(std::distance(h_sampled.begin(), last), max_samples);
 }
 
 /**

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -480,6 +480,38 @@ TEST_F(IsolationForestTest, MaxFeaturesFitStoresOriginalFeatureIds)
   EXPECT_EQ(model.global_feature_indices.size(), 0);
 }
 
+TEST_F(IsolationForestTest, ConstantFeaturesDoNotStopSplitting)
+{
+  const int n_samples    = 64;
+  const int n_features   = 8;
+  const int n_estimators = 4;
+  const int varying_col  = n_features - 1;
+
+  thrust::host_vector<float> h_X(static_cast<size_t>(n_samples) * n_features, 0.0f);
+  for (int row = 0; row < n_samples; ++row) {
+    h_X[static_cast<size_t>(varying_col) * n_samples + row] = static_cast<float>(row);
+  }
+  thrust::device_vector<float> X_colmajor = h_X;
+
+  IF_params params;
+  params.n_estimators = n_estimators;
+  params.max_samples  = n_samples;
+  params.max_features = n_features;
+  params.seed         = 42;
+
+  IsolationForestF model;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+  auto compact = get_compact_trees(*handle, &model);
+
+  ASSERT_EQ(compact.tree_offsets.size(), n_estimators);
+  for (int tree = 0; tree < n_estimators; ++tree) {
+    const auto& root = compact.nodes[compact.tree_offsets[tree]];
+    EXPECT_EQ(root.feature_idx, varying_col);
+    EXPECT_GE(root.left_child, 0);
+    EXPECT_GE(root.right_child, 0);
+  }
+}
+
 /**
  * @brief Test: Anomaly scores are in valid range [0, 1].
  *

--- a/cpp/tests/sg/isolation_forest_test.cu
+++ b/cpp/tests/sg/isolation_forest_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -453,11 +453,11 @@ TEST_F(IsolationForestTest, MaxFeaturesFitStoresOriginalFeatureIds)
                                 n_estimators * sizeof(int),
                                 cudaMemcpyDeviceToHost,
                                 stream));
-  std::vector<IsolationTree::IFNode> h_nodes(static_cast<size_t>(n_estimators) *
-                                             model.max_nodes_per_tree);
+  std::vector<IsolationTree::IFNode<float>> h_nodes(static_cast<size_t>(n_estimators) *
+                                                    model.max_nodes_per_tree);
   RAFT_CUDA_TRY(cudaMemcpyAsync(h_nodes.data(),
                                 model.global_nodes.data(),
-                                h_nodes.size() * sizeof(IsolationTree::IFNode),
+                                h_nodes.size() * sizeof(IsolationTree::IFNode<float>),
                                 cudaMemcpyDeviceToHost,
                                 stream));
   handle->sync_stream(stream);
@@ -474,6 +474,10 @@ TEST_F(IsolationForestTest, MaxFeaturesFitStoresOriginalFeatureIds)
     }
   }
   EXPECT_TRUE(saw_split);
+
+  params.max_features = n_features;
+  fit(*handle, &model, X_colmajor.data().get(), n_samples, n_features, params);
+  EXPECT_EQ(model.global_feature_indices.size(), 0);
 }
 
 /**
@@ -683,18 +687,14 @@ TEST_F(IsolationForestTest, CNormalizationConstant)
   //   H(255) ≈ ln(255) + 0.5772 ≈ 5.541 + 0.577 ≈ 6.118
   //   c(256) = 2 * 6.118 - 2 * 255/256 ≈ 12.236 - 1.992 ≈ 10.24
 
-  float c_256 = compute_c_normalization<float>(256);
-  EXPECT_NEAR(c_256, 10.24f, 0.1f);
+  double c_256 = compute_c_normalization(256);
+  EXPECT_NEAR(c_256, 10.24, 0.1);
 
-  float c_2 = compute_c_normalization<float>(2);
-  EXPECT_FLOAT_EQ(c_2, 1.0f);
+  double c_2 = compute_c_normalization(2);
+  EXPECT_DOUBLE_EQ(c_2, 1.0);
 
-  float c_1 = compute_c_normalization<float>(1);
-  EXPECT_FLOAT_EQ(c_1, 0.0f);
-
-  // Double precision
-  double c_256_d = compute_c_normalization<double>(256);
-  EXPECT_NEAR(c_256_d, 10.24, 0.1);
+  double c_1 = compute_c_normalization(1);
+  EXPECT_DOUBLE_EQ(c_1, 0.0);
 }
 
 /**
@@ -920,6 +920,20 @@ TEST_F(IsolationForestTest, PredictThreshold)
   // Lower threshold should produce more anomaly predictions
   EXPECT_GE(anomalies_low, anomalies_high)
     << "Lower threshold should produce at least as many anomalies";
+
+  thrust::device_vector<float> scores(n_samples);
+  score_samples(
+    *handle, &model, X_rowmajor.data().get(), n_samples, n_features, scores.data().get());
+  float boundary = scores[0];
+  thrust::device_vector<int> pred_boundary(n_samples);
+  predict(*handle,
+          &model,
+          X_rowmajor.data().get(),
+          n_samples,
+          n_features,
+          pred_boundary.data().get(),
+          boundary);
+  EXPECT_EQ(pred_boundary[0], -1) << "A score exactly at the threshold is not anomalous";
 }
 
 /**

--- a/python/cuml/cuml/__init__.py
+++ b/python/cuml/cuml/__init__.py
@@ -29,6 +29,7 @@ from cuml.datasets.regression import make_regression
 from cuml.decomposition.incremental_pca import IncrementalPCA
 from cuml.decomposition.pca import PCA
 from cuml.decomposition.tsvd import TruncatedSVD
+from cuml.ensemble.isolation_forest import IsolationForest
 from cuml.ensemble.randomforestclassifier import RandomForestClassifier
 from cuml.ensemble.randomforestregressor import RandomForestRegressor
 from cuml.explainer.kernel_shap import KernelExplainer
@@ -133,6 +134,7 @@ __all__ = [
     "Handle",
     "HDBSCAN",
     "IncrementalPCA",
+    "IsolationForest",
     "KernelDensity",
     "KernelExplainer",
     "KernelRidge",

--- a/python/cuml/cuml/ensemble/CMakeLists.txt
+++ b/python/cuml/cuml/ensemble/CMakeLists.txt
@@ -10,6 +10,7 @@ add_module_gpu_default(
   "randomforest_common.pyx" ${randomforestclassifier_algo} ${randomforestregressor_algo}
   ${ensemble_algo}
 )
+add_module_gpu_default("isolation_forest.pyx" ${isolationforest_algo} ${ensemble_algo})
 
 set(linked_libraries ${cuml_sg_libraries} ${CUML_PYTHON_TREELITE_TARGET})
 

--- a/python/cuml/cuml/ensemble/CMakeLists.txt
+++ b/python/cuml/cuml/ensemble/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/python/cuml/cuml/ensemble/CMakeLists.txt
+++ b/python/cuml/cuml/ensemble/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/python/cuml/cuml/ensemble/__init__.py
+++ b/python/cuml/cuml/ensemble/__init__.py
@@ -6,3 +6,4 @@
 
 from cuml.ensemble.randomforestclassifier import RandomForestClassifier
 from cuml.ensemble.randomforestregressor import RandomForestRegressor
+from cuml.ensemble.isolation_forest import IsolationForest

--- a/python/cuml/cuml/ensemble/__init__.py
+++ b/python/cuml/cuml/ensemble/__init__.py
@@ -1,9 +1,9 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
 
+from cuml.ensemble.isolation_forest import IsolationForest
 from cuml.ensemble.randomforestclassifier import RandomForestClassifier
 from cuml.ensemble.randomforestregressor import RandomForestRegressor
-from cuml.ensemble.isolation_forest import IsolationForest

--- a/python/cuml/cuml/ensemble/__init__.py
+++ b/python/cuml/cuml/ensemble/__init__.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -11,16 +11,14 @@ algorithm, which is an unsupervised learning method for detecting anomalies.
 """
 
 import builtins
-import math
-from numbers import Integral, Real
 import warnings
+from numbers import Integral, Real
 
 import cupy as cp
-import nvforest
 import numpy as np
+import nvforest
 import treelite
 
-from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
 from cuml.internals.input_utils import input_to_cuml_array
@@ -32,8 +30,6 @@ from cuml.internals.validation import check_random_seed
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t, uintptr_t
 from libcpp cimport bool
-from libcpp.memory cimport shared_ptr
-from libcpp.vector cimport vector
 from pylibraft.common.handle cimport handle_t
 
 from cuml.internals.logger cimport level_enum
@@ -727,13 +723,17 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         if self._dtype == np.float32:
             forest_f = <IsolationForestF*><uintptr_t>self._forest_float
             with nogil:
-                score_samples(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
-                             <float*>scores_ptr, verbose)
+                score_samples(
+                    handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
+                    <float*>scores_ptr, verbose
+                )
         else:
             forest_d = <IsolationForestD*><uintptr_t>self._forest_double
             with nogil:
-                score_samples(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
-                             <double*>scores_ptr, verbose)
+                score_samples(
+                    handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
+                    <double*>scores_ptr, verbose
+                )
 
         # Transform from original paper convention to sklearn convention:
         #
@@ -834,13 +834,17 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         if self._dtype == np.float32:
             forest_f = <IsolationForestF*><uintptr_t>self._forest_float
             with nogil:
-                predict(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
-                       <int*>pred_ptr, threshold_f, verbose)
+                predict(
+                    handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
+                    <int*>pred_ptr, threshold_f, verbose
+                )
         else:
             forest_d = <IsolationForestD*><uintptr_t>self._forest_double
             with nogil:
-                predict(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
-                       <int*>pred_ptr, threshold_d, verbose)
+                predict(
+                    handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
+                    <int*>pred_ptr, threshold_d, verbose
+                )
 
         # Our C++ returns: 1 for anomaly, -1 for normal
         # sklearn returns: -1 for anomaly, 1 for normal

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -49,6 +49,7 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
         int n_estimators
         int max_samples
         int max_depth
+        bool bootstrap
         uint64_t seed
 
     # C++ struct declaration with default constructor
@@ -184,16 +185,17 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         `ceil(log2(max_samples))`, which is the theoretical maximum depth
         needed to isolate any sample.
     max_features : float, default=1.0
-        Accepted for sklearn API compatibility. The current fast GPU builder
+        Accepted for sklearn API compatibility. The current GPU builder
         uses all features when selecting random split features.
     bootstrap : bool, default=False
-        Accepted for sklearn API compatibility. The current fast GPU builder
-        samples rows with replacement.
+        If True, individual trees are fit on random subsets of the training
+        data sampled with replacement. Otherwise, sampling is without
+        replacement.
     random_state : int, RandomState instance or None, default=None
         Controls random row sampling and split selection. Pass an int for
         reproducible results across runs.
     max_batch_size : int, default=4096
-        Accepted for sklearn API compatibility. The current fast GPU builder
+        Accepted for sklearn API compatibility. The current GPU builder
         builds each tree in a single CUDA block and does not batch nodes.
     contamination : float or "auto", default="auto"
         The proportion of outliers in the data set. The current implementation
@@ -235,12 +237,12 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
     **sklearn Convention (used by Python API):**
 
-    For compatibility with sklearn, the Python methods ``score_samples()`` and
-    ``decision_function()`` transform the scores so that:
-    - More negative scores indicate anomalies
-    - Scores around 0 indicate normal points
-
-    The transformation is: sklearn_score = -(paper_score - 0.5)
+    For compatibility with sklearn, the Python method ``score_samples()``
+    returns the opposite of the original paper score:
+    ``sklearn_score = -paper_score``. ``decision_function()`` then subtracts
+    ``offset_``. With the sklearn ``contamination="auto"`` offset of ``-0.5``,
+    negative decision function values correspond to paper scores greater than
+    0.5 and are predicted as anomalies.
 
     **Implementation Details:**
 
@@ -434,6 +436,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         params.n_estimators = self.n_estimators
         params.max_samples = actual_max_samples
         params.max_depth = actual_max_depth
+        params.bootstrap = self.bootstrap
         params.seed = seed
 
         # Get handle and verbosity
@@ -593,7 +596,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             avg_path_lengths = avg_path_lengths.reshape(-1)
 
         paper_scores = cp.power(2.0, -avg_path_lengths / self._c_normalization)
-        scores_sklearn = -(paper_scores - 0.5)
+        scores_sklearn = -paper_scores
 
         return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
 
@@ -612,11 +615,11 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
             **sklearn** inverts this convention so that:
                 - More negative scores → anomalies
-                - Scores around 0 → normal points
+                - Scores closer to 0 → more normal points
 
             This method follows sklearn's convention for drop-in compatibility.
             The C++ backend returns the original paper's scores, which are then
-            transformed here as: sklearn_score = -(paper_score - 0.5)
+            transformed here as: sklearn_score = -paper_score
 
         Parameters
         ----------
@@ -627,10 +630,8 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         -------
         scores : ndarray of shape (n_samples,)
             The anomaly scores (sklearn convention: lower/more negative = more anomalous).
-            Typical range is approximately [-0.5, 0.5] where:
-            - Scores << 0: likely anomalies
-            - Scores ≈ 0: normal points
-            - Scores >> 0: very normal points
+            Typical range is approximately [-1.0, 0.0], where values below
+            ``offset_`` are predicted as anomalies.
         """
         if self._forest_float is None and self._forest_double is None:
             raise RuntimeError("Model has not been fitted. Call fit() first.")
@@ -685,16 +686,16 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         #   - Very normal: s ≈ 0 (long paths, hard to isolate)
         #
         # sklearn convention:
-        #   - Anomalies: negative scores
-        #   - Normal: scores around 0
+        #   - score_samples returns the opposite of the paper score
+        #   - decision_function = score_samples - offset_
         #
-        # Transformation: sklearn_score = -(paper_score - 0.5)
-        #   - paper_score=1.0 (anomaly) → sklearn_score=-0.5
-        #   - paper_score=0.5 (normal)  → sklearn_score=0.0
-        #   - paper_score=0.0 (v.normal)→ sklearn_score=+0.5
+        # Transformation: sklearn_score = -paper_score
+        #   - paper_score=1.0 (anomaly) → sklearn_score=-1.0
+        #   - paper_score=0.5 (normal threshold) → sklearn_score=-0.5
+        #   - paper_score=0.0 (v.normal) → sklearn_score=0.0
         #
         scores_cp = scores.to_output("cupy")
-        scores_sklearn = -(scores_cp - 0.5)
+        scores_sklearn = -scores_cp
 
         return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
 
@@ -702,7 +703,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         """
         Compute the decision function of X.
 
-        The decision function is the anomaly score plus the offset.
+        The decision function is ``score_samples(X) - offset_``.
         Negative values indicate anomalies.
 
         Parameters

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -244,12 +244,15 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
     **Implementation Details:**
 
-    The fast GPU builder constructs all trees in one CUDA launch with one block
-    per tree. For each internal node it selects a random feature, computes the
+    The GPU builder constructs all trees in one CUDA launch with one block per
+    tree. For each internal node it selects a random feature, computes the
     minimum and maximum value for that feature in the current node partition,
-    and draws a random threshold uniformly between those values. Leaf nodes
-    store pre-computed path lengths (`depth + c(n_leaf)`), which keeps inference
-    to a simple tree traversal followed by the Isolation Forest score transform.
+    and draws a random threshold uniformly between those values. Tree nodes,
+    per-tree offsets, and per-tree metadata are stored in RMM-backed global
+    memory, which supports both default and deeper non-default tree settings.
+    Leaf nodes store pre-computed path lengths (`depth + c(n_leaf)`), which
+    keeps inference to a simple tree traversal followed by the Isolation Forest
+    score transform.
 
     Fitted models can be exported to Treelite with ``as_treelite()`` and loaded
     into nvForest with ``as_nvforest()``. The exported Treelite model predicts

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -174,7 +174,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
     ----------
     n_estimators : int, default=100
         The number of isolation trees in the ensemble.
-    max_samples : int or float, default=256
+    max_samples : int, float or "auto", default="auto"
         The number of samples to draw from X to train each isolation tree.
         - If int, then draw `max_samples` samples.
         - If float, then draw `max_samples * n_samples` samples.
@@ -271,7 +271,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self,
         *,
         n_estimators=100,
-        max_samples=256,
+        max_samples="auto",
         max_depth=None,
         max_features=1.0,
         bootstrap=False,

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -14,7 +14,9 @@ import math
 import warnings
 
 import cupy as cp
+import nvforest
 import numpy as np
+import treelite
 
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.array import CumlArray
@@ -22,7 +24,8 @@ from cuml.internals.base import Base, get_handle
 from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.internals.utils import check_random_seed
+from cuml.internals.treelite import safe_treelite_call
+from cuml.internals.validation import check_random_seed
 
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t, uintptr_t
@@ -32,6 +35,11 @@ from libcpp.vector cimport vector
 from pylibraft.common.handle cimport handle_t
 
 from cuml.internals.logger cimport level_enum
+from cuml.internals.treelite cimport (
+    TreeliteFreeModel,
+    TreeliteModelHandle,
+    TreeliteSerializeModelToBytes,
+)
 
 
 # C++ declarations from isolation_forest.hpp
@@ -52,6 +60,12 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
 
     ctypedef IsolationForestModel[float] IsolationForestF
     ctypedef IsolationForestModel[double] IsolationForestD
+
+    cdef void build_treelite_isolation_forest[T](
+        TreeliteModelHandle* model_handle,
+        const handle_t& handle,
+        const IsolationForestModel[T]* forest
+    ) except +
 
     cdef void fit(
         const handle_t& handle,
@@ -268,6 +282,9 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self._forest_float = None
         self._forest_double = None
         self._dtype = None
+        self._treelite_model_bytes = None
+        self._nvforest_model = None
+        self._c_normalization = None
 
         super().__init__(verbose=verbose, output_type=output_type)
 
@@ -345,6 +362,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         # Cannot pickle C++ pointers directly - would need serialization
         state["_forest_float"] = None
         state["_forest_double"] = None
+        state.pop("_nvforest_model", None)
         warnings.warn(
             "IsolationForest model serialization is not fully supported. "
             "The model will need to be re-fitted after unpickling."
@@ -429,6 +447,9 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
         cdef IsolationForestF* forest_f
         cdef IsolationForestD* forest_d
+        cdef TreeliteModelHandle tl_handle
+        cdef const char* tl_bytes = NULL
+        cdef size_t tl_bytes_len
 
         if X_m.dtype == np.float32:
             forest_f = new IsolationForestF()
@@ -437,6 +458,10 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
                     params, verbose)
             self._forest_float = <uintptr_t>forest_f
             self._n_samples_per_tree = forest_f.n_samples_per_tree
+            self._c_normalization = forest_f.c_normalization
+            with nogil:
+                build_treelite_isolation_forest[float](
+                    &tl_handle, handle_[0], forest_f)
         else:
             forest_d = new IsolationForestD()
             with nogil:
@@ -444,6 +469,22 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
                     params, verbose)
             self._forest_double = <uintptr_t>forest_d
             self._n_samples_per_tree = forest_d.n_samples_per_tree
+            self._c_normalization = forest_d.c_normalization
+            with nogil:
+                build_treelite_isolation_forest[double](
+                    &tl_handle, handle_[0], forest_d)
+
+        # Serialize the Treelite handle immediately, following the RandomForest
+        # ABI-safe pattern for Python wheels/conda environments.
+        safe_treelite_call(
+            TreeliteSerializeModelToBytes(tl_handle, &tl_bytes, &tl_bytes_len),
+            "Failed to serialize Treelite model to bytes:"
+        )
+        safe_treelite_call(
+            TreeliteFreeModel(tl_handle), "Failed to free Treelite model:"
+        )
+        self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
+        self._nvforest_model = None
 
         # Set offset based on contamination
         if self.contamination == "auto":
@@ -454,6 +495,111 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             self.offset_ = -0.5
 
         return self
+
+    def as_treelite(self):
+        """
+        Converts this estimator to a Treelite model.
+
+        The exported Treelite model predicts average path length across the
+        isolation trees. cuML applies the Isolation Forest score transform
+        separately to produce sklearn-compatible anomaly scores.
+
+        Returns
+        -------
+        treelite.Model
+        """
+        if self._treelite_model_bytes is None:
+            raise RuntimeError("Model has not been fitted. Call fit() first.")
+
+        return treelite.Model.deserialize_bytes(self._treelite_model_bytes)
+
+    def as_nvforest(
+        self, layout="depth_first", default_chunk_size=None, align_bytes=None,
+    ):
+        """
+        Create a nvForest model from the Treelite-exported Isolation Forest.
+
+        Returns
+        -------
+        nvforest_model : nvforest.ForestInference
+            A forest inference model that predicts average path length.
+        """
+        if self._treelite_model_bytes is None:
+            raise RuntimeError("Model has not been fitted. Call fit() first.")
+
+        return nvforest.load_from_treelite_model(
+            tl_model=treelite.Model.deserialize_bytes(self._treelite_model_bytes),
+            device="gpu",
+            layout=layout,
+            default_chunk_size=default_chunk_size,
+            align_bytes=align_bytes,
+            handle=get_handle(),
+        )
+
+    def _get_inference_nvforest_model(
+        self,
+        layout="depth_first",
+        default_chunk_size=None,
+        align_bytes=None,
+    ):
+        if (
+            layout == "depth_first" and default_chunk_size is None
+            and align_bytes is None
+        ):
+            if self._nvforest_model is None:
+                self._nvforest_model = self.as_nvforest()
+            return self._nvforest_model
+
+        return self.as_nvforest(
+            layout=layout,
+            default_chunk_size=default_chunk_size,
+            align_bytes=align_bytes,
+        )
+
+    def _score_samples_nvforest(
+        self,
+        X,
+        layout="depth_first",
+        default_chunk_size=None,
+        align_bytes=None,
+    ):
+        """
+        Compute sklearn-compatible anomaly scores through nvForest inference.
+
+        This helper is intentionally private while parity and benchmark coverage
+        are added. Public ``score_samples`` continues to use the existing C++
+        scoring path.
+        """
+        if self._treelite_model_bytes is None:
+            raise RuntimeError("Model has not been fitted. Call fit() first.")
+
+        X_m = input_to_cuml_array(
+            X,
+            check_dtype=[np.float32, np.float64],
+            convert_to_dtype=self._dtype,
+            order="C",
+        ).array
+
+        if X_m.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"X has {X_m.shape[1]} features, but IsolationForest was fitted "
+                f"with {self.n_features_in_} features."
+            )
+
+        nvforest_model = self._get_inference_nvforest_model(
+            layout=layout,
+            default_chunk_size=default_chunk_size,
+            align_bytes=align_bytes,
+        )
+        avg_path_lengths = nvforest_model.predict(X_m.to_output("cupy"))
+        avg_path_lengths = cp.asarray(avg_path_lengths, dtype=self._dtype)
+        if avg_path_lengths.ndim == 2 and avg_path_lengths.shape[1] == 1:
+            avg_path_lengths = avg_path_lengths.reshape(-1)
+
+        paper_scores = cp.power(2.0, -avg_path_lengths / self._c_normalization)
+        scores_sklearn = -(paper_scores - 0.5)
+
+        return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
 
     def score_samples(self, X):
         """

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -11,6 +11,7 @@ algorithm, which is an unsupervised learning method for detecting anomalies.
 """
 
 import math
+from numbers import Real
 import warnings
 
 import cupy as cp
@@ -198,9 +199,11 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         Accepted for sklearn API compatibility. The current GPU builder
         builds each tree in a single CUDA block and does not batch nodes.
     contamination : float or "auto", default="auto"
-        The proportion of outliers in the data set. The current implementation
-        uses the sklearn ``"auto"`` offset (-0.5); float contamination values
-        are accepted but do not yet compute a data-dependent offset.
+        The proportion of outliers in the data set, used to define the offset
+        for ``decision_function`` and ``predict``.
+        - If ``"auto"``, the offset is set to -0.5 as in sklearn.
+        - If float, must be in the range (0, 0.5] and the offset is set to
+          the corresponding training-score quantile.
     verbose : int or boolean, default=False
         Sets logging level.
     output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \\
@@ -406,8 +409,30 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         cdef size_t n_rows = X_m.shape[0]
         cdef int n_cols = X_m.shape[1]
         cdef uintptr_t X_ptr = X_m.ptr
+        cdef double contamination_fraction = 0.0
+        cdef bint use_contamination_quantile = False
         self.n_features_in_ = n_cols
         self._dtype = X_m.dtype
+
+        if isinstance(self.contamination, str):
+            if self.contamination != "auto":
+                raise ValueError(
+                    "contamination must be 'auto' or a float in the range "
+                    "(0, 0.5]."
+                )
+        elif isinstance(self.contamination, Real):
+            contamination_fraction = float(self.contamination)
+            if contamination_fraction <= 0.0 or contamination_fraction > 0.5:
+                raise ValueError(
+                    "contamination must be 'auto' or a float in the range "
+                    "(0, 0.5]."
+                )
+            use_contamination_quantile = True
+        else:
+            raise ValueError(
+                "contamination must be 'auto' or a float in the range "
+                "(0, 0.5]."
+            )
 
         # Compute max_samples
         cdef int actual_max_samples
@@ -485,11 +510,13 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
         self._nvforest_model = None
 
-        # Only the sklearn "auto" offset is implemented for now. Supporting a
-        # float contamination requires scoring the training data and computing
-        # the corresponding score quantile.
-        if self.contamination == "auto":
-            self.offset_ = -0.5
+        if use_contamination_quantile:
+            training_scores = cp.asarray(self.score_samples(X_m.to_output("cupy")))
+            self.offset_ = float(
+                cp.percentile(
+                    training_scores, 100.0 * contamination_fraction
+                ).get()
+            )
         else:
             self.offset_ = -0.5
 
@@ -767,9 +794,11 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         cdef IsolationForestF* forest_f
         cdef IsolationForestD* forest_d
 
-        # Use threshold of 0.5 (scores > 0.5 are anomalies in our C++ impl)
-        cdef float threshold_f = 0.5
-        cdef double threshold_d = 0.5
+        # C++ predict thresholds original paper scores, while Python
+        # score_samples returns -paper_score and decision_function subtracts
+        # offset_. Therefore decision_function < 0 maps to paper_score > -offset_.
+        cdef float threshold_f = <float>(-self.offset_)
+        cdef double threshold_d = <double>(-self.offset_)
 
         if self._dtype == np.float32:
             forest_f = <IsolationForestF*><uintptr_t>self._forest_float

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -10,8 +10,9 @@ This module provides a GPU-accelerated implementation of the Isolation Forest
 algorithm, which is an unsupervised learning method for detecting anomalies.
 """
 
+import builtins
 import math
-from numbers import Real
+from numbers import Integral, Real
 import warnings
 
 import cupy as cp
@@ -50,6 +51,7 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
         int n_estimators
         int max_samples
         int max_depth
+        int max_features
         bool bootstrap
         uint64_t seed
 
@@ -291,6 +293,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self._treelite_model_bytes = None
         self._nvforest_model = None
         self._c_normalization = None
+        self._n_features_per_tree = None
 
         super().__init__(verbose=verbose, output_type=output_type)
 
@@ -414,6 +417,33 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self.n_features_in_ = n_cols
         self._dtype = X_m.dtype
 
+        cdef int actual_max_features
+        if isinstance(self.max_features, builtins.bool):
+            raise ValueError(
+                "max_features must be an int in [1, n_features] or a float "
+                "in (0.0, 1.0]."
+            )
+        elif isinstance(self.max_features, Integral):
+            if self.max_features < 1 or self.max_features > n_cols:
+                raise ValueError(
+                    "max_features must be an int in [1, n_features] or a "
+                    "float in (0.0, 1.0]."
+                )
+            actual_max_features = int(self.max_features)
+        elif isinstance(self.max_features, Real):
+            if self.max_features <= 0.0 or self.max_features > 1.0:
+                raise ValueError(
+                    "max_features must be an int in [1, n_features] or a "
+                    "float in (0.0, 1.0]."
+                )
+            actual_max_features = max(1, int(self.max_features * n_cols))
+        else:
+            raise ValueError(
+                "max_features must be an int in [1, n_features] or a float "
+                "in (0.0, 1.0]."
+            )
+        self._n_features_per_tree = actual_max_features
+
         if isinstance(self.contamination, str):
             if self.contamination != "auto":
                 raise ValueError(
@@ -461,6 +491,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         params.n_estimators = self.n_estimators
         params.max_samples = actual_max_samples
         params.max_depth = actual_max_depth
+        params.max_features = actual_max_features
         params.bootstrap = self.bootstrap
         params.seed = seed
 

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -164,10 +164,10 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         >>> clf.fit(X)
         IsolationForest()
 
-        >>> # Predict anomalies (1 for anomaly, -1 for normal)
+        >>> # Predict anomalies (-1 for anomaly, 1 for normal)
         >>> predictions = clf.predict(X)
 
-        >>> # Get anomaly scores (higher = more anomalous)
+        >>> # Get sklearn-compatible anomaly scores (lower = more anomalous)
         >>> scores = clf.score_samples(X)
 
     Parameters
@@ -184,22 +184,21 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         `ceil(log2(max_samples))`, which is the theoretical maximum depth
         needed to isolate any sample.
     max_features : float, default=1.0
-        The fraction of features to draw from X to train each isolation tree.
-        Must be in the range (0.0, 1.0].
+        Accepted for sklearn API compatibility. The current fast GPU builder
+        uses all features when selecting random split features.
     bootstrap : bool, default=False
-        If True, individual trees are fit on random subsets of the training
-        data sampled with replacement. Otherwise, sampling is without replacement.
+        Accepted for sklearn API compatibility. The current fast GPU builder
+        samples rows with replacement.
     random_state : int, RandomState instance or None, default=None
-        Controls the randomness of the bootstrapping of the samples and
-        the sampling of the features. Pass an int for reproducible results
-        across runs.
+        Controls random row sampling and split selection. Pass an int for
+        reproducible results across runs.
     max_batch_size : int, default=4096
-        Maximum number of nodes processed per batch during tree building.
+        Accepted for sklearn API compatibility. The current fast GPU builder
+        builds each tree in a single CUDA block and does not batch nodes.
     contamination : float or "auto", default="auto"
-        The proportion of outliers in the data set. Used to define the threshold
-        for the `decision_function` and `predict` methods. If "auto", the
-        threshold is set to 0.5 (the theoretical threshold for scoring).
-        - If float, the contamination should be in the range (0, 0.5].
+        The proportion of outliers in the data set. The current implementation
+        uses the sklearn ``"auto"`` offset (-0.5); float contamination values
+        are accepted but do not yet compute a data-dependent offset.
     verbose : int or boolean, default=False
         Sets logging level.
     output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \\
@@ -243,19 +242,18 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
     The transformation is: sklearn_score = -(paper_score - 0.5)
 
-    **Implementation Differences from sklearn:**
+    **Implementation Details:**
 
-    This GPU implementation uses quantile-based discrete split thresholds for
-    efficiency, whereas sklearn uses continuous random thresholds. To mitigate
-    potential issues with tied values in features, small random jitter is
-    automatically added to the training data. This approach works well for most
-    datasets but may show reduced performance on datasets where:
+    The fast GPU builder constructs all trees in one CUDA launch with one block
+    per tree. For each internal node it selects a random feature, computes the
+    minimum and maximum value for that feature in the current node partition,
+    and draws a random threshold uniformly between those values. Leaf nodes
+    store pre-computed path lengths (`depth + c(n_leaf)`), which keeps inference
+    to a simple tree traversal followed by the Isolation Forest score transform.
 
-    - Anomalies are tightly clustered rather than scattered
-    - Many features have few unique values or many tied values
-
-    For best results, ensure your data has continuous features and anomalies
-    that are scattered outliers rather than dense clusters.
+    Fitted models can be exported to Treelite with ``as_treelite()`` and loaded
+    into nvForest with ``as_nvforest()``. The exported Treelite model predicts
+    average path length; cuML applies the anomaly score transform separately.
 
     For additional docs, see `scikit-learn's IsolationForest
     <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html>`_.
@@ -406,11 +404,6 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self.n_features_in_ = n_cols
         self._dtype = X_m.dtype
 
-        # NOTE: Jitter is NOT needed for the fast builder because it picks true
-        # random thresholds between min/max values (not quantile bins). The fast
-        # builder naturally handles duplicate values. Jitter was only needed for
-        # the generic RF-based builder which uses quantile-based binning.
-
         # Compute max_samples
         cdef int actual_max_samples
         if isinstance(self.max_samples, str) and self.max_samples == "auto":
@@ -486,12 +479,12 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
         self._nvforest_model = None
 
-        # Set offset based on contamination
+        # Only the sklearn "auto" offset is implemented for now. Supporting a
+        # float contamination requires scoring the training data and computing
+        # the corresponding score quantile.
         if self.contamination == "auto":
             self.offset_ = -0.5
         else:
-            # For contamination-based threshold, we would need to compute
-            # scores on training data and find the quantile
             self.offset_ = -0.5
 
         return self

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -1,0 +1,666 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+Isolation Forest implementation for GPU-accelerated anomaly detection.
+
+This module provides a GPU-accelerated implementation of the Isolation Forest
+algorithm, which is an unsupervised learning method for detecting anomalies.
+"""
+
+import math
+import warnings
+
+import cupy as cp
+import numpy as np
+
+from cuml.common.doc_utils import generate_docstring
+from cuml.internals.array import CumlArray
+from cuml.internals.base import Base, get_handle
+from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
+from cuml.internals.mixins import CMajorInputTagMixin
+from cuml.internals.utils import check_random_seed
+
+from libc.stddef cimport size_t
+from libc.stdint cimport uint64_t, uintptr_t
+from libcpp cimport bool
+from libcpp.memory cimport shared_ptr
+from libcpp.vector cimport vector
+from pylibraft.common.handle cimport handle_t
+
+from cuml.internals.logger cimport level_enum
+
+
+# C++ declarations from isolation_forest.hpp
+cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
+
+    cdef struct IF_params:
+        int n_estimators
+        int max_samples
+        int max_depth
+        uint64_t seed
+
+    # C++ struct declaration with default constructor
+    cdef cppclass IsolationForestModel[T]:
+        IsolationForestModel() except +  # Default constructor
+        int n_features
+        int n_samples_per_tree
+        T c_normalization
+
+    ctypedef IsolationForestModel[float] IsolationForestF
+    ctypedef IsolationForestModel[double] IsolationForestD
+
+    cdef void fit(
+        const handle_t& handle,
+        IsolationForestF* forest,
+        const float* input,
+        size_t n_rows,
+        int n_cols,
+        const IF_params& params,
+        level_enum verbosity
+    ) except +
+
+    cdef void fit(
+        const handle_t& handle,
+        IsolationForestD* forest,
+        const double* input,
+        size_t n_rows,
+        int n_cols,
+        const IF_params& params,
+        level_enum verbosity
+    ) except +
+
+    cdef void score_samples(
+        const handle_t& handle,
+        const IsolationForestF* forest,
+        const float* input,
+        size_t n_rows,
+        int n_cols,
+        float* scores,
+        level_enum verbosity
+    ) except +
+
+    cdef void score_samples(
+        const handle_t& handle,
+        const IsolationForestD* forest,
+        const double* input,
+        size_t n_rows,
+        int n_cols,
+        double* scores,
+        level_enum verbosity
+    ) except +
+
+    cdef void predict(
+        const handle_t& handle,
+        const IsolationForestF* forest,
+        const float* input,
+        size_t n_rows,
+        int n_cols,
+        int* predictions,
+        float threshold,
+        level_enum verbosity
+    ) except +
+
+    cdef void predict(
+        const handle_t& handle,
+        const IsolationForestD* forest,
+        const double* input,
+        size_t n_rows,
+        int n_cols,
+        int* predictions,
+        double threshold,
+        level_enum verbosity
+    ) except +
+
+
+class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
+    """
+    GPU-accelerated Isolation Forest for anomaly detection.
+
+    Isolation Forest is an unsupervised learning algorithm for anomaly detection
+    that works by isolating anomalies rather than profiling normal data points.
+    It uses the concept that anomalies are few and different, so they are easier
+    to isolate.
+
+    The algorithm builds an ensemble of isolation trees where each tree is
+    constructed by randomly selecting a feature and then randomly selecting a
+    split value between the minimum and maximum values of the selected feature.
+    Anomalies have shorter average path lengths in the trees because they are
+    easier to isolate.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        >>> import cupy as cp
+        >>> from cuml.ensemble import IsolationForest
+
+        >>> # Create synthetic data with some outliers
+        >>> rng = cp.random.default_rng(42)
+        >>> X_inliers = rng.standard_normal((100, 2), dtype=cp.float32)
+        >>> X_outliers = rng.uniform(low=-4, high=4, size=(20, 2)).astype(cp.float32)
+        >>> X = cp.vstack([X_inliers, X_outliers])
+
+        >>> # Fit the model
+        >>> clf = IsolationForest(n_estimators=100, random_state=42)
+        >>> clf.fit(X)
+        IsolationForest()
+
+        >>> # Predict anomalies (1 for anomaly, -1 for normal)
+        >>> predictions = clf.predict(X)
+
+        >>> # Get anomaly scores (higher = more anomalous)
+        >>> scores = clf.score_samples(X)
+
+    Parameters
+    ----------
+    n_estimators : int, default=100
+        The number of isolation trees in the ensemble.
+    max_samples : int or float, default=256
+        The number of samples to draw from X to train each isolation tree.
+        - If int, then draw `max_samples` samples.
+        - If float, then draw `max_samples * n_samples` samples.
+        - If "auto", then `max_samples=min(256, n_samples)`.
+    max_depth : int, default=None
+        Maximum depth of each isolation tree. If None, depth is set to
+        `ceil(log2(max_samples))`, which is the theoretical maximum depth
+        needed to isolate any sample.
+    max_features : float, default=1.0
+        The fraction of features to draw from X to train each isolation tree.
+        Must be in the range (0.0, 1.0].
+    bootstrap : bool, default=False
+        If True, individual trees are fit on random subsets of the training
+        data sampled with replacement. Otherwise, sampling is without replacement.
+    random_state : int, RandomState instance or None, default=None
+        Controls the randomness of the bootstrapping of the samples and
+        the sampling of the features. Pass an int for reproducible results
+        across runs.
+    max_batch_size : int, default=4096
+        Maximum number of nodes processed per batch during tree building.
+    contamination : float or "auto", default="auto"
+        The proportion of outliers in the data set. Used to define the threshold
+        for the `decision_function` and `predict` methods. If "auto", the
+        threshold is set to 0.5 (the theoretical threshold for scoring).
+        - If float, the contamination should be in the range (0, 0.5].
+    verbose : int or boolean, default=False
+        Sets logging level.
+    output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \\
+        'numba', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
+        Return results and set estimator attributes to the indicated output
+        type.
+
+    Attributes
+    ----------
+    n_features_in_ : int
+        Number of features seen during fit.
+    offset_ : float
+        Offset used to compute `decision_function` from raw anomaly scores.
+
+    Notes
+    -----
+    The implementation is based on the original Isolation Forest paper:
+    Liu, F. T., Ting, K. M., & Zhou, Z. H. (2008). Isolation forest.
+    In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422).
+
+    **Original Paper Scoring (used internally by C++ backend):**
+
+    The anomaly score is computed as: s(x) = 2^(-E[h(x)] / c(n))
+
+    where:
+    - h(x) is the path length of sample x in an isolation tree
+    - E[h(x)] is the average path length over all trees
+    - c(n) is the average path length in an unsuccessful search in a BST
+
+    In this convention:
+    - s ≈ 1.0: Anomaly (short path, easy to isolate)
+    - s ≈ 0.5: Normal (average path length)
+    - s ≈ 0.0: Very normal (long path, hard to isolate)
+
+    **sklearn Convention (used by Python API):**
+
+    For compatibility with sklearn, the Python methods ``score_samples()`` and
+    ``decision_function()`` transform the scores so that:
+    - More negative scores indicate anomalies
+    - Scores around 0 indicate normal points
+
+    The transformation is: sklearn_score = -(paper_score - 0.5)
+
+    **Implementation Differences from sklearn:**
+
+    This GPU implementation uses quantile-based discrete split thresholds for
+    efficiency, whereas sklearn uses continuous random thresholds. To mitigate
+    potential issues with tied values in features, small random jitter is
+    automatically added to the training data. This approach works well for most
+    datasets but may show reduced performance on datasets where:
+
+    - Anomalies are tightly clustered rather than scattered
+    - Many features have few unique values or many tied values
+
+    For best results, ensure your data has continuous features and anomalies
+    that are scattered outliers rather than dense clusters.
+
+    For additional docs, see `scikit-learn's IsolationForest
+    <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html>`_.
+    """
+
+    _cpu_class_path = "sklearn.ensemble.IsolationForest"
+
+    def __init__(
+        self,
+        *,
+        n_estimators=100,
+        max_samples=256,
+        max_depth=None,
+        max_features=1.0,
+        bootstrap=False,
+        random_state=None,
+        max_batch_size=4096,
+        contamination="auto",
+        verbose=False,
+        output_type=None,
+    ):
+        # Initialize internal pointers before Base init so cleanup is safe
+        # even if constructor raises early.
+        self._forest_float = None
+        self._forest_double = None
+        self._dtype = None
+
+        super().__init__(verbose=verbose, output_type=output_type)
+
+        self.n_estimators = n_estimators
+        self.max_samples = max_samples
+        self.max_depth = max_depth
+        self.max_features = max_features
+        self.bootstrap = bootstrap
+        self.random_state = random_state
+        self.max_batch_size = max_batch_size
+        self.contamination = contamination
+
+    def __del__(self):
+        """Clean up C++ model memory."""
+        self._free_model()
+
+    def _free_model(self):
+        """Free the C++ model memory."""
+        cdef IsolationForestF* f_ptr
+        cdef IsolationForestD* d_ptr
+
+        if hasattr(self, "_forest_float") and self._forest_float is not None:
+            f_ptr = <IsolationForestF*><uintptr_t>self._forest_float
+            del f_ptr
+            self._forest_float = None
+
+        if hasattr(self, "_forest_double") and self._forest_double is not None:
+            d_ptr = <IsolationForestD*><uintptr_t>self._forest_double
+            del d_ptr
+            self._forest_double = None
+
+    @classmethod
+    def _get_param_names(cls):
+        return [
+            *super()._get_param_names(),
+            "n_estimators",
+            "max_samples",
+            "max_depth",
+            "max_features",
+            "bootstrap",
+            "random_state",
+            "max_batch_size",
+            "contamination",
+        ]
+
+    @classmethod
+    def _params_from_cpu(cls, model):
+        """Convert sklearn model parameters to cuML parameters."""
+        if model.warm_start:
+            raise UnsupportedOnGPU("`warm_start=True` is not supported")
+
+        return {
+            "n_estimators": model.n_estimators,
+            "max_samples": model.max_samples,
+            "max_features": model.max_features,
+            "bootstrap": model.bootstrap,
+            "random_state": model.random_state,
+            "contamination": model.contamination,
+        }
+
+    def _params_to_cpu(self):
+        """Convert cuML parameters to sklearn parameters."""
+        return {
+            "n_estimators": self.n_estimators,
+            "max_samples": self.max_samples,
+            "max_features": self.max_features,
+            "bootstrap": self.bootstrap,
+            "random_state": self.random_state,
+            "contamination": self.contamination,
+        }
+
+    def __getstate__(self):
+        """Pickle support - serialize state."""
+        state = self.__dict__.copy()
+        # Cannot pickle C++ pointers directly - would need serialization
+        state["_forest_float"] = None
+        state["_forest_double"] = None
+        warnings.warn(
+            "IsolationForest model serialization is not fully supported. "
+            "The model will need to be re-fitted after unpickling."
+        )
+        return state
+
+    def __setstate__(self, state):
+        """Pickle support - restore state."""
+        self.__dict__.update(state)
+
+    def fit(self, X, y=None):
+        """
+        Fit the Isolation Forest model.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input samples. Internally, it will be converted to float32
+            or float64.
+        y : Ignored
+            Not used, present for API consistency.
+
+        Returns
+        -------
+        self : IsolationForest
+            Fitted estimator.
+        """
+        # Free any existing model
+        self._free_model()
+
+        # Convert input to cuML array (column-major for fit)
+        X_m = input_to_cuml_array(
+            X,
+            check_dtype=[np.float32, np.float64],
+            order="F",  # Column-major for fit
+        ).array
+
+        cdef size_t n_rows = X_m.shape[0]
+        cdef int n_cols = X_m.shape[1]
+        cdef uintptr_t X_ptr = X_m.ptr
+        self.n_features_in_ = n_cols
+        self._dtype = X_m.dtype
+
+        # NOTE: Jitter is NOT needed for the fast builder because it picks true
+        # random thresholds between min/max values (not quantile bins). The fast
+        # builder naturally handles duplicate values. Jitter was only needed for
+        # the generic RF-based builder which uses quantile-based binning.
+
+        # Compute max_samples
+        cdef int actual_max_samples
+        if isinstance(self.max_samples, str) and self.max_samples == "auto":
+            actual_max_samples = min(256, n_rows)
+        elif isinstance(self.max_samples, float):
+            actual_max_samples = int(self.max_samples * n_rows)
+        else:
+            actual_max_samples = min(self.max_samples, n_rows)
+
+        # Compute max_depth (-1 means auto in C++)
+        cdef int actual_max_depth
+        if self.max_depth is None:
+            actual_max_depth = -1  # C++ will compute ceil(log2(max_samples))
+        else:
+            actual_max_depth = self.max_depth
+
+        # Get random seed
+        cdef uint64_t seed = (
+            0 if self.random_state is None
+            else check_random_seed(self.random_state)
+        )
+
+        # Setup parameters
+        cdef IF_params params
+        params.n_estimators = self.n_estimators
+        params.max_samples = actual_max_samples
+        params.max_depth = actual_max_depth
+        params.seed = seed
+
+        # Get handle and verbosity
+        handle = get_handle()
+        cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
+        cdef level_enum verbose = <level_enum>self._verbose_level
+
+        cdef IsolationForestF* forest_f
+        cdef IsolationForestD* forest_d
+
+        if X_m.dtype == np.float32:
+            forest_f = new IsolationForestF()
+            with nogil:
+                fit(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
+                    params, verbose)
+            self._forest_float = <uintptr_t>forest_f
+            self._n_samples_per_tree = forest_f.n_samples_per_tree
+        else:
+            forest_d = new IsolationForestD()
+            with nogil:
+                fit(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
+                    params, verbose)
+            self._forest_double = <uintptr_t>forest_d
+            self._n_samples_per_tree = forest_d.n_samples_per_tree
+
+        # Set offset based on contamination
+        if self.contamination == "auto":
+            self.offset_ = -0.5
+        else:
+            # For contamination-based threshold, we would need to compute
+            # scores on training data and find the quantile
+            self.offset_ = -0.5
+
+        return self
+
+    def score_samples(self, X):
+        """
+        Compute the anomaly score of X.
+
+        Returns sklearn-compatible scores where **more negative = more anomalous**.
+
+        .. note:: Score Convention Difference
+
+            The **original paper** (Liu et al. 2008) defines:
+                s(x) = 2^(-E[h(x)] / c(n))
+
+            Where higher scores (close to 1) indicate anomalies.
+
+            **sklearn** inverts this convention so that:
+                - More negative scores → anomalies
+                - Scores around 0 → normal points
+
+            This method follows sklearn's convention for drop-in compatibility.
+            The C++ backend returns the original paper's scores, which are then
+            transformed here as: sklearn_score = -(paper_score - 0.5)
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input samples.
+
+        Returns
+        -------
+        scores : ndarray of shape (n_samples,)
+            The anomaly scores (sklearn convention: lower/more negative = more anomalous).
+            Typical range is approximately [-0.5, 0.5] where:
+            - Scores << 0: likely anomalies
+            - Scores ≈ 0: normal points
+            - Scores >> 0: very normal points
+        """
+        if self._forest_float is None and self._forest_double is None:
+            raise RuntimeError("Model has not been fitted. Call fit() first.")
+
+        # Convert input to cuML array (row-major for inference)
+        X_m = input_to_cuml_array(
+            X,
+            check_dtype=[np.float32, np.float64],
+            convert_to_dtype=self._dtype,
+            order="C",  # Row-major for inference
+        ).array
+
+        cdef size_t n_rows = X_m.shape[0]
+        cdef int n_cols = X_m.shape[1]
+
+        if n_cols != self.n_features_in_:
+            raise ValueError(
+                f"X has {n_cols} features, but IsolationForest was fitted "
+                f"with {self.n_features_in_} features."
+            )
+
+        # Allocate output
+        scores = CumlArray.zeros(n_rows, dtype=self._dtype, order="C")
+
+        # Get handle and verbosity
+        handle = get_handle()
+        cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
+        cdef level_enum verbose = <level_enum>self._verbose_level
+
+        cdef uintptr_t X_ptr = X_m.ptr
+        cdef uintptr_t scores_ptr = scores.ptr
+        cdef IsolationForestF* forest_f
+        cdef IsolationForestD* forest_d
+
+        if self._dtype == np.float32:
+            forest_f = <IsolationForestF*><uintptr_t>self._forest_float
+            with nogil:
+                score_samples(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
+                             <float*>scores_ptr, verbose)
+        else:
+            forest_d = <IsolationForestD*><uintptr_t>self._forest_double
+            with nogil:
+                score_samples(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
+                             <double*>scores_ptr, verbose)
+
+        # Transform from original paper convention to sklearn convention:
+        #
+        # Original paper (Liu et al. 2008):
+        #   s(x) = 2^(-E[h(x)] / c(n))
+        #   - Anomalies: s ≈ 1 (short paths, easy to isolate)
+        #   - Normal:    s ≈ 0.5 (average path length)
+        #   - Very normal: s ≈ 0 (long paths, hard to isolate)
+        #
+        # sklearn convention:
+        #   - Anomalies: negative scores
+        #   - Normal: scores around 0
+        #
+        # Transformation: sklearn_score = -(paper_score - 0.5)
+        #   - paper_score=1.0 (anomaly) → sklearn_score=-0.5
+        #   - paper_score=0.5 (normal)  → sklearn_score=0.0
+        #   - paper_score=0.0 (v.normal)→ sklearn_score=+0.5
+        #
+        scores_cp = scores.to_output("cupy")
+        scores_sklearn = -(scores_cp - 0.5)
+
+        return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
+
+    def decision_function(self, X):
+        """
+        Compute the decision function of X.
+
+        The decision function is the anomaly score plus the offset.
+        Negative values indicate anomalies.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input samples.
+
+        Returns
+        -------
+        scores : ndarray of shape (n_samples,)
+            The decision function. Negative values indicate anomalies.
+        """
+        return self.score_samples(X) - self.offset_
+
+    def predict(self, X):
+        """
+        Predict if samples are anomalies or not.
+
+        Returns -1 for anomalies and 1 for normal samples.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input samples.
+
+        Returns
+        -------
+        labels : ndarray of shape (n_samples,)
+            1 for inliers, -1 for outliers.
+        """
+        if self._forest_float is None and self._forest_double is None:
+            raise RuntimeError("Model has not been fitted. Call fit() first.")
+
+        # Convert input to cuML array (row-major for inference)
+        X_m = input_to_cuml_array(
+            X,
+            check_dtype=[np.float32, np.float64],
+            convert_to_dtype=self._dtype,
+            order="C",  # Row-major for inference
+        ).array
+
+        cdef size_t n_rows = X_m.shape[0]
+        cdef int n_cols = X_m.shape[1]
+
+        if n_cols != self.n_features_in_:
+            raise ValueError(
+                f"X has {n_cols} features, but IsolationForest was fitted "
+                f"with {self.n_features_in_} features."
+            )
+
+        # Allocate output
+        predictions = CumlArray.zeros(n_rows, dtype=np.int32, order="C")
+
+        # Get handle and verbosity
+        handle = get_handle()
+        cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
+        cdef level_enum verbose = <level_enum>self._verbose_level
+
+        cdef uintptr_t X_ptr = X_m.ptr
+        cdef uintptr_t pred_ptr = predictions.ptr
+        cdef IsolationForestF* forest_f
+        cdef IsolationForestD* forest_d
+
+        # Use threshold of 0.5 (scores > 0.5 are anomalies in our C++ impl)
+        cdef float threshold_f = 0.5
+        cdef double threshold_d = 0.5
+
+        if self._dtype == np.float32:
+            forest_f = <IsolationForestF*><uintptr_t>self._forest_float
+            with nogil:
+                predict(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
+                       <int*>pred_ptr, threshold_f, verbose)
+        else:
+            forest_d = <IsolationForestD*><uintptr_t>self._forest_double
+            with nogil:
+                predict(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
+                       <int*>pred_ptr, threshold_d, verbose)
+
+        # Our C++ returns: 1 for anomaly, -1 for normal
+        # sklearn returns: -1 for anomaly, 1 for normal
+        # So we need to negate
+        preds_cp = predictions.to_output("cupy")
+        preds_sklearn = -preds_cp
+
+        return CumlArray(preds_sklearn).to_output(self._get_output_type(X))
+
+    def fit_predict(self, X, y=None):
+        """
+        Fit the model and predict on X.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input samples.
+        y : Ignored
+            Not used, present for API consistency.
+
+        Returns
+        -------
+        labels : ndarray of shape (n_samples,)
+            1 for inliers, -1 for outliers.
+        """
+        return self.fit(X).predict(X)

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -19,13 +19,12 @@ import numpy as np
 import nvforest
 import treelite
 
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.input_utils import input_to_cuml_array
 from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import CMajorInputTagMixin
+from cuml.internals.outputs import mlfunc
 from cuml.internals.treelite import safe_treelite_call
-from cuml.internals.validation import check_random_seed
+from cuml.internals.validation import check_inputs, check_random_seed
 
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t, uintptr_t
@@ -130,7 +129,7 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
     ) except +
 
 
-class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
+class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     """
     GPU-accelerated Isolation Forest for anomaly detection.
 
@@ -393,6 +392,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         """Pickle support - restore state."""
         self.__dict__.update(state)
 
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, sample_weight=None):
         """
         Fit the Isolation Forest model.
@@ -420,16 +420,18 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         # Free any existing model
         self._free_model()
 
-        # Convert input to cuML array (column-major for fit)
-        X_m = input_to_cuml_array(
+        # Convert input to a column-major device array for fit.
+        X_m = check_inputs(
+            self,
             X,
-            check_dtype=[np.float32, np.float64],
-            order="F",  # Column-major for fit
-        ).array
+            dtype=(np.float32, np.float64),
+            order="F",
+            reset=True,
+        )
 
         cdef size_t n_rows = X_m.shape[0]
         cdef int n_cols = X_m.shape[1]
-        cdef uintptr_t X_ptr = X_m.ptr
+        cdef uintptr_t X_ptr = X_m.data.ptr
         cdef double contamination_fraction = 0.0
         cdef bint use_contamination_quantile = False
         self.n_features_in_ = n_cols
@@ -592,7 +594,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self._nvforest_model = None
 
         if use_contamination_quantile:
-            training_scores = cp.asarray(self.score_samples(X_m.to_output("cupy")))
+            training_scores = self.score_samples(X_m)
             self.offset_ = float(
                 cp.percentile(
                     training_scores, 100.0 * contamination_fraction
@@ -680,25 +682,19 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         if self._treelite_model_bytes is None:
             raise RuntimeError("Model has not been fitted. Call fit() first.")
 
-        X_m = input_to_cuml_array(
+        X_m = check_inputs(
+            self,
             X,
-            check_dtype=[np.float32, np.float64],
-            convert_to_dtype=self._dtype,
+            dtype=self._dtype,
             order="C",
-        ).array
-
-        if X_m.shape[1] != self.n_features_in_:
-            raise ValueError(
-                f"X has {X_m.shape[1]} features, but IsolationForest was fitted "
-                f"with {self.n_features_in_} features."
-            )
+        )
 
         nvforest_model = self._get_inference_nvforest_model(
             layout=layout,
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,
         )
-        avg_path_lengths = nvforest_model.predict(X_m.to_output("cupy"))
+        avg_path_lengths = nvforest_model.predict(X_m)
         avg_path_lengths = cp.asarray(avg_path_lengths, dtype=self._dtype)
         if avg_path_lengths.ndim == 2 and avg_path_lengths.shape[1] == 1:
             avg_path_lengths = avg_path_lengths.reshape(-1)
@@ -713,8 +709,9 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             )
         scores_sklearn = -paper_scores
 
-        return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
+        return scores_sklearn
 
+    @mlfunc(preserve_index=True)
     def score_samples(self, X):
         """
         Compute the anomaly score of X.
@@ -751,33 +748,27 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         if self._forest_float is None and self._forest_double is None:
             raise RuntimeError("Model has not been fitted. Call fit() first.")
 
-        # Convert input to cuML array (row-major for inference)
-        X_m = input_to_cuml_array(
+        # Convert input to a row-major device array for inference.
+        X_m = check_inputs(
+            self,
             X,
-            check_dtype=[np.float32, np.float64],
-            convert_to_dtype=self._dtype,
-            order="C",  # Row-major for inference
-        ).array
+            dtype=self._dtype,
+            order="C",
+        )
 
         cdef size_t n_rows = X_m.shape[0]
         cdef int n_cols = X_m.shape[1]
 
-        if n_cols != self.n_features_in_:
-            raise ValueError(
-                f"X has {n_cols} features, but IsolationForest was fitted "
-                f"with {self.n_features_in_} features."
-            )
-
         # Allocate output
-        scores = CumlArray.zeros(n_rows, dtype=self._dtype, order="C")
+        scores = cp.zeros(n_rows, dtype=self._dtype, order="C")
 
         # Get handle and verbosity
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
         cdef level_enum verbose = <level_enum>self._verbose_level
 
-        cdef uintptr_t X_ptr = X_m.ptr
-        cdef uintptr_t scores_ptr = scores.ptr
+        cdef uintptr_t X_ptr = X_m.data.ptr
+        cdef uintptr_t scores_ptr = scores.data.ptr
         cdef IsolationForestF* forest_f
         cdef IsolationForestD* forest_d
 
@@ -813,11 +804,9 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         #   - paper_score=0.5 (normal threshold) → sklearn_score=-0.5
         #   - paper_score=0.0 (v.normal) → sklearn_score=0.0
         #
-        scores_cp = scores.to_output("cupy")
-        scores_sklearn = -scores_cp
+        return -scores
 
-        return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
-
+    @mlfunc(preserve_index=True)
     def decision_function(self, X):
         """
         Compute the decision function of X.
@@ -837,6 +826,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         """
         return self.score_samples(X) - self.offset_
 
+    @mlfunc(preserve_index=True)
     def predict(self, X):
         """
         Predict if samples are anomalies or not.
@@ -856,33 +846,27 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         if self._forest_float is None and self._forest_double is None:
             raise RuntimeError("Model has not been fitted. Call fit() first.")
 
-        # Convert input to cuML array (row-major for inference)
-        X_m = input_to_cuml_array(
+        # Convert input to a row-major device array for inference.
+        X_m = check_inputs(
+            self,
             X,
-            check_dtype=[np.float32, np.float64],
-            convert_to_dtype=self._dtype,
-            order="C",  # Row-major for inference
-        ).array
+            dtype=self._dtype,
+            order="C",
+        )
 
         cdef size_t n_rows = X_m.shape[0]
         cdef int n_cols = X_m.shape[1]
 
-        if n_cols != self.n_features_in_:
-            raise ValueError(
-                f"X has {n_cols} features, but IsolationForest was fitted "
-                f"with {self.n_features_in_} features."
-            )
-
         # Allocate output
-        predictions = CumlArray.zeros(n_rows, dtype=np.int32, order="C")
+        predictions = cp.zeros(n_rows, dtype=np.int32, order="C")
 
         # Get handle and verbosity
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
         cdef level_enum verbose = <level_enum>self._verbose_level
 
-        cdef uintptr_t X_ptr = X_m.ptr
-        cdef uintptr_t pred_ptr = predictions.ptr
+        cdef uintptr_t X_ptr = X_m.data.ptr
+        cdef uintptr_t pred_ptr = predictions.data.ptr
         cdef IsolationForestF* forest_f
         cdef IsolationForestD* forest_d
 
@@ -910,11 +894,9 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         # Our C++ returns: 1 for anomaly, -1 for normal
         # sklearn returns: -1 for anomaly, 1 for normal
         # So we need to negate
-        preds_cp = predictions.to_output("cupy")
-        preds_sklearn = -preds_cp
+        return -predictions
 
-        return CumlArray(preds_sklearn).to_output(self._get_output_type(X))
-
+    @mlfunc(preserve_index=True)
     def fit_predict(self, X, y=None, sample_weight=None):
         """
         Fit the model and predict on X.

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -197,8 +197,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     random_state : int, RandomState instance or None, default=None
         Controls random row sampling and split selection. Pass an int for
         reproducible results across runs.
-    max_batch_size : int, default=4096
-        Currently unused.
     contamination : float or "auto", default="auto"
         The proportion of outliers in the data set, used to define the offset
         for ``decision_function`` and ``predict``.
@@ -260,7 +258,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         max_features=1.0,
         bootstrap=False,
         random_state=None,
-        max_batch_size=4096,
         contamination="auto",
         warm_start=False,
         verbose=False,
@@ -284,7 +281,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self.max_features = max_features
         self.bootstrap = bootstrap
         self.random_state = random_state
-        self.max_batch_size = max_batch_size
         self.contamination = contamination
         self.warm_start = warm_start
 
@@ -317,7 +313,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "max_features",
             "bootstrap",
             "random_state",
-            "max_batch_size",
             "contamination",
             "warm_start",
         ]

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -133,6 +133,163 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
     ) except +
 
 
+cdef class _IsolationForestModel:
+    """Own the native Isolation Forest model for the estimator lifetime."""
+
+    cdef IsolationForestF* model_f
+    cdef IsolationForestD* model_d
+
+    @staticmethod
+    cdef _IsolationForestModel new_float32():
+        cdef _IsolationForestModel self = (
+            _IsolationForestModel.__new__(_IsolationForestModel)
+        )
+        self.model_f = new IsolationForestF()
+        return self
+
+    @staticmethod
+    cdef _IsolationForestModel new_float64():
+        cdef _IsolationForestModel self = (
+            _IsolationForestModel.__new__(_IsolationForestModel)
+        )
+        self.model_d = new IsolationForestD()
+        return self
+
+    cdef void fit_and_build_treelite(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        const IF_params& params,
+        level_enum verbose,
+        TreeliteModelHandle* tl_handle,
+    ) except *:
+        if self.model_f != NULL:
+            with nogil:
+                fit(
+                    handle,
+                    self.model_f,
+                    <float*>input_ptr,
+                    n_rows,
+                    n_cols,
+                    params,
+                    verbose,
+                )
+                build_treelite_isolation_forest[float](
+                    tl_handle, handle, self.model_f
+                )
+        elif self.model_d != NULL:
+            with nogil:
+                fit(
+                    handle,
+                    self.model_d,
+                    <double*>input_ptr,
+                    n_rows,
+                    n_cols,
+                    params,
+                    verbose,
+                )
+                build_treelite_isolation_forest[double](
+                    tl_handle, handle, self.model_d
+                )
+        else:
+            raise RuntimeError("Isolation Forest model is not initialized.")
+
+    cdef int get_n_samples_per_tree(self) except -1:
+        if self.model_f != NULL:
+            return self.model_f.n_samples_per_tree
+        if self.model_d != NULL:
+            return self.model_d.n_samples_per_tree
+        raise RuntimeError("Isolation Forest model is not initialized.")
+
+    cdef double get_c_normalization(self) except *:
+        if self.model_f != NULL:
+            return self.model_f.c_normalization
+        if self.model_d != NULL:
+            return self.model_d.c_normalization
+        raise RuntimeError("Isolation Forest model is not initialized.")
+
+    cdef void score(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        uintptr_t scores_ptr,
+        level_enum verbose,
+    ) except *:
+        if self.model_f != NULL:
+            with nogil:
+                score_samples(
+                    handle,
+                    self.model_f,
+                    <float*>input_ptr,
+                    n_rows,
+                    n_cols,
+                    <float*>scores_ptr,
+                    verbose,
+                )
+        elif self.model_d != NULL:
+            with nogil:
+                score_samples(
+                    handle,
+                    self.model_d,
+                    <double*>input_ptr,
+                    n_rows,
+                    n_cols,
+                    <double*>scores_ptr,
+                    verbose,
+                )
+        else:
+            raise RuntimeError("Isolation Forest model is not initialized.")
+
+    cdef void predict_labels(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        uintptr_t predictions_ptr,
+        double threshold,
+        level_enum verbose,
+    ) except *:
+        if self.model_f != NULL:
+            with nogil:
+                predict(
+                    handle,
+                    self.model_f,
+                    <float*>input_ptr,
+                    n_rows,
+                    n_cols,
+                    <int*>predictions_ptr,
+                    <float>threshold,
+                    verbose,
+                )
+        elif self.model_d != NULL:
+            with nogil:
+                predict(
+                    handle,
+                    self.model_d,
+                    <double*>input_ptr,
+                    n_rows,
+                    n_cols,
+                    <int*>predictions_ptr,
+                    threshold,
+                    verbose,
+                )
+        else:
+            raise RuntimeError("Isolation Forest model is not initialized.")
+
+    def __dealloc__(self):
+        if self.model_f != NULL:
+            del self.model_f
+            self.model_f = NULL
+        if self.model_d != NULL:
+            del self.model_d
+            self.model_d = NULL
+
+
 class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     """
     GPU-accelerated Isolation Forest for anomaly detection.
@@ -263,10 +420,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         verbose=False,
         output_type=None,
     ):
-        # Initialize internal pointers before Base init so cleanup is safe
-        # even if constructor raises early.
-        self._forest_float = None
-        self._forest_double = None
+        self._model = None
         self._dtype = None
         self._treelite_model_bytes = None
         self._nvforest_model = None
@@ -283,25 +437,6 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         self.random_state = random_state
         self.contamination = contamination
         self.warm_start = warm_start
-
-    def __del__(self):
-        """Clean up C++ model memory."""
-        self._free_model()
-
-    def _free_model(self):
-        """Free the C++ model memory."""
-        cdef IsolationForestF* f_ptr
-        cdef IsolationForestD* d_ptr
-
-        if hasattr(self, "_forest_float") and self._forest_float is not None:
-            f_ptr = <IsolationForestF*><uintptr_t>self._forest_float
-            del f_ptr
-            self._forest_float = None
-
-        if hasattr(self, "_forest_double") and self._forest_double is not None:
-            d_ptr = <IsolationForestD*><uintptr_t>self._forest_double
-            del d_ptr
-            self._forest_double = None
 
     @classmethod
     def _get_param_names(cls):
@@ -358,9 +493,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     def __getstate__(self):
         """Pickle support - serialize state."""
         state = self.__dict__.copy()
-        # Cannot pickle C++ pointers directly - would need serialization
-        state["_forest_float"] = None
-        state["_forest_double"] = None
+        # The native model is not currently serialized.
+        state["_model"] = None
         state.pop("_nvforest_model", None)
         warnings.warn(
             "IsolationForest model serialization is not fully supported. "
@@ -397,8 +531,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         if sample_weight is not None:
             raise UnsupportedOnGPU("`sample_weight` is not supported")
 
-        # Free any existing model
-        self._free_model()
+        # Release any existing native model.
+        self._model = None
 
         # Convert input to a column-major device array for fit.
         X_m = check_inputs(
@@ -529,8 +663,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
         cdef level_enum verbose = <level_enum>self._verbose_level
 
-        cdef IsolationForestF* forest_f
-        cdef IsolationForestD* forest_d
+        cdef _IsolationForestModel model
         cdef TreeliteModelHandle tl_handle = NULL
         cdef const char* tl_bytes = NULL
         cdef size_t tl_bytes_len
@@ -538,27 +671,21 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         try:
             if X_m.dtype == np.float32:
-                forest_f = new IsolationForestF()
-                self._forest_float = <uintptr_t>forest_f
-                with nogil:
-                    fit(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
-                        params, verbose)
-                self._n_samples_per_tree = forest_f.n_samples_per_tree
-                self._c_normalization = forest_f.c_normalization
-                with nogil:
-                    build_treelite_isolation_forest[float](
-                        &tl_handle, handle_[0], forest_f)
+                model = _IsolationForestModel.new_float32()
             else:
-                forest_d = new IsolationForestD()
-                self._forest_double = <uintptr_t>forest_d
-                with nogil:
-                    fit(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
-                        params, verbose)
-                self._n_samples_per_tree = forest_d.n_samples_per_tree
-                self._c_normalization = forest_d.c_normalization
-                with nogil:
-                    build_treelite_isolation_forest[double](
-                        &tl_handle, handle_[0], forest_d)
+                model = _IsolationForestModel.new_float64()
+            self._model = model
+            model.fit_and_build_treelite(
+                handle_[0],
+                X_ptr,
+                n_rows,
+                n_cols,
+                params,
+                verbose,
+                &tl_handle,
+            )
+            self._n_samples_per_tree = model.get_n_samples_per_tree()
+            self._c_normalization = model.get_c_normalization()
 
             # Serialize the Treelite handle immediately, following the
             # RandomForest ABI-safe pattern for Python wheels/conda environments.
@@ -576,7 +703,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         except Exception:
             if tl_handle != NULL:
                 TreeliteFreeModel(tl_handle)
-            self._free_model()
+            self._model = None
             self._treelite_model_bytes = None
             self._nvforest_model = None
             raise
@@ -722,7 +849,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             Typical range is approximately [-1.0, 0.0], where values below
             ``offset_`` are predicted as anomalies.
         """
-        if self._forest_float is None and self._forest_double is None:
+        cdef _IsolationForestModel model = self._model
+        if model is None:
             raise RuntimeError("Model has not been fitted. Call fit() first.")
 
         # Convert input to a row-major device array for inference.
@@ -746,23 +874,14 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         cdef uintptr_t X_ptr = X_m.data.ptr
         cdef uintptr_t scores_ptr = scores.data.ptr
-        cdef IsolationForestF* forest_f
-        cdef IsolationForestD* forest_d
-
-        if self._dtype == np.float32:
-            forest_f = <IsolationForestF*><uintptr_t>self._forest_float
-            with nogil:
-                score_samples(
-                    handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
-                    <float*>scores_ptr, verbose
-                )
-        else:
-            forest_d = <IsolationForestD*><uintptr_t>self._forest_double
-            with nogil:
-                score_samples(
-                    handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
-                    <double*>scores_ptr, verbose
-                )
+        model.score(
+            handle_[0],
+            X_ptr,
+            n_rows,
+            n_cols,
+            scores_ptr,
+            verbose,
+        )
 
         # Transform from original paper convention to sklearn convention:
         #
@@ -820,7 +939,8 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         labels : ndarray of shape (n_samples,)
             1 for inliers, -1 for outliers.
         """
-        if self._forest_float is None and self._forest_double is None:
+        cdef _IsolationForestModel model = self._model
+        if model is None:
             raise RuntimeError("Model has not been fitted. Call fit() first.")
 
         # Convert input to a row-major device array for inference.
@@ -844,29 +964,21 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         cdef uintptr_t X_ptr = X_m.data.ptr
         cdef uintptr_t pred_ptr = predictions.data.ptr
-        cdef IsolationForestF* forest_f
-        cdef IsolationForestD* forest_d
 
         # C++ predict thresholds original paper scores, while Python
         # score_samples returns -paper_score and decision_function subtracts
         # offset_. Therefore decision_function < 0 maps to paper_score > -offset_.
-        cdef float threshold_f = <float>(-self.offset_)
         cdef double threshold_d = <double>(-self.offset_)
 
-        if self._dtype == np.float32:
-            forest_f = <IsolationForestF*><uintptr_t>self._forest_float
-            with nogil:
-                predict(
-                    handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
-                    <int*>pred_ptr, threshold_f, verbose
-                )
-        else:
-            forest_d = <IsolationForestD*><uintptr_t>self._forest_double
-            with nogil:
-                predict(
-                    handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
-                    <int*>pred_ptr, threshold_d, verbose
-                )
+        model.predict_labels(
+            handle_[0],
+            X_ptr,
+            n_rows,
+            n_cols,
+            pred_ptr,
+            threshold_d,
+            verbose,
+        )
 
         # Our C++ returns: 1 for anomaly, -1 for normal
         # sklearn returns: -1 for anomaly, 1 for normal

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -56,7 +56,7 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
         IsolationForestModel() except +  # Default constructor
         int n_features
         int n_samples_per_tree
-        T c_normalization
+        double c_normalization
 
     ctypedef IsolationForestModel[float] IsolationForestF
     ctypedef IsolationForestModel[double] IsolationForestD
@@ -184,8 +184,9 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         `ceil(log2(max_samples))`, which is the theoretical maximum depth
         needed to isolate any sample.
     max_features : float, default=1.0
-        Accepted for sklearn API compatibility. The current GPU builder
-        uses all features when selecting random split features.
+        The number of features to draw from X to train each isolation tree.
+        - If int, draw exactly ``max_features`` features.
+        - If float, draw ``max_features * n_features`` features.
     bootstrap : bool, default=False
         If True, individual trees are fit on random subsets of the training
         data sampled with replacement. Otherwise, sampling is without
@@ -202,6 +203,8 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         - If ``"auto"``, the offset is set to -0.5 as in sklearn.
         - If float, must be in the range (0, 0.5] and the offset is set to
           the corresponding training-score quantile.
+    warm_start : bool, default=False
+        ``warm_start=True`` is not currently supported.
     verbose : int or boolean, default=False
         Sets logging level.
     output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \\
@@ -215,9 +218,16 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         Number of features seen during fit.
     offset_ : float
         Offset used to compute `decision_function` from raw anomaly scores.
+    max_samples_ : int
+        The actual number of samples used to train each tree.
 
     Notes
     -----
+    The sklearn attributes ``estimator_``, ``estimators_``,
+    ``estimators_features_``, and ``estimators_samples_`` are not currently
+    exposed because the GPU model stores the forest in compact device buffers
+    rather than as individual sklearn tree estimators.
+
     The implementation is based on the original Isolation Forest paper:
     Liu, F. T., Ting, K. M., & Zhou, Z. H. (2008). Isolation forest.
     In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422).
@@ -278,6 +288,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         random_state=None,
         max_batch_size=4096,
         contamination="auto",
+        warm_start=False,
         verbose=False,
         output_type=None,
     ):
@@ -301,6 +312,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         self.random_state = random_state
         self.max_batch_size = max_batch_size
         self.contamination = contamination
+        self.warm_start = warm_start
 
     def __del__(self):
         """Clean up C++ model memory."""
@@ -333,6 +345,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             "random_state",
             "max_batch_size",
             "contamination",
+            "warm_start",
         ]
 
     @classmethod
@@ -348,6 +361,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             "bootstrap": model.bootstrap,
             "random_state": model.random_state,
             "contamination": model.contamination,
+            "warm_start": model.warm_start,
         }
 
     def _params_to_cpu(self):
@@ -359,6 +373,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             "bootstrap": self.bootstrap,
             "random_state": self.random_state,
             "contamination": self.contamination,
+            "warm_start": self.warm_start,
         }
 
     def __getstate__(self):
@@ -378,7 +393,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         """Pickle support - restore state."""
         self.__dict__.update(state)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, sample_weight=None):
         """
         Fit the Isolation Forest model.
 
@@ -389,12 +404,19 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             or float64.
         y : Ignored
             Not used, present for API consistency.
+        sample_weight : array-like of shape (n_samples,), default=None
+            Not currently supported.
 
         Returns
         -------
         self : IsolationForest
             Fitted estimator.
         """
+        if self.warm_start:
+            raise UnsupportedOnGPU("`warm_start=True` is not supported")
+        if sample_weight is not None:
+            raise UnsupportedOnGPU("`sample_weight` is not supported")
+
         # Free any existing model
         self._free_model()
 
@@ -462,12 +484,44 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
         # Compute max_samples
         cdef int actual_max_samples
-        if isinstance(self.max_samples, str) and self.max_samples == "auto":
+        if isinstance(self.max_samples, str):
+            if self.max_samples != "auto":
+                raise ValueError(
+                    "max_samples must be 'auto', a positive int, or a float "
+                    "in (0.0, 1.0]."
+                )
             actual_max_samples = min(256, n_rows)
-        elif isinstance(self.max_samples, float):
-            actual_max_samples = int(self.max_samples * n_rows)
-        else:
+        elif isinstance(self.max_samples, builtins.bool):
+            raise ValueError(
+                "max_samples must be 'auto', a positive int, or a float "
+                "in (0.0, 1.0]."
+            )
+        elif isinstance(self.max_samples, Integral):
+            if self.max_samples <= 0:
+                raise ValueError("max_samples must be a positive integer.")
+            if self.max_samples > n_rows:
+                warnings.warn(
+                    f"max_samples ({self.max_samples}) is greater than the "
+                    f"total number of samples ({n_rows}). max_samples will "
+                    "be set to n_samples for estimation.",
+                    UserWarning,
+                )
             actual_max_samples = min(self.max_samples, n_rows)
+        elif isinstance(self.max_samples, Real):
+            if self.max_samples <= 0.0 or self.max_samples > 1.0:
+                raise ValueError("float max_samples must be in (0.0, 1.0].")
+            actual_max_samples = int(self.max_samples * n_rows)
+            if actual_max_samples < 1:
+                raise ValueError(
+                    "max_samples resolves to 0 samples; increase max_samples "
+                    "or provide more training rows."
+                )
+        else:
+            raise ValueError(
+                "max_samples must be 'auto', a positive int, or a float "
+                "in (0.0, 1.0]."
+            )
+        self.max_samples_ = actual_max_samples
 
         # Compute max_depth (-1 means auto in C++)
         cdef int actual_max_depth
@@ -649,7 +703,14 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
         if avg_path_lengths.ndim == 2 and avg_path_lengths.shape[1] == 1:
             avg_path_lengths = avg_path_lengths.reshape(-1)
 
-        paper_scores = cp.power(2.0, -avg_path_lengths / self._c_normalization)
+        if self._c_normalization <= 0:
+            paper_scores = cp.full(
+                avg_path_lengths.shape, 0.5, dtype=self._dtype
+            )
+        else:
+            paper_scores = cp.power(
+                2.0, -avg_path_lengths / self._c_normalization
+            )
         scores_sklearn = -paper_scores
 
         return CumlArray(scores_sklearn).to_output(self._get_output_type(X))
@@ -854,7 +915,7 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
 
         return CumlArray(preds_sklearn).to_output(self._get_output_type(X))
 
-    def fit_predict(self, X, y=None):
+    def fit_predict(self, X, y=None, sample_weight=None):
         """
         Fit the model and predict on X.
 
@@ -864,10 +925,12 @@ class IsolationForest(Base, InteropMixin, CMajorInputTagMixin):
             The input samples.
         y : Ignored
             Not used, present for API consistency.
+        sample_weight : array-like of shape (n_samples,), default=None
+            Not currently supported.
 
         Returns
         -------
         labels : ndarray of shape (n_samples,)
             1 for inliers, -1 for outliers.
         """
-        return self.fit(X).predict(X)
+        return self.fit(X, sample_weight=sample_weight).predict(X)

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -170,7 +170,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         >>> # Predict anomalies (-1 for anomaly, 1 for normal)
         >>> predictions = clf.predict(X)
 
-        >>> # Get sklearn-compatible anomaly scores (lower = more anomalous)
+        >>> # Get anomaly scores (lower = more anomalous)
         >>> scores = clf.score_samples(X)
 
     Parameters
@@ -198,12 +198,11 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         Controls random row sampling and split selection. Pass an int for
         reproducible results across runs.
     max_batch_size : int, default=4096
-        Accepted for sklearn API compatibility. The current GPU builder
-        builds each tree in a single CUDA block and does not batch nodes.
+        Currently unused.
     contamination : float or "auto", default="auto"
         The proportion of outliers in the data set, used to define the offset
         for ``decision_function`` and ``predict``.
-        - If ``"auto"``, the offset is set to -0.5 as in sklearn.
+        - If ``"auto"``, the offset is set to -0.5.
         - If float, must be in the range (0, 0.5] and the offset is set to
           the corresponding training-score quantile.
     warm_start : bool, default=False
@@ -228,16 +227,11 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
     Notes
     -----
-    The sklearn attributes ``estimator_``, ``estimators_``,
-    ``estimators_features_``, and ``estimators_samples_`` are not currently
-    exposed because the GPU model stores the forest in compact device buffers
-    rather than as individual sklearn tree estimators.
-
     The implementation is based on the original Isolation Forest paper:
     Liu, F. T., Ting, K. M., & Zhou, Z. H. (2008). Isolation forest.
     In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422).
 
-    **Original Paper Scoring (used internally by C++ backend):**
+    **Scoring**
 
     The anomaly score is computed as: s(x) = 2^(-E[h(x)] / c(n))
 
@@ -246,38 +240,13 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     - E[h(x)] is the average path length over all trees
     - c(n) is the average path length in an unsuccessful search in a BST
 
-    In this convention:
-    - s ≈ 1.0: Anomaly (short path, easy to isolate)
-    - s ≈ 0.5: Normal (average path length)
-    - s ≈ 0.0: Very normal (long path, hard to isolate)
-
-    **sklearn Convention (used by Python API):**
-
-    For compatibility with sklearn, the Python method ``score_samples()``
-    returns the opposite of the original paper score:
-    ``sklearn_score = -paper_score``. ``decision_function()`` then subtracts
-    ``offset_``. With the sklearn ``contamination="auto"`` offset of ``-0.5``,
-    negative decision function values correspond to paper scores greater than
-    0.5 and are predicted as anomalies.
-
-    **Implementation Details:**
-
-    The GPU builder constructs all trees in one CUDA launch with one block per
-    tree. For each internal node it selects a random feature, computes the
-    minimum and maximum value for that feature in the current node partition,
-    and draws a random threshold uniformly between those values. Tree nodes,
-    per-tree offsets, and per-tree metadata are stored in RMM-backed global
-    memory, which supports both default and deeper non-default tree settings.
-    Leaf nodes store pre-computed path lengths (`depth + c(n_leaf)`), which
-    keeps inference to a simple tree traversal followed by the Isolation Forest
-    score transform.
+    Higher values of s indicate more anomalous samples. ``score_samples()``
+    returns the negative of s, so lower values indicate more anomalous samples.
+    ``decision_function()`` subtracts ``offset_`` from these scores; negative
+    decision-function values are predicted as anomalies.
 
     Fitted models can be exported to Treelite with ``as_treelite()`` and loaded
-    into nvForest with ``as_nvforest()``. The exported Treelite model predicts
-    average path length; cuML applies the anomaly score transform separately.
-
-    For additional docs, see `scikit-learn's IsolationForest
-    <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html>`_.
+    into nvForest with ``as_nvforest()``.
     """
 
     _cpu_class_path = "sklearn.ensemble.IsolationForest"
@@ -640,8 +609,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         Converts this estimator to a Treelite model.
 
         The exported Treelite model predicts average path length across the
-        isolation trees. cuML applies the Isolation Forest score transform
-        separately to produce sklearn-compatible anomaly scores.
+        isolation trees.
 
         Returns
         -------
@@ -746,22 +714,9 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         """
         Compute the anomaly score of X.
 
-        Returns sklearn-compatible scores where **more negative = more anomalous**.
-
-        .. note:: Score Convention Difference
-
-            The **original paper** (Liu et al. 2008) defines:
-                s(x) = 2^(-E[h(x)] / c(n))
-
-            Where higher scores (close to 1) indicate anomalies.
-
-            **sklearn** inverts this convention so that:
-                - More negative scores → anomalies
-                - Scores closer to 0 → more normal points
-
-            This method follows sklearn's convention for drop-in compatibility.
-            The C++ backend returns the original paper's scores, which are then
-            transformed here as: sklearn_score = -paper_score
+        Lower scores indicate more anomalous samples. The returned scores are
+        the negative of the anomaly scores defined in the original Isolation
+        Forest paper.
 
         Parameters
         ----------
@@ -771,7 +726,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         Returns
         -------
         scores : ndarray of shape (n_samples,)
-            The anomaly scores (sklearn convention: lower/more negative = more anomalous).
+            The anomaly scores. Lower values indicate more anomalous samples.
             Typical range is approximately [-1.0, 0.0], where values below
             ``offset_`` are predicted as anomalies.
         """

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -134,26 +134,7 @@ cdef extern from "cuml/ensemble/isolation_forest.hpp" namespace "ML" nogil:
 
 
 cdef class _IsolationForestModel:
-    """Own the native Isolation Forest model for the estimator lifetime."""
-
-    cdef IsolationForestF* model_f
-    cdef IsolationForestD* model_d
-
-    @staticmethod
-    cdef _IsolationForestModel new_float32():
-        cdef _IsolationForestModel self = (
-            _IsolationForestModel.__new__(_IsolationForestModel)
-        )
-        self.model_f = new IsolationForestF()
-        return self
-
-    @staticmethod
-    cdef _IsolationForestModel new_float64():
-        cdef _IsolationForestModel self = (
-            _IsolationForestModel.__new__(_IsolationForestModel)
-        )
-        self.model_d = new IsolationForestD()
-        return self
+    """Common interface for dtype-specific native model owners."""
 
     cdef void fit_and_build_treelite(
         self,
@@ -165,50 +146,13 @@ cdef class _IsolationForestModel:
         level_enum verbose,
         TreeliteModelHandle* tl_handle,
     ) except *:
-        if self.model_f != NULL:
-            with nogil:
-                fit(
-                    handle,
-                    self.model_f,
-                    <float*>input_ptr,
-                    n_rows,
-                    n_cols,
-                    params,
-                    verbose,
-                )
-                build_treelite_isolation_forest[float](
-                    tl_handle, handle, self.model_f
-                )
-        elif self.model_d != NULL:
-            with nogil:
-                fit(
-                    handle,
-                    self.model_d,
-                    <double*>input_ptr,
-                    n_rows,
-                    n_cols,
-                    params,
-                    verbose,
-                )
-                build_treelite_isolation_forest[double](
-                    tl_handle, handle, self.model_d
-                )
-        else:
-            raise RuntimeError("Isolation Forest model is not initialized.")
+        raise NotImplementedError()
 
     cdef int get_n_samples_per_tree(self) except -1:
-        if self.model_f != NULL:
-            return self.model_f.n_samples_per_tree
-        if self.model_d != NULL:
-            return self.model_d.n_samples_per_tree
-        raise RuntimeError("Isolation Forest model is not initialized.")
+        raise NotImplementedError()
 
     cdef double get_c_normalization(self) except *:
-        if self.model_f != NULL:
-            return self.model_f.c_normalization
-        if self.model_d != NULL:
-            return self.model_d.c_normalization
-        raise RuntimeError("Isolation Forest model is not initialized.")
+        raise NotImplementedError()
 
     cdef void score(
         self,
@@ -219,30 +163,7 @@ cdef class _IsolationForestModel:
         uintptr_t scores_ptr,
         level_enum verbose,
     ) except *:
-        if self.model_f != NULL:
-            with nogil:
-                score_samples(
-                    handle,
-                    self.model_f,
-                    <float*>input_ptr,
-                    n_rows,
-                    n_cols,
-                    <float*>scores_ptr,
-                    verbose,
-                )
-        elif self.model_d != NULL:
-            with nogil:
-                score_samples(
-                    handle,
-                    self.model_d,
-                    <double*>input_ptr,
-                    n_rows,
-                    n_cols,
-                    <double*>scores_ptr,
-                    verbose,
-                )
-        else:
-            raise RuntimeError("Isolation Forest model is not initialized.")
+        raise NotImplementedError()
 
     cdef void predict_labels(
         self,
@@ -254,40 +175,181 @@ cdef class _IsolationForestModel:
         double threshold,
         level_enum verbose,
     ) except *:
-        if self.model_f != NULL:
-            with nogil:
-                predict(
-                    handle,
-                    self.model_f,
-                    <float*>input_ptr,
-                    n_rows,
-                    n_cols,
-                    <int*>predictions_ptr,
-                    <float>threshold,
-                    verbose,
-                )
-        elif self.model_d != NULL:
-            with nogil:
-                predict(
-                    handle,
-                    self.model_d,
-                    <double*>input_ptr,
-                    n_rows,
-                    n_cols,
-                    <int*>predictions_ptr,
-                    threshold,
-                    verbose,
-                )
-        else:
-            raise RuntimeError("Isolation Forest model is not initialized.")
+        raise NotImplementedError()
+
+
+cdef class _IsolationForestModelFloat32(_IsolationForestModel):
+    """Own a float32 native Isolation Forest model."""
+
+    cdef IsolationForestF* model
+
+    def __cinit__(self):
+        self.model = NULL
+        self.model = new IsolationForestF()
 
     def __dealloc__(self):
-        if self.model_f != NULL:
-            del self.model_f
-            self.model_f = NULL
-        if self.model_d != NULL:
-            del self.model_d
-            self.model_d = NULL
+        if self.model != NULL:
+            del self.model
+            self.model = NULL
+
+    cdef void fit_and_build_treelite(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        const IF_params& params,
+        level_enum verbose,
+        TreeliteModelHandle* tl_handle,
+    ) except *:
+        with nogil:
+            fit(
+                handle,
+                self.model,
+                <float*>input_ptr,
+                n_rows,
+                n_cols,
+                params,
+                verbose,
+            )
+            build_treelite_isolation_forest[float](
+                tl_handle, handle, self.model
+            )
+
+    cdef int get_n_samples_per_tree(self) except -1:
+        return self.model.n_samples_per_tree
+
+    cdef double get_c_normalization(self) except *:
+        return self.model.c_normalization
+
+    cdef void score(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        uintptr_t scores_ptr,
+        level_enum verbose,
+    ) except *:
+        with nogil:
+            score_samples(
+                handle,
+                self.model,
+                <float*>input_ptr,
+                n_rows,
+                n_cols,
+                <float*>scores_ptr,
+                verbose,
+            )
+
+    cdef void predict_labels(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        uintptr_t predictions_ptr,
+        double threshold,
+        level_enum verbose,
+    ) except *:
+        with nogil:
+            predict(
+                handle,
+                self.model,
+                <float*>input_ptr,
+                n_rows,
+                n_cols,
+                <int*>predictions_ptr,
+                <float>threshold,
+                verbose,
+            )
+
+
+cdef class _IsolationForestModelFloat64(_IsolationForestModel):
+    """Own a float64 native Isolation Forest model."""
+
+    cdef IsolationForestD* model
+
+    def __cinit__(self):
+        self.model = NULL
+        self.model = new IsolationForestD()
+
+    def __dealloc__(self):
+        if self.model != NULL:
+            del self.model
+            self.model = NULL
+
+    cdef void fit_and_build_treelite(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        const IF_params& params,
+        level_enum verbose,
+        TreeliteModelHandle* tl_handle,
+    ) except *:
+        with nogil:
+            fit(
+                handle,
+                self.model,
+                <double*>input_ptr,
+                n_rows,
+                n_cols,
+                params,
+                verbose,
+            )
+            build_treelite_isolation_forest[double](
+                tl_handle, handle, self.model
+            )
+
+    cdef int get_n_samples_per_tree(self) except -1:
+        return self.model.n_samples_per_tree
+
+    cdef double get_c_normalization(self) except *:
+        return self.model.c_normalization
+
+    cdef void score(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        uintptr_t scores_ptr,
+        level_enum verbose,
+    ) except *:
+        with nogil:
+            score_samples(
+                handle,
+                self.model,
+                <double*>input_ptr,
+                n_rows,
+                n_cols,
+                <double*>scores_ptr,
+                verbose,
+            )
+
+    cdef void predict_labels(
+        self,
+        const handle_t& handle,
+        uintptr_t input_ptr,
+        size_t n_rows,
+        int n_cols,
+        uintptr_t predictions_ptr,
+        double threshold,
+        level_enum verbose,
+    ) except *:
+        with nogil:
+            predict(
+                handle,
+                self.model,
+                <double*>input_ptr,
+                n_rows,
+                n_cols,
+                <int*>predictions_ptr,
+                threshold,
+                verbose,
+            )
 
 
 class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
@@ -671,9 +733,9 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         try:
             if X_m.dtype == np.float32:
-                model = _IsolationForestModel.new_float32()
+                model = _IsolationForestModelFloat32()
             else:
-                model = _IsolationForestModel.new_float64()
+                model = _IsolationForestModelFloat64()
             self._model = model
             model.fit_and_build_treelite(
                 handle_[0],

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -20,7 +20,11 @@ import nvforest
 import treelite
 
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
+from cuml.internals.interop import (
+    InteropMixin,
+    UnsupportedOnCPU,
+    UnsupportedOnGPU,
+)
 from cuml.internals.mixins import CMajorInputTagMixin
 from cuml.internals.outputs import mlfunc
 from cuml.internals.treelite import safe_treelite_call
@@ -161,7 +165,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
         >>> # Fit the model
         >>> clf = IsolationForest(n_estimators=100, random_state=42)
         >>> clf.fit(X)
-        IsolationForest()
+        IsolationForest(random_state=42)
 
         >>> # Predict anomalies (-1 for anomaly, 1 for normal)
         >>> predictions = clf.predict(X)
@@ -205,11 +209,13 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
     warm_start : bool, default=False
         ``warm_start=True`` is not currently supported.
     verbose : int or boolean, default=False
-        Sets logging level.
-    output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \\
-        'numba', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
+        Sets logging level. It must be one of `cuml.common.logger.level_*`.
+        See :ref:`verbosity-levels` for more info.
+    output_type : {None, 'input', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
         Return results and set estimator attributes to the indicated output
-        type.
+        type. If None, the output type set at the module level
+        (`cuml.global_settings.output_type`) will be used. See
+        :ref:`output-data-type-configuration` for more info.
 
     Attributes
     ----------
@@ -374,6 +380,16 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             "contamination": self.contamination,
             "warm_start": self.warm_start,
         }
+
+    def _attrs_from_cpu(self, model):
+        raise UnsupportedOnGPU(
+            "Conversion of a fitted sklearn IsolationForest is not supported"
+        )
+
+    def _attrs_to_cpu(self, model):
+        raise UnsupportedOnCPU(
+            "Conversion of a fitted cuML IsolationForest is not supported"
+        )
 
     def __getstate__(self):
         """Pickle support - serialize state."""
@@ -554,42 +570,56 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
 
         cdef IsolationForestF* forest_f
         cdef IsolationForestD* forest_d
-        cdef TreeliteModelHandle tl_handle
+        cdef TreeliteModelHandle tl_handle = NULL
         cdef const char* tl_bytes = NULL
         cdef size_t tl_bytes_len
+        cdef int tl_free_status
 
-        if X_m.dtype == np.float32:
-            forest_f = new IsolationForestF()
-            with nogil:
-                fit(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
-                    params, verbose)
-            self._forest_float = <uintptr_t>forest_f
-            self._n_samples_per_tree = forest_f.n_samples_per_tree
-            self._c_normalization = forest_f.c_normalization
-            with nogil:
-                build_treelite_isolation_forest[float](
-                    &tl_handle, handle_[0], forest_f)
-        else:
-            forest_d = new IsolationForestD()
-            with nogil:
-                fit(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
-                    params, verbose)
-            self._forest_double = <uintptr_t>forest_d
-            self._n_samples_per_tree = forest_d.n_samples_per_tree
-            self._c_normalization = forest_d.c_normalization
-            with nogil:
-                build_treelite_isolation_forest[double](
-                    &tl_handle, handle_[0], forest_d)
+        try:
+            if X_m.dtype == np.float32:
+                forest_f = new IsolationForestF()
+                self._forest_float = <uintptr_t>forest_f
+                with nogil:
+                    fit(handle_[0], forest_f, <float*>X_ptr, n_rows, n_cols,
+                        params, verbose)
+                self._n_samples_per_tree = forest_f.n_samples_per_tree
+                self._c_normalization = forest_f.c_normalization
+                with nogil:
+                    build_treelite_isolation_forest[float](
+                        &tl_handle, handle_[0], forest_f)
+            else:
+                forest_d = new IsolationForestD()
+                self._forest_double = <uintptr_t>forest_d
+                with nogil:
+                    fit(handle_[0], forest_d, <double*>X_ptr, n_rows, n_cols,
+                        params, verbose)
+                self._n_samples_per_tree = forest_d.n_samples_per_tree
+                self._c_normalization = forest_d.c_normalization
+                with nogil:
+                    build_treelite_isolation_forest[double](
+                        &tl_handle, handle_[0], forest_d)
 
-        # Serialize the Treelite handle immediately, following the RandomForest
-        # ABI-safe pattern for Python wheels/conda environments.
-        safe_treelite_call(
-            TreeliteSerializeModelToBytes(tl_handle, &tl_bytes, &tl_bytes_len),
-            "Failed to serialize Treelite model to bytes:"
-        )
-        safe_treelite_call(
-            TreeliteFreeModel(tl_handle), "Failed to free Treelite model:"
-        )
+            # Serialize the Treelite handle immediately, following the
+            # RandomForest ABI-safe pattern for Python wheels/conda environments.
+            safe_treelite_call(
+                TreeliteSerializeModelToBytes(
+                    tl_handle, &tl_bytes, &tl_bytes_len
+                ),
+                "Failed to serialize Treelite model to bytes:"
+            )
+            tl_free_status = TreeliteFreeModel(tl_handle)
+            tl_handle = NULL
+            safe_treelite_call(
+                tl_free_status, "Failed to free Treelite model:"
+            )
+        except Exception:
+            if tl_handle != NULL:
+                TreeliteFreeModel(tl_handle)
+            self._free_model()
+            self._treelite_model_bytes = None
+            self._nvforest_model = None
+            raise
+
         self._treelite_model_bytes = <bytes>(tl_bytes[:tl_bytes_len])
         self._nvforest_model = None
 

--- a/python/cuml/cuml/ensemble/isolation_forest.pyx
+++ b/python/cuml/cuml/ensemble/isolation_forest.pyx
@@ -518,10 +518,7 @@ class IsolationForest(InteropMixin, CMajorInputTagMixin, Base):
             actual_max_depth = self.max_depth
 
         # Get random seed
-        cdef uint64_t seed = (
-            0 if self.random_state is None
-            else check_random_seed(self.random_state)
-        )
+        cdef uint64_t seed = check_random_seed(self.random_state)
 
         # Setup parameters
         cdef IF_params params

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -1,0 +1,580 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+Pytest tests for cuML's IsolationForest implementation.
+
+These tests are designed to be:
+1. Complete - covering all API methods and parameters
+2. Fast-running - using small datasets for unit tests
+3. Based on sklearn IsolationForest test patterns
+4. Validating sklearn compatibility
+"""
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_blobs
+from sklearn.ensemble import IsolationForest as skIsolationForest
+
+from cuml import IsolationForest as cuIsolationForest
+from cuml.testing.utils import stress_param, unit_param
+
+
+# =============================================================================
+# Fixtures for test data
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def synthetic_data_small():
+    """Small dataset for fast unit tests."""
+    rng = np.random.RandomState(42)
+    # Normal data centered at origin
+    X_normal = rng.randn(100, 4).astype(np.float32)
+    # Outliers far from origin
+    X_outliers = rng.uniform(low=-6, high=6, size=(10, 4)).astype(np.float32)
+    X = np.vstack([X_normal, X_outliers])
+    # Labels: 1 for normal, -1 for outliers (sklearn convention)
+    y_true = np.array([1] * 100 + [-1] * 10)
+    return X, y_true
+
+
+@pytest.fixture(scope="module")
+def blobs_data():
+    """Blob dataset for clustering-like anomaly detection."""
+    X, _ = make_blobs(
+        n_samples=200,
+        n_features=4,
+        centers=2,
+        cluster_std=1.0,
+        random_state=42,
+    )
+    return X.astype(np.float32)
+
+
+# =============================================================================
+# Basic functionality tests
+# =============================================================================
+
+
+def test_fit_returns_self(synthetic_data_small):
+    """fit() should return self for method chaining."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    result = clf.fit(X)
+    assert result is clf
+
+
+def test_fit_predict(synthetic_data_small):
+    """fit_predict() should work correctly."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    predictions = clf.fit_predict(X)
+    assert predictions.shape == (X.shape[0],)
+    assert set(np.unique(predictions)).issubset({-1, 1})
+
+
+def test_predict_returns_correct_shape(synthetic_data_small):
+    """predict() should return array of shape (n_samples,)."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    predictions = clf.predict(X)
+    assert predictions.shape == (X.shape[0],)
+
+
+def test_predict_returns_valid_labels(synthetic_data_small):
+    """predict() should return only -1 (anomaly) or 1 (normal)."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    predictions = clf.predict(X)
+    unique_labels = set(np.unique(predictions))
+    assert unique_labels.issubset({-1, 1})
+
+
+def test_score_samples_returns_correct_shape(synthetic_data_small):
+    """score_samples() should return array of shape (n_samples,)."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    scores = clf.score_samples(X)
+    assert scores.shape == (X.shape[0],)
+
+
+def test_decision_function_returns_correct_shape(synthetic_data_small):
+    """decision_function() should return array of shape (n_samples,)."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    df = clf.decision_function(X)
+    assert df.shape == (X.shape[0],)
+
+
+def test_n_features_in_set_after_fit(synthetic_data_small):
+    """n_features_in_ should be set after fit."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    assert clf.n_features_in_ == X.shape[1]
+
+
+# =============================================================================
+# Parameter handling tests
+# =============================================================================
+
+
+def test_default_parameters():
+    """Default parameters should match expected values."""
+    clf = cuIsolationForest()
+    assert clf.n_estimators == 100
+    assert clf.max_samples == 256
+    assert clf.max_depth is None
+    assert clf.max_features == 1.0
+    assert clf.bootstrap is False
+    assert clf.contamination == "auto"
+
+
+@pytest.mark.parametrize("n_estimators", [10, 50, 100])
+def test_n_estimators_parameter(blobs_data, n_estimators):
+    """n_estimators parameter should be respected."""
+    clf = cuIsolationForest(n_estimators=n_estimators, random_state=42)
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+@pytest.mark.parametrize("max_samples", [32, 64, 128, 256])
+def test_max_samples_int(blobs_data, max_samples):
+    """Integer max_samples should subsample correctly."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_samples=max_samples, random_state=42
+    )
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+@pytest.mark.parametrize("max_samples", [0.5, 0.8, 1.0])
+def test_max_samples_float(blobs_data, max_samples):
+    """Float max_samples should work as fraction."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_samples=max_samples, random_state=42
+    )
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+def test_max_samples_auto(blobs_data):
+    """max_samples='auto' should use min(256, n_samples)."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_samples="auto", random_state=42
+    )
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+@pytest.mark.parametrize("max_depth", [2, 4, 8, None])
+def test_max_depth_parameter(blobs_data, max_depth):
+    """max_depth parameter should be respected."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_depth=max_depth, random_state=42
+    )
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+@pytest.mark.parametrize("max_features", [0.5, 0.8, 1.0])
+def test_max_features_parameter(blobs_data, max_features):
+    """max_features parameter should be respected."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_features=max_features, random_state=42
+    )
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+@pytest.mark.parametrize("bootstrap", [True, False])
+def test_bootstrap_parameter(blobs_data, bootstrap):
+    """bootstrap parameter should be respected."""
+    clf = cuIsolationForest(
+        n_estimators=10, bootstrap=bootstrap, random_state=42
+    )
+    clf.fit(blobs_data)
+    predictions = clf.predict(blobs_data)
+    assert predictions.shape[0] == blobs_data.shape[0]
+
+
+# =============================================================================
+# Data type tests
+# =============================================================================
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_float_dtypes(dtype):
+    """Should handle float32 and float64."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 4).astype(dtype)
+
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+
+    scores = clf.score_samples(X)
+    assert scores.shape == (X.shape[0],)
+
+    predictions = clf.predict(X)
+    assert predictions.shape == (X.shape[0],)
+
+
+# =============================================================================
+# Anomaly detection quality tests
+# =============================================================================
+
+
+def test_outliers_score_lower_sklearn_convention(synthetic_data_small):
+    """
+    Outliers should have lower (more negative) scores than inliers.
+    In sklearn convention: more negative = more anomalous.
+    """
+    X, y_true = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=50, random_state=42)
+    clf.fit(X)
+
+    scores = clf.score_samples(X)
+    scores = np.asarray(scores)
+
+    inlier_mask = y_true == 1
+    outlier_mask = y_true == -1
+    mean_inlier_score = np.mean(scores[inlier_mask])
+    mean_outlier_score = np.mean(scores[outlier_mask])
+
+    assert mean_outlier_score < mean_inlier_score, (
+        f"Outliers should have lower scores than inliers. "
+        f"Got inlier={mean_inlier_score:.4f}, outlier={mean_outlier_score:.4f}"
+    )
+
+
+def test_outliers_detected_by_predict(synthetic_data_small):
+    """predict() should detect at least some outliers."""
+    X, y_true = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=50, random_state=42)
+    clf.fit(X)
+
+    predictions = clf.predict(X)
+    predictions = np.asarray(predictions)
+
+    n_detected = np.sum(predictions == -1)
+    assert n_detected > 0, "Should detect at least some anomalies"
+
+
+def test_extreme_outliers_detected():
+    """Extreme outliers should be reliably detected."""
+    rng = np.random.RandomState(42)
+    X_normal = rng.randn(200, 4).astype(np.float32)
+    X_outlier = np.array([[100, 100, 100, 100]], dtype=np.float32)
+    X = np.vstack([X_normal, X_outlier])
+
+    clf = cuIsolationForest(n_estimators=100, random_state=42)
+    clf.fit(X)
+
+    scores = clf.score_samples(X)
+    scores = np.asarray(scores)
+
+    outlier_score = scores[-1]
+    normal_scores = scores[:-1]
+    assert outlier_score < np.percentile(
+        normal_scores, 5
+    ), "Extreme outlier should have very low score"
+
+
+# =============================================================================
+# sklearn compatibility tests
+# =============================================================================
+
+
+def test_api_compatibility(blobs_data):
+    """cuML IF should have the same API as sklearn IF."""
+    cu_clf = cuIsolationForest(n_estimators=10, random_state=42)
+    sk_clf = skIsolationForest(n_estimators=10, random_state=42)
+
+    cu_clf.fit(blobs_data)
+    sk_clf.fit(blobs_data)
+
+    cu_preds = cu_clf.predict(blobs_data)
+    sk_preds = sk_clf.predict(blobs_data)
+    assert cu_preds.shape == sk_preds.shape
+
+    cu_scores = cu_clf.score_samples(blobs_data)
+    sk_scores = sk_clf.score_samples(blobs_data)
+    assert cu_scores.shape == sk_scores.shape
+
+    cu_df = cu_clf.decision_function(blobs_data)
+    sk_df = sk_clf.decision_function(blobs_data)
+    assert cu_df.shape == sk_df.shape
+
+
+def test_score_convention_matches_sklearn(synthetic_data_small):
+    """
+    Score convention should match sklearn:
+    - More negative scores = more anomalous
+    - Outliers should have negative decision_function values
+    """
+    X, y_true = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=50, random_state=42)
+    clf.fit(X)
+
+    df = clf.decision_function(X)
+    df = np.asarray(df)
+
+    outlier_mask = y_true == -1
+    inlier_mask = y_true == 1
+    mean_outlier_df = np.mean(df[outlier_mask])
+    mean_inlier_df = np.mean(df[inlier_mask])
+    assert mean_outlier_df < mean_inlier_df
+
+
+def test_similar_results_to_sklearn(blobs_data):
+    """
+    cuML IF should produce similar (not identical) results to sklearn.
+
+    Note: Results won't be identical due to different RNG implementations,
+    tree building algorithms, and GPU vs CPU computation.
+    But the relative ordering should be similar.
+    """
+    X = blobs_data
+
+    cu_clf = cuIsolationForest(n_estimators=100, random_state=42)
+    sk_clf = skIsolationForest(n_estimators=100, random_state=42)
+
+    cu_clf.fit(X)
+    sk_clf.fit(X)
+
+    cu_scores = np.asarray(cu_clf.score_samples(X))
+    sk_scores = sk_clf.score_samples(X)
+
+    correlation = np.corrcoef(cu_scores, sk_scores)[0, 1]
+    assert correlation > 0.5, (
+        f"Score correlation with sklearn should be > 0.5, got {correlation:.3f}"
+    )
+
+
+# =============================================================================
+# Determinism tests
+# =============================================================================
+
+
+def test_same_random_state_same_results(blobs_data):
+    """Same random_state should produce identical results.
+
+    Note: n_streams=1 is required for deterministic behavior.
+    With n_streams > 1, trees are built in parallel and results may vary.
+    """
+    clf1 = cuIsolationForest(n_estimators=20, random_state=42, n_streams=1)
+    clf2 = cuIsolationForest(n_estimators=20, random_state=42, n_streams=1)
+
+    clf1.fit(blobs_data)
+    clf2.fit(blobs_data)
+
+    scores1 = np.asarray(clf1.score_samples(blobs_data))
+    scores2 = np.asarray(clf2.score_samples(blobs_data))
+
+    np.testing.assert_array_almost_equal(
+        scores1, scores2, decimal=5,
+        err_msg="Same random_state should produce identical scores"
+    )
+
+
+def test_different_random_state_different_results(blobs_data):
+    """Different random_state should produce different results.
+
+    Note: n_streams=1 is required for deterministic behavior.
+    With n_streams > 1, trees are built in parallel and results may vary.
+    """
+    clf1 = cuIsolationForest(n_estimators=20, random_state=42, n_streams=1)
+    clf2 = cuIsolationForest(n_estimators=20, random_state=123, n_streams=1)
+
+    clf1.fit(blobs_data)
+    clf2.fit(blobs_data)
+
+    scores1 = np.asarray(clf1.score_samples(blobs_data))
+    scores2 = np.asarray(clf2.score_samples(blobs_data))
+
+    assert not np.allclose(scores1, scores2), (
+        "Different random_state should produce different scores"
+    )
+
+
+# =============================================================================
+# Edge case tests
+# =============================================================================
+
+
+def test_small_dataset():
+    """Should handle small datasets."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(20, 3).astype(np.float32)
+
+    clf = cuIsolationForest(n_estimators=5, max_samples=10, random_state=42)
+    clf.fit(X)
+    scores = clf.score_samples(X)
+    assert scores.shape == (X.shape[0],)
+
+
+def test_single_feature():
+    """Should handle single-feature data."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 1).astype(np.float32)
+
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    scores = clf.score_samples(X)
+    assert scores.shape == (X.shape[0],)
+
+
+def test_many_features():
+    """Should handle high-dimensional data."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 50).astype(np.float32)
+
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+    scores = clf.score_samples(X)
+    assert scores.shape == (X.shape[0],)
+
+
+def test_predict_before_fit_raises():
+    """predict() before fit() should raise an error."""
+    clf = cuIsolationForest()
+    X = np.random.randn(10, 3).astype(np.float32)
+
+    with pytest.raises(RuntimeError, match="not been fitted"):
+        clf.predict(X)
+
+
+def test_score_samples_before_fit_raises():
+    """score_samples() before fit() should raise an error."""
+    clf = cuIsolationForest()
+    X = np.random.randn(10, 3).astype(np.float32)
+
+    with pytest.raises(RuntimeError, match="not been fitted"):
+        clf.score_samples(X)
+
+
+def test_feature_mismatch_raises(blobs_data):
+    """Predicting with wrong number of features should raise."""
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(blobs_data)
+
+    X_wrong = np.random.randn(10, blobs_data.shape[1] + 1).astype(np.float32)
+
+    with pytest.raises(ValueError, match="features"):
+        clf.predict(X_wrong)
+
+
+# =============================================================================
+# Performance-oriented tests (parameterized by test level)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "nrows", [unit_param(200), stress_param(50000)]
+)
+@pytest.mark.parametrize(
+    "ncols", [unit_param(10), stress_param(200)]
+)
+@pytest.mark.parametrize("dtype", [np.float32])
+def test_isolation_forest_scaling(nrows, ncols, dtype):
+    """Test IF scales with data size."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(nrows, ncols).astype(dtype)
+
+    clf = cuIsolationForest(n_estimators=20, random_state=42)
+    clf.fit(X)
+
+    scores = clf.score_samples(X)
+    assert scores.shape == (nrows,)
+
+    predictions = clf.predict(X)
+    assert predictions.shape == (nrows,)
+    assert set(np.unique(predictions)).issubset({-1, 1})
+
+
+@pytest.mark.parametrize("n_estimators", [unit_param(10), stress_param(50)])
+def test_n_estimators_scaling(blobs_data, n_estimators):
+    """Test IF with different numbers of estimators."""
+    clf = cuIsolationForest(n_estimators=n_estimators, random_state=42)
+    clf.fit(blobs_data)
+
+    scores = clf.score_samples(blobs_data)
+    predictions = clf.predict(blobs_data)
+
+    assert scores.shape == (blobs_data.shape[0],)
+    assert predictions.shape == (blobs_data.shape[0],)
+
+
+# =============================================================================
+# Integration tests
+# =============================================================================
+
+
+def test_full_workflow(synthetic_data_small):
+    """Test complete anomaly detection workflow."""
+    X, y_true = synthetic_data_small
+
+    # Split data (don't use outliers in training for realistic scenario)
+    X_train = X[y_true == 1]  # Only normal points for training
+    X_test = X
+
+    # Train model
+    clf = cuIsolationForest(n_estimators=50, random_state=42)
+    clf.fit(X_train)
+
+    # Get predictions and scores
+    predictions = clf.predict(X_test)
+    scores = clf.score_samples(X_test)
+    df = clf.decision_function(X_test)
+
+    # Basic sanity checks
+    assert predictions.shape == X_test.shape[:1]
+    assert scores.shape == X_test.shape[:1]
+    assert df.shape == X_test.shape[:1]
+
+    # Check that model detected something
+    predictions = np.asarray(predictions)
+    n_anomalies = np.sum(predictions == -1)
+    assert n_anomalies > 0, "Should detect some anomalies"
+
+
+def test_train_on_pure_data_detect_outliers():
+    """Train on pure data, then detect injected outliers."""
+    rng = np.random.RandomState(42)
+
+    # Pure training data (no outliers)
+    X_train = rng.randn(500, 4).astype(np.float32)
+
+    # Test data with injected outliers
+    X_test_normal = rng.randn(100, 4).astype(np.float32)
+    X_test_outliers = np.array([
+        [10, 10, 10, 10],
+        [-10, -10, -10, -10],
+        [5, -5, 5, -5],
+    ], dtype=np.float32)
+    X_test = np.vstack([X_test_normal, X_test_outliers])
+
+    # Train and predict
+    clf = cuIsolationForest(n_estimators=100, random_state=42)
+    clf.fit(X_train)
+    predictions = clf.predict(X_test)
+    predictions = np.asarray(predictions)
+
+    # The injected outliers should be detected
+    outlier_predictions = predictions[-3:]
+    detected_outliers = np.sum(outlier_predictions == -1)
+    assert detected_outliers >= 2, (
+        f"Should detect at least 2 of 3 injected outliers, got {detected_outliers}"
+    )

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -12,8 +12,10 @@ These tests are designed to be:
 4. Validating sklearn compatibility
 """
 
+import cupy as cp
 import numpy as np
 import pytest
+import treelite
 from sklearn.datasets import make_blobs
 from sklearn.ensemble import IsolationForest as skIsolationForest
 
@@ -361,6 +363,77 @@ def test_similar_results_to_sklearn(blobs_data):
     assert correlation > 0.5, (
         f"Score correlation with sklearn should be > 0.5, got {correlation:.3f}"
     )
+
+
+# =============================================================================
+# Treelite / nvForest export tests
+# =============================================================================
+
+
+def test_as_treelite_metadata(blobs_data):
+    """as_treelite() should return a valid Treelite IF model."""
+    n_estimators = 10
+    clf = cuIsolationForest(n_estimators=n_estimators, random_state=42)
+    clf.fit(blobs_data)
+
+    tl_model = clf.as_treelite()
+    assert isinstance(tl_model, treelite.Model)
+    assert tl_model.num_tree == n_estimators
+    assert tl_model.num_feature == blobs_data.shape[1]
+
+
+def test_as_treelite_serialize_roundtrip(blobs_data):
+    """Treelite-exported IF models should serialize and deserialize."""
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(blobs_data)
+
+    tl_model = clf.as_treelite()
+    roundtrip_model = treelite.Model.deserialize_bytes(
+        tl_model.serialize_bytes()
+    )
+
+    assert roundtrip_model.num_tree == tl_model.num_tree
+    assert roundtrip_model.num_feature == tl_model.num_feature
+
+
+def test_as_nvforest_loads(blobs_data):
+    """as_nvforest() should load the Treelite IF model for GPU inference."""
+    X = cp.asarray(blobs_data)
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+    clf.fit(X)
+
+    nvforest_model = clf.as_nvforest()
+    avg_path_lengths = cp.asarray(nvforest_model.predict(X))
+
+    assert "ForestInferenceRegressor" in type(nvforest_model).__name__
+    assert avg_path_lengths.shape[0] == X.shape[0]
+    assert bool(cp.all(cp.isfinite(avg_path_lengths)))
+
+
+def test_nvforest_score_parity(blobs_data):
+    """nvForest-backed scores should match the current C++ scoring path."""
+    X = cp.asarray(blobs_data)
+    clf = cuIsolationForest(n_estimators=25, random_state=42)
+    clf.fit(X)
+
+    cpp_scores = cp.asarray(clf.score_samples(X))
+    nvforest_scores = cp.asarray(clf._score_samples_nvforest(X))
+
+    cp.testing.assert_allclose(cpp_scores, nvforest_scores, rtol=1e-5, atol=1e-6)
+
+
+def test_treelite_export_before_fit_raises(blobs_data):
+    """Treelite and nvForest export should require a fitted model."""
+    clf = cuIsolationForest()
+
+    with pytest.raises(RuntimeError, match="not been fitted"):
+        clf.as_treelite()
+
+    with pytest.raises(RuntimeError, match="not been fitted"):
+        clf.as_nvforest()
+
+    with pytest.raises(RuntimeError, match="not been fitted"):
+        clf._score_samples_nvforest(blobs_data)
 
 
 # =============================================================================

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -130,7 +130,7 @@ def test_default_parameters():
     """Default parameters should match expected values."""
     clf = cuIsolationForest()
     assert clf.n_estimators == 100
-    assert clf.max_samples == 256
+    assert clf.max_samples == "auto"
     assert clf.max_depth is None
     assert clf.max_features == 1.0
     assert clf.bootstrap is False

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -218,7 +218,7 @@ def test_max_features_parameter(blobs_data, max_features):
 
 @pytest.mark.parametrize("bootstrap", [True, False])
 def test_bootstrap_parameter(blobs_data, bootstrap):
-    """bootstrap parameter should be respected."""
+    """Both sklearn bootstrap sampling modes should fit and predict."""
     clf = cuIsolationForest(
         n_estimators=10, bootstrap=bootstrap, random_state=42
     )
@@ -353,6 +353,22 @@ def test_score_convention_matches_sklearn(synthetic_data_small):
     mean_outlier_df = np.mean(df[outlier_mask])
     mean_inlier_df = np.mean(df[inlier_mask])
     assert mean_outlier_df < mean_inlier_df
+
+
+def test_score_decision_predict_consistency(synthetic_data_small):
+    """decision_function and predict should be derived from score_samples."""
+    X, _ = synthetic_data_small
+    clf = cuIsolationForest(n_estimators=50, random_state=42)
+    clf.fit(X)
+
+    scores = np.asarray(clf.score_samples(X))
+    decision = np.asarray(clf.decision_function(X))
+    predictions = np.asarray(clf.predict(X))
+
+    np.testing.assert_allclose(decision, scores - clf.offset_)
+    np.testing.assert_array_equal(
+        predictions, np.where(decision < 0, -1, 1)
+    )
 
 
 def test_similar_results_to_sklearn(blobs_data):

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -205,15 +205,36 @@ def test_deep_max_depth_global_memory(blobs_data):
     assert set(np.unique(predictions)).issubset({-1, 1})
 
 
-@pytest.mark.parametrize("max_features", [0.5, 0.8, 1.0])
-def test_max_features_parameter(blobs_data, max_features):
+@pytest.mark.parametrize(
+    "max_features, expected_features",
+    [
+        (1, 1),
+        (2, 2),
+        (0.5, 2),
+        (0.8, 3),
+        (1.0, 4),
+    ],
+)
+def test_max_features_parameter(blobs_data, max_features, expected_features):
     """max_features parameter should be respected."""
     clf = cuIsolationForest(
         n_estimators=10, max_features=max_features, random_state=42
     )
     clf.fit(blobs_data)
+    assert clf._n_features_per_tree == expected_features
     predictions = clf.predict(blobs_data)
     assert predictions.shape[0] == blobs_data.shape[0]
+
+
+@pytest.mark.parametrize("max_features", [0, -1, 1.1, "invalid", True])
+def test_invalid_max_features_raises(blobs_data, max_features):
+    """Invalid max_features values should raise during fit."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_features=max_features, random_state=42
+    )
+
+    with pytest.raises(ValueError, match="max_features"):
+        clf.fit(blobs_data)
 
 
 @pytest.mark.parametrize("bootstrap", [True, False])

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -227,6 +227,37 @@ def test_bootstrap_parameter(blobs_data, bootstrap):
     assert predictions.shape[0] == blobs_data.shape[0]
 
 
+def test_contamination_float_sets_score_quantile_offset(blobs_data):
+    """Float contamination should set offset_ from training score quantile."""
+    contamination = 0.1
+    clf = cuIsolationForest(
+        n_estimators=25, contamination=contamination, random_state=42
+    )
+    clf.fit(blobs_data)
+
+    scores = np.asarray(clf.score_samples(blobs_data))
+    decision = np.asarray(clf.decision_function(blobs_data))
+    predictions = np.asarray(clf.predict(blobs_data))
+    expected_offset = np.percentile(scores, 100.0 * contamination)
+
+    assert clf.offset_ == pytest.approx(expected_offset, rel=1e-6, abs=1e-6)
+    np.testing.assert_allclose(decision, scores - clf.offset_)
+    np.testing.assert_array_equal(
+        predictions, np.where(decision < 0, -1, 1)
+    )
+
+
+@pytest.mark.parametrize("contamination", [0.0, -0.1, 0.51, 1.0, "invalid"])
+def test_invalid_contamination_raises(blobs_data, contamination):
+    """contamination should match sklearn's accepted range."""
+    clf = cuIsolationForest(
+        n_estimators=10, contamination=contamination, random_state=42
+    )
+
+    with pytest.raises(ValueError, match="contamination"):
+        clf.fit(blobs_data)
+
+
 # =============================================================================
 # Data type tests
 # =============================================================================

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -369,13 +369,9 @@ def test_similar_results_to_sklearn(blobs_data):
 
 
 def test_same_random_state_same_results(blobs_data):
-    """Same random_state should produce identical results.
-
-    Note: n_streams=1 is required for deterministic behavior.
-    With n_streams > 1, trees are built in parallel and results may vary.
-    """
-    clf1 = cuIsolationForest(n_estimators=20, random_state=42, n_streams=1)
-    clf2 = cuIsolationForest(n_estimators=20, random_state=42, n_streams=1)
+    """Same random_state should produce identical results."""
+    clf1 = cuIsolationForest(n_estimators=20, random_state=42)
+    clf2 = cuIsolationForest(n_estimators=20, random_state=42)
 
     clf1.fit(blobs_data)
     clf2.fit(blobs_data)
@@ -390,13 +386,9 @@ def test_same_random_state_same_results(blobs_data):
 
 
 def test_different_random_state_different_results(blobs_data):
-    """Different random_state should produce different results.
-
-    Note: n_streams=1 is required for deterministic behavior.
-    With n_streams > 1, trees are built in parallel and results may vary.
-    """
-    clf1 = cuIsolationForest(n_estimators=20, random_state=42, n_streams=1)
-    clf2 = cuIsolationForest(n_estimators=20, random_state=123, n_streams=1)
+    """Different random_state should produce different results."""
+    clf1 = cuIsolationForest(n_estimators=20, random_state=42)
+    clf2 = cuIsolationForest(n_estimators=20, random_state=123)
 
     clf1.fit(blobs_data)
     clf2.fit(blobs_data)

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -190,6 +190,21 @@ def test_max_depth_parameter(blobs_data, max_depth):
     assert predictions.shape[0] == blobs_data.shape[0]
 
 
+def test_deep_max_depth_global_memory(blobs_data):
+    """Deep global-memory trees should fit and score."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_samples=64, max_depth=17, random_state=42
+    )
+    clf.fit(blobs_data)
+
+    scores = clf.score_samples(blobs_data)
+    predictions = clf.predict(blobs_data)
+
+    assert scores.shape == (blobs_data.shape[0],)
+    assert predictions.shape == (blobs_data.shape[0],)
+    assert set(np.unique(predictions)).issubset({-1, 1})
+
+
 @pytest.mark.parametrize("max_features", [0.5, 0.8, 1.0])
 def test_max_features_parameter(blobs_data, max_features):
     """max_features parameter should be respected."""

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -22,7 +22,6 @@ from sklearn.ensemble import IsolationForest as skIsolationForest
 from cuml import IsolationForest as cuIsolationForest
 from cuml.testing.utils import stress_param, unit_param
 
-
 # =============================================================================
 # Fixtures for test data
 # =============================================================================
@@ -263,9 +262,7 @@ def test_contamination_float_sets_score_quantile_offset(blobs_data):
 
     assert clf.offset_ == pytest.approx(expected_offset, rel=1e-6, abs=1e-6)
     np.testing.assert_allclose(decision, scores - clf.offset_)
-    np.testing.assert_array_equal(
-        predictions, np.where(decision < 0, -1, 1)
-    )
+    np.testing.assert_array_equal(predictions, np.where(decision < 0, -1, 1))
 
 
 @pytest.mark.parametrize("contamination", [0.0, -0.1, 0.51, 1.0, "invalid"])
@@ -356,9 +353,9 @@ def test_extreme_outliers_detected():
 
     outlier_score = scores[-1]
     normal_scores = scores[:-1]
-    assert outlier_score < np.percentile(
-        normal_scores, 5
-    ), "Extreme outlier should have very low score"
+    assert outlier_score < np.percentile(normal_scores, 5), (
+        "Extreme outlier should have very low score"
+    )
 
 
 # =============================================================================
@@ -418,9 +415,7 @@ def test_score_decision_predict_consistency(synthetic_data_small):
     predictions = np.asarray(clf.predict(X))
 
     np.testing.assert_allclose(decision, scores - clf.offset_)
-    np.testing.assert_array_equal(
-        predictions, np.where(decision < 0, -1, 1)
-    )
+    np.testing.assert_array_equal(predictions, np.where(decision < 0, -1, 1))
 
 
 def test_similar_results_to_sklearn(blobs_data):
@@ -502,7 +497,9 @@ def test_nvforest_score_parity(blobs_data):
     cpp_scores = cp.asarray(clf.score_samples(X))
     nvforest_scores = cp.asarray(clf._score_samples_nvforest(X))
 
-    cp.testing.assert_allclose(cpp_scores, nvforest_scores, rtol=1e-5, atol=1e-6)
+    cp.testing.assert_allclose(
+        cpp_scores, nvforest_scores, rtol=1e-5, atol=1e-6
+    )
 
 
 def test_treelite_export_before_fit_raises(blobs_data):
@@ -536,8 +533,10 @@ def test_same_random_state_same_results(blobs_data):
     scores2 = np.asarray(clf2.score_samples(blobs_data))
 
     np.testing.assert_array_almost_equal(
-        scores1, scores2, decimal=5,
-        err_msg="Same random_state should produce identical scores"
+        scores1,
+        scores2,
+        decimal=5,
+        err_msg="Same random_state should produce identical scores",
     )
 
 
@@ -629,12 +628,8 @@ def test_feature_mismatch_raises(blobs_data):
 # =============================================================================
 
 
-@pytest.mark.parametrize(
-    "nrows", [unit_param(200), stress_param(50000)]
-)
-@pytest.mark.parametrize(
-    "ncols", [unit_param(10), stress_param(200)]
-)
+@pytest.mark.parametrize("nrows", [unit_param(200), stress_param(50000)])
+@pytest.mark.parametrize("ncols", [unit_param(10), stress_param(200)])
 @pytest.mark.parametrize("dtype", [np.float32])
 def test_isolation_forest_scaling(nrows, ncols, dtype):
     """Test IF scales with data size."""
@@ -707,11 +702,14 @@ def test_train_on_pure_data_detect_outliers():
 
     # Test data with injected outliers
     X_test_normal = rng.randn(100, 4).astype(np.float32)
-    X_test_outliers = np.array([
-        [10, 10, 10, 10],
-        [-10, -10, -10, -10],
-        [5, -5, 5, -5],
-    ], dtype=np.float32)
+    X_test_outliers = np.array(
+        [
+            [10, 10, 10, 10],
+            [-10, -10, -10, -10],
+            [5, -5, 5, -5],
+        ],
+        dtype=np.float32,
+    )
     X_test = np.vstack([X_test_normal, X_test_outliers])
 
     # Train and predict

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -20,7 +20,7 @@ from sklearn.datasets import make_blobs
 from sklearn.ensemble import IsolationForest as skIsolationForest
 
 from cuml import IsolationForest as cuIsolationForest
-from cuml.internals.interop import UnsupportedOnGPU
+from cuml.internals.interop import UnsupportedOnCPU, UnsupportedOnGPU
 from cuml.testing.utils import stress_param, unit_param
 
 # =============================================================================
@@ -299,6 +299,33 @@ def test_unsupported_warm_start(blobs_data):
 
     with pytest.raises(UnsupportedOnGPU, match="warm_start"):
         clf.fit(blobs_data)
+
+
+def test_unfitted_sklearn_conversion_preserves_parameters():
+    """Unfitted estimators may still be converted in either direction."""
+    cu_model = cuIsolationForest(n_estimators=7, random_state=42)
+    sk_model = cu_model.as_sklearn()
+    assert isinstance(sk_model, skIsolationForest)
+    assert sk_model.n_estimators == 7
+
+    roundtrip = cuIsolationForest.from_sklearn(sk_model)
+    assert roundtrip.n_estimators == 7
+    assert roundtrip.random_state == 42
+
+
+def test_fitted_sklearn_conversion_is_explicitly_unsupported(blobs_data):
+    """Fitted conversion must not silently drop the trained forest."""
+    cu_model = cuIsolationForest(n_estimators=5, random_state=42).fit(
+        blobs_data
+    )
+    with pytest.raises(UnsupportedOnCPU, match="fitted"):
+        cu_model.as_sklearn()
+
+    sk_model = skIsolationForest(n_estimators=5, random_state=42).fit(
+        blobs_data
+    )
+    with pytest.raises(UnsupportedOnGPU, match="fitted"):
+        cuIsolationForest.from_sklearn(sk_model)
 
 
 def test_contamination_float_sets_score_quantile_offset(blobs_data):

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -651,6 +651,37 @@ def test_different_random_state_different_results(blobs_data):
     )
 
 
+def test_none_random_state_uses_numpy_global_state(blobs_data):
+    """random_state=None should draw its seed from NumPy's global RNG."""
+    random_state = np.random.get_state()
+    try:
+        np.random.seed(42)
+        scores1 = np.asarray(
+            cuIsolationForest(n_estimators=20)
+            .fit(blobs_data)
+            .score_samples(blobs_data)
+        )
+
+        np.random.seed(42)
+        scores2 = np.asarray(
+            cuIsolationForest(n_estimators=20)
+            .fit(blobs_data)
+            .score_samples(blobs_data)
+        )
+
+        np.random.seed(123)
+        scores3 = np.asarray(
+            cuIsolationForest(n_estimators=20)
+            .fit(blobs_data)
+            .score_samples(blobs_data)
+        )
+    finally:
+        np.random.set_state(random_state)
+
+    np.testing.assert_array_equal(scores1, scores2)
+    assert not np.allclose(scores1, scores3)
+
+
 # =============================================================================
 # Edge case tests
 # =============================================================================

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -378,6 +378,20 @@ def test_float_dtypes(dtype):
     assert predictions.shape == (X.shape[0],)
 
 
+def test_refit_replaces_native_model():
+    """Refitting should replace the native model, including across dtypes."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 4)
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+
+    for dtype in (np.float32, np.float64):
+        X_dtype = X.astype(dtype)
+        clf.fit(X_dtype)
+        scores = np.asarray(clf.score_samples(X_dtype))
+        assert scores.shape == (X.shape[0],)
+        assert scores.dtype == dtype
+
+
 # =============================================================================
 # Anomaly detection quality tests
 # =============================================================================

--- a/python/cuml/tests/test_isolation_forest.py
+++ b/python/cuml/tests/test_isolation_forest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -20,6 +20,7 @@ from sklearn.datasets import make_blobs
 from sklearn.ensemble import IsolationForest as skIsolationForest
 
 from cuml import IsolationForest as cuIsolationForest
+from cuml.internals.interop import UnsupportedOnGPU
 from cuml.testing.utils import stress_param, unit_param
 
 # =============================================================================
@@ -178,6 +179,43 @@ def test_max_samples_auto(blobs_data):
     assert predictions.shape[0] == blobs_data.shape[0]
 
 
+@pytest.mark.parametrize(
+    "max_samples",
+    [0, -1, 0.0, -0.1, 1.1, 1.5, "invalid", True],
+)
+def test_invalid_max_samples_raises(blobs_data, max_samples):
+    """Invalid max_samples values should raise a clear ValueError."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_samples=max_samples, random_state=42
+    )
+
+    with pytest.raises(ValueError, match="max_samples"):
+        clf.fit(blobs_data)
+
+
+def test_max_samples_larger_than_input_warns_and_sets_attribute(blobs_data):
+    """Large integer max_samples should warn, cap, and set max_samples_."""
+    clf = cuIsolationForest(
+        n_estimators=10,
+        max_samples=blobs_data.shape[0] + 1,
+        random_state=42,
+    )
+
+    with pytest.warns(UserWarning, match="greater than"):
+        clf.fit(blobs_data)
+
+    assert clf.max_samples_ == blobs_data.shape[0]
+
+
+def test_max_samples_attribute(blobs_data):
+    """max_samples_ should expose the resolved number of rows per tree."""
+    clf = cuIsolationForest(
+        n_estimators=10, max_samples=0.5, random_state=42
+    ).fit(blobs_data)
+
+    assert clf.max_samples_ == int(0.5 * blobs_data.shape[0])
+
+
 @pytest.mark.parametrize("max_depth", [2, 4, 8, None])
 def test_max_depth_parameter(blobs_data, max_depth):
     """max_depth parameter should be respected."""
@@ -245,6 +283,22 @@ def test_bootstrap_parameter(blobs_data, bootstrap):
     clf.fit(blobs_data)
     predictions = clf.predict(blobs_data)
     assert predictions.shape[0] == blobs_data.shape[0]
+
+
+def test_unsupported_sample_weight(blobs_data):
+    """sample_weight should fail explicitly until backend support is added."""
+    clf = cuIsolationForest(n_estimators=10, random_state=42)
+
+    with pytest.raises(UnsupportedOnGPU, match="sample_weight"):
+        clf.fit(blobs_data, sample_weight=np.ones(blobs_data.shape[0]))
+
+
+def test_unsupported_warm_start(blobs_data):
+    """warm_start=True should fail explicitly."""
+    clf = cuIsolationForest(n_estimators=10, random_state=42, warm_start=True)
+
+    with pytest.raises(UnsupportedOnGPU, match="warm_start"):
+        clf.fit(blobs_data)
 
 
 def test_contamination_float_sets_score_quantile_offset(blobs_data):
@@ -500,6 +554,20 @@ def test_nvforest_score_parity(blobs_data):
     cp.testing.assert_allclose(
         cpp_scores, nvforest_scores, rtol=1e-5, atol=1e-6
     )
+
+
+def test_nvforest_score_parity_single_sample():
+    """c(1)=0 should produce the neutral -0.5 score on both paths."""
+    X = cp.asarray([[1.0, 2.0]], dtype=cp.float32)
+    clf = cuIsolationForest(n_estimators=2, random_state=42).fit(X)
+
+    cpp_scores = cp.asarray(clf.score_samples(X))
+    nvforest_scores = cp.asarray(clf._score_samples_nvforest(X))
+
+    cp.testing.assert_allclose(
+        cpp_scores, cp.asarray([-0.5], dtype=cp.float32)
+    )
+    cp.testing.assert_allclose(cpp_scores, nvforest_scores)
 
 
 def test_treelite_export_before_fit_raises(blobs_data):

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -16,7 +16,11 @@ from cuml.cluster import (
 from cuml.compose import ColumnTransformer
 from cuml.covariance import EmpiricalCovariance, LedoitWolf
 from cuml.decomposition import PCA, IncrementalPCA, TruncatedSVD
-from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
+from cuml.ensemble import (
+    IsolationForest,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
 from cuml.feature_extraction.text import TfidfTransformer
 from cuml.kernel_ridge import KernelRidge
 from cuml.linear_model import (
@@ -145,6 +149,8 @@ def _all_cuml_estimators():
 
 
 EXCLUDED = {
+    # Ensemble
+    IsolationForest: "Not yet tested for sklearn compat",
     # Linear model
     MBSGDClassifier: "Not yet tested for sklearn compat",
     MBSGDRegressor: "Not yet tested for sklearn compat",

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -113,6 +113,7 @@ ESTIMATORS = [
     ElasticNet(),
     Lasso(),
     LinearRegression(),
+    IsolationForest(),
     RandomForestClassifier(),
     RandomForestRegressor(),
     KMeans(),
@@ -149,8 +150,6 @@ def _all_cuml_estimators():
 
 
 EXCLUDED = {
-    # Ensemble
-    IsolationForest: "Not yet tested for sklearn compat",
     # Linear model
     MBSGDClassifier: "Not yet tested for sklearn compat",
     MBSGDRegressor: "Not yet tested for sklearn compat",
@@ -187,6 +186,23 @@ EXCLUDED = {
 
 
 XFAILS = {
+    IsolationForest: {
+        "check_estimators_unfitted": (
+            "Unfitted methods raise RuntimeError instead of NotFittedError"
+        ),
+        "check_sample_weights_pandas_series": "Sample weights are not supported",
+        "check_sample_weights_not_an_array": "Sample weights are not supported",
+        "check_sample_weights_list": "Sample weights are not supported",
+        "check_all_zero_sample_weights_error": "Sample weights are not supported",
+        "check_sample_weights_shape": "Sample weights are not supported",
+        "check_sample_weights_not_overwritten": "Sample weights are not supported",
+        "check_sample_weight_equivalence_on_dense_data": (
+            "Sample weights are not supported"
+        ),
+        "check_estimators_pickle": (
+            "Pickling does not preserve the fitted model state"
+        ),
+    },
     KMeans: {
         "check_sample_weight_equivalence_on_dense_data": "Sample weights not equal to repeating data",
     },


### PR DESCRIPTION
New version of the Isolation Forest PR. 

This PR introduces a high-performance GPU implementation of the Isolation Forest algorithm for unsupervised anomaly detection. The implementation can achieve from tens to thousands of times speedup over scikit-learn depending on hardware, dataset, hyperparameters, and input layout, scaling to datasets of 25M+ samples while maintaining equivalent detection quality (ROC-AUC).

> **Update**: This PR now includes Treelite export and nvForest-backed inference. The trained cuML model exports its compact isolation trees to a Treelite regression forest that predicts average path length; cuML then applies the standard Isolation Forest score transform to preserve sklearn-compatible `score_samples()` semantics.

---

## Algorithm

### Background

Isolation Forest [(Liu et al., 2008)](https://ieeexplore.ieee.org/document/4781136) detects anomalies by exploiting the key insight that anomalies are few and different,  and therefore they are more susceptible to isolation than normal points. Rather than profiling normal behavior, the algorithm directly isolates anomalies using random recursive partitioning.

**Core principle**: Anomalies have shorter average path lengths in randomly constructed trees because they are easier to separate from the majority of data.

### Algorithm Description

```
IsolationForest(X, n_trees, max_samples):
    for t in 1..n_trees:
        subsample = random_sample(X, max_samples)  # Default: 256 samples
        tree = build_isolation_tree(subsample, max_depth=ceil(log2(max_samples)))
        forest.append(tree)

build_isolation_tree(X, depth):
    if depth == 0 or |X| <= 1:
        return Leaf(size=|X|)
    feature = random_choice(features)
    threshold = random_uniform(min(X[feature]), max(X[feature]))
    left = X[X[feature] < threshold]
    right = X[X[feature] >= threshold]
    return Node(feature, threshold, 
                build_isolation_tree(left, depth-1),
                build_isolation_tree(right, depth-1))
```

### GPU Implementation

The implementation uses a single-kernel implementation where all trees are built in parallel:

```
┌─────────────────────────────────────────────────────────────┐
│                    GPU Kernel Launch                         │
│  ┌─────────┐ ┌─────────┐ ┌─────────┐     ┌─────────┐       │
│  │ Block 0 │ │ Block 1 │ │ Block 2 │ ... │Block N-1│       │
│  │ Tree 0  │ │ Tree 1  │ │ Tree 2  │     │Tree N-1 │       │
│  └─────────┘ └─────────┘ └─────────┘     └─────────┘       │
└─────────────────────────────────────────────────────────────┘
```

**Key design decisions:**

1. **One block per tree**: Each CUDA block builds one complete isolation tree independently
2. **Subsample gathering**: Random indices generated, then data gathered into contiguous row-major buffer for cache-friendly tree building
3. **Iterative DFS**: Tree construction uses explicit stack in shared memory
4. **Random splits**: Feature and threshold selected via cuRAND per node

**Kernel structure:**
```cpp
__global__ void build_isolation_trees_kernel(...) {
    int tree_id = blockIdx.x;
    
    // Phase 1: Generate random sample indices
    // Phase 2: Gather subsample into contiguous buffer (col-major → row-major)
    // Phase 3: Build tree iteratively using shared memory stack
}
```

### Treelite / nvForest Inference

After fitting, the model compacts the used nodes from the padded GPU tree representation and exports them to Treelite. The exported Treelite model is represented as a regression forest:

- Internal nodes store the Isolation Forest split feature and threshold
- Leaf nodes store pre-computed path length (`depth + c(n_leaf)`)
- The Treelite forest averages tree outputs to produce `E[h(x)]`, the mean path length
- cuML applies the Isolation Forest scoring formula outside Treelite:

```
paper_score = 2^(-E[h(x)] / c(max_samples))
sklearn_score = -(paper_score - 0.5)
```

This keeps the exported tree structure faithful to the trained model while allowing nvForest to execute the expensive tree traversal path efficiently on GPU. The Python API exposes `as_treelite()` and `as_nvforest()`, and internal nvForest-backed scoring matches the existing cuML scoring path within ~3e-7 on the benchmark below.

### Quick Complexity Analysis

| Operation | CPU (sklearn) | GPU (cuML) |
|-----------|---------------|------------|
| **Training** | O(n_trees × max_samples × log(max_samples) × n_features) | O(max_samples × log(max_samples) × n_features) - parallelized across trees |

**Memory complexity:**
- Tree storage: O(n_trees × 2^max_depth) nodes
- Subsample buffer: O(n_trees × max_samples × n_features) - temporary during training
- Typical: 100 trees × 256 samples × 100 features × 4 bytes ≈ 10 MB temporary

---

### Why Isolation Forest Training is Memory-Bound

**Arithmetic Intensity Analysis**

**Step 1: Subsample Gathering**
```
Per tree:
  - Load 256 random rows from dataset (column-major)
  - Each row: D features × 4 bytes
  
  Memory: 256 × D × 4 bytes
  Compute: 0 FLOPs (just data movement)
  
  Arithmetic Intensity = 0 FLOP/byte  ← Pure memory operation
```

**Step 2: Tree Building**
```
Per tree (256 samples, max_depth ≈ 8):
  - ~255 nodes to potentially create
  - Per node:
    - Find min/max of one feature: 2 comparisons × samples_in_node
    - Generate random threshold: ~3 FLOPs
    - Partition samples: ~samples_in_node comparisons + swaps
  
  Total FLOPs per tree: ~3000-5000 FLOPs
  Data already in shared memory: 256 × D × 4 bytes loaded once
  
  Arithmetic Intensity ≈ 4000 / (256 × 100 × 4) ≈ 0.04 FLOP/byte
```

#### Comparison

| Algorithm | Arithmetic Intensity | Bound |
|-----------|---------------------|-------|
| Matrix Multiply (GEMM) | ~100-1000 FLOP/byte | Compute |
| Gradient Boosting Training | ~1-10 FLOP/byte | Mixed |
| **Isolation Forest Training** | **~0.04 FLOP/byte** | **Memory** |
| Memory Copy | 0 FLOP/byte | Memory |

#### Why So Memory-Bound?

1. **Subsampling is the dominant cost**: The algorithm only uses 256 samples per tree (configurable) regardless of dataset size. Gathering these 256 scattered rows is pure memory bandwidth and latency. 

2. **Minimal computation per sample**: Unlike gradient boosting (histogram binning, gradient computation), IF just does:
   - 1 random feature selection
   - 1 min/max scan
   - 1 random threshold
   - 1 partition

3. **Tree building is fast**: With only 256 samples and depth ~8, building one tree is trivial compute (~4000 FLOPs = microseconds on any GPU).


## Evaluation

### Detection Quality

The first round of tests show that GPU implementation produces **equivalent detection quality** to sklearn on synthetic datasets mimicking real-world anomaly detection scenarios:

#### Credit Card Fraud-like (285K samples, 30 features, 0.17% anomalies)
<img width="1435" height="395" alt="Screenshot 2026-02-02 at 14 08 55" src="https://github.com/user-attachments/assets/3c79b040-9609-4fd8-9461-7b32e1c26f8e" />

#### Network Intrusion-like (2.8M samples, 78 features, 20% anomalies)  
<img width="1432" height="392" alt="Screenshot 2026-02-02 at 14 09 15" src="https://github.com/user-attachments/assets/6812e147-2af0-4a88-9030-07f4a8d952de" />

#### High-Dimensional (1M samples, 200 features, 2% anomalies)
<img width="1434" height="394" alt="Screenshot 2026-02-02 at 14 08 59" src="https://github.com/user-attachments/assets/577e79b0-a149-4b13-8c9a-e0478edb9809" />



**Key observations from figures:**
- **Score Correlation**: High correlation (>0.9) between cuML and sklearn scores, showing similar ranking behavior
- **Score Distributions**: Different absolute ranges but same separation between normal/anomaly classes
- **ROC Curves**: Nearly identical curves with matching AUC values (1.0000 on these well-separated synthetic datasets)

> **Note**: Exact score matching is not expected due to different random number generators and tree construction order. What matters is equivalent **ranking quality**, which ROC-AUC measures.

---

## Microbenchmark Performance Results

> **Disclaimer**: All benchmarks below are synthetic microbenchmarks on a single hardware configuration. Absolute times and speedup ratios will vary with different GPUs, CPUs, memory bandwidth, dataset characteristics, and system load. They are intended to illustrate scaling trends, not to guarantee production performance.
>
> **Hardware**: NVIDIA RTX Pro 6000 Blackwell (95 GB GDDR7, ~1.8 TB/s) — AMD Ryzen Threadripper PRO 7965WX 24-Cores  
> **Benchmark script**: [`python/cuml/tests/scripts/if_bench.py`](python/cuml/tests/scripts/if_bench.py)

The benchmark compares four input paths:
- **cuML (F,GPU)** — column-major (Fortran-order) GPU data, the optimal path with zero internal copy
- **cuML (C,GPU)** — row-major (C-order) GPU data, measures relayout overhead
- **cuML (CPU)** — NumPy CPU data passed to cuML, measures host→device transfer + relayout + fit
- **sklearn** — scikit-learn `IsolationForest` on CPU (`n_jobs=-1`)

### Training + Treelite Export Scaling (up to 10 GB)

The current `fit()` path includes GPU tree construction **and** Treelite model construction/serialization. On the optimal F-order GPU input path, training + Treelite export remains in the low-millisecond range up to 10 GB.

| Dataset Size | Rows | cuML (F,GPU) | cuML (C,GPU) | cuML (CPU) | sklearn | F-GPU speedup vs sklearn |
|--------------|------|--------------|--------------|------------|---------|---------------------------|
| 4 MB | 10,000 | 0.010s | 0.008s | 0.008s | 0.109s | 10.9x |
| 10 MB | 25,000 | 0.006s | 0.002s | 0.014s | 0.121s | 20.2x |
| 20 MB | 50,000 | 0.006s | 0.005s | 0.022s | 0.149s | 24.8x |
| 40 MB | 100,000 | 0.005s | 0.006s | 0.041s | 0.158s | 31.6x |
| 100 MB | 250,000 | 0.005s | 0.006s | 0.068s | 0.186s | 37.2x |
| 200 MB | 500,000 | 0.005s | 0.006s | 0.131s | 0.199s | 39.8x |
| 400 MB | 1,000,000 | 0.007s | 0.007s | 0.246s | 0.252s | 36.0x |
| 1 GB | 2,500,000 | 0.003s | 0.009s | 0.467s | 0.460s | 153.3x |
| 2 GB | 5,000,000 | 0.007s | 0.024s | 0.925s | 0.811s | 115.9x |
| 4 GB | 10,000,000 | 0.005s | 0.037s | 1.839s | 1.532s | 306.4x |
| 10 GB | 25,000,000 | 0.005s | 0.076s | 6.878s | 24.787s | **4,957.4x** |

#### Training Throughput

| Dataset Size | cuML (F,GPU) | cuML (C,GPU) | cuML (CPU) | sklearn |
|--------------|--------------|--------------|------------|---------|
| 4 MB | 1,004,531 rows/s | 1,205,644 rows/s | 1,257,106 rows/s | 91,714 rows/s |
| 10 MB | 4,516,051 rows/s | 11,343,805 rows/s | 1,817,610 rows/s | 206,962 rows/s |
| 20 MB | 8,399,512 rows/s | 9,169,036 rows/s | 2,232,279 rows/s | 336,664 rows/s |
| 40 MB | 21,943,939 rows/s | 15,587,898 rows/s | 2,466,664 rows/s | 634,382 rows/s |
| 100 MB | 46,227,400 rows/s | 41,397,260 rows/s | 3,686,573 rows/s | 1,341,572 rows/s |
| 200 MB | 92,847,528 rows/s | 83,160,540 rows/s | 3,802,457 rows/s | 2,517,556 rows/s |
| 400 MB | 151,079,311 rows/s | 141,707,932 rows/s | 4,058,353 rows/s | 3,974,036 rows/s |
| 1 GB | 837,441,823 rows/s | 268,914,100 rows/s | 5,358,897 rows/s | 5,436,266 rows/s |
| 2 GB | 742,197,978 rows/s | 205,560,916 rows/s | 5,407,163 rows/s | 6,165,504 rows/s |
| 4 GB | 1,888,910,884 rows/s | 270,300,383 rows/s | 5,437,180 rows/s | 6,527,926 rows/s |
| 10 GB | **4,962,118,198 rows/s** | 328,928,870 rows/s | 3,634,768 rows/s | 1,008,580 rows/s |

### Dataset Width Scaling (Fixed 4 GB)

This benchmark holds total input size fixed at 4 GB while varying feature count. As columns increase, row count decreases, so this measures sensitivity to dataset shape at a constant memory footprint. The `fit()` timing includes Treelite model construction/serialization.

| Columns | Rows | cuML (F,GPU) | cuML (C,GPU) | cuML (CPU) | sklearn | F-GPU speedup vs sklearn |
|---------|------|--------------|--------------|------------|---------|---------------------------|
| 8 | 125,000,000 | 0.007s | 0.012s | 1.972s | 37.383s | **5,340.4x** |
| 16 | 62,500,000 | 0.026s | 0.012s | 0.713s | 8.663s | 333.2x |
| 32 | 31,250,000 | 0.009s | 0.029s | 0.318s | 4.522s | 502.4x |
| 64 | 15,625,000 | 0.005s | 0.032s | 0.323s | 2.353s | 470.6x |
| 128 | 7,812,500 | 0.006s | 0.034s | 0.325s | 1.223s | 203.8x |
| 256 | 3,906,250 | 0.003s | 0.035s | 0.360s | 0.617s | 205.7x |
| 512 | 1,953,125 | 0.006s | 0.027s | 0.322s | 0.379s | 63.2x |
| 1024 | 976,562 | 0.005s | 0.025s | 0.316s | 0.273s | 54.6x |
| 2048 | 488,281 | 0.013s | 0.039s | 0.313s | 0.196s | 15.1x |

### Treelite / nvForest Inference Scaling (up to 10 GB)

The inference benchmark separates Treelite deserialization (`as_treelite()`), nvForest model loading (`as_nvforest()`), current cuML C++ scoring, nvForest-backed scoring, and sklearn scoring. The `Fit` column also includes Treelite serialization because export is performed during `fit()`.

| Dataset Size | Rows | Fit | Treelite | nvForest load | cuML score | nvForest score | sklearn score | Max score diff |
|--------------|------|-----|----------|---------------|------------|----------------|---------------|----------------|
| 4 MB | 10,000 | 0.006s | 0.000s | 0.012s | 0.002s | 0.001s | 0.029s | 2.68e-7 |
| 10 MB | 25,000 | 0.005s | 0.002s | 0.003s | 0.001s | 0.000s | 0.068s | 2.68e-7 |
| 20 MB | 50,000 | 0.005s | 0.000s | 0.002s | 0.001s | 0.000s | 0.135s | 2.38e-7 |
| 40 MB | 100,000 | 0.003s | 0.001s | 0.002s | 0.001s | 0.000s | 0.272s | 2.68e-7 |
| 100 MB | 250,000 | 0.003s | 0.000s | 0.002s | 0.002s | 0.001s | 0.689s | 2.38e-7 |
| 200 MB | 500,000 | 0.003s | 0.000s | 0.002s | 0.004s | 0.002s | 1.403s | 2.68e-7 |
| 400 MB | 1,000,000 | 0.002s | 0.000s | 0.002s | 0.006s | 0.002s | 2.746s | 2.68e-7 |
| 1 GB | 2,500,000 | 0.002s | 0.000s | 0.002s | 0.015s | 0.004s | 6.965s | 2.98e-7 |
| 2 GB | 5,000,000 | 0.005s | 0.000s | 0.003s | 0.029s | 0.007s | 13.806s | 2.68e-7 |
| 4 GB | 10,000,000 | 0.005s | 0.000s | 0.002s | 0.057s | 0.014s | 26.730s | 3.28e-7 |
| 10 GB | 25,000,000 | 0.006s | 0.000s | 0.002s | 0.141s | 0.033s | 68.647s | 3.28e-7 |

#### Inference Throughput

| Dataset Size | cuML score | nvForest score | sklearn score |
|--------------|------------|----------------|---------------|
| 4 MB | 5,231,286 rows/s | 11,608,254 rows/s | 340,173 rows/s |
| 10 MB | 44,249,354 rows/s | 94,856,501 rows/s | 367,111 rows/s |
| 20 MB | 75,199,278 rows/s | 163,838,272 rows/s | 369,359 rows/s |
| 40 MB | 126,189,016 rows/s | 224,780,221 rows/s | 367,692 rows/s |
| 100 MB | 124,374,149 rows/s | 365,230,095 rows/s | 362,625 rows/s |
| 200 MB | 142,071,043 rows/s | 327,824,784 rows/s | 356,404 rows/s |
| 400 MB | 159,708,640 rows/s | 466,135,707 rows/s | 364,164 rows/s |
| 1 GB | 168,557,920 rows/s | 614,880,905 rows/s | 358,960 rows/s |
| 2 GB | 171,312,449 rows/s | 680,810,180 rows/s | 362,174 rows/s |
| 4 GB | 175,256,953 rows/s | 736,178,615 rows/s | 374,106 rows/s |
| 10 GB | 177,387,928 rows/s | **760,045,583 rows/s** | 364,183 rows/s |

### Performance Analysis

**Key Points:**

1. **Training + export remains low-latency**: On the RTX Pro 6000 Blackwell, cuML (F,GPU) trains and serializes the Treelite model in the low-millisecond range up to 10 GB (25M rows × 100 features). 

2. **Memory layout matters**: The F-order GPU path is the optimal path. C-order GPU data pays re-layout overhead, and CPU input additionally pays host→device transfer cost.

3. **Dataset shape matters at fixed memory footprint**: On a fixed 4 GB input, cuML remains in the low-millisecond range from 8 to 2048 columns. Speedup is largest for tall/narrow data (**~5,340x** at 8 columns, 125M rows) and narrows as row count decreases for very wide data (**~15x** at 2048 columns, 488K rows). Sklearn performance scales with number of rows. 

4. **nvForest inference is substantially faster than the current C++ scoring path**: At 10 GB, nvForest-backed scoring takes **0.033s** versus **0.141s** for current cuML scoring, a **~4.3x** speedup while matching scores within **3.28e-7** max absolute difference.

5. **Inference vs sklearn is orders of magnitude faster**: At 10 GB, nvForest scoring takes **0.033s** versus sklearn's **68.647s**, a **~2,080x** inference speedup. Current cuML scoring is also **~487x** faster than sklearn at this size. This wasn't a comprehensive benchmark of nvForest, so take that context in mind. 

6. **Throughput scales with dataset size**: Training and inference throughput improve as problem sizes become large enough to amortize fixed overheads. nvForest inference reaches **760M rows/s** at 10 GB.

#### Dataset Size Limits

The implementation does not have a small algorithmic row-count limit in the training path: `n_rows` is represented as `size_t`, and tree construction samples only `max_samples` rows per tree. In practice, the maximum supported dataset size is determined by GPU memory and the input path. F-order GPU input is the most memory-efficient path, while C-order GPU or CPU input  require additional full-matrix layout conversion and/or host-to-device transfer buffers.

This PR has benchmarked synthetic datasets up to **25M rows × 100 features** (~10 GB, `float32`) on the RTX Pro 6000 Blackwell system. Larger datasets and less favorable input paths need to be validated in follow-up PRs, including stress tests near device-memory limits and tests that cover `cuml.accel` CPU-input ingestion behavior.

###  Results on Other Hardware, with C-major data


H100, L40, DGX Spark benchmarks: 

#### Training Speedup vs sklearn (varying dataset size)

| Dataset Size | Rows | H100/Xeon 112c/speedup | L40/AMD 64c/speedup | DGX Spark GPU/CPU/Speedup |
|--------------|------|------------------|---------------|-----------|
| 4 MB | 10K | 0.002s / 0.523s / **333.6x** | 0.002s / 0.387s / **200.9x** | 0.010s / 0.132s / **13.4x** |
| 10 MB | 25K | 0.014s / 0.615s / **45.1x** | 0.002s / 0.395s / **175.1x** | 0.011s / 0.136s / **12.8x** |
| 20 MB | 50K | 0.003s / 0.681s / **234.0x** | 0.002s / 0.482s / **214.4x** | 0.012s / 0.160s / **13.3x** |
| 40 MB | 100K | 0.003s / 0.745s / **241.2x** | 0.003s / 0.508s / **196.3x** | 0.013s / 0.171s / **13.0x** |
| 100 MB | 250K | 0.003s / 0.794s / **256.4x** | 0.003s / 0.533s / **200.5x** | 0.017s / 0.194s / **11.2x** |
| 200 MB | 500K | 0.003s / 0.810s / **279.6x** | 0.004s / 0.566s / **146.7x** | 0.021s / 0.217s / **10.4x** |
| 400 MB | 1M | 0.004s / 0.862s / **234.5x** | 0.006s / 0.732s / **132.3x** | 0.031s / 0.272s / **8.7x** |
| 1 GB | 2.5M | 0.007s / 1.307s / **178.2x** | 0.011s / 1.299s / **120.2x** | 0.071s / 0.404s / **5.7x** |
| 2 GB | 5M | 0.015s / 2.192s / **147.3x** | 0.019s / 2.068s / **107.6x** | 0.136s / 0.630s / **4.6x** |
| 4 GB | 10M | 0.031s / 3.752s / **122.4x** | 0.037s / 3.486s / **94.9x** | 0.259s / 0.994s / **3.8x** |
| 10 GB | 25M | 0.069s / 6.753s / **97.6x** | 0.087s / 7.391s / **85.4x** | 0.659s / 2.166s / **3.3x** |

*Format: cuML time / sklearn time / **Speedup***

#### Column Scaling (Fixed 4GB dataset, 100 trees)

| Columns | Rows | H100 | L40 | DGX Spark |
|---------|------|------|-----|-----------|
| 8 | 125M | 0.010s | 0.017s / **1186x** | 0.201s / **47x** |
| 16 | 62.5M | 0.011s | 0.016s / **789x** | 0.204s / **25x** |
| 32 | 31.25M | 0.055s | 0.030s / **289x** | 0.249s / **11x** |
| 64 | 15.6M | 0.029s | 0.034s / **148x** | 0.256s / **6x** |
| 128 | 7.8M | 0.030s | 0.037s / **62x** | 0.263s / **3x** |
| 256 | 3.9M | 0.029s | 0.039s / **38x** | 0.266s / **2x** |
| 512 | 1.95M | 0.026s | 0.041s / **23x** | 0.274s / **1.2x** |
| 1024 | 976K | 0.024s | 0.044s / **17x** | 0.287s / **0.9x** |
| 2048 | 488K | 0.026s | 0.047s / **12x** | 0.347s / **0.7x** |

#### Tree Scaling (Fixed 4GB dataset, 100 columns)

| Trees | H100 | L40 | DGX Spark |
|-------|------|-----|-----------|
| 10 | 0.029s | 0.035s / **12x** | 0.259s / 0.6x |
| 25 | 0.034s | 0.035s / **26x** | 0.257s / 1.2x |
| 50 | 0.049s | 0.035s / **51x** | 0.256s / 2.1x |
| 100 | 0.056s | 0.035s / **100x** | 0.261s / 3.9x |
| 200 | 0.039s | 0.036s / **192x** | 0.260s / 7.6x |
| 500 | 0.029s | 0.038s / **461x** | 0.273s / 17.8x |
| 1000 | 0.042s | 0.041s / **846x** | 0.280s / 34.8x |

#### Memory-Bandwidth Analysis

The ~10x performance gap between discrete GPUs (H100/L40 with HBM) and integrated GB10 (LPDDR5X) confirms the algorithm is heavily memory-bandwidth bound:

| System | Memory Bandwidth | Training Time (4GB) | Ratio |
|--------|------------------|---------------------|-------|
| H100 | 3,350 GB/s | 0.031s | 1.0x |
| L40 | 864 GB/s | 0.037s | 1.2x |
| GB10 | ~270 GB/s | 0.259s | 8.4x |


---

## Files Changed

- `cpp/include/cuml/ensemble/isolation_forest.hpp` - Public C++ API
- `cpp/src/isolation_forest/isolation_forest.cuh` - Core implementation
- `cpp/src/isolation_forest/isolation_tree_builder.cuh` - CUDA kernel
- `cpp/src/isolation_forest/isolation_forest.cu` - Template instantiations and Treelite export builder
- `cpp/tests/sg/isolation_forest_test.cu` - C++ unit tests including Treelite export metadata coverage
- `python/cuml/cuml/ensemble/isolation_forest.pyx` - Python bindings, Treelite export, and nvForest-backed scoring helper
- `python/cuml/tests/test_isolation_forest.py` - Python tests including Treelite serialization and nvForest score parity
- `python/cuml/tests/scripts/if_bench.py` - Training, export, and inference benchmark script