### PR TITLE
fix(clang-format): preserve SPDX comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
@@ -107,7 +107,7 @@ repos:
             args: ['format', '--cleanup']
             additional_dependencies: ['pyyaml>=6.0', 'packaging>=21.0']
     - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v1.4.2
+      rev: v1.6.0
       hooks:
         - id: verify-copyright
           name: verify-copyright-cuml

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ IWYU pragma:'
+CommentPragmas: '^ ?[*]? ?(IWYU pragma:|SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ ?[*]? ?(IWYU pragma:|SPDX-)'
+CommentPragmas: '(IWYU pragma:|SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform

--- a/python/cuml/tests/test_benchmark_config.py
+++ b/python/cuml/tests/test_benchmark_config.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -1128,6 +1128,7 @@ def test_collect_package_snapshot_prefers_conda(monkeypatch):
             [
                 {
                     "name": "cuml",
+                    # rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
                     "version": "26.06",
                     "build_string": "cuda13_py313_0",
                     "channel": "rapidsai-nightly",
@@ -1147,6 +1148,7 @@ def test_collect_package_snapshot_prefers_conda(monkeypatch):
         "packages": [
             {
                 "name": "cuml",
+                # rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
                 "version": "26.06",
                 "build": "cuda13_py313_0",
                 "channel": "rapidsai-nightly",
@@ -1166,6 +1168,7 @@ def test_collect_package_snapshot_falls_back_to_pip(monkeypatch):
         return [
             {
                 "name": "cuml",
+                # rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
                 "version": "26.06",
                 "editable_project_location": "/tmp",
             }
@@ -1178,6 +1181,7 @@ def test_collect_package_snapshot_falls_back_to_pip(monkeypatch):
     assert snapshot == {
         "package_snapshot_source": "pip",
         "conda_prefix": "/tmp/conda-env",
+        # rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
         "packages": [{"name": "cuml", "version": "26.06"}],
         "conda_error": "conda failed",
     }


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/303.

This updates clang-format's `CommentPragmas` to preserve SPDX copyright and license lines. Without this, clang-format reflows the canonical notice produced by `verify-copyright`, so consecutive pre-commit runs keep modifying the same block comment. Where a header was already corrupted, this also restores its canonical two-line form.
