### PR TITLE
[FEA] Add host-streaming support to single-GPU KMeans

### DIFF
--- a/cpp/include/cuml/cluster/kmeans.hpp
+++ b/cpp/include/cuml/cluster/kmeans.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,17 +22,18 @@ namespace kmeans {
  * @param[in]     handle        The handle to the cuML library context that
  manages the CUDA resources.
  * @param[in]     params        Parameters for KMeans model.
- * @param[in]     X             Training instances to cluster. It must be noted
- that the data must be in row-major format and stored in device accessible
- * location.
+ * @param[in]     X             Training instances to cluster, in row-major
+ * format. May live on the device or on the host.
  * @param[in]     n_samples     Number of samples in the input X.
  * @param[in]     n_features    Number of features or the dimensions of each
  * sample.
- * @param[in]     sample_weight The weights for each observation in X.
+ * @param[in]     sample_weight The weights for each observation in X. If non-null, sample_weight
+ must have the same memory residency as X.
  * @param[inout]  centroids     [in] When init is InitMethod::Array, use
  centroids  as the initial cluster centers
  *                              [out] Otherwise, generated centroids from the
- kmeans algorithm is stored at the address pointed by 'centroids'.
+ kmeans algorithm is stored at the address pointed by 'centroids'. `centroids`
+ * must always live on the device.
  * @param[out]    inertia       Sum of squared distances of samples to their
  closest cluster center.
  * @param[out]    n_iter        Number of iterations run.

--- a/cpp/include/cuml/cluster/kmeans_params.hpp
+++ b/cpp/include/cuml/cluster/kmeans_params.hpp
@@ -23,11 +23,11 @@ struct KMeansParams {
   double tol                          = 1e-4;
   rapids_logger::level_enum verbosity = rapids_logger::level_enum::info;
   raft::random::RngState rng_state{0, raft::random::GeneratorType::GenPhilox};
-  int n_init                        = 1;
-  double oversampling_factor        = 2.0;
-  int batch_samples                 = 1 << 15;
-  int batch_centroids               = 0;
-  std::int64_t init_size            = 0;
+  int n_init                         = 1;
+  double oversampling_factor         = 2.0;
+  int batch_samples                  = 1 << 15;
+  int batch_centroids                = 0;
+  std::int64_t init_size             = 0;
   std::int64_t device_buffer_samples = 0;
 };
 

--- a/cpp/include/cuml/cluster/kmeans_params.hpp
+++ b/cpp/include/cuml/cluster/kmeans_params.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,10 +23,12 @@ struct KMeansParams {
   double tol                          = 1e-4;
   rapids_logger::level_enum verbosity = rapids_logger::level_enum::info;
   raft::random::RngState rng_state{0, raft::random::GeneratorType::GenPhilox};
-  int n_init                 = 1;
-  double oversampling_factor = 2.0;
-  int batch_samples          = 1 << 15;
-  int batch_centroids        = 0;
+  int n_init                        = 1;
+  double oversampling_factor        = 2.0;
+  int batch_samples                 = 1 << 15;
+  int batch_centroids               = 0;
+  std::int64_t init_size            = 0;
+  std::int64_t streaming_batch_size = 0;
 };
 
 }  // end namespace kmeans

--- a/cpp/include/cuml/cluster/kmeans_params.hpp
+++ b/cpp/include/cuml/cluster/kmeans_params.hpp
@@ -28,7 +28,7 @@ struct KMeansParams {
   int batch_samples                 = 1 << 15;
   int batch_centroids               = 0;
   std::int64_t init_size            = 0;
-  std::int64_t streaming_batch_size = 0;
+  std::int64_t device_buffer_samples = 0;
 };
 
 }  // end namespace kmeans

--- a/cpp/src/kmeans/kmeans_fit.cu
+++ b/cpp/src/kmeans/kmeans_fit.cu
@@ -1,39 +1,75 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include "../ml_cuda_utils.h"
 
 #include <cuml/cluster/kmeans.hpp>
 #include <cuml/cluster/kmeans_params.hpp>
 
 #include <raft/core/handle.hpp>
+#include <raft/core/host_mdspan.hpp>
 
 #include <cuvs/cluster/kmeans.hpp>
 #include <kmeans/kmeans_params.hpp>
