### PR TITLE
Update `cuml.tsa` to use new validation

### DIFF
--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -2,15 +2,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-from typing import Dict, Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Tuple, Union
 
+import cupy as cp
 import numpy as np
 
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals import logger, nvtx, reflect, run_in_internal_context
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.validation import check_array
 from cuml.tsa.batched_lbfgs import batched_fmin_lbfgs_b
 
 from libc.stdint cimport uintptr_t
@@ -109,18 +109,18 @@ cdef class ARIMAParamsWrapper:
         cdef ARIMAOrder order = model.order
 
         cdef uintptr_t d_mu_ptr = \
-            model.mu_.ptr if order.k else <uintptr_t> NULL
+            model.mu_.data.ptr if order.k else <uintptr_t> NULL
         cdef uintptr_t d_beta_ptr = \
-            model.beta_.ptr if order.n_exog else <uintptr_t> NULL
+            model.beta_.data.ptr if order.n_exog else <uintptr_t> NULL
         cdef uintptr_t d_ar_ptr = \
-            model.ar_.ptr if order.p else <uintptr_t> NULL
+            model.ar_.data.ptr if order.p else <uintptr_t> NULL
         cdef uintptr_t d_ma_ptr = \
-            model.ma_.ptr if order.q else <uintptr_t> NULL
+            model.ma_.data.ptr if order.q else <uintptr_t> NULL
         cdef uintptr_t d_sar_ptr = \
-            model.sar_.ptr if order.P else <uintptr_t> NULL
+            model.sar_.data.ptr if order.P else <uintptr_t> NULL
         cdef uintptr_t d_sma_ptr = \
-            model.sma_.ptr if order.Q else <uintptr_t> NULL
-        cdef uintptr_t d_sigma2_ptr = <uintptr_t> model.sigma2_.ptr
+            model.sma_.data.ptr if order.Q else <uintptr_t> NULL
+        cdef uintptr_t d_sigma2_ptr = <uintptr_t> model.sigma2_.data.ptr
 
         self.params.mu = <double*> d_mu_ptr
         self.params.beta = <double*> d_beta_ptr
@@ -315,10 +315,17 @@ class ARIMA(Base):
                              "Required: max(p+s*P, q+s*Q) <= 1024")
 
         # Endogenous variable. Float64 only for now.
