### PR TITLE
Use current CUDA device in cuml.accel UVM capability check

### DIFF
--- a/python/cuml/cuml/accel/core.py
+++ b/python/cuml/cuml/accel/core.py
@@ -185,9 +185,17 @@ def _is_concurrent_managed_access_supported():
     """
 
     # Ensure CUDA is initialized before checking cudaDevAttrConcurrentManagedAccess
-    runtime.cudaFree(0)
+    init_err = runtime.cudaFree(0)
+    if init_err != runtime.cudaError_t.cudaSuccess:
+        logger.error(f"cudaFree(0) returned error {init_err} while initializing CUDA")
 
-    device_id = 0
+    err, device_id = runtime.cudaGetDevice()
+    if err != runtime.cudaError_t.cudaSuccess:
+        logger.error(
+            f"Failed to get current CUDA device for managed access check with error {err}"
+        )
+        return False
+
     err, supports_managed_access = runtime.cudaDeviceGetAttribute(
         runtime.cudaDeviceAttr.cudaDevAttrConcurrentManagedAccess, device_id
     )

--- a/python/cuml/cuml_accel_tests/test_core.py
+++ b/python/cuml/cuml_accel_tests/test_core.py
@@ -10,7 +10,13 @@ import sklearn
 from packaging.version import Version
 
 import cuml.accel
-from cuml.accel.core import _CONSTRAINTS, CheckConstraint
+import cuml.accel.core as accel_core
+from cuml.accel.core import (
+    _CONSTRAINTS,
+    CheckConstraint,
+    _is_concurrent_managed_access_supported,
+    logger,
+)
 from cuml.accel.estimator_proxy import ProxyBase
 
 
@@ -203,3 +209,64 @@ def test_constraints_match_installed_versions(capsys):
             f"{log_lines}"
         )
         assert False, msg
+
+
+def test_is_concurrent_managed_access_supported_uses_current_device(monkeypatch):
+    # Validate that we query attributes for the current CUDA device.
+    calls = []
+
+    def fake_cuda_free(_: int):
+        calls.append(("cudaFree", 0))
+        return accel_core.runtime.cudaError_t.cudaSuccess
+
+    def fake_cuda_get_device():
+        calls.append(("cudaGetDevice",))
+        return accel_core.runtime.cudaError_t.cudaSuccess, 7
+
+    def fake_cuda_device_attribute(attr, device):
+        calls.append(("cudaDeviceGetAttribute", attr, device))
+        return accel_core.runtime.cudaError_t.cudaSuccess, 1
+
+    monkeypatch.setattr(accel_core.runtime, "cudaFree", fake_cuda_free)
+    monkeypatch.setattr(accel_core.runtime, "cudaGetDevice", fake_cuda_get_device)
+    monkeypatch.setattr(
+        accel_core.runtime, "cudaDeviceGetAttribute", fake_cuda_device_attribute
+    )
+
+    assert _is_concurrent_managed_access_supported()
+    assert calls == [
+        ("cudaFree", 0),
+        ("cudaGetDevice",),
+        (
+            "cudaDeviceGetAttribute",
+            accel_core.runtime.cudaDeviceAttr.cudaDevAttrConcurrentManagedAccess,
+            7,
+        ),
+    ]
+
+
+def test_is_concurrent_managed_access_supported_logs_cuda_free_result(monkeypatch):
+    # Check that cudaFree(0) return value is logged before continuing.
+    messages = []
+
+    def fake_cuda_free(_: int):
+        return accel_core.runtime.cudaError_t.cudaErrorInvalidValue
+
+    def fake_cuda_get_device():
+        return accel_core.runtime.cudaError_t.cudaSuccess, 0
+
+    def fake_cuda_device_attribute(attr, device):
+        return accel_core.runtime.cudaError_t.cudaSuccess, 0
+
+    def fake_error(message):
+        messages.append(message)
+
+    monkeypatch.setattr(accel_core.runtime, "cudaFree", fake_cuda_free)
+    monkeypatch.setattr(accel_core.runtime, "cudaGetDevice", fake_cuda_get_device)
+    monkeypatch.setattr(
+        accel_core.runtime, "cudaDeviceGetAttribute", fake_cuda_device_attribute
+    )
+    monkeypatch.setattr(logger, "error", fake_error)
+
+    assert not _is_concurrent_managed_access_supported()
+    assert any("cudaFree(0)" in message for message in messages)


### PR DESCRIPTION
## Summary
- Update `_is_concurrent_managed_access_supported()` to check `cudaGetDevice()` and use the active device for `cudaDevAttrConcurrentManagedAccess`.
- Capture and log the return code from `cudaFree(0)` while keeping the check flow functional.
- Add regressions in `python/cuml/cuml_accel_tests/test_core.py`:
  - validate the current-device query path is used.
  - validate that `cudaFree(0)` errors are logged.

## Why
The helper previously hardcoded `device_id = 0`, which could query the wrong GPU when the current CUDA device had changed. It also ignored `cudaFree(0)` return status, making initialization failures silent.