+
+#include <optional>
 
 namespace ML {
 namespace kmeans {
 
 template <typename value_t, typename idx_t>
-void fit_impl(const raft::handle_t& handle,
-              const KMeansParams& params,
-              const value_t* X,
-              idx_t n_samples,
-              idx_t n_features,
-              const value_t* sample_weight,
-              value_t* centroids,
-              value_t& inertia,
-              idx_t& n_iter)
+void fit_impl_host(const raft::handle_t& handle,
+                   const KMeansParams& params,
+                   const value_t* X,
+                   idx_t n_samples,
+                   idx_t n_features,
+                   const value_t* sample_weight,
+                   value_t* centroids,
+                   value_t& inertia,
+                   idx_t& n_iter)
 {
+  auto inertia_view  = raft::make_host_scalar_view<value_t>(&inertia);
+  auto n_samples_64  = static_cast<int64_t>(n_samples);
+  auto n_features_64 = static_cast<int64_t>(n_features);
+  auto X_view = raft::make_host_matrix_view<const value_t, int64_t>(X, n_samples_64, n_features_64);
+  std::optional<raft::host_vector_view<const value_t, int64_t>> sw = std::nullopt;
+  if (sample_weight != nullptr)
+    sw = std::make_optional(
+      raft::make_host_vector_view<const value_t, int64_t>(sample_weight, n_samples_64));
+  auto centroids_view_64 =
+    raft::make_device_matrix_view<value_t, int64_t>(centroids, params.n_clusters, n_features_64);
+  int64_t n_iter_64   = 0;
+  auto n_iter_view_64 = raft::make_host_scalar_view<int64_t>(&n_iter_64);
+
+  cuvs::cluster::kmeans::fit(
+    handle, to_cuvs(params), X_view, sw, centroids_view_64, inertia_view, n_iter_view_64);
+  n_iter = static_cast<idx_t>(n_iter_64);
+  return;
+}
+
+template <typename value_t, typename idx_t>
+void fit_impl_device(const raft::handle_t& handle,
+                     const KMeansParams& params,
+                     const value_t* X,
+                     idx_t n_samples,
+                     idx_t n_features,
+                     const value_t* sample_weight,
+                     value_t* centroids,
+                     value_t& inertia,
+                     idx_t& n_iter)
+{
+  auto centroids_view =
+    raft::make_device_matrix_view<value_t, idx_t>(centroids, params.n_clusters, n_features);
+  auto inertia_view = raft::make_host_scalar_view<value_t>(&inertia);
+
   auto X_view = raft::make_device_matrix_view(X, n_samples, n_features);
   std::optional<raft::device_vector_view<const value_t, idx_t>> sw = std::nullopt;
   if (sample_weight != nullptr)
     sw = std::make_optional(
       raft::make_device_vector_view<const value_t, idx_t>(sample_weight, n_samples));
-  auto centroids_view =
-    raft::make_device_matrix_view<value_t, idx_t>(centroids, params.n_clusters, n_features);
-  auto inertia_view = raft::make_host_scalar_view<value_t>(&inertia);
-  auto n_iter_view  = raft::make_host_scalar_view<idx_t>(&n_iter);
+  auto n_iter_view = raft::make_host_scalar_view<idx_t>(&n_iter);
 
   cuvs::cluster::kmeans::fit(
     handle, to_cuvs(params), X_view, sw, centroids_view, inertia_view, n_iter_view);
@@ -49,7 +85,13 @@ void fit(const raft::handle_t& handle,
          float& inertia,
          int& n_iter)
 {
-  fit_impl(handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  if (ML::is_device_or_managed_type(X)) {
+    fit_impl_device(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  } else {
+    fit_impl_host(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  }
 }
 
 void fit(const raft::handle_t& handle,
@@ -62,7 +104,13 @@ void fit(const raft::handle_t& handle,
          double& inertia,
          int& n_iter)
 {
-  fit_impl(handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  if (ML::is_device_or_managed_type(X)) {
+    fit_impl_device(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  } else {
+    fit_impl_host(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  }
 }
 
 void fit(const raft::handle_t& handle,
@@ -75,7 +123,13 @@ void fit(const raft::handle_t& handle,
          float& inertia,
          int64_t& n_iter)
 {
-  fit_impl(handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  if (ML::is_device_or_managed_type(X)) {
+    fit_impl_device(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  } else {
+    fit_impl_host(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  }
 }
 
 void fit(const raft::handle_t& handle,
@@ -88,7 +142,13 @@ void fit(const raft::handle_t& handle,
          double& inertia,
          int64_t& n_iter)
 {
-  fit_impl(handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  if (ML::is_device_or_managed_type(X)) {
+    fit_impl_device(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  } else {
+    fit_impl_host(
+      handle, params, X, n_samples, n_features, sample_weight, centroids, inertia, n_iter);
+  }
 }
 
 };  // end namespace kmeans

--- a/cpp/src/kmeans/kmeans_params.hpp
+++ b/cpp/src/kmeans/kmeans_params.hpp
@@ -16,19 +16,19 @@ inline cuvs::cluster::kmeans::params to_cuvs(KMeansParams const& config)
 {
   cuvs::cluster::kmeans::params params;
 
-  params.metric               = static_cast<cuvs::distance::DistanceType>(config.metric);
-  params.n_clusters           = config.n_clusters;
-  params.init                 = static_cast<cuvs::cluster::kmeans::params::InitMethod>(config.init);
-  params.max_iter             = config.max_iter;
-  params.tol                  = config.tol;
-  params.verbosity            = config.verbosity;
-  params.rng_state            = config.rng_state;
-  params.n_init               = config.n_init;
-  params.oversampling_factor  = config.oversampling_factor;
-  params.batch_samples        = config.batch_samples;
-  params.batch_centroids      = config.batch_centroids;
-  params.init_size            = config.init_size;
-  params.streaming_batch_size = config.streaming_batch_size;
+  params.metric              = static_cast<cuvs::distance::DistanceType>(config.metric);
+  params.n_clusters          = config.n_clusters;
+  params.init                = static_cast<cuvs::cluster::kmeans::params::InitMethod>(config.init);
+  params.max_iter            = config.max_iter;
+  params.tol                 = config.tol;
+  params.verbosity           = config.verbosity;
+  params.rng_state           = config.rng_state;
+  params.n_init              = config.n_init;
+  params.oversampling_factor = config.oversampling_factor;
+  params.batch_samples       = config.batch_samples;
+  params.batch_centroids     = config.batch_centroids;
+  params.init_size           = config.init_size;
+  params.device_buffer_samples = config.device_buffer_samples;
 
   return params;
 }

--- a/cpp/src/kmeans/kmeans_params.hpp
+++ b/cpp/src/kmeans/kmeans_params.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,17 +16,19 @@ inline cuvs::cluster::kmeans::params to_cuvs(KMeansParams const& config)
 {
   cuvs::cluster::kmeans::params params;
 
-  params.metric              = static_cast<cuvs::distance::DistanceType>(config.metric);
-  params.n_clusters          = config.n_clusters;
-  params.init                = static_cast<cuvs::cluster::kmeans::params::InitMethod>(config.init);
-  params.max_iter            = config.max_iter;
-  params.tol                 = config.tol;
-  params.verbosity           = config.verbosity;
-  params.rng_state           = config.rng_state;
-  params.n_init              = config.n_init;
-  params.oversampling_factor = config.oversampling_factor;
-  params.batch_samples       = config.batch_samples;
-  params.batch_centroids     = config.batch_centroids;
+  params.metric               = static_cast<cuvs::distance::DistanceType>(config.metric);
+  params.n_clusters           = config.n_clusters;
+  params.init                 = static_cast<cuvs::cluster::kmeans::params::InitMethod>(config.init);
+  params.max_iter             = config.max_iter;
+  params.tol                  = config.tol;
+  params.verbosity            = config.verbosity;
+  params.rng_state            = config.rng_state;
+  params.n_init               = config.n_init;
+  params.oversampling_factor  = config.oversampling_factor;
+  params.batch_samples        = config.batch_samples;
+  params.batch_centroids      = config.batch_centroids;
+  params.init_size            = config.init_size;
+  params.streaming_batch_size = config.streaming_batch_size;
 
   return params;
 }

--- a/cpp/src/ml_cuda_utils.h
+++ b/cpp/src/ml_cuda_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,13 +22,7 @@ inline cudaMemoryType memory_type(const void* p)
 {
   cudaPointerAttributes att;
   cudaError_t err = cudaPointerGetAttributes(&att, p);
-  ASSERT(err == cudaSuccess || err == cudaErrorInvalidValue, "%s", cudaGetErrorString(err));
-
-  if (err == cudaErrorInvalidValue) {
-    // Make sure the current thread error status has been reset
-    err = cudaGetLastError();
-    ASSERT(err == cudaErrorInvalidValue, "%s", cudaGetErrorString(err));
-  }
+  ASSERT(err == cudaSuccess, "cudaPointerGetAttributes failed: %s", cudaGetErrorString(err));
   return att.type;
 }
 

--- a/python/cuml/cuml/cluster/cpp/kmeans.pxd
+++ b/python/cuml/cuml/cluster/cpp/kmeans.pxd
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -29,7 +29,9 @@ cdef extern from "cuml/cluster/kmeans_params.hpp" namespace "ML::kmeans" nogil:
         int n_init,
         double oversampling_factor,
         int batch_samples,
-        int batch_centroids
+        int batch_centroids,
+        int64_t init_size,
+        int64_t streaming_batch_size
 
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans" nogil:

--- a/python/cuml/cuml/cluster/cpp/kmeans.pxd
+++ b/python/cuml/cuml/cluster/cpp/kmeans.pxd
@@ -31,7 +31,7 @@ cdef extern from "cuml/cluster/kmeans_params.hpp" namespace "ML::kmeans" nogil:
         int batch_samples,
         int batch_centroids,
         int64_t init_size,
-        int64_t streaming_batch_size
+        int64_t device_buffer_samples
 
 
 cdef extern from "cuml/cluster/kmeans.hpp" namespace "ML::kmeans" nogil:

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -456,23 +456,25 @@ class KMeans(InteropMixin,
         n_clusters`. It might become necessary to lower this number when
         `n_clusters` becomes prohibitively large.
     device_buffer_samples : int (default = 0)
-        Number of samples to stream from host to device per GPU batch when
-        fitting with host-resident inputs. Set to a positive value to bound peak
-        GPU memory when the full dataset does not fit on the device; this enables
-        the out-of-core host fit path. When set to 0 (default), host inputs are
-        copied to the device in full and the standard device fit is used (no
-        streaming). Ignored when the input is already device-resident (e.g.
-        cupy.ndarray, cudf.DataFrame).
+        Number of host samples to buffer to the device per GPU batch when
+        fitting with host-resident inputs. This selects the fit path for
+        host-resident inputs: the out-of-core host fit path is used
+        only when ``0 < device_buffer_samples < n_samples``. When
+        ``device_buffer_samples == 0`` (default) or
+        ``device_buffer_samples >= n_samples``, host inputs are copied to the
+        device in full and the standard device fit is used. Ignored when the
+        input is already device-resident (e.g. cupy.ndarray, cudf.DataFrame),
+        which always uses the device fit.
     init_size : int (default = 0)
         Number of samples to randomly draw for the KMeansPlusPlus initialization
         step. A random subset of this size is used for centroid seeding. Only
-        applies on the out-of-core host fit path, i.e. when the input is
-        host-resident *and* ``device_buffer_samples > 0``. When set to 0
-        (default) on that path, ``min(3 * n_clusters, n_samples)`` is used. It is
-        ignored on the device fit path — which includes device-resident inputs
-        as well as host inputs with ``device_buffer_samples=0`` (those are copied
-        to the device in full) — where the full dataset is always used for
-        seeding.
+        applies when the out-of-core host fit path is actually
+        selected, i.e. when the input is host-resident and
+        ``0 < device_buffer_samples < n_samples``. When set to 0 (default) on
+        that path, ``min(3 * n_clusters, n_samples)`` is used. It is ignored on
+        the device fit path — device-resident inputs, as well as host inputs
+        that are copied to the device in full (``device_buffer_samples == 0`` or
+        ``>= n_samples``) — where the full dataset is always used for seeding.
     output_type : {None, 'input', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
         Return results and set estimator attributes to the indicated output
         type. If None, the output type set at the module level
@@ -669,10 +671,12 @@ class KMeans(InteropMixin,
         data_on_device = isinstance(X, cp.ndarray)
         n_samples = X.shape[0]
 
-        # Only take the cuVS host (out-of-core) fit path when the user has
-        # explicitly opted into host-to-device streaming via `device_buffer_samples > 0`.
-        # For the default (``device_buffer_samples == 0``) copy host inputs to the
-        # device and use the device fit.
+        # Take the cuVS host (out-of-core) fit path only when the input
+        # is host-resident and the batch actually splits the data
+        # (``0 < device_buffer_samples < n_samples``). When the batch is 0
+        # (default) or would cover all rows (``>= n_samples``), copy host inputs
+        # to the device and use the device fit; device-resident inputs always
+        # use the device fit.
         use_host_path = (not data_on_device) and device_buffer_samples > 0 \
             and device_buffer_samples < n_samples
 

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -663,10 +663,21 @@ class KMeans(InteropMixin,
             mem_type=None,
             reset=True,
         )
-        n_rows, n_cols = X.shape
+        data_on_device = isinstance(X, cp.ndarray)
 
-        if sample_weight is None:
-            sample_weight = cp.ones(shape=n_rows, dtype=X.dtype)
+        # `streaming_batch_size` only affects the host-to-device streaming
+        # path. When `X` is already on device take the standard device-data fit path.
+        use_host_path = streaming_batch_size > 0 and not data_on_device
+        if use_host_path:
+            X = cp.asnumpy(X, order="C")
+            if sample_weight is not None:
+                sample_weight = cp.asnumpy(sample_weight)
+        else:
+            X = cp.asarray(X, order="C")
+            if sample_weight is not None:
+                sample_weight = cp.asarray(sample_weight)
+
+        n_rows, n_cols = X.shape
 
         self._validate_fit_row_constraints(n_rows)
 

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -587,7 +587,7 @@ class KMeans(InteropMixin,
 
         return {
             "cluster_centers_": self.cluster_centers_.get(order="A"),
-            "labels_": self.labels_.get(order="A"),
+            "labels_": cp.asnumpy(self.labels_),
             "inertia_": self.inertia_,
             "n_iter_": self.n_iter_,
             # sklearn's KMeans relies on a few private attributes to work

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -458,19 +458,21 @@ class KMeans(InteropMixin,
     device_buffer_samples : int (default = 0)
         Number of samples to stream from host to device per GPU batch when
         fitting with host-resident inputs. Set to a positive value to bound peak
-        GPU memory when the full dataset does not fit on the device. When set to
-        0 (default), the whole partition is processed in a single batch (all
-        samples staged to device at once). Ignored when the input is already
-        device-resident (e.g. cupy.ndarray, cudf.DataFrame) — the standard
-        device-data fit path is used and no batching is performed.
+        GPU memory when the full dataset does not fit on the device; this enables
+        the out-of-core host fit path. When set to 0 (default), host inputs are
+        copied to the device in full and the standard device fit is used (no
+        streaming). Ignored when the input is already device-resident (e.g.
+        cupy.ndarray, cudf.DataFrame).
     init_size : int (default = 0)
         Number of samples to randomly draw for the KMeansPlusPlus initialization
         step. A random subset of this size is used for centroid seeding. Only
-        applies when the input is not device accessible (which always uses the
-        out-of-core host fit path, regardless of ``device_buffer_samples``); for
-        device-resident data the full dataset is always used for seeding and
-        this parameter is ignored. When set to 0 (default) with host data,
-        ``min(3 * n_clusters, n_samples)`` is used.
+        applies on the out-of-core host fit path, i.e. when the input is
+        host-resident *and* ``device_buffer_samples > 0``. When set to 0
+        (default) on that path, ``min(3 * n_clusters, n_samples)`` is used. It is
+        ignored on the device fit path — which includes device-resident inputs
+        as well as host inputs with ``device_buffer_samples=0`` (those are copied
+        to the device in full) — where the full dataset is always used for
+        seeding.
     output_type : {None, 'input', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
         Return results and set estimator attributes to the indicated output
         type. If None, the output type set at the module level
@@ -666,7 +668,20 @@ class KMeans(InteropMixin,
         )
         data_on_device = isinstance(X, cp.ndarray)
 
-        if not data_on_device:
+        # Only take the cuVS host (out-of-core) fit path when the user has
+        # explicitly opted into host-to-device streaming via `device_buffer_samples > 0`.
+        # For the default (``device_buffer_samples == 0``) copy host inputs to the
+        # device and use the device fit.
+        #
+        # TODO: This is a workaround to accommodate failing cuml.accel check.
+        # Drop this host mdspan handling when cuVS kmeans++
+        # Reference issue: https://github.com/NVIDIA/cuvs/issues/2359
+        # host-data fit is made reproducible, drop this gate and let cuVS handle host
+        # inputs once the above issue is handled.
+        use_host_path = (not data_on_device) and device_buffer_samples > 0 \
+            and device_buffer_samples < n_samples
+
+        if use_host_path:
             X = cp.asnumpy(X, order="C")
             if sample_weight is not None:
                 sample_weight = cp.asnumpy(sample_weight)
@@ -709,7 +724,7 @@ class KMeans(InteropMixin,
         cdef lib.KMeansParams params
         _kmeans_init_params(self, params)
         n_iter = _kmeans_fit(handle_[0], params, X, sample_weight, centers)
-        if not data_on_device:
+        if use_host_path:
             labels, inertia = _kmeans_predict_host_chunked(
                 handle_[0], params, X, sample_weight, centers,
                 device_buffer_samples,

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -4,6 +4,7 @@
 from numbers import Integral
 
 import cupy as cp
+import numpy as np
 
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.base import Base, get_handle
@@ -49,6 +50,8 @@ cdef _kmeans_init_params(kmeans, lib.KMeansParams& params):
     params.verbosity = kmeans._verbose_level
     params.metric = DistanceType.L2Expanded
     params.batch_samples = int(kmeans.max_samples_per_batch)
+    params.init_size = int(kmeans.init_size)
+    params.streaming_batch_size = int(kmeans.streaming_batch_size)
     params.oversampling_factor = kmeans.oversampling_factor
 
     # Ensure random_state is set when running on multi-gpu
@@ -94,16 +97,27 @@ cdef _kmeans_fit(
     sample_weight,
     centers,
 ):
-    """Fit the kmeans centers and return `n_iter`"""
+    """Fit the kmeans centers and return `n_iter`.
+
+    `X` and `sample_weight` may live on either the device or the host.
+    `centers` always lives on the device.
+    """
     cdef int64_t n_rows = X.shape[0]
     cdef int64_t n_cols = X.shape[1]
 
     cdef bool values_f32 = X.dtype == cp.float32
-    cdef bool indices_i32 = _kmeans_indices_i32(n_rows, n_cols)
+    # Indices fitting in int32 is for device arrays
+    cdef bool host_data = not hasattr(X, "__cuda_array_interface__")
+    cdef bool indices_i32 = (not host_data) and _kmeans_indices_i32(n_rows, n_cols)
 
-    cdef uintptr_t X_ptr = X.data.ptr
+    cdef uintptr_t X_ptr = X.data.ptr if isinstance(X, cp.ndarray) else X.ctypes.data
     cdef uintptr_t centers_ptr = centers.data.ptr
-    cdef uintptr_t sample_weight_ptr = sample_weight.data.ptr
+    cdef uintptr_t sample_weight_ptr = 0
+    if sample_weight is not None:
+        sample_weight_ptr = (
+            sample_weight.data.ptr if isinstance(sample_weight, cp.ndarray)
+            else sample_weight.ctypes.data
+        )
 
     cdef int n_iter_32 = 0
     cdef int64_t n_iter_64 = 0
@@ -170,6 +184,7 @@ cdef _kmeans_predict(
     X,
     sample_weight,
     centers,
+    bool normalize_weights=True,
 ):
     """Predict labels & inertia from a fit `KMeans`.
 
@@ -190,7 +205,9 @@ cdef _kmeans_predict(
 
     cdef uintptr_t X_ptr = X.data.ptr
     cdef uintptr_t centers_ptr = centers.data.ptr
-    cdef uintptr_t sample_weight_ptr = sample_weight.data.ptr
+    cdef uintptr_t sample_weight_ptr = (
+        sample_weight.data.ptr if sample_weight is not None else 0
+    )
     cdef uintptr_t labels_ptr = labels.data.ptr
 
     cdef bool values_f32 = X.dtype == cp.float32
@@ -209,7 +226,7 @@ cdef _kmeans_predict(
                     <int>n_rows,
                     <int>n_cols,
                     <float*>sample_weight_ptr,
-                    True,
+                    normalize_weights,
                     <int*>labels_ptr,
                     inertia_f32,
                 )
@@ -222,7 +239,7 @@ cdef _kmeans_predict(
                     <int64_t>n_rows,
                     <int64_t>n_cols,
                     <float*>sample_weight_ptr,
-                    True,
+                    normalize_weights,
                     <int64_t*>labels_ptr,
                     inertia_f32,
                 )
@@ -236,7 +253,7 @@ cdef _kmeans_predict(
                     <int>n_rows,
                     <int>n_cols,
                     <double*>sample_weight_ptr,
-                    True,
+                    normalize_weights,
                     <int*>labels_ptr,
                     inertia_f64,
                 )
@@ -249,7 +266,7 @@ cdef _kmeans_predict(
                     <int64_t>n_rows,
                     <int64_t>n_cols,
                     <double*>sample_weight_ptr,
-                    True,
+                    normalize_weights,
                     <int64_t*>labels_ptr,
                     inertia_f64,
                 )
@@ -257,6 +274,76 @@ cdef _kmeans_predict(
     inertia = inertia_f32 if values_f32 else inertia_f64
 
     return labels, inertia
+
+
+cdef _kmeans_predict_host_chunked(
+    handle_t& handle,
+    lib.KMeansParams& params,
+    X,
+    sample_weight,
+    centers,
+    int64_t batch_size,
+):
+    """Predict labels & total inertia for host-resident `X` in chunks.
+
+    Streams chunks of `batch_size` host rows into a single reusable device
+    buffer, runs the existing device-data predict on each chunk, and stitches
+    the per-chunk labels into a single host (`numpy.ndarray`) result.
+
+    Returns (`numpy.ndarray` of labels, `float` total inertia).
+    """
+    cdef int64_t n_rows = X.shape[0]
+    cdef int64_t n_cols = X.shape[1]
+    cdef int64_t cap = batch_size if batch_size > 0 else n_rows
+    if cap > n_rows:
+        cap = n_rows
+
+    cdef bool uniform = sample_weight is None
+    cdef double scale = 1.0
+    if uniform:
+        sw_buf = cp.ones(cap, dtype=X.dtype)
+    else:
+        total_sw = float(sample_weight.sum())
+        if total_sw > 0:
+            scale = n_rows / total_sw
+        sw_buf = cp.empty(shape=cap, dtype=X.dtype)
+
+    X_buf = cp.empty(shape=(cap, n_cols), dtype=X.dtype, order="C")
+
+    labels_dtype = (
+        np.int32
+        if _kmeans_indices_i32(n_rows, n_cols)
+        and _kmeans_indices_i32(centers.shape[0], n_cols)
+        else np.int64
+    )
+    labels_host = np.empty(n_rows, dtype=labels_dtype)
+
+    cdef int64_t start = 0
+    cdef int64_t end = 0
+    cdef int64_t n = 0
+    total_inertia = 0.0
+    while start < n_rows:
+        end = start + cap
+        if end > n_rows:
+            end = n_rows
+        n = end - start
+
+        # For non-uniform, copy the raw slice and scale on-device.
+        X_buf[:n].set(X[start:end])
+        if not uniform:
+            sw_buf[:n].set(sample_weight[start:end])
+            sw_buf[:n] *= scale
+
+        batch_labels, batch_inertia = _kmeans_predict(
+            handle, params, X_buf[:n], sw_buf[:n], centers,
+            normalize_weights=False,
+        )
+        labels_host[start:end] = cp.asnumpy(batch_labels)
+        total_inertia += float(batch_inertia)
+
+        start = end
+
+    return labels_host, total_inertia
 
 
 class KMeans(InteropMixin,
@@ -368,6 +455,20 @@ class KMeans(InteropMixin,
         batched pairwise distance computation is :py:`max_samples_per_batch *
         n_clusters`. It might become necessary to lower this number when
         `n_clusters` becomes prohibitively large.
+    streaming_batch_size : int (default = 0)
+        Number of samples to stream from host to device per GPU batch when
+        fitting with host-resident inputs. Set to a positive value to bound peak GPU memory
+        when the full dataset does not fit on the device. When set to 0
+        (default), all samples are copied to device at once. Ignored when
+        the input is already device-resident (e.g. cupy.ndarray,
+        cudf.DataFrame) — the standard device-data fit path is used and
+        no batching is performed.
+    init_size : int (default = 0)
+        Number of samples to randomly draw for the KMeansPlusPlus initialization
+        step. A random subset of this size is used for centroid seeding. Only applies
+        when dataset is on host; for device data the full dataset is always used for
+        seeding and this parameter is ignored. When set to 0 (default) with host data
+        uses `min(3 * n_clusters, n_samples)` as a default.
     output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \
         'numba', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
         Return results and set estimator attributes to the indicated output
@@ -417,6 +518,8 @@ class KMeans(InteropMixin,
             "n_init",
             "oversampling_factor",
             "max_samples_per_batch",
+            "streaming_batch_size",
+            "init_size",
             "init",
             "max_iter",
             "n_clusters",
@@ -505,6 +608,8 @@ class KMeans(InteropMixin,
         n_init="auto",
         oversampling_factor=2.0,
         max_samples_per_batch=1<<15,
+        streaming_batch_size=0,
+        init_size=0,
         output_type=None,
     ):
         super().__init__(verbose=verbose, output_type=output_type)
@@ -516,6 +621,8 @@ class KMeans(InteropMixin,
         self.n_init = n_init
         self.oversampling_factor = oversampling_factor
         self.max_samples_per_batch = max_samples_per_batch
+        self.streaming_batch_size = streaming_batch_size
+        self.init_size = init_size
 
     @property
     def _n_features_out(self):
@@ -530,6 +637,19 @@ class KMeans(InteropMixin,
         Compute k-means clustering with X.
 
         """
+        streaming_batch_size = int(self.streaming_batch_size)
+        if streaming_batch_size < 0:
+            raise ValueError(
+                f"streaming_batch_size must be >= 0, got "
+                f"{streaming_batch_size}."
+            )
+        if streaming_batch_size > 0 and self._multi_gpu:
+            raise ValueError(
+                f"streaming_batch_size={streaming_batch_size} is not "
+                f"supported for the multi-GPU KMeans fit path; set "
+                f"streaming_batch_size=0."
+            )
+
         self._validate_fit_params()
 
         # Process input arrays
@@ -539,7 +659,8 @@ class KMeans(InteropMixin,
             sample_weight=sample_weight,
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
-            order="C",
+            order=None,
+            mem_type=None,
             reset=True,
         )
         n_rows, n_cols = X.shape
@@ -555,7 +676,6 @@ class KMeans(InteropMixin,
                 shape=(self.n_clusters, n_cols), dtype=X.dtype, order="C",
             )
         else:
-            # Initial array provided, coerce to device array and validate
             centers = check_array(
                 self.init,
                 order="C",
@@ -580,7 +700,15 @@ class KMeans(InteropMixin,
         cdef lib.KMeansParams params
         _kmeans_init_params(self, params)
         n_iter = _kmeans_fit(handle_[0], params, X, sample_weight, centers)
-        labels, inertia = _kmeans_predict(handle_[0], params, X, sample_weight, centers)
+        if use_host_path:
+            labels, inertia = _kmeans_predict_host_chunked(
+                handle_[0], params, X, sample_weight, centers,
+                streaming_batch_size,
+            )
+        else:
+            labels, inertia = _kmeans_predict(
+                handle_[0], params, X, sample_weight, centers,
+            )
         handle.sync()
 
         # Store fitted attributes and return

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -457,18 +457,20 @@ class KMeans(InteropMixin,
         `n_clusters` becomes prohibitively large.
     device_buffer_samples : int (default = 0)
         Number of samples to stream from host to device per GPU batch when
-        fitting with host-resident inputs. Set to a positive value to bound peak GPU memory
-        when the full dataset does not fit on the device. When set to 0
-        (default), all samples are copied to device at once. Ignored when
-        the input is already device-resident (e.g. cupy.ndarray,
-        cudf.DataFrame) — the standard device-data fit path is used and
-        no batching is performed.
+        fitting with host-resident inputs. Set to a positive value to bound peak
+        GPU memory when the full dataset does not fit on the device. When set to
+        0 (default), the whole partition is processed in a single batch (all
+        samples staged to device at once). Ignored when the input is already
+        device-resident (e.g. cupy.ndarray, cudf.DataFrame) — the standard
+        device-data fit path is used and no batching is performed.
     init_size : int (default = 0)
         Number of samples to randomly draw for the KMeansPlusPlus initialization
-        step. A random subset of this size is used for centroid seeding. Only applies
-        when dataset is on host; for device data the full dataset is always used for
-        seeding and this parameter is ignored. When set to 0 (default) with host data
-        uses `min(3 * n_clusters, n_samples)` as a default.
+        step. A random subset of this size is used for centroid seeding. Only
+        applies when the input is not device accessible (which always uses the
+        out-of-core host fit path, regardless of ``device_buffer_samples``); for
+        device-resident data the full dataset is always used for seeding and
+        this parameter is ignored. When set to 0 (default) with host data,
+        ``min(3 * n_clusters, n_samples)`` is used.
     output_type : {'input', 'array', 'dataframe', 'series', 'df_obj', \
         'numba', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
         Return results and set estimator attributes to the indicated output
@@ -665,10 +667,7 @@ class KMeans(InteropMixin,
         )
         data_on_device = isinstance(X, cp.ndarray)
 
-        # `device_buffer_samples` only affects the host-to-device streaming
-        # path. When `X` is already on device take the standard device-data fit path.
-        use_host_path = device_buffer_samples > 0 and not data_on_device
-        if use_host_path:
+        if not data_on_device:
             X = cp.asnumpy(X, order="C")
             if sample_weight is not None:
                 sample_weight = cp.asnumpy(sample_weight)
@@ -711,7 +710,7 @@ class KMeans(InteropMixin,
         cdef lib.KMeansParams params
         _kmeans_init_params(self, params)
         n_iter = _kmeans_fit(handle_[0], params, X, sample_weight, centers)
-        if use_host_path:
+        if not data_on_device:
             labels, inertia = _kmeans_predict_host_chunked(
                 handle_[0], params, X, sample_weight, centers,
                 device_buffer_samples,

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -458,23 +458,22 @@ class KMeans(InteropMixin,
     device_buffer_samples : int (default = 0)
         Number of host samples to buffer to the device per GPU batch when
         fitting with host-resident inputs. This selects the fit path for
-        host-resident inputs: the out-of-core host fit path is used
-        only when ``0 < device_buffer_samples < n_samples``. When
-        ``device_buffer_samples == 0`` (default) or
-        ``device_buffer_samples >= n_samples``, host inputs are copied to the
-        device in full and the standard device fit is used. Ignored when the
-        input is already device-resident (e.g. cupy.ndarray, cudf.DataFrame),
+        host-resident inputs: the out-of-core host fit path is used whenever
+        ``device_buffer_samples > 0``. When ``device_buffer_samples == 0``
+        (default), host inputs are copied to the device in full and the
+        standard device fit is used. Ignored when the input is already
+        device-resident (e.g. cupy.ndarray, cudf.DataFrame),
         which always uses the device fit.
     init_size : int (default = 0)
         Number of samples to randomly draw for the KMeansPlusPlus initialization
         step. A random subset of this size is used for centroid seeding. Only
-        applies when the out-of-core host fit path is actually
-        selected, i.e. when the input is host-resident and
-        ``0 < device_buffer_samples < n_samples``. When set to 0 (default) on
-        that path, ``min(3 * n_clusters, n_samples)`` is used. It is ignored on
-        the device fit path — device-resident inputs, as well as host inputs
-        that are copied to the device in full (``device_buffer_samples == 0`` or
-        ``>= n_samples``) — where the full dataset is always used for seeding.
+        applies when the out-of-core host fit path is actually selected, i.e.
+        when the input is host-resident and ``device_buffer_samples > 0``. When
+        set to 0 (default) on that path, ``min(3 * n_clusters, n_samples)`` is
+        used. It is ignored on the device fit path — device-resident inputs, as
+        well as host inputs that are copied to the device in full
+        (``device_buffer_samples == 0``) — where the full dataset is always used
+        for seeding.
     output_type : {None, 'input', 'cupy', 'numpy', 'cudf', 'pandas'}, default=None
         Return results and set estimator attributes to the indicated output
         type. If None, the output type set at the module level
@@ -669,16 +668,14 @@ class KMeans(InteropMixin,
             reset=True,
         )
         data_on_device = isinstance(X, cp.ndarray)
-        n_samples = X.shape[0]
 
-        # Take the cuVS host (out-of-core) fit path only when the input
-        # is host-resident and the batch actually splits the data
-        # (``0 < device_buffer_samples < n_samples``). When the batch is 0
-        # (default) or would cover all rows (``>= n_samples``), copy host inputs
-        # to the device and use the device fit; device-resident inputs always
-        # use the device fit.
-        use_host_path = (not data_on_device) and device_buffer_samples > 0 \
-            and device_buffer_samples < n_samples
+        # Take the host (out-of-core) fit path when the input is host-resident
+        # and a positive batch size is set (``device_buffer_samples > 0``); if
+        # the batch is ``>= n_samples`` cuVS processes all rows in a single
+        # batch. When the batch is 0 (default), copy host inputs to the device
+        # and use the device fit; device-resident inputs always use the device
+        # fit.
+        use_host_path = (not data_on_device) and device_buffer_samples > 0
 
         if use_host_path:
             X = cp.asnumpy(X, order="C")

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -51,7 +51,7 @@ cdef _kmeans_init_params(kmeans, lib.KMeansParams& params):
     params.metric = DistanceType.L2Expanded
     params.batch_samples = int(kmeans.max_samples_per_batch)
     params.init_size = int(kmeans.init_size)
-    params.streaming_batch_size = int(kmeans.streaming_batch_size)
+    params.device_buffer_samples = int(kmeans.device_buffer_samples)
     params.oversampling_factor = kmeans.oversampling_factor
 
     # Ensure random_state is set when running on multi-gpu
@@ -455,7 +455,7 @@ class KMeans(InteropMixin,
         batched pairwise distance computation is :py:`max_samples_per_batch *
         n_clusters`. It might become necessary to lower this number when
         `n_clusters` becomes prohibitively large.
-    streaming_batch_size : int (default = 0)
+    device_buffer_samples : int (default = 0)
         Number of samples to stream from host to device per GPU batch when
         fitting with host-resident inputs. Set to a positive value to bound peak GPU memory
         when the full dataset does not fit on the device. When set to 0
@@ -518,7 +518,7 @@ class KMeans(InteropMixin,
             "n_init",
             "oversampling_factor",
             "max_samples_per_batch",
-            "streaming_batch_size",
+            "device_buffer_samples",
             "init_size",
             "init",
             "max_iter",
@@ -608,7 +608,7 @@ class KMeans(InteropMixin,
         n_init="auto",
         oversampling_factor=2.0,
         max_samples_per_batch=1<<15,
-        streaming_batch_size=0,
+        device_buffer_samples=0,
         init_size=0,
         output_type=None,
     ):
@@ -621,7 +621,7 @@ class KMeans(InteropMixin,
         self.n_init = n_init
         self.oversampling_factor = oversampling_factor
         self.max_samples_per_batch = max_samples_per_batch
-        self.streaming_batch_size = streaming_batch_size
+        self.device_buffer_samples = device_buffer_samples
         self.init_size = init_size
 
     @property
@@ -637,17 +637,17 @@ class KMeans(InteropMixin,
         Compute k-means clustering with X.
 
         """
-        streaming_batch_size = int(self.streaming_batch_size)
-        if streaming_batch_size < 0:
+        device_buffer_samples = int(self.device_buffer_samples)
+        if device_buffer_samples < 0:
             raise ValueError(
-                f"streaming_batch_size must be >= 0, got "
-                f"{streaming_batch_size}."
+                f"device_buffer_samples must be >= 0, got "
+                f"{device_buffer_samples}."
             )
-        if streaming_batch_size > 0 and self._multi_gpu:
+        if device_buffer_samples > 0 and self._multi_gpu:
             raise ValueError(
-                f"streaming_batch_size={streaming_batch_size} is not "
+                f"device_buffer_samples={device_buffer_samples} is not "
                 f"supported for the multi-GPU KMeans fit path; set "
-                f"streaming_batch_size=0."
+                f"device_buffer_samples=0."
             )
 
         self._validate_fit_params()
@@ -665,9 +665,9 @@ class KMeans(InteropMixin,
         )
         data_on_device = isinstance(X, cp.ndarray)
 
-        # `streaming_batch_size` only affects the host-to-device streaming
+        # `device_buffer_samples` only affects the host-to-device streaming
         # path. When `X` is already on device take the standard device-data fit path.
-        use_host_path = streaming_batch_size > 0 and not data_on_device
+        use_host_path = device_buffer_samples > 0 and not data_on_device
         if use_host_path:
             X = cp.asnumpy(X, order="C")
             if sample_weight is not None:
@@ -714,7 +714,7 @@ class KMeans(InteropMixin,
         if use_host_path:
             labels, inertia = _kmeans_predict_host_chunked(
                 handle_[0], params, X, sample_weight, centers,
-                streaming_batch_size,
+                device_buffer_samples,
             )
         else:
             labels, inertia = _kmeans_predict(

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -107,7 +107,7 @@ cdef _kmeans_fit(
 
     cdef bool values_f32 = X.dtype == cp.float32
     # Indices fitting in int32 is for device arrays
-    cdef bool host_data = not hasattr(X, "__cuda_array_interface__")
+    cdef bool host_data = not isinstance(X, cp.ndarray)
     cdef bool indices_i32 = (not host_data) and _kmeans_indices_i32(n_rows, n_cols)
 
     cdef uintptr_t X_ptr = X.data.ptr if isinstance(X, cp.ndarray) else X.ctypes.data

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -667,6 +667,7 @@ class KMeans(InteropMixin,
             reset=True,
         )
         data_on_device = isinstance(X, cp.ndarray)
+        n_samples = X.shape[0]
 
         # Only take the cuVS host (out-of-core) fit path when the user has
         # explicitly opted into host-to-device streaming via `device_buffer_samples > 0`.

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -673,12 +673,6 @@ class KMeans(InteropMixin,
         # explicitly opted into host-to-device streaming via `device_buffer_samples > 0`.
         # For the default (``device_buffer_samples == 0``) copy host inputs to the
         # device and use the device fit.
-        #
-        # TODO: This is a workaround to accommodate failing cuml.accel check.
-        # Drop this host mdspan handling when cuVS kmeans++
-        # Reference issue: https://github.com/NVIDIA/cuvs/issues/2359
-        # host-data fit is made reproducible, drop this gate and let cuVS handle host
-        # inputs once the above issue is handled.
         use_host_path = (not data_on_device) and device_buffer_samples > 0 \
             and device_buffer_samples < n_samples
 

--- a/python/cuml/tests/test_kmeans.py
+++ b/python/cuml/tests/test_kmeans.py
@@ -483,7 +483,7 @@ def test_kmeans_streaming_batch_size_host_path(
     """The single-GPU host-streaming fit path should agree with the device
     path on identical inputs.
     """
-    n_rows = 4096
+    n_rows = 4000
     n_cols = 16
     n_clusters = 8
 

--- a/python/cuml/tests/test_kmeans.py
+++ b/python/cuml/tests/test_kmeans.py
@@ -474,11 +474,11 @@ def test_kmeans_init_wrong_shape():
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("streaming_batch_size", [256, 1024, 5000])
+@pytest.mark.parametrize("device_buffer_samples", [256, 1024, 5000])
 @pytest.mark.parametrize("weighted", [False, True])
 @pytest.mark.parametrize("init_method", ["explicit", "default"])
-def test_kmeans_streaming_batch_size_host_path(
-    dtype, streaming_batch_size, weighted, init_method
+def test_kmeans_device_buffer_samples_host_path(
+    dtype, device_buffer_samples, weighted, init_method
 ):
     """The single-GPU host-streaming fit path should agree with the device
     path on identical inputs.
@@ -518,11 +518,11 @@ def test_kmeans_streaming_batch_size_host_path(
         common_kwargs["init_size"] = n_rows
 
     host_model = cuml.KMeans(
-        streaming_batch_size=streaming_batch_size, **common_kwargs
+        device_buffer_samples=device_buffer_samples, **common_kwargs
     )
     host_model.fit(X_host, sample_weight=sample_weight_host)
 
-    dev_model = cuml.KMeans(streaming_batch_size=0, **common_kwargs)
+    dev_model = cuml.KMeans(device_buffer_samples=0, **common_kwargs)
     dev_model.fit(X_dev, sample_weight=sample_weight_dev)
 
     host_labels = cp.asnumpy(cp.asarray(host_model.labels_))

--- a/python/cuml/tests/test_kmeans.py
+++ b/python/cuml/tests/test_kmeans.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -471,3 +471,75 @@ def test_kmeans_init_wrong_shape():
         ),
     ):
         model.fit(X)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("streaming_batch_size", [256, 1024, 5000])
+@pytest.mark.parametrize("weighted", [False, True])
+@pytest.mark.parametrize("init_method", ["explicit", "default"])
+def test_kmeans_streaming_batch_size_host_path(
+    dtype, streaming_batch_size, weighted, init_method
+):
+    """The single-GPU host-streaming fit path should agree with the device
+    path on identical inputs.
+    """
+    n_rows = 4096
+    n_cols = 16
+    n_clusters = 8
+
+    X_dev, _ = make_blobs(
+        n_samples=n_rows,
+        n_features=n_cols,
+        centers=n_clusters,
+        cluster_std=0.5,
+        random_state=42,
+        dtype=dtype,
+    )
+    X_host = cp.asnumpy(X_dev).astype(dtype)
+
+    if weighted:
+        sample_weight_host = np.linspace(0.5, 1.5, num=n_rows, dtype=dtype)
+        sample_weight_dev = cp.asarray(sample_weight_host)
+    else:
+        sample_weight_host = None
+        sample_weight_dev = None
+
+    common_kwargs = dict(
+        n_clusters=n_clusters,
+        n_init=1,
+        tol=1e-3,
+        random_state=42,
+    )
+    if init_method == "explicit":
+        rng = np.random.RandomState(1234)
+        init_idx = rng.choice(n_rows, size=n_clusters, replace=False)
+        common_kwargs["init"] = X_host[init_idx]
+    else:
+        common_kwargs["init_size"] = n_rows
+
+    host_model = cuml.KMeans(
+        streaming_batch_size=streaming_batch_size, **common_kwargs
+    )
+    host_model.fit(X_host, sample_weight=sample_weight_host)
+
+    dev_model = cuml.KMeans(streaming_batch_size=0, **common_kwargs)
+    dev_model.fit(X_dev, sample_weight=sample_weight_dev)
+
+    host_labels = cp.asnumpy(cp.asarray(host_model.labels_))
+    dev_labels = cp.asnumpy(cp.asarray(dev_model.labels_))
+    assert host_labels.shape == (n_rows,)
+    assert dev_labels.shape == (n_rows,)
+
+    if init_method == "explicit":
+        np.testing.assert_allclose(
+            cp.asnumpy(cp.asarray(host_model.cluster_centers_)),
+            cp.asnumpy(cp.asarray(dev_model.cluster_centers_)),
+            atol=0.1,
+            rtol=0.1,
+        )
+    np.testing.assert_allclose(
+        float(host_model.inertia_),
+        float(dev_model.inertia_),
+        rtol=1e-3,
+    )
+    assert adjusted_rand_score(dev_labels, host_labels) >= 0.97


### PR DESCRIPTION
Adds `device_buffer_samples` to single-GPU KMeans for host-resident input data.

For host-resident inputs, positive values select host-streamed fitting, avoiding an up-front full-device copy of `X`. Device-resident inputs continue to use the standard device path and ignore `device_buffer_samples`. The PR wires `device_buffer_samples` and `init_size` through C++ and Python, rejects positive `device_buffer_samples` values for multi-GPU use, computes labels and inertia in chunks for the host path, and adds weighted and unweighted parity tests against the existing device path.

Depends on https://github.com/NVIDIA/cuvs/pull/2328 (merged).

Follow-up: https://github.com/NVIDIA/cuvs/issues/2359

Closes https://github.com/rapidsai/cuml/issues/8202
