### PR TITLE
Fix clang-tidy on conda

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -18,6 +18,14 @@ rapids-dependency-file-generator \
 rapids-mamba-retry env create --yes -f env.yaml -n clang_tidy
 # Temporarily allow unbound variables for conda activation.
 set +u && conda activate clang_tidy && set -u
+
+# clang-tidy parses the GCC compile command with clang. Newer conda compilers add
+# this GCC-only optimization flag, which clang reports as an error.
+for flags_var in CFLAGS CXXFLAGS; do
+  if [[ -n "${!flags_var:-}" ]]; then
+    export "${flags_var}=$(printf '%s' "${!flags_var}" | sed -E 's/(^|[[:space:]])-fno-merge-constants([[:space:]]|$)/ /g; s/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  fi
+done
 
 ./build.sh --configure-only libcuml
 


### PR DESCRIPTION
New conda-forge compilers have broken our `clang-tidy` support. Attempting a workaround here.