### PR TITLE
Avoid host sync in `_repr_mimebundle_` when possible

### DIFF
--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -725,14 +725,9 @@ class ProxyBase(BaseEstimator, metaclass=ProxyBaseMeta):
     def _more_tags(self):
         return self._cpu._more_tags()
 
-    def _repr_mimebundle_(self, **kwargs):
+    def _html_repr(self):
         self._sync_attrs_to_cpu()
-        return self._cpu._repr_mimebundle_(**kwargs)
-
-    @property
-    def _repr_html_(self):
-        self._sync_attrs_to_cpu()
-        return self._cpu._repr_html_
+        return self._cpu._html_repr()
 
 
 class _ArrayAPIWrapper(Base, InteropMixin):

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -542,6 +542,14 @@ class ProxyBase(BaseEstimator, metaclass=ProxyBaseMeta):
         return self._cpu._sklearn_auto_wrap_output_keys
 
     ############################################################
+    # set_callbacks handling                                   #
+    ############################################################
+
+    def _gpu_set_callbacks(self, *callbacks):
+        self._cpu.set_callbacks(*callbacks)
+        return self._gpu
+
+    ############################################################
     # Standard magic methods                                   #
     ############################################################
 
@@ -596,10 +604,6 @@ class ProxyBase(BaseEstimator, metaclass=ProxyBaseMeta):
             )
 
         return getattr(self._cpu, name)
-
-    def _gpu_set_callbacks(self, *callbacks):
-        self._cpu.set_callbacks(*callbacks)
-        return self._gpu
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name in ("_cpu", "_gpu", "_synced"):

--- a/python/cuml/cuml_accel_tests/test_estimator_proxy.py
+++ b/python/cuml/cuml_accel_tests/test_estimator_proxy.py
@@ -192,6 +192,19 @@ def test_repr_mimebundle():
         assert "<span>Fitted</span>" in html_repr
 
 
+def test_repr_mimebundle_display_text():
+    """If `display="text"` is configured, no host sync is needed"""
+    X, y = make_classification()
+    model = LogisticRegression(C=1.5).fit(X, y)
+    with sklearn.config_context(display="text"):
+        # The conditional definition of `_repr_html_` is proxied through
+        assert not hasattr(model, "_repr_html_")
+        mimebundle = model._repr_mimebundle_()
+    # No host sync needed to repr
+    assert not hasattr(model._cpu, "n_features_in_")
+    assert "text/html" not in mimebundle
+
+
 def test_pipeline_repr():
     """sklearn's pretty printer requires you not override __repr__
     for pipelines to repr properly"""


### PR DESCRIPTION
The default html repr in sklearn requires access to fitted attributes, forcing a host sync. If `display="text"` is configured we can avoid this cost.

Also does a small readability fix for `set_callbacks` handling - in my rush to fix that issue, a method was put in a weird place in the file. Reordered here to improve readability.