### PR TITLE
Fix hinge loss decision-function shape handling

### DIFF
--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -1829,9 +1829,6 @@ def test_sparse_pairwise_distances_output_types(input_type, output_type):
             assert isinstance(S, cp.ndarray)
 
 
-@pytest.mark.xfail(
-    reason="Temporarily disabling this test. See rapidsai/cuml#3569"
-)
 @pytest.mark.parametrize(
     "nrows, ncols, n_info",
     [
@@ -1866,7 +1863,7 @@ def test_hinge_loss(nrows, ncols, n_info, input_type, n_classes):
     cuml_model = cu_log()
     cuml_model.fit(X_train, y_train)
     cu_predict_decision = cuml_model.decision_function(X_test)
-    cu_loss = cuml_hinge(y_test, cu_predict_decision.T, labels=cp.unique(y))
+    cu_loss = cuml_hinge(y_test, cu_predict_decision, labels=cp.unique(y))
     if input_type == "cudf":
         y_test = y_test.to_numpy()
         y = y.to_numpy()
@@ -1877,7 +1874,7 @@ def test_hinge_loss(nrows, ncols, n_info, input_type, n_classes):
         cu_predict_decision = cp.asnumpy(cu_predict_decision)
 
     cu_loss_using_sk = sk_hinge(
-        y_test, cu_predict_decision.T, labels=np.unique(y)
+        y_test, cu_predict_decision, labels=np.unique(y)
     )
     # compare the accuracy of the two models
     cp.testing.assert_array_almost_equal(cu_loss, cu_loss_using_sk)


### PR DESCRIPTION
Remove the stale xfail from `test_hinge_loss` and pass `LogisticRegression.decision_function` output to `hinge_loss` without transposing it. `decision_function` already returns sklearn-shaped scores, so the transpose was turning multiclass scores into `(n_classes, n_samples)` and causing the current failure.

Closes #3569

Validation:
`pytest -q python/cuml/tests/test_metrics.py -k "test_hinge_loss" -rxX`
