### PR TITLE
ci: test wheel on smaller citestwheel image

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,24 +14,24 @@ jobs:
       - check-nightly-ci
       - changed-files
       - checks
-      - clang-tidy
-      - conda-cpp-build
-      - conda-cpp-tests
-      - conda-cpp-checks
-      - conda-python-build
-      - conda-python-tests-singlegpu
-      - conda-python-tests-dask
-      - conda-python-tests-cudf-pandas-integration
-      - conda-python-scikit-learn-accel-tests
-      - conda-python-cuml-accel-upstream-tests
-      - conda-notebook-tests
-      - docs-build
+      # - clang-tidy
+      # - conda-cpp-build
+      # - conda-cpp-tests
+      # - conda-cpp-checks
+      # - conda-python-build
+      # - conda-python-tests-singlegpu
+      # - conda-python-tests-dask
+      # - conda-python-tests-cudf-pandas-integration
+      # - conda-python-scikit-learn-accel-tests
+      # - conda-python-cuml-accel-upstream-tests
+      # - conda-notebook-tests
+      # - docs-build
       - telemetry-setup
       - wheel-build-libcuml
       - wheel-build-cuml
       - wheel-tests-cuml
       - wheel-tests-cuml-dask
-      - devcontainer
+      # - devcontainer
     permissions:
       actions: read
       contents: read
@@ -278,199 +278,199 @@ jobs:
       enable_check_generated_files: false
       ignored_pr_jobs: >-
         telemetry-summarize
-  clang-tidy:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    with:
-      build_type: pull-request
-      node_type: "cpu8"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/run_clang_tidy.sh"
-  conda-cpp-build:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
-    with:
-      build_type: pull-request
-      node_type: cpu16
-      script: ci/build_cpp.sh
-  conda-cpp-tests:
-    needs: [conda-cpp-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      script: ci/test_cpp.sh
-  conda-cpp-checks:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@main
-    with:
-      build_type: pull-request
-      package_name: libcuml
-  conda-python-build:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
-    with:
-      build_type: pull-request
-      script: ci/build_python.sh
-      # Build a conda package for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  conda-python-tests-singlegpu:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      script: "ci/test_python_singlegpu.sh"
-  conda-python-tests-cudf-pandas-integration:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      # Select the amd64 entry with the highest CUDA and Python version
-      matrix_filter: map(select(.ARCH=="amd64")) | [max_by([.CUDA_VER,.PY_VER]|map(split(".")|map(tonumber)))]
-      build_type: pull-request
-      script: "ci/test_python_integration.sh"
-  conda-python-tests-dask:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      script: "ci/test_python_dask.sh"
-  conda-python-scikit-learn-accel-tests:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      script: "ci/test_python_scikit_learn_tests.sh"
-      # One run for each dependencies config on amd64, breaking ties by highest Python version
-      matrix_filter: |
-        (
-          map(select(.ARCH == "amd64"))
-          | sort_by(.PY_VER)
-          | unique_by(.DEPENDENCIES)
-        )
-          + (
-          map(select(.ARCH == "amd64"))
-          | map(select(.DEPENDENCIES == "oldest"))
-          | sort_by(.PY_VER)
-          | map(.DEPENDENCIES = "intermediate")
-        )
-  conda-python-cuml-accel-upstream-tests:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      script: "ci/test_python_cuml_accel_upstream.sh"
-      # One run for each dependencies config on amd64, breaking ties by highest Python version
-      matrix_filter: map(select(.ARCH == "amd64")) | sort_by(.PY_VER) | unique_by(.DEPENDENCIES)
-  conda-notebook-tests:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/test_notebooks.sh"
-  docs-build:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-cuda13.0.2-ubuntu22.04-py3.13"
-      script: "ci/build_docs.sh"
+  # clang-tidy:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "cpu8"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/run_clang_tidy.sh"
+  # conda-cpp-build:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu16
+  #     script: ci/build_cpp.sh
+  # conda-cpp-tests:
+  #   needs: [conda-cpp-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_cpp.sh
+  # conda-cpp-checks:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     package_name: libcuml
+  # conda-python-build:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_python.sh
+  #     # Build a conda package for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # conda-python-tests-singlegpu:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/test_python_singlegpu.sh"
+  # conda-python-tests-cudf-pandas-integration:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     # Select the amd64 entry with the highest CUDA and Python version
+  #     matrix_filter: map(select(.ARCH=="amd64")) | [max_by([.CUDA_VER,.PY_VER]|map(split(".")|map(tonumber)))]
+  #     build_type: pull-request
+  #     script: "ci/test_python_integration.sh"
+  # conda-python-tests-dask:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/test_python_dask.sh"
+  # conda-python-scikit-learn-accel-tests:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/test_python_scikit_learn_tests.sh"
+  #     # One run for each dependencies config on amd64, breaking ties by highest Python version
+  #     matrix_filter: |
+  #       (
+  #         map(select(.ARCH == "amd64"))
+  #         | sort_by(.PY_VER)
+  #         | unique_by(.DEPENDENCIES)
+  #       )
+  #         + (
+  #         map(select(.ARCH == "amd64"))
+  #         | map(select(.DEPENDENCIES == "oldest"))
+  #         | sort_by(.PY_VER)
+  #         | map(.DEPENDENCIES = "intermediate")
+  #       )
+  # conda-python-cuml-accel-upstream-tests:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/test_python_cuml_accel_upstream.sh"
+  #     # One run for each dependencies config on amd64, breaking ties by highest Python version
+  #     matrix_filter: map(select(.ARCH == "amd64")) | sort_by(.PY_VER) | unique_by(.DEPENDENCIES)
+  # conda-notebook-tests:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/test_notebooks.sh"
+  # docs-build:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-cuda13.0.2-ubuntu22.04-py3.13"
+  #     script: "ci/build_docs.sh"
   wheel-build-libcuml:
     needs: checks
     permissions:
@@ -519,7 +519,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -533,33 +533,33 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
       script: ci/test_wheel_dask.sh
-  devcontainer:
-    needs: telemetry-setup
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
-    with:
-      arch: '["amd64", "arm64"]'
-      cuda: '["13.3"]'
-      node_type: "cpu8"
-      env: |
-        SCCACHE_DIST_MAX_RETRIES=inf
-        SCCACHE_SERVER_LOG=sccache=debug
-        SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
-      build_command: |
-        sccache --zero-stats;
-        build-all -j0 --verbose -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON 2>&1 | tee telemetry-artifacts/build.log;
-        sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
+  # devcontainer:
+  #   needs: telemetry-setup
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
+  #   with:
+  #     arch: '["amd64", "arm64"]'
+  #     cuda: '["13.3"]'
+  #     node_type: "cpu8"
+  #     env: |
+  #       SCCACHE_DIST_MAX_RETRIES=inf
+  #       SCCACHE_SERVER_LOG=sccache=debug
+  #       SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
+  #     build_command: |
+  #       sccache --zero-stats;
+  #       build-all -j0 --verbose -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON 2>&1 | tee telemetry-artifacts/build.log;
+  #       sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4


### PR DESCRIPTION
xref rapidsai/build-planning#143
xref rapidsai/ci-imgs#400
xref rapidsai/shared-workflows#521

Test run using the smaller `cuda-base` image as the parent image of `citestwheel`

This shouldn't be merged. If all projects can run wheel tests with this image, we'll swap out the image upstream in `shared-workflows`.
