### PR TITLE
Warn in `cuml.accel` if proxying a package outside a range of tested versions

### DIFF
--- a/python/cuml/cuml/accel/accelerator.py
+++ b/python/cuml/cuml/accel/accelerator.py
@@ -110,14 +110,16 @@ def wrap_module(
     return out
 
 
-class ModuleTransform:
+class ModuleHandler:
     def __init__(
         self,
         override: LazyNamespace | None = None,
         patch: LazyNamespace | None = None,
+        callback: Callable[[], Any] | None = None,
     ):
         self.override = override
         self.patch = patch
+        self.callback = callback
 
     @staticmethod
     def _load_namespace(
@@ -139,6 +141,9 @@ class ModuleTransform:
 
     def apply(self, module: AccelModule) -> None:
         """Load and apply patches/overrides to an accelerated module."""
+        if self.callback is not None:
+            self.callback()
+
         if self.patch is not None:
             ns = self._load_namespace(module, self.patch)
             for k, v in ns.items():
@@ -155,11 +160,11 @@ class AccelLoader(importlib.abc.Loader):
     def __init__(
         self,
         spec: importlib.machinery.ModuleSpec,
-        transform: ModuleTransform,
+        handler: ModuleHandler,
         exclude: Callable[[str], bool] | None = None,
     ) -> None:
         self._spec = spec
-        self._transform = transform
+        self._handler = handler
         self._exclude = exclude
 
     def create_module(
@@ -173,7 +178,7 @@ class AccelLoader(importlib.abc.Loader):
         assert isinstance(module, AccelModule)
         assert self._spec.loader is not None
         self._spec.loader.exec_module(module._accel_module)
-        self._transform.apply(module)
+        self._handler.apply(module)
 
 
 class AccelFinder(importlib.abc.MetaPathFinder):
@@ -197,7 +202,7 @@ class AccelFinder(importlib.abc.MetaPathFinder):
         if fullname in self._importing:
             return None
 
-        if (transform := self.accelerator.transforms.get(fullname)) is None:
+        if (handler := self.accelerator.modules.get(fullname)) is None:
             return None
 
         try:
@@ -211,7 +216,7 @@ class AccelFinder(importlib.abc.MetaPathFinder):
 
         spec = importlib.machinery.ModuleSpec(
             name=fullname,
-            loader=AccelLoader(real_spec, transform, self.accelerator.exclude),
+            loader=AccelLoader(real_spec, handler, self.accelerator.exclude),
             origin=real_spec.origin,
             loader_state=real_spec.loader_state,
             is_package=real_spec.submodule_search_locations is not None,
@@ -232,7 +237,7 @@ class Accelerator:
     """
 
     exclude: Callable[[str], bool]
-    transforms: dict[str, ModuleTransform]
+    modules: dict[str, ModuleHandler]
     _lock: RLock
     _installed: bool
 
@@ -244,7 +249,7 @@ class Accelerator:
         else:
             self.exclude = frozenset(exclude or ()).__contains__
 
-        self.transforms = {}
+        self.modules = {}
         self._lock = RLock()
         self._installed = False
 
@@ -267,6 +272,7 @@ class Accelerator:
         name: str,
         override: LazyNamespace | None = None,
         patch: LazyNamespace | None = None,
+        callback: Callable[[], Any] | None = None,
     ):
         """Register a new override or patch for a module.
 
@@ -284,7 +290,7 @@ class Accelerator:
         ----------
         name : str
             The name of the unaccelerated module to patch.
-        override, patch : mapping, callable, or str
+        override, patch : mapping, callable, str, or None, default=None
             May be one of the following:
 
             - A mapping of attributes to override/patch in the accelerated
@@ -294,6 +300,9 @@ class Accelerator:
             - A string name of a module to import containing overrides or
               patches. All names specified in `__all__` in the module will be
               used to override/patch attributes in the accelerated module.
+        callback : callable or None, default=None
+            A callback taking no arguments to be called upong first loading
+            of this module.
 
         Examples
         --------
@@ -308,10 +317,12 @@ class Accelerator:
         >>> accel.register("foobar", "fast.foobar")
         """
         assert not self._installed
-        assert name not in self.transforms
-        self.transforms[name] = ModuleTransform(override=override, patch=patch)
+        assert name not in self.modules
+        self.modules[name] = ModuleHandler(
+            override=override, patch=patch, callback=callback
+        )
 
-    def _maybe_transform(self, name: str) -> None:
+    def _handle_if_already_imported(self, name: str) -> None:
         if (module := sys.modules.get(name)) is None:
             # Not imported yet, import system will load patch lazily later
             return
@@ -333,8 +344,8 @@ class Accelerator:
         if getattr(parent, child_name, None) is module:
             setattr(parent, child_name, accelerated)
 
-        # 4. Apply module transforms
-        self.transforms[name].apply(accelerated)
+        # 4. Apply module handler
+        self.modules[name].apply(accelerated)
 
     def install(self) -> None:
         """Install the accelerator.
@@ -350,8 +361,8 @@ class Accelerator:
             # Install the import hook. This handles patching any modules imported later.
             sys.meta_path.insert(0, AccelFinder(self))
 
-            # Wrap any modules that are already imported.
-            for name in self.transforms:
-                self._maybe_transform(name)
+            # Handle any modules that are already imported.
+            for name in self.modules:
+                self._handle_if_already_imported(name)
 
             self._installed = True

--- a/python/cuml/cuml/accel/accelerator.py
+++ b/python/cuml/cuml/accel/accelerator.py
@@ -301,7 +301,7 @@ class Accelerator:
               patches. All names specified in `__all__` in the module will be
               used to override/patch attributes in the accelerated module.
         callback : callable or None, default=None
-            A callback taking no arguments to be called upong first loading
+            A callback taking no arguments to be called upon first loading
             of this module.
 
         Examples

--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -5,11 +5,14 @@
 from __future__ import annotations
 
 import enum
+import importlib.metadata
 import os
 from typing import Literal
 
 from cuda.bindings import runtime
+from packaging.requirements import Requirement
 
+import cuml
 from cuml.accel.accelerator import Accelerator
 from cuml.internals.outputs import set_global_output_type
 
@@ -82,6 +85,45 @@ class Logger:
 logger = Logger()
 
 
+class CheckConstraint:
+    """A version constraint checker.
+
+    A warning will be logged if the constraint is not satisfied.
+
+    Parameters
+    ----------
+    constraint: str
+        A constraint on the installed version of the package, in the form
+        of a valid requirements string.
+    """
+
+    def __init__(self, requirement: str) -> None:
+        self.requirement = Requirement(requirement)
+
+    def __call__(self) -> bool:
+        """Check the constraint.
+
+        Returns whether the constraint was satisfied, and logs a warning if
+        it wasn't.
+        """
+        version = importlib.metadata.version(self.requirement.name)
+        if not self.requirement.specifier.contains(version):
+            logger.warn(
+                f"Warning: `cuml.accel` version {cuml.__version__} was tested "
+                f"with {self.requirement!s}, but {self.requirement.name}={version} "
+                f"was found. Things may work, but you may also encounter "
+                f"potentially subtle breakage."
+            )
+            return False
+        return True
+
+
+_CONSTRAINTS = {
+    "sklearn": CheckConstraint("scikit-learn>=1.6,<=1.9"),
+    "hdbscan": CheckConstraint("hdbscan>=0.8.39,<=0.8.44"),
+    "umap": CheckConstraint("umap-learn>=0.5.7,<=0.5.12"),
+}
+
 _OVERRIDES = {
     "hdbscan",
     "sklearn.cluster",
@@ -105,7 +147,7 @@ _PATCHES = {
     "sklearn.utils.discovery",
 }
 
-ACCELERATED_MODULES = sorted(_OVERRIDES.union(_PATCHES))
+ACCELERATED_MODULES = sorted(_OVERRIDES.union(_PATCHES).union(_CONSTRAINTS))
 
 
 def _exclude_from_acceleration(module: str) -> bool:
@@ -132,6 +174,7 @@ for module in ACCELERATED_MODULES:
         patch=(
             f"cuml.accel._patches.{module}" if module in _PATCHES else None
         ),
+        callback=_CONSTRAINTS.get(module),
     )
 
 

--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -119,7 +119,7 @@ class CheckConstraint:
 
 
 _CONSTRAINTS = {
-    "sklearn": CheckConstraint("scikit-learn>=1.6,<=1.9"),
+    "sklearn": CheckConstraint("scikit-learn>=1.6.0,<=1.9.0"),
     "hdbscan": CheckConstraint("hdbscan>=0.8.39,<=0.8.44"),
     "umap": CheckConstraint("umap-learn>=0.5.7,<=0.5.12"),
 }

--- a/python/cuml/cuml_accel_tests/test_accelerator.py
+++ b/python/cuml/cuml_accel_tests/test_accelerator.py
@@ -94,19 +94,29 @@ def mockmod(clean_meta_path):
 
 
 def test_accelerator(mockmod):
+    call_count = 0
+
+    def callback():
+        nonlocal call_count
+        call_count += 1
+
     def fizz():
         return "FIZZ"
 
     accel = Accelerator()
+    accel.register(f"{mockmod}.utils", {"fizz": fizz}, callback=callback)
     assert not accel.installed
-    accel.register(f"{mockmod}.utils", {"fizz": fizz})
+    assert call_count == 0
+
     accel.install()
     assert accel.installed
+    assert call_count == 0
 
-    # No harm in calling install more than once
+    # No harm in calling install more than once, it's a no-op
     accel.install()
 
     mod = importlib.import_module(mockmod)
+    assert call_count == 1  # callback delayed until first import
     assert mod.fizz is fizz
     assert mod.utils.fizz is fizz
     assert sys.modules[f"{mockmod}.utils"] is mod.utils
@@ -185,20 +195,28 @@ def test_accelerator_import_in_override(mockmod):
 
 
 def test_accelerator_install_after_import(mockmod):
+    callback_called = False
+
+    def callback():
+        nonlocal callback_called
+        callback_called = True
+
     def fizz():
         return "FIZZ"
 
     accel = Accelerator()
-    accel.register(f"{mockmod}.utils", {"fizz": fizz})
+    accel.register(f"{mockmod}.utils", {"fizz": fizz}, callback=callback)
 
     mod = importlib.import_module(mockmod)
     assert mod.utils.fizz is not fizz
+    assert not callback_called
 
     accel.install()
 
     assert isinstance(mod.utils, AccelModule)
     assert sys.modules[f"{mockmod}.utils"] is mod.utils
     assert mod.utils.fizz is fizz
+    assert callback_called
 
 
 def test_accelerator_module_patch(mockmod):

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -9,6 +9,7 @@ import pytest
 from packaging.version import Version
 
 import cuml.accel
+from cuml.accel.core import _CONSTRAINTS
 from cuml.accel.estimator_proxy import ProxyBase
 
 
@@ -142,3 +143,30 @@ def test_proxied_methods_signature_compatibility(cls, name):
                 Parameter.KEYWORD_ONLY,
                 Parameter.VAR_KEYWORD,
             }
+
+
+def test_constraints_match_installed_versions(capsys):
+    """This test checks all registered version constraints, and errors if
+    they're not met in the test environment. Since we test oldest and latest
+    versions in CI, this test will error if we ever update our dependencies
+    without also updating the constraints."""
+
+    invalid = []
+    for constraint in _CONSTRAINTS.values():
+        if not constraint():
+            invalid.append(f"- {constraint.requirement!s}")
+
+    stdout, _ = capsys.readouterr()
+    logs = [
+        line for line in stdout.split("\n") if line.startswith("[cuml.accel]")
+    ]
+    if invalid:
+        msg = (
+            "Please update `cuml.accel.core._CONSTRAINTS` to match the new "
+            "runtime constraints.\n\n"
+            "Currently the following constraints failed:\n\n"
+            f"{'\n'.join(invalid)}\n\n"
+            "leading to the following user-facing logs:\n\n"
+            f"{'\n'.join(logs)}"
+        )
+        assert False, msg

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -176,22 +176,26 @@ def test_constraints_match_installed_versions(capsys):
     versions in CI, this test will error if we ever update our dependencies
     without also updating the constraints."""
 
-    invalid = []
-    for constraint in _CONSTRAINTS.values():
-        if not constraint():
-            invalid.append(f"- {constraint.requirement!s}")
-
-    stdout, _ = capsys.readouterr()
-    logs = [
-        line for line in stdout.split("\n") if line.startswith("[cuml.accel]")
+    missed_constraints = [
+        constraint for constraint in _CONSTRAINTS.values() if not constraint()
     ]
-    if invalid:
+
+    if missed_constraints:
+        constraint_lines = "\n".join(
+            f"- {c.requirement!s}" for c in missed_constraints
+        )
+        stdout, _ = capsys.readouterr()
+        log_lines = "\n".join(
+            line
+            for line in stdout.split("\n")
+            if line.startswith("[cuml.accel]")
+        )
         msg = (
             "Please update `cuml.accel.core._CONSTRAINTS` to match the new "
             "runtime constraints.\n\n"
             "Currently the following constraints failed:\n\n"
-            f"{'\n'.join(invalid)}\n\n"
+            f"{constraint_lines}\n\n"
             "leading to the following user-facing logs:\n\n"
-            f"{'\n'.join(logs)}"
+            f"{log_lines}"
         )
         assert False, msg

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -6,10 +6,11 @@ import multiprocessing
 from inspect import Parameter, signature
 
 import pytest
+import sklearn
 from packaging.version import Version
 
 import cuml.accel
-from cuml.accel.core import _CONSTRAINTS
+from cuml.accel.core import _CONSTRAINTS, CheckConstraint
 from cuml.accel.estimator_proxy import ProxyBase
 
 
@@ -143,6 +144,30 @@ def test_proxied_methods_signature_compatibility(cls, name):
                 Parameter.KEYWORD_ONLY,
                 Parameter.VAR_KEYWORD,
             }
+
+
+def test_check_constraints(capsys):
+    # A constraingt we know to be met
+    constraint = CheckConstraint("scikit-learn>=1.0")
+    assert constraint()
+    stdout, _ = capsys.readouterr()
+    logs = [
+        line for line in stdout.split("\n") if line.startswith("[cuml.accel]")
+    ]
+    assert not logs
+
+    # A constraint we know to not be met
+    constraint = CheckConstraint("scikit-learn>=1.0,<=1.4")
+
+    assert not constraint()
+    stdout, _ = capsys.readouterr()
+    logs = [
+        line for line in stdout.split("\n") if line.startswith("[cuml.accel]")
+    ]
+    assert len(logs) == 1
+    log = logs[0]
+    assert str(constraint.requirement) in log
+    assert sklearn.__version__ in log
 
 
 def test_constraints_match_installed_versions(capsys):

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -147,7 +147,7 @@ def test_proxied_methods_signature_compatibility(cls, name):
 
 
 def test_check_constraints(capsys):
-    # A constraingt we know to be met
+    # A constraint we know to be met
     constraint = CheckConstraint("scikit-learn>=1.0")
     assert constraint()
     stdout, _ = capsys.readouterr()
@@ -176,9 +176,13 @@ def test_constraints_match_installed_versions(capsys):
     versions in CI, this test will error if we ever update our dependencies
     without also updating the constraints."""
 
-    missed_constraints = [
-        constraint for constraint in _CONSTRAINTS.values() if not constraint()
-    ]
+    missed_constraints = []
+    for constraint in _CONSTRAINTS.values():
+        version = importlib.metadata.version(constraint.requirement.name)
+        # Skip checking constraints on prereleases so this test doesn't fail
+        # when run with sklearn prereleases as part of nightly runs.
+        if not Version(version).is_prerelease and not constraint():
+            missed_constraints.append(constraint)
 
     if missed_constraints:
         constraint_lines = "\n".join(


### PR DESCRIPTION
This adds a new logged warning in `cuml.accel` when a user tries to use it with a version of a proxied package (currently `scikit-learn`, `umap-learn`, or `hdbscan`) outside the range of packages we've tested with.

The purpose of this warning is to let the user know:

- The version they're running with is outside the range we've tested to be working
- Things _may_ work, or _may_ break. We cannot guarantee anything.

The warning looks like this:

```
In [1]: %load_ext cuml.accel
[cuml.accel] Warning: `cuml.accel` version 26.08.00 was tested with scikit-learn<1.9,>=1.6, but scikit-learn=1.9.0 was found. Things may work, but you may also encounter potentially subtle breakage.
```

The warning is delayed until the package is imported. For `sklearn` (a required dependency of cuml) this means the warning will always effectively happen right away when `cuml.accel` is loaded. For `hdbscan` and `umap-learn` the warning won't happen until the user imports those packages (if ever). This means a user with an invalid version of `umap-learn` installed won't see a warning for that unless they actually try using `cuml.accel` with `umap-learn`.

To ensure the constraints remain aligned with the versions we test against, I've added a test in `cuml_accel_tests` that checks the constraints match the versions installed in CI. Since we test the oldest and latest versions in CI, this will prevent ever updating `dependencies.yaml` without also updating `cuml.accel.core._CONSTRAINTS`.

Fixes #8211.