### PR TITLE
Avoid executing cuml.accel getting started notebook

### DIFF
--- a/docs/source/cuml-accel/examples/getting_started.ipynb
+++ b/docs/source/cuml-accel/examples/getting_started.ipynb
@@ -444,6 +444,9 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.13.11"
+    },
+    "nbsphinx": {
+      "execute": "never"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Mitigation for #8351. Must be reverted prior to release.
