### PR TITLE
Add IPython magic for setting `cuml.accel` log level

### DIFF
--- a/docs/source/cuml-accel/logging-and-profiling.rst
+++ b/docs/source/cuml-accel/logging-and-profiling.rst
@@ -52,17 +52,19 @@ When using the programmatic installation method, you can set the log level direc
    # Install with warning logging (default)
    cuml.accel.install(log_level="warn")
 
-Jupyter Notebooks
------------------
+Jupyter/IPython
+---------------
 
-Since the magic command doesn't accept arguments, use the programmatic installation:
+The log level may be set in Jupyter notebooks or IPython through the
+``cuml.accel.log_level`` line magic after loading the ``cuml.accel`` extension:
 
 .. code-block:: python
 
-   import cuml
+   # Load the cuml.accel extension, enabling cuml.accel
+   %load_ext cuml.accel
 
-   # Install with desired log level before other imports
-   cuml.accel.install(log_level="debug")
+   # Set the log level to info
+   %cuml.accel.log_level info
 
 Environment Variable
 ~~~~~~~~~~~~~~~~~~~~

--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -49,7 +49,14 @@ class Logger:
         level : {'error', 'warn', 'info', 'debug'}
             The log level to set.
         """
-        self.level = Logger._Level[level.upper()]
+        try:
+            level = Logger._Level[level.upper()]
+        except KeyError:
+            raise ValueError(
+                f"level should be one of ['error', 'warn', 'info', 'debug']; "
+                f"got {level!r} instead."
+            ) from None
+        self.level = level
 
     def error(self, msg: str) -> None:
         """Log a message at ERROR level."""

--- a/python/cuml/cuml/accel/magics.py
+++ b/python/cuml/cuml/accel/magics.py
@@ -86,7 +86,7 @@ def run_cell_with_profiler(source, namespace, profiler):
 
 
 def load_ipython_extension(ip):
-    from IPython.core.magic import Magics, cell_magic, magics_class
+    from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
 
     try:
         # Small UX nicety, added in IPython 8.10
@@ -98,6 +98,38 @@ def load_ipython_extension(ip):
 
     @magics_class
     class CumlAccelMagics(Magics):
+        @line_magic("cuml.accel.log_level")
+        def log_level(self, line):
+            """Get or set the current `cuml.accel` log level.
+
+            Usage
+            -----
+            %cuml.accel.log_level [log_level]
+
+            Options
+            -------
+            log_level: {error, warn, info, debug}, optional
+                The log level to configure. If not specified, the current log
+                level is returned instead.
+
+            Examples
+            --------
+            Set the log level to debug:
+
+              In [1]: %cuml.accel.log_level debug
+
+            Get the current log level:
+
+              In [2]: %cuml.accel.log_level
+              Out[2]: 'debug'
+            """
+            from cuml.accel.core import logger
+
+            if line := line.strip():
+                logger.set_level(line)
+            else:
+                return logger.level.name.lower()
+
         @cell_magic("cuml.accel.profile")
         @output_can_be_silenced
         def profile(self, _, cell):

--- a/python/cuml/cuml_accel_tests/test_logging.py
+++ b/python/cuml/cuml_accel_tests/test_logging.py
@@ -1,7 +1,9 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
+import re
+
 import pytest
 from sklearn.datasets import make_classification, make_regression
 from sklearn.linear_model import Ridge
@@ -28,6 +30,17 @@ def get_logs(capsys):
         ]
 
     return get_logs
+
+
+def test_set_level_error():
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "level should be one of ['error', 'warn', 'info', 'debug']; "
+            "got 'invalid' instead."
+        ),
+    ):
+        logger.set_level("invalid")
 
 
 @pytest.mark.parametrize(

--- a/python/cuml/cuml_accel_tests/test_magics.py
+++ b/python/cuml/cuml_accel_tests/test_magics.py
@@ -316,3 +316,23 @@ def test_line_profiler_magic_applies_to_the_correct_source():
         gpu_used.append(parts[3].strip() != "-")
     assert counts == [1, 1, 1, 1, 1]
     assert gpu_used == [False, False, False, True, True]
+
+
+def test_log_level_magic():
+    run_script(
+        """
+        ip.run_line_magic("load_ext", "cuml.accel")
+
+        out = ip.run_line_magic("cuml.accel.log_level", "")
+        assert out == "warn"
+
+        out = ip.run_line_magic("cuml.accel.log_level", "debug")
+        assert out is None
+
+        from cuml.accel.core import logger
+        assert logger.level.name.lower() == "debug"
+
+        out = ip.run_line_magic("cuml.accel.log_level", "")
+        assert out == "debug"
+        """
+    )


### PR DESCRIPTION
This adds a new ``cuml.accel.log_level`` IPython magic for configuring the accelerator log level within a Jupyter or IPython environment.

```
In [1]: %load_ext cuml.accel

In [2]: %cuml.accel.log_level
Out[2]: 'warn'

In [3]: %cuml.accel.log_level debug

In [4]: %cuml.accel.log_level
Out[4]: 'debug'
```

Previously users would have to use the programmatic installation (``cuml.accel.install(log_level='debug')``) or reach into the internals to change the log level after installation.

I wanted this for a quick demo, and it was easy enough to add.