### PR TITLE
Fix clang-tidy failures in CUDA 13.2 CI

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-modernize-*,-clang-diagnostic-#pragma-messages,-readability-identifier-naming,-clang-diagnostic-switch'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -19,6 +19,7 @@ VERSION_REGEX = re.compile(r"  LLVM version ([0-9.]+)")
 GPU_ARCH_REGEX = re.compile(r"sm_(\d+)")
 SPACES = re.compile(r"\s+")
 SEPARATOR = "-" * 16
+UNSUPPORTED_CLANG_FLAGS = ("-fno-merge-constants",)
 
 
 def _read_config_file(config_file):
@@ -180,6 +181,9 @@ def get_tidy_args(cmd, exe):
     # remove compilation and output targets from the original command
     remove_item_plus_one(command, "-c")
     remove_item_plus_one(command, "-o")
+    for flag in UNSUPPORTED_CLANG_FLAGS:
+        while remove_item(command, flag) >= 0:
+            pass
     if is_cuda:
         # replace nvcc's "-gencode ..." with clang's "--cuda-gpu-arch ..."
         archs = get_gpu_archs(command)


### PR DESCRIPTION
Fixes the clang-tidy PR job by:

- Remove the obsolete `AnalyzeTemporaryDtors` key from `.clang-tidy`, which clang-tidy 20 rejects.
- Filter the GCC-only `-fno-merge-constants` flag before invoking clang-tidy, since CUDA 13.2 toolchain commands can include it and clang treats it as an error under `WarningsAsErrors`.