### PR TITLE
Simplify `reflect` decorator

### DIFF
--- a/python/cuml/cuml/__init__.py
+++ b/python/cuml/cuml/__init__.py
@@ -16,6 +16,7 @@ else:
 import cupy
 from rmm.allocators.cupy import rmm_cupy_allocator
 
+import cuml.accel
 import cuml.feature_extraction
 from cuml._version import __git_commit__, __version__
 from cuml.cluster.agglomerative import AgglomerativeClustering

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -856,7 +856,7 @@ class ColumnTransformer(TransformerMixin, BaseComposition, BaseEstimator):
         self.fit_transform(X, y=y)
         return self
 
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit_transform(self, X, y=None) -> SparseCumlArray:
         """Fit all transformers, transform the data and concatenate results.
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -324,7 +324,7 @@ class MinMaxScaler(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "MinMaxScaler":
         """Compute the minimum and maximum to be used for later scaling.
 
@@ -347,7 +347,7 @@ class MinMaxScaler(TransformerMixin,
         self._reset()
         return self.partial_fit(X, y)
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def partial_fit(self, X, y=None) -> "MinMaxScaler":
         """Online computation of min and max on X for later scaling.
 
@@ -709,7 +709,7 @@ class StandardScaler(TransformerMixin,
         }
         return {**attrs, **super()._attrs_to_cpu(model)}
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "StandardScaler":
         """Compute the mean and std to be used for later scaling.
 
@@ -727,7 +727,7 @@ class StandardScaler(TransformerMixin,
         self._reset()
         return self.partial_fit(X, y)
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def partial_fit(self, X, y=None) -> "StandardScaler":
         """
         Online computation of mean and std on X for later scaling.
@@ -1024,7 +1024,7 @@ class MaxAbsScaler(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "MaxAbsScaler":
         """Compute the maximum absolute value to be used for later scaling.
 
@@ -1039,7 +1039,7 @@ class MaxAbsScaler(TransformerMixin,
         self._reset()
         return self.partial_fit(X, y)
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def partial_fit(self, X, y=None) -> "MaxAbsScaler":
         """
         Online computation of max absolute value of X for later scaling.
@@ -1287,7 +1287,7 @@ class RobustScaler(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "RobustScaler":
         """Compute the median and quantiles to be used for scaling.
 
@@ -1618,7 +1618,7 @@ class PolynomialFeatures(TransformerMixin,
             feature_names.append(name)
         return feature_names
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "PolynomialFeatures":
         """
         Compute number of output features.
@@ -1924,7 +1924,7 @@ class Normalizer(TransformerMixin,
         tags.requires_fit = False
         return tags
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "Normalizer":
         """Do nothing and return the estimator unchanged
 
@@ -2059,7 +2059,7 @@ class Binarizer(TransformerMixin,
         tags.requires_fit = False
         return tags
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "Binarizer":
         """Do nothing and return the estimator unchanged
 
@@ -2200,7 +2200,7 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
         # Needed for backported inspect.signature compatibility with PyPy
         pass
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, K, y=None) -> 'KernelCenterer':
         """Fit KernelCenterer
 
@@ -2458,7 +2458,7 @@ class QuantileTransformer(TransformerMixin,
         # https://github.com/numpy/numpy/issues/14685
         self.quantiles_ = np.array(cpu_np.maximum.accumulate(self.quantiles_))
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> 'QuantileTransformer':
         """Compute the quantiles used for transforming.
 
@@ -2887,7 +2887,7 @@ class PowerTransformer(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> 'PowerTransformer':
         """Estimate the optimal parameter lambda for each feature.
 
@@ -2908,7 +2908,7 @@ class PowerTransformer(TransformerMixin,
         self._fit(X, y=y, force_transform=False)
         return self
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit_transform(self, X, y=None) -> CumlArray:
         return self._fit(X, y, force_transform=True)
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -152,7 +152,7 @@ class KBinsDiscretizer(TransformerMixin,
             "strategy"
         ]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "KBinsDiscretizer":
         """
         Fit the estimator.

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -98,7 +98,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
                               " want to proceed regardless, set"
                               " 'check_inverse=False'.", UserWarning)
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "FunctionTransformer":
         """Fit transformer by checking X.
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -314,7 +314,7 @@ class SimpleImputer(SparseInputTagMixin, AllowNaNTagMixin,
 
         return X
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "SimpleImputer":
         """Fit the imputer on X.
 
@@ -701,7 +701,7 @@ class MissingIndicator(AllowNaNTagMixin,
 
         return missing_features_info[0]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "MissingIndicator":
         """Fit the transformer on X.
 
@@ -760,7 +760,7 @@ class MissingIndicator(AllowNaNTagMixin,
 
         return imputer_mask
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit_transform(self, X, y=None) -> SparseCumlArray:
         """Generate missing values indicator for X.
 

--- a/python/cuml/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cuml/cluster/agglomerative.pyx
@@ -138,7 +138,7 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
         self.c = c
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "AgglomerativeClustering":
         """
         Fit the hierarchical clustering from features.

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -298,7 +298,7 @@ class DBSCAN(InteropMixin,
         self.algorithm = algorithm
 
     @generate_docstring(skip_parameters_heading=True)
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(
         self,
         X,

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -909,7 +909,7 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
         self.prediction_data = True
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "HDBSCAN":
         """
         Fit HDBSCAN model from features.

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -530,7 +530,7 @@ class KMeans(InteropMixin,
         return self.n_clusters
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, sample_weight=None, *, convert_dtype=True) -> "KMeans":
         """
         Compute k-means clustering with X.

--- a/python/cuml/cuml/cluster/spectral_clustering.pyx
+++ b/python/cuml/cuml/cluster/spectral_clustering.pyx
@@ -267,7 +267,7 @@ class SpectralClustering(InteropMixin,
         self.fit(X, y=y)
         return self.labels_
 
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(self, X, y=None) -> "SpectralClustering":
         """Perform spectral clustering on ``X``.
 

--- a/python/cuml/cuml/covariance/empirical_covariance.py
+++ b/python/cuml/cuml/covariance/empirical_covariance.py
@@ -145,7 +145,7 @@ class EmpiricalCovariance(InteropMixin, Base):
         self.store_precision = store_precision
         self.assume_centered = assume_centered
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "EmpiricalCovariance":
         """Fit the maximum likelihood covariance estimator to X.
 

--- a/python/cuml/cuml/covariance/ledoit_wolf.py
+++ b/python/cuml/cuml/covariance/ledoit_wolf.py
@@ -226,7 +226,7 @@ class LedoitWolf(InteropMixin, Base):
         self.assume_centered = assume_centered
         self.block_size = block_size
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "LedoitWolf":
         """Fit the Ledoit-Wolf shrunk covariance model to X.
 

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -201,7 +201,7 @@ class IncrementalPCA(PCA):
         )
         self.batch_size = batch_size
 
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "IncrementalPCA":
         """
         Fit the model with X, using minibatches of size batch_size.

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -466,7 +466,7 @@ class PCA(InteropMixin,
         self.noise_variance_ = noise_variance
 
     @generate_docstring(X='dense_sparse')
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "PCA":
         """
         Fit the model with X. y is currently ignored.
@@ -507,7 +507,7 @@ class PCA(InteropMixin,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit_transform(self, X, y=None) -> CumlArray:
         """
         Fit the model with X and apply the dimensionality reduction on X.

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -287,7 +287,7 @@ class TruncatedSVD(InteropMixin,
         return self.components_.shape[0]
 
     @generate_docstring()
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(self, X, y=None) -> "TruncatedSVD":
         """
         Fit model on training cudf DataFrame X. y is currently ignored.
@@ -300,7 +300,7 @@ class TruncatedSVD(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit_transform(self, X, y=None, *, convert_dtype=True) -> CumlArray:
         """
         Fit model to X and perform dimensionality reduction on X.

--- a/python/cuml/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/cuml/experimental/linear_model/lars.pyx
@@ -200,7 +200,7 @@ class Lars(RegressorMixin, Base):
         return gram
 
     @generate_docstring(y="dense_anydtype")
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, convert_dtype=True) -> "Lars":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -17,7 +17,6 @@ from cupy.cuda import Stream
 from cuml.internals.array import CumlArray
 from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.global_settings import GlobalSettings
-from cuml.internals.validation import check_features
 
 __all__ = (
     "check_output_type",
@@ -427,15 +426,11 @@ def reflect(
         provide ``None`` to disable this inference entirely; in this case the
         output type is expected to be specified manually either internal or
         external to the method.
-    reset : bool or "type", default=False
-        If True, both the features and reflected type are reset on the estimator.
-        If ``"type"``, only the reflected type is reset on the estimator.
+    reset : bool, default=False
+        If True, the input type for reflection is reset on the estimator.
         Defaults to False, to not reset anything. Most estimators should set
         ``reset=True`` on any fit-like methods.
     """
-    # Local to avoid circular imports
-    import cuml.accel
-
     if func is None:
         return lambda func: reflect(
             func,
@@ -463,33 +458,22 @@ def reflect(
     if array is not None:
         array = _get_param(sig, array)
 
-    if reset not in (True, False, "type"):
-        raise ValueError(f"reset={reset!r} is not supported")
-
-    if (reset is not False) and (model is None or array is None):
+    if reset and (model is None or array is None):
         raise ValueError(
-            f"`reset={reset}` is not valid with `array=None` or `model=None`"
+            "`reset=True` is not valid with `array=None` or `model=None`"
         )
 
     @functools.wraps(func)
     def inner(*args, **kwargs):
-        # Accept list/tuple inputs when accelerator is active
-        accept_lists = cuml.accel.enabled()
-
         # Bind arguments
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
 
         model_arg = None if model is None else bound.arguments[model]
         array_arg = None if array is None else bound.arguments[array]
-        if accept_lists and isinstance(array_arg, (list, tuple)):
-            array_arg = np.asarray(array_arg)
-
         with enter_internal_context() as was_external:
-            if reset is not False:
+            if reset:
                 model_arg._set_output_type(array_arg)
-            if reset is True:
-                check_features(model_arg, array_arg, reset=True)
 
             res = func(*args, **kwargs)
 

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.py
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.py
@@ -292,7 +292,7 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         ).to_output("cupy")
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "KernelRidge":

--- a/python/cuml/cuml/linear_model/elastic_net.py
+++ b/python/cuml/cuml/linear_model/elastic_net.py
@@ -229,7 +229,7 @@ class ElasticNet(
         return cupyx.scipy.sparse.csr_matrix(self.coef_.to_output("cupy"))
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "ElasticNet":

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -309,7 +309,7 @@ class LinearRegression(InteropMixin,
         return coef, intercept
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "LinearRegression":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/linear_model/logistic_regression.py
@@ -295,7 +295,7 @@ class LogisticRegression(
         return l1_strength, l2_strength
 
     @generate_docstring(X="dense_sparse")
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "LogisticRegression":

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -174,7 +174,7 @@ class MBSGDClassifier(
         self.n_iter_no_change = n_iter_no_change
 
     @generate_docstring()
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(self, X, y, *, convert_dtype=True) -> "MBSGDClassifier":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -162,7 +162,7 @@ class MBSGDRegressor(
         self.n_iter_no_change = n_iter_no_change
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, *, convert_dtype=True) -> "MBSGDRegressor":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -356,7 +356,7 @@ class Ridge(InteropMixin,
         return coef, intercept, None
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "Ridge":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/manifold/spectral_embedding.pyx
+++ b/python/cuml/cuml/manifold/spectral_embedding.pyx
@@ -205,7 +205,7 @@ class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
         self.fit(X, y)
         return self.embedding_
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None) -> "SpectralEmbedding":
         """Fit the model from data in X.
 

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -567,7 +567,7 @@ class TSNE(InteropMixin,
     @generate_docstring(skip_parameters_heading=True,
                         X='dense_sparse',
                         convert_dtype_cast='np.float32')
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True, knn_graph=None) -> "TSNE":
         """
         Fit X into an embedded space.

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -1208,7 +1208,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         X="dense_sparse",
         skip_parameters_heading=True,
     )
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True, knn_graph=None) -> "UMAP":
         """
         Fit X into an embedded space.

--- a/python/cuml/cuml/multiclass/multiclass.py
+++ b/python/cuml/cuml/multiclass/multiclass.py
@@ -32,7 +32,7 @@ class _BaseMulticlassClassifier(ClassifierMixin, Base):
         return self.multiclass_estimator.classes_
 
     @generate_docstring(y="dense_anydtype")
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit(self, X, y) -> "_BaseMulticlassClassifier":
         """
         Fit a multiclass classifier.

--- a/python/cuml/cuml/neighbors/kernel_density.pyx
+++ b/python/cuml/cuml/neighbors/kernel_density.pyx
@@ -212,7 +212,7 @@ class KernelDensity(InteropMixin, Base):
         self.metric = metric
         self.metric_params = metric_params
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(
         self, X, y=None, sample_weight=None, *, convert_dtype=True
     ) -> "KernelDensity":

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -209,7 +209,7 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
         self.weights = weights
 
     @generate_docstring(convert_dtype_cast='np.float32')
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, *, convert_dtype=True) -> "KNeighborsClassifier":
         """
         Fit a GPU index for k-nearest neighbors classifier model.

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -211,7 +211,7 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
         self.weights = weights
 
     @generate_docstring(convert_dtype_cast='np.float32')
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, *, convert_dtype=True) -> "KNeighborsRegressor":
         """
         Fit a GPU index for k-nearest neighbors regression model.

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -609,7 +609,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
                 )
 
     @generate_docstring(X='dense_sparse')
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True) -> "NearestNeighbors":
         """
         Fit GPU index for performing nearest neighbor queries.

--- a/python/cuml/cuml/preprocessing/_label.py
+++ b/python/cuml/cuml/preprocessing/_label.py
@@ -109,7 +109,7 @@ class LabelEncoder(InteropMixin, Base):
             )
             raise ValueError(msg)
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     @generate_docstring(
         y="dense_anydtype",
         y_shape="n_samples",
@@ -138,7 +138,7 @@ class LabelEncoder(InteropMixin, Base):
         self.classes_ = classes
         return CumlArray(data=y, index=index)
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     @generate_docstring(
         y="dense_anydtype",
         y_shape="n_samples",

--- a/python/cuml/cuml/preprocessing/_target_encoder.py
+++ b/python/cuml/cuml/preprocessing/_target_encoder.py
@@ -203,7 +203,7 @@ class TargetEncoder(InteropMixin, Base):
         self.stat = stat
         self.multi_feature_mode = multi_feature_mode
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, *, fold_ids=None):
         """
         Fit a TargetEncoder instance to a set of categories

--- a/python/cuml/cuml/preprocessing/label.py
+++ b/python/cuml/cuml/preprocessing/label.py
@@ -396,7 +396,7 @@ class LabelBinarizer(InteropMixin, Base):
         self.fit_transform(y)
         return self
 
-    @cuml.internals.reflect(reset="type")
+    @cuml.internals.reflect(reset=True)
     def fit_transform(self, y):
         """
         Fit label binarizer and transform labels to binary labels.

--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -80,7 +80,7 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
         raise NotImplementedError
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None, *, convert_dtype=True):
         """Generate a random projection matrix."""
         # Use `mem_type=None` & `order=None` to minimize copies or transfers. We

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -311,7 +311,7 @@ class CD(FMajorInputTagMixin, Base):
         self.shuffle = shuffle
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, convert_dtype=True, sample_weight=None) -> "CD":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/solvers/qn.pyx
+++ b/python/cuml/cuml/solvers/qn.pyx
@@ -538,7 +538,7 @@ class QN(Base):
         self.penalty_normalized = penalty_normalized
 
     @generate_docstring(X="dense_sparse")
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "QN":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -408,7 +408,7 @@ class SGD(FMajorInputTagMixin, Base):
         self.n_iter_no_change = n_iter_no_change
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, *, convert_dtype=True) -> "SGD":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -223,7 +223,7 @@ class LinearSVC(InteropMixin, LinearClassifierMixin, ClassifierMixin, Base):
         self.multi_class = multi_class
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "LinearSVC":

--- a/python/cuml/cuml/svm/linear_svr.py
+++ b/python/cuml/cuml/svm/linear_svr.py
@@ -200,7 +200,7 @@ class LinearSVR(InteropMixin, LinearPredictMixin, RegressorMixin, Base):
         self.lbfgs_memory = lbfgs_memory
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype=True
     ) -> "LinearSVR":

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -346,7 +346,7 @@ class SVC(ClassifierMixin, SVMBase):
         return self
 
     @generate_docstring(y="dense_anydtype")
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "SVC":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/svm/svr.py
+++ b/python/cuml/cuml/svm/svr.py
@@ -132,7 +132,7 @@ class SVR(RegressorMixin, SVMBase):
     _cpu_class_path = "sklearn.svm.SVR"
 
     @generate_docstring()
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "SVR":
         """
         Fit the model with X and y.

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -91,7 +91,7 @@ class ImplementsCudaArrayInterface:
 class DummyEstimator(Base):
     X_ = CumlArrayDescriptor()
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X, y=None):
         X = check_inputs(self, X, reset=True)
         self.X_ = CumlArray(data=X)
@@ -526,7 +526,7 @@ def test_array_descriptor_cache_behavior():
 
 def test_decorators_set_cupy_ptds():
     class MyEstimator(Base):
-        @reflect(reset="type")
+        @reflect(reset=True)
         def fit(self, X, y=None):
             assert cp.cuda.get_current_stream() is cp.cuda.Stream.ptds
             return self

--- a/wiki/python/ESTIMATOR_GUIDE.md
+++ b/wiki/python/ESTIMATOR_GUIDE.md
@@ -95,7 +95,7 @@ At a high level, all cuML Estimators must:
       def __init__(self):
          ...
    ```
-5. Use the `@reflect` decorator on public API methods that return arrays. Use `@reflect(reset="type")` on fit-like methods in combination with the appropriate `cuml.internals.validation` helpers, and use plain `@reflect` on inference methods:
+5. Use the `@reflect` decorator on public API methods that return arrays. Use `@reflect(reset=True)` on fit-like methods in combination with the appropriate `cuml.internals.validation` helpers, and use plain `@reflect` on inference methods:
    ```python
    from cuml.internals import reflect
    from cuml.internals.array import CumlArray
@@ -103,7 +103,7 @@ At a high level, all cuML Estimators must:
 
    class MyEstimator(Base):
 
-      @reflect(reset="type")
+      @reflect(reset=True)
       def fit(self, X) -> "MyEstimator":
          ...
 
@@ -149,7 +149,7 @@ class MyEstimator(Base):
     def _get_param_names(cls):
         return super()._get_param_names() + ["extra_arg"]
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X) -> "MyEstimator":
         X_m = check_inputs(self, X, order="K", reset=True)
         # Replace this placeholder with estimator training.
@@ -164,7 +164,7 @@ class MyEstimator(Base):
         return X_m
 ```
 
-Fit-like methods should use `@reflect(reset="type")` in combination with the appropriate validation helpers. Pass `reset=True` to validation when fitting. Methods that return scalars usually do not need `@reflect`; use `@run_in_internal_context` only when the method calls reflected methods internally.
+Fit-like methods should use `@reflect(reset=True)` in combination with the appropriate validation helpers. Pass `reset=True` to validation when fitting. Methods that return scalars usually do not need `@reflect`; use `@run_in_internal_context` only when the method calls reflected methods internally.
 
 ## Background
 
@@ -207,7 +207,7 @@ from cuml.internals import reflect
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 
-@reflect(reset="type")
+@reflect(reset=True)
 def fit(self, X, y, *, convert_dtype=True):
     X_m, y_m = check_inputs(
         self,
@@ -378,7 +378,7 @@ class SampleEstimator(Base):
       # Init with a cupy array
       self.my_cupy_array_ = cp.zeros((10, 10))
 
-   @reflect(reset="type")
+   @reflect(reset=True)
    def fit(self, X):
       # reset=True on check_inputs sets n_features_in_ and feature_names_in_
       X_m = check_inputs(self, X, order="K", reset=True)
@@ -462,7 +462,7 @@ from cuml.internals.base import Base
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 class MyEstimator(Base):
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X):
         self.coef_ = check_inputs(self, X, order="K", reset=True)
         return self
@@ -476,7 +476,7 @@ class MyEstimator(Base):
 
 | Decorator Usage | When to Use |
 | :-------------- | :---------- |
-| `@reflect(reset="type")` | Fit-like methods that store `_input_type` through reflection while validation helpers set or check `n_features_in_`. |
+| `@reflect(reset=True)` | Fit-like methods that store `_input_type` through reflection while validation helpers set or check `n_features_in_`. |
 | `@reflect` | Transform/predict methods that return arrays. |
 | `@reflect(array=None)` | Methods with no array input (e.g., `forecast(nsteps)`). Uses fit-time input type. |
 
@@ -531,8 +531,8 @@ def support_(self):
 Use these rules when choosing a decorator:
 
 - If a public method returns array-like data directly to the user, use `@reflect`.
-- If a fit-like method calls validation helpers directly, use `@reflect(reset="type")` and pass `reset=True` to validation.
-- If a fit-like method needs feature metadata, use `@reflect(reset="type")` in combination with the appropriate validation helper functions.
+- If a fit-like method calls validation helpers directly, use `@reflect(reset=True)` and pass `reset=True` to validation.
+- If a fit-like method needs feature metadata, use `@reflect(reset=True)` in combination with the appropriate validation helper functions.
 - If a method has no array input and should use the fit-time input type for output conversion, use `@reflect(array=None)`.
 - If a method returns a scalar or needs to call reflected methods internally without automatic output conversion, use `@run_in_internal_context`.
 - If code inside an internal context needs user-facing output-type inference or needs to call an external estimator, temporarily use `exit_internal_context()`.
@@ -577,7 +577,7 @@ class TestEstimator(Base):
     def _method_int(self) -> int:
         return 1 if self.method_name == "type1" else 0
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X) -> "TestEstimator":
         X_m = check_inputs(self, X, order="K", reset=True)
         method = self._method_int()
@@ -596,7 +596,7 @@ class TestEstimator(Base):
 
         self.method_name = 1 if method_name == "type1" else 0
 
-    @reflect(reset="type")
+    @reflect(reset=True)
     def fit(self, X) -> "TestEstimator":
         X_m = check_inputs(self, X, order="K", reset=True)
 


### PR DESCRIPTION
Now that all modules have been converted to the new ingest system, we can remove `reflect(reset="type")` and revert to `reflect(reset=True)` everywhere. The meaning of `reflect(reset=True)` is the old meaning of `reflect(reset="type")`, which was only around to let us migrate incrementally.

- Renames `reflect(reset="type")`  back to `reflect(reset=True)` everywhere.
- Removes all handling of `check_features` in the `reflect` decorator.
- Removes no longer needed `cuml.accel` path for handling list/tuple inputs in the `reflect` decorator. Those just work now, and don't require extra handling or duplicate conversion here.
- Updates the `ESTIMATOR_GUIDE.md` to reflect these changes.

Part of #7428.