### PR TITLE
Remove xfail markers for cuml.accel examples

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-examples.yaml
@@ -3,18 +3,6 @@
   strict: false
   tests:
   - "decomposition::plot_faces_decomposition"
-- reason: 'cuml.accel bug: native crash in cuml PCA'
-  marker: cuml_accel_bugs
-  tests:
-  - "decomposition::plot_pca_vs_fa_model_selection"
-- reason: 'cuml.accel bug: treelite export does not set classes_ on DecisionTreeClassifier sub-estimators'
-  marker: cuml_accel_bugs
-  tests:
-  - "ensemble::plot_forest_iris"
-- reason: 'cuml.accel bug: unhashable kernel object passed to pairwise_kernels'
-  marker: cuml_accel_bugs
-  tests:
-  - "gaussian_process::plot_compare_gpr_krr"
 - reason: 'Missing optional dependency: plotly'
   strict: false
   tests:


### PR DESCRIPTION
This PR removes xfail markers that caused failures in nightly test: https://github.com/rapidsai/cuml/actions/runs/28229406180/job/83629207110

These tests pass now because of the following PRs merged yesterday:
- https://github.com/rapidsai/cuml/pull/8290: Fixed `plot_pca_vs_fa_model_selection` and `plot_compare_gpr_krr` because it adds CPU fallbacks
- https://github.com/rapidsai/cuml/pull/8291: Fixed `plot_forest_iris`
