### PR TITLE
Deprecate `PorterStemmer`

### DIFF
--- a/python/cuml/cuml/preprocessing/text/stem/porter_stemmer.py
+++ b/python/cuml/cuml/preprocessing/text/stem/porter_stemmer.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
+import warnings
 
 import cudf
 import cupy as cp
@@ -36,6 +36,12 @@ from .porter_stemmer_utils.suffix_utils import (
 class PorterStemmer:
     """
     A word stemmer based on the Porter stemming algorithm.
+
+    .. deprecated:: 26.08
+
+        This class was deprecated in version 26.08 and will be removed
+        in version 26.10. Please transition to an alternative Porter
+        Stemmer implementation.
 
     Porter, M. "An algorithm for suffix stripping."
     Program 14.3 (1980): 130-137.
@@ -77,6 +83,12 @@ class PorterStemmer:
     """
 
     def __init__(self, mode="NLTK_EXTENSIONS"):
+        warnings.warn(
+            "`cuml.preprocessing.text.stem.PorterStemmer` was deprecated "
+            "in version 26.08 and will be removed in version 26.10. Please "
+            "transition to an alternative Porter Stemmer implementation.",
+            FutureWarning,
+        )
         if mode != "NLTK_EXTENSIONS":
             raise ValueError(
                 "Only PorterStemmer.NLTK_EXTENSIONS is supported currently"

--- a/python/cuml/tests/stemmer_tests/test_stemmer.py
+++ b/python/cuml/tests/stemmer_tests/test_stemmer.py
@@ -1,14 +1,26 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import cudf
+import pytest
 from nltk import stem as nltk_stem
 
 from cuml.preprocessing.text import stem as rapids_stem
 
 
+def test_deprecated():
+    with pytest.warns(
+        FutureWarning,
+        match=r"`cuml\.preprocessing\.text\.stem\.PorterStemmer`",
+    ):
+        rapids_stem.PorterStemmer()
+
+
+@pytest.mark.filterwarnings(
+    "ignore:`cuml.preprocessing.text.stem.PorterStemmer`:FutureWarning"
+)
 def test_same_results():
     # This is a list of 100 random words from nltk treebank.
     word_ls = [

--- a/python/cuml/tests/stemmer_tests/test_steps.py
+++ b/python/cuml/tests/stemmer_tests/test_steps.py
@@ -1,12 +1,15 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
-
-
 import cudf
+import pytest
 
 from cuml.preprocessing.text.stem.porter_stemmer import PorterStemmer
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:`cuml.preprocessing.text.stem.PorterStemmer`:FutureWarning"
+)
 
 
 def test_step1a():


### PR DESCRIPTION
This deprecates `cuml.preprocessing.text.stem.PorterStemmer`.

- There's no sklearn equivalent implementation
- The API doesn't match the sklearn API conventions we want `cuml` to center on.
- The algorithm is very domain specific, and is stale enough (and outside our team's expertise enough) that we don't want to invest time in it.

Fixes #8302.