### PR TITLE
A few fixups to multi-gpu implementations

### DIFF
--- a/python/cuml/cuml/common/opg_data_utils_mg.pyx
+++ b/python/cuml/cuml/common/opg_data_utils_mg.pyx
@@ -37,10 +37,7 @@ def build_data_t(parts):
         data_f32 = new vector[floatData_t *]()
         for part in parts:
             data_f32.push_back(
-                new floatData_t(
-                    <float*><uintptr_t>(part.data.ptr),
-                    len(part),
-                )
+                new floatData_t(<float*><uintptr_t>(part.data.ptr), part.size)
             )
         return <uintptr_t> data_f32
 
@@ -48,10 +45,7 @@ def build_data_t(parts):
         data_f64 = new vector[doubleData_t *]()
         for part in parts:
             data_f64.push_back(
-                new doubleData_t(
-                    <double*><uintptr_t>(part.data.ptr),
-                    len(part),
-                )
+                new doubleData_t(<double*><uintptr_t>(part.data.ptr), part.size)
             )
         return <uintptr_t> data_f64
 

--- a/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
+++ b/python/cuml/cuml/linear_model/logistic_regression_mg.pyx
@@ -356,9 +356,9 @@ class LogisticRegressionMG(LogisticRegression):
             coef = coef[:-1].T
         else:
             if n_classes <= 2:
-                intercept = cp.zeros(shape=1)
+                intercept = cp.zeros(shape=1, dtype=X.dtype)
             else:
-                intercept = cp.zeros(shape=n_classes)
+                intercept = cp.zeros(shape=n_classes, dtype=X.dtype)
             coef = coef.T
 
         # Store fitted attributes

--- a/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -49,10 +49,7 @@ def _build_part_inputs(arrays, parts_to_ranks, m, n, local_rank, convert_dtype):
     cdef vector[floatData_t*] *local_parts = new vector[floatData_t*]()
     for arr in cupy_arrays:
         local_parts.push_back(
-            new floatData_t(
-                <float*><uintptr_t>arr.data.ptr,
-                arr.shape[0] * arr.shape[1] * sizeof(float),
-            )
+            new floatData_t(<float*><uintptr_t>arr.data.ptr, arr.size)
         )
 
     cdef vector[RankSizePair*] parts_to_ranks_vec

--- a/python/cuml/tests/dask/test_dask_logistic_regression.py
+++ b/python/cuml/tests/dask/test_dask_logistic_regression.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -213,6 +213,9 @@ def _test_lbfgs(
 
     lr_coef = array_to_numpy(lr.coef_)
     lr_intercept = array_to_numpy(lr.intercept_)
+
+    assert lr_coef.dtype == datatype
+    assert lr_intercept.dtype == datatype
 
     if penalty == "l2" or penalty is None:
         sk_solver = "lbfgs"


### PR DESCRIPTION
A few tiny fixups after #8241.

- Fix dtype of zero intercept in `LogisticRegressionMG` to match `dtype` of `X` (and adds a test).
- Fix setting of `totalSize` in a few places to be the correct `totalSize`. AFAICT this field is never read currently (so not a bug with any observable behavior), and the old code had the same mistake, but it's still good to fix it.

These were pointed out in a post-merge review: https://github.com/rapidsai/cuml/pull/8241#pullrequestreview-4467934477