### PR TITLE
`cuml.accel` SVM onnx support 

### DIFF
--- a/docs/source/cuml-accel/limitations.rst
+++ b/docs/source/cuml-accel/limitations.rst
@@ -527,24 +527,12 @@ SVC
   ``CalibratedClassifierCV(SVC(), ensemble=False)`` instead. This will be
   supported across ``scikit-learn`` versions, and won't require CPU fallback.
 
-Additional notes:
-
-- ONNX export via ``skl2onnx`` is not supported for this estimator.
-- Using ``SVC`` in the same process as ``LinearSVC`` under ``cuml.accel`` can
-  cause a segfault.
-
 SVR
 ^^^
 
 ``SVR`` will fall back to CPU in the following cases:
 
 - If ``kernel="precomputed"`` or is a callable.
-
-Additional notes:
-
-- ONNX export via ``skl2onnx`` is not supported for this estimator.
-- Using ``SVR`` in the same process as ``LinearSVR`` under ``cuml.accel`` can
-  cause a segfault.
 
 LinearSVC
 ^^^^^^^^^

--- a/python/cuml/cuml/accel/_overrides/sklearn/svm.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/svm.py
@@ -31,12 +31,7 @@ def _has_probability(model):
 
 class SVC(ProxyBase):
     _gpu_class = cuml.svm.SVC
-    _not_implemented_attributes = frozenset(
-        (
-            "class_weight_",
-            "n_iter_",
-        )
-    )
+    _other_attributes = frozenset(("_gamma",))
 
     def _gpu_fit(self, X, y, sample_weight=None):
         classes = np.unique(np.asanyarray(y))
@@ -62,7 +57,7 @@ class SVC(ProxyBase):
 
 class SVR(ProxyBase):
     _gpu_class = cuml.svm.SVR
-    _not_implemented_attributes = frozenset(("n_iter_",))
+    _other_attributes = frozenset(("_gamma",))
 
 
 class LinearSVC(ProxyBase):

--- a/python/cuml/cuml_accel_tests/test_onnx.py
+++ b/python/cuml/cuml_accel_tests/test_onnx.py
@@ -30,10 +30,6 @@ FloatTensorType = skl2onnx.common.data_types.FloatTensorType
 xfail_unsupported = pytest.mark.xfail(
     reason="not supported by skl2onnx", strict=True
 )
-xfail_proxy_private_attr = pytest.mark.xfail(
-    reason="skl2onnx accesses private attributes not exposed by the proxy",
-    strict=True,
-)
 xfail_skl2onnx_bug = pytest.mark.xfail(
     reason="skl2onnx conversion error", strict=True
 )
@@ -74,8 +70,10 @@ classifiers = [
     pytest.param(LinearSVC(dual="auto"), id="LinearSVC"),
     pytest.param(
         SVC(kernel="linear"),
-        marks=xfail_proxy_private_attr,
         id="SVC",
+        marks=pytest.mark.filterwarnings(
+            "ignore:Attribute `prob[A|B]_` was deprecated:FutureWarning"
+        ),
     ),
     pytest.param(
         OneVsOneClassifier(LinearSVC(dual="auto")),
@@ -96,11 +94,7 @@ regressors = [
     ),
     pytest.param(KNeighborsRegressor(), id="KNeighborsRegressor"),
     pytest.param(LinearSVR(dual="auto"), id="LinearSVR"),
-    pytest.param(
-        SVR(kernel="linear"),
-        marks=xfail_proxy_private_attr,
-        id="SVR",
-    ),
+    pytest.param(SVR(kernel="linear"), id="SVR"),
 ]
 
 transformers = [

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -649,7 +649,6 @@
   marker: cuml_accel_invalid_sklearn_tests
   tests:
   - "sklearn.model_selection.tests.test_search::test_grid_search_score_method"
-  - "sklearn.svm.tests.test_svm::test_gamma_scale"
   - "sklearn.svm.tests.test_svm::test_svc_raises_error_internal_representation"
 - reason: This test asserts a copy hasn't happened, but that's not actually guaranteed by the interface.
   marker: cuml_accel_invalid_sklearn_tests


### PR DESCRIPTION
- Adds support for `skl2onnx` to work with `SVC`/`SVR` under `cuml.accel`
- Updates tests to fix xfails
- Removes onnx notes in the `cuml.accel` limitations
- Also removes the notes on segfaults for `SVC`/`SVR` in that section. The cause there doesn't make sense (our test suite intermingles these estimators all the time and never sees these issues), and I cannot reproduce the issue locally.

Fixes #7822