### PR TITLE
Pin upper bound for cython version

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,<3.3.0a0
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,<3.3.0a0
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,<3.3.0a0
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,<3.3.0a0
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -342,7 +342,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cython cython>=3.2.2
+          - &cython cython>=3.2.2,<3.3.0a0
           - &treelite treelite>=4.7.0,<5.0.0
   py_run_cuml:
     common:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -112,7 +112,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "certifi",
-    "cython>=3.2.2",
+    "cython>=3.2.2,<3.3.0a0",
     "hdbscan>=0.8.39",
     "hypothesis>=6.0,<7",
     "ipython>=7.32.0",
@@ -189,7 +189,7 @@ matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=4.0",
     "cuda-python>=13.0.1,<14.0",
-    "cython>=3.2.2",
+    "cython>=3.2.2,<3.3.0a0",
     "libcuml==26.8.*,>=0.0.0a0",
     "libnvforest==26.8.*,>=0.0.0a0",
     "libraft==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
Attempting to fix broken devcontainers CI (failing due to cython version). 
Currently downloads cython 3.3.0a: (https://github.com/rapidsai/cuml/actions/runs/28126511711/job/83291646790#step:9:567)

This PR pins an upper bound for the cython version.