### PR TITLE
Add SVC multiclass class_weight regression test

### DIFF
--- a/python/cuml/tests/test_svm.py
+++ b/python/cuml/tests/test_svm.py
@@ -270,6 +270,26 @@ def test_svc_weights(class_weight, sample_weight):
     compare_svm(cu_model, sk_model, X, y, coef_tol=1e-5, report_summary=True)
 
 
+@pytest.mark.parametrize("decision_function_shape", ["ovo", "ovr"])
+def test_svc_multiclass_class_weight_dict(decision_function_shape):
+    X, y = make_blobs(
+        n_samples=45,
+        n_features=4,
+        centers=3,
+        random_state=137,
+    )
+
+    model = cu_svm.SVC(
+        class_weight={0: 1000.0, 1: 0.0001, 2: 0.0001},
+        decision_function_shape=decision_function_shape,
+        kernel="linear",
+        max_iter=1000,
+    )
+
+    model.fit(X, y)
+    assert cp.asnumpy(model.classes_).tolist() == [0, 1, 2]
+
+
 @pytest.mark.parametrize(
     "params",
     [


### PR DESCRIPTION
## Summary

Add regression coverage for multiclass SVC with dict `class_weight` through both `ovo` and `ovr` wrappers.

Current `upstream/main` already has the helper behavior that matches sklearn for binary subproblems: extra class-weight keys are allowed when every class in the current subproblem has a weight. This test locks in that behavior, covering the compatibility failure seen while validating #8306.

## Testing

- `pre-commit run --files python/cuml/tests/test_svm.py`
- `conda run -n cuml_dev python -m py_compile python/cuml/tests/test_svm.py`

Targeted runtime pytest was not run locally because importing the unbuilt local package in this worktree hits the known `cuml.internals.logger` circular import issue before collection.