### PR TITLE
switch from 'cuda-python' to specific components (e.g. 'cuda-bindings')

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,10 +9,10 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,10 +9,10 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,10 +9,10 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,10 +9,10 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/recipes/cuml/recipe.yaml
+++ b/conda/recipes/cuml/recipe.yaml
@@ -92,8 +92,8 @@ requirements:
     - treelite ${{ treelite_version }}
     - cuda-cudart-dev
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
+      then: cuda-bindings >=12.9.2,<13.0
+      else: cuda-bindings >=13.0.1,<14.0
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
@@ -113,8 +113,8 @@ requirements:
     - rich
     - treelite ${{ treelite_version }}
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
+      then: cuda-bindings >=12.9.2,<13.0
+      else: cuda-bindings >=13.0.1,<14.0
   ignore_run_exports:
     by_name:
       - cuda-cudart

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -620,6 +620,20 @@ dependencies:
               - libopenblas<=0.3.30
           - matrix:
             packages:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              dependencies: "oldest"
+              cuda: "12.*"
+            packages:
+              - cuda-bindings==12.9.2
+          - matrix:
+              dependencies: "oldest"
+              cuda: "13.*"
+            packages:
+              - cuda-bindings==13.0.1
+          - matrix:
+            packages:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
@@ -735,11 +749,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cuda-python>=12.9.2,<13.0
+              - cuda-bindings>=12.9.2,<13.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cuda-python>=13.0.1,<14.0
+              - cuda-bindings>=13.0.1,<14.0
   depends_on_cudf:
     common:
       - output_types: conda

--- a/python/cuml/pyproject.toml
+++ b/python/cuml/pyproject.toml
@@ -83,7 +83,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-python>=13.0.1,<14.0",
+    "cuda-bindings>=13.0.1,<14.0",
     "cuda-toolkit[cublas,cufft,curand,cusolver,cusparse]==13.*",
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
@@ -188,7 +188,7 @@ dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=4.0",
-    "cuda-python>=13.0.1,<14.0",
+    "cuda-bindings>=13.0.1,<14.0",
     "cython>=3.2.2,!=3.2.7",
     "libcuml==26.8.*,>=0.0.0a0",
     "libnvforest==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/285

`cuda-python` is a metapackage and sometimes pulls in components that RAPIDS libraries don't need. This PR is part of a series dropping direct use of `cuda-python` in favor of depending only on those specific components.

* drops dependency on `cuda-python`
* adds explicit dependencies on components:
  - `cuda-bindings >=12.9.2,<13.0` (CUDA 12), `cuda-bindings >=13.0.1,<14.0` (CUDA 13)
* adds explicit testing of oldest `cuda-bindings` in CI

## Notes for Reviewers

### Why these specific bounds?

* these roughly match what we were getting with `cuda-python`
* worked through finding compatible ranges in https://github.com/rapidsai/rmm/pull/2460#discussion_r3514148466
* `cuda-bindings` major version follows the CTK major version, so kept a ceiling just like we currently have for `cuda-python`

### This PR has dependencies

* [ ] https://github.com/rapidsai/cudf/pull/23091
* [x] https://github.com/NVIDIA/raft/pull/3068
* [x] https://github.com/rapidsai/rmm/pull/2460