### PR TITLE
skip Cython 3.2.7

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,!=3.2.7
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,!=3.2.7
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,!=3.2.7
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -18,7 +18,7 @@ dependencies:
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cuvs==26.8.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.2.2
+- cython>=3.2.2,!=3.2.7
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
 - dask-ml>=2024

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -78,7 +78,8 @@ requirements:
   host:
     - cuda-version =${{ cuda_version }}
     - cudf =${{ minor_version }}
-    - cython >=3.2.2
+    # skipping Cython 3.2.7 because of https://github.com/cython/cython/issues/7781
+    - cython >=3.2.2,!=3.2.7
     - libcuml =${{ version }}
     - nvforest =${{ minor_version }}
     - pip

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -342,7 +342,8 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cython cython>=3.2.2
+          # skipping Cython 3.2.7 because of https://github.com/cython/cython/issues/7781
+          - &cython cython>=3.2.2,!=3.2.7
           - &treelite treelite>=4.7.0,<5.0.0
   py_run_cuml:
     common:

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -112,7 +112,7 @@ classifiers = [
 [project.optional-dependencies]
 test = [
     "certifi",
-    "cython>=3.2.2",
+    "cython>=3.2.2,!=3.2.7",
     "hdbscan>=0.8.39",
     "hypothesis>=6.0,<7",
     "ipython>=7.32.0",
@@ -189,7 +189,7 @@ matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=4.0",
     "cuda-python>=13.0.1,<14.0",
-    "cython>=3.2.2",
+    "cython>=3.2.2,!=3.2.7",
     "libcuml==26.8.*,>=0.0.0a0",
     "libnvforest==26.8.*,>=0.0.0a0",
     "libraft==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
Building against Cython 3.2.7 is failing, because of the issues described in https://github.com/cython/cython/issues/7781

This ensures we skip that version here, which should unblock CI.

more details: https://github.com/rapidsai/cuml/pull/8287#issuecomment-4844117013