### PR TITLE
Solution (#7199): [BUG] Label-permutation invariance appears inconsistent for `homo

### DIFF
--- a/path/to/cuml/common/exceptions.py
+++ b/path/to/cuml/common/exceptions.py
@@ -1,0 +1,4 @@
+# Modified cuml.common.exceptions module to add CumlValueError
+class CumlValueError(Exception):
+    """Value error for cuML"""
+    pass

--- a/path/to/cuml/common/logger.py
+++ b/path/to/cuml/common/logger.py
@@ -1,0 +1,8 @@
+# Modified cuml.common.logger module to add debug message for label permutation invariance
+import logging
+
+logger = logging.getLogger(__name__)
+
+def debug(message):
+    """Log a debug message"""
+    logger.debug(message)

--- a/path/to/cuml/common/utils.py
+++ b/path/to/cuml/common/utils.py
@@ -1,0 +1,8 @@
+# Modified cuml.common.utils module to add sort_labels function
+import numpy as np
+
+def sort_labels(labels):
+    """Sort labels to ensure permutation invariance"""
+    unique_labels = np.unique(labels)
+    sorted_labels = np.sort(unique_labels)
+    return sorted_labels

--- a/path/to/cuml/metrics.py
+++ b/path/to/cuml/metrics.py
@@ -1,0 +1,147 @@
+# Modified cuml.metrics module to fix label-permutation invariance issue
+import numpy as np
+from cuml.common import utils
+from cuml.common import logger
+from cuml.common.exceptions import CumlValueError
+
+def _check_labels(labels):
+    """Check if labels are valid"""
+    if not isinstance(labels, np.ndarray):
+        raise CumlValueError("Labels must be a numpy array")
+    if not labels.dtype.kind in ['i', 'u']:
+        raise CumlValueError("Labels must be integers")
+    if labels.size == 0:
+        raise CumlValueError("Labels must not be empty")
+
+def homogeneity_score(y_true, y_pred):
+    """Compute homogeneity score between two clusterings.
+    This metric is independent of the absolute values of the labels:
+    a permutation of the class or cluster label values won’t change the score value in any way.
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        Ground truth class labels.
+    y_pred : array-like, shape (n_samples,)
+        Cluster labels to evaluate.
+    Returns
+    -------
+    homogeneity : float
+        Homogeneity of the clustering.
+    """
+    _check_labels(y_true)
+    _check_labels(y_pred)
+    unique_labels = np.unique(y_true)
+    unique_pred_labels = np.unique(y_pred)
+    if len(unique_labels) != len(unique_pred_labels):
+        raise CumlValueError("Number of unique true labels and predicted labels must be equal")
+    # Sort labels to ensure permutation invariance
+    sorted_labels = np.sort(unique_labels)
+    sorted_pred_labels = np.sort(unique_pred_labels)
+    # Compute contingency matrix
+    contingency = np.zeros((len(unique_labels), len(unique_pred_labels)), dtype=np.int32)
+    for i, label in enumerate(y_true):
+        contingency[np.searchsorted(sorted_labels, label), np.searchsorted(sorted_pred_labels, y_pred[i])] += 1
+    # Compute homogeneity score
+    homogeneity = np.sum(contingency * contingency) / np.sum(contingency)
+    return homogeneity
+
+def completeness_score(y_true, y_pred):
+    """Compute completeness score between two clusterings.
+    This metric is independent of the absolute values of the labels:
+    a permutation of the class or cluster label values won’t change the score value in any way.
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        Ground truth class labels.
+    y_pred : array-like, shape (n_samples,)
+        Cluster labels to evaluate.
+    Returns
+    -------
+    completeness : float
+        Completeness of the clustering.
+    """
+    _check_labels(y_true)
+    _check_labels(y_pred)
+    unique_labels = np.unique(y_true)
+    unique_pred_labels = np.unique(y_pred)
+    if len(unique_labels) != len(unique_pred_labels):
+        raise CumlValueError("Number of unique true labels and predicted labels must be equal")
+    # Sort labels to ensure permutation invariance
+    sorted_labels = np.sort(unique_labels)
+    sorted_pred_labels = np.sort(unique_pred_labels)
+    # Compute contingency matrix
+    contingency = np.zeros((len(unique_labels), len(unique_pred_labels)), dtype=np.int32)
+    for i, label in enumerate(y_true):
+        contingency[np.searchsorted(sorted_labels, label), np.searchsorted(sorted_pred_labels, y_pred[i])] += 1
+    # Compute completeness score
+    completeness = np.sum(contingency * contingency) / np.sum(contingency)
+    return completeness
+
+def v_measure_score(y_true, y_pred):
+    """Compute v-measure score between two clusterings.
+    This metric is independent of the absolute values of the labels:
+    a permutation of the class or cluster label values won’t change the score value in any way.
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        Ground truth class labels.
+    y_pred : array-like, shape (n_samples,)
+        Cluster labels to evaluate.
+    Returns
+    -------
+    v_measure : float
+        V-measure of the clustering.
+    """
+    _check_labels(y_true)
+    _check_labels(y_pred)
+    unique_labels = np.unique(y_true)
+    unique_pred_labels = np.unique(y_pred)
+    if len(unique_labels) != len(unique_pred_labels):
+        raise CumlValueError("Number of unique true labels and predicted labels must be equal")
+    # Sort labels to ensure permutation invariance
+    sorted_labels = np.sort(unique_labels)
+    sorted_pred_labels = np.sort(unique_pred_labels)
+    # Compute contingency matrix
+    contingency = np.zeros((len(unique_labels), len(unique_pred_labels)), dtype=np.int32)
+    for i, label in enumerate(y_true):
+        contingency[np.searchsorted(sorted_labels, label), np.searchsorted(sorted_pred_labels, y_pred[i])] += 1
+    # Compute v-measure score
+    homogeneity = np.sum(contingency * contingency) / np.sum(contingency)
+    completeness = np.sum(contingency * contingency) / np.sum(contingency)
+    v_measure = 2 * homogeneity * completeness / (homogeneity + completeness)
+    return v_measure
+
+def mutual_info_score(y_true, y_pred):
+    """Compute mutual information between two clusterings.
+    This metric is independent of the absolute values of the labels:
+    a permutation of the class or cluster label values won’t change the score value in any way.
+    Parameters
+    ----------
+    y_true : array-like, shape (n_samples,)
+        Ground truth class labels.
+    y_pred : array-like, shape (n_samples,)
+        Cluster labels to evaluate.
+    Returns
+    -------
+    mutual_info : float
+        Mutual information of the clustering.
+    """
+    _check_labels(y_true)
+    _check_labels(y_pred)
+    unique_labels = np.unique(y_true)
+    unique_pred_labels = np.unique(y_pred)
+    if len(unique_labels) != len(unique_pred_labels):
+        raise CumlValueError("Number of unique true labels and predicted labels must be equal")
+    # Sort labels to ensure permutation invariance
+    sorted_labels = np.sort(unique_labels)
+    sorted_pred_labels = np.sort(unique_pred_labels)
+    # Compute contingency matrix
+    contingency = np.zeros((len(unique_labels), len(unique_pred_labels)), dtype=np.int32)
+    for i, label in enumerate(y_true):
+        contingency[np.searchsorted(sorted_labels, label), np.searchsorted(sorted_pred_labels, y_pred[i])] += 1
+    # Compute mutual information score
+    mutual_info = 0
+    for i in range(len(unique_labels)):
+        for j in range(len(unique_pred_labels)):
+            mutual_info += contingency[i, j] * np.log2(contingency[i, j] / np.sum(contingency[i, :]) / np.sum(contingency[:, j]))
+    return mutual_info

--- a/path/to/test/test_metrics.py
+++ b/path/to/test/test_metrics.py
@@ -1,0 +1,30 @@
+# Modified test_metrics.py to test label permutation invariance
+import numpy as np
+from cuml.metrics import homogeneity_score, completeness_score, v_measure_score, mutual_info_score
+from cuml.common.utils import sort_labels
+
+def test_label_permutation_invariance():
+    """Test label permutation invariance"""
+    y_true = np.array([0, 0, 0, 1, 1, 0, 1])
+    y_pred = np.array([1, 0, 1, 0, 1, 1, 0])
+    sorted_labels = sort_labels(y_true)
+    sorted_pred_labels = sort_labels(y_pred)
+    # Test homogeneity score
+    s1 = homogeneity_score(y_true, y_pred)
+    s2 = homogeneity_score(y_true, 1 - y_pred)
+    assert np.isclose(s1, s2)
+    # Test completeness score
+    s1 = completeness_score(y_true, y_pred)
+    s2 = completeness_score(y_true, 1 - y_pred)
+    assert np.isclose(s1, s2)
+    # Test v-measure score
+    s1 = v_measure_score(y_true, y_pred)
+    s2 = v_measure_score(y_true, 1 - y_pred)
+    assert np.isclose(s1, s2)
+    # Test mutual information score
+    s1 = mutual_info_score(y_true, y_pred)
+    s2 = mutual_info_score(y_true, 1 - y_pred)
+    assert np.isclose(s1, s2)
+
+if __name__ == "__main__":
+    test_label_permutation_invariance()


### PR DESCRIPTION
This PR fixes the label-permutation invariance issue for the `homogeneity_score`, `completeness_score`, `v_measure_score`, and `mutual_info_score` functions in the cuml.metrics module.

Changes made:

* Sorted unique labels before computing contingency matrix to ensure results are invariant to label permutations.
* Added tests to verify the fix.

Testing instructions:

* Run `python -m unittest tests.test_metrics` to run the tests for the cuml.metrics module.
* Verify that the tests pass with the fix applied.
* Test the functions with various input datasets to ensure that the results are consistent and invariant to label permutations.