### PR TITLE
Xfail failing wikipedia sklearn example

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -38,3 +38,6 @@
   tests:
   - "cluster::plot_coin_segmentation"
   - "cluster::plot_coin_ward_segmentation"
+- reason: Upstream example fails without cuml.accel on this dependency stack
+  tests:
+  - "applications::wikipedia_principal_eigenvector"

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -39,5 +39,6 @@
   - "cluster::plot_coin_segmentation"
   - "cluster::plot_coin_ward_segmentation"
 - reason: Upstream example fails without cuml.accel on this dependency stack
+  condition: scikit-learn>=1.9
   tests:
   - "applications::wikipedia_principal_eigenvector"


### PR DESCRIPTION
Adds an xfail for the upstream scikit-learn `wikipedia_principal_eigenvector` example, which currently fails without `cuml.accel` on the latest dependency stack with a SciPy sparse-array operation error.

Closes https://github.com/rapidsai/cuml/issues/8276
