### PR TITLE
Handle OpenML checksum failures in sklearn examples

### DIFF
--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/example_collector.py
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/example_collector.py
@@ -43,6 +43,7 @@ _NETWORK_ERROR_PATTERNS = (
     "requests.exceptions.ConnectionError",
     "requests.exceptions.Timeout",
     "sklearn.datasets._openml.OpenMLError",
+    "md5 checksum of local file for https://openml.org/",
     "socket.gaierror",
     "socket.timeout",
     "ssl.SSLError",


### PR DESCRIPTION
Treats OpenML dataset checksum mismatches as network xfails in the scikit-learn examples runner.

Closes #8358
