### PR TITLE
Deprecate `convert_dtype`

### DIFF
--- a/python/cuml/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cuml/cluster/agglomerative.pyx
@@ -139,7 +139,7 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "AgglomerativeClustering":
+    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "AgglomerativeClustering":
         """
         Fit the hierarchical clustering from features.
         """

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -306,7 +306,7 @@ class DBSCAN(InteropMixin,
         sample_weight=None,
         *,
         out_dtype="int32",
-        convert_dtype=True
+        convert_dtype="deprecated"
     ) -> "DBSCAN":
         """
         Perform DBSCAN clustering from features.
@@ -487,7 +487,7 @@ class DBSCAN(InteropMixin,
         sample_weight=None,
         *,
         out_dtype="int32",
-        convert_dtype=True,
+        convert_dtype="deprecated",
     ) -> CumlArray:
         """
         Performs clustering on X and returns cluster labels.

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -910,7 +910,7 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "HDBSCAN":
+    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "HDBSCAN":
         """
         Fit HDBSCAN model from features.
         """
@@ -1184,7 +1184,12 @@ def all_points_membership_vectors(clusterer, int batch_size=4096):
 
 
 @reflect(model="clusterer", array="points_to_predict")
-def membership_vector(clusterer, points_to_predict, int batch_size=4096, convert_dtype=True):
+def membership_vector(
+    clusterer,
+    points_to_predict,
+    int batch_size=4096,
+    convert_dtype="deprecated",
+):
     """
     Predict soft cluster membership. The result produces a vector
     for each point in ``points_to_predict`` that gives a probability that
@@ -1264,7 +1269,7 @@ def membership_vector(clusterer, points_to_predict, int batch_size=4096, convert
 
 
 @reflect(model="clusterer", array="points_to_predict")
-def approximate_predict(clusterer, points_to_predict, convert_dtype=True):
+def approximate_predict(clusterer, points_to_predict, convert_dtype="deprecated"):
     """Predict the cluster label of new points. The returned labels
     will be those of the original clustering found by ``clusterer``,
     and therefore are not (necessarily) the cluster labels that would

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -531,7 +531,7 @@ class KMeans(InteropMixin,
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y=None, sample_weight=None, *, convert_dtype=True) -> "KMeans":
+    def fit(self, X, y=None, sample_weight=None, *, convert_dtype="deprecated") -> "KMeans":
         """
         Compute k-means clustering with X.
 
@@ -610,7 +610,7 @@ class KMeans(InteropMixin,
         """
         return self.fit(X, sample_weight=sample_weight).labels_
 
-    def _predict_labels_inertia(self, X, convert_dtype=True, sample_weight=None):
+    def _predict_labels_inertia(self, X, convert_dtype="deprecated", sample_weight=None):
         """
         Predict the closest cluster each sample in X belongs to.
 
@@ -621,10 +621,12 @@ class KMeans(InteropMixin,
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
             ndarray, cuda array interface compliant array like CuPy
 
-        convert_dtype : bool, optional (default = False)
-            When set to True, the predict method will, when necessary, convert
-            the input to the data type which was used to train the model. This
-            will increase memory used for the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         sample_weight : array-like (device or host) shape = (n_samples,), default=None # noqa
             The weights for each observation in X. If None, all observations
@@ -674,7 +676,7 @@ class KMeans(InteropMixin,
         self,
         X,
         *,
-        convert_dtype=True,
+        convert_dtype="deprecated",
     ) -> CumlArray:
         """
         Predict the closest cluster each sample in X belongs to.
@@ -688,7 +690,7 @@ class KMeans(InteropMixin,
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
     @reflect
-    def transform(self, X, *, convert_dtype=True) -> CumlArray:
+    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Transform X to a cluster-distance space.
 
@@ -784,7 +786,7 @@ class KMeans(InteropMixin,
                                                         of X on the K-means \
                                                         objective.'})
     @run_in_internal_context
-    def score(self, X, y=None, sample_weight=None, *, convert_dtype=True):
+    def score(self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"):
         """
         Opposite of the value of X on the K-means objective.
 
@@ -801,7 +803,7 @@ class KMeans(InteropMixin,
                                        'shape': '(n_samples, n_clusters)'})
     @reflect
     def fit_transform(
-        self, X, y=None, sample_weight=None, *, convert_dtype=False
+        self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"
     ) -> CumlArray:
         """
         Compute clustering and transform X to cluster-distance space.

--- a/python/cuml/cuml/common/doc_utils.py
+++ b/python/cuml/cuml/common/doc_utils.py
@@ -32,46 +32,38 @@ from inspect import signature
 
 _parameters_docstrings = {
     "dense": "{name} : array-like (device or host) shape = {shape}\n"
-    "    Dense matrix. If datatype is other than floats or doubles,\n"
-    "    then the data will be converted to float which increases memory\n"
-    "    utilization. Set the parameter convert_dtype to False to avoid \n"
-    "    this, then the method will throw an error instead.  \n"
+    "    Dense matrix with dtype float32 or float64.\n"
     "    Acceptable formats: CUDA array interface compliant objects like\n"
     "    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas\n"
     "    DataFrame/Series.",
     "dense_anydtype": "{name} : array-like (device or host) shape = {shape}\n"
-    "    Dense matrix of any dtype.\n"
+    "    Dense matrix with any dtype.\n"
     "    Acceptable formats: CUDA array interface compliant objects like\n"
     "    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas\n"
     "    DataFrame/Series.",
     "dense_intdtype": "{name} : array-like (device or host) shape = {shape}\n"
-    "    Dense matrix of type np.int32.\n"
+    "    Dense matrix with dtype int32.\n"
     "    Acceptable formats: CUDA array interface compliant objects like\n"
     "    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas\n"
     "    DataFrame/Series.",
     "sparse": "{name} : sparse array-like (device) shape = {shape}\n"
-    "    Dense matrix containing floats or doubles.\n"
+    "    Sparse matrix with dtype float32 or float64.\n"
     "    Acceptable formats: cupyx.scipy.sparse",
     "dense_sparse": "{name} : array-like (device or host) shape = {shape}\n"
-    "    Dense or sparse matrix containing floats or doubles.\n"
+    "    Dense or sparse matrix with dtype float32 or float64.\n"
     "    Acceptable dense formats: CUDA array interface compliant objects like\n"  # noqa
     "    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas\n"
     "    DataFrame/Series.",
-    "convert_dtype_fit": "convert_dtype : bool, optional (default = {default})\n"
-    "    When set to True, the train method will, when necessary, convert\n"
-    "    y to be the same data type as X if they differ. This\n"
-    "    will increase memory used for the method.",
-    "convert_dtype_other": "convert_dtype : bool, optional (default = {default})\n"
-    "    When set to True, the {func_name} method will, when necessary,\n"
-    "    convert the input to the data type which was used to train the\n"
-    "    model. This will increase memory used for the method.",
-    "convert_dtype_single": "convert_dtype : bool, optional (default = {default})\n"
-    "    When set to True, the method will automatically\n"
-    "    convert the inputs to {dtype}.",
+    "convert_dtype": "convert_dtype : bool, optional (default = 'deprecated')\n"
+    "    .. deprecated:: 26.08\n"
+    "        `convert_dtype` was deprecated in version 26.08 and will be removed\n"
+    "        in version 26.10. cuML only copies input arrays when necessary\n"
+    "        (e.g. to unify dtypes), there is no reason to provide this keyword\n"
+    "        going forward.\n",
     "sample_weight": "sample_weight : array-like (device or host) shape = (n_samples,), default={default}\n"  # noqa
     "    The weights for each observation in X. If None, all observations\n"
     "    are assigned equal weight.\n"
-    "    Acceptable dense formats: CUDA array interface compliant objects like\n"  # noqa
+    "    Acceptable formats: CUDA array interface compliant objects like\n"  # noqa
     "    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas\n"
     "    DataFrame/Series.",  # noqa
     "return_sparse": "return_sparse : bool, optional (default = {default})\n"
@@ -114,7 +106,12 @@ _return_values_docstrings = {
 
 _return_values_possible_values = ["name", "type", "shape", "description"]
 
-_simple_params = ["return_sparse", "sparse_tol", "sample_weight"]
+_simple_params = [
+    "convert_dtype",
+    "return_sparse",
+    "sparse_tol",
+    "sample_weight",
+]
 
 
 def generate_docstring(
@@ -122,7 +119,6 @@ def generate_docstring(
     X_shape="(n_samples, n_features)",
     y="dense",
     y_shape="(n_samples, 1)",
-    convert_dtype_cast=False,
     skip_parameters=[],
     skip_parameters_heading=False,
     prepend_parameters=True,
@@ -152,7 +148,7 @@ def generate_docstring(
     # anything, and the decorator auto detects the parameters and defaults
 
     @generate_docstring()
-    def fit(self, X, y, convert_dtype=True):
+    def fit(self, X, y):
 
     # for a function that takes X as dense or sparse
 
@@ -179,12 +175,6 @@ def generate_docstring(
         dense_anydtype, dense_intdtype, sparse, dense_sparse
     y_shape : str (default = '(n_samples, 1)')
         Shape of variable y
-    convert_dtype_cast : Boolean or str (default = False)
-        If not false, use it to specify when convert_dtype is used to convert
-        to a single specific dtype (as opposed to converting the dtype of one
-        variable to the dtype of another for example). Example of this is how
-        NearestNeighbors and UMAP use convert_dtype to convert inputs to
-        np.float32.
     skip_parameters : list of str (default = [])
         Use if you want the decorator to skip generating a docstring entry
         for a specific parameter
@@ -240,36 +230,10 @@ def generate_docstring(
                 func.__doc__ += _parameters_docstrings[y].format(
                     name=par, shape=y_shape
                 )
-
-            # convert_dtype requires some magic to distinguish
-            # whether we use the fit version or the version
-            # for the other methods.
-            elif par == "convert_dtype" and par not in skip_parameters:
-                if not convert_dtype_cast:
-                    if func.__name__ == "fit":
-                        k = "convert_dtype_fit"
-                    else:
-                        k = "convert_dtype_other"
-
-                    func.__doc__ += _parameters_docstrings[k].format(
-                        default=params["convert_dtype"].default,
-                        func_name=func.__name__,
-                    )
-
-                else:
-                    func.__doc__ += _parameters_docstrings[
-                        "convert_dtype_single"
-                    ].format(
-                        default=params["convert_dtype"].default,
-                        dtype=convert_dtype_cast,
-                    )
-
-            # All other parameters only take a default (for now).
-            else:
-                if par in _simple_params:
-                    func.__doc__ += _parameters_docstrings[par].format(
-                        default=params[par].default
-                    )
+            elif par in _simple_params:
+                func.__doc__ += _parameters_docstrings[par].format(
+                    default=params[par].default
+                )
             func.__doc__ += "\n\n"
 
         if skip_parameters_heading and prepend_parameters:
@@ -324,8 +288,7 @@ def insert_into_docstring(parameters=False, return_values=False):
                            return_values=[('dense', '(n_samples, n_features)'),
                                           ('dense',
                                            '(n_samples, n_features)')])
-    def kneighbors(self, X=None, n_neighbors=None, return_distance=True,
-                   convert_dtype=True):
+    def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         \"""
         Query the GPU index for the k nearest neighbors of column vectors in X.
 
@@ -339,10 +302,6 @@ def insert_into_docstring(parameters=False, return_values=False):
 
         return_distance: Boolean
             If False, distances will not be returned
-
-        convert_dtype : bool, optional (default = True)
-            When set to True, the kneighbors method will automatically
-            convert the inputs to np.float32.
 
         Returns
         -------

--- a/python/cuml/cuml/covariance/empirical_covariance.py
+++ b/python/cuml/cuml/covariance/empirical_covariance.py
@@ -146,7 +146,9 @@ class EmpiricalCovariance(InteropMixin, Base):
         self.assume_centered = assume_centered
 
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "EmpiricalCovariance":
+    def fit(
+        self, X, y=None, *, convert_dtype="deprecated"
+    ) -> "EmpiricalCovariance":
         """Fit the maximum likelihood covariance estimator to X.
 
         Parameters
@@ -156,8 +158,12 @@ class EmpiricalCovariance(InteropMixin, Base):
             and `n_features` is the number of features.
         y : Ignored
             Not used, present for API consistency.
-        convert_dtype : bool, default=True
-            If True, convert the input data to float32.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         Returns
         -------

--- a/python/cuml/cuml/covariance/ledoit_wolf.py
+++ b/python/cuml/cuml/covariance/ledoit_wolf.py
@@ -227,7 +227,7 @@ class LedoitWolf(InteropMixin, Base):
         self.block_size = block_size
 
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "LedoitWolf":
+    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "LedoitWolf":
         """Fit the Ledoit-Wolf shrunk covariance model to X.
 
         Parameters
@@ -237,8 +237,12 @@ class LedoitWolf(InteropMixin, Base):
             and `n_features` is the number of features.
         y : Ignored
             Not used, present for API consistency.
-        convert_dtype : bool, default=True
-            If True, convert the input data to float32.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         Returns
         -------

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -155,7 +155,7 @@ class RandomForestClassifier(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(self, X, y, convert_dtype=False, broadcast_data=False):
+    def fit(self, X, y, convert_dtype="deprecated", broadcast_data=False):
         """
         Fit the input data with a Random Forest classifier
 
@@ -196,10 +196,13 @@ class RandomForestClassifier(
         y : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, 1)
             Labels of training examples.
             **y must be partitioned the same way as X**
-        convert_dtype : bool, optional (default = False)
-            When set to True, the fit method will, when necessary, convert
-            y to be of dtype int32. This will increase memory used for
-            the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         broadcast_data : bool, optional (default = False)
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
@@ -230,7 +233,7 @@ class RandomForestClassifier(
         self,
         X,
         threshold=0.5,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -247,10 +250,13 @@ class RandomForestClassifier(
             (n_samples, n_features).
         threshold : float (default = 0.5)
             Threshold used for classification.
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will, when necessary, convert
-            the input to the data type which was used to train the model. This
-            will increase memory used for the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.

--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -138,7 +138,7 @@ class RandomForestRegressor(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(self, X, y, convert_dtype=False, broadcast_data=False):
+    def fit(self, X, y, convert_dtype="deprecated", broadcast_data=False):
         """
         Fit the input data with a Random Forest regression model
 
@@ -175,10 +175,13 @@ class RandomForestRegressor(
         y : Dask cuDF DataFrame or CuPy backed Dask Array (n_rows, 1)
             Labels of training examples.
             **y must be partitioned the same way as X**
-        convert_dtype : bool, optional (default = False)
-            When set to True, the fit method will, when necessary, convert
-            y to be the same data type as X if they differ. This will increase
-            memory used for the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         broadcast_data : bool, optional (default = False)
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
@@ -197,7 +200,7 @@ class RandomForestRegressor(
     def predict(
         self,
         X,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -212,10 +215,13 @@ class RandomForestRegressor(
         X : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, n_features)
             Distributed dense matrix (floats or doubles) of shape
             (n_samples, n_features).
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will, when necessary, convert
-            the input to the data type which was used to train the model. This
-            will increase memory used for the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.

--- a/python/cuml/cuml/dask/manifold/umap.py
+++ b/python/cuml/cuml/dask/manifold/umap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -87,7 +87,7 @@ class UMAP(BaseEstimator, DelayedTransformMixin):
 
         self._set_internal_model(model)
 
-    def transform(self, X, convert_dtype=True):
+    def transform(self, X, convert_dtype="deprecated"):
         """
         Transform X into the existing embedded space and return that
         transformed output.

--- a/python/cuml/cuml/dask/neighbors/kneighbors_classifier.py
+++ b/python/cuml/cuml/dask/neighbors/kneighbors_classifier.py
@@ -162,7 +162,7 @@ class KNeighborsClassifier(NearestNeighbors):
                 convert_dtype,
             )
 
-    def predict(self, X, convert_dtype=True):
+    def predict(self, X, convert_dtype="deprecated"):
         """
         Predict labels for a query from previously stored index
         and index labels.
@@ -174,9 +174,12 @@ class KNeighborsClassifier(NearestNeighbors):
             Query data.
             Acceptable formats: dask cuDF, dask CuPy/NumPy/Numba Array
 
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will automatically
-            convert the data to the right formats.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         Returns
         -------
@@ -274,7 +277,7 @@ class KNeighborsClassifier(NearestNeighbors):
 
         return to_output(out_futures, self.datatype).squeeze()
 
-    def score(self, X, y, convert_dtype=True):
+    def score(self, X, y, convert_dtype="deprecated"):
         """
         Predict labels for a query from previously stored index
         and index labels.
@@ -307,7 +310,7 @@ class KNeighborsClassifier(NearestNeighbors):
         mean_match = matched.mean()
         return float(mean_match.compute())
 
-    def predict_proba(self, X, convert_dtype=True):
+    def predict_proba(self, X, convert_dtype="deprecated"):
         """
         Provide score by comparing predictions and ground truth.
 
@@ -317,9 +320,12 @@ class KNeighborsClassifier(NearestNeighbors):
             Query data.
             Acceptable formats: dask cuDF, dask CuPy/NumPy/Numba Array
 
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will automatically
-            convert the data to the right formats.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         Returns
         -------

--- a/python/cuml/cuml/dask/neighbors/kneighbors_regressor.py
+++ b/python/cuml/cuml/dask/neighbors/kneighbors_regressor.py
@@ -111,7 +111,7 @@ class KNeighborsRegressor(NearestNeighbors):
             convert_dtype,
         )
 
-    def predict(self, X, convert_dtype=True):
+    def predict(self, X, convert_dtype="deprecated"):
         """
         Predict outputs for a query from previously stored index
         and outputs.
@@ -123,9 +123,12 @@ class KNeighborsRegressor(NearestNeighbors):
             Query data.
             Acceptable formats: dask cuDF, dask CuPy/NumPy/Numba Array
 
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will automatically
-            convert the data to the right formats.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         Returns
         -------
@@ -240,7 +243,7 @@ class KNeighborsRegressor(NearestNeighbors):
         -------
         score
         """
-        y_pred_plain = self.predict(X, convert_dtype=True)
+        y_pred_plain = self.predict(X)
         if not isinstance(y_pred_plain, da.Array):
             y_pred = y_pred_plain.to_dask_array(lengths=True)
         else:

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -202,7 +202,9 @@ class IncrementalPCA(PCA):
         self.batch_size = batch_size
 
     @cuml.internals.reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "IncrementalPCA":
+    def fit(
+        self, X, y=None, *, convert_dtype="deprecated"
+    ) -> "IncrementalPCA":
         """
         Fit the model with X, using minibatches of size batch_size.
 
@@ -396,7 +398,7 @@ class IncrementalPCA(PCA):
         return self
 
     @cuml.internals.reflect
-    def transform(self, X, *, convert_dtype=False) -> CumlArray:
+    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Apply dimensionality reduction to X.
 
@@ -406,19 +408,19 @@ class IncrementalPCA(PCA):
 
         Parameters
         ----------
-
         X : array-like or sparse matrix, shape (n_samples, n_features)
             New data, where n_samples is the number of samples
             and n_features is the number of features.
 
-        convert_dtype : bool, optional (default = False)
-            When set to True, the transform method will automatically
-            convert the input to the data type which was used to train the
-            model. This will increase memory used for the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         Returns
         -------
-
         X_new : array-like, shape (n_samples, n_components)
 
         """

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -467,7 +467,7 @@ class PCA(InteropMixin,
 
     @generate_docstring(X='dense_sparse')
     @cuml.internals.reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "PCA":
+    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "PCA":
         """
         Fit the model with X. y is currently ignored.
 
@@ -584,7 +584,7 @@ class PCA(InteropMixin,
         self,
         X,
         *,
-        convert_dtype=False,
+        convert_dtype="deprecated",
         return_sparse=False,
         sparse_tol=1e-10,
     ) -> CumlArray:
@@ -679,7 +679,7 @@ class PCA(InteropMixin,
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.reflect
-    def transform(self, X, *, convert_dtype=True) -> CumlArray:
+    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Apply dimensionality reduction to X.
 

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -301,7 +301,7 @@ class TruncatedSVD(InteropMixin,
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.reflect(reset=True)
-    def fit_transform(self, X, y=None, *, convert_dtype=True) -> CumlArray:
+    def fit_transform(self, X, y=None, *, convert_dtype="deprecated") -> CumlArray:
         """
         Fit model to X and perform dimensionality reduction on X.
         y is currently ignored.
@@ -398,7 +398,7 @@ class TruncatedSVD(InteropMixin,
                                        'description': 'X in original space',
                                        'shape': '(n_samples, n_features)'})
     @cuml.internals.reflect
-    def inverse_transform(self, X, *, convert_dtype=False) -> CumlArray:
+    def inverse_transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Transform X back to its original space.
         Returns X_original whose transform would be X.
@@ -462,7 +462,7 @@ class TruncatedSVD(InteropMixin,
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
     @cuml.internals.reflect
-    def transform(self, X, *, convert_dtype=True) -> CumlArray:
+    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Perform dimensionality reduction on X.
 

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -237,22 +237,13 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         message="fit RF-Classifier @randomforestclassifier.pyx",
         domain="cuml_python",
     )
-    @generate_docstring(
-        skip_parameters_heading=True,
-        y="dense_intdtype",
-        convert_dtype_cast="np.float32",
-    )
+    @generate_docstring(y="dense_intdtype")
     @cuml.internals.reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "RandomForestClassifier":
+    def fit(
+        self, X, y, *, convert_dtype="deprecated"
+    ) -> "RandomForestClassifier":
         """
         Perform Random Forest Classification on the input data
-
-        Parameters
-        ----------
-        convert_dtype : bool, optional (default = True)
-            When set to True, the fit method will, when necessary, convert
-            y to be of dtype int32. This will increase memory used for
-            the method.
         """
         X, y, classes = check_inputs(
             self,
@@ -283,7 +274,7 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         X,
         *,
         threshold=0.5,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -296,9 +287,13 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         X : {}
         threshold : float (default = 0.5)
             Threshold used for classification.
-        convert_dtype : bool (default = True)
-            When True, automatically convert the input to the data type used
-            to train the model. This may increase memory usage.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Forest layout for GPU inference. Options: 'depth_first', 'layered',
             'breadth_first'.
@@ -343,7 +338,7 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         self,
         X,
         *,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -354,9 +349,13 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         Parameters
         ----------
         X : {}
-        convert_dtype : bool (default = True)
-            When True, automatically convert the input to the data type used
-            to train the model. This may increase memory usage.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -399,7 +398,7 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         self,
         X,
         *,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -410,9 +409,13 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         Parameters
         ----------
         X : {}
-        convert_dtype : bool (default = True)
-            When True, automatically convert the input to the data type used
-            to train the model. This may increase memory usage.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -458,7 +461,7 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         y,
         *,
         threshold=0.5,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -472,9 +475,13 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         y : {}
         threshold : float (default = 0.5)
             Threshold used for classification predictions
-        convert_dtype : bool (default = True)
-            When True, automatically convert the input to the data type used
-            to train the model. This may increase memory usage.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.

--- a/python/cuml/cuml/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/ensemble/randomforestregressor.py
@@ -201,7 +201,9 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
     )
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "RandomForestRegressor":
+    def fit(
+        self, X, y, *, convert_dtype="deprecated"
+    ) -> "RandomForestRegressor":
         """
         Perform Random Forest Regression on the input data
 
@@ -230,7 +232,7 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         self,
         X,
         *,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -241,10 +243,13 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         Parameters
         ----------
         X : {}
-        convert_dtype : bool, optional (default = True)
-            When set to True, the predict method will, when necessary, convert
-            the input to the data type which was used to train the model. This
-            will increase memory used for the method.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -300,7 +305,7 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         X,
         y,
         *,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -312,9 +317,13 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         ----------
         X : {}
         y : {}
-        convert_dtype : bool (default = True)
-            When True, automatically convert the input to the data type used
-            to train the model. This may increase memory usage.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
+
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.

--- a/python/cuml/cuml/experimental/linear_model/lars.pyx
+++ b/python/cuml/cuml/experimental/linear_model/lars.pyx
@@ -201,7 +201,7 @@ class Lars(RegressorMixin, Base):
 
     @generate_docstring(y="dense_anydtype")
     @reflect(reset=True)
-    def fit(self, X, y, convert_dtype=True) -> "Lars":
+    def fit(self, X, y, convert_dtype="deprecated") -> "Lars":
         """
         Fit the model with X and y.
 
@@ -339,7 +339,7 @@ class Lars(RegressorMixin, Base):
         }
     )
     @reflect
-    def predict(self, X, convert_dtype=True) -> CumlArray:
+    def predict(self, X, convert_dtype="deprecated") -> CumlArray:
         """Predicts `y` values for `X`."""
         check_is_fitted(self)
 

--- a/python/cuml/cuml/explainer/tree_shap.pyx
+++ b/python/cuml/cuml/explainer/tree_shap.pyx
@@ -155,7 +155,7 @@ cdef class TreeExplainer:
     cdef object num_class
     cdef object data
 
-    def __init__(self, *, model, data=None, convert_dtype=True):
+    def __init__(self, *, model, data=None, convert_dtype="deprecated"):
         if data is not None:
             data = check_array(
                 data,
@@ -213,7 +213,7 @@ cdef class TreeExplainer:
         # Process Treelite model to extract path info
         self.path_info = extract_path_info(tl_handle)
 
-    def shap_values(self, X, convert_dtype=True):
+    def shap_values(self, X, convert_dtype="deprecated"):
         """
         Estimate the SHAP values for a set of samples. For a given row, the
         SHAP values plus the `expected_value` attribute sum up to the raw
@@ -288,7 +288,12 @@ cdef class TreeExplainer:
             preds = preds[:, :-1]
         return preds
 
-    def shap_interaction_values(self, X, method='shapley-interactions', convert_dtype=True):
+    def shap_interaction_values(
+        self,
+        X,
+        method='shapley-interactions',
+        convert_dtype="deprecated",
+    ):
         """
         Estimate the SHAP interaction values for a set of samples. For a
         given row, the SHAP values plus the `expected_value` attribute sum

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -571,9 +571,7 @@ def check_array(
         output. If the input doesn't have a supported dtype, it will be
         converted to the first listed dtype.
     convert_dtype : bool, default="deprecated"
-
         .. deprecated:: 26.08
-
             `convert_dtype` was deprecated in version 26.08 and will be removed
             in version 26.10. cuML only copies input arrays when necessary
             (e.g. to unify dtypes), there is no reason to provide this keyword
@@ -1068,9 +1066,7 @@ def check_y(
         dtypes to enforce a dtype for the output. If the input doesn't have a
         supported dtype, it will be converted to the first listed dtype.
     convert_dtype : bool, default="deprecated"
-
         .. deprecated:: 26.08
-
             `convert_dtype` was deprecated in version 26.08 and will be removed
             in version 26.10. cuML only copies input arrays when necessary
             (e.g. to unify dtypes), there is no reason to provide this keyword
@@ -1330,9 +1326,7 @@ def check_sample_weight(
         output. If the input doesn't have a supported dtype, it will be
         converted to the first listed dtype.
     convert_dtype : bool, default="deprecated"
-
         .. deprecated:: 26.08
-
             `convert_dtype` was deprecated in version 26.08 and will be removed
             in version 26.10. cuML only copies input arrays when necessary
             (e.g. to unify dtypes), there is no reason to provide this keyword
@@ -1468,9 +1462,7 @@ def check_inputs(
         The dtype(s) to support for sample_weight. If not specified, defaults
         to the output dtype of ``X``.
     convert_dtype : bool, default="deprecated"
-
         .. deprecated:: 26.08
-
             `convert_dtype` was deprecated in version 26.08 and will be removed
             in version 26.10. cuML only copies input arrays when necessary
             (e.g. to unify dtypes), there is no reason to provide this keyword

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -538,7 +538,7 @@ def check_array(
     accept_sparse=False,
     accept_large_sparse=False,
     dtype=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     copy=False,
@@ -570,9 +570,15 @@ def check_array(
         Pass a dtype or a list of supported dtypes to enforce a dtype for the
         output. If the input doesn't have a supported dtype, it will be
         converted to the first listed dtype.
-    convert_dtype : bool, default=True
-        Whether to support dtype conversion. If False, an error will be raised
-        if the input isn't a supported dtype.
+    convert_dtype : bool, default="deprecated"
+
+        .. deprecated:: 26.08
+
+            `convert_dtype` was deprecated in version 26.08 and will be removed
+            in version 26.10. cuML only copies input arrays when necessary
+            (e.g. to unify dtypes), there is no reason to provide this keyword
+            going forward.
+
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray`` if dense, or a ``cupyx.scipy.sparse.spmatrix`` if
@@ -627,6 +633,15 @@ def check_array(
     if order not in ("F", "C", "A", None):
         raise ValueError(f"Unsupported {order=!r}")
 
+    if convert_dtype != "deprecated":
+        warnings.warn(
+            "`convert_dtype` was deprecated in version 26.08 and will be "
+            "removed in version 26.10. cuML only copies input arrays when "
+            "necessary (e.g. to unify dtypes), there is no reason to "
+            "provide this keyword going forward.",
+            FutureWarning,
+        )
+
     if dtype is not None:
         if not isinstance(dtype, (list, tuple)):
             dtype = [dtype]
@@ -670,7 +685,7 @@ def check_array(
         if dtype is None:
             dtype = array_dtype
         elif array_dtype not in dtype:
-            if convert_dtype:
+            if convert_dtype is not False:
                 # Convert to first provided dtype
                 dtype = dtype[0]
             else:
@@ -1032,7 +1047,7 @@ def check_y(
     y,
     *,
     dtype=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     accept_multi_output=False,
@@ -1052,9 +1067,15 @@ def check_y(
         the input dtype will be used. Pass a dtype or a list of supported
         dtypes to enforce a dtype for the output. If the input doesn't have a
         supported dtype, it will be converted to the first listed dtype.
-    convert_dtype : bool, default=True
-        Whether to support dtype conversion. If False, an error will be raised
-        if the input isn't a supported dtype.
+    convert_dtype : bool, default="deprecated"
+
+        .. deprecated:: 26.08
+
+            `convert_dtype` was deprecated in version 26.08 and will be removed
+            in version 26.10. cuML only copies input arrays when necessary
+            (e.g. to unify dtypes), there is no reason to provide this keyword
+            going forward.
+
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray``. If 'host', the output will be a ``numpy.ndarray``. If
@@ -1292,7 +1313,7 @@ def check_sample_weight(
     sample_weight,
     *,
     dtype=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     ensure_non_negative=False,
@@ -1308,9 +1329,15 @@ def check_sample_weight(
         Pass a dtype or a list of supported dtypes to enforce a dtype for the
         output. If the input doesn't have a supported dtype, it will be
         converted to the first listed dtype.
-    convert_dtype : bool, default=True
-        Whether to support dtype conversion. If False, an error will be raised
-        if the input isn't a supported dtype.
+    convert_dtype : bool, default="deprecated"
+
+        .. deprecated:: 26.08
+
+            `convert_dtype` was deprecated in version 26.08 and will be removed
+            in version 26.10. cuML only copies input arrays when necessary
+            (e.g. to unify dtypes), there is no reason to provide this keyword
+            going forward.
+
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray``. If 'host', the output will be a ``numpy.ndarray``. If
@@ -1381,7 +1408,7 @@ def check_inputs(
     dtype=None,
     y_dtype=...,
     sample_weight_dtype=...,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     copy=False,
@@ -1440,9 +1467,15 @@ def check_inputs(
     sample_weight_dtype : None, dtype, list[dtype], default=...
         The dtype(s) to support for sample_weight. If not specified, defaults
         to the output dtype of ``X``.
-    convert_dtype : bool, default=True
-        Whether to support dtype conversion. If False, an error will be raised
-        if the input isn't a supported dtype.
+    convert_dtype : bool, default="deprecated"
+
+        .. deprecated:: 26.08
+
+            `convert_dtype` was deprecated in version 26.08 and will be removed
+            in version 26.10. cuML only copies input arrays when necessary
+            (e.g. to unify dtypes), there is no reason to provide this keyword
+            going forward.
+
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray`` if dense, or a ``cupyx.scipy.sparse.spmatrix`` if

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.py
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.py
@@ -294,7 +294,7 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
     @generate_docstring()
     @reflect(reset=True)
     def fit(
-        self, X, y, sample_weight=None, *, convert_dtype=True
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "KernelRidge":
         X, y, index = check_inputs(
             self,
@@ -329,7 +329,7 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         return self
 
     @reflect
-    def predict(self, X, *, convert_dtype=True):
+    def predict(self, X, *, convert_dtype="deprecated"):
         """
         Predict using the kernel ridge model.
 

--- a/python/cuml/cuml/linear_model/base.py
+++ b/python/cuml/cuml/linear_model/base.py
@@ -21,7 +21,7 @@ class LinearPredictMixin:
         }
     )
     @cuml.internals.reflect
-    def predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Predicts `y` values for `X`.
         """
@@ -59,7 +59,7 @@ class LinearClassifierMixin:
         },
     )
     @cuml.internals.reflect
-    def decision_function(self, X, *, convert_dtype=True) -> CumlArray:
+    def decision_function(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """Predict confidence scores for samples."""
         check_is_fitted(self)
 

--- a/python/cuml/cuml/linear_model/elastic_net.py
+++ b/python/cuml/cuml/linear_model/elastic_net.py
@@ -231,7 +231,7 @@ class ElasticNet(
     @generate_docstring()
     @reflect(reset=True)
     def fit(
-        self, X, y, sample_weight=None, *, convert_dtype=True
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "ElasticNet":
         """
         Fit the model with X and y.

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -310,7 +310,14 @@ class LinearRegression(InteropMixin,
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "LinearRegression":
+    def fit(
+        self,
+        X,
+        y,
+        sample_weight=None,
+        *,
+        convert_dtype="deprecated",
+    ) -> "LinearRegression":
         """
         Fit the model with X and y.
 

--- a/python/cuml/cuml/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/linear_model/logistic_regression.py
@@ -297,7 +297,7 @@ class LogisticRegression(
     @generate_docstring(X="dense_sparse")
     @cuml.internals.reflect(reset=True)
     def fit(
-        self, X, y, sample_weight=None, *, convert_dtype=True
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "LogisticRegression":
         """
         Fit the model with X and y.
@@ -341,7 +341,7 @@ class LogisticRegression(
         },
     )
     @cuml.internals.run_in_internal_context
-    def predict(self, X, *, convert_dtype=True):
+    def predict(self, X, *, convert_dtype="deprecated"):
         """
         Predicts the y for X.
 
@@ -371,7 +371,7 @@ class LogisticRegression(
         },
     )
     @cuml.internals.reflect
-    def predict_proba(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict_proba(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Predicts the class probabilities for each class in X
         """
@@ -401,7 +401,7 @@ class LogisticRegression(
         },
     )
     @cuml.internals.reflect
-    def predict_log_proba(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict_log_proba(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Predicts the log class probabilities for each class in X
         """

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -175,7 +175,7 @@ class MBSGDClassifier(
 
     @generate_docstring()
     @cuml.internals.reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "MBSGDClassifier":
+    def fit(self, X, y, *, convert_dtype="deprecated") -> "MBSGDClassifier":
         """
         Fit the model with X and y.
 
@@ -214,7 +214,7 @@ class MBSGDClassifier(
         }
     )
     @cuml.internals.run_in_internal_context
-    def predict(self, X, *, convert_dtype=True):
+    def predict(self, X, *, convert_dtype="deprecated"):
         """
         Predicts the y for X.
 

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -163,7 +163,7 @@ class MBSGDRegressor(
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "MBSGDRegressor":
+    def fit(self, X, y, *, convert_dtype="deprecated") -> "MBSGDRegressor":
         """
         Fit the model with X and y.
 

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -357,7 +357,7 @@ class Ridge(InteropMixin,
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "Ridge":
+    def fit(self, X, y, sample_weight=None, *, convert_dtype="deprecated") -> "Ridge":
         """
         Fit the model with X and y.
         """

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -565,10 +565,9 @@ class TSNE(InteropMixin,
         return self.embedding_.shape[1]
 
     @generate_docstring(skip_parameters_heading=True,
-                        X='dense_sparse',
-                        convert_dtype_cast='np.float32')
+                        X='dense_sparse')
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True, knn_graph=None) -> "TSNE":
+    def fit(self, X, y=None, *, convert_dtype="deprecated", knn_graph=None) -> "TSNE":
         """
         Fit X into an embedded space.
 
@@ -683,15 +682,16 @@ class TSNE(InteropMixin,
 
         return self
 
-    @generate_docstring(convert_dtype_cast='np.float32',
-                        return_values={'name': 'X_new',
+    @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
                                        'description': 'Embedding of the \
                                                        data in \
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
     @reflect
-    def fit_transform(self, X, y=None, *, convert_dtype=True, knn_graph=None) -> CumlArray:
+    def fit_transform(
+        self, X, y=None, *, convert_dtype="deprecated", knn_graph=None
+    ) -> CumlArray:
         """
         Fit X into an embedded space and return that transformed output.
         """

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -1202,12 +1202,11 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         self.device_ids = device_ids
 
     @generate_docstring(
-        convert_dtype_cast="np.float32",
         X="dense_sparse",
         skip_parameters_heading=True,
     )
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True, knn_graph=None) -> "UMAP":
+    def fit(self, X, y=None, *, convert_dtype="deprecated", knn_graph=None) -> "UMAP":
         """
         Fit X into an embedded space.
 
@@ -1429,7 +1428,6 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         return self
 
     @generate_docstring(
-        convert_dtype_cast="np.float32",
         skip_parameters_heading=True,
         return_values={
             "name": "X_new",
@@ -1440,7 +1438,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
     )
     @reflect
     def fit_transform(
-        self, X, y=None, *, convert_dtype=True, knn_graph=None
+        self, X, y=None, *, convert_dtype="deprecated", knn_graph=None
     ) -> CumlArray:
         """
         Fit X into an embedded space and return that transformed
@@ -1466,7 +1464,6 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         return self.embedding_
 
     @generate_docstring(
-        convert_dtype_cast="np.float32",
         return_values={
             "name": "X_new",
             "type": "dense",
@@ -1475,7 +1472,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         }
     )
     @reflect
-    def transform(self, X, *, convert_dtype=True) -> CumlArray:
+    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Transform X into the existing embedded space and return that
         transformed output.
@@ -1595,7 +1592,6 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         return CumlArray(data=out, index=index)
 
     @generate_docstring(
-        convert_dtype_cast="np.float32",
         X_shape="(n_samples, n_components)",
         return_values={
             "name": "X_new",
@@ -1605,7 +1601,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         }
     )
     @reflect
-    def inverse_transform(self, X, *, convert_dtype=True) -> CumlArray:
+    def inverse_transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """Transform X in the existing embedded space back into the input
         data space and return that transformed output.
         """
@@ -1852,7 +1848,7 @@ def simplicial_set_embedding(
     metric_kwds=None,
     output_metric="euclidean",
     output_metric_kwds=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     verbose=False,
 ):
     """Perform a fuzzy simplicial set embedding, using a specified

--- a/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -19,7 +19,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
                                int n) except +
 
 
-def adjusted_rand_score(labels_true, labels_pred, convert_dtype=True) -> float:
+def adjusted_rand_score(labels_true, labels_pred, convert_dtype="deprecated") -> float:
     """
     Adjusted_rand_score is a clustering similarity metric based on the Rand
     index and is corrected for chance.

--- a/python/cuml/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/cuml/metrics/cluster/silhouette_score.pyx
@@ -41,7 +41,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics::Batched" nog
 
 def _silhouette_coeff(
         X, labels, metric='euclidean', sil_scores=None, chunksize=None,
-        convert_dtype=True):
+        convert_dtype="deprecated"):
     """Function wrapped by silhouette_score and silhouette_samples to compute
     silhouette coefficients.
 
@@ -145,7 +145,7 @@ def cython_silhouette_score(
     labels,
     metric='euclidean',
     chunksize=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
 ):
     """Calculate the mean silhouette coefficient for the provided data.
 
@@ -184,7 +184,7 @@ def cython_silhouette_samples(
     labels,
     metric='euclidean',
     chunksize=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
 ):
     """Calculate the silhouette coefficient for each sample in the provided data.
 

--- a/python/cuml/cuml/metrics/confusion_matrix.py
+++ b/python/cuml/cuml/metrics/confusion_matrix.py
@@ -19,7 +19,7 @@ def confusion_matrix(
     labels=None,
     sample_weight=None,
     normalize=None,
-    convert_dtype=True,
+    convert_dtype="deprecated",
 ) -> cp.ndarray:
     """Compute confusion matrix to evaluate the accuracy of a classification.
 
@@ -39,9 +39,12 @@ def confusion_matrix(
         Normalizes confusion matrix over the true (rows), predicted (columns)
         conditions or all the population. If None, confusion matrix will not be
         normalized.
-    convert_dtype : bool, optional (default=True)
-        When set to True, the confusion matrix method will automatically
-        convert the predictions, ground truth, and labels arrays to np.int32.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     Returns
     -------

--- a/python/cuml/cuml/metrics/kl_divergence.pyx
+++ b/python/cuml/cuml/metrics/kl_divergence.pyx
@@ -24,7 +24,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
         int n) except +
 
 
-def kl_divergence(P, Q, convert_dtype=True):
+def kl_divergence(P, Q, convert_dtype="deprecated"):
     """
     Calculates the "Kullback-Leibler" Divergence
     The KL divergence tells us how well the probability distribution Q
@@ -44,10 +44,12 @@ def kl_divergence(P, Q, convert_dtype=True):
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
         ndarray, cuda array interface compliant array like CuPy.
 
-    convert_dtype : bool, optional (default = True)
-        When set to True, the method will, convert P and
-        Q to be the same data type: float32. This
-        will increase memory used for the method.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     Returns
     -------

--- a/python/cuml/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/cuml/metrics/pairwise_distances.pyx
@@ -107,7 +107,7 @@ def nan_euclidean_distances(
     squared=False,
     missing_values=cp.nan,
     copy=True,
-    convert_dtype=True,
+    convert_dtype="deprecated",
 ):
     """Calculate the euclidean distances in the presence of missing values.
 
@@ -153,10 +153,12 @@ def nan_euclidean_distances(
         False can reduce memory usage, but may result in mutation
         of X and Y.
 
-    convert_dtype : bool, optional (default = True)
-        When set to True, the method will, when necessary, convert ``X``
-        to a supported floating-point dtype and convert ``Y`` to match
-        ``X``'s dtype. This will increase memory used for the method.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     Returns
     -------
@@ -265,7 +267,7 @@ def _ensure_boolean(X, metric):
 
 @reflect
 def pairwise_distances(
-    X, Y=None, metric="euclidean", convert_dtype=True, **kwds
+    X, Y=None, metric="euclidean", convert_dtype="deprecated", **kwds
 ):
     """Compute the distance matrix from a feature array X and optional Y.
 
@@ -293,10 +295,12 @@ def pairwise_distances(
 
         - Supports sparse only: ['dice', 'inner_product', 'jaccard'].
 
-    convert_dtype : bool, optional (default = True)
-        When set to True, the method will, when necessary, convert
-        Y to be the same data type as X if they differ. This
-        will increase memory used for the method.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     **kwds : optional keyword parameters
         Any additional metric-specific parameters. For example, with
@@ -499,7 +503,7 @@ def pairwise_distances(
 
 @reflect
 def sparse_pairwise_distances(
-    X, Y=None, metric="euclidean", convert_dtype=True, **kwds
+    X, Y=None, metric="euclidean", convert_dtype="deprecated", **kwds
 ):
     """
     Compute the distance matrix from a vector array `X` and optional `Y`.
@@ -541,10 +545,12 @@ def sparse_pairwise_distances(
         The metric to use when calculating distance between instances in a
         feature array.
 
-    convert_dtype : bool, optional (default = True)
-        When set to True, the method will, when necessary, convert
-        Y to be the same data type as X if they differ. This
-        will increase memory used for the method.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     **kwds : optional keyword parameters
         Any additional metric-specific parameters. For example, with

--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -184,7 +184,7 @@ def pairwise_kernels(
     metric="linear",
     *,
     filter_params=False,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     **kwds,
 ):
     """
@@ -224,10 +224,13 @@ def pairwise_kernels(
         kernel value as a single number.
     filter_params : bool, default=False
         Whether to filter invalid parameters or not.
-    convert_dtype : bool, optional (default = True)
-        When set to True, the method will, when necessary, convert
-        Y to be the same data type as X if they differ. This
-        will increase memory used for the method.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
+
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the kernel function.
 

--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -40,7 +40,7 @@ def trustworthiness(
     X_embedded,
     n_neighbors=5,
     metric='euclidean',
-    convert_dtype=True,
+    convert_dtype="deprecated",
     batch_size=512,
 ) -> float:
     """
@@ -64,9 +64,12 @@ def trustworthiness(
             Metric used to compute the trustworthiness. For the moment only
             'euclidean' is supported.
 
-        convert_dtype : bool, optional (default=True)
-            When set to True, the trustworthiness method will automatically
-            convert the inputs to np.float32.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         batch_size : int (default=512)
             The number of samples to use for each batch.

--- a/python/cuml/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/cuml/naive_bayes/naive_bayes.py
@@ -65,7 +65,7 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         """An optional transform to apply to X after it's been validated"""
         return X
 
-    def _check_predict(self, X, *, convert_dtype=True):
+    def _check_predict(self, X, *, convert_dtype="deprecated"):
         """Validate X and return (X, index) for predict."""
         X, index = check_inputs(
             self,
@@ -88,7 +88,7 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         sample_weight=None,
         *,
         reset=False,
-        convert_dtype=True,
+        convert_dtype="deprecated",
     ):
         """Validate and return (X, y, classes, sample_weight) for fit."""
         if reset:
@@ -149,7 +149,7 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         },
     )
     @run_in_internal_context
-    def predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Perform classification on an array of test vectors X.
 
@@ -181,7 +181,7 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         },
     )
     @reflect
-    def predict_log_proba(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict_log_proba(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Return log-probability estimates for the test vector X.
 
@@ -313,7 +313,7 @@ class GaussianNB(_BaseNB):
         classes=None,
         sample_weight=None,
         reset=False,
-        convert_dtype=True,
+        convert_dtype="deprecated",
     ) -> "GaussianNB":
         classes, reset = self._check_classes(classes, reset)
         X, y, classes, sample_weight = self._check_fit(
@@ -666,7 +666,7 @@ class _BaseDiscreteNB(_BaseNB):
         y,
         classes=None,
         reset=False,
-        convert_dtype=True,
+        convert_dtype="deprecated",
     ) -> "_BaseDiscreteNB":
         if self.alpha < 0:
             raise ValueError(f"Expected alpha >= 0, got {self.alpha}")

--- a/python/cuml/cuml/neighbors/kernel_density.pyx
+++ b/python/cuml/cuml/neighbors/kernel_density.pyx
@@ -214,7 +214,7 @@ class KernelDensity(InteropMixin, Base):
 
     @reflect(reset=True)
     def fit(
-        self, X, y=None, sample_weight=None, *, convert_dtype=True
+        self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "KernelDensity":
         """Fit the Kernel Density model on the data.
 
@@ -279,7 +279,7 @@ class KernelDensity(InteropMixin, Base):
         return self
 
     @reflect
-    def score_samples(self, X, *, convert_dtype=True) -> CumlArray:
+    def score_samples(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """Compute the log-likelihood of each sample under the model.
 
         Parameters

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -208,9 +208,9 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
         )
         self.weights = weights
 
-    @generate_docstring(convert_dtype_cast='np.float32')
+    @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "KNeighborsClassifier":
+    def fit(self, X, y, *, convert_dtype="deprecated") -> "KNeighborsClassifier":
         """
         Fit a GPU index for k-nearest neighbors classifier model.
 
@@ -239,13 +239,12 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
         """Whether the output is 2d"""
         return self._y.ndim == 2 and self._y.shape[1] != 1
 
-    @generate_docstring(convert_dtype_cast='np.float32',
-                        return_values={'name': 'X_new',
+    @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
                                        'description': 'Labels predicted',
                                        'shape': '(n_samples, 1)'})
     @run_in_internal_context
-    def predict(self, X, *, convert_dtype=True):
+    def predict(self, X, *, convert_dtype="deprecated"):
         """
         Use the trained k-nearest neighbors classifier to
         predict the labels for X
@@ -309,13 +308,12 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
             index=knn_indices.index,
         )
 
-    @generate_docstring(convert_dtype_cast='np.float32',
-                        return_values={'name': 'X_new',
+    @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
                                        'description': 'Labels probabilities',
                                        'shape': '(n_samples, 1)'})
     @reflect
-    def predict_proba(self, X, *, convert_dtype=True) -> CumlArray | list[CumlArray]:
+    def predict_proba(self, X, *, convert_dtype="deprecated"):
         """
         Use the trained k-nearest neighbors classifier to
         predict the label probabilities for X

--- a/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -84,8 +84,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         ncols: number of columns
         rank: rank of current worker
         n_neighbors: number of nearest neighbors to query
-        convert_dtype: since only float32 inputs are supported, should
-               the input be automatically converted?
+        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------
@@ -191,8 +190,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         n_unique: array with number of possible labels for each columns
         ncols: number of columns
         rank: int rank of current worker
-        convert_dtype: since only float32 inputs are supported, should
-               the input be automatically converted?
+        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -210,9 +210,9 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
         )
         self.weights = weights
 
-    @generate_docstring(convert_dtype_cast='np.float32')
+    @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "KNeighborsRegressor":
+    def fit(self, X, y, *, convert_dtype="deprecated") -> "KNeighborsRegressor":
         """
         Fit a GPU index for k-nearest neighbors regression model.
 
@@ -235,13 +235,12 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
 
         return self
 
-    @generate_docstring(convert_dtype_cast='np.float32',
-                        return_values={'name': 'X_new',
+    @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, n_features)'})
     @reflect
-    def predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Use the trained k-nearest neighbors regression model to
         predict the labels for X

--- a/python/cuml/cuml/neighbors/kneighbors_regressor_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor_mg.pyx
@@ -73,8 +73,7 @@ class KNeighborsRegressorMG(NearestNeighborsMG):
         ncols: number of columns
         n_outputs: number of outputs columns
         rank: rank of current worker
-        convert_dtype: since only float32 inputs are supported, should
-               the input be automatically converted?
+        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -525,12 +525,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
     def _attrs_from_cpu(self, model):
         if scipy.sparse.issparse(model._fit_X):
             fit_X = SparseCumlArray(
-                check_array(
-                    model._fit_X,
-                    dtype="float32",
-                    accept_sparse=["csr"],
-                    convert_dtype=True,
-                )
+                check_array(model._fit_X, dtype="float32", accept_sparse=["csr"])
             )
         else:
             fit_X = to_gpu(model._fit_X, order="C", dtype=np.float32)
@@ -610,7 +605,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
 
     @generate_docstring(X='dense_sparse')
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True) -> "NearestNeighbors":
+    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "NearestNeighbors":
         """
         Fit GPU index for performing nearest neighbor queries.
 
@@ -707,7 +702,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
         n_neighbors=None,
         return_distance=True,
         *,
-        convert_dtype=True,
+        convert_dtype="deprecated",
         two_pass_precision=False
     ) -> typing.Union[CumlArray, typing.Tuple[CumlArray, CumlArray]]:
         """
@@ -724,9 +719,12 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
         return_distance: Boolean
             If False, distances will not be returned
 
-        convert_dtype : bool, optional (default = True)
-            When set to True, the kneighbors method will automatically
-            convert the inputs to np.float32.
+        convert_dtype : bool, default="deprecated"
+            .. deprecated:: 26.08
+                `convert_dtype` was deprecated in version 26.08 and will be
+                removed in version 26.10. cuML only copies input arrays when
+                necessary (e.g. to unify dtypes), there is no reason to provide
+                this keyword going forward.
 
         two_pass_precision : bool, optional (default = False)
             When set to True, a slow second pass will be used to improve the
@@ -791,7 +789,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
         return (distances, indices) if return_distance else indices
 
     def _kneighbors_dense(
-        self, X, int n_neighbors, convert_dtype=True, two_pass_precision=False
+        self, X, int n_neighbors, convert_dtype="deprecated", two_pass_precision=False
     ):
         if is_sparse(X):
             raise ValueError("A NearestNeighbors model trained on dense "
@@ -903,7 +901,6 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
             X,
             dtype="float32",
             accept_sparse=["csr"],
-            convert_dtype=True,
             input_name="X",
         )
         cdef int* X_indptr = <int *><uintptr_t>X_cp.indptr.data.ptr
@@ -1269,7 +1266,6 @@ class NearestNeighbors(NeighborsBase):
         X_cp = check_array(
             X,
             dtype="float32",
-            convert_dtype=True,
             order="C",
             input_name="X",
         )

--- a/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -108,8 +108,7 @@ class NearestNeighborsMG(NearestNeighbors):
         ncols: number of columns
         rank: rank of current worker
         n_neighbors: number of nearest neighbors to query
-        convert_dtype: since only float32 inputs are supported, should
-               the input be automatically converted?
+        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------

--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -81,7 +81,7 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y=None, *, convert_dtype=True):
+    def fit(self, X, y=None, *, convert_dtype="deprecated"):
         """Generate a random projection matrix."""
         # Use `mem_type=None` & `order=None` to minimize copies or transfers. We
         # don't need to access the data here, just ensure it's valid and get
@@ -125,7 +125,7 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
 
     @generate_docstring()
     @reflect
-    def transform(self, X, *, convert_dtype=True) -> CumlArray:
+    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """Project the data by taking the matrix product with the random matrix."""
         check_is_fitted(self)
         X, index = check_inputs(
@@ -157,7 +157,9 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
 
     @generate_docstring()
     @reflect
-    def fit_transform(self, X, y=None, *, convert_dtype=True) -> CumlArray:
+    def fit_transform(
+        self, X, y=None, *, convert_dtype="deprecated"
+    ) -> CumlArray:
         """Fit to data, then transform it."""
         return self.fit(X, convert_dtype=convert_dtype).transform(
             X, convert_dtype=convert_dtype

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -81,7 +81,7 @@ def fit_cd(
     y,
     sample_weight=None,
     *,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     loss="squared_loss",
     double alpha=0.0001,
     double l1_ratio=0.15,
@@ -102,8 +102,13 @@ def fit_cd(
         The target values.
     sample_weight : None or array-like, shape=(n_samples,)
         The sample weights.
-    convert_dtype : bool, default=True
-        When set to True, will convert array inputs to be of the proper dtypes.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
+
     **kwargs
         Remaining keyword arguments match the hyperparameters
         to ``CD``, see the ``CD`` docs for more information.
@@ -312,7 +317,7 @@ class CD(FMajorInputTagMixin, Base):
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, convert_dtype=True, sample_weight=None) -> "CD":
+    def fit(self, X, y, convert_dtype="deprecated", sample_weight=None) -> "CD":
         """
         Fit the model with X and y.
         """
@@ -341,7 +346,7 @@ class CD(FMajorInputTagMixin, Base):
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
     @reflect
-    def predict(self, X, convert_dtype=True) -> CumlArray:
+    def predict(self, X, convert_dtype="deprecated") -> CumlArray:
         """
         Predicts the y for X.
         """

--- a/python/cuml/cuml/solvers/qn.pyx
+++ b/python/cuml/cuml/solvers/qn.pyx
@@ -127,7 +127,7 @@ def fit_qn(
     y,
     sample_weight=None,
     *,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     loss="l2",
     class_weight=None,
     bool fit_intercept=True,
@@ -155,8 +155,13 @@ def fit_qn(
         The target values.
     sample_weight : None or array-like, shape=(n_samples,)
         The sample weights.
-    convert_dtype : bool, default=True
-        When set to True, will convert array inputs to be of the proper dtypes.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
+
     class_weight : dict or 'balanced', default=None
         Weights associated per-classes, or None for uniform weights. If 'balanced',
         weights inversely proportional to the class frequencies will be used.
@@ -539,7 +544,7 @@ class QN(Base):
 
     @generate_docstring(X="dense_sparse")
     @reflect(reset=True)
-    def fit(self, X, y, sample_weight=None, convert_dtype=True) -> "QN":
+    def fit(self, X, y, sample_weight=None, convert_dtype="deprecated") -> "QN":
         """
         Fit the model with X and y.
         """
@@ -593,7 +598,7 @@ class QN(Base):
 
     @generate_docstring(X="dense_sparse")
     @reflect
-    def predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """Predicts the y for X."""
         check_is_fitted(self)
 

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -103,7 +103,7 @@ def fit_sgd(
     X,
     y,
     *,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     return_classes=False,
     loss="squared_loss",
     penalty=None,
@@ -409,7 +409,7 @@ class SGD(FMajorInputTagMixin, Base):
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, *, convert_dtype=True) -> "SGD":
+    def fit(self, X, y, *, convert_dtype="deprecated") -> "SGD":
         """
         Fit the model with X and y.
 
@@ -446,7 +446,7 @@ class SGD(FMajorInputTagMixin, Base):
         }
     )
     @reflect
-    def predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Predicts the y for X.
 

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -62,7 +62,7 @@ def fit(
     y,
     sample_weight=None,
     *,
-    convert_dtype=True,
+    convert_dtype="deprecated",
     is_classifier=False,
     class_weight=None,
     n_streams=0,

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -225,7 +225,7 @@ class LinearSVC(InteropMixin, LinearClassifierMixin, ClassifierMixin, Base):
     @generate_docstring()
     @reflect(reset=True)
     def fit(
-        self, X, y, sample_weight=None, *, convert_dtype=True
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "LinearSVC":
         """Fit the model according to the given training data."""
         n_streams = self.n_streams
@@ -279,7 +279,7 @@ class LinearSVC(InteropMixin, LinearClassifierMixin, ClassifierMixin, Base):
         },
     )
     @run_in_internal_context
-    def predict(self, X, *, convert_dtype=True):
+    def predict(self, X, *, convert_dtype="deprecated"):
         """Predict class labels for samples in X."""
         scores = self.decision_function(X, convert_dtype=convert_dtype)
         index = scores.index

--- a/python/cuml/cuml/svm/linear_svr.py
+++ b/python/cuml/cuml/svm/linear_svr.py
@@ -202,7 +202,7 @@ class LinearSVR(InteropMixin, LinearPredictMixin, RegressorMixin, Base):
     @generate_docstring()
     @reflect(reset=True)
     def fit(
-        self, X, y, sample_weight=None, *, convert_dtype=True
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "LinearSVR":
         """Fit the model according to the given training data."""
         coef, intercept, n_iter, _ = cuml.svm.linear.fit(

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -347,7 +347,9 @@ class SVC(ClassifierMixin, SVMBase):
 
     @generate_docstring(y="dense_anydtype")
     @reflect(reset=True)
-    def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "SVC":
+    def fit(
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
+    ) -> "SVC":
         """
         Fit the model with X and y.
 
@@ -412,7 +414,7 @@ class SVC(ClassifierMixin, SVMBase):
         }
     )
     @run_in_internal_context
-    def predict(self, X, *, convert_dtype=True):
+    def predict(self, X, *, convert_dtype="deprecated"):
         """
         Predicts the class labels for X. The returned y values are the class
         labels associated to sign(decision_function(X)).
@@ -443,7 +445,7 @@ class SVC(ClassifierMixin, SVMBase):
         }
     )
     @reflect
-    def decision_function(self, X, *, convert_dtype=True) -> CumlArray:
+    def decision_function(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Calculates the decision function values for X.
 

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -478,7 +478,7 @@ class SVMBase(InteropMixin,
         self._gamma = gamma
         self._sparse = sparse_X
 
-    def _predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def _predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """Perform `predict`."""
         check_is_fitted(self)
 

--- a/python/cuml/cuml/svm/svr.py
+++ b/python/cuml/cuml/svm/svr.py
@@ -133,7 +133,9 @@ class SVR(RegressorMixin, SVMBase):
 
     @generate_docstring()
     @reflect(reset=True)
-    def fit(self, X, y, sample_weight=None, *, convert_dtype=True) -> "SVR":
+    def fit(
+        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
+    ) -> "SVR":
         """
         Fit the model with X and y.
 
@@ -171,7 +173,7 @@ class SVR(RegressorMixin, SVMBase):
         }
     )
     @reflect
-    def predict(self, X, *, convert_dtype=True) -> CumlArray:
+    def predict(self, X, *, convert_dtype="deprecated") -> CumlArray:
         """
         Predicts the values for X.
 

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -183,9 +183,12 @@ class ARIMA(Base):
         type. If None, the output type set at the module level
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
-    convert_dtype : boolean
-        When set to True, the model will automatically convert the inputs to
-        np.float64.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     Attributes
     ----------
@@ -288,7 +291,7 @@ class ARIMA(Base):
                  simple_differencing=True,
                  verbose=False,
                  output_type=None,
-                 convert_dtype=True):
+                 convert_dtype="deprecated"):
 
         # Initialize base class
         super().__init__(verbose=verbose, output_type=output_type)
@@ -550,7 +553,7 @@ class ARIMA(Base):
                 params[names[i]] = getattr(self, "{}_".format(names[i]))
         return params
 
-    def set_fit_params(self, params: Mapping[str, object], convert_dtype=True):
+    def set_fit_params(self, params: Mapping[str, object], convert_dtype="deprecated"):
         """Set all the fit parameters. Not to be confused with ``set_params``
         Note: `unpack()` can be used to load a compact vector of the
         parameters
@@ -610,7 +613,7 @@ class ARIMA(Base):
         end=None,
         level=None,
         exog=None,
-        convert_dtype=True
+        convert_dtype="deprecated"
     ):
         """Compute in-sample and/or out-of-sample prediction for each series
 
@@ -856,7 +859,7 @@ class ARIMA(Base):
             maxiter: int = 1000,
             method="ml",
             truncate: int = 0,
-            convert_dtype: bool = True) -> "ARIMA":
+            convert_dtype = "deprecated") -> "ARIMA":
         r"""Fit the ARIMA model to each time series.
 
         Parameters
@@ -951,7 +954,7 @@ class ARIMA(Base):
 
     @nvtx.annotate(message="tsa.arima.ARIMA._loglike", domain="cuml_python")
     @run_in_internal_context
-    def _loglike(self, x, trans=True, method="ml", truncate=0, convert_dtype=True):
+    def _loglike(self, x, trans=True, method="ml", truncate=0, convert_dtype="deprecated"):
         """Compute the batched log-likelihood for the given parameters.
 
         Parameters
@@ -1023,7 +1026,7 @@ class ARIMA(Base):
                    domain="cuml_python")
     @run_in_internal_context
     def _loglike_grad(self, x, h=1e-8, trans=True, method="ml", truncate=0,
-                      convert_dtype=True):
+                      convert_dtype="deprecated"):
         """Compute the gradient (via finite differencing) of the batched
         log-likelihood.
 
@@ -1149,7 +1152,7 @@ class ARIMA(Base):
 
     @nvtx.annotate(message="tsa.arima.ARIMA.unpack", domain="cuml_python")
     @run_in_internal_context
-    def unpack(self, x: Union[list, np.ndarray], convert_dtype=True):
+    def unpack(self, x: Union[list, np.ndarray], convert_dtype="deprecated"):
         """Unpack linearized parameter vector `x` into the separate
         parameter arrays of the model
 

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -117,9 +117,12 @@ class AutoARIMA(Base):
         type. If None, the output type set at the module level
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
-    convert_dtype : boolean
-        When set to True, the model will automatically convert the inputs to
-        np.float64.
+    convert_dtype : bool, default="deprecated"
+        .. deprecated:: 26.08
+            `convert_dtype` was deprecated in version 26.08 and will be
+            removed in version 26.10. cuML only copies input arrays when
+            necessary (e.g. to unify dtypes), there is no reason to provide
+            this keyword going forward.
 
     Notes
     -----
@@ -160,7 +163,7 @@ class AutoARIMA(Base):
                  simple_differencing=True,
                  verbose=False,
                  output_type=None,
-                 convert_dtype=True):
+                 convert_dtype="deprecated"):
         # Initialize base class
         super().__init__(verbose=verbose, output_type=output_type)
         self._set_output_type(endog)

--- a/python/cuml/cuml/tsa/seasonality.py
+++ b/python/cuml/cuml/tsa/seasonality.py
@@ -8,7 +8,7 @@ from cuml.internals.validation import check_array
 
 
 @reflect
-def seas_test(y, s, convert_dtype=True):
+def seas_test(y, s, convert_dtype="deprecated"):
     """
     Perform Wang, Smith & Hyndman's test to decide whether seasonal
     differencing is needed

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -38,7 +38,7 @@ def kpss_test(
     int D=0,
     int s=0,
     double pval_threshold=0.05,
-    convert_dtype=True,
+    convert_dtype="deprecated",
 ):
     """
     Perform the KPSS stationarity test on the data differenced according

--- a/python/cuml/tests/dask/test_dask_kneighbors_classifier.py
+++ b/python/cuml/tests/dask/test_dask_kneighbors_classifier.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -128,7 +128,7 @@ def test_predict_and_score(dataset, datatype, parameters, client):
         client=client, n_neighbors=n_neighbors, batch_size=batch_size
     )
     d_model.fit(X_train, y_train)
-    d_outputs = d_model.predict(X_test, convert_dtype=True)
+    d_outputs = d_model.predict(X_test)
     d_outputs = d_outputs.compute()
 
     d_outputs = (
@@ -163,7 +163,7 @@ def test_predict_proba(dataset, datatype, parameters, client):
 
     d_model = dKNNClf(client=client, n_neighbors=n_neighbors)
     d_model.fit(X_train, y_train)
-    d_probas = d_model.predict_proba(X_test, convert_dtype=True)
+    d_probas = d_model.predict_proba(X_test)
     d_probas = da.compute(d_probas)[0]
 
     if datatype == "dask_cudf":

--- a/python/cuml/tests/dask/test_dask_kneighbors_regressor.py
+++ b/python/cuml/tests/dask/test_dask_kneighbors_regressor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -119,7 +119,7 @@ def test_predict_and_score(dataset, datatype, parameters, client):
         client=client, n_neighbors=n_neighbors, batch_size=batch_size
     )
     d_model.fit(X_train, y_train)
-    d_outputs = d_model.predict(X_test, convert_dtype=True)
+    d_outputs = d_model.predict(X_test)
     d_outputs = d_outputs.compute()
 
     d_outputs = (

--- a/python/cuml/tests/test_elastic_net.py
+++ b/python/cuml/tests/test_elastic_net.py
@@ -286,7 +286,7 @@ def test_elastic_net_default(datatype, nrows, column_info):
 
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("test_dtype", [np.float64, np.float32])
-def test_elastic_net_predict_convert_dtype(train_dtype, test_dtype):
+def test_elastic_net_predict_mixed_dtypes(train_dtype, test_dtype):
     X, y = make_regression(
         n_samples=50, n_features=10, n_informative=5, random_state=0
     )
@@ -303,7 +303,7 @@ def test_elastic_net_predict_convert_dtype(train_dtype, test_dtype):
 
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("test_dtype", [np.float64, np.float32])
-def test_lasso_predict_convert_dtype(train_dtype, test_dtype):
+def test_lasso_predict_mixed_dtypes(train_dtype, test_dtype):
     X, y = make_regression(
         n_samples=50, n_features=10, n_informative=5, random_state=0
     )

--- a/python/cuml/tests/test_kernel_density.py
+++ b/python/cuml/tests/test_kernel_density.py
@@ -397,9 +397,7 @@ def test_all_kernels_all_metrics(metric, kernel):
     h = 1.0
 
     kde = KernelDensity(kernel=kernel, metric=metric, bandwidth=h)
-    # fit with convert_dtype=False so float64 test data stays float64,
-    # matching the float64 Python reference distances.
-    kde.fit(X, convert_dtype=False)
+    kde.fit(X)
     cuml_log = as_type("numpy", kde.score_samples(Q))
 
     # -inf is valid (zero density when all train points are beyond the bandwidth);

--- a/python/cuml/tests/test_linear_regression.py
+++ b/python/cuml/tests/test_linear_regression.py
@@ -236,7 +236,7 @@ def test_linear_regression_model_default_generalized(dataset):
 @example(train_dtype=np.float32, test_dtype=np.float64)
 @example(train_dtype=np.float64, test_dtype=np.float32)
 @example(train_dtype=np.float64, test_dtype=np.float64)
-def test_linreg_predict_convert_dtype(train_dtype, test_dtype):
+def test_linreg_predict_mixed_dtypes(train_dtype, test_dtype):
     X, y = make_regression(
         n_samples=50, n_features=10, n_informative=5, random_state=0
     )

--- a/python/cuml/tests/test_logistic_regression.py
+++ b/python/cuml/tests/test_logistic_regression.py
@@ -364,7 +364,7 @@ def test_logistic_regression_predict_proba(
 def test_logistic_regression_input_type_consistency(constructor, dtype):
     X = constructor([[5, 10], [3, 1], [7, 8]]).astype(dtype)
     y = constructor([0, 1, 1]).astype(dtype)
-    clf = cuLog().fit(X, y, convert_dtype=True)
+    clf = cuLog().fit(X, y)
 
     assert isinstance(clf.predict_proba(X), type(X))
     expected_type = cudf.Series if constructor == cudf.DataFrame else type(X)
@@ -471,7 +471,7 @@ def test_logistic_regression_categorical_y(y_kind):
 @example(
     dataset=small_classification_dataset(np.float64), test_dtype=np.float64
 )
-def test_logistic_predict_convert_dtype(dataset, test_dtype):
+def test_logistic_predict_output_dtype(dataset, test_dtype):
     X_train, X_test, y_train, y_test = dataset
 
     # Assumption needed to avoid qn.h: logistic loss invalid C error.

--- a/python/cuml/tests/test_metrics.py
+++ b/python/cuml/tests/test_metrics.py
@@ -931,8 +931,7 @@ def test_confusion_matrix_random(n_samples, dtype, problem_type):
     y_true, y_pred, _, _ = generate_random_labels(
         lambda rng: rng.randint(0, upper_range, n_samples).astype(dtype)
     )
-    convert_dtype = True if dtype == np.float32 else False
-    cm = confusion_matrix(y_true, y_pred, convert_dtype=convert_dtype)
+    cm = confusion_matrix(y_true, y_pred)
     ref = sk_confusion_matrix(y_true, y_pred)
     cp.testing.assert_array_almost_equal(ref, cm, decimal=4)
 
@@ -1029,15 +1028,6 @@ def test_confusion_matrix_errors():
             np.array([0, 1], dtype=np.int32),
             normalize="bogus",
         )
-
-
-def test_confusion_matrix_convert_dtype():
-    # convert_dtype=True should coerce float labels to int32.
-    y_true = np.array([0, 1, 2, 1], dtype=np.float32)
-    y_pred = np.array([0, 1, 1, 1], dtype=np.float32)
-    cm = confusion_matrix(y_true, y_pred, convert_dtype=True)
-    ref = sk_confusion_matrix(y_true.astype(np.int32), y_pred.astype(np.int32))
-    cp.testing.assert_array_equal(cm, ref)
 
 
 def test_roc_auc_score():
@@ -1220,7 +1210,7 @@ def naive_kl_divergence_dist(X, Y):
     )
 
 
-def ref_dense_pairwise_dist(X, Y=None, metric=None, convert_dtype=False):
+def ref_dense_pairwise_dist(X, Y=None, metric=None):
     # Select sklearn except for Hellinger that
     # sklearn doesn't support
     if Y is None:
@@ -1310,15 +1300,15 @@ def test_pairwise_distances(metric: str, matrix_size, is_col_major):
     S2 = ref_dense_pairwise_dist(X, Y, metric=metric)
     cp.testing.assert_array_almost_equal(S, S2, decimal=compare_precision)
 
-    # Test sending an int type with convert_dtype=True
+    # Integer inputs
     if metric != "kldivergence":
         Y = prep_dense_array(
             rng.randint(10, size=Y.shape),
             metric=metric,
             col_major=is_col_major,
         )
-        S = pairwise_distances(X, Y, metric=metric, convert_dtype=True)
-        S2 = ref_dense_pairwise_dist(X, Y, metric=metric, convert_dtype=True)
+        S = pairwise_distances(X, Y, metric=metric)
+        S2 = ref_dense_pairwise_dist(X, Y, metric=metric)
         cp.testing.assert_array_almost_equal(S, S2, decimal=compare_precision)
 
     # Test that uppercase on the metric name throws an error.
@@ -1782,7 +1772,7 @@ def test_pairwise_distances_sparse_corner_cases(
     S2 = ref_pairwise_distances_sparse(X, Y, metric=metric)
     cp.testing.assert_array_almost_equal(S, S2, decimal=compare_precision)
 
-    # Change precision of one parameter, should work (convert_dtype=True)
+    # Changing precision of one parameter works
     Y = Y.astype(cp.float32)
     S = pairwise_distances(X, Y, metric=metric)
     S2 = ref_pairwise_distances_sparse(X, Y, metric=metric)
@@ -1802,7 +1792,7 @@ def test_pairwise_distances_sparse_corner_cases(
     S2 = ref_pairwise_distances_sparse(X, Y, metric=metric)
     cp.testing.assert_array_almost_equal(S, S2, decimal=compare_precision)
 
-    # Test sending an int type (convert_dtype=True)
+    # Test sending an int type
     if metric != "hellinger":
         compare_precision = 2
         Y = Y * 100
@@ -2051,13 +2041,7 @@ def test_kl_divergence(nfeatures, input_type, dtypeP, dtypeQ):
         P = cp.asarray(P, dtype=dtypeP)
         Q = cp.asarray(Q, dtype=dtypeQ)
 
-    if dtypeP != dtypeQ:
-        with pytest.raises(ValueError, match="dtype"):
-            cu_kl_divergence(P, Q, convert_dtype=False)
-        cu_res = cu_kl_divergence(P, Q)
-    else:
-        cu_res = cu_kl_divergence(P, Q, convert_dtype=False)
-
+    cu_res = cu_kl_divergence(P, Q)
     cp.testing.assert_array_almost_equal(cu_res, sk_res)
 
 

--- a/python/cuml/tests/test_nearest_neighbors.py
+++ b/python/cuml/tests/test_nearest_neighbors.py
@@ -10,7 +10,6 @@ import cudf
 import cupy as cp
 import cupyx
 import numpy as np
-import pandas as pd
 import pytest
 import sklearn
 import sklearn.datasets
@@ -422,30 +421,6 @@ def test_knn_fit_twice():
     knn_cu.kneighbors(X, k)
 
     del knn_cu
-
-
-@pytest.mark.parametrize("input_type", ["ndarray"])
-@pytest.mark.parametrize("nrows", [unit_param(500), stress_param(70000)])
-@pytest.mark.parametrize("n_feats", [unit_param(20), stress_param(1000)])
-def test_nn_downcast_fails(input_type, nrows, n_feats):
-    X, y = sklearn.datasets.make_blobs(
-        n_samples=nrows, n_features=n_feats, random_state=0
-    )
-
-    knn_cu = cuKNN()
-    if input_type == "dataframe":
-        X_pd = pd.DataFrame({"fea%d" % i: X[0:, i] for i in range(X.shape[1])})
-        X_cudf = cudf.DataFrame(X_pd)
-        knn_cu.fit(X_cudf, convert_dtype=True)
-
-    with pytest.raises(Exception):
-        knn_cu.fit(X, convert_dtype=False)
-
-    # Test fit() fails when downcast corrupted data
-    X = np.array([[np.finfo(np.float32).max]], dtype=np.float64)
-    knn_cu = cuKNN()
-    with pytest.raises(Exception):
-        knn_cu.fit(X, convert_dtype=False)
 
 
 def check_knn_graph(

--- a/python/cuml/tests/test_random_forest.py
+++ b/python/cuml/tests/test_random_forest.py
@@ -509,16 +509,13 @@ def test_rf_classification_seed(small_clf, datatype):
 @pytest.mark.parametrize(
     "datatype", [(np.float64, np.float32), (np.float32, np.float64)]
 )
-@pytest.mark.parametrize("convert_dtype", [True, False])
 @pytest.mark.filterwarnings("ignore:To use pickling(.*)::cuml[.*]")
 @pytest.mark.skipif(
     cudf_pandas_active,
     reason="cudf.pandas causes sklearn RF estimators crashes sometimes. "
     "Issue: https://github.com/rapidsai/cuml/issues/5991",
 )
-def test_rf_classification_fit_and_predict_dtypes_differ(
-    small_clf, datatype, convert_dtype
-):
+def test_rf_classification_fit_and_predict_dtypes_differ(small_clf, datatype):
     X, y = small_clf
     X = X.astype(datatype[0])
     y = y.astype(np.int32)
@@ -530,14 +527,7 @@ def test_rf_classification_fit_and_predict_dtypes_differ(
     cuml_model = curfc()
     cuml_model.fit(X_train, y_train)
 
-    if not convert_dtype:
-        with pytest.raises(
-            ValueError, match=r".*Expected array with dtype in.*"
-        ):
-            preds = cuml_model.predict(X_test, convert_dtype=convert_dtype)
-        return
-
-    preds = cuml_model.predict(X_test, convert_dtype=convert_dtype)
+    preds = cuml_model.predict(X_test)
     acc = accuracy_score(y_test, preds)
     if X.shape[0] < 500000:
         sk_model = skrfc(random_state=10)
@@ -569,7 +559,7 @@ def test_rf_regression_fit_and_predict_dtypes_differ(large_reg, datatype):
 
     cuml_model = curfr()
     cuml_model.fit(X_train, y_train)
-    preds = cuml_model.predict(X_test, convert_dtype=True)
+    preds = cuml_model.predict(X_test)
     r2 = r2_score(y_test, preds)
     if X.shape[0] < 500000:
         sk_model = skrfr(random_state=10)

--- a/python/cuml/tests/test_solver_attributes.py
+++ b/python/cuml/tests/test_solver_attributes.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from cuml import LogisticRegression as cuLog
@@ -24,7 +24,7 @@ def test_mbsgd_regressor_attributes():
 
 def test_logistic_regression_attributes():
     X, y = make_classification()
-    clf = cuLog().fit(X, y, convert_dtype=True)
+    clf = cuLog().fit(X, y)
 
     attrs = [
         "coef_",

--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -473,7 +473,7 @@ def test_svr_skl_cmp_weighted():
 @pytest.mark.parametrize("classifier", [True, False])
 @pytest.mark.parametrize("train_dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("test_dtype", [np.float64, np.float32])
-def test_svm_predict_convert_dtype(train_dtype, test_dtype, classifier):
+def test_svm_predict_mixed_dtypes(train_dtype, test_dtype, classifier):
     X, y = make_classification(n_samples=50, random_state=0)
 
     X = X.astype(train_dtype)

--- a/python/cuml/tests/test_trustworthiness.py
+++ b/python/cuml/tests/test_trustworthiness.py
@@ -64,13 +64,6 @@ def test_trustworthiness_mismatched_rows():
         )
 
 
-def test_trustworthiness_convert_dtype_false_rejects_float64():
-    X, _ = make_blobs(n_samples=20, n_features=4, random_state=0)  # float64
-    X_embedded, _ = make_blobs(n_samples=20, n_features=2, random_state=0)
-    with pytest.raises(ValueError, match="dtype"):
-        cuml_trustworthiness(X, X_embedded, convert_dtype=False)
-
-
 def test_trustworthiness_rejects_1d_input():
     X = np.arange(20, dtype=np.float32)
     X_embedded = np.arange(20, dtype=np.float32)

--- a/python/cuml/tests/test_tsne.py
+++ b/python/cuml/tests/test_tsne.py
@@ -62,7 +62,7 @@ def test_tsne_knn_graph_used(
     )
 
     # Fit works and results in decent score with provided knn_graph
-    Y = tsne.fit_transform(X, convert_dtype=True, knn_graph=knn_graph)
+    Y = tsne.fit_transform(X, knn_graph=knn_graph)
     trust = trustworthiness(X, Y, n_neighbors=DEFAULT_N_NEIGHBORS)
     assert trust >= 0.80
 
@@ -98,17 +98,13 @@ def test_tsne_knn_parameters(
         perplexity=DEFAULT_PERPLEXITY,
     )
 
-    embed = tsne.fit_transform(X, convert_dtype=True, knn_graph=knn_graph)
+    embed = tsne.fit_transform(X, knn_graph=knn_graph)
     validate_embedding(X, embed)
 
-    embed = tsne.fit_transform(
-        X, convert_dtype=True, knn_graph=knn_graph.tocoo()
-    )
+    embed = tsne.fit_transform(X, knn_graph=knn_graph.tocoo())
     validate_embedding(X, embed)
 
-    embed = tsne.fit_transform(
-        X, convert_dtype=True, knn_graph=knn_graph.tocsc()
-    )
+    embed = tsne.fit_transform(X, knn_graph=knn_graph.tocsc())
     validate_embedding(X, embed)
 
 
@@ -230,7 +226,7 @@ def test_tsne_fit_transform_on_digits_sparse(input_type, method):
         "float32"
     )
 
-    embedding = fitter.fit_transform(new_data, convert_dtype=True)
+    embedding = fitter.fit_transform(new_data)
 
     if input_type == "cupy":
         embedding = embedding.get()
@@ -272,21 +268,17 @@ def test_tsne_knn_parameters_sparse(type_knn_graph, input_type, method):
 
     new_data = sp_prefix.csr_matrix(scipy.sparse.csr_matrix(digits))
 
-    Y = tsne.fit_transform(new_data, convert_dtype=True, knn_graph=knn_graph)
+    Y = tsne.fit_transform(new_data, knn_graph=knn_graph)
     if input_type == "cupy":
         Y = Y.get()
     validate_embedding(digits, Y, 0.85)
 
-    Y = tsne.fit_transform(
-        new_data, convert_dtype=True, knn_graph=knn_graph.tocoo()
-    )
+    Y = tsne.fit_transform(new_data, knn_graph=knn_graph.tocoo())
     if input_type == "cupy":
         Y = Y.get()
     validate_embedding(digits, Y, 0.85)
 
-    Y = tsne.fit_transform(
-        new_data, convert_dtype=True, knn_graph=knn_graph.tocsc()
-    )
+    Y = tsne.fit_transform(new_data, knn_graph=knn_graph.tocsc())
     if input_type == "cupy":
         Y = Y.get()
     validate_embedding(digits, Y, 0.85)

--- a/python/cuml/tests/test_umap.py
+++ b/python/cuml/tests/test_umap.py
@@ -52,9 +52,7 @@ def test_blobs_cluster(nrows, n_feats, build_algo):
     data, labels = datasets.make_blobs(
         n_samples=nrows, n_features=n_feats, centers=5, random_state=0
     )
-    embedding = cuUMAP(build_algo=build_algo).fit_transform(
-        data, convert_dtype=True
-    )
+    embedding = cuUMAP(build_algo=build_algo).fit_transform(data)
 
     if nrows < 500000:
         score = adjusted_rand_score(labels, KMeans(5).fit_predict(embedding))
@@ -93,7 +91,7 @@ def test_umap_fit_transform_score(nrows, n_feats, build_algo):
     cuml_model = cuUMAP(n_neighbors=10, min_dist=0.01, build_algo=build_algo)
 
     embedding = model.fit_transform(data)
-    cuml_embedding = cuml_model.fit_transform(data, convert_dtype=True)
+    cuml_embedding = cuml_model.fit_transform(data)
 
     assert not np.isnan(embedding).any()
     assert not np.isnan(cuml_embedding).any()
@@ -112,7 +110,7 @@ def test_supervised_umap_trustworthiness_on_iris():
     data = iris.data
     embedding = cuUMAP(
         n_neighbors=10, random_state=0, min_dist=0.01
-    ).fit_transform(data, iris.target, convert_dtype=True)
+    ).fit_transform(data, iris.target)
     trust = trustworthiness(iris.data, embedding, n_neighbors=10)
     assert trust >= 0.97
 
@@ -124,7 +122,7 @@ def test_semisupervised_umap_trustworthiness_on_iris():
     target[25:75] = -1
     embedding = cuUMAP(
         n_neighbors=10, random_state=0, min_dist=0.01
-    ).fit_transform(data, target, convert_dtype=True)
+    ).fit_transform(data, target)
 
     trust = trustworthiness(iris.data, embedding, n_neighbors=10)
     assert trust >= 0.97
@@ -135,7 +133,7 @@ def test_umap_trustworthiness_on_iris():
     data = iris.data
     embedding = cuUMAP(
         n_neighbors=10, min_dist=0.01, random_state=0
-    ).fit_transform(data, convert_dtype=True)
+    ).fit_transform(data)
     trust = trustworthiness(iris.data, embedding, n_neighbors=10)
     assert trust >= 0.97
 
@@ -157,9 +155,9 @@ def test_umap_transform_on_iris(target_metric):
         random_state=42,
         target_metric=target_metric,
     )
-    fitter.fit(data, convert_dtype=True)
+    fitter.fit(data)
     new_data = iris.data[~iris_selection]
-    embedding = fitter.transform(new_data, convert_dtype=True)
+    embedding = fitter.transform(new_data)
 
     assert not np.isnan(embedding).any()
 
@@ -195,10 +193,10 @@ def test_umap_transform_on_digits_sparse(
     new_data = sparse.csr_matrix(sp.csr_matrix(digits.data[~digits_selection]))
 
     if xform_method == "fit":
-        fitter.fit(data, convert_dtype=True)
-        embedding = fitter.transform(new_data, convert_dtype=True)
+        fitter.fit(data)
+        embedding = fitter.transform(new_data)
     else:
-        embedding = fitter.fit_transform(new_data, convert_dtype=True)
+        embedding = fitter.fit_transform(new_data)
 
     if input_type == "cupy":
         embedding = embedding.get()
@@ -226,11 +224,11 @@ def test_umap_transform_on_digits(target_metric):
         random_state=42,
         target_metric=target_metric,
     )
-    fitter.fit(data, convert_dtype=True)
+    fitter.fit(data)
 
     new_data = digits.data[~digits_selection]
 
-    embedding = fitter.transform(new_data, convert_dtype=True)
+    embedding = fitter.transform(new_data)
     trust = trustworthiness(
         digits.data[~digits_selection], embedding, n_neighbors=15
     )
@@ -266,7 +264,7 @@ def test_umap_fit_transform_trust(name, target_metric):
         n_neighbors=10, min_dist=0.01, target_metric=target_metric
     )
     embedding = model.fit_transform(data)
-    cuml_embedding = cuml_model.fit_transform(data, convert_dtype=True)
+    cuml_embedding = cuml_model.fit_transform(data)
 
     trust = trustworthiness(data, embedding, n_neighbors=10)
     cuml_trust = trustworthiness(data, cuml_embedding, n_neighbors=10)
@@ -330,7 +328,7 @@ def test_umap_fit_transform_score_default(target_metric, build_algo):
     cuml_model = cuUMAP(target_metric=target_metric, build_algo=build_algo)
 
     embedding = model.fit_transform(data)
-    cuml_embedding = cuml_model.fit_transform(data, convert_dtype=True)
+    cuml_embedding = cuml_model.fit_transform(data)
 
     cuml_score = adjusted_rand_score(
         labels, KMeans(10).fit_predict(cuml_embedding)
@@ -355,8 +353,8 @@ def test_umap_fit_transform_against_fit_and_transform(build_algo):
 
     cuml_model = cuUMAP(build_algo=build_algo)
 
-    ft_embedding = cuml_model.fit_transform(data, convert_dtype=True)
-    fit_embedding_same_input = cuml_model.transform(data, convert_dtype=True)
+    ft_embedding = cuml_model.fit_transform(data)
+    fit_embedding_same_input = cuml_model.transform(data)
 
     assert joblib.hash(ft_embedding) != joblib.hash(fit_embedding_same_input)
 
@@ -366,14 +364,12 @@ def test_umap_fit_transform_against_fit_and_transform(build_algo):
 
     cuml_model = cuUMAP(hash_input=True)
 
-    ft_embedding = cuml_model.fit_transform(data, convert_dtype=True)
-    fit_embedding_same_input = cuml_model.transform(data, convert_dtype=True)
+    ft_embedding = cuml_model.fit_transform(data)
+    fit_embedding_same_input = cuml_model.transform(data)
 
     assert joblib.hash(ft_embedding) == joblib.hash(fit_embedding_same_input)
 
-    fit_embedding_diff_input = cuml_model.transform(
-        data[1:], convert_dtype=True
-    )
+    fit_embedding_diff_input = cuml_model.transform(data[1:])
     assert joblib.hash(ft_embedding) != joblib.hash(fit_embedding_diff_input)
 
 
@@ -408,7 +404,7 @@ def test_umap_fit_transform_reproducibility(n_components, random_state):
             random_state=random_state,
             build_algo="brute_force_knn",
         )
-        return reducer.fit_transform(data, convert_dtype=True)
+        return reducer.fit_transform(data)
 
     state = copy.deepcopy(random_state)
     cuml_embedding1 = get_embedding(n_components, state)
@@ -450,7 +446,7 @@ def test_umap_force_serial_epochs_reproducibility(n_components, init):
             random_state=42,
             force_serial_epochs=True,
             build_algo="brute_force_knn",
-        ).fit_transform(data, convert_dtype=True)
+        ).fit_transform(data)
 
     cuml_embedding1 = get_embedding()
     cuml_embedding2 = get_embedding()
@@ -498,8 +494,8 @@ def test_umap_transform_reproducibility(n_components, random_state):
             random_state=random_state,
             build_algo="brute_force_knn",
         )
-        reducer.fit(fit_data, convert_dtype=True)
-        return reducer.transform(transform_data, convert_dtype=True)
+        reducer.fit(fit_data)
+        return reducer.transform(transform_data)
 
     state = copy.deepcopy(random_state)
     cuml_embedding1 = get_embedding(n_components, state)
@@ -527,7 +523,7 @@ def test_umap_fit_transform_trustworthiness_with_consistency_enabled():
         init="random",
         random_state=42,
     )
-    embedding = algo.fit_transform(data, convert_dtype=True)
+    embedding = algo.fit_transform(data)
     trust = trustworthiness(iris.data, embedding, n_neighbors=10)
     assert trust >= 0.97
 
@@ -546,8 +542,8 @@ def test_umap_transform_trustworthiness_with_consistency_enabled():
         init="random",
         random_state=42,
     )
-    model.fit(fit_data, convert_dtype=True)
-    embedding = model.transform(transform_data, convert_dtype=True)
+    model.fit(fit_data)
+    embedding = model.transform(transform_data)
     trust = trustworthiness(transform_data, embedding, n_neighbors=10)
     assert trust >= 0.92
 
@@ -828,7 +824,6 @@ def test_umap_knn_graph(n_neighbors, build_algo, data_on_gpu):
         embd = model.fit_transform(
             cp.array(data) if data_on_gpu else data,
             knn_graph=knn_graph,
-            convert_dtype=True,
         )
 
         return embd.get() if data_on_gpu else embd
@@ -843,11 +838,8 @@ def test_umap_knn_graph(n_neighbors, build_algo, data_on_gpu):
         model.fit(
             cp.array(data) if data_on_gpu else data,
             knn_graph=knn_graph,
-            convert_dtype=True,
         )
-        embd = model.transform(
-            cp.array(data) if data_on_gpu else data, convert_dtype=True
-        )
+        embd = model.transform(cp.array(data) if data_on_gpu else data)
         return embd.get() if data_on_gpu else embd
 
     def test_trustworthiness(embedding):
@@ -1142,12 +1134,10 @@ def test_umap_trustworthiness_on_batch_nnd(
     )
 
     if fit_then_transform:
-        cuml_model.fit(digits.data, convert_dtype=True)
+        cuml_model.fit(digits.data)
         cuml_embedding = cuml_model.transform(digits.data)
     else:
-        cuml_embedding = cuml_model.fit_transform(
-            digits.data, convert_dtype=True
-        )
+        cuml_embedding = cuml_model.fit_transform(digits.data)
 
     cuml_trust = trustworthiness(
         digits.data, cuml_embedding, n_neighbors=10, metric=metric
@@ -1188,7 +1178,7 @@ def test_umap_fit_transform_batch_brute_force_reproducibility(
             build_algo="brute_force_knn",
             build_kwds={"knn_n_clusters": num_clusters},
         )
-        return reducer.fit_transform(data, convert_dtype=True)
+        return reducer.fit_transform(data)
 
     state = copy.deepcopy(random_state)
     cuml_embedding1 = get_embedding(n_components, state)

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -812,6 +812,27 @@ def test_check_array_sparse_copy(mem_type, format):
         assert ptr(res.indptr) != ptr(array.indptr)
 
 
+def test_convert_dtype_deprecated():
+    model = MyModel()
+    X = cp.array([[1, 2], [3, 4], [5, 6]], dtype="float32")
+    y = sample_weight = cp.array([1, 2, 3], dtype="float32")
+
+    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
+        check_array(X, dtype="float64", convert_dtype=True)
+
+    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
+        check_inputs(model, X, dtype="float64", convert_dtype=True)
+
+    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
+        check_y(y, dtype="float64", convert_dtype=True)
+
+    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
+        check_sample_weight(sample_weight, dtype="float64", convert_dtype=True)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:`convert_dtype` was deprecated:FutureWarning"
+)
 def test_check_array_convert_dtype():
     array = cp.array([[1, 2, 3]], dtype="float32")
 


### PR DESCRIPTION
This deprecates the `convert_dtype` kwarg everywhere in `cuml`.

See #7646 for more information. In short, we're removing it for the following reasons:

> - There are other reasons we make a copy within cuml besides incorrect dtype. We also have `order` requirements, contiguity requirements, host/device requirements, or sometimes even algorithmic mutation requirements. Singling out dtype over other reasons to say "don't ever copy" feels off.
> - The documentation makes it sound like setting `convert_dtype=False` may be a memory optimization, but in reality it just removes one place where we might make a copy and replaces it with a loud error. I fail to see the use case for this option.
> - Additional kwargs on methods and functions muddy our API and make it harder for a user to find valid options. There is a usability cost to too many knobs.
> - Not every method or function implements `convert_dtype`, and not every method or function implements it consistently. An inconsistent API is a UX issue.

There is no replacement option, as the parameter either led to errors or did nothing if the inputs were of the required dtype. Users who were providing this parameter before should just stop using it.

Fixes #7646.