### PR TITLE
Add benchmark coverage for missing cuML estimators 2

### DIFF
--- a/python/cuml/cuml/benchmark/algorithms.py
+++ b/python/cuml/cuml/benchmark/algorithms.py
@@ -60,10 +60,16 @@ _build_cpu_skl_classifier = None
 _build_mnmg_umap = None
 
 # cuML preprocessing classes (fallback to sklearn if not available)
+Binarizer = sklearn.preprocessing.Binarizer
+KBinsDiscretizer = sklearn.preprocessing.KBinsDiscretizer
+LabelBinarizer = sklearn.preprocessing.LabelBinarizer
+LabelEncoder = sklearn.preprocessing.LabelEncoder
 MaxAbsScaler = sklearn.preprocessing.MaxAbsScaler
 MinMaxScaler = sklearn.preprocessing.MinMaxScaler
 Normalizer = sklearn.preprocessing.Normalizer
 PolynomialFeatures = sklearn.preprocessing.PolynomialFeatures
+PowerTransformer = sklearn.preprocessing.PowerTransformer
+QuantileTransformer = sklearn.preprocessing.QuantileTransformer
 RobustScaler = sklearn.preprocessing.RobustScaler
 SimpleImputer = skSimpleImputer
 StandardScaler = sklearn.preprocessing.StandardScaler
@@ -76,10 +82,16 @@ if is_cuml_available():
     import cuml.metrics as _cuml_metrics
     import cuml.naive_bayes
     from cuml.preprocessing import (
+        Binarizer,
+        KBinsDiscretizer,
+        LabelBinarizer,
+        LabelEncoder,
         MaxAbsScaler,
         MinMaxScaler,
         Normalizer,
         PolynomialFeatures,
+        PowerTransformer,
+        QuantileTransformer,
         RobustScaler,
         SimpleImputer,
         StandardScaler,
@@ -298,6 +310,13 @@ def _treelite_format_hook(data):
 def _numpy_format_hook(data):
     """Helper function converting data into numpy array"""
     return _training_data_to_numpy(data[0], data[1])
+
+
+def _labels_as_features_hook(data):
+    """Helper function using labels as input for target-only transformers."""
+    if len(data) >= 4:
+        return data[1], None, data[3], None
+    return data[1], None
 
 
 @functools.cache
@@ -712,6 +731,58 @@ def all_algorithms():
             shared_args=dict(),
             name="PolynomialFeatures",
             accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.Binarizer,
+            Binarizer,
+            shared_args=dict(),
+            name="Binarizer",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.KBinsDiscretizer,
+            KBinsDiscretizer,
+            shared_args=dict(),
+            name="KBinsDiscretizer",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.PowerTransformer,
+            PowerTransformer,
+            shared_args=dict(),
+            name="PowerTransformer",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.QuantileTransformer,
+            QuantileTransformer,
+            shared_args=dict(),
+            name="QuantileTransformer",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.LabelEncoder,
+            LabelEncoder,
+            shared_args=dict(),
+            name="LabelEncoder",
+            accepts_labels=False,
+            cpu_data_prep_hook=_labels_as_features_hook,
+            cuml_data_prep_hook=_labels_as_features_hook,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.LabelBinarizer,
+            LabelBinarizer,
+            shared_args=dict(),
+            name="LabelBinarizer",
+            accepts_labels=False,
+            cpu_data_prep_hook=_labels_as_features_hook,
+            cuml_data_prep_hook=_labels_as_features_hook,
             bench_func=fit_transform,
         ),
     ]

--- a/python/cuml/cuml/benchmark/configs/single_gpu.yaml
+++ b/python/cuml/cuml/benchmark/configs/single_gpu.yaml
@@ -777,6 +777,166 @@ benchmarks:
           default: {rows: [400000]}
           nightly: {rows: [1600000]}
 
+  - id: binarizer_fittransform
+    algorithm: Binarizer
+    dataset: classification
+    operation: fit_transform
+    tags: [preprocessing]
+    variants:
+      narrow:
+        features: [128]
+        tiers:
+          default: {rows: [210000]}
+          nightly: {rows: [1050000]}
+      medium:
+        features: [512]
+        tiers:
+          default: {rows: [52000]}
+          nightly: {rows: [260000]}
+      wide:
+        features: [1024]
+        tiers:
+          default: {rows: [26000]}
+          nightly: {rows: [130000]}
+
+  - id: kbinsdiscretizer_fittransform
+    algorithm: KBinsDiscretizer
+    dataset: classification
+    operation: fit_transform
+    params:
+      n_bins: 16
+      encode: ordinal
+      strategy: uniform
+    tags: [preprocessing]
+    variants:
+      narrow:
+        features: [128]
+        tiers:
+          default: {rows: [210000]}
+          nightly: {rows: [1050000]}
+      medium:
+        features: [512]
+        tiers:
+          default: {rows: [52000]}
+          nightly: {rows: [260000]}
+      wide:
+        features: [1024]
+        tiers:
+          default: {rows: [26000]}
+          nightly: {rows: [130000]}
+
+  - id: powertransformer_fittransform
+    algorithm: PowerTransformer
+    dataset: classification
+    operation: fit_transform
+    params:
+      method: yeo-johnson
+    tags: [preprocessing]
+    variants:
+      narrow:
+        features: [16]
+        tiers:
+          default: {rows: [20000]}
+          nightly: {rows: [80000]}
+      medium:
+        features: [64]
+        tiers:
+          default: {rows: [5000]}
+          nightly: {rows: [20000]}
+      wide:
+        features: [128]
+        tiers:
+          default: {rows: [2500]}
+          nightly: {rows: [10000]}
+
+  - id: quantiletransformer_fittransform
+    algorithm: QuantileTransformer
+    dataset: classification
+    operation: fit_transform
+    params:
+      n_quantiles: 1000
+      subsample: 100000
+      random_state: 42
+    tags: [preprocessing]
+    variants:
+      narrow:
+        features: [64]
+        tiers:
+          default: {rows: [100000]}
+          nightly: {rows: [400000]}
+      medium:
+        features: [256]
+        tiers:
+          default: {rows: [25000]}
+          nightly: {rows: [100000]}
+      wide:
+        features: [512]
+        tiers:
+          default: {rows: [12000]}
+          nightly: {rows: [48000]}
+
+  - id: labelencoder_fittransform
+    algorithm: LabelEncoder
+    dataset: classification
+    operation: fit_transform
+    dataset_params:
+      n_clusters_per_class: 1
+      n_informative: 8
+    tags: [preprocessing, labels]
+    variants:
+      classes2:
+        features: [16]
+        dataset_params:
+          n_classes: 2
+        tiers:
+          default: {rows: [10000000]}
+          nightly: {rows: [40000000]}
+      classes32:
+        features: [16]
+        dataset_params:
+          n_classes: 32
+        tiers:
+          default: {rows: [5000000]}
+          nightly: {rows: [20000000]}
+      classes256:
+        features: [16]
+        dataset_params:
+          n_classes: 256
+        tiers:
+          default: {rows: [2000000]}
+          nightly: {rows: [8000000]}
+
+  - id: labelbinarizer_fittransform
+    algorithm: LabelBinarizer
+    dataset: classification
+    operation: fit_transform
+    dataset_params:
+      n_clusters_per_class: 1
+      n_informative: 8
+    tags: [preprocessing, labels]
+    variants:
+      classes2:
+        features: [16]
+        dataset_params:
+          n_classes: 2
+        tiers:
+          default: {rows: [10000000]}
+          nightly: {rows: [40000000]}
+      classes8:
+        features: [16]
+        dataset_params:
+          n_classes: 8
+        tiers:
+          default: {rows: [2000000]}
+          nightly: {rows: [8000000]}
+      classes32:
+        features: [16]
+        dataset_params:
+          n_classes: 32
+        tiers:
+          default: {rows: [500000]}
+          nightly: {rows: [2000000]}
+
   - id: tsne_fit
     algorithm: TSNE
     dataset: blobs

--- a/python/cuml/cuml/benchmark/datagen.py
+++ b/python/cuml/cuml/benchmark/datagen.py
@@ -123,16 +123,29 @@ def _gen_data_classification(
     n_features=100,
     random_state=42,
     n_classes=2,
+    n_informative=None,
+    n_redundant=None,
+    n_clusters_per_class=None,
     dtype=np.float32,
 ):
     """Generate classification data using optimal backend."""
     if is_gpu_available() and is_cuml_available():
-        X, y = cuml_datasets.make_classification(
+        gen_kwargs = dict(
             n_samples=n_samples,
             n_features=n_features,
             n_classes=n_classes,
             random_state=random_state,
             dtype=dtype,
+        )
+        if n_informative is not None:
+            gen_kwargs["n_informative"] = n_informative
+        if n_redundant is not None:
+            gen_kwargs["n_redundant"] = n_redundant
+        if n_clusters_per_class is not None:
+            gen_kwargs["n_clusters_per_class"] = n_clusters_per_class
+
+        X, y = cuml_datasets.make_classification(
+            **gen_kwargs,
         )
         return cudf.DataFrame(X), cudf.Series(y)
 
@@ -140,15 +153,19 @@ def _gen_data_classification(
     # Note: GPU path uses cuml_datasets.make_classification (different defaults);
     # CPU path uses these settings. Slight differences in data generation may
     # affect cross-backend comparability of benchmark results.
-    n_informative = max(2, n_features // 2)
-    n_redundant = min(2, n_features - n_informative)
+    if n_informative is None:
+        n_informative = max(2, n_features // 2)
+    if n_redundant is None:
+        n_redundant = min(2, n_features - n_informative)
+    if n_clusters_per_class is None:
+        n_clusters_per_class = 1
     X, y = sklearn_make_classification(
         n_samples=n_samples,
         n_features=n_features,
         n_classes=n_classes,
         n_informative=n_informative,
         n_redundant=n_redundant,
-        n_clusters_per_class=1,
+        n_clusters_per_class=n_clusters_per_class,
         random_state=random_state,
     )
     return pd.DataFrame(X.astype(dtype)), pd.Series(y)


### PR DESCRIPTION
Partially answers #8117

Adds several missing estimators to the benchmark registry and to the single-GPU config manifest :

- `Binarizer`,
- `KBinsDiscretizer`
- `PowerTransformer`
- `QuantileTransformer`
- `LabelEncoder`
- `LabelBinarizer`

Also improved data generation for multi-class benchmark datasets.