-        self.d_y, self.n_obs, self.batch_size, self.dtype \
-            = input_to_cuml_array(
-                endog, check_dtype=np.float64,
-                convert_to_dtype=(np.float64 if convert_dtype else None))
+        self.d_y = d_y = check_array(
+            endog,
+            dtype="float64",
+            order="F",
+            convert_dtype=convert_dtype,
+            ensure_2d=False,
+            ensure_all_finite=False,
+        )
+        self.n_obs = d_y.shape[0]
+        self.batch_size = d_y.shape[1] if d_y.ndim == 2 else 1
+        self.dtype = d_y.dtype
 
         if self.n_obs < d + s * D + 1:
             raise ValueError("ERROR: Number of observations too small for the"
@@ -326,11 +333,16 @@ class ARIMA(Base):
 
         # Exogenous variables
         if exog is not None:
-            self.d_exog, n_obs_exog, n_cols_exog, _ \
-                = input_to_cuml_array(exog,
-                                      convert_to_dtype=(np.float64 if convert_dtype
-                                                        else None),
-                                      check_dtype=np.float64)
+            self.d_exog = d_exog = check_array(
+                exog,
+                dtype="float64",
+                order="F",
+                convert_dtype=convert_dtype,
+                ensure_2d=False,
+                ensure_all_finite=False,
+            )
+            n_obs_exog = d_exog.shape[0]
+            n_cols_exog = d_exog.shape[1] if d_exog.ndim == 2 else 1
 
             if n_cols_exog % self.batch_size != 0:
                 raise ValueError("Number of columns in exog is not a multiple"
@@ -353,19 +365,24 @@ class ARIMA(Base):
 
         self.simple_differencing = simple_differencing
 
-        self._d_y_diff = CumlArray.empty(
-            (self.n_obs - d - s * D, self.batch_size), self.dtype)
+        self._d_y_diff = cp.empty(
+            (self.n_obs - d - s * D, self.batch_size),
+            dtype=self.dtype,
+            order="F",
+        )
         if n_exog > 0:
-            self._d_exog_diff = CumlArray.empty(
+            self._d_exog_diff = cp.empty(
                 (self.n_obs - d - s * D, self.batch_size * n_exog),
-                self.dtype)
+                dtype=self.dtype,
+                order="F",
+            )
 
         self.n_obs_diff = self.n_obs - d - D * s
 
         # Allocate temporary storage
         temp_mem_size = ARIMAMemory[double].compute_size(
             cpp_order, <int> self.batch_size, <int> self.n_obs)
-        self._temp_mem = CumlArray.empty(temp_mem_size, np.byte)
+        self._temp_mem = cp.empty(temp_mem_size, dtype="int8")
 
         self._initial_calc()
 
@@ -376,8 +393,8 @@ class ARIMA(Base):
         the CumlArrayDescriptors work
         """
 
-        cdef uintptr_t d_y_ptr = self.d_y.ptr
-        cdef uintptr_t d_y_diff_ptr = self._d_y_diff.ptr
+        cdef uintptr_t d_y_ptr = self.d_y.data.ptr
+        cdef uintptr_t d_y_diff_ptr = self._d_y_diff.data.ptr
         cdef uintptr_t d_exog_ptr
         cdef uintptr_t d_exog_diff_ptr
         handle = get_handle()
@@ -403,8 +420,8 @@ class ARIMA(Base):
             self.order_diff = cpp_order_diff
 
             if cpp_order_diff.n_exog > 0:
-                d_exog_ptr = self.d_exog.ptr
-                d_exog_diff_ptr = self._d_exog_diff.ptr
+                d_exog_ptr = self.d_exog.data.ptr
+                d_exog_diff_ptr = self._d_exog_diff.data.ptr
                 batched_diff(handle_[0], <double*> d_exog_diff_ptr,
                              <double*> d_exog_ptr,
                              <int> self.batch_size * cpp_order_diff.n_exog,
@@ -435,15 +452,15 @@ class ARIMA(Base):
             self.order_diff if self.simple_differencing else self.order
         cdef ARIMAParams[double] cpp_params = ARIMAParamsWrapper(self).params
 
-        ic = CumlArray.empty(self.batch_size, self.dtype)
-        cdef uintptr_t d_ic_ptr = ic.ptr
+        ic = cp.empty(self.batch_size, self.dtype)
+        cdef uintptr_t d_ic_ptr = ic.data.ptr
         cdef uintptr_t d_y_kf_ptr = \
-            self._d_y_diff.ptr if self.simple_differencing else self.d_y.ptr
+            self._d_y_diff.data.ptr if self.simple_differencing else self.d_y.data.ptr
 
         cdef uintptr_t d_exog_kf_ptr = <uintptr_t> NULL
         if order.n_exog:
-            d_exog_kf_ptr = (self._d_exog_diff.ptr if self.simple_differencing
-                             else self.d_exog.ptr)
+            d_exog_kf_ptr = (self._d_exog_diff.data.ptr if self.simple_differencing
+                             else self.d_exog.data.ptr)
 
         n_obs_kf = (self.n_obs_diff if self.simple_differencing
                     else self.n_obs)
@@ -455,7 +472,7 @@ class ARIMA(Base):
         except KeyError as e:
             raise NotImplementedError("IC type '{}' unknown".format(ic_type))
 
-        cdef uintptr_t d_temp_mem = self._temp_mem.ptr
+        cdef uintptr_t d_temp_mem = self._temp_mem.data.ptr
         arima_mem_ptr = new ARIMAMemory[double](
             order, <int> self.batch_size, <int> self.n_obs,
             <char*> d_temp_mem)
@@ -472,19 +489,19 @@ class ARIMA(Base):
 
     @property
     @reflect
-    def aic(self) -> CumlArray:
+    def aic(self):
         """Akaike Information Criterion"""
         return self._ic("aic")
 
     @property
     @reflect
-    def aicc(self) -> CumlArray:
+    def aicc(self):
         """Corrected Akaike Information Criterion"""
         return self._ic("aicc")
 
     @property
     @reflect
-    def bic(self) -> CumlArray:
+    def bic(self):
         """Bayesian Information Criterion"""
         return self._ic("bic")
 
@@ -496,7 +513,7 @@ class ARIMA(Base):
                 + 1)
 
     @reflect
-    def get_fit_params(self) -> Dict[str, CumlArray]:
+    def get_fit_params(self):
         """Get all the fit parameters. Not to be confused with get_params
         Note: pack() can be used to get a compact vector of the parameters
 
@@ -535,11 +552,12 @@ class ARIMA(Base):
         """
         for param_name in ["mu", "beta", "ar", "ma", "sar", "sma", "sigma2"]:
             if param_name in params:
-                array, *_ = input_to_cuml_array(
+                array = check_array(
                     params[param_name],
-                    convert_to_dtype=(np.float64 if convert_dtype
-                                      else None),
-                    check_dtype=np.float64
+                    dtype="float64",
+                    convert_dtype=convert_dtype,
+                    ensure_2d=False,
+                    ensure_all_finite=False,
                 )
                 setattr(self, "{}_".format(param_name), array)
 
@@ -579,7 +597,7 @@ class ARIMA(Base):
         level=None,
         exog=None,
         convert_dtype=True
-    ) -> Union[CumlArray, Tuple[CumlArray, CumlArray, CumlArray]]:
+    ):
         """Compute in-sample and/or out-of-sample prediction for each series
 
         Parameters
@@ -662,12 +680,16 @@ class ARIMA(Base):
         # Future values of the exogenous variables
         cdef uintptr_t d_exog_fut_ptr = <uintptr_t> NULL
         if order.n_exog and end > self.n_obs:
-            d_exog_fut, n_obs_fut, n_cols_fut, _ = input_to_cuml_array(
+            d_exog_fut = check_array(
                 exog,
-                convert_to_dtype=(np.float64 if convert_dtype
-                                  else None),
-                check_dtype=np.float64
+                dtype="float64",
+                convert_dtype=convert_dtype,
+                order="F",
+                ensure_2d=False,
+                ensure_all_finite=False,
             )
+            n_obs_fut = d_exog_fut.shape[0]
+            n_cols_fut = d_exog_fut.shape[1] if d_exog_fut.ndim == 2 else 1
             if n_obs_fut != end - self.n_obs:
                 raise ValueError(
                     "Dimensions mismatch: `exog` should contain {}"
@@ -676,29 +698,30 @@ class ARIMA(Base):
                 raise ValueError(
                     "Dimensions mismatch: `exog` should have {} columns"
                     .format(self.batch_size * order.n_exog))
-            d_exog_fut_ptr = d_exog_fut.ptr
+            d_exog_fut_ptr = d_exog_fut.data.ptr
 
         # allocate predictions and intervals device memory
         cdef uintptr_t d_y_p_ptr = <uintptr_t> NULL
         cdef uintptr_t d_lower_ptr = <uintptr_t> NULL
         cdef uintptr_t d_upper_ptr = <uintptr_t> NULL
-        d_y_p = CumlArray.empty((predict_size, self.batch_size),
-                                dtype=np.float64, order="F")
-        d_y_p_ptr = d_y_p.ptr
+        d_y_p = cp.empty((predict_size, self.batch_size), dtype="float64", order="F")
+        d_y_p_ptr = d_y_p.data.ptr
         if level is not None:
-            d_lower = CumlArray.empty((predict_size, self.batch_size),
-                                      dtype=np.float64, order="F")
-            d_upper = CumlArray.empty((predict_size, self.batch_size),
-                                      dtype=np.float64, order="F")
-            d_lower_ptr = d_lower.ptr
-            d_upper_ptr = d_upper.ptr
+            d_lower = cp.empty(
+                (predict_size, self.batch_size), dtype="float64", order="F"
+            )
+            d_upper = cp.empty(
+                (predict_size, self.batch_size), dtype="float64", order="F"
+            )
+            d_lower_ptr = d_lower.data.ptr
+            d_upper_ptr = d_upper.data.ptr
 
-        cdef uintptr_t d_y_ptr = self.d_y.ptr
+        cdef uintptr_t d_y_ptr = self.d_y.data.ptr
         cdef uintptr_t d_exog_ptr = <uintptr_t> NULL
         if order.n_exog:
-            d_exog_ptr = self.d_exog.ptr
+            d_exog_ptr = self.d_exog.data.ptr
 
-        cdef uintptr_t d_temp_mem = self._temp_mem.ptr
+        cdef uintptr_t d_temp_mem = self._temp_mem.data.ptr
         arima_mem_ptr = new ARIMAMemory[double](
             order, <int> self.batch_size, <int> self.n_obs,
             <char*> d_temp_mem)
@@ -727,7 +750,7 @@ class ARIMA(Base):
         nsteps: int,
         level=None,
         exog=None
-    ) -> Union[CumlArray, Tuple[CumlArray, CumlArray, CumlArray]]:
+    ):
         """Forecast the given model `nsteps` into the future.
 
         Parameters
@@ -772,24 +795,21 @@ class ARIMA(Base):
         cdef ARIMAOrder order = self.order
 
         if order.k and not hasattr(self, "mu_"):
-            self.mu_ = CumlArray.empty(self.batch_size, np.float64)
+            self.mu_ = cp.empty(self.batch_size, dtype="float64", order="F")
         if order.n_exog and not hasattr(self, "beta_"):
-            self.beta_ = CumlArray.empty((order.n_exog, self.batch_size),
-                                         np.float64)
+            self.beta_ = cp.empty(
+                (order.n_exog, self.batch_size), dtype="float64", order="F"
+            )
         if order.p and not hasattr(self, "ar_"):
-            self.ar_ = CumlArray.empty((order.p, self.batch_size),
-                                       np.float64)
+            self.ar_ = cp.empty((order.p, self.batch_size), dtype="float64", order="F")
         if order.q and not hasattr(self, "ma_"):
-            self.ma_ = CumlArray.empty((order.q, self.batch_size),
-                                       np.float64)
+            self.ma_ = cp.empty((order.q, self.batch_size), dtype="float64", order="F")
         if order.P and not hasattr(self, "sar_"):
-            self.sar_ = CumlArray.empty((order.P, self.batch_size),
-                                        np.float64)
+            self.sar_ = cp.empty((order.P, self.batch_size), dtype="float64", order="F")
         if order.Q and not hasattr(self, "sma_"):
-            self.sma_ = CumlArray.empty((order.Q, self.batch_size),
-                                        np.float64)
+            self.sma_ = cp.empty((order.Q, self.batch_size), dtype="float64", order="F")
         if not hasattr(self, "sigma2_"):
-            self.sigma2_ = CumlArray.empty(self.batch_size, np.float64)
+            self.sigma2_ = cp.empty(self.batch_size, dtype="float64", order="F")
 
     @nvtx.annotate(message="tsa.arima.ARIMA._estimate_x0",
                    domain="cuml_python")
@@ -802,10 +822,10 @@ class ARIMA(Base):
         cdef ARIMAOrder order = self.order
         cdef ARIMAParams[double] cpp_params = ARIMAParamsWrapper(self).params
 
-        cdef uintptr_t d_y_ptr = self.d_y.ptr
+        cdef uintptr_t d_y_ptr = self.d_y.data.ptr
         cdef uintptr_t d_exog_ptr = <uintptr_t> NULL
         if order.n_exog:
-            d_exog_ptr = self.d_exog.ptr
+            d_exog_ptr = self.d_exog.data.ptr
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
@@ -948,27 +968,29 @@ class ARIMA(Base):
         cdef ARIMAOrder order = self.order
         cdef ARIMAOrder order_kf = self.order_diff if diff else self.order
 
-        d_x_array, *_ = \
-            input_to_cuml_array(x,
-                                convert_to_dtype=(np.float64 if convert_dtype
-                                                  else None),
-                                check_dtype=np.float64,
-                                order='C')
-        cdef uintptr_t d_x_ptr = d_x_array.ptr
+        d_x_array = check_array(
+            x,
+            dtype="float64",
+            convert_dtype=convert_dtype,
+            order="C",
+            ensure_2d=False,
+            ensure_all_finite=False,
+        )
+        cdef uintptr_t d_x_ptr = d_x_array.data.ptr
 
         cdef uintptr_t d_y_kf_ptr = \
-            self._d_y_diff.ptr if diff else self.d_y.ptr
+            self._d_y_diff.data.ptr if diff else self.d_y.data.ptr
 
         cdef uintptr_t d_exog_kf_ptr = <uintptr_t> NULL
         if order.n_exog:
-            d_exog_kf_ptr = self._d_exog_diff.ptr if diff else self.d_exog.ptr
+            d_exog_kf_ptr = self._d_exog_diff.data.ptr if diff else self.d_exog.data.ptr
 
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
         n_obs_kf = (self.n_obs_diff if diff else self.n_obs)
 
-        cdef uintptr_t d_temp_mem = self._temp_mem.ptr
+        cdef uintptr_t d_temp_mem = self._temp_mem.data.ptr
         arima_mem_ptr = new ARIMAMemory[double](
             order, <int> self.batch_size, <int> self.n_obs,
             <char*> d_temp_mem)
@@ -1020,31 +1042,33 @@ class ARIMA(Base):
         cdef LoglikeMethod ll_method = CSS if method == "css" else MLE
         diff = ll_method != MLE or self.simple_differencing
 
-        grad = CumlArray.empty(N * self.batch_size, np.float64)
-        cdef uintptr_t d_grad = <uintptr_t> grad.ptr
+        grad = cp.empty(N * self.batch_size, dtype="float64", order="F")
+        cdef uintptr_t d_grad = <uintptr_t> grad.data.ptr
 
         cdef ARIMAOrder order = self.order
         cdef ARIMAOrder order_kf = self.order_diff if diff else self.order
 
-        d_x_array, *_ = \
-            input_to_cuml_array(x,
-                                convert_to_dtype=(np.float64 if convert_dtype
-                                                  else None),
-                                check_dtype=np.float64,
-                                order='C')
-        cdef uintptr_t d_x_ptr = d_x_array.ptr
+        d_x_array = check_array(
+            x,
+            dtype="float64",
+            convert_dtype=convert_dtype,
+            order="C",
+            ensure_2d=False,
+            ensure_all_finite=False,
+        )
+        cdef uintptr_t d_x_ptr = d_x_array.data.ptr
 
         cdef uintptr_t d_y_kf_ptr = \
-            self._d_y_diff.ptr if diff else self.d_y.ptr
+            self._d_y_diff.data.ptr if diff else self.d_y.data.ptr
 
         cdef uintptr_t d_exog_kf_ptr = <uintptr_t> NULL
         if order.n_exog:
-            d_exog_kf_ptr = self._d_exog_diff.ptr if diff else self.d_exog.ptr
+            d_exog_kf_ptr = self._d_exog_diff.data.ptr if diff else self.d_exog.data.ptr
 
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
-        cdef uintptr_t d_temp_mem = self._temp_mem.ptr
+        cdef uintptr_t d_temp_mem = self._temp_mem.data.ptr
         arima_mem_ptr = new ARIMAMemory[double](
             order, <int> self.batch_size, <int> self.n_obs,
             <char*> d_temp_mem)
@@ -1059,7 +1083,7 @@ class ARIMA(Base):
 
         del arima_mem_ptr
 
-        return grad.to_output("numpy")
+        return grad.get(order="A")
 
     @property
     @run_in_internal_context
@@ -1082,19 +1106,19 @@ class ARIMA(Base):
         cdef ARIMAParams[double] cpp_params = ARIMAParamsWrapper(self).params
 
         cdef uintptr_t d_y_kf_ptr = \
-            self._d_y_diff.ptr if self.simple_differencing else self.d_y.ptr
+            self._d_y_diff.data.ptr if self.simple_differencing else self.d_y.data.ptr
 
         cdef uintptr_t d_exog_kf_ptr = <uintptr_t> NULL
         if order.n_exog:
-            d_exog_kf_ptr = (self._d_exog_diff.ptr if self.simple_differencing
-                             else self.d_exog.ptr)
+            d_exog_kf_ptr = (self._d_exog_diff.data.ptr if self.simple_differencing
+                             else self.d_exog.data.ptr)
 
         n_obs_kf = (self.n_obs_diff if self.simple_differencing
                     else self.n_obs)
 
         cdef LoglikeMethod ll_method = MLE
 
-        cdef uintptr_t d_temp_mem = self._temp_mem.ptr
+        cdef uintptr_t d_temp_mem = self._temp_mem.data.ptr
         arima_mem_ptr = new ARIMAMemory[double](
             order, <int> self.batch_size, <int> self.n_obs,
             <char*> d_temp_mem)
@@ -1129,13 +1153,15 @@ class ARIMA(Base):
         cdef ARIMAOrder order = self.order
         cdef ARIMAParams[double] cpp_params = ARIMAParamsWrapper(self).params
 
-        d_x_array, *_ = \
-            input_to_cuml_array(x,
-                                convert_to_dtype=(np.float64 if convert_dtype
-                                                  else None),
-                                check_dtype=np.float64,
-                                order='C')
-        cdef uintptr_t d_x_ptr = d_x_array.ptr
+        d_x_array = check_array(
+            x,
+            dtype="float64",
+            convert_dtype=convert_dtype,
+            order="C",
+            ensure_2d=False,
+            ensure_all_finite=False,
+        )
+        cdef uintptr_t d_x_ptr = d_x_array.data.ptr
 
         cpp_unpack(handle_[0], cpp_params, order, <int> self.batch_size,
                    <double*>d_x_ptr)
@@ -1157,14 +1183,15 @@ class ARIMA(Base):
         cdef ARIMAOrder order = self.order
         cdef ARIMAParams[double] cpp_params = ARIMAParamsWrapper(self).params
 
-        d_x_array = CumlArray.empty(self.complexity * self.batch_size,
-                                    np.float64)
-        cdef uintptr_t d_x_ptr = d_x_array.ptr
+        d_x_array = cp.empty(
+            self.complexity * self.batch_size, dtype="float64", order="F"
+        )
+        cdef uintptr_t d_x_ptr = d_x_array.data.ptr
 
         cpp_pack(handle_[0], cpp_params, order, <int> self.batch_size,
                  <double*>d_x_ptr)
 
-        return d_x_array.to_output("numpy")
+        return d_x_array.get(order="A")
 
     @nvtx.annotate(message="tsa.arima.ARIMA._batched_transform",
                    domain="cuml_python")
@@ -1190,7 +1217,7 @@ class ARIMA(Base):
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
         Tx = np.zeros(self.batch_size * N)
 
-        cdef uintptr_t d_temp_mem = self._temp_mem.ptr
+        cdef uintptr_t d_temp_mem = self._temp_mem.data.ptr
         arima_mem_ptr = new ARIMAMemory[double](
             order, <int> self.batch_size, <int> self.n_obs,
             <char*> d_temp_mem)

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -3,16 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import itertools
-import typing
 
 import cupy as cp
 import numpy as np
 
-from cuml.common import input_to_cuml_array, using_output_type
 from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals import logger, reflect, run_in_internal_context
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
+from cuml.internals.validation import check_array
 from cuml.tsa.arima import ARIMA
 from cuml.tsa.seasonality import seas_test
 from cuml.tsa.stationarity import kpss_test
@@ -168,10 +166,16 @@ class AutoARIMA(Base):
         self._set_output_type(endog)
 
         # Get device array. Float64 only for now.
-        self.d_y, self.n_obs, self.batch_size, self.dtype \
-            = input_to_cuml_array(
-                endog, check_dtype=np.float64,
-                convert_to_dtype=(np.float64 if convert_dtype else None))
+        self.d_y = d_y = check_array(
+            endog,
+            dtype="float64",
+            convert_dtype=convert_dtype,
+            order="F",
+            ensure_2d=False,
+            ensure_all_finite=False,
+        )
+        self.n_obs = d_y.shape[0]
+        self.batch_size = d_y.shape[1] if d_y.ndim == 2 else 1
 
         self.simple_differencing = simple_differencing
 
@@ -179,7 +183,7 @@ class AutoARIMA(Base):
 
     @run_in_internal_context
     def _initial_calc(self):
-        cdef uintptr_t d_y_ptr = self.d_y.ptr
+        cdef uintptr_t d_y_ptr = self.d_y.data.ptr
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
@@ -272,8 +276,7 @@ class AutoARIMA(Base):
             method = "css" if self.n_obs >= 100 and s >= 4 else "ml"
 
         # Original index
-        d_index, *_ = input_to_cuml_array(np.r_[:self.batch_size],
-                                          convert_to_dtype=np.int32)
+        d_index = cp.arange(self.batch_size, dtype="int32")
 
         #
         # Choose the hyper-parameter D
@@ -292,19 +295,13 @@ class AutoARIMA(Base):
                 raise ValueError("Unknown seasonal diff test: {}"
                                  .format(seasonal_test))
 
-            with using_output_type("cupy"):
-                mask_cp = tests_map[seasonal_test](self.d_y, s)
-
-            mask = input_to_cuml_array(mask_cp)[0]
-            del mask_cp
+            mask = tests_map[seasonal_test](self.d_y, s)
             data_D = {}
-            out0, index0, out1, index1 = _divide_by_mask(self.d_y, mask,
-                                                         d_index)
+            out0, index0, out1, index1 = _divide_by_mask(self.d_y, mask, d_index)
             if out0 is not None:
                 data_D[0] = (out0, index0)
             if out1 is not None:
                 data_D[1] = (out1, index1)
-            del mask, out0, index0, out1, index1
 
         #
         # Choose the hyper-parameter d
@@ -323,12 +320,10 @@ class AutoARIMA(Base):
                                      .format(test))
                 data_temp, id_temp = data_D[D_]
                 for d_ in d_options[:-1]:
-                    mask_cp = tests_map[test](data_temp.to_output("cupy"),
-                                              d_, D_, s)
-                    mask = input_to_cuml_array(mask_cp)[0]
-                    del mask_cp
-                    out0, index0, out1, index1 \
-                        = _divide_by_mask(data_temp, mask, id_temp)
+                    mask = tests_map[test](data_temp, d_, D_, s)
+                    out0, index0, out1, index1 = _divide_by_mask(
+                        data_temp, mask, id_temp
+                    )
                     if out1 is not None:
                         data_dD[(d_, D_)] = (out1, index1)
                     if out0 is not None:
@@ -338,8 +333,6 @@ class AutoARIMA(Base):
                 else:  # (when the for loop reaches its end naturally)
                     # The remaining series are assigned the max possible d
                     data_dD[(d_options[-1], D_)] = (data_temp, id_temp)
-                del data_temp, id_temp, mask, out0, index0, out1, index1
-        del data_D
 
         #
         # Choose the hyper-parameters p, q, P, Q, k
@@ -367,7 +360,7 @@ class AutoARIMA(Base):
                 if p_ + q_ + P_ + Q_ + k_ == 0:
                     continue
                 s_ = s if (P_ + D_ + Q_) else 0
-                model = ARIMA(endog=data_temp.to_output("cupy"),
+                model = ARIMA(endog=data_temp,
                               order=(p_, d_, q_),
                               seasonal_order=(P_, D_, Q_, s_),
                               fit_intercept=k_,
@@ -378,13 +371,12 @@ class AutoARIMA(Base):
                           truncate=truncate)
                 all_ic.append(model._ic(ic))
                 all_orders.append((p_, q_, P_, Q_, s_, k_))
-                del model
 
             # Organize the results into a matrix
             n_models = len(all_orders)
-            ic_matrix, *_ = input_to_cuml_array(
-                cp.concatenate([ic_arr.to_output('cupy').reshape(batch_size, 1)
-                                for ic_arr in all_ic], 1))
+            ic_matrix = cp.concatenate(
+                [ic_arr.reshape(batch_size, 1) for ic_arr in all_ic], axis=1
+            )
 
             # Divide the batch, choosing the best model for each series
             sub_batches, sub_id = _divide_by_min(data_temp, ic_matrix, id_temp)
@@ -394,7 +386,7 @@ class AutoARIMA(Base):
                 p_, q_, P_, Q_, s_, k_ = all_orders[i]
                 self.models.append(
                     ARIMA(
-                        sub_batches[i].to_output("cupy"),
+                        sub_batches[i],
                         order=(p_, d_, q_),
                         seasonal_order=(P_, D_, Q_, s_),
                         fit_intercept=k_,
@@ -404,13 +396,12 @@ class AutoARIMA(Base):
                 )
                 id_tracker.append(sub_id[i])
 
-            del all_ic, all_orders, ic_matrix, sub_batches, sub_id
-
         # Build a map to match each series to its model and position in the
         # sub-batch
         logger.info("Finalizing...")
-        self.id_to_model, self.id_to_pos = _build_division_map(id_tracker,
-                                                               self.batch_size)
+        self.id_to_model, self.id_to_pos = _build_division_map(
+            id_tracker, self.batch_size
+        )
 
     @run_in_internal_context
     def fit(self,
@@ -445,8 +436,7 @@ class AutoARIMA(Base):
         start=0,
         end=None,
         level=None
-    ) -> typing.Union[CumlArray, typing.Tuple[CumlArray, CumlArray,
-                                              CumlArray]]:
+    ):
         """Compute in-sample and/or out-of-sample prediction for each series
 
         Parameters
@@ -476,13 +466,13 @@ class AutoARIMA(Base):
         upper_list = []
         for model in self.models:
             if level is None:
-                pred, *_ = input_to_cuml_array(model.predict(start, end))
+                pred, *_ = model.predict(start, end)
                 pred_list.append(pred)
             else:
                 pred, low, upp = model.predict(start, end, level=level)
-                pred_list.append(input_to_cuml_array(pred)[0])
-                lower_list.append(input_to_cuml_array(low)[0])
-                upper_list.append(input_to_cuml_array(upp)[0])
+                pred_list.append(pred)
+                lower_list.append(low)
+                upper_list.append(upp)
 
         # Put all the predictions together
         y_p = _merge_series(pred_list, self.id_to_model, self.id_to_pos,
@@ -500,12 +490,7 @@ class AutoARIMA(Base):
             return y_p, lower, upper
 
     @reflect(array=None)
-    def forecast(self,
-                 nsteps: int,
-                 level=None) -> typing.Union[CumlArray,
-                                             typing.Tuple[CumlArray,
-                                                          CumlArray,
-                                                          CumlArray]]:
+    def forecast(self, nsteps: int, level=None):
         """Forecast `nsteps` into the future.
 
         Parameters
@@ -563,23 +548,23 @@ def _divide_by_mask(original, mask, batch_id):
 
     Parameters
     ----------
-    original : CumlArray (float32 or float64)
+    original : cp.ndarray (float32 or float64)
         Original batch
-    mask : CumlArray (bool)
+    mask : cp.ndarray (bool)
         Boolean mask: False for the 1st sub-batch and True for the second
-    batch_id : CumlArray (int)
+    batch_id : cp.ndarray (int)
         Integer array to track the id of each member in the initial batch
 
     Returns
     -------
-    out0 : CumlArray (float32 or float64)
+    out0 : cp.ndarray (float32 or float64)
         Sub-batch 0, or None if empty
-    batch0_id : CumlArray (int)
+    batch0_id : cp.ndarray (int)
         Indices of the members of the sub-batch 0 in the initial batch,
         or None if empty
-    out1 : CumlArray (float32 or float64)
+    out1 : cp.ndarray (float32 or float64)
         Sub-batch 1, or None if empty
-    batch1_id : CumlArray (int)
+    batch1_id : cp.ndarray (int)
         Indices of the members of the sub-batch 1 in the initial batch,
         or None if empty
     """
@@ -592,9 +577,9 @@ def _divide_by_mask(original, mask, batch_id):
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
-    index = CumlArray.empty(batch_size, np.int32)
-    cdef uintptr_t d_index = index.ptr
-    cdef uintptr_t d_mask = mask.ptr
+    index = cp.empty(batch_size, np.int32)
+    cdef uintptr_t d_index = index.data.ptr
+    cdef uintptr_t d_mask = mask.data.ptr
 
     # Compute the index of each series in their new batch
     nb_true = divide_by_mask_build_index(handle_[0],
@@ -602,13 +587,13 @@ def _divide_by_mask(original, mask, batch_id):
                                          <int*> d_index,
                                          <int> batch_size)
 
-    out0 = CumlArray.empty((n_obs, batch_size - nb_true), dtype)
-    out1 = CumlArray.empty((n_obs, nb_true), dtype)
+    out0 = cp.empty((n_obs, batch_size - nb_true), dtype, order="F")
+    out1 = cp.empty((n_obs, nb_true), dtype, order="F")
 
     # Type declarations (can't be in if-else statements)
     cdef uintptr_t d_out0
     cdef uintptr_t d_out1
-    cdef uintptr_t d_original = original.ptr
+    cdef uintptr_t d_original = original.data.ptr
     cdef uintptr_t d_batch0_id
     cdef uintptr_t d_batch1_id
     cdef uintptr_t d_batch_id
@@ -629,10 +614,10 @@ def _divide_by_mask(original, mask, batch_id):
 
     # If both sub-batches have elements
     else:
-        out0 = CumlArray.empty((n_obs, batch_size - nb_true), dtype)
-        out1 = CumlArray.empty((n_obs, nb_true), dtype)
-        d_out0 = out0.ptr
-        d_out1 = out1.ptr
+        out0 = cp.empty((n_obs, batch_size - nb_true), dtype, order="F")
+        out1 = cp.empty((n_obs, nb_true), dtype, order="F")
+        d_out0 = out0.data.ptr
+        d_out1 = out1.data.ptr
 
         # Build the two sub-batches
         if dtype == np.float32:
@@ -655,11 +640,11 @@ def _divide_by_mask(original, mask, batch_id):
                                    <int> n_obs)
 
         # Also keep track of the original id of the series in the batch
-        batch0_id = CumlArray.empty(batch_size - nb_true, np.int32)
-        batch1_id = CumlArray.empty(nb_true, np.int32)
-        d_batch0_id = batch0_id.ptr
-        d_batch1_id = batch1_id.ptr
-        d_batch_id = batch_id.ptr
+        batch0_id = cp.empty(batch_size - nb_true, np.int32)
+        batch1_id = cp.empty(nb_true, np.int32)
+        d_batch0_id = batch0_id.data.ptr
+        d_batch1_id = batch1_id.data.ptr
+        d_batch_id = batch_id.data.ptr
 
         divide_by_mask_execute(handle_[0],
                                <int*> d_batch_id,
@@ -679,18 +664,18 @@ def _divide_by_min(original, metrics, batch_id):
 
     Parameters:
     ----------
-    original : CumlArray (float32 or float64)
+    original : cp.ndarray (float32 or float64)
         Original batch
-    metrics : CumlArray (float32 or float64)
+    metrics : cp.ndarray (float32 or float64)
         Matrix of shape (batch_size, n_sub) containing the metrics to minimize
-    batch_id : CumlArray (int)
+    batch_id : cp.ndarray (int)
         Integer array to track the id of each member in the initial batch
 
     Returns
     -------
-    sub_batches : List[CumlArray] (float32 or float64)
+    sub_batches : List[cp.ndarray] (float32 or float64)
         List of arrays containing each sub-batch, or None if empty
-    sub_id : List[CumlArray] (int)
+    sub_id : List[cp.ndarray] (int)
         List of arrays containing the indices of each member in the initial
         batch, or None if empty
     """
@@ -704,14 +689,14 @@ def _divide_by_min(original, metrics, batch_id):
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
-    batch_buffer = CumlArray.empty(batch_size, np.int32)
-    index_buffer = CumlArray.empty(batch_size, np.int32)
+    batch_buffer = cp.empty(batch_size, np.int32)
+    index_buffer = cp.empty(batch_size, np.int32)
     cdef vector[int] size_buffer
     size_buffer.resize(n_sub)
 
-    cdef uintptr_t d_metrics = metrics.ptr
-    cdef uintptr_t d_batch = batch_buffer.ptr
-    cdef uintptr_t d_index = index_buffer.ptr
+    cdef uintptr_t d_metrics = metrics.data.ptr
+    cdef uintptr_t d_batch = batch_buffer.data.ptr
+    cdef uintptr_t d_index = index_buffer.data.ptr
 
     # Compute which sub-batch each series belongs to, its position in
     # the sub-batch, and the size of each sub-batch
@@ -734,18 +719,20 @@ def _divide_by_min(original, metrics, batch_id):
 
     # Build a list of cuML arrays for the sub-batches and a vector of pointers
     # to be passed to the next C++ step
-    sub_batches = [CumlArray.empty((n_obs, s), dtype) if s else None
-                   for s in size_buffer]
+    sub_batches = [
+        cp.empty((n_obs, s), dtype, order="F") if s else None
+        for s in size_buffer
+    ]
     cdef vector[uintptr_t] sub_ptr
     sub_ptr.resize(n_sub)
     for i in range(n_sub):
         if size_buffer[i]:
-            sub_ptr[i] = <uintptr_t> sub_batches[i].ptr
+            sub_ptr[i] = <uintptr_t> sub_batches[i].data.ptr
         else:
             sub_ptr[i] = <uintptr_t> NULL
 
     # Execute the batch sub-division
-    cdef uintptr_t d_original = original.ptr
+    cdef uintptr_t d_original = original.data.ptr
     if dtype == np.float32:
         divide_by_min_execute(handle_[0],
                               <float*> d_original,
@@ -767,16 +754,18 @@ def _divide_by_min(original, metrics, batch_id):
 
     # Keep track of the id of the series if requested
     cdef vector[uintptr_t] id_ptr
-    sub_id = [CumlArray.empty(s, np.int32) if s else None
-              for s in size_buffer]
+    sub_id = [
+        cp.empty(s, np.int32, order="F") if s else None
+        for s in size_buffer
+    ]
     id_ptr.resize(n_sub)
     for i in range(n_sub):
         if size_buffer[i]:
-            id_ptr[i] = <uintptr_t> sub_id[i].ptr
+            id_ptr[i] = <uintptr_t> sub_id[i].data.ptr
         else:
             id_ptr[i] = <uintptr_t> NULL
 
-    cdef uintptr_t d_batch_id = batch_id.ptr
+    cdef uintptr_t d_batch_id = batch_id.data.ptr
     divide_by_min_execute(handle_[0],
                           <int*> d_batch_id,
                           <int*> d_batch,
@@ -795,16 +784,16 @@ def _build_division_map(id_tracker, batch_size):
 
     Parameters
     ----------
-    id_tracker : List[CumlArray] (int)
+    id_tracker : List[cp.ndarray] (int)
         List of the index arrays of each sub-batch
     batch_size : int
         Size of the initial batch
 
     Returns
     -------
-    id_to_model : CumlArray (int)
+    id_to_model : cp.ndarray (int)
         Associates each batch member with a model
-    id_to_pos : CumlArray (int)
+    id_to_pos : cp.ndarray (int)
         Position of each member in the respective sub-batch
     """
     handle = get_handle()
@@ -812,21 +801,21 @@ def _build_division_map(id_tracker, batch_size):
 
     n_sub = len(id_tracker)
 
-    id_to_pos = CumlArray.empty(batch_size, np.int32)
-    id_to_model = CumlArray.empty(batch_size, np.int32)
+    id_to_pos = cp.empty(batch_size, np.int32)
+    id_to_model = cp.empty(batch_size, np.int32)
 
     cdef vector[uintptr_t] id_ptr
     cdef vector[int] size_vec
     id_ptr.resize(n_sub)
     size_vec.resize(n_sub)
     for i in range(n_sub):
-        id_ptr[i] = id_tracker[i].ptr
+        id_ptr[i] = id_tracker[i].data.ptr
         size_vec[i] = len(id_tracker[i])
 
     cdef uintptr_t hd_id = <uintptr_t> id_ptr.data()
     cdef uintptr_t h_size = <uintptr_t> size_vec.data()
-    cdef uintptr_t d_id_to_pos = id_to_pos.ptr
-    cdef uintptr_t d_id_to_model = id_to_model.ptr
+    cdef uintptr_t d_id_to_pos = id_to_pos.data.ptr
+    cdef uintptr_t d_id_to_model = id_to_model.data.ptr
 
     cpp_build_division_map(handle_[0],
                            <const int**> hd_id,
@@ -846,18 +835,18 @@ def _merge_series(data_in, id_to_sub, id_to_pos, batch_size):
 
     Parameters
     ----------
-    data_in : List[CumlArray] (float32 or float64)
+    data_in : List[cp.ndarray] (float32 or float64)
         List of sub-batches to merge
-    id_to_model : CumlArray (int)
+    id_to_model : cp.ndarray (int)
         Associates each member of the batch with a sub-batch
-    id_to_pos : CumlArray (int)
+    id_to_pos : cp.ndarray (int)
         Position of each member of the batch in its respective sub-batch
     batch_size : int
         Size of the initial batch
 
     Returns
     -------
-    data_out : CumlArray (float32 or float64)
+    data_out : cp.ndarray (float32 or float64)
         Merged batch
     """
     dtype = data_in[0].dtype
@@ -870,14 +859,14 @@ def _merge_series(data_in, id_to_sub, id_to_pos, batch_size):
     cdef vector[uintptr_t] in_ptr
     in_ptr.resize(n_sub)
     for i in range(n_sub):
-        in_ptr[i] = data_in[i].ptr
+        in_ptr[i] = data_in[i].data.ptr
 
-    data_out = CumlArray.empty((n_obs, batch_size), dtype)
+    data_out = cp.empty((n_obs, batch_size), dtype, order="F")
 
     cdef uintptr_t hd_in = <uintptr_t> in_ptr.data()
-    cdef uintptr_t d_id_to_pos = id_to_pos.ptr
-    cdef uintptr_t d_id_to_sub = id_to_sub.ptr
-    cdef uintptr_t d_out = data_out.ptr
+    cdef uintptr_t d_id_to_pos = id_to_pos.data.ptr
+    cdef uintptr_t d_id_to_sub = id_to_sub.data.ptr
+    cdef uintptr_t d_out = data_out.data.ptr
 
     if dtype == np.float32:
         cpp_merge_series(handle_[0],

--- a/python/cuml/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/cuml/tsa/holtwinters.pyx
@@ -5,12 +5,10 @@ import cudf
 import cupy as cp
 import numpy as np
 
-from cuml.common import using_output_type
 from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.input_utils import input_to_cupy_array
 from cuml.internals.outputs import run_in_internal_context
+from cuml.internals.validation import check_array
 
 from libc.stdint cimport uintptr_t
 from pylibraft.common.handle cimport handle_t
@@ -224,14 +222,19 @@ class ExponentialSmoothing(Base):
         self.fit_executed_flag = False
         self.h = 0
 
-    def _check_dims(self, ts_input, is_cudf=False) -> CumlArray:
+    def _check_dims(self, ts_input, is_cudf=False):
         err_mess = ("ExponentialSmoothing initialized with "
                     + str(self.ts_num) +
                     " time series, but data has dimension ")
 
         is_cudf = isinstance(ts_input, cudf.DataFrame)
 
-        mod_ts_input = input_to_cupy_array(ts_input, order="C").array
+        mod_ts_input = check_array(
+            ts_input,
+            order="C",
+            ensure_2d=False,
+            ensure_all_finite=False,
+        )
 
         if len(mod_ts_input.shape) == 1:
             self.n = mod_ts_input.shape[0]
@@ -251,7 +254,7 @@ class ExponentialSmoothing(Base):
                 raise ValueError(err_mess + str(d2))
         else:
             raise ValueError("Data input must have 1 or 2 dimensions.")
-        return CumlArray(data=mod_ts_input)
+        return mod_ts_input
 
     @run_in_internal_context
     def fit(self) -> "ExponentialSmoothing":
@@ -260,9 +263,9 @@ class ExponentialSmoothing(Base):
         Calculates the level, trend, season, and SSE components.
         """
 
-        X_m = self._check_dims(self.endog)
+        X = self._check_dims(self.endog)
 
-        self.dtype = X_m.dtype
+        self.dtype = X.dtype
 
         if self.n < self.start_periods*self.seasonal_periods:
             raise ValueError("Length of time series (" + str(self.n) +
@@ -278,7 +281,7 @@ class ExponentialSmoothing(Base):
         cdef int leveltrend_coef_offset, season_coef_offset
         cdef int error_len
 
-        input_ptr = X_m.ptr
+        input_ptr = X.data.ptr
 
         buffer_size(<int> self.n, <int> self.ts_num,
                     <int> self.seasonal_periods,
@@ -293,14 +296,15 @@ class ExponentialSmoothing(Base):
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
         cdef uintptr_t level_ptr, trend_ptr, season_ptr, SSE_ptr
 
-        self.level = CumlArray.zeros(components_len, dtype=self.dtype)
-        self.trend = CumlArray.zeros(components_len, dtype=self.dtype)
-        self.season = CumlArray.zeros(components_len, dtype=self.dtype)
-        self.SSE = CumlArray.zeros(self.ts_num, dtype=self.dtype)
-        level_ptr = self.level.ptr
-        trend_ptr = self.trend.ptr
-        season_ptr = self.season.ptr
-        SSE_ptr = self.SSE.ptr
+        level = cp.zeros(components_len, dtype=self.dtype)
+        trend = cp.zeros(components_len, dtype=self.dtype)
+        season = cp.zeros(components_len, dtype=self.dtype)
+        SSE = cp.zeros(self.ts_num, dtype=self.dtype)
+
+        level_ptr = level.data.ptr
+        trend_ptr = trend.data.ptr
+        season_ptr = season.data.ptr
+        SSE_ptr = SSE.data.ptr
 
         cdef float eps_f = np.float32(self.eps)
         cdef double eps_d = np.float64(self.eps)
@@ -327,16 +331,15 @@ class ExponentialSmoothing(Base):
             raise TypeError("ExponentialSmoothing supports only float32"
                             " and float64 input, but input type "
                             + str(self.dtype) + " passed.")
-        num_rows = int(components_len/self.ts_num)
-
-        with using_output_type("cupy"):
-            self.level = self.level.reshape((self.ts_num, num_rows), order='F')
-            self.trend = self.trend.reshape((self.ts_num, num_rows), order='F')
-            self.season = self.season.reshape((self.ts_num, num_rows),
-                                              order='F')
-
         handle.sync()
+
+        num_rows = int(components_len/self.ts_num)
+        self.level = level.reshape((self.ts_num, num_rows), order='F')
+        self.trend = trend.reshape((self.ts_num, num_rows), order='F')
+        self.season = season.reshape((self.ts_num, num_rows), order='F')
+        self.SSE = SSE
         self.fit_executed_flag = True
+
         return self
 
     @run_in_internal_context
@@ -375,13 +378,13 @@ class ExponentialSmoothing(Base):
 
             if h > self.h:
                 self.h = h
-                self.forecasted_points = CumlArray.zeros(self.ts_num*h,
-                                                         dtype=self.dtype)
-                with using_output_type("cuml"):
-                    forecast_ptr = self.forecasted_points.ptr
-                    level_ptr = self.level.ptr
-                    trend_ptr = self.trend.ptr
-                    season_ptr = self.season.ptr
+                self.forecasted_points = cp.zeros(
+                    (self.ts_num, h), dtype=self.dtype, order="F"
+                )
+                forecast_ptr = self.forecasted_points.data.ptr
+                level_ptr = self.level.data.ptr
+                trend_ptr = self.trend.data.ptr
+                season_ptr = self.season.data.ptr
 
                 if self.dtype == np.float32:
                     forecast(handle_[0], <int> self.n,
@@ -403,26 +406,19 @@ class ExponentialSmoothing(Base):
                              <double*> season_ptr,
                              <double*> forecast_ptr)
 
-                with using_output_type("cupy"):
-                    self.forecasted_points =\
-                        self.forecasted_points.reshape((self.ts_num, h),
-                                                       order='F')
                 handle.sync()
 
             if index is None:
                 if self.ts_num == 1:
-                    return cudf.Series(
-                        self.forecasted_points.ravel(order='F')[:h])
+                    return cudf.Series(self.forecasted_points.ravel(order='F')[:h])
                 else:
-                    return cudf.DataFrame(
-                        self.forecasted_points[:, :h].T)
+                    return cudf.DataFrame(self.forecasted_points[:, :h].T)
             else:
                 if index < 0 or index >= self.ts_num:
                     raise IndexError("Index input: " + str(index) +
                                      " outside of range [0, " +
                                      str(self.ts_num) + "]")
-                return cudf.Series(cp.asarray(
-                    self.forecasted_points[index, :h]))
+                return cudf.Series(self.forecasted_points[index, :h])
         else:
             raise ValueError("Fit() the model before forecast()")
 

--- a/python/cuml/cuml/tsa/seasonality.py
+++ b/python/cuml/cuml/tsa/seasonality.py
@@ -1,28 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
+import cupy as cp
 import numpy as np
 
 from cuml.internals import reflect
 from cuml.internals.array import CumlArray
-from cuml.internals.input_utils import input_to_cuml_array, input_to_host_array
-
-
-def python_seas_test(y, batch_size, n_obs, s, threshold=0.64):
-    """Python prototype to be ported later in CUDA"""
-    # TODO: our own implementation of STL
-    from statsmodels.tsa.seasonal import STL
-
-    results = []
-    for i in range(batch_size):
-        stlfit = STL(y[:, i], s).fit()
-        seasonal = stlfit.seasonal
-        residual = stlfit.resid
-        heuristics = max(
-            0, min(1, 1 - np.var(residual) / np.var(residual + seasonal))
-        )
-        results.append(heuristics > threshold)
-
-    return results
+from cuml.internals.validation import check_array
 
 
 @reflect
@@ -45,6 +28,9 @@ def seas_test(y, s, convert_dtype=True) -> CumlArray:
     stationarity : List[bool]
         For each series in the batch, whether it needs seasonal differencing
     """
+    # TODO: our own implementation of STL
+    from statsmodels.tsa.seasonal import STL
+
     if s <= 1:
         raise ValueError(
             "ERROR: Invalid period for the seasonal differencing test: {}".format(
@@ -52,17 +38,25 @@ def seas_test(y, s, convert_dtype=True) -> CumlArray:
             )
         )
 
-    # At the moment we use a host array
-    h_y, n_obs, batch_size, _ = input_to_host_array(
+    y = check_array(
         y,
-        convert_to_dtype=(np.float32 if convert_dtype else None),
-        check_dtype=[np.float32, np.float64],
+        dtype=("float32", "float64"),
+        convert_dtype=convert_dtype,
+        mem_type="host",
+        ensure_all_finite=False,
+        input_name="y",
     )
+    n_obs, batch_size = y.shape
 
-    python_res = python_seas_test(h_y, batch_size, n_obs, s)
-    d_res, *_ = input_to_cuml_array(
-        np.array(python_res),
-        convert_to_dtype=(bool if convert_dtype else None),
-        check_dtype=bool,
-    )
-    return d_res
+    threshold = 0.64
+    results = []
+    for i in range(batch_size):
+        stlfit = STL(y[:, i], s).fit()
+        seasonal = stlfit.seasonal
+        residual = stlfit.resid
+        heuristics = max(
+            0, min(1, 1 - np.var(residual) / np.var(residual + seasonal))
+        )
+        results.append(heuristics > threshold)
+
+    return cp.asarray(results)

--- a/python/cuml/cuml/tsa/seasonality.py
+++ b/python/cuml/cuml/tsa/seasonality.py
@@ -4,12 +4,11 @@ import cupy as cp
 import numpy as np
 
 from cuml.internals import reflect
-from cuml.internals.array import CumlArray
 from cuml.internals.validation import check_array
 
 
 @reflect
-def seas_test(y, s, convert_dtype=True) -> CumlArray:
+def seas_test(y, s, convert_dtype=True):
     """
     Perform Wang, Smith & Hyndman's test to decide whether seasonal
     differencing is needed

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
+import cupy as cp
 import numpy as np
 
 from cuml.internals import get_handle, reflect
 from cuml.internals.array import CumlArray
-from cuml.internals.input_utils import input_to_cuml_array
+from cuml.internals.validation import check_array
 
 from libc.stdint cimport uintptr_t
 from libcpp cimport bool as boolcpp
@@ -32,7 +33,14 @@ cdef extern from "cuml/tsa/stationarity.h" namespace "ML" nogil:
 
 
 @reflect
-def kpss_test(y, d=0, D=0, s=0, pval_threshold=0.05, convert_dtype=True) -> CumlArray:
+def kpss_test(
+    y,
+    int d=0,
+    int D=0,
+    int s=0,
+    double pval_threshold=0.05,
+    convert_dtype=True,
+) -> CumlArray:
     """
     Perform the KPSS stationarity test on the data differenced according
     to the given order
@@ -57,35 +65,49 @@ def kpss_test(y, d=0, D=0, s=0, pval_threshold=0.05, convert_dtype=True) -> Cuml
     stationarity : List[bool]
         A list of the stationarity test result for each series in the batch
     """
-    d_y, n_obs, batch_size, dtype = \
-        input_to_cuml_array(y,
-                            convert_to_dtype=(np.float32 if convert_dtype
-                                              else None),
-                            check_dtype=[np.float32, np.float64])
-    cdef uintptr_t d_y_ptr = d_y.ptr
+    d_y = check_array(
+        y,
+        dtype=("float32", "float64"),
+        convert_dtype=convert_dtype,
+        order="F",
+        input_name="y",
+        ensure_all_finite=False,
+    )
+    cdef int n_obs = d_y.shape[0]
+    cdef int batch_size = d_y.shape[1]
+
+    cdef uintptr_t d_y_ptr = d_y.data.ptr
 
     handle = get_handle()
     cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
 
-    results = CumlArray.empty(batch_size, dtype=bool)
-    cdef uintptr_t d_results = results.ptr
+    results = cp.empty(batch_size, dtype=bool)
+    cdef uintptr_t d_results = results.data.ptr
 
     # Call C++ function
-    if dtype == np.float32:
-        cpp_kpss(handle_[0],
-                 <float*> d_y_ptr,
-                 <boolcpp*> d_results,
-                 <int> batch_size,
-                 <int> n_obs,
-                 <int> d, <int> D, <int> s,
-                 <float> pval_threshold)
-    elif dtype == np.float64:
-        cpp_kpss(handle_[0],
-                 <double*> d_y_ptr,
-                 <boolcpp*> d_results,
-                 <int> batch_size,
-                 <int> n_obs,
-                 <int> d, <int> D, <int> s,
-                 <double> pval_threshold)
+    if d_y.dtype == np.float32:
+        cpp_kpss(
+            handle_[0],
+            <float*> d_y_ptr,
+            <boolcpp*> d_results,
+            batch_size,
+            n_obs,
+            d,
+            D,
+            s,
+            <float> pval_threshold
+        )
+    elif d_y.dtype == np.float64:
+        cpp_kpss(
+            handle_[0],
+            <double*> d_y_ptr,
+            <boolcpp*> d_results,
+            batch_size,
+            n_obs,
+            d,
+            D,
+            s,
+            pval_threshold
+        )
 
-    return results
+    return CumlArray(data=results)

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -4,7 +4,6 @@ import cupy as cp
 import numpy as np
 
 from cuml.internals import get_handle, reflect
-from cuml.internals.array import CumlArray
 from cuml.internals.validation import check_array
 
 from libc.stdint cimport uintptr_t
@@ -40,7 +39,7 @@ def kpss_test(
     int s=0,
     double pval_threshold=0.05,
     convert_dtype=True,
-) -> CumlArray:
+):
     """
     Perform the KPSS stationarity test on the data differenced according
     to the given order
@@ -110,4 +109,4 @@ def kpss_test(
             pval_threshold
         )
 
-    return CumlArray(data=results)
+    return results

--- a/python/cuml/tests/test_arima.py
+++ b/python/cuml/tests/test_arima.py
@@ -30,7 +30,6 @@ from scipy.optimize import approx_fprime
 from sklearn.model_selection import train_test_split
 
 import cuml.tsa.arima as arima
-from cuml.internals.input_utils import input_to_host_array
 from cuml.testing.utils import stress_param
 
 sm = pytest.importorskip("statsmodels.api")
@@ -347,9 +346,9 @@ def get_ref_fit(data, order, seasonal_order, intercept, dtype):
 
 
 def mase(y_train, y_test, y_fc, s):
-    y_train_np = input_to_host_array(y_train).array
-    y_test_np = input_to_host_array(y_test).array
-    y_fc_np = input_to_host_array(y_fc).array
+    y_train_np = y_train.to_numpy()
+    y_test_np = y_test.to_numpy()
+    y_fc_np = y_fc
 
     diff = np.abs(y_train_np[s:] - y_train_np[:-s])
     scale = np.nanmean(diff, axis=0)

--- a/python/cuml/tests/test_auto_arima.py
+++ b/python/cuml/tests/test_auto_arima.py
@@ -1,12 +1,12 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import cupy as cp
 import numpy as np
 import pytest
 
-from cuml.internals.input_utils import input_to_cuml_array
 from cuml.tsa import auto_arima
 
 ###############################################################################
@@ -47,9 +47,9 @@ def test_divide_by_mask(batch_size, n_obs, prop_true, dtype):
         [False] * (batch_size - nb_true) + [True] * nb_true
     )
     b_id_np = np.array(range(batch_size), dtype=np.int32)
-    data, *_ = input_to_cuml_array(data_np)
-    mask, *_ = input_to_cuml_array(mask_np)
-    b_id, *_ = input_to_cuml_array(b_id_np)
+    data = cp.asarray(data_np, order="F")
+    mask = cp.asarray(mask_np, order="F")
+    b_id = cp.asarray(b_id_np, order="F")
 
     # Call the tested function
     sub_data, sub_id = [None, None], [None, None]
@@ -74,12 +74,8 @@ def test_divide_by_mask(batch_size, n_obs, prop_true, dtype):
             assert sub_id[i] is None
         # When the sub-batch is not empty, compare to the reference
         else:
-            np.testing.assert_allclose(
-                sub_data[i].to_output("numpy"), sub_data_ref[i]
-            )
-            np.testing.assert_array_equal(
-                sub_id[i].to_output("numpy"), sub_id_ref[i]
-            )
+            np.testing.assert_allclose(sub_data[i].get(), sub_data_ref[i])
+            np.testing.assert_array_equal(sub_id[i].get(), sub_id_ref[i])
 
 
 @pytest.mark.parametrize("batch_size", [10, 100])
@@ -102,9 +98,9 @@ def test_divide_by_min(batch_size, n_obs, n_sub, dtype):
         .transpose()
     )
     b_id_np = np.array(range(batch_size), dtype=np.int32)
-    data, *_ = input_to_cuml_array(data_np)
-    crit, *_ = input_to_cuml_array(crit_np)
-    b_id, *_ = input_to_cuml_array(b_id_np)
+    data = cp.asarray(data_np, order="F")
+    crit = cp.asarray(crit_np, order="F")
+    b_id = cp.asarray(b_id_np)
 
     # Call the tested function
     sub_batches, sub_id = auto_arima._divide_by_min(data, crit, b_id)
@@ -128,11 +124,9 @@ def test_divide_by_min(batch_size, n_obs, n_sub, dtype):
         # When the sub-batch is not empty, compare to the reference
         else:
             np.testing.assert_allclose(
-                sub_batches[i].to_output("numpy"), sub_batches_ref[i]
+                sub_batches[i].get(), sub_batches_ref[i]
             )
-            np.testing.assert_array_equal(
-                sub_id[i].to_output("numpy"), sub_id_ref[i]
-            )
+            np.testing.assert_array_equal(sub_id[i].get(), sub_id_ref[i])
 
 
 @pytest.mark.parametrize("batch_size", [25, 103, 1001])
@@ -145,10 +139,7 @@ def test_build_division_map(batch_size, n_sub):
     # Note: in the real use case the individual id arrays are sorted but the
     # helper function doesn't require that
     tracker_np = np.array_split(np.random.permutation(batch_size), n_sub)
-    tracker = [
-        input_to_cuml_array(tr, convert_to_dtype=np.int32)[0]
-        for tr in tracker_np
-    ]
+    tracker = [cp.asarray(tr, dtype="int32") for tr in tracker_np]
 
     # Call the tested function
     id_to_model, id_to_pos = auto_arima._build_division_map(
@@ -161,10 +152,8 @@ def test_build_division_map(batch_size, n_sub):
     )
 
     # Compare the results
-    np.testing.assert_array_equal(
-        id_to_model.to_output("numpy"), id_to_model_ref
-    )
-    np.testing.assert_array_equal(id_to_pos.to_output("numpy"), id_to_pos_ref)
+    np.testing.assert_array_equal(id_to_model.get(), id_to_model_ref)
+    np.testing.assert_array_equal(id_to_pos.get(), id_to_pos_ref)
 
 
 @pytest.mark.parametrize("batch_size", [10, 100])
@@ -180,12 +169,8 @@ def test_merge_series(batch_size, n_obs, n_sub, dtype):
     id_to_sub_np, id_to_pos_np = _build_division_map_ref(
         tracker_np, batch_size, n_sub
     )
-    id_to_sub, *_ = input_to_cuml_array(
-        id_to_sub_np, convert_to_dtype=np.int32
-    )
-    id_to_pos, *_ = input_to_cuml_array(
-        id_to_pos_np, convert_to_dtype=np.int32
-    )
+    id_to_sub = cp.asarray(id_to_sub_np, dtype="int32", order="F")
+    id_to_pos = cp.asarray(id_to_pos_np, dtype="int32", order="F")
 
     # Generate the final dataset (expected result)
     data_np = (
@@ -202,10 +187,10 @@ def test_merge_series(batch_size, n_obs, n_sub, dtype):
         )
         for j in range(len(tracker_np[i])):
             data_piece[:, j] = data_np[:, tracker_np[i][j]]
-        data_div.append(input_to_cuml_array(data_piece)[0])
+        data_div.append(cp.asarray(data_piece, order="F"))
 
     # Call the tested function
     data = auto_arima._merge_series(data_div, id_to_sub, id_to_pos, batch_size)
 
     # Compare the results
-    np.testing.assert_allclose(data.to_output("numpy"), data_np)
+    np.testing.assert_allclose(data.get(), data_np)


### PR DESCRIPTION
This:

- Updates `cuml.tsa` to use new validation pipeline instead of legacy `input_to_*` methods.
- Updates the internals of `cuml.tsa` to use `cupy` instead of `CumlArray`
- Updates some internals-only tests of `cuml.tsa` to use `cupy` instead of `CumlArray`

After this, `cuml.tsa` is fully based on `cupy` and the new ingest routines, no legacy `CumlArray` usage remains.

Fixes #8005.