### PR TITLE
Add benchmark coverage for missing cuML estimators 3

### DIFF
--- a/python/cuml/cuml/benchmark/algorithms.py
+++ b/python/cuml/cuml/benchmark/algorithms.py
@@ -15,6 +15,7 @@ import sklearn.cluster
 import sklearn.covariance
 import sklearn.decomposition
 import sklearn.ensemble
+import sklearn.impute
 import sklearn.kernel_ridge
 import sklearn.linear_model
 import sklearn.manifold
@@ -33,6 +34,7 @@ try:
         fit,
         fit_kneighbors,
         fit_predict,
+        fit_score_samples,
         fit_transform,
         transform,
     )
@@ -45,6 +47,7 @@ except ImportError:
         fit,
         fit_kneighbors,
         fit_predict,
+        fit_score_samples,
         fit_transform,
         transform,
     )
@@ -62,17 +65,22 @@ _build_mnmg_umap = None
 # cuML preprocessing classes (fallback to sklearn if not available)
 Binarizer = sklearn.preprocessing.Binarizer
 KBinsDiscretizer = sklearn.preprocessing.KBinsDiscretizer
+KernelCenterer = sklearn.preprocessing.KernelCenterer
 LabelBinarizer = sklearn.preprocessing.LabelBinarizer
 LabelEncoder = sklearn.preprocessing.LabelEncoder
 MaxAbsScaler = sklearn.preprocessing.MaxAbsScaler
 MinMaxScaler = sklearn.preprocessing.MinMaxScaler
+MissingIndicator = sklearn.impute.MissingIndicator
 Normalizer = sklearn.preprocessing.Normalizer
+OneHotEncoder = sklearn.preprocessing.OneHotEncoder
+OrdinalEncoder = sklearn.preprocessing.OrdinalEncoder
 PolynomialFeatures = sklearn.preprocessing.PolynomialFeatures
 PowerTransformer = sklearn.preprocessing.PowerTransformer
 QuantileTransformer = sklearn.preprocessing.QuantileTransformer
 RobustScaler = sklearn.preprocessing.RobustScaler
 SimpleImputer = skSimpleImputer
 StandardScaler = sklearn.preprocessing.StandardScaler
+TargetEncoder = sklearn.preprocessing.TargetEncoder
 
 if is_cuml_available():
     import cuml as _cuml
@@ -84,17 +92,22 @@ if is_cuml_available():
     from cuml.preprocessing import (
         Binarizer,
         KBinsDiscretizer,
+        KernelCenterer,
         LabelBinarizer,
         LabelEncoder,
         MaxAbsScaler,
         MinMaxScaler,
+        MissingIndicator,
         Normalizer,
+        OneHotEncoder,
+        OrdinalEncoder,
         PolynomialFeatures,
         PowerTransformer,
         QuantileTransformer,
         RobustScaler,
         SimpleImputer,
         StandardScaler,
+        TargetEncoder,
     )
 
     cuml = _cuml
@@ -319,6 +332,31 @@ def _labels_as_features_hook(data):
     return data[1], None
 
 
+def _as_array_for_matmul(X):
+    """Convert dataframe-like inputs to an array while preserving device type."""
+    if hasattr(X, "to_cupy"):
+        return X.to_cupy()
+    if hasattr(X, "to_numpy"):
+        return X.to_numpy()
+    return X
+
+
+def _linear_kernel(X, Y=None):
+    """Compute a linear kernel matrix for KernelCenterer benchmarks."""
+    X_arr = _as_array_for_matmul(X)
+    Y_arr = X_arr if Y is None else _as_array_for_matmul(Y)
+    return X_arr @ Y_arr.T
+
+
+def _linear_kernel_hook(data):
+    """Helper function converting feature data into a square kernel matrix."""
+    K_train = _linear_kernel(data[0])
+    if len(data) >= 4 and data[2] is not None:
+        K_test = _linear_kernel(data[2], data[0])
+        return K_train, None, K_test, None
+    return K_train, None
+
+
 @functools.cache
 def all_algorithms():
     """Returns all defined AlgorithmPair objects.
@@ -343,6 +381,7 @@ def all_algorithms():
             cuml.random_projection.SparseRandomProjection
         )
         cuml_NearestNeighbors = cuml.neighbors.NearestNeighbors
+        cuml_KernelDensity = cuml.neighbors.KernelDensity
         cuml_DBSCAN = cuml.DBSCAN
         cuml_HDBSCAN = cuml.cluster.HDBSCAN
         cuml_LinearRegression = cuml.linear_model.LinearRegression
@@ -362,6 +401,14 @@ def all_algorithms():
         cuml_KNeighborsRegressor = cuml.neighbors.KNeighborsRegressor
         cuml_GaussianNB = cuml.naive_bayes.GaussianNB
         cuml_MultinomialNB = cuml.naive_bayes.MultinomialNB
+        cuml_BernoulliNB = cuml.naive_bayes.BernoulliNB
+        cuml_ComplementNB = cuml.naive_bayes.ComplementNB
+        cuml_CategoricalNB = cuml.naive_bayes.CategoricalNB
+        cuml_TargetEncoder = TargetEncoder
+        cuml_OneHotEncoder = OneHotEncoder
+        cuml_OrdinalEncoder = OrdinalEncoder
+        cuml_MissingIndicator = MissingIndicator
+        cuml_KernelCenterer = KernelCenterer
         cuml_UMAP = cuml.manifold.UMAP
         accuracy_fn = cuml_metrics.accuracy_score
         r2_fn = cuml_metrics.r2_score
@@ -382,7 +429,11 @@ def all_algorithms():
             None
         )
         cuml_KNeighborsClassifier = cuml_KNeighborsRegressor = None
-        cuml_GaussianNB = cuml_MultinomialNB = cuml_UMAP = None
+        cuml_KernelDensity = None
+        cuml_GaussianNB = cuml_MultinomialNB = None
+        cuml_BernoulliNB = cuml_ComplementNB = cuml_CategoricalNB = None
+        cuml_TargetEncoder = cuml_OneHotEncoder = cuml_OrdinalEncoder = None
+        cuml_MissingIndicator = cuml_KernelCenterer = cuml_UMAP = None
         accuracy_fn = metrics.accuracy_score
         r2_fn = metrics.r2_score
         trustworthiness_fn = None
@@ -474,6 +525,14 @@ def all_algorithms():
             name="NearestNeighbors",
             accepts_labels=False,
             bench_func=fit_kneighbors,
+        ),
+        AlgorithmPair(
+            sklearn.neighbors.KernelDensity,
+            cuml_KernelDensity,
+            shared_args=dict(kernel="gaussian", bandwidth=1.0),
+            name="KernelDensity",
+            accepts_labels=False,
+            bench_func=fit_score_samples,
         ),
         AlgorithmPair(
             sklearn.cluster.DBSCAN,
@@ -668,6 +727,33 @@ def all_algorithms():
             accuracy_function=accuracy_fn,
         ),
         AlgorithmPair(
+            sklearn.naive_bayes.BernoulliNB,
+            cuml_BernoulliNB,
+            shared_args={},
+            cuml_args={},
+            name="BernoulliNB",
+            accepts_labels=True,
+            accuracy_function=accuracy_fn,
+        ),
+        AlgorithmPair(
+            sklearn.naive_bayes.ComplementNB,
+            cuml_ComplementNB,
+            shared_args={},
+            cuml_args={},
+            name="ComplementNB",
+            accepts_labels=True,
+            accuracy_function=accuracy_fn,
+        ),
+        AlgorithmPair(
+            sklearn.naive_bayes.CategoricalNB,
+            cuml_CategoricalNB,
+            shared_args={},
+            cuml_args={},
+            name="CategoricalNB",
+            accepts_labels=True,
+            accuracy_function=accuracy_fn,
+        ),
+        AlgorithmPair(
             sklearn.naive_bayes.GaussianNB,
             cuml_GaussianNB,
             shared_args={},
@@ -763,6 +849,55 @@ def all_algorithms():
             shared_args=dict(),
             name="QuantileTransformer",
             accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.TargetEncoder,
+            cuml_TargetEncoder,
+            shared_args=dict(smooth=0.0),
+            cpu_args=dict(cv=4, random_state=42),
+            cuml_args=dict(
+                n_folds=4,
+                seed=42,
+                split_method="interleaved",
+                multi_feature_mode="independent",
+            ),
+            name="TargetEncoder",
+            accepts_labels=True,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.OneHotEncoder,
+            cuml_OneHotEncoder,
+            shared_args=dict(sparse_output=False, handle_unknown="ignore"),
+            name="OneHotEncoder",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.OrdinalEncoder,
+            cuml_OrdinalEncoder,
+            shared_args=dict(),
+            name="OrdinalEncoder",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.impute.MissingIndicator,
+            cuml_MissingIndicator,
+            shared_args=dict(features="all", sparse=False),
+            name="MissingIndicator",
+            accepts_labels=False,
+            bench_func=fit_transform,
+        ),
+        AlgorithmPair(
+            sklearn.preprocessing.KernelCenterer,
+            cuml_KernelCenterer,
+            shared_args=dict(),
+            name="KernelCenterer",
+            accepts_labels=False,
+            cpu_data_prep_hook=_linear_kernel_hook,
+            cuml_data_prep_hook=_linear_kernel_hook,
             bench_func=fit_transform,
         ),
         AlgorithmPair(

--- a/python/cuml/cuml/benchmark/bench_helper_funcs.py
+++ b/python/cuml/cuml/benchmark/bench_helper_funcs.py
@@ -66,6 +66,10 @@ def kneighbors(m, x, y=None):
     call(m, "kneighbors", x)
 
 
+def score_samples(m, x, y=None):
+    call(m, "score_samples", x[: min(x.shape[0], 1024)])
+
+
 def fit_predict(m, x, y=None):
     if hasattr(m, "predict"):
         fit(m, x, y)
@@ -88,6 +92,11 @@ def fit_kneighbors(m, x, y=None):
         kneighbors(m, x)
     else:
         call(m, "fit_kneighbors", x, y)
+
+
+def fit_score_samples(m, x, y=None):
+    fit(m, x, y)
+    score_samples(m, x)
 
 
 def _training_data_to_numpy(X, y):

--- a/python/cuml/cuml/benchmark/config.py
+++ b/python/cuml/cuml/benchmark/config.py
@@ -109,6 +109,7 @@ ALLOWED_OPERATIONS = {
     "fit_transform",
     "fit_predict",
     "fit_kneighbors",
+    "fit_score_samples",
     "kneighbors",
 }
 ALLOWED_BACKENDS = {"cpu", "gpu"}

--- a/python/cuml/cuml/benchmark/configs/single_gpu.yaml
+++ b/python/cuml/cuml/benchmark/configs/single_gpu.yaml
@@ -1002,3 +1002,130 @@ benchmarks:
         tiers:
           default: {rows: [1000000]}
           nightly: {rows: [4000000]}
+
+  - id: kerneldensity_fitscoresamples
+    algorithm: KernelDensity
+    dataset: blobs
+    operation: fit_score_samples
+    backends: [gpu]
+    tags: [neighbors, density]
+    variants:
+      base:
+        features: [16]
+        tiers:
+          default: {rows: [20000]}
+          nightly: {rows: [80000]}
+
+  - id: bernoullinb_fit
+    algorithm: BernoulliNB
+    dataset: binary_classification
+    operation: fit
+    backends: [gpu]
+    tags: [naive-bayes]
+    variants:
+      base:
+        features: [256]
+        tiers:
+          default: {rows: [200000]}
+          nightly: {rows: [800000]}
+
+  - id: complementnb_fit
+    algorithm: ComplementNB
+    dataset: count_classification
+    operation: fit
+    backends: [gpu]
+    tags: [naive-bayes]
+    variants:
+      base:
+        features: [256]
+        tiers:
+          default: {rows: [200000]}
+          nightly: {rows: [800000]}
+
+  - id: categoricalnb_fit
+    algorithm: CategoricalNB
+    dataset: categorical_classification
+    operation: fit
+    backends: [gpu]
+    dataset_params:
+      n_categories: 16
+    tags: [naive-bayes]
+    variants:
+      base:
+        features: [64]
+        tiers:
+          default: {rows: [200000]}
+          nightly: {rows: [800000]}
+
+  - id: targetencoder_fittransform
+    algorithm: TargetEncoder
+    dataset: categorical_classification
+    operation: fit_transform
+    backends: [gpu]
+    dataset_params:
+      n_categories: 64
+    tags: [preprocessing, encoding]
+    variants:
+      base:
+        features: [16]
+        tiers:
+          default: {rows: [200000]}
+          nightly: {rows: [800000]}
+
+  - id: onehotencoder_fittransform
+    algorithm: OneHotEncoder
+    dataset: categorical_classification
+    operation: fit_transform
+    backends: [gpu]
+    dataset_params:
+      n_categories: 8
+    tags: [preprocessing, encoding]
+    variants:
+      base:
+        features: [16]
+        tiers:
+          default: {rows: [100000]}
+          nightly: {rows: [400000]}
+
+  - id: ordinalencoder_fittransform
+    algorithm: OrdinalEncoder
+    dataset: categorical_classification
+    operation: fit_transform
+    backends: [gpu]
+    dataset_params:
+      n_categories: 64
+    tags: [preprocessing, encoding]
+    variants:
+      base:
+        features: [32]
+        tiers:
+          default: {rows: [500000]}
+          nightly: {rows: [2000000]}
+
+  - id: missingindicator_fittransform
+    algorithm: MissingIndicator
+    dataset: missing_classification
+    operation: fit_transform
+    backends: [gpu]
+    dataset_params:
+      missing_rate: 0.1
+    tags: [preprocessing, missing-values]
+    variants:
+      base:
+        features: [128]
+        tiers:
+          default: {rows: [200000]}
+          nightly: {rows: [800000]}
+
+  - id: kernelcenterer_fittransform
+    algorithm: KernelCenterer
+    dataset: blobs
+    operation: fit_transform
+    backends: [gpu]
+    tags: [preprocessing, kernel]
+    variants:
+      base:
+        features: [16]
+        tiers:
+          default: {rows: [4096]}
+          nightly: {rows: [8192]}

--- a/python/cuml/cuml/benchmark/datagen.py
+++ b/python/cuml/cuml/benchmark/datagen.py
@@ -171,6 +171,83 @@ def _gen_data_classification(
     return pd.DataFrame(X.astype(dtype)), pd.Series(y)
 
 
+def _gen_data_binary_classification(
+    n_samples=int(1e6),
+    n_features=100,
+    random_state=42,
+    positive_probability=0.2,
+    dtype=np.float32,
+):
+    """Generate binary feature classification data for Bernoulli models."""
+    rng = np.random.default_rng(random_state)
+    X = rng.binomial(
+        1, positive_probability, size=(n_samples, n_features)
+    ).astype(dtype)
+    n_informative = max(1, min(n_features, 8))
+    scores = X[:, :n_informative].sum(axis=1)
+    threshold = max(1, int(np.ceil(n_informative * positive_probability)))
+    y = (scores >= threshold).astype(np.int32)
+    return pd.DataFrame(X), pd.Series(y)
+
+
+def _gen_data_count_classification(
+    n_samples=int(1e6),
+    n_features=100,
+    random_state=42,
+    n_classes=2,
+    dtype=np.float32,
+):
+    """Generate non-negative count data for multinomial-style models."""
+    rng = np.random.default_rng(random_state)
+    y = rng.integers(0, n_classes, size=n_samples, dtype=np.int32)
+    feature_class = np.arange(n_features) % n_classes
+    X = rng.poisson(1.0, size=(n_samples, n_features)).astype(dtype)
+    for class_id in range(n_classes):
+        row_mask = y == class_id
+        col_idx = np.flatnonzero(feature_class == class_id)
+        if row_mask.any() and col_idx.size > 0:
+            X[np.ix_(row_mask, col_idx)] += rng.poisson(
+                2.0, size=(row_mask.sum(), col_idx.size)
+            ).astype(dtype)
+    return pd.DataFrame(X), pd.Series(y)
+
+
+def _gen_data_categorical_classification(
+    n_samples=int(1e6),
+    n_features=100,
+    random_state=42,
+    n_categories=16,
+    n_classes=2,
+    dtype=np.float32,
+):
+    """Generate integer-coded categorical data for categorical estimators."""
+    rng = np.random.default_rng(random_state)
+    X = rng.integers(
+        0, n_categories, size=(n_samples, n_features), dtype=np.int32
+    )
+    n_informative = max(1, min(n_features, 4))
+    y = (X[:, :n_informative].sum(axis=1) % n_classes).astype(np.int32)
+    return pd.DataFrame(X.astype(dtype)), pd.Series(y)
+
+
+def _gen_data_missing_classification(
+    n_samples=int(1e6),
+    n_features=100,
+    random_state=42,
+    missing_rate=0.1,
+    dtype=np.float32,
+):
+    """Generate numeric data with missing values for missingness indicators."""
+    rng = np.random.default_rng(random_state)
+    X = rng.normal(size=(n_samples, n_features)).astype(dtype)
+    y = (X[:, 0] > 0).astype(np.int32)
+    mask = rng.random(size=X.shape) < missing_rate
+    if not mask.any() and X.size > 0:
+        mask[0, 0] = True
+    X[mask] = np.nan
+    return pd.DataFrame(X), pd.Series(y)
+
+
 # Default location to cache datasets
 DATASETS_DIRECTORY = "."
 
@@ -506,6 +583,10 @@ _data_generators = {
     "blobs": _gen_data_blobs,
     "zeros": _gen_data_zeros,
     "classification": _gen_data_classification,
+    "binary_classification": _gen_data_binary_classification,
+    "count_classification": _gen_data_count_classification,
+    "categorical_classification": _gen_data_categorical_classification,
+    "missing_classification": _gen_data_missing_classification,
     "regression": _gen_data_regression,
     "airline_regression": _gen_data_airline_regression,
     "airline_classification": _gen_data_airline_classification,
@@ -603,7 +684,16 @@ def gen_data(
         datasets_root_dir, "%s_y.pkl" % dataset_name
     )
 
-    mock_datasets = ["regression", "classification", "blobs", "zeros"]
+    mock_datasets = [
+        "regression",
+        "classification",
+        "binary_classification",
+        "count_classification",
+        "categorical_classification",
+        "missing_classification",
+        "blobs",
+        "zeros",
+    ]
     if dataset_name in mock_datasets:
         gen_kwargs = {"dtype": dtype, **kwargs}
         if n_samples is not None:


### PR DESCRIPTION
Closes #8117

Adds several missing estimators to the benchmark registry and to the single-GPU config manifest :

- `KernelDensity`
- `BernoulliNB`
- `ComplementNB`
- `CategoricalNB`
- `TargetEncoder`
- `OneHotEncoder`
- `OrdinalEncoder`
- `MissingIndicator`
- `KernelCenterer`

Also expanded data generation.