### PR TITLE
Remove stale sklearn example xfail

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -38,7 +38,3 @@
   tests:
   - "cluster::plot_coin_segmentation"
   - "cluster::plot_coin_ward_segmentation"
-- reason: numpy>=2.4 no longer accepts newshape as a keyword argument in np.reshape (deprecated in 2.1)
-  condition: numpy>=2.4
-  tests:
-  - "gaussian_process::plot_gpr_noisy"


### PR DESCRIPTION
Remove the strict xfail for `gaussian_process::plot_gpr_noisy`, which now XPASSes in latest-deps sklearn example CI with NumPy 2.4.

Closes #8260
