### PR TITLE
Finish migration to new decorators/descriptors

### DIFF
--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_column_transformer.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Andreas Mueller
 # SPDX-FileCopyrightText: Joris Van den Bossche
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Original authors from Sckit-Learn:
@@ -34,7 +34,6 @@ from sklearn.base import clone
 from sklearn.utils import Bunch
 
 import cuml
-from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.global_settings import _global_settings_data
 from cuml.internals.validation import check_is_fitted, check_features, check_array
 
@@ -849,7 +848,7 @@ class ColumnTransformer(TransformerMixin, BaseComposition, BaseEstimator):
             else:
                 raise
 
-    @cuml.internals.reflect
+    @cuml.internals.mlfunc
     def fit(self, X, y=None) -> "ColumnTransformer":
         """Fit all transformers using X.
 
@@ -873,8 +872,8 @@ class ColumnTransformer(TransformerMixin, BaseComposition, BaseEstimator):
         self.fit_transform(X, y=y)
         return self
 
-    @cuml.internals.reflect(reset=True)
-    def fit_transform(self, X, y=None) -> SparseCumlArray:
+    @cuml.internals.mlfunc(set_input_type=True)
+    def fit_transform(self, X, y=None):
         """Fit all transformers, transform the data and concatenate results.
 
         Parameters
@@ -925,8 +924,8 @@ class ColumnTransformer(TransformerMixin, BaseComposition, BaseEstimator):
 
         return self._hstack(list(Xs))
 
-    @cuml.internals.reflect
-    def transform(self, X) -> SparseCumlArray:
+    @cuml.internals.mlfunc
+    def transform(self, X):
         """Transform X separately by each transformer, concatenate results.
 
         Parameters

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_data.py
@@ -5,7 +5,7 @@
 # SPDX-FileCopyrightText: Eric Martin <eric@ericmart.in>
 # SPDX-FileCopyrightText: Giorgio Patrini <giorgio.patrini@anu.edu.au>
 # SPDX-FileCopyrightText: Eric Chang <ericchang2017@u.northwestern.edu>
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 # Original authors from Sckit-Learn:
@@ -34,13 +34,10 @@ from cupyx.scipy import sparse
 from scipy import optimize, stats
 from scipy.special import boxcox
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.sparse import csr_row_normalize_l1, csr_row_normalize_l2
-from cuml.internals.array import CumlArray
-from cuml.internals.array_sparse import SparseCumlArray
-from cuml.internals.interop import InteropMixin, to_cpu, to_gpu
+from cuml.internals.interop import InteropMixin
 from cuml.internals.mixins import AllowNaNTagMixin, SparseInputTagMixin
-from cuml.internals.outputs import using_output_type, reflect
+from cuml.internals.outputs import using_output_type, mlfunc, ReflectedAttr
 from cuml.internals.validation import check_is_fitted, check_array, check_inputs
 from cuml.thirdparty_adapters.sparsefuncs_fast import csr_polynomial_expansion
 
@@ -90,7 +87,7 @@ def _handle_zeros_in_scale(scale, copy=True):
         return scale
 
 
-@reflect
+@mlfunc
 def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
     """Standardize a dataset along any axis
 
@@ -289,12 +286,12 @@ class MinMaxScaler(TransformerMixin,
     transform.
     """
 
-    scale_ = CumlArrayDescriptor()
-    min_ = CumlArrayDescriptor()
-    n_samples_seen_ = CumlArrayDescriptor()
-    data_min_ = CumlArrayDescriptor()
-    data_max_ = CumlArrayDescriptor()
-    data_range_ = CumlArrayDescriptor()
+    scale_ = ReflectedAttr()
+    min_ = ReflectedAttr()
+    n_samples_seen_ = ReflectedAttr()
+    data_min_ = ReflectedAttr()
+    data_max_ = ReflectedAttr()
+    data_range_ = ReflectedAttr()
 
     def __init__(self, feature_range=(0, 1), *, copy=True):
         self.feature_range = feature_range
@@ -323,7 +320,7 @@ class MinMaxScaler(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "MinMaxScaler":
         """Compute the minimum and maximum to be used for later scaling.
 
@@ -346,7 +343,7 @@ class MinMaxScaler(TransformerMixin,
         self._reset()
         return self.partial_fit(X, y)
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def partial_fit(self, X, y=None) -> "MinMaxScaler":
         """Online computation of min and max on X for later scaling.
 
@@ -401,8 +398,8 @@ class MinMaxScaler(TransformerMixin,
         self.data_range_ = data_range
         return self
 
-    @reflect
-    def transform(self, X) -> CumlArray:
+    @mlfunc
+    def transform(self, X):
         """Scale features of X according to feature_range.
 
         Parameters
@@ -428,8 +425,8 @@ class MinMaxScaler(TransformerMixin,
 
         return X
 
-    @reflect
-    def inverse_transform(self, X) -> CumlArray:
+    @mlfunc
+    def inverse_transform(self, X):
         """Undo the scaling of X according to feature_range.
 
         Parameters
@@ -452,7 +449,7 @@ class MinMaxScaler(TransformerMixin,
         return X
 
 
-@reflect
+@mlfunc
 def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     """Transform features by scaling each feature to a given range.
 
@@ -628,10 +625,10 @@ class StandardScaler(TransformerMixin,
     affect model performance.
     """  # noqa
 
-    scale_ = CumlArrayDescriptor()
-    n_samples_seen_ = CumlArrayDescriptor()
-    mean_ = CumlArrayDescriptor()
-    var_ = CumlArrayDescriptor()
+    scale_ = ReflectedAttr()
+    n_samples_seen_ = ReflectedAttr()
+    mean_ = ReflectedAttr()
+    var_ = ReflectedAttr()
 
     def __init__(self, *, copy=True, with_mean=True, with_std=True):
         self.with_mean = with_mean
@@ -690,10 +687,10 @@ class StandardScaler(TransformerMixin,
     def _attrs_from_cpu(self, model):
         """Convert sklearn StandardScaler fitted attributes to cuML format."""
         attrs = {
-            "mean_": to_gpu(mean) if (mean := getattr(model, "mean_", None)) is not None else None,
-            "var_": to_gpu(var) if (var := getattr(model, "var_", None)) is not None else None,
-            "scale_": to_gpu(scale) if (scale := getattr(model, "scale_", None)) is not None else None,
-            "n_samples_seen_": to_gpu(nss) if (nss := getattr(model, "n_samples_seen_", None)) is not None else None,
+            "mean_": np.asarray(mean) if (mean := getattr(model, "mean_", None)) is not None else None,
+            "var_": np.asarray(var) if (var := getattr(model, "var_", None)) is not None else None,
+            "scale_": np.asarray(scale) if (scale := getattr(model, "scale_", None)) is not None else None,
+            "n_samples_seen_": np.asarray(nss) if (nss := getattr(model, "n_samples_seen_", None)) is not None else None,
         }
         return {**attrs, **super()._attrs_from_cpu(model)}
 
@@ -701,14 +698,14 @@ class StandardScaler(TransformerMixin,
         """Convert cuML StandardScaler fitted attributes to sklearn format."""
 
         attrs = {
-            "mean_": to_cpu(mean) if (mean := getattr(self, "mean_", None)) is not None else None,
-            "var_": to_cpu(var) if (var := getattr(self, "var_", None)) is not None else None,
-            "scale_": to_cpu(scale) if (scale := getattr(self, "scale_", None)) is not None else None,
-            "n_samples_seen_": None if (nss := getattr(self, "n_samples_seen_", None)) is None else cpu_np.int64(nss) if cpu_np.isscalar(nss) else to_cpu(nss),
+            "mean_": mean.get() if (mean := getattr(self, "mean_", None)) is not None else None,
+            "var_": var.get() if (var := getattr(self, "var_", None)) is not None else None,
+            "scale_": scale.get() if (scale := getattr(self, "scale_", None)) is not None else None,
+            "n_samples_seen_": None if (nss := getattr(self, "n_samples_seen_", None)) is None else cpu_np.int64(nss) if cpu_np.isscalar(nss) else nss.get(),
         }
         return {**attrs, **super()._attrs_to_cpu(model)}
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "StandardScaler":
         """Compute the mean and std to be used for later scaling.
 
@@ -726,7 +723,7 @@ class StandardScaler(TransformerMixin,
         self._reset()
         return self.partial_fit(X, y)
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def partial_fit(self, X, y=None) -> "StandardScaler":
         """
         Online computation of mean and std on X for later scaling.
@@ -853,8 +850,8 @@ class StandardScaler(TransformerMixin,
 
         return self
 
-    @reflect
-    def transform(self, X, copy=None) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X, copy=None):
         """Perform standardization by centering and scaling
 
         Parameters
@@ -893,8 +890,8 @@ class StandardScaler(TransformerMixin,
 
         return X
 
-    @reflect
-    def inverse_transform(self, X, copy=None) -> SparseCumlArray:
+    @mlfunc
+    def inverse_transform(self, X, copy=None):
         """Scale back the data to the original representation
 
         Parameters
@@ -997,9 +994,9 @@ class MaxAbsScaler(TransformerMixin,
     transform.
     """
 
-    scale_ = CumlArrayDescriptor()
-    n_samples_seen_ = CumlArrayDescriptor()
-    max_abs_ = CumlArrayDescriptor()
+    scale_ = ReflectedAttr()
+    n_samples_seen_ = ReflectedAttr()
+    max_abs_ = ReflectedAttr()
 
     def __init__(self, *, copy=True):
         self.copy = copy
@@ -1023,7 +1020,7 @@ class MaxAbsScaler(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "MaxAbsScaler":
         """Compute the maximum absolute value to be used for later scaling.
 
@@ -1038,7 +1035,7 @@ class MaxAbsScaler(TransformerMixin,
         self._reset()
         return self.partial_fit(X, y)
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def partial_fit(self, X, y=None) -> "MaxAbsScaler":
         """
         Online computation of max absolute value of X for later scaling.
@@ -1087,8 +1084,8 @@ class MaxAbsScaler(TransformerMixin,
         self.scale_ = _handle_zeros_in_scale(max_abs)
         return self
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Scale the data
 
         Parameters
@@ -1113,8 +1110,8 @@ class MaxAbsScaler(TransformerMixin,
 
         return X
 
-    @reflect
-    def inverse_transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def inverse_transform(self, X):
         """Scale back the data to the original representation
 
         Parameters
@@ -1134,7 +1131,7 @@ class MaxAbsScaler(TransformerMixin,
         return X
 
 
-@reflect
+@mlfunc
 def maxabs_scale(X, *, axis=0, copy=True):
     """Scale each feature to the [-1, 1] range without breaking the sparsity.
 
@@ -1267,8 +1264,8 @@ class RobustScaler(TransformerMixin,
 
     """
 
-    center_ = CumlArrayDescriptor()
-    scale_ = CumlArrayDescriptor()
+    center_ = ReflectedAttr()
+    scale_ = ReflectedAttr()
 
     def __init__(self, *, with_centering=True, with_scaling=True,
                  quantile_range=(25.0, 75.0), copy=True):
@@ -1286,7 +1283,7 @@ class RobustScaler(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "RobustScaler":
         """Compute the median and quantiles to be used for scaling.
 
@@ -1353,8 +1350,8 @@ class RobustScaler(TransformerMixin,
 
         return self
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Center and scale the data.
 
         Parameters
@@ -1382,8 +1379,8 @@ class RobustScaler(TransformerMixin,
                 X /= self.scale_
         return X
 
-    @reflect
-    def inverse_transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def inverse_transform(self, X):
         """Scale back the data to the original representation
 
         Parameters
@@ -1407,7 +1404,7 @@ class RobustScaler(TransformerMixin,
         return X
 
 
-@reflect
+@mlfunc
 def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
                  quantile_range=(25.0, 75.0), copy=True):
     """
@@ -1617,7 +1614,7 @@ class PolynomialFeatures(TransformerMixin,
             feature_names.append(name)
         return feature_names
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "PolynomialFeatures":
         """
         Compute number of output features.
@@ -1641,8 +1638,8 @@ class PolynomialFeatures(TransformerMixin,
         self.n_output_features_ = sum(1 for _ in combinations)
         return self
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Transform data to polynomial features
 
         Parameters
@@ -1769,7 +1766,7 @@ class PolynomialFeatures(TransformerMixin,
         return XP  # TODO keep order
 
 
-@reflect
+@mlfunc
 def normalize(X, norm='l2', *, axis=1, copy=True, return_norm=False):
     """Scale input vectors individually to unit norm (vector length).
 
@@ -1923,7 +1920,7 @@ class Normalizer(TransformerMixin,
         tags.requires_fit = False
         return tags
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "Normalizer":
         """Do nothing and return the estimator unchanged
 
@@ -1937,8 +1934,8 @@ class Normalizer(TransformerMixin,
         check_inputs(self, X, accept_sparse="csr", reset=True)
         return self
 
-    @reflect
-    def transform(self, X, copy=None) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X, copy=None):
         """Scale each non zero row of X to unit norm
 
         Parameters
@@ -1954,7 +1951,7 @@ class Normalizer(TransformerMixin,
         return normalize(X, norm=self.norm, axis=1, copy=copy)
 
 
-@reflect
+@mlfunc
 def binarize(X, *, threshold=0.0, copy=True):
     """Boolean thresholding of array-like or sparse matrix
 
@@ -2058,7 +2055,7 @@ class Binarizer(TransformerMixin,
         tags.requires_fit = False
         return tags
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "Binarizer":
         """Do nothing and return the estimator unchanged
 
@@ -2072,8 +2069,8 @@ class Binarizer(TransformerMixin,
         check_inputs(self, X, accept_sparse=['csr', 'csc'], reset=True)
         return self
 
-    @reflect
-    def transform(self, X, copy=None) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X, copy=None):
         """Binarize each element of X
 
         Parameters
@@ -2089,7 +2086,7 @@ class Binarizer(TransformerMixin,
         return binarize(X, threshold=self.threshold, copy=copy)
 
 
-@reflect
+@mlfunc
 def add_dummy_feature(X, value=1.0):
     """Augment dataset with an additional dummy feature.
 
@@ -2199,7 +2196,7 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
         # Needed for backported inspect.signature compatibility with PyPy
         pass
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, K, y=None) -> 'KernelCenterer':
         """Fit KernelCenterer
 
@@ -2224,8 +2221,8 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
         self.K_fit_all_ = self.K_fit_rows_.sum() / n_samples
         return self
 
-    @reflect
-    def transform(self, K, copy=True) -> CumlArray:
+    @mlfunc
+    def transform(self, K, copy=True):
         """Center kernel matrix.
 
         Parameters
@@ -2352,8 +2349,8 @@ class QuantileTransformer(TransformerMixin,
     transform.
     """
 
-    quantiles_ = CumlArrayDescriptor()
-    references_ = CumlArrayDescriptor()
+    quantiles_ = ReflectedAttr()
+    references_ = ReflectedAttr()
 
     def __init__(self, *, n_quantiles=1000, output_distribution='uniform',
                  ignore_implicit_zeros=False, subsample=int(1e5),
@@ -2457,7 +2454,7 @@ class QuantileTransformer(TransformerMixin,
         # https://github.com/numpy/numpy/issues/14685
         self.quantiles_ = np.array(cpu_np.maximum.accumulate(self.quantiles_))
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> 'QuantileTransformer':
         """Compute the quantiles used for transforming.
 
@@ -2637,8 +2634,8 @@ class QuantileTransformer(TransformerMixin,
 
         return X
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Feature-wise transformation of the data.
 
         Parameters
@@ -2659,8 +2656,8 @@ class QuantileTransformer(TransformerMixin,
 
         return self._transform(X, inverse=False)
 
-    @reflect
-    def inverse_transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def inverse_transform(self, X):
         """Back-projection to the original space.
 
         Parameters
@@ -2886,7 +2883,7 @@ class PowerTransformer(TransformerMixin,
             "copy"
         ]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> 'PowerTransformer':
         """Estimate the optimal parameter lambda for each feature.
 
@@ -2907,8 +2904,8 @@ class PowerTransformer(TransformerMixin,
         self._fit(X, y=y, force_transform=False)
         return self
 
-    @reflect(reset=True)
-    def fit_transform(self, X, y=None) -> CumlArray:
+    @mlfunc(set_input_type=True)
+    def fit_transform(self, X, y=None):
         return self._fit(X, y, force_transform=True)
 
     def _fit(self, X, y=None, force_transform=False):
@@ -2946,8 +2943,8 @@ class PowerTransformer(TransformerMixin,
 
         return X
 
-    @reflect
-    def transform(self, X) -> CumlArray:
+    @mlfunc
+    def transform(self, X):
         """Apply the power transform to each feature using the fitted lambdas.
 
         Parameters
@@ -2981,8 +2978,8 @@ class PowerTransformer(TransformerMixin,
 
         return X
 
-    @reflect
-    def inverse_transform(self, X) -> CumlArray:
+    @mlfunc
+    def inverse_transform(self, X):
         """Apply the inverse power transformation using the fitted lambdas.
 
         The inverse of the Box-Cox transformation is given by::

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_discretization.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Henry Lin <hlin117@gmail.com>
 # SPDX-FileCopyrightText: Tom Dupré la Tour
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 # Original authors from Sckit-Learn:
@@ -24,11 +24,9 @@ import numpy as cpu_np
 from cuml.cluster import KMeans
 from cuml.internals.mixins import SparseInputTagMixin
 from cuml.preprocessing.encoders import OneHotEncoder
+from cuml.internals.outputs import using_output_type, mlfunc, ReflectedAttr
 from cuml.internals.validation import check_is_fitted, check_inputs, check_array
 
-from ....common.array_descriptor import CumlArrayDescriptor
-from ....internals.array_sparse import SparseCumlArray
-from ....internals.outputs import using_output_type, reflect
 from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
 from ..utils.validation import FLOAT_DTYPES
 
@@ -137,7 +135,7 @@ class KBinsDiscretizer(TransformerMixin,
            [ 0.5,  3.5, -1.5,  1.5]])
 
     """
-    n_bins_ = CumlArrayDescriptor()
+    n_bins_ = ReflectedAttr()
 
     def __init__(self, n_bins=5, *, encode='onehot', strategy='quantile'):
         self.n_bins = n_bins
@@ -152,7 +150,7 @@ class KBinsDiscretizer(TransformerMixin,
             "strategy"
         ]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "KBinsDiscretizer":
         """
         Fit the estimator.
@@ -279,8 +277,8 @@ class KBinsDiscretizer(TransformerMixin,
                              .format(KBinsDiscretizer.__name__, indices))
         return n_bins
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """
         Discretize the data.
 
@@ -317,8 +315,8 @@ class KBinsDiscretizer(TransformerMixin,
         Xt = self._encoder.transform(Xt)
         return Xt
 
-    @reflect
-    def inverse_transform(self, Xt) -> SparseCumlArray:
+    @mlfunc
+    def inverse_transform(self, Xt):
         """
         Transform discretized data back to original feature space.
 

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_function_transformer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # This code originates from the Scikit-Learn library,
@@ -11,10 +11,9 @@ import warnings
 
 import cuml
 from cuml.internals.mixins import _ensure_transformer_tags
+from cuml.internals.outputs import mlfunc
 from cuml.internals.validation import check_inputs
 
-from ....internals.array_sparse import SparseCumlArray
-from ....internals.outputs import reflect
 from ..utils.skl_dependencies import BaseEstimator, TransformerMixin
 from ..utils.validation import _allclose_dense_sparse
 
@@ -98,7 +97,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
                               " want to proceed regardless, set"
                               " 'check_inverse=False'.", UserWarning)
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "FunctionTransformer":
         """Fit transformer by checking X.
 
@@ -117,8 +116,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             self._check_inverse_transform(X)
         return self
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Transform X using the forward function.
 
         Parameters
@@ -133,8 +132,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         """
         return self._transform(X, func=self.func, kw_args=self.kw_args)
 
-    @reflect
-    def inverse_transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def inverse_transform(self, X):
         """Transform X using the inverse function.
 
         Parameters

--- a/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
+++ b/python/cuml/cuml/_thirdparty/sklearn/preprocessing/_imputation.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Nicolas Tresegnie <nicolas.tresegnie@gmail.com>
 # SPDX-FileCopyrightText: Sergey Feldman <sergeyfeldman@gmail.com>
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Original authors from Sckit-Learn:
@@ -29,11 +29,9 @@ from cuml.internals.mixins import (
     StringInputTagMixin,
     _ensure_transformer_tags,
 )
+from cuml.internals.outputs import mlfunc, ReflectedAttr
 from cuml.internals.validation import check_is_fitted, check_inputs
 
-from ....common.array_descriptor import CumlArrayDescriptor
-from ....internals.array_sparse import SparseCumlArray
-from ....internals.outputs import reflect
 from ....thirdparty_adapters import (
     _get_mask,
     _masked_column_mean,
@@ -242,7 +240,7 @@ class SimpleImputer(SparseInputTagMixin, AllowNaNTagMixin,
 
     """
 
-    statistics_ = CumlArrayDescriptor()
+    statistics_ = ReflectedAttr()
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -314,7 +312,7 @@ class SimpleImputer(SparseInputTagMixin, AllowNaNTagMixin,
 
         return X
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "SimpleImputer":
         """Fit the imputer on X.
 
@@ -427,8 +425,8 @@ class SimpleImputer(SparseInputTagMixin, AllowNaNTagMixin,
         elif strategy == "constant":
             return np.full(X.shape[1], fill_value, dtype=X.dtype)
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Impute all missing values in X.
 
         Parameters
@@ -558,7 +556,7 @@ class MissingIndicator(AllowNaNTagMixin,
            [False, False]])
 
     """
-    features_ = CumlArrayDescriptor()
+    features_ = ReflectedAttr()
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -701,7 +699,7 @@ class MissingIndicator(AllowNaNTagMixin,
 
         return missing_features_info[0]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "MissingIndicator":
         """Fit the transformer on X.
 
@@ -720,8 +718,8 @@ class MissingIndicator(AllowNaNTagMixin,
 
         return self
 
-    @reflect
-    def transform(self, X) -> SparseCumlArray:
+    @mlfunc
+    def transform(self, X):
         """Generate missing values indicator for X.
 
         Parameters
@@ -760,8 +758,8 @@ class MissingIndicator(AllowNaNTagMixin,
 
         return imputer_mask
 
-    @reflect(reset=True)
-    def fit_transform(self, X, y=None) -> SparseCumlArray:
+    @mlfunc(set_input_type=True)
+    def fit_transform(self, X, y=None):
         """Generate missing values indicator for X.
 
         Parameters

--- a/python/cuml/cuml/accel/_overrides/sklearn/linear_model.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/linear_model.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -9,7 +9,6 @@ from packaging.version import Version
 import cuml.linear_model
 from cuml.accel.estimator_proxy import ProxyBase
 from cuml.common.sparse import is_sparse
-from cuml.internals.array import CumlArray
 from cuml.internals.interop import UnsupportedOnGPU
 from cuml.internals.outputs import using_output_type
 from cuml.internals.validation import check_y
@@ -59,9 +58,7 @@ class Ridge(ProxyBase):
             if len(y_shape) == 2 and y_shape[1] == 1:
                 with using_output_type("cupy"):
                     # Reshape coef_ to be a 2D array
-                    self._gpu.coef_ = CumlArray(
-                        data=self._gpu.coef_.reshape(1, -1)
-                    )
+                    self._gpu.coef_ = self._gpu.coef_.reshape(1, -1)
 
         return self
 

--- a/python/cuml/cuml/accel/estimator_proxy.py
+++ b/python/cuml/cuml/accel/estimator_proxy.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from cuml.accel import profilers
 from cuml.accel.core import logger
 from cuml.internals.base import Base
 from cuml.internals.interop import InteropMixin, UnsupportedOnGPU, is_fitted
-from cuml.internals.outputs import reflect, using_output_type
+from cuml.internals.outputs import mlfunc, using_output_type
 from cuml.internals.validation import check_inputs
 
 __all__ = ("ProxyBase", "ArrayAPIProxyBase", "is_proxy")
@@ -781,7 +781,7 @@ class _ArrayAPIWrapper(InteropMixin, Base):
             if hasattr(cls._internal_class, name):
                 setattr(cls, name, _make_method(name))
 
-    @reflect(array="X")
+    @mlfunc(array_arg="X")
     def _call_method(self, name, X, *args, **kwargs):
         """Call method `name` on the wrapped sklearn estimator."""
         if name in ("fit", "fit_transform", "fit_predict"):

--- a/python/cuml/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cuml/cluster/agglomerative.pyx
@@ -1,15 +1,13 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
-from cuml.internals.outputs import reflect
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs
 
 from libc.stdint cimport uintptr_t
@@ -104,8 +102,8 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
         The children of each non-leave node.
     """
 
-    labels_ = CumlArrayDescriptor(order="C")
-    children_ = CumlArrayDescriptor(order="C")
+    labels_ = ReflectedAttr()
+    children_ = ReflectedAttr()
 
     @classmethod
     def _get_param_names(cls):
@@ -138,7 +136,7 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
         self.c = c
 
     @generate_docstring()
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated") -> "AgglomerativeClustering":
         """
         Fit the hierarchical clustering from features.
@@ -206,8 +204,8 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
         self.n_connected_components_ = 1
         self.n_leaves_ = n_rows
         self.n_clusters_ = n_clusters
-        self.labels_ = CumlArray(data=labels)
-        self.children_ = CumlArray(data=children)
+        self.labels_ = labels
+        self.children_ = children
 
         return self
 
@@ -215,8 +213,8 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
                                        "type": "dense",
                                        "description": "Cluster indexes",
                                        "shape": "(n_samples, 1)"})
-    @reflect
-    def fit_predict(self, X, y=None) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_predict(self, X, y=None):
         """
         Fit and return the assigned cluster labels.
         """

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -1,21 +1,15 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals import logger, reflect
-from cuml.internals.array import CumlArray
+from cuml.internals import logger
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+from cuml.internals.outputs import ArrayIndexPair, ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs
 
 from libc.stdint cimport int64_t, uintptr_t
@@ -220,9 +214,9 @@ class DBSCAN(InteropMixin,
     """
     _multi_gpu = False
 
-    core_sample_indices_ = CumlArrayDescriptor(order="C")
-    components_ = CumlArrayDescriptor(order="C")
-    labels_ = CumlArrayDescriptor(order="C")
+    core_sample_indices_ = ReflectedAttr()
+    components_ = ReflectedAttr()
+    labels_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.cluster.DBSCAN"
 
@@ -263,17 +257,23 @@ class DBSCAN(InteropMixin,
 
     def _attrs_from_cpu(self, model):
         return {
-            "core_sample_indices_": to_gpu(model.core_sample_indices_, order="C"),
-            "components_": to_gpu(model.components_, order="C"),
-            "labels_": to_gpu(model.labels_, order="C"),
+            "core_sample_indices_": cp.asarray(model.core_sample_indices_, order="C"),
+            "components_": cp.asarray(model.components_, order="C"),
+            "labels_": ArrayIndexPair(cp.asarray(model.labels_, order="C"), None),
             **super()._attrs_from_cpu(model),
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "core_sample_indices_": to_cpu(self.core_sample_indices_, order="C"),
-            "components_": to_cpu(self.components_, order="C"),
-            "labels_": to_cpu(self.labels_, order="C"),
+            "core_sample_indices_": (
+                None if self.core_sample_indices_ is None
+                else self.core_sample_indices_.get(order="C")
+            ),
+            "components_": (
+                None if self.components_ is None
+                else self.components_.get(order="C")
+            ),
+            "labels_": self.labels_.array.get(order="C"),
             **super()._attrs_to_cpu(model),
         }
 
@@ -298,7 +298,7 @@ class DBSCAN(InteropMixin,
         self.algorithm = algorithm
 
     @generate_docstring(skip_parameters_heading=True)
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(
         self,
         X,
@@ -465,13 +465,9 @@ class DBSCAN(InteropMixin,
             components = None
 
         # Store fitted attributes
-        self.labels_ = CumlArray(data=labels, index=index)
-        self.core_sample_indices_ = (
-            None if core_sample_indices is None else CumlArray(data=core_sample_indices)
-        )
-        self.components_ = (
-            None if components is None else CumlArray(data=components)
-        )
+        self.labels_ = ArrayIndexPair(labels, index)
+        self.core_sample_indices_ = core_sample_indices
+        self.components_ = components
         return self
 
     @generate_docstring(skip_parameters_heading=True,
@@ -479,7 +475,7 @@ class DBSCAN(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Cluster labels',
                                        'shape': '(n_samples, 1)'})
-    @reflect
+    @mlfunc(preserve_index=True)
     def fit_predict(
         self,
         X,
@@ -488,7 +484,7 @@ class DBSCAN(InteropMixin,
         *,
         out_dtype="int32",
         convert_dtype="deprecated",
-    ) -> CumlArray:
+    ):
         """
         Performs clustering on X and returns cluster labels.
 

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -1,21 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
 import numpy as np
 
 import cuml
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals import logger, reflect
-from cuml.internals.array import CumlArray
+from cuml.internals import logger
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+from cuml.internals.outputs import ArrayIndexPair, ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 from cython.operator cimport dereference as deref
@@ -189,7 +183,7 @@ cdef class _HDBSCANState:
 
         self.core_dists = cp.empty(n_rows, dtype=np.float32)
         cdef handle_t *handle_ = <handle_t*> <size_t> handle.getHandle()
-        cdef float* X_ptr = <float*><uintptr_t>X.ptr
+        cdef float* X_ptr = <float*><uintptr_t>X.data.ptr
         cdef float* core_dists_ptr = <float*><uintptr_t>self.core_dists.data.ptr
         cdef bool allow_single_cluster = model.allow_single_cluster
         cdef int64_t max_cluster_size = model.max_cluster_size
@@ -406,7 +400,7 @@ cdef class _HDBSCANState:
 
         cdef int n_rows = X.shape[0]
         cdef int n_cols = X.shape[1]
-        cdef int64_t* labels_ptr = <int64_t*><uintptr_t>labels.ptr
+        cdef int64_t* labels_ptr = <int64_t*><uintptr_t>labels.data.ptr
         cdef int64_t* inverse_label_map_ptr = (
             <int64_t*><uintptr_t>self.inverse_label_map.data.ptr
         )
@@ -667,9 +661,9 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
         Even then in some optimized cases a tree may not be generated.
 
     """
-    labels_ = CumlArrayDescriptor()
-    probabilities_ = CumlArrayDescriptor()
-    cluster_persistence_ = CumlArrayDescriptor()
+    labels_ = ReflectedAttr()
+    probabilities_ = ReflectedAttr()
+    cluster_persistence_ = ReflectedAttr()
 
     _cpu_class_path = "hdbscan.HDBSCAN"
 
@@ -749,8 +743,8 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
             # Sparse input
             raise UnsupportedOnGPU("Sparse inputs are not supported")
 
-        raw_data = to_gpu(raw_data_cpu, order="C", dtype="float32")
-        labels = to_gpu(model.labels_, order="C", dtype="int64")
+        raw_data = cp.asarray(raw_data_cpu, order="C", dtype="float32")
+        labels = cp.asarray(model.labels_, order="C", dtype="int64")
         state = _HDBSCANState.from_sklearn(model, raw_data)
         if model._prediction_data is not None:
             state.generate_prediction_data(raw_data, labels)
@@ -759,10 +753,10 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
             # XXX: `hdbscan.HDBSCAN` doesn't set `n_features_in_` currently, we need
             # to infer this ourselves from the raw data.
             "n_features_in_": raw_data_cpu.shape[1],
-            "labels_": labels,
-            "probabilities_": to_gpu(model.probabilities_, dtype="float32"),
-            "cluster_persistence_": to_gpu(model.cluster_persistence_, dtype="float32"),
-            "_raw_data": raw_data,
+            "labels_": ArrayIndexPair(labels, None),
+            "probabilities_": cp.asarray(model.probabilities_, dtype="float32"),
+            "cluster_persistence_": cp.asarray(model.cluster_persistence_, dtype="float32"),
+            "_raw_data": ArrayIndexPair(raw_data, None),
             "_raw_data_cpu": raw_data_cpu,
             "_state": state,
             "n_clusters_": state.n_clusters,
@@ -774,9 +768,9 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
 
     def _attrs_to_cpu(self, model):
         out = {
-            "labels_": to_cpu(self.labels_),
-            "probabilities_": to_cpu(self.probabilities_),
-            "cluster_persistence_": to_cpu(self.cluster_persistence_),
+            "labels_": self.labels_.array.get(order="A"),
+            "probabilities_": self.probabilities_.get(order="A"),
+            "cluster_persistence_": self.cluster_persistence_.get(order="A"),
             "_condensed_tree": self._condensed_tree,
             "_single_linkage_tree": self._single_linkage_tree,
             "_min_spanning_tree": self._min_spanning_tree,
@@ -832,7 +826,7 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
 
     def _get_raw_data_cpu(self):
         if getattr(self, "_raw_data_cpu") is None:
-            self._raw_data_cpu = self._raw_data.to_output("numpy")
+            self._raw_data_cpu = self._raw_data.array.get(order="A")
         return self._raw_data_cpu
 
     @property
@@ -905,11 +899,11 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
         with cuml.using_output_type("cuml"):
             labels = self.labels_
 
-        self._state.generate_prediction_data(self._raw_data, labels)
+        self._state.generate_prediction_data(self._raw_data.array, labels)
         self.prediction_data = True
 
     @generate_docstring()
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated") -> "HDBSCAN":
         """
         Fit HDBSCAN model from features.
@@ -936,7 +930,7 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
             return_index=True,
             reset=True,
         )
-        self._raw_data = CumlArray(X, index=index)
+        self._raw_data = ArrayIndexPair(X, index)
         self._raw_data_cpu = None
 
         # Validate and prepare hyperparameters
@@ -1053,9 +1047,9 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
         # Store state on model
         self._state = state
         self.n_clusters_ = n_clusters
-        self.labels_ = CumlArray(data=labels, index=index)
-        self.probabilities_ = CumlArray(data=probabilities)
-        self.cluster_persistence_ = CumlArray(data=cluster_persistence)
+        self.labels_ = ArrayIndexPair(labels, index)
+        self.probabilities_ = probabilities
+        self.cluster_persistence_ = cluster_persistence
         self._min_spanning_tree = min_spanning_tree
         self._single_linkage_tree = single_linkage_tree
 
@@ -1068,8 +1062,8 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
                                        "type": "dense",
                                        "description": "Cluster indexes",
                                        "shape": "(n_samples, 1)"})
-    @reflect
-    def fit_predict(self, X, y=None) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_predict(self, X, y=None):
         """
         Fit the HDBSCAN model from features and return
         cluster labels.
@@ -1117,7 +1111,7 @@ def _check_clusterer(clusterer):
     return state
 
 
-@reflect(model="clusterer", array=None)
+@mlfunc(model_arg="clusterer", array_arg=None)
 def all_points_membership_vectors(clusterer, int batch_size=4096):
     """
     Predict soft cluster membership vectors for all points in the
@@ -1148,19 +1142,19 @@ def all_points_membership_vectors(clusterer, int batch_size=4096):
     if batch_size <= 0:
         raise ValueError("batch_size must be > 0")
 
-    n_rows = clusterer._raw_data.shape[0]
+    n_rows = clusterer._raw_data.array.shape[0]
 
     if clusterer.n_clusters_ == 0:
-        return CumlArray(
-            data=cp.zeros(n_rows, dtype=np.float32, order="C"),
-            index=clusterer._raw_data.index,
+        return ArrayIndexPair(
+            cp.zeros(n_rows, dtype=np.float32, order="C"),
+            clusterer._raw_data.index,
         )
 
     membership_vec = cp.empty(
         (n_rows, clusterer.n_clusters_,), dtype="float32", order="C",
     )
 
-    raw_data = clusterer._raw_data.to_output("cupy")
+    raw_data = clusterer._raw_data.array
     cdef _HDBSCANState state = <_HDBSCANState?>clusterer._state
     cdef float* X_ptr = <float*><uintptr_t>raw_data.data.ptr
     cdef float* membership_vec_ptr = <float*><uintptr_t>membership_vec.data.ptr
@@ -1180,10 +1174,10 @@ def all_points_membership_vectors(clusterer, int batch_size=4096):
         )
     handle.sync()
 
-    return CumlArray(data=membership_vec, index=clusterer._raw_data.index)
+    return ArrayIndexPair(membership_vec, clusterer._raw_data.index)
 
 
-@reflect(model="clusterer", array="points_to_predict")
+@mlfunc(model_arg="clusterer", array_arg="points_to_predict", preserve_index=True)
 def membership_vector(
     clusterer,
     points_to_predict,
@@ -1224,13 +1218,12 @@ def membership_vector(
     if batch_size <= 0:
         raise ValueError("batch_size must be > 0")
 
-    points_to_predict, index = check_inputs(
+    points_to_predict = check_inputs(
         clusterer,
         points_to_predict,
         dtype="float32",
         convert_dtype=convert_dtype,
         order="C",
-        return_index=True,
     )
     cdef int n_prediction_points = points_to_predict.shape[0]
 
@@ -1238,9 +1231,9 @@ def membership_vector(
         (n_prediction_points, clusterer.n_clusters_,), dtype="float32", order="C"
     )
     if clusterer.n_clusters_ == 0:
-        return CumlArray(data=membership_vec, index=index)
+        return membership_vec
 
-    raw_data = clusterer._raw_data.to_output("cupy")
+    raw_data = clusterer._raw_data.array
     cdef _HDBSCANState state = <_HDBSCANState?>clusterer._state
     cdef float* X_ptr = <float*><uintptr_t>raw_data.data.ptr
     cdef float* points_to_predict_ptr = <float*><uintptr_t>points_to_predict.data.ptr
@@ -1265,10 +1258,10 @@ def membership_vector(
         )
     handle.sync()
 
-    return CumlArray(data=membership_vec, index=index)
+    return membership_vec
 
 
-@reflect(model="clusterer", array="points_to_predict")
+@mlfunc(model_arg="clusterer", array_arg="points_to_predict", preserve_index=True)
 def approximate_predict(clusterer, points_to_predict, convert_dtype="deprecated"):
     """Predict the cluster label of new points. The returned labels
     will be those of the original clustering found by ``clusterer``,
@@ -1309,23 +1302,22 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype="deprecated"
             "will be automatically predicted as outliers."
         )
 
-    points_to_predict, index = check_inputs(
+    points_to_predict = check_inputs(
         clusterer,
         points_to_predict,
         dtype="float32",
         convert_dtype=convert_dtype,
         order="C",
-        return_index=True,
     )
     cdef int n_prediction_points = points_to_predict.shape[0]
 
     prediction_labels = cp.empty(n_prediction_points, dtype="int64")
     prediction_probs = cp.empty(n_prediction_points, dtype="float32")
 
-    raw_data = clusterer._raw_data.to_output("cupy")
+    raw_data = clusterer._raw_data.array
     cdef _HDBSCANState state = <_HDBSCANState?>clusterer._state
     cdef float* X_ptr = <float*><uintptr_t>raw_data.data.ptr
-    cdef int64_t* labels_ptr = <int64_t*><uintptr_t>clusterer.labels_.ptr
+    cdef int64_t* labels_ptr = <int64_t*><uintptr_t>clusterer.labels_.array.data.ptr
     cdef float* points_to_predict_ptr = <float*><uintptr_t>points_to_predict.data.ptr
     cdef int64_t* prediction_labels_ptr = <int64_t*><uintptr_t>prediction_labels.data.ptr
     cdef float* prediction_probs_ptr = <float*><uintptr_t>prediction_probs.data.ptr
@@ -1350,10 +1342,7 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype="deprecated"
         )
     handle.sync()
 
-    return (
-        CumlArray(data=prediction_labels, index=index),
-        CumlArray(data=prediction_probs, index=index),
-    )
+    return prediction_labels, prediction_probs
 
 
 ###########################################################

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -1,21 +1,14 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
-from cuml.internals.outputs import reflect, run_in_internal_context
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_array,
     check_inputs,
@@ -411,8 +404,8 @@ class KMeans(InteropMixin,
     """
     _multi_gpu = False
 
-    labels_ = CumlArrayDescriptor(order="C")
-    cluster_centers_ = CumlArrayDescriptor(order="C")
+    labels_ = ReflectedAttr()
+    cluster_centers_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.cluster.KMeans"
 
@@ -457,7 +450,7 @@ class KMeans(InteropMixin,
     def _params_to_cpu(self):
         init = self.init
         if not isinstance(init, str):
-            init = to_cpu(init)  # array-like
+            init = cp.asnumpy(init)  # array-like
         elif init == "scalable-k-means++":
             init = "k-means++"
         return {
@@ -471,9 +464,9 @@ class KMeans(InteropMixin,
 
     def _attrs_from_cpu(self, model):
         return {
-            "cluster_centers_": to_gpu(model.cluster_centers_, order="C"),
-            "labels_": to_gpu(model.labels_, order="C"),
-            "inertia_": to_gpu(model.inertia_),
+            "cluster_centers_": cp.asarray(model.cluster_centers_, order="C"),
+            "labels_": cp.asarray(model.labels_, order="C"),
+            "inertia_": model.inertia_,
             "n_iter_": model.n_iter_,
             **super()._attrs_from_cpu(model),
         }
@@ -489,9 +482,9 @@ class KMeans(InteropMixin,
             n_threads = _openmp_effective_n_threads()
 
         return {
-            "cluster_centers_": to_cpu(self.cluster_centers_),
-            "labels_": to_cpu(self.labels_),
-            "inertia_": to_cpu(self.inertia_),
+            "cluster_centers_": self.cluster_centers_.get(order="A"),
+            "labels_": self.labels_.get(order="A"),
+            "inertia_": self.inertia_,
             "n_iter_": self.n_iter_,
             # sklearn's KMeans relies on a few private attributes to work
             "_n_features_out": self._n_features_out,
@@ -530,7 +523,7 @@ class KMeans(InteropMixin,
         return self.n_clusters
 
     @generate_docstring()
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, sample_weight=None, *, convert_dtype="deprecated") -> "KMeans":
         """
         Compute k-means clustering with X.
@@ -591,8 +584,8 @@ class KMeans(InteropMixin,
         handle.sync()
 
         # Store fitted attributes and return
-        self.cluster_centers_ = CumlArray(data=centers)
-        self.labels_ = CumlArray(data=labels)
+        self.cluster_centers_ = centers
+        self.labels_ = labels
         self.inertia_ = inertia
         self.n_iter_ = n_iter
 
@@ -602,8 +595,8 @@ class KMeans(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Cluster indexes',
                                        'shape': '(n_samples, 1)'})
-    @reflect
-    def fit_predict(self, X, y=None, sample_weight=None) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_predict(self, X, y=None, sample_weight=None):
         """
         Compute cluster centers and predict cluster index for each sample.
 
@@ -662,7 +655,7 @@ class KMeans(InteropMixin,
             params,
             X,
             sample_weight,
-            self.cluster_centers_.to_output("cupy")
+            self.cluster_centers_
         )
         handle.sync()
         return labels, inertia
@@ -671,26 +664,21 @@ class KMeans(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Cluster indexes',
                                        'shape': '(n_samples, 1)'})
-    @reflect
-    def predict(
-        self,
-        X,
-        *,
-        convert_dtype="deprecated",
-    ) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def predict(self, X, *, convert_dtype="deprecated"):
         """
         Predict the closest cluster each sample in X belongs to.
 
         """
         labels, _ = self._predict_labels_inertia(X, convert_dtype=convert_dtype)
-        return CumlArray(data=labels)
+        return labels
 
     @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    @reflect
-    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X, *, convert_dtype="deprecated"):
         """
         Transform X to a cluster-distance space.
 
@@ -723,7 +711,7 @@ class KMeans(InteropMixin,
         )
 
         cdef uintptr_t X_ptr = X.data.ptr
-        cdef uintptr_t centers_ptr = self.cluster_centers_.ptr
+        cdef uintptr_t centers_ptr = self.cluster_centers_.data.ptr
         cdef uintptr_t out_ptr = out.data.ptr
 
         handle = get_handle()
@@ -778,14 +766,14 @@ class KMeans(InteropMixin,
                         <double*>out_ptr,
                     )
         handle.sync()
-        return CumlArray(data=out)
+        return out
 
     @generate_docstring(return_values={'name': 'score',
                                        'type': 'float',
                                        'description': 'Opposite of the value \
                                                         of X on the K-means \
                                                         objective.'})
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def score(self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"):
         """
         Opposite of the value of X on the K-means objective.
@@ -801,10 +789,10 @@ class KMeans(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
-    @reflect
+    @mlfunc(preserve_index=True)
     def fit_transform(
         self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> CumlArray:
+    ):
         """
         Compute clustering and transform X to cluster-distance space.
 

--- a/python/cuml/cuml/cluster/spectral_clustering.pyx
+++ b/python/cuml/cuml/cluster/spectral_clustering.pyx
@@ -1,21 +1,14 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 import cupyx.scipy.sparse as sp
 
-import cuml
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import ClusterMixin, CMajorInputTagMixin
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs, check_random_seed
 
 from libc.stdint cimport uint64_t, uintptr_t
@@ -158,7 +151,7 @@ class SpectralClustering(InteropMixin,
       Stella X. Yu, Jianbo Shi
       https://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf
     """
-    labels_ = CumlArrayDescriptor()
+    labels_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.cluster.SpectralClustering"
 
@@ -198,13 +191,13 @@ class SpectralClustering(InteropMixin,
 
     def _attrs_from_cpu(self, model):
         return {
-            "labels_": to_gpu(model.labels_, order="C"),
+            "labels_": cp.asarray(model.labels_, order="C"),
             **super()._attrs_from_cpu(model),
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "labels_": to_cpu(self.labels_, order="C"),
+            "labels_": self.labels_.get(order="C"),
             **super()._attrs_to_cpu(model),
         }
 
@@ -243,8 +236,8 @@ class SpectralClustering(InteropMixin,
             "affinity",
         ]
 
-    @cuml.internals.reflect
-    def fit_predict(self, X, y=None) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_predict(self, X, y=None):
         """Perform spectral clustering on ``X`` and return cluster labels.
 
         Parameters
@@ -267,7 +260,7 @@ class SpectralClustering(InteropMixin,
         self.fit(X, y=y)
         return self.labels_
 
-    @cuml.internals.reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "SpectralClustering":
         """Perform spectral clustering on ``X``.
 
@@ -390,11 +383,11 @@ class SpectralClustering(InteropMixin,
             else:
                 raise
 
-        self.labels_ = CumlArray(data=labels)
+        self.labels_ = labels
         return self
 
 
-@cuml.internals.reflect
+@mlfunc(preserve_index=True)
 def spectral_clustering(
     X,
     *,

--- a/python/cuml/cuml/covariance/empirical_covariance.py
+++ b/python/cuml/cuml/covariance/empirical_covariance.py
@@ -7,11 +7,9 @@ import warnings
 import cupy as cp
 import numpy as np
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals import reflect, run_in_internal_context
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.interop import InteropMixin, to_cpu, to_gpu
+from cuml.internals.interop import InteropMixin
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 
@@ -87,9 +85,9 @@ class EmpiricalCovariance(InteropMixin, Base):
         The scikit-learn CPU implementation.
     """
 
-    covariance_ = CumlArrayDescriptor()
-    location_ = CumlArrayDescriptor()
-    precision_ = CumlArrayDescriptor()
+    covariance_ = ReflectedAttr()
+    location_ = ReflectedAttr()
+    precision_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.covariance.EmpiricalCovariance"
 
@@ -115,21 +113,25 @@ class EmpiricalCovariance(InteropMixin, Base):
 
     def _attrs_from_cpu(self, model):
         return {
-            "covariance_": to_gpu(model.covariance_),
-            "location_": to_gpu(model.location_),
-            "precision_": to_gpu(model.precision_)
-            if self.store_precision
-            else None,
+            "covariance_": cp.asarray(model.covariance_),
+            "location_": cp.asarray(model.location_),
+            "precision_": (
+                None
+                if model.precision_ is None
+                else cp.asarray(model.precision_)
+            ),
             **super()._attrs_from_cpu(model),
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "covariance_": to_cpu(self.covariance_),
-            "location_": to_cpu(self.location_),
-            "precision_": to_cpu(self.precision_)
-            if self.store_precision
-            else None,
+            "covariance_": self.covariance_.get(order="A"),
+            "location_": self.location_.get(order="A"),
+            "precision_": (
+                None
+                if self.precision_ is None
+                else self.precision_.get(order="A")
+            ),
             **super()._attrs_to_cpu(model),
         }
 
@@ -145,7 +147,7 @@ class EmpiricalCovariance(InteropMixin, Base):
         self.store_precision = store_precision
         self.assume_centered = assume_centered
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(
         self, X, y=None, *, convert_dtype="deprecated"
     ) -> "EmpiricalCovariance":
@@ -192,17 +194,17 @@ class EmpiricalCovariance(InteropMixin, Base):
             X, assume_centered=self.assume_centered
         )
 
-        self.location_ = CumlArray(data=location)
-        self.covariance_ = CumlArray(data=covariance)
+        self.location_ = location
+        self.covariance_ = covariance
 
         if self.store_precision:
-            self.precision_ = CumlArray(data=cp.linalg.pinv(covariance))
+            self.precision_ = cp.linalg.pinv(covariance)
         else:
             self.precision_ = None
 
         return self
 
-    @reflect
+    @mlfunc
     def get_precision(self):
         """Getter for the precision matrix.
 
@@ -215,12 +217,9 @@ class EmpiricalCovariance(InteropMixin, Base):
 
         if self.store_precision:
             return self.precision_
+        return cp.linalg.pinv(self.covariance_)
 
-        covariance = self.covariance_.to_output("cupy")
-        precision = cp.linalg.pinv(covariance)
-        return precision
-
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def score(self, X_test, y=None) -> float:
         """Compute the log-likelihood of X_test under the estimated model.
 
@@ -242,16 +241,12 @@ class EmpiricalCovariance(InteropMixin, Base):
             X_test,
             dtype=("float32", "float64"),
         )
-        precision = self.get_precision().to_output("cupy")
-        location = self.location_.to_output("cupy")
-
         test_cov = _empirical_covariance(
-            X_test - location, assume_centered=True
+            X_test - self.location_, assume_centered=True
         )
+        return _log_likelihood(test_cov, self.get_precision())
 
-        return _log_likelihood(test_cov, precision)
-
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def error_norm(
         self, comp_cov, norm="frobenius", scaling=True, squared=True
     ):
@@ -277,8 +272,8 @@ class EmpiricalCovariance(InteropMixin, Base):
         check_is_fitted(self)
 
         comp_cov = check_inputs(self, comp_cov, dtype=("float32", "float64"))
-        self_cov = self.covariance_.to_output("cupy")
-        diff = comp_cov - self_cov
+
+        diff = comp_cov - self.covariance_
 
         if norm == "frobenius":
             error = cp.sum(diff**2)
@@ -290,14 +285,14 @@ class EmpiricalCovariance(InteropMixin, Base):
             )
 
         if scaling:
-            error = error / self_cov.shape[0]
+            error = error / self.covariance_.shape[0]
 
         if not squared:
             error = cp.sqrt(error)
 
         return float(error)
 
-    @reflect
+    @mlfunc
     def mahalanobis(self, X):
         """Compute the squared Mahalanobis distances of given observations.
 
@@ -313,10 +308,10 @@ class EmpiricalCovariance(InteropMixin, Base):
         """
         check_is_fitted(self)
         X = check_inputs(self, X, dtype=("float32", "float64"))
-        precision = self.get_precision().to_output("cupy")
-        location = self.location_.to_output("cupy")
 
-        X_centered = X - location
-        mahal = cp.sum(cp.dot(X_centered, precision) * X_centered, axis=1)
+        X_centered = X - self.location_
+        mahal = cp.sum(
+            cp.dot(X_centered, self.get_precision()) * X_centered, axis=1
+        )
 
         return mahal

--- a/python/cuml/cuml/covariance/empirical_covariance.py
+++ b/python/cuml/cuml/covariance/empirical_covariance.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import warnings

--- a/python/cuml/cuml/covariance/ledoit_wolf.py
+++ b/python/cuml/cuml/covariance/ledoit_wolf.py
@@ -7,11 +7,9 @@ import warnings
 import cupy as cp
 import numpy as np
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals import reflect, run_in_internal_context
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.interop import InteropMixin, to_cpu, to_gpu
+from cuml.internals.interop import InteropMixin
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 
@@ -161,9 +159,9 @@ class LedoitWolf(InteropMixin, Base):
     Analysis, Volume 88, Issue 2, February 2004, pages 365-411.
     """
 
-    covariance_ = CumlArrayDescriptor()
-    location_ = CumlArrayDescriptor()
-    precision_ = CumlArrayDescriptor()
+    covariance_ = ReflectedAttr()
+    location_ = ReflectedAttr()
+    precision_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.covariance.LedoitWolf"
 
@@ -192,22 +190,26 @@ class LedoitWolf(InteropMixin, Base):
 
     def _attrs_from_cpu(self, model):
         return {
-            "covariance_": to_gpu(model.covariance_),
-            "location_": to_gpu(model.location_),
-            "precision_": to_gpu(model.precision_)
-            if self.store_precision
-            else None,
+            "covariance_": cp.asarray(model.covariance_),
+            "location_": cp.asarray(model.location_),
+            "precision_": (
+                None
+                if model.precision_ is None
+                else cp.asarray(model.precision_)
+            ),
             "shrinkage_": model.shrinkage_,
             **super()._attrs_from_cpu(model),
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "covariance_": to_cpu(self.covariance_),
-            "location_": to_cpu(self.location_),
-            "precision_": to_cpu(self.precision_)
-            if self.store_precision
-            else None,
+            "covariance_": self.covariance_.get(order="A"),
+            "location_": self.location_.get(order="A"),
+            "precision_": (
+                None
+                if self.precision_ is None
+                else self.precision_.get(order="A")
+            ),
             "shrinkage_": self.shrinkage_,
             **super()._attrs_to_cpu(model),
         }
@@ -226,7 +228,7 @@ class LedoitWolf(InteropMixin, Base):
         self.assume_centered = assume_centered
         self.block_size = block_size
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated") -> "LedoitWolf":
         """Fit the Ledoit-Wolf shrunk covariance model to X.
 
@@ -277,17 +279,17 @@ class LedoitWolf(InteropMixin, Base):
         shrunk_cov.flat[:: X.shape[1] + 1] += shrinkage * mu
 
         self.shrinkage_ = shrinkage
-        self.location_ = CumlArray(data=location)
-        self.covariance_ = CumlArray(data=shrunk_cov)
+        self.location_ = location
+        self.covariance_ = shrunk_cov
 
         if self.store_precision:
-            self.precision_ = CumlArray(data=cp.linalg.pinv(shrunk_cov))
+            self.precision_ = cp.linalg.pinv(shrunk_cov)
         else:
             self.precision_ = None
 
         return self
 
-    @reflect
+    @mlfunc
     def get_precision(self):
         """Getter for the precision matrix.
 
@@ -300,12 +302,9 @@ class LedoitWolf(InteropMixin, Base):
 
         if self.store_precision:
             return self.precision_
-        else:
-            covariance = self.covariance_.to_output("cupy")
-            precision = cp.linalg.pinv(covariance)
-            return precision
+        return cp.linalg.pinv(self.covariance_)
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def score(self, X_test, y=None) -> float:
         """Compute the log-likelihood of X_test under the estimated model.
 
@@ -329,10 +328,9 @@ class LedoitWolf(InteropMixin, Base):
             X_test,
             dtype=("float32", "float64"),
         )
-        precision = self.get_precision().to_output("cupy")
-        location = self.location_.to_output("cupy")
 
-        X_centered = X_test - location
+        precision = self.get_precision()
+        X_centered = X_test - self.location_
         log_det_precision = cp.linalg.slogdet(precision)[1]
         mahal = cp.sum(cp.dot(X_centered, precision) * X_centered, axis=1)
 
@@ -344,7 +342,7 @@ class LedoitWolf(InteropMixin, Base):
 
         return float(log_likelihood)
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def error_norm(
         self, comp_cov, norm="frobenius", scaling=True, squared=True
     ):
@@ -370,9 +368,8 @@ class LedoitWolf(InteropMixin, Base):
         check_is_fitted(self)
 
         comp_cov = check_inputs(self, comp_cov, dtype=("float32", "float64"))
-        self_cov = self.covariance_.to_output("cupy")
 
-        diff = self_cov - comp_cov
+        diff = self.covariance_ - comp_cov
 
         if norm == "frobenius":
             error = cp.sum(diff**2)
@@ -384,7 +381,7 @@ class LedoitWolf(InteropMixin, Base):
             )
 
         if scaling:
-            n_features = self_cov.shape[0]
+            n_features = self.covariance_.shape[0]
             error = error / n_features
 
         if not squared:
@@ -392,7 +389,7 @@ class LedoitWolf(InteropMixin, Base):
 
         return float(error)
 
-    @reflect
+    @mlfunc
     def mahalanobis(self, X):
         """Compute the squared Mahalanobis distances of given observations.
 
@@ -408,10 +405,10 @@ class LedoitWolf(InteropMixin, Base):
         """
         check_is_fitted(self)
         X = check_inputs(self, X, dtype=("float32", "float64"))
-        precision = self.get_precision().to_output("cupy")
-        location = self.location_.to_output("cupy")
 
-        X_centered = X - location
-        mahal = cp.sum(cp.dot(X_centered, precision) * X_centered, axis=1)
+        X_centered = X - self.location_
+        mahal = cp.sum(
+            cp.dot(X_centered, self.get_precision()) * X_centered, axis=1
+        )
 
         return mahal

--- a/python/cuml/cuml/covariance/ledoit_wolf.py
+++ b/python/cuml/cuml/covariance/ledoit_wolf.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import warnings

--- a/python/cuml/cuml/dask/common/base.py
+++ b/python/cuml/cuml/dask/common/base.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -19,7 +19,6 @@ from toolz import first
 from cuml.dask.common import parts_to_ranks
 from cuml.dask.common.input_utils import DistributedDataHandler
 from cuml.dask.common.utils import get_client, wait_and_raise_from_futures
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 
 
@@ -220,12 +219,7 @@ class BaseEstimator:
                 "Attribute %s not found in %s" % (attr, type(self))
             )
 
-        if isinstance(ret_attr, CumlArray):
-            # Dask wrappers aren't meant to be pickled, so we can
-            # store the raw type on the instance
-            return ret_attr.to_output(self.output_type)
-        else:
-            return ret_attr
+        return ret_attr
 
 
 class DelayedParallelFunc(object):

--- a/python/cuml/cuml/dask/naive_bayes/naive_bayes.py
+++ b/python/cuml/cuml/dask/naive_bayes/naive_bayes.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -170,11 +170,6 @@ class MultinomialNB(BaseEstimator, DelayedPredictionMixin):
         return arrs.shape[0]
 
     def predict(self, X):
-        # TODO: Once cupy sparse arrays are fully supported underneath Dask
-        # arrays, and Naive Bayes is refactored to use CumlArray, this can
-        # extend DelayedPredictionMixin.
-        # Ref: https://github.com/rapidsai/cuml/issues/1834
-        # Ref: https://github.com/rapidsai/cuml/issues/1387
         """
         Use distributed Naive Bayes model to predict the classes for a
         given set of data samples.
@@ -191,6 +186,9 @@ class MultinomialNB(BaseEstimator, DelayedPredictionMixin):
         dask.Array containing predicted classes
 
         """
+        # TODO: This could be refactored to use DelayedPredictionMixin
+        # Ref: https://github.com/rapidsai/cuml/issues/1834
+        # Ref: https://github.com/rapidsai/cuml/issues/1387
         if not isinstance(X, dask.array.core.Array):
             raise ValueError("Only dask.Array is supported for X")
 

--- a/python/cuml/cuml/datasets/arima.pyx
+++ b/python/cuml/cuml/datasets/arima.pyx
@@ -6,7 +6,7 @@ from random import randint
 
 import cupy as cp
 
-from cuml.internals import get_handle, reflect
+from cuml.internals import get_handle, mlfunc
 from cuml.tsa._deprecation import deprecated_tsa_api
 
 from libc.stdint cimport uint64_t, uintptr_t
@@ -42,7 +42,7 @@ cdef extern from "cuml/datasets/make_arima.hpp" namespace "ML" nogil:
 
 
 @deprecated_tsa_api("cuml.datasets.make_arima")
-@reflect(array=None)
+@mlfunc(array_arg=None)
 def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
                seasonal_order=(0, 0, 0, 0), intercept=False,
                random_state=None, dtype="float64"):

--- a/python/cuml/cuml/datasets/blobs.py
+++ b/python/cuml/cuml/datasets/blobs.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -71,7 +71,7 @@ def _get_centers(rs, centers, center_box, n_samples, n_features, dtype):
 
 
 @nvtx.annotate(message="datasets.make_blobs", domain="cuml_python")
-@cuml.internals.reflect(array=None)
+@cuml.internals.mlfunc(array_arg=None)
 def make_blobs(
     n_samples=100,
     n_features=2,

--- a/python/cuml/cuml/datasets/classification.py
+++ b/python/cuml/cuml/datasets/classification.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -33,7 +33,7 @@ def _generate_hypercube(samples, dimensions, random_state):
 
 
 @nvtx.annotate(message="datasets.make_classification", domain="cuml_python")
-@cuml.internals.reflect(array=None)
+@cuml.internals.mlfunc(array_arg=None)
 def make_classification(
     n_samples=100,
     n_features=20,

--- a/python/cuml/cuml/datasets/regression.pyx
+++ b/python/cuml/cuml/datasets/regression.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from random import randint
@@ -7,7 +7,7 @@ from random import randint
 import cupy as cp
 
 import cuml.internals.nvtx as nvtx
-from cuml.internals import get_handle, reflect
+from cuml.internals import get_handle, mlfunc
 
 from libc.stdint cimport uint64_t, uintptr_t
 from libcpp cimport bool
@@ -49,7 +49,7 @@ cdef extern from "cuml/datasets/make_regression.hpp" namespace "ML" nogil:
 
 
 @nvtx.annotate(message="datasets.make_regression", domain="cuml_python")
-@reflect(array=None)
+@mlfunc(array_arg=None)
 def make_regression(
     n_samples=100,
     n_features=2,

--- a/python/cuml/cuml/decomposition/base_mg.py
+++ b/python/cuml/cuml/decomposition/base_mg.py
@@ -1,12 +1,11 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 
 import cuml.common.opg_data_utils_mg as opg
-from cuml.internals import run_in_internal_context
-from cuml.internals.array import CumlArray
+from cuml.internals.outputs import convert_arrays, mlfunc
 from cuml.internals.validation import check_inputs
 
 
@@ -15,7 +14,7 @@ class BaseDecompositionMG:
         self.handle = handle
         super().__init__(**kwargs)
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def fit(
         self, X, total_rows, n_cols, parts_rank_size, rank, _transform=False
     ):
@@ -101,7 +100,7 @@ class BaseDecompositionMG:
         if _transform:
             output_type = self._get_output_type(X[0])
             trans_out = [
-                CumlArray(data=part).to_output(output_type)
+                convert_arrays(part, output_type=output_type)
                 for part in trans_arys
             ]
 

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -7,13 +7,11 @@ import numbers
 
 import cupy as cp
 
-import cuml.internals
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.sparse import is_sparse
 from cuml.decomposition.pca import PCA
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.interop import InteropMixin, to_cpu, to_gpu
+from cuml.internals.interop import InteropMixin
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_array,
     check_features,
@@ -180,7 +178,7 @@ class IncrementalPCA(PCA):
     """
 
     _cpu_class_path = "sklearn.decomposition.IncrementalPCA"
-    var_ = CumlArrayDescriptor(order="F")
+    var_ = ReflectedAttr()
 
     def __init__(
         self,
@@ -201,7 +199,7 @@ class IncrementalPCA(PCA):
         )
         self.batch_size = batch_size
 
-    @cuml.internals.reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(
         self, X, y=None, *, convert_dtype="deprecated"
     ) -> "IncrementalPCA":
@@ -255,7 +253,7 @@ class IncrementalPCA(PCA):
 
         return self
 
-    @cuml.internals.run_in_internal_context
+    @mlfunc(convert_output=False)
     def partial_fit(self, X, y=None, *, check_input=True) -> "IncrementalPCA":
         """
         Incremental fit with X. All of X is processed as a single batch.
@@ -376,18 +374,14 @@ class IncrementalPCA(PCA):
         # Store results
         self.n_samples_ = n_total_samples
         self.n_samples_seen_ = n_total_samples
-        self.components_ = CumlArray(
-            data=cp.asfortranarray(V[: self.n_components_])
-        )
-        self.singular_values_ = CumlArray(data=S[: self.n_components_])
-        self.mean_ = CumlArray(data=col_mean)
-        self.var_ = CumlArray(data=col_var)
-        self.explained_variance_ = CumlArray(
-            data=explained_variance[: self.n_components_]
-        )
-        self.explained_variance_ratio_ = CumlArray(
-            data=explained_variance_ratio[: self.n_components_]
-        )
+        self.components_ = cp.asfortranarray(V[: self.n_components_])
+        self.singular_values_ = S[: self.n_components_]
+        self.mean_ = col_mean
+        self.var_ = col_var
+        self.explained_variance_ = explained_variance[: self.n_components_]
+        self.explained_variance_ratio_ = explained_variance_ratio[
+            : self.n_components_
+        ]
         if self.n_components_ < n_features:
             self.noise_variance_ = float(
                 explained_variance[self.n_components_ :].mean()
@@ -397,8 +391,8 @@ class IncrementalPCA(PCA):
 
         return self
 
-    @cuml.internals.reflect
-    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X, *, convert_dtype="deprecated"):
         """
         Apply dimensionality reduction to X.
 
@@ -449,7 +443,7 @@ class IncrementalPCA(PCA):
                 min_batch_size=self.n_components or 0,
             ):
                 output.append(self._transform_sparse(X[batch]))
-            return CumlArray(data=cp.vstack(output))
+            return cp.vstack(output)
         else:
             # `PCA.transform` validates `X` itself, so don't re-check here.
             return super().transform(X)
@@ -486,16 +480,14 @@ class IncrementalPCA(PCA):
     # `feature_names_in_` handling.
     def _attrs_from_cpu(self, model):
         out = {
-            "components_": to_gpu(model.components_, order="F"),
-            "explained_variance_": to_gpu(
-                model.explained_variance_, order="F"
+            "components_": cp.asarray(model.components_, order="F"),
+            "explained_variance_": cp.asarray(model.explained_variance_),
+            "explained_variance_ratio_": cp.asarray(
+                model.explained_variance_ratio_
             ),
-            "explained_variance_ratio_": to_gpu(
-                model.explained_variance_ratio_, order="F"
-            ),
-            "singular_values_": to_gpu(model.singular_values_, order="F"),
-            "mean_": to_gpu(model.mean_, order="F"),
-            "var_": to_gpu(model.var_, order="F"),
+            "singular_values_": cp.asarray(model.singular_values_),
+            "mean_": cp.asarray(model.mean_),
+            "var_": cp.asarray(model.var_),
             "n_components_": model.n_components_,
             "n_samples_seen_": model.n_samples_seen_,
             "noise_variance_": model.noise_variance_,
@@ -507,14 +499,12 @@ class IncrementalPCA(PCA):
 
     def _attrs_to_cpu(self, model):
         out = {
-            "components_": to_cpu(self.components_),
-            "explained_variance_": to_cpu(self.explained_variance_),
-            "explained_variance_ratio_": to_cpu(
-                self.explained_variance_ratio_
-            ),
-            "singular_values_": to_cpu(self.singular_values_),
-            "mean_": to_cpu(self.mean_),
-            "var_": to_cpu(self.var_),
+            "components_": self.components_.get(order="A"),
+            "explained_variance_": self.explained_variance_.get(),
+            "explained_variance_ratio_": self.explained_variance_ratio_.get(),
+            "singular_values_": self.singular_values_.get(),
+            "mean_": self.mean_.get(),
+            "var_": self.var_.get(),
             "n_components_": self.n_components_,
             "n_samples_seen_": self.n_samples_seen_,
             "noise_variance_": self.noise_variance_,

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -1,24 +1,17 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 import cupyx.scipy.sparse
 import numpy as np
 
-import cuml.internals
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.sparse import is_sparse, sparse_cov_and_mean
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import FMajorInputTagMixin, SparseInputTagMixin
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_array,
     check_inputs,
@@ -236,11 +229,11 @@ class PCA(InteropMixin,
     <http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html>`_.
     """
 
-    components_ = CumlArrayDescriptor(order='F')
-    explained_variance_ = CumlArrayDescriptor(order='F')
-    explained_variance_ratio_ = CumlArrayDescriptor(order='F')
-    singular_values_ = CumlArrayDescriptor(order='F')
-    mean_ = CumlArrayDescriptor(order='F')
+    components_ = ReflectedAttr()
+    explained_variance_ = ReflectedAttr()
+    explained_variance_ratio_ = ReflectedAttr()
+    singular_values_ = ReflectedAttr()
+    mean_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.decomposition.PCA"
 
@@ -296,11 +289,11 @@ class PCA(InteropMixin,
 
     def _attrs_from_cpu(self, model):
         return {
-            "components_": to_gpu(model.components_, order="F"),
-            "explained_variance_": to_gpu(model.explained_variance_, order="F"),
-            "explained_variance_ratio_": to_gpu(model.explained_variance_ratio_, order="F"),
-            "singular_values_": to_gpu(model.singular_values_, order="F"),
-            "mean_": to_gpu(model.mean_, order="F"),
+            "components_": cp.asarray(model.components_, order="F"),
+            "explained_variance_": cp.asarray(model.explained_variance_),
+            "explained_variance_ratio_": cp.asarray(model.explained_variance_ratio_),
+            "singular_values_": cp.asarray(model.singular_values_),
+            "mean_": cp.asarray(model.mean_),
             "n_components_": model.n_components_,
             "n_samples_": model.n_samples_,
             "noise_variance_": model.noise_variance_,
@@ -309,11 +302,11 @@ class PCA(InteropMixin,
 
     def _attrs_to_cpu(self, model):
         return {
-            "components_": to_cpu(self.components_),
-            "explained_variance_": to_cpu(self.explained_variance_),
-            "explained_variance_ratio_": to_cpu(self.explained_variance_ratio_),
-            "singular_values_": to_cpu(self.singular_values_),
-            "mean_": to_cpu(self.mean_),
+            "components_": self.components_.get(order="A"),
+            "explained_variance_": self.explained_variance_.get(),
+            "explained_variance_ratio_": self.explained_variance_ratio_.get(),
+            "singular_values_": self.singular_values_.get(),
+            "mean_": self.mean_.get(),
             "n_components_": self.n_components_,
             "n_samples_": self.n_samples_,
             "noise_variance_": self.noise_variance_,
@@ -422,11 +415,11 @@ class PCA(InteropMixin,
         handle.sync()
 
         # Store results
-        self.components_ = CumlArray(data=components)
-        self.explained_variance_ = CumlArray(data=explained_variance)
-        self.explained_variance_ratio_ = CumlArray(data=explained_variance_ratio)
-        self.mean_ = CumlArray(data=mean)
-        self.singular_values_ = CumlArray(data=singular_values)
+        self.components_ = components
+        self.explained_variance_ = explained_variance
+        self.explained_variance_ratio_ = explained_variance_ratio
+        self.mean_ = mean
+        self.singular_values_ = singular_values
         self.noise_variance_ = float(noise_variance.item())
 
     def _fit_sparse(self, X):
@@ -458,15 +451,15 @@ class PCA(InteropMixin,
         )
 
         # Store results
-        self.components_ = CumlArray(data=cp.asfortranarray(components))
-        self.explained_variance_ = CumlArray(data=explained_variance)
-        self.explained_variance_ratio_ = CumlArray(data=explained_variance_ratio)
-        self.mean_ = CumlArray(data=mean)
-        self.singular_values_ = CumlArray(data=singular_values)
+        self.components_ = cp.asfortranarray(components)
+        self.explained_variance_ = explained_variance
+        self.explained_variance_ratio_ = explained_variance_ratio
+        self.mean_ = mean
+        self.singular_values_ = singular_values
         self.noise_variance_ = noise_variance
 
     @generate_docstring(X='dense_sparse')
-    @cuml.internals.reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated") -> "PCA":
         """
         Fit the model with X. y is currently ignored.
@@ -509,8 +502,8 @@ class PCA(InteropMixin,
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
-    @cuml.internals.reflect(reset=True)
-    def fit_transform(self, X, y=None) -> CumlArray:
+    @mlfunc(set_input_type=True, preserve_index=True)
+    def fit_transform(self, X, y=None):
         """
         Fit the model with X and apply the dimensionality reduction on X.
 
@@ -518,15 +511,12 @@ class PCA(InteropMixin,
         return self.fit(X).transform(X)
 
     def _inverse_transform_sparse(self, X, return_sparse=False, sparse_tol=1e-10):
-        components = self.components_.to_output("cupy")
-        explained_variance = self.explained_variance_.to_output("cupy")
-        mean = self.mean_.to_output("cupy")
-
+        components = self.components_
         if self.whiten:
-            components = cp.sqrt(explained_variance[:, None]) * components
+            components = cp.sqrt(self.explained_variance_[:, None]) * components
 
         out = X @ components
-        out += mean
+        out += self.mean_
 
         if return_sparse:
             out[out < sparse_tol] = 0
@@ -534,7 +524,7 @@ class PCA(InteropMixin,
 
         return out
 
-    def _inverse_transform_dense(self, X, *, index=None):
+    def _inverse_transform_dense(self, X):
         dtype = X.dtype
         n_rows = X.shape[0]
 
@@ -548,9 +538,9 @@ class PCA(InteropMixin,
 
         cdef uintptr_t X_ptr = X.data.ptr
         cdef uintptr_t X_inv_ptr = out.data.ptr
-        cdef uintptr_t components_ptr = self.components_.ptr
-        cdef uintptr_t singular_values_ptr = self.singular_values_.ptr
-        cdef uintptr_t mean_ptr = self.mean_.ptr
+        cdef uintptr_t components_ptr = self.components_.data.ptr
+        cdef uintptr_t singular_values_ptr = self.singular_values_.data.ptr
+        cdef uintptr_t mean_ptr = self.mean_.data.ptr
         cdef bool use_float32 = dtype == np.float32
         handle = get_handle()
         cdef handle_t* h_ = <handle_t*><size_t>handle.getHandle()
@@ -574,14 +564,14 @@ class PCA(InteropMixin,
                                     params)
         handle.sync()
 
-        return CumlArray(data=out, index=index)
+        return out
 
     @generate_docstring(X='dense_sparse',
                         return_values={'name': 'X_inv',
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_features)'})
-    @cuml.internals.reflect
+    @mlfunc(preserve_index=True)
     def inverse_transform(
         self,
         X,
@@ -589,7 +579,7 @@ class PCA(InteropMixin,
         convert_dtype="deprecated",
         return_sparse=False,
         sparse_tol=1e-10,
-    ) -> CumlArray:
+    ):
         """
         Transform data back to its original space.
 
@@ -597,13 +587,12 @@ class PCA(InteropMixin,
 
         """
         check_is_fitted(self)
-        X, index = check_array(
+        X = check_array(
             X,
             accept_sparse=True,
             dtype=self.components_.dtype,
             convert_dtype=convert_dtype,
             order="F",
-            return_index=True,
         )
         if X.shape[1] != self.n_components_:
             raise ValueError(
@@ -614,23 +603,19 @@ class PCA(InteropMixin,
             return self._inverse_transform_sparse(
                 X, return_sparse=return_sparse, sparse_tol=sparse_tol
             )
-        return self._inverse_transform_dense(X, index=index)
+        return self._inverse_transform_dense(X)
 
     def _transform_sparse(self, X):
-        components = self.components_.to_output("cupy")
-        explained_variance = self.explained_variance_.to_output("cupy")
-        mean = self.mean_.to_output("cupy")
-
-        out = X @ components.T
-        out -= (mean.reshape((1, -1)) @ components.T)
+        out = X @ self.components_.T
+        out -= (self.mean_.reshape((1, -1)) @ self.components_.T)
         if self.whiten:
-            scale = cp.sqrt(explained_variance)
+            scale = cp.sqrt(self.explained_variance_)
             min_scale = cp.finfo(scale.dtype).eps
             scale[scale < min_scale] = min_scale
             out /= scale
         return out
 
-    def _transform_dense(self, X, *, index=None):
+    def _transform_dense(self, X):
         dtype = X.dtype
         n_rows, n_cols = X.shape
 
@@ -644,9 +629,9 @@ class PCA(InteropMixin,
 
         cdef uintptr_t X_ptr = X.data.ptr
         cdef uintptr_t out_ptr = out.data.ptr
-        cdef uintptr_t components_ptr = self.components_.ptr
-        cdef uintptr_t singular_values_ptr = self.singular_values_.ptr
-        cdef uintptr_t mean_ptr = self.mean_.ptr
+        cdef uintptr_t components_ptr = self.components_.data.ptr
+        cdef uintptr_t singular_values_ptr = self.singular_values_.data.ptr
+        cdef uintptr_t mean_ptr = self.mean_.data.ptr
         cdef bool use_float32 = dtype == np.float32
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
@@ -673,15 +658,15 @@ class PCA(InteropMixin,
                     params
                 )
         handle.sync()
-        return CumlArray(data=out, index=index)
+        return out
 
     @generate_docstring(X='dense_sparse',
                         return_values={'name': 'trans',
                                        'type': 'dense_sparse',
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
-    @cuml.internals.reflect
-    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X, *, convert_dtype="deprecated"):
         """
         Apply dimensionality reduction to X.
 
@@ -691,15 +676,14 @@ class PCA(InteropMixin,
         """
         check_is_fitted(self)
 
-        X, index = check_inputs(
+        X = check_inputs(
             self,
             X,
             accept_sparse=True,
             dtype=self.components_.dtype,
             convert_dtype=convert_dtype,
             order="F",
-            return_index=True,
         )
         if is_sparse(X):
             return self._transform_sparse(X)
-        return self._transform_dense(X, index=index)
+        return self._transform_dense(X)

--- a/python/cuml/cuml/decomposition/pca_mg.pyx
+++ b/python/cuml/cuml/decomposition/pca_mg.pyx
@@ -1,13 +1,12 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 
 from cuml.decomposition import PCA
 from cuml.decomposition.base_mg import BaseDecompositionMG
-from cuml.internals import run_in_internal_context
-from cuml.internals.array import CumlArray
+from cuml.internals.outputs import mlfunc
 
 from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
@@ -51,7 +50,7 @@ cdef extern from "cuml/decomposition/pca_mg.hpp" namespace "ML::PCA::opg" nogil:
 
 
 class PCAMG(BaseDecompositionMG, PCA):
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _mg_fit(self, uintptr_t X_ptr, n_rows, n_cols, dtype, input_desc_ptr):
         # Validate and initialize parameters
         cdef paramsPCAMG params
@@ -122,9 +121,9 @@ class PCAMG(BaseDecompositionMG, PCA):
         self.handle.sync()
 
         # Store results
-        self.components_ = CumlArray(data=components)
-        self.explained_variance_ = CumlArray(data=explained_variance)
-        self.explained_variance_ratio_ = CumlArray(data=explained_variance_ratio)
-        self.mean_ = CumlArray(data=mean)
-        self.singular_values_ = CumlArray(data=singular_values)
+        self.components_ = components
+        self.explained_variance_ = explained_variance
+        self.explained_variance_ratio_ = explained_variance_ratio
+        self.mean_ = mean
+        self.singular_values_ = singular_values
         self.noise_variance_ = noise_variance.get().item()

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -1,18 +1,15 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-
 import cupy as cp
 import numpy as np
 
-import cuml.internals
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import InteropMixin, to_cpu, to_gpu
+from cuml.internals.interop import InteropMixin
 from cuml.internals.mixins import FMajorInputTagMixin
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_array,
     check_inputs,
@@ -199,10 +196,10 @@ class TruncatedSVD(InteropMixin,
 
     """
 
-    components_ = CumlArrayDescriptor(order='F')
-    explained_variance_ = CumlArrayDescriptor(order='F')
-    explained_variance_ratio_ = CumlArrayDescriptor(order='F')
-    singular_values_ = CumlArrayDescriptor(order='F')
+    components_ = ReflectedAttr()
+    explained_variance_ = ReflectedAttr()
+    explained_variance_ratio_ = ReflectedAttr()
+    singular_values_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.decomposition.TruncatedSVD"
 
@@ -246,19 +243,19 @@ class TruncatedSVD(InteropMixin,
 
     def _attrs_from_cpu(self, model):
         return {
-            "components_": to_gpu(model.components_, order="F"),
-            "explained_variance_": to_gpu(model.explained_variance_, order="F"),
-            "explained_variance_ratio_": to_gpu(model.explained_variance_ratio_, order="F"),
-            "singular_values_": to_gpu(model.singular_values_, order="F"),
+            "components_": cp.asarray(model.components_, order="F"),
+            "explained_variance_": cp.asarray(model.explained_variance_),
+            "explained_variance_ratio_": cp.asarray(model.explained_variance_ratio_),
+            "singular_values_": cp.asarray(model.singular_values_),
             **super()._attrs_from_cpu(model),
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "components_": to_cpu(self.components_),
-            "explained_variance_": to_cpu(self.explained_variance_),
-            "explained_variance_ratio_": to_cpu(self.explained_variance_ratio_),
-            "singular_values_": to_cpu(self.singular_values_),
+            "components_": self.components_.get(order="A"),
+            "explained_variance_": self.explained_variance_.get(),
+            "explained_variance_ratio_": self.explained_variance_ratio_.get(),
+            "singular_values_": self.singular_values_.get(),
             **super()._attrs_to_cpu(model),
         }
 
@@ -287,7 +284,7 @@ class TruncatedSVD(InteropMixin,
         return self.components_.shape[0]
 
     @generate_docstring()
-    @cuml.internals.reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "TruncatedSVD":
         """
         Fit model on training cudf DataFrame X. y is currently ignored.
@@ -300,14 +297,14 @@ class TruncatedSVD(InteropMixin,
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @cuml.internals.reflect(reset=True)
-    def fit_transform(self, X, y=None, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(set_input_type=True, preserve_index=True)
+    def fit_transform(self, X, y=None, *, convert_dtype="deprecated"):
         """
         Fit model to X and perform dimensionality reduction on X.
         y is currently ignored.
 
         """
-        X, index = check_inputs(
+        X = check_inputs(
             self,
             X,
             dtype=("float32", "float64"),
@@ -315,7 +312,6 @@ class TruncatedSVD(InteropMixin,
             order="F",
             ensure_min_samples=2,
             ensure_min_features=2,
-            return_index=True,
             reset=True,
         )
 
@@ -388,19 +384,19 @@ class TruncatedSVD(InteropMixin,
         handle.sync()
 
         # Store results
-        self.components_ = CumlArray(data=components)
-        self.explained_variance_ = CumlArray(data=explained_variance)
-        self.explained_variance_ratio_ = CumlArray(data=explained_variance_ratio)
-        self.singular_values_ = CumlArray(data=singular_values)
+        self.components_ = components
+        self.explained_variance_ = explained_variance
+        self.explained_variance_ratio_ = explained_variance_ratio
+        self.singular_values_ = singular_values
 
-        return CumlArray(data=out, index=index)
+        return out
 
     @generate_docstring(return_values={'name': 'X_original',
                                        'type': 'dense',
                                        'description': 'X in original space',
                                        'shape': '(n_samples, n_features)'})
-    @cuml.internals.reflect
-    def inverse_transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def inverse_transform(self, X, *, convert_dtype="deprecated"):
         """
         Transform X back to its original space.
         Returns X_original whose transform would be X.
@@ -408,12 +404,11 @@ class TruncatedSVD(InteropMixin,
         """
         check_is_fitted(self)
 
-        X, index = check_array(
+        X = check_array(
             X,
             dtype=self.components_.dtype,
             convert_dtype=convert_dtype,
             order="F",
-            return_index=True,
         )
         if X.shape[1] != self.n_components:
             raise ValueError(
@@ -433,7 +428,7 @@ class TruncatedSVD(InteropMixin,
 
         cdef uintptr_t X_ptr = X.data.ptr
         cdef uintptr_t out_ptr = out.data.ptr
-        cdef uintptr_t components_ptr = self.components_.ptr
+        cdef uintptr_t components_ptr = self.components_.data.ptr
         cdef bool use_float32 = dtype == np.float32
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
@@ -457,27 +452,26 @@ class TruncatedSVD(InteropMixin,
                 )
         handle.sync()
 
-        return CumlArray(data=out, index=index)
+        return out
 
     @generate_docstring(return_values={'name': 'X_new',
                                        'type': 'dense',
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
-    @cuml.internals.reflect
-    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X, *, convert_dtype="deprecated"):
         """
         Perform dimensionality reduction on X.
 
         """
         check_is_fitted(self)
 
-        X, index = check_inputs(
+        X = check_inputs(
             self,
             X,
             dtype=self.components_.dtype,
             convert_dtype=convert_dtype,
             order="F",
-            return_index=True,
         )
 
         n_rows = X.shape[0]
@@ -492,7 +486,7 @@ class TruncatedSVD(InteropMixin,
 
         cdef uintptr_t X_ptr = X.data.ptr
         cdef uintptr_t out_ptr = out.data.ptr
-        cdef uintptr_t components_ptr = self.components_.ptr
+        cdef uintptr_t components_ptr = self.components_.data.ptr
         cdef bool use_float32 = dtype == np.float32
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
@@ -516,4 +510,4 @@ class TruncatedSVD(InteropMixin,
                 )
         handle.sync()
 
-        return CumlArray(data=out, index=index)
+        return out

--- a/python/cuml/cuml/decomposition/tsvd_mg.pyx
+++ b/python/cuml/cuml/decomposition/tsvd_mg.pyx
@@ -1,13 +1,12 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 
 from cuml.decomposition import TruncatedSVD
 from cuml.decomposition.base_mg import BaseDecompositionMG
-from cuml.internals import run_in_internal_context
-from cuml.internals.array import CumlArray
+from cuml.internals.outputs import mlfunc
 
 from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
@@ -51,7 +50,7 @@ cdef extern from "cuml/decomposition/tsvd_mg.hpp" namespace "ML::TSVD::opg" nogi
 
 
 class TSVDMG(BaseDecompositionMG, TruncatedSVD):
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _mg_fit_transform(
         self,
         uintptr_t X_ptr,
@@ -134,7 +133,7 @@ class TSVDMG(BaseDecompositionMG, TruncatedSVD):
         self.handle.sync()
 
         # Store results
-        self.components_ = CumlArray(data=components)
-        self.explained_variance_ = CumlArray(data=explained_variance)
-        self.explained_variance_ratio_ = CumlArray(data=explained_variance_ratio)
-        self.singular_values_ = CumlArray(data=singular_values)
+        self.components_ = components
+        self.explained_variance_ = explained_variance
+        self.explained_variance_ratio_ = explained_variance_ratio
+        self.singular_values_ = singular_values

--- a/python/cuml/cuml/explainer/sampling.py
+++ b/python/cuml/cuml/explainer/sampling.py
@@ -1,18 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cudf
 import cupy as cp
 import pandas as pd
 
-import cuml
 from cuml import KMeans
-from cuml.internals.array import CumlArray
+from cuml.internals.outputs import ArrayIndexPair, mlfunc, using_output_type
 from cuml.internals.validation import check_array
 from cuml.preprocessing import SimpleImputer
 
 
-@cuml.internals.reflect
+@mlfunc
 def kmeans_sampling(X, k, round_values=True, detailed=False, random_state=0):
     """
     Adapted from :
@@ -57,7 +56,7 @@ def kmeans_sampling(X, k, round_values=True, detailed=False, random_state=0):
     if X.ndim == 1:
         X = X.reshape(-1, 1)
 
-    with cuml.using_output_type("cupy"):
+    with using_output_type("cupy"):
         # in case there are any missing values in data impute them
         imp = SimpleImputer(missing_values=cp.nan, strategy="mean")
         X = imp.fit_transform(X)
@@ -75,9 +74,9 @@ def kmeans_sampling(X, k, round_values=True, detailed=False, random_state=0):
 
         if detailed:
             return (
-                CumlArray(data=summary),
+                summary,
                 group_names,
-                CumlArray(kmeans.labels_, index=index),
+                ArrayIndexPair(kmeans.labels_, index=index),
             )
         else:
-            return CumlArray(data=summary)
+            return summary

--- a/python/cuml/cuml/feature_extraction/_tfidf.py
+++ b/python/cuml/cuml/feature_extraction/_tfidf.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -160,7 +160,7 @@ class TfidfTransformer(Base):
         # Free up memory occupied by below
         del self.__df
 
-    @cuml.internals.run_in_internal_context
+    @cuml.internals.mlfunc(convert_output=False)
     def fit(self, X, y=None) -> "TfidfTransformer":
         """Learn the idf vector (global term weights).
 
@@ -177,7 +177,7 @@ class TfidfTransformer(Base):
 
         return self
 
-    @cuml.internals.run_in_internal_context
+    @cuml.internals.mlfunc(convert_output=False)
     def transform(self, X, copy=True):
         """Transform a count matrix to a tf or tf-idf representation
 
@@ -229,7 +229,7 @@ class TfidfTransformer(Base):
 
         return X
 
-    @cuml.internals.run_in_internal_context
+    @cuml.internals.mlfunc(convert_output=False)
     def fit_transform(self, X, y=None, copy=True):
         """
         Fit TfidfTransformer to X, then transform X.

--- a/python/cuml/cuml/internals/interop.py
+++ b/python/cuml/cuml/internals/interop.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import Any
 import cupy as cp
 import numpy as np
 
-from cuml.internals.outputs import using_output_type
+from cuml.internals.outputs import mlfunc
 
 __all__ = (
     "UnsupportedOnGPU",
@@ -191,6 +191,7 @@ class InteropMixin:
                 pass
         return out
 
+    @mlfunc(convert_output=False)
     def _sync_attrs_to_cpu(self, model) -> None:
         """Sync any fitted attributes from ``self`` to ``model``.
 
@@ -203,15 +204,11 @@ class InteropMixin:
             # GPU model not fitted, nothing to do
             return
 
-        # XXX: we use this for now to ensure _attrs_to_cpu can rely on
-        # a consistent type for all fitted attributes, rather than
-        # having things potentially vary based on `self.output_type`.
-        with using_output_type("cuml"):
-            attrs = self._attrs_to_cpu(model)
-
+        attrs = self._attrs_to_cpu(model)
         for name, value in attrs.items():
             setattr(model, name, value)
 
+    @mlfunc(convert_output=False)
     def _sync_attrs_from_cpu(self, model) -> None:
         """Sync any fitted attributes from ``model`` to ``self``.
 

--- a/python/cuml/cuml/internals/outputs.py
+++ b/python/cuml/cuml/internals/outputs.py
@@ -48,16 +48,13 @@ OUTPUT_TYPES = (
 
 def check_output_type(output_type: str) -> str:
     """Validate and normalize an ``output_type`` value"""
-    # normalize as lower, keeping original str reference to appease the sklearn
-    # standard estimator checks as much as possible.
-    if output_type != (temp := output_type.lower()):
-        output_type = temp
+    output_type = output_type.lower()
     # Check for allowed types. Allow 'cuml' to support internal estimators
     if output_type != "cuml" and output_type not in OUTPUT_TYPES:
         valid_output_types = ", ".join(map(repr, OUTPUT_TYPES))
         raise ValueError(
-            f"`output_type` must be one of {valid_output_types}"
-            f" or None. Got: {output_type!r}"
+            f"`{output_type=!r}` is not supported. "
+            f"Expected one of {valid_output_types}, or None."
         )
     return output_type
 
@@ -486,6 +483,7 @@ def convert_arrays(obj, output_type="cupy", index=None, _legacy=False):
     out : object
         The equivalent output, with arrays coerced to `output_type`.
     """
+    check_output_type(output_type)
     # TODO: legacy output paths, remove once `CumlArray`/`SparseCumlArray`
     # are no longer used anywhere.
     if isinstance(obj, CumlArray):

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.py
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import warnings
@@ -9,18 +9,11 @@ import numpy as np
 from cupy import linalg
 from cupyx import geterr, lapack, seterr
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals import reflect, run_in_internal_context
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import RegressorMixin
+from cuml.internals.outputs import ArrayIndexPair, ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_consistent_length,
     check_inputs,
@@ -188,8 +181,8 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
 
     """
 
-    dual_coef_ = CumlArrayDescriptor()
-    X_fit_ = CumlArrayDescriptor()
+    dual_coef_ = ReflectedAttr()
+    X_fit_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.kernel_ridge.KernelRidge"
 
@@ -240,15 +233,15 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
             raise UnsupportedOnGPU("Sparse inputs are not supported")
 
         return {
-            "dual_coef_": to_gpu(model.dual_coef_),
-            "X_fit_": to_gpu(model.X_fit_),
+            "dual_coef_": cp.asarray(model.dual_coef_),
+            "X_fit_": ArrayIndexPair(cp.asarray(model.X_fit_), None),
             **super()._attrs_from_cpu(model),
         }
 
     def _attrs_to_cpu(self, model):
         return {
-            "dual_coef_": to_cpu(self.dual_coef_),
-            "X_fit_": to_cpu(self.X_fit_),
+            "dual_coef_": self.dual_coef_.get(order="A"),
+            "X_fit_": self.X_fit_.array.get(order="A"),
             **super()._attrs_to_cpu(model),
         }
 
@@ -277,7 +270,7 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         tags.target_tags.multi_output = True
         return tags
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _get_kernel(self, X, Y=None):
         if isinstance(self.kernel, str):
             params = {
@@ -289,10 +282,10 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
             params = self.kernel_params or {}
         return pairwise_kernels(
             X, Y, metric=self.kernel, filter_params=True, **params
-        ).to_output("cupy")
+        )
 
     @generate_docstring()
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(
         self, X, y, sample_weight=None, *, convert_dtype="deprecated"
     ) -> "KernelRidge":
@@ -324,11 +317,11 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         if ravel:
             dual_coef = dual_coef.ravel()
 
-        self.X_fit_ = CumlArray(data=X, index=index)
-        self.dual_coef_ = CumlArray(data=dual_coef)
+        self.X_fit_ = ArrayIndexPair(X, index)
+        self.dual_coef_ = dual_coef
         return self
 
-    @reflect
+    @mlfunc(preserve_index=True)
     def predict(self, X, *, convert_dtype="deprecated"):
         """
         Predict using the kernel ridge model.
@@ -350,11 +343,8 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         X = check_inputs(
             self,
             X,
-            dtype=self.X_fit_.dtype,
+            dtype=self.X_fit_.array.dtype,
             convert_dtype=convert_dtype,
         )
-        K = self._get_kernel(X, self.X_fit_.to_output("cupy")).astype(
-            X.dtype, copy=False
-        )
-        dual_coef = self.dual_coef_.to_output("cupy")
-        return CumlArray(data=cp.dot(K, dual_coef))
+        K = self._get_kernel(X, self.X_fit_.array).astype(X.dtype, copy=False)
+        return cp.dot(K, self.dual_coef_)

--- a/python/cuml/cuml/manifold/spectral_embedding.pyx
+++ b/python/cuml/cuml/manifold/spectral_embedding.pyx
@@ -1,21 +1,14 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
 import cupyx.scipy.sparse as cp_sp
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import CMajorInputTagMixin
-from cuml.internals.outputs import reflect
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs, check_random_seed
 
 from libc.stdint cimport int64_t, uint64_t, uintptr_t
@@ -116,7 +109,7 @@ class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
     (100, 2)
     """
     _cpu_class_path = "sklearn.manifold.SpectralEmbedding"
-    embedding_ = CumlArrayDescriptor(order="F")
+    embedding_ = ReflectedAttr()
 
     # Private so that `spectral_embedding` can share the same code
     _drop_first = True
@@ -170,19 +163,19 @@ class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
     def _attrs_from_cpu(self, model):
         return {
             "n_neighbors_": model.n_neighbors_,
-            "embedding_": to_gpu(model.embedding_, order="F"),
+            "embedding_": cp.asarray(model.embedding_, order="F"),
             **super()._attrs_from_cpu(model)
         }
 
     def _attrs_to_cpu(self, model):
         return {
             "n_neighbors_": self.n_neighbors_,
-            "embedding_": to_cpu(self.embedding_, order="F"),
+            "embedding_": self.embedding_.get(order="F"),
             **super()._attrs_to_cpu(model),
         }
 
-    @reflect
-    def fit_transform(self, X, y=None) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_transform(self, X, y=None):
         """Fit the model from data in X and transform X.
 
         Parameters
@@ -205,7 +198,7 @@ class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
         self.fit(X, y)
         return self.embedding_
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None) -> "SpectralEmbedding":
         """Fit the model from data in X.
 
@@ -331,12 +324,12 @@ class SpectralEmbedding(InteropMixin, CMajorInputTagMixin, Base):
                 )
         handle.sync()
 
-        self.embedding_ = CumlArray(data=embedding)
+        self.embedding_ = embedding
 
         return self
 
 
-@reflect
+@mlfunc(preserve_index=True)
 def spectral_embedding(
     A,
     *,

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -1,23 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import warnings
 
-import cupy
-import numpy as np
+import cupy as cp
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.sparse import is_sparse
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import CMajorInputTagMixin, SparseInputTagMixin
-from cuml.internals.outputs import reflect
+from cuml.internals.outputs import ArrayIndexPair, ReflectedAttr, mlfunc
 from cuml.internals.validation import check_inputs, check_random_seed
 from cuml.manifold.utils import extract_knn_graph
 
@@ -400,7 +392,7 @@ class TSNE(InteropMixin,
         (https://arxiv.org/abs/1807.11824).
 
     """
-    embedding_ = CumlArrayDescriptor(order="F")
+    embedding_ = ReflectedAttr()
 
     _cpu_class_path = "sklearn.manifold.TSNE"
 
@@ -490,8 +482,8 @@ class TSNE(InteropMixin,
 
     def _attrs_from_cpu(self, model):
         return {
-            "embedding_": to_gpu(model.embedding_),
-            "kl_divergence_": to_gpu(model.kl_divergence_),
+            "embedding_": ArrayIndexPair(cp.asarray(model.embedding_, order="F"), None),
+            "kl_divergence_": model.kl_divergence_,
             "learning_rate_": model.learning_rate_,
             "n_iter_": model.n_iter_,
             **super()._attrs_from_cpu(model)
@@ -499,8 +491,8 @@ class TSNE(InteropMixin,
 
     def _attrs_to_cpu(self, model):
         return {
-            "embedding_": to_cpu(self.embedding_),
-            "kl_divergence_": to_cpu(self.kl_divergence_),
+            "embedding_": self.embedding_.array.get(order="A"),
+            "kl_divergence_": self.kl_divergence_,
             "learning_rate_": self.learning_rate_,
             "n_iter_": self.n_iter_,
             **super()._attrs_to_cpu(model)
@@ -566,7 +558,7 @@ class TSNE(InteropMixin,
 
     @generate_docstring(skip_parameters_heading=True,
                         X='dense_sparse')
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated", knn_graph=None) -> "TSNE":
         """
         Fit X into an embedded space.
@@ -631,10 +623,10 @@ class TSNE(InteropMixin,
             knn_indices_ptr = <uintptr_t>knn_indices.data.ptr
 
         # Allocate output array
-        embedding = cupy.zeros(
+        embedding = cp.zeros(
             (n_samples, self.n_components),
             order="F",
-            dtype=np.float32,
+            dtype=cp.float32,
         )
         cdef uintptr_t embed_ptr = <uintptr_t>embedding.data.ptr
 
@@ -680,7 +672,7 @@ class TSNE(InteropMixin,
         self._kl_divergence_ = kl_divergence
         self.n_iter_ = n_iter
         self.learning_rate_ = params.pre_learning_rate
-        self.embedding_ = CumlArray(data=embedding, index=index)
+        self.embedding_ = ArrayIndexPair(embedding, index)
 
         return self
 
@@ -690,10 +682,10 @@ class TSNE(InteropMixin,
                                                        data in \
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
-    @reflect
+    @mlfunc(preserve_index=True)
     def fit_transform(
         self, X, y=None, *, convert_dtype="deprecated", knn_graph=None
-    ) -> CumlArray:
+    ):
         """
         Fit X into an embedded space and return that transformed output.
         """

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import ctypes
@@ -13,20 +13,13 @@ import numpy as np
 import scipy.sparse
 import scipy.spatial
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
 from cuml.common.sparse import is_sparse
-from cuml.internals import logger, reflect
-from cuml.internals.array import CumlArray
-from cuml.internals.array_sparse import SparseCumlArray
+from cuml.internals import logger
 from cuml.internals.base import Base, get_handle
-from cuml.internals.interop import (
-    InteropMixin,
-    UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
-)
+from cuml.internals.interop import InteropMixin, UnsupportedOnGPU
 from cuml.internals.mixins import CMajorInputTagMixin, SparseInputTagMixin
+from cuml.internals.outputs import ArrayIndexPair, ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_array,
     check_consistent_length,
@@ -54,6 +47,8 @@ from cuml.metrics.distance_type cimport DistanceType
 
 def _joblib_hash(X):
     """A thin shim around joblib.hash"""
+    if cupyx.scipy.sparse.issparse(X) or isinstance(X, cp.ndarray):
+        X = X.get()
     if scipy.sparse.issparse(X):
         # XXX: joblib.hash doesn't special case sparse inputs, meaning that
         # it's sensitive to what should be irrelevant internal state. For now
@@ -932,9 +927,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
        Bringing UMAP Closer to the Speed of Light with GPU Acceleration
        <https://arxiv.org/abs/2008.00325>`_
     """
-    embedding_ = CumlArrayDescriptor(order="C")
-    _sigmas = CumlArrayDescriptor(order="C")
-    _rhos = CumlArrayDescriptor(order="C")
+    embedding_ = ReflectedAttr()
 
     _cpu_class_path = "umap.UMAP"
 
@@ -1054,14 +1047,15 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
 
     def _attrs_from_cpu(self, model):
         if scipy.sparse.issparse(model._raw_data):
-            raw_data = SparseCumlArray(
-                check_array(model._raw_data, dtype="float32", accept_sparse="csr")
-            )
+            raw_data = cupyx.scipy.sparse.csr_matrix(model._raw_data, dtype="float32")
         else:
-            raw_data = to_gpu(model._raw_data)
+            raw_data = cp.asarray(model._raw_data)
 
         attrs = {
-            "embedding_": to_gpu(model.embedding_, order="C"),
+            "embedding_": ArrayIndexPair(
+                cp.asarray(model.embedding_, order="C"),
+                None,
+            ),
             "graph_": model.graph_.tocoo(),
             "_raw_data": raw_data,
             "_input_hash": model._input_hash,
@@ -1075,9 +1069,9 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
 
         # Transfer _sigmas and _rhos if available (needed for inverse_transform)
         if hasattr(model, "_sigmas") and model._sigmas is not None:
-            attrs["_sigmas"] = to_gpu(model._sigmas)
+            attrs["_sigmas"] = cp.asarray(model._sigmas)
         if hasattr(model, "_rhos") and model._rhos is not None:
-            attrs["_rhos"] = to_gpu(model._rhos)
+            attrs["_rhos"] = cp.asarray(model._rhos)
 
         return attrs
 
@@ -1086,7 +1080,9 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
 
         disconnection_distance = DISCONNECTION_DISTANCES.get(self.metric, np.inf)
 
-        raw_data = self._raw_data.to_output("numpy")
+        raw_data = self._raw_data
+        if cupyx.scipy.sparse.issparse(raw_data) or isinstance(raw_data, cp.ndarray):
+            raw_data = raw_data.get()
 
         if (input_hash := getattr(self, "_input_hash", None)) is None:
             input_hash = _joblib_hash(raw_data)
@@ -1098,7 +1094,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             knn_indices = cp.asnumpy(knn_indices)
 
         attrs = {
-            "embedding_": to_cpu(self.embedding_),
+            "embedding_": self.embedding_.array.get(order="A"),
             "graph_": self.graph_.tocsr(),
             "graph_dists_": None,
             "_raw_data": raw_data,
@@ -1127,9 +1123,9 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
 
         # Transfer _sigmas and _rhos if available (needed for inverse_transform)
         if hasattr(self, "_sigmas") and self._sigmas is not None:
-            attrs["_sigmas"] = to_cpu(self._sigmas)
+            attrs["_sigmas"] = self._sigmas.get()
         if hasattr(self, "_rhos") and self._rhos is not None:
-            attrs["_rhos"] = to_cpu(self._rhos)
+            attrs["_rhos"] = self._rhos.get()
 
         return attrs
 
@@ -1205,7 +1201,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         X="dense_sparse",
         skip_parameters_heading=True,
     )
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated", knn_graph=None) -> "UMAP":
         """
         Fit X into an embedded space.
@@ -1281,14 +1277,14 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         cdef size_t X_nnz = 0
 
         if X_is_sparse:
-            X_m = SparseCumlArray(X)
-            X_ptr = X_m.data.ptr
-            X_indices_ptr = X_m.indices.ptr
-            X_indptr_ptr = X_m.indptr.ptr
-            X_nnz = X_m.nnz
+            X_ptr = X.data.data.ptr
+            X_indices_ptr = X.indices.data.ptr
+            X_indptr_ptr = X.indptr.data.ptr
+            X_nnz = X.nnz
+        elif isinstance(X, np.ndarray):
+            X_ptr = X.ctypes.data
         else:
-            X_m = CumlArray(data=X, index=index)
-            X_ptr = X_m.ptr
+            X_ptr = X.data.ptr
 
         cdef uintptr_t y_ptr = 0
         if y is not None:
@@ -1355,13 +1351,13 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         cdef uintptr_t sigmas_ptr = 0
         cdef uintptr_t rhos_ptr = 0
         if not X_is_sparse:
-            sigmas_cp = cp.zeros(n_rows, dtype=np.float32)
-            rhos_cp = cp.zeros(n_rows, dtype=np.float32)
-            sigmas_ptr = <uintptr_t>sigmas_cp.data.ptr
-            rhos_ptr = <uintptr_t>rhos_cp.data.ptr
+            sigmas = cp.zeros(n_rows, dtype=np.float32)
+            rhos = cp.zeros(n_rows, dtype=np.float32)
+            sigmas_ptr = <uintptr_t>sigmas.data.ptr
+            rhos_ptr = <uintptr_t>rhos.data.ptr
         else:
-            sigmas_cp = None
-            rhos_cp = None
+            sigmas = None
+            rhos = None
 
         with nogil:
             if X_is_sparse:
@@ -1406,22 +1402,18 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             ),
             order="C"
         )
-        self.embedding_ = CumlArray(data=embedding, index=index)
+        self.embedding_ = ArrayIndexPair(embedding, index)
         self.graph_ = copy_raft_host_coo_to_scipy_coo(fss_graph)
-        self._raw_data = X_m
+        self._raw_data = X
         self._sparse_data = X_is_sparse
         self._supervised = y is not None
         self._knn_indices = knn_indices
         self._knn_dists = knn_dists
-        self._sigmas = (
-            CumlArray(data=sigmas_cp) if sigmas_cp is not None else None
-        )
-        self._rhos = (
-            CumlArray(data=rhos_cp) if rhos_cp is not None else None
-        )
+        self._sigmas = sigmas
+        self._rhos = rhos
 
         if self.hash_input:
-            self._input_hash = _joblib_hash(X_m.to_output("numpy"))
+            self._input_hash = _joblib_hash(X)
         else:
             self._input_hash = None
 
@@ -1436,10 +1428,10 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             "shape": "(n_samples, n_components)"
         }
     )
-    @reflect
+    @mlfunc(preserve_index=True)
     def fit_transform(
         self, X, y=None, *, convert_dtype="deprecated", knn_graph=None
-    ) -> CumlArray:
+    ):
         """
         Fit X into an embedded space and return that transformed
         output.
@@ -1471,8 +1463,8 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             "shape": "(n_samples, n_components)"
         }
     )
-    @reflect
-    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X, *, convert_dtype="deprecated"):
         """
         Transform X into the existing embedded space and return that
         transformed output.
@@ -1486,25 +1478,18 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         """
         check_is_fitted(self)
 
-        X, index = check_inputs(
+        X = check_inputs(
             self,
             X,
             dtype="float32",
             convert_dtype=convert_dtype,
             order="C",
             accept_sparse="csr",
-            return_index=True,
         )
-
         X_input_sparse = is_sparse(X)
 
-        if self.hash_input:
-            if X_input_sparse:
-                X_for_hash = X.get()
-            else:
-                X_for_hash = cp.asnumpy(X)
-            if _joblib_hash(X_for_hash) == self._input_hash:
-                return self.embedding_
+        if self.hash_input and _joblib_hash(X) == self._input_hash:
+            return self.embedding_
 
         if self._sparse_data and not X_input_sparse:
             logger.warn(
@@ -1541,16 +1526,20 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             X_indices_ptr = <uintptr_t>X.indices.data.ptr
             X_ptr = <uintptr_t>X.data.data.ptr
             X_nnz = X.nnz
-            orig_indptr_ptr = self._raw_data.indptr.ptr
-            orig_indices_ptr = self._raw_data.indices.ptr
-            orig_ptr = self._raw_data.data.ptr
+            orig_indptr_ptr = self._raw_data.indptr.data.ptr
+            orig_indices_ptr = self._raw_data.indices.data.ptr
+            orig_ptr = self._raw_data.data.data.ptr
             orig_nnz = self._raw_data.nnz
         else:
             X_ptr = <uintptr_t>X.data.ptr
-            orig_ptr = self._raw_data.ptr
+            orig_ptr = (
+                self._raw_data.data.ptr
+                if isinstance(self._raw_data, cp.ndarray)
+                else self._raw_data.ctypes.data
+            )
 
         cdef uintptr_t out_ptr = <uintptr_t>out.data.ptr
-        cdef uintptr_t embedding_ptr = self.embedding_.ptr
+        cdef uintptr_t embedding_ptr = self.embedding_.array.data.ptr
         handle = get_handle(device_ids=self.device_ids)
         cdef handle_t* handle_ = <handle_t*><uintptr_t>handle.getHandle()
 
@@ -1589,7 +1578,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
                 )
         handle.sync()
 
-        return CumlArray(data=out, index=index)
+        return out
 
     @generate_docstring(
         X_shape="(n_samples, n_components)",
@@ -1600,8 +1589,8 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             "shape": "(n_samples, n_features)"
         }
     )
-    @reflect
-    def inverse_transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def inverse_transform(self, X, *, convert_dtype="deprecated"):
         """Transform X in the existing embedded space back into the input
         data space and return that transformed output.
         """
@@ -1619,12 +1608,11 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             )
 
         # skip n_features_in_ validation
-        X, index = check_array(
+        X = check_array(
             X,
             dtype="float32",
             convert_dtype=convert_dtype,
             order="C",
-            return_index=True,
         )
 
         n_samples = X.shape[0]
@@ -1635,9 +1623,9 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             )
 
         # Get numpy arrays for preprocessing
-        embedding_np = self.embedding_.to_output("numpy")
-        X_np = cp.asnumpy(X)
-        raw_data_np = self._raw_data.to_output("numpy")
+        embedding_np = cp.asnumpy(self.embedding_.array, order="A")
+        X_np = cp.asnumpy(X, order="A")
+        raw_data_np = cp.asnumpy(self._raw_data, order="A")
 
         # Phase 1: Compute neighborhoods via Delaunay triangulation + BFS (CPU)
         # Cap neighborhood size to prevent explosion for high-dimensional data.
@@ -1681,8 +1669,8 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
                 "These may be missing if the model was loaded from a CPU UMAP "
                 "model that did not have them, or if the model was not fitted."
             )
-        cdef uintptr_t sigmas_ptr = self._sigmas.ptr
-        cdef uintptr_t rhos_ptr = self._rhos.ptr
+        cdef uintptr_t sigmas_ptr = self._sigmas.data.ptr
+        cdef uintptr_t rhos_ptr = self._rhos.data.ptr
 
         cdef lib.UMAPParams params
         init_params(self, params, n_rows=n_samples, is_sparse=False, is_fit=False)
@@ -1700,7 +1688,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         )
         handle.sync()
 
-        return CumlArray(data=inv_transformed_gpu, index=index)
+        return inv_transformed_gpu
 
 
 def fuzzy_simplicial_set(
@@ -1830,7 +1818,7 @@ def fuzzy_simplicial_set(
     return fss_graph.view_cupy_coo()
 
 
-@reflect
+@mlfunc(preserve_index=True)
 def simplicial_set_embedding(
     data,
     graph,
@@ -1938,13 +1926,12 @@ def simplicial_set_embedding(
         The optimized of ``graph`` into an ``n_components`` dimensional
         euclidean space.
     """
-    X, index = check_array(
+    X = check_array(
         data,
         dtype="float32",
         convert_dtype=convert_dtype,
         order="C",
         input_name="X",
-        return_index=True,
     )
 
     cdef int n_rows = X.shape[0]
@@ -2049,4 +2036,4 @@ def simplicial_set_embedding(
             &params,
             <float*> embedding_ptr
         )
-    return CumlArray(data=embedding, index=index)
+    return embedding

--- a/python/cuml/cuml/metrics/_ranking.py
+++ b/python/cuml/cuml/metrics/_ranking.py
@@ -1,23 +1,19 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import math
-import typing
 
 import cupy as cp
 import numpy as np
 
-import cuml.internals
-from cuml.internals.array import CumlArray
+from cuml.internals.outputs import mlfunc
 from cuml.internals.validation import check_array, check_consistent_length
 
 
-@cuml.internals.reflect
-def precision_recall_curve(
-    y_true, probs_pred
-) -> typing.Tuple[CumlArray, CumlArray, CumlArray]:
+@mlfunc
+def precision_recall_curve(y_true, probs_pred):
     """
     Compute precision-recall pairs for different probability thresholds
 

--- a/python/cuml/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/cuml/metrics/pairwise_distances.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import warnings
@@ -8,7 +8,7 @@ import cupy as cp
 import cupyx.scipy.sparse as cp_sp
 from sklearn.exceptions import DataConversionWarning
 
-from cuml.internals import get_handle, reflect
+from cuml.internals import get_handle, mlfunc
 from cuml.internals.outputs import using_output_type
 from cuml.internals.validation import check_array
 
@@ -99,7 +99,7 @@ def _determine_metric(metric, is_sparse=False):
     return metrics[metric]
 
 
-@reflect
+@mlfunc
 def nan_euclidean_distances(
     X,
     Y=None,
@@ -265,7 +265,7 @@ def _ensure_boolean(X, metric):
     return X
 
 
-@reflect
+@mlfunc
 def pairwise_distances(
     X, Y=None, metric="euclidean", convert_dtype="deprecated", **kwds
 ):
@@ -501,7 +501,7 @@ def pairwise_distances(
     return out
 
 
-@reflect
+@mlfunc
 def sparse_pairwise_distances(
     X, Y=None, metric="euclidean", convert_dtype="deprecated", **kwds
 ):

--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import inspect
@@ -177,7 +177,7 @@ def custom_kernel(X, Y, func, **kwds):
     return K
 
 
-@cuml.internals.reflect
+@cuml.internals.mlfunc
 def pairwise_kernels(
     X,
     Y=None,

--- a/python/cuml/cuml/preprocessing/_target_encoder.py
+++ b/python/cuml/cuml/preprocessing/_target_encoder.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import warnings
@@ -8,16 +8,13 @@ import cudf
 import cupy as cp
 import numpy as np
 
-from cuml.internals.array import CumlArray
 from cuml.internals.base import Base
 from cuml.internals.interop import (
     InteropMixin,
     UnsupportedOnCPU,
     UnsupportedOnGPU,
-    to_cpu,
-    to_gpu,
 )
-from cuml.internals.outputs import reflect
+from cuml.internals.outputs import mlfunc
 from cuml.internals.validation import (
     check_classification_targets,
     check_consistent_length,
@@ -110,7 +107,7 @@ class TargetEncoder(InteropMixin, Base):
         The training DataFrame used during fitting, containing the original
         features, target values, and fold assignments. Set to ``None`` if
         the encoder was loaded from a sklearn model via :meth:`from_sklearn`.
-    train_encode : cuml.internals.array.CumlArray or None
+    train_encode : cupy array or None
         The encoded values for the training data, computed during
         :meth:`fit` or :meth:`fit_transform`. Set to ``None`` if the
         encoder was loaded from a sklearn model via :meth:`from_sklearn`.
@@ -203,7 +200,7 @@ class TargetEncoder(InteropMixin, Base):
         self.stat = stat
         self.multi_feature_mode = multi_feature_mode
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y, *, fold_ids=None):
         """
         Fit a TargetEncoder instance to a set of categories
@@ -231,8 +228,8 @@ class TargetEncoder(InteropMixin, Base):
         self.train = train
         return self
 
-    @reflect
-    def fit_transform(self, X, y, *, fold_ids=None) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_transform(self, X, y, *, fold_ids=None):
         """
         Simultaneously fit and transform an input
 
@@ -261,8 +258,8 @@ class TargetEncoder(InteropMixin, Base):
         self.fit(X, y, fold_ids=fold_ids)
         return self.train_encode
 
-    @reflect
-    def transform(self, X) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X):
         """
         Transform an input into its categorical keys.
 
@@ -313,7 +310,7 @@ class TargetEncoder(InteropMixin, Base):
 
         test = test.sort_values("id")
         res = test[result_cols].to_cupy()
-        return CumlArray(res)
+        return res
 
     def _fit_transform(self, X, y, fold_ids):
         if self.smooth < 0:
@@ -471,7 +468,7 @@ class TargetEncoder(InteropMixin, Base):
         # Sort by original index and return results
         df = df.sort_values("id")
         res = df[result_cols].to_cupy()
-        return CumlArray(res), df
+        return res, df
 
     def _compute_single_feature_encoding(self, train, col, out_col):
         """Compute target encoding for a single feature column."""
@@ -598,7 +595,7 @@ class TargetEncoder(InteropMixin, Base):
         df["out"] = df["out"].nans_to_nulls().fillna(self.y_stat_val)
         df = df.sort_values("id")
         res = df["out"].to_cupy().reshape(-1, 1)
-        return CumlArray(res)
+        return res
 
     def _check_X(self, X, reset=False):
         # Check features
@@ -703,7 +700,7 @@ class TargetEncoder(InteropMixin, Base):
             if cat.dtype == np.object_:
                 categories_gpu.append(cat)  # Keep as numpy array
             else:
-                categories_gpu.append(to_gpu(cat))
+                categories_gpu.append(cp.asarray(cat))
         n_features = len(model.categories_)
 
         # Generate column names matching cuML's internal format
@@ -724,7 +721,7 @@ class TargetEncoder(InteropMixin, Base):
         return {
             "encode_all": encode_all,
             "_encodings_per_feature": [
-                to_gpu(enc) for enc in model.encodings_
+                cp.asarray(enc) for enc in model.encodings_
             ],
             "categories_": categories_gpu,
             "classes_": model.classes_,
@@ -744,29 +741,17 @@ class TargetEncoder(InteropMixin, Base):
         in independent mode, we have exact encodings. Multi-feature combination
         mode cannot be converted to sklearn.
         """
-        # Handle categories that may be numpy arrays, cupy arrays, or CumlArrays
+        # Handle categories that may be numpy arrays or cupy arrays
         categories_cpu = []
         for cat in self.categories_:
-            if isinstance(cat, np.ndarray):
-                categories_cpu.append(cat)
-            elif isinstance(cat, cp.ndarray):
-                # cupy array - convert to numpy directly
-                categories_cpu.append(cp.asnumpy(cat))
-            else:
-                # CumlArray or other - use to_cpu
-                categories_cpu.append(to_cpu(cat))
+            categories_cpu.append(cp.asnumpy(cat))
         n_features = len(self.categories_)
 
         # Use per-feature encodings if available (from independent mode or sklearn)
         if hasattr(self, "_encodings_per_feature"):
             encodings_list = []
             for enc in self._encodings_per_feature:
-                if isinstance(enc, np.ndarray):
-                    encodings_list.append(enc)
-                elif isinstance(enc, cp.ndarray):
-                    encodings_list.append(cp.asnumpy(enc))
-                else:
-                    encodings_list.append(to_cpu(enc))
+                encodings_list.append(cp.asnumpy(enc))
         elif n_features == 1:
             # Single feature: extract encodings directly (exact conversion)
             cats = self.categories_[0]

--- a/python/cuml/cuml/preprocessing/encoders.py
+++ b/python/cuml/cuml/preprocessing/encoders.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import warnings
@@ -14,7 +14,7 @@ import cuml
 from cuml.common.doc_utils import generate_docstring
 from cuml.internals.base import Base
 from cuml.internals.output_utils import cudf_to_pandas
-from cuml.internals.outputs import run_in_internal_context
+from cuml.internals.outputs import mlfunc
 from cuml.internals.validation import check_features, check_is_fitted
 from cuml.preprocessing._label import LabelEncoder
 
@@ -327,7 +327,7 @@ class OneHotEncoder(BaseEncoder):
             "type": "sparse matrix if sparse_output=True else a 2-d array",
         }
     )
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def transform(self, X):
         """Transform X using one-hot encoding."""
         check_is_fitted(self)
@@ -405,7 +405,7 @@ class OneHotEncoder(BaseEncoder):
                 "Internal Error: {}".format(input_types_str, repr(e))
             )
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def inverse_transform(self, X):
         """Convert the data back to the original representation. In case unknown
         categories are encountered (all zeros in the one-hot encoding), ``None`` is used
@@ -623,7 +623,7 @@ class OrdinalEncoder(BaseEncoder):
             "type": "Type is specified by the `output_type` parameter.",
         }
     )
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def transform(self, X):
         """Transform X using ordinal encoding."""
         check_is_fitted(self)
@@ -652,7 +652,7 @@ class OrdinalEncoder(BaseEncoder):
         X = self._check_input(X)
         return self.fit(X).transform(X)
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
 

--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -1,16 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
 import cupyx.scipy.sparse as sp
 import numpy as np
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.common.doc_utils import generate_docstring
-from cuml.internals.array import CumlArray
-from cuml.internals.array_sparse import SparseCumlArray
 from cuml.internals.base import Base
 from cuml.internals.mixins import SparseInputTagMixin
-from cuml.internals.outputs import reflect
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import (
     check_inputs,
     check_is_fitted,
@@ -51,7 +48,7 @@ def johnson_lindenstrauss_min_dim(n_samples, eps=0.1):
 class _BaseRandomProjection(SparseInputTagMixin, Base):
     """Base class for RandomProjection estimators."""
 
-    components_ = CumlArrayDescriptor()
+    components_ = ReflectedAttr()
 
     def __init__(
         self,
@@ -80,7 +77,7 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
         raise NotImplementedError
 
     @generate_docstring()
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X, y=None, *, convert_dtype="deprecated"):
         """Generate a random projection matrix."""
         # Use `mem_type=None` & `order=None` to minimize copies or transfers. We
@@ -124,23 +121,21 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
         return self
 
     @generate_docstring()
-    @reflect
-    def transform(self, X, *, convert_dtype="deprecated") -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X, *, convert_dtype="deprecated"):
         """Project the data by taking the matrix product with the random matrix."""
         check_is_fitted(self)
-        X, index = check_inputs(
+        X = check_inputs(
             self,
             X,
             dtype=("float32", "float64"),
             convert_dtype=convert_dtype,
             accept_sparse=("csr", "csc"),
             accept_large_sparse=True,
-            return_index=True,
         )
-        components = self.components_.to_output("cupy")
 
         # Compute the output
-        out = X @ components.T
+        out = X @ self.components_.T
 
         # Coerce to correct dtype if needed (sparse matrices astype doesn't
         # support copy=False, so we need to use the more verbose version here).
@@ -153,13 +148,11 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
                 return out
             out = out.toarray()
 
-        return CumlArray(data=out, index=index)
+        return out
 
     @generate_docstring()
-    @reflect
-    def fit_transform(
-        self, X, y=None, *, convert_dtype="deprecated"
-    ) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def fit_transform(self, X, y=None, *, convert_dtype="deprecated"):
         """Fit to data, then transform it."""
         return self.fit(X, convert_dtype=convert_dtype).transform(
             X, convert_dtype=convert_dtype
@@ -241,13 +234,11 @@ class GaussianRandomProjection(_BaseRandomProjection):
     def _gen_random_matrix(self, n_components, n_features, dtype):
         seed = check_random_seed(self.random_state)
         rng = cp.random.RandomState(seed)
-        return CumlArray(
-            data=rng.normal(
-                loc=0.0,
-                scale=1.0 / np.sqrt(n_components),
-                size=(n_components, n_features),
-            ).astype(dtype, copy=False)
-        )
+        return rng.normal(
+            loc=0.0,
+            scale=1.0 / np.sqrt(n_components),
+            size=(n_components, n_features),
+        ).astype(dtype, copy=False)
 
 
 class SparseRandomProjection(_BaseRandomProjection):
@@ -396,10 +387,8 @@ class SparseRandomProjection(_BaseRandomProjection):
             components = (
                 rng.binomial(1, 0.5, (n_components, n_features)) * 2 - 1
             )
-            return CumlArray(
-                data=(1 / np.sqrt(n_components) * components).astype(
-                    dtype, copy=False
-                )
+            return (1 / np.sqrt(n_components) * components).astype(
+                dtype, copy=False
             )
 
         k = int(density * n_features * n_components)
@@ -421,8 +410,6 @@ class SparseRandomProjection(_BaseRandomProjection):
         factor = np.sqrt(1 / density) / np.sqrt(n_components)
         data = cp.multiply(data, factor, dtype=dtype)
 
-        return SparseCumlArray(
-            data=sp.coo_matrix(
-                (data, (i, j)), shape=(n_components, n_features)
-            ).asformat("csr")
-        )
+        return sp.coo_matrix(
+            (data, (i, j)), shape=(n_components, n_features)
+        ).asformat("csr")

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from typing import Mapping, Optional, Tuple, Union
@@ -7,8 +7,7 @@ from typing import Mapping, Optional, Tuple, Union
 import cupy as cp
 import numpy as np
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals import logger, nvtx, reflect, run_in_internal_context
+from cuml.internals import ReflectedAttr, logger, mlfunc, nvtx
 from cuml.internals.base import Base, get_handle
 from cuml.internals.validation import check_array
 from cuml.tsa._deprecation import warn_deprecated_tsa_api
@@ -273,18 +272,18 @@ class ARIMA(Base):
 
     """
 
-    d_y = CumlArrayDescriptor()
+    d_y = ReflectedAttr()
     # TODO: (MDD) Should this be public? Its not listed in the attributes doc
-    _d_y_diff = CumlArrayDescriptor()
-    _temp_mem = CumlArrayDescriptor()
+    _d_y_diff = ReflectedAttr()
+    _temp_mem = ReflectedAttr()
 
-    mu_ = CumlArrayDescriptor()
-    beta_ = CumlArrayDescriptor()
-    ar_ = CumlArrayDescriptor()
-    ma_ = CumlArrayDescriptor()
-    sar_ = CumlArrayDescriptor()
-    sma_ = CumlArrayDescriptor()
-    sigma2_ = CumlArrayDescriptor()
+    mu_ = ReflectedAttr()
+    beta_ = ReflectedAttr()
+    ar_ = ReflectedAttr()
+    ma_ = ReflectedAttr()
+    sar_ = ReflectedAttr()
+    sma_ = ReflectedAttr()
+    sigma2_ = ReflectedAttr()
 
     def __init__(self,
                  endog,
@@ -396,11 +395,11 @@ class ARIMA(Base):
 
         self._initial_calc()
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _initial_calc(self):
         """
         This separates the initial calculation from the initialization to make
-        the CumlArrayDescriptors work
+        ReflectedAttr work.
         """
 
         cdef uintptr_t d_y_ptr = self.d_y.data.ptr
@@ -512,19 +511,19 @@ class ARIMA(Base):
         return ic
 
     @property
-    @reflect
+    @mlfunc
     def aic(self):
         """Akaike Information Criterion"""
         return self._ic("aic")
 
     @property
-    @reflect
+    @mlfunc
     def aicc(self):
         """Corrected Akaike Information Criterion"""
         return self._ic("aicc")
 
     @property
-    @reflect
+    @mlfunc
     def bic(self):
         """Bayesian Information Criterion"""
         return self._ic("bic")
@@ -536,7 +535,7 @@ class ARIMA(Base):
         return (order.p + order.P + order.q + order.Q + order.k + order.n_exog
                 + 1)
 
-    @reflect
+    @mlfunc
     def get_fit_params(self):
         """Get all the fit parameters. Not to be confused with get_params
         Note: pack() can be used to get a compact vector of the parameters
@@ -613,7 +612,7 @@ class ARIMA(Base):
         raise NotImplementedError("ARIMA is unable to be cloned via "
                                   "`get_params` and `set_params`.")
 
-    @reflect(array=None)
+    @mlfunc(array_arg=None)
     def predict(
         self,
         start=0,
@@ -768,7 +767,7 @@ class ARIMA(Base):
                     d_upper)
 
     @nvtx.annotate(message="tsa.arima.ARIMA.forecast", domain="cuml_python")
-    @reflect(array=None)
+    @mlfunc(array_arg=None)
     def forecast(
         self,
         nsteps: int,
@@ -837,7 +836,7 @@ class ARIMA(Base):
 
     @nvtx.annotate(message="tsa.arima.ARIMA._estimate_x0",
                    domain="cuml_python")
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _estimate_x0(self):
         """Internal method. Estimate initial parameters of the model.
         """
@@ -858,7 +857,7 @@ class ARIMA(Base):
                     <double*> d_exog_ptr, <int> self.batch_size,
                     <int> self.n_obs, order, <bool> self.missing)
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def fit(self,
             start_params: Optional[Mapping[str, object]] = None,
             opt_disp: int = -1,
@@ -960,7 +959,7 @@ class ARIMA(Base):
         return self
 
     @nvtx.annotate(message="tsa.arima.ARIMA._loglike", domain="cuml_python")
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _loglike(self, x, trans=True, method="ml", truncate=0, convert_dtype="deprecated"):
         """Compute the batched log-likelihood for the given parameters.
 
@@ -1031,7 +1030,7 @@ class ARIMA(Base):
 
     @nvtx.annotate(message="tsa.arima.ARIMA._loglike_grad",
                    domain="cuml_python")
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _loglike_grad(self, x, h=1e-8, trans=True, method="ml", truncate=0,
                       convert_dtype="deprecated"):
         """Compute the gradient (via finite differencing) of the batched
@@ -1110,7 +1109,7 @@ class ARIMA(Base):
         return grad.get(order="A")
 
     @property
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def llf(self):
         """Log-likelihood of a fit model. Shape: (batch_size,)
         """
@@ -1158,7 +1157,7 @@ class ARIMA(Base):
         return np.array(vec_loglike, dtype=np.float64)
 
     @nvtx.annotate(message="tsa.arima.ARIMA.unpack", domain="cuml_python")
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def unpack(self, x: Union[list, np.ndarray], convert_dtype="deprecated"):
         """Unpack linearized parameter vector `x` into the separate
         parameter arrays of the model
@@ -1191,7 +1190,7 @@ class ARIMA(Base):
                    <double*>d_x_ptr)
 
     @nvtx.annotate(message="tsa.arima.ARIMA.pack", domain="cuml_python")
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def pack(self) -> np.ndarray:
         """Pack parameters of the model into a linearized vector `x`
 

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import itertools
@@ -7,8 +7,7 @@ import itertools
 import cupy as cp
 import numpy as np
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals import logger, reflect, run_in_internal_context
+from cuml.internals import ReflectedAttr, logger, mlfunc
 from cuml.internals.base import Base, get_handle
 from cuml.internals.validation import check_array
 from cuml.tsa._deprecation import warn_deprecated_tsa_api
@@ -160,7 +159,7 @@ class AutoARIMA(Base):
 
     """
 
-    d_y = CumlArrayDescriptor()
+    d_y = ReflectedAttr()
 
     def __init__(self,
                  endog,
@@ -192,7 +191,7 @@ class AutoARIMA(Base):
 
         self._initial_calc()
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def _initial_calc(self):
         cdef uintptr_t d_y_ptr = self.d_y.data.ptr
         handle = get_handle()
@@ -206,7 +205,7 @@ class AutoARIMA(Base):
             raise ValueError(
                 "Missing observations are not supported in AutoARIMA yet")
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def search(self,
                s=None,
                d=range(3),
@@ -414,7 +413,7 @@ class AutoARIMA(Base):
             id_tracker, self.batch_size
         )
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def fit(self,
             h: float = 1e-8,
             maxiter: int = 1000,
@@ -441,7 +440,7 @@ class AutoARIMA(Base):
             logger.debug("Fitting {} ({})".format(model, method))
             model.fit(h=h, maxiter=maxiter, method=method, truncate=truncate)
 
-    @reflect(array=None)
+    @mlfunc(array_arg=None)
     def predict(
         self,
         start=0,
@@ -500,7 +499,7 @@ class AutoARIMA(Base):
         else:
             return y_p, lower, upper
 
-    @reflect(array=None)
+    @mlfunc(array_arg=None)
     def forecast(self, nsteps: int, level=None):
         """Forecast `nsteps` into the future.
 
@@ -525,7 +524,7 @@ class AutoARIMA(Base):
         """
         return self.predict(self.n_obs, self.n_obs + nsteps, level)
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def summary(self):
         """Display a quick summary of the models selected by `search`
         """

--- a/python/cuml/cuml/tsa/holtwinters.pyx
+++ b/python/cuml/cuml/tsa/holtwinters.pyx
@@ -1,13 +1,12 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cudf
 import cupy as cp
 import numpy as np
 
-from cuml.common.array_descriptor import CumlArrayDescriptor
 from cuml.internals.base import Base, get_handle
-from cuml.internals.outputs import run_in_internal_context
+from cuml.internals.outputs import ReflectedAttr, mlfunc
 from cuml.internals.validation import check_array
 from cuml.tsa._deprecation import warn_deprecated_tsa_api
 
@@ -155,11 +154,11 @@ class ExponentialSmoothing(Base):
 
     """
 
-    forecasted_points = CumlArrayDescriptor()
-    level = CumlArrayDescriptor()
-    trend = CumlArrayDescriptor()
-    season = CumlArrayDescriptor()
-    SSE = CumlArrayDescriptor()
+    forecasted_points = ReflectedAttr()
+    level = ReflectedAttr()
+    trend = ReflectedAttr()
+    season = ReflectedAttr()
+    SSE = ReflectedAttr()
 
     def __init__(self, endog, *, seasonal="additive",
                  seasonal_periods=2, start_periods=2,
@@ -263,7 +262,7 @@ class ExponentialSmoothing(Base):
             raise ValueError("Data input must have 1 or 2 dimensions.")
         return mod_ts_input
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def fit(self) -> "ExponentialSmoothing":
         """
         Perform fitting on the given `endog` dataset.
@@ -349,7 +348,7 @@ class ExponentialSmoothing(Base):
 
         return self
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def forecast(self, h=1, index=None):
         """
         Forecasts future points based on the fitted model.
@@ -429,7 +428,7 @@ class ExponentialSmoothing(Base):
         else:
             raise ValueError("Fit() the model before forecast()")
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def score(self, index=None):
         """
         Returns the score of the model.
@@ -461,7 +460,7 @@ class ExponentialSmoothing(Base):
         else:
             raise ValueError("Fit() the model before score()")
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def get_level(self, index=None):
         """
         Returns the level component of the model.
@@ -493,7 +492,7 @@ class ExponentialSmoothing(Base):
         else:
             raise ValueError("Fit() the model to get level values")
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def get_trend(self, index=None):
         """
         Returns the trend component of the model.
@@ -525,7 +524,7 @@ class ExponentialSmoothing(Base):
         else:
             raise ValueError("Fit() the model to get trend values")
 
-    @run_in_internal_context
+    @mlfunc(convert_output=False)
     def get_season(self, index=None):
         """
         Returns the season component of the model.

--- a/python/cuml/cuml/tsa/seasonality.py
+++ b/python/cuml/cuml/tsa/seasonality.py
@@ -1,15 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
 import numpy as np
 
-from cuml.internals import reflect
+from cuml.internals import mlfunc
 from cuml.internals.validation import check_array
 from cuml.tsa._deprecation import deprecated_tsa_api
 
 
 @deprecated_tsa_api("cuml.tsa.seasonality.seas_test")
-@reflect
+@mlfunc
 def seas_test(y, s, convert_dtype="deprecated"):
     """
     Perform Wang, Smith & Hyndman's test to decide whether seasonal

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
 import numpy as np
 
-from cuml.internals import get_handle, reflect
+from cuml.internals import get_handle, mlfunc
 from cuml.internals.validation import check_array
 from cuml.tsa._deprecation import deprecated_tsa_api
 
@@ -33,7 +33,7 @@ cdef extern from "cuml/tsa/stationarity.h" namespace "ML" nogil:
 
 
 @deprecated_tsa_api("cuml.tsa.stationarity.kpss_test")
-@reflect
+@mlfunc
 def kpss_test(
     y,
     int d=0,

--- a/python/cuml/tests/test_reflection.py
+++ b/python/cuml/tests/test_reflection.py
@@ -176,7 +176,7 @@ def test_set_global_output_type():
     cuml.set_global_output_type(None)
     assert gs.output_type is None
 
-    with pytest.raises(ValueError, match="`output_type` must be one of"):
+    with pytest.raises(ValueError, match="`output_type='bad'`"):
         cuml.set_global_output_type("bad")
 
 
@@ -195,7 +195,7 @@ def test_using_output_type():
         assert gs.output_type is None
     assert gs.output_type == "cupy"
 
-    with pytest.raises(ValueError, match="`output_type` must be one of"):
+    with pytest.raises(ValueError, match="`output_type='bad'`"):
         with cuml.using_output_type("bad"):
             pass
 
@@ -296,9 +296,9 @@ def test_global_output_type(input_type, output_type):
 
 def test_invalid_estimator_output_type():
     X = rand_array("numpy")
-    model = cuml.DBSCAN(eps=1.0, min_samples=1, output_type="invalid")
+    model = cuml.DBSCAN(eps=1.0, min_samples=1)
     model.fit(X)
-    assert model.output_type == "invalid"
+    model.output_type = "invalid"
 
     # Descriptor raises appropriately
     with pytest.raises(ValueError, match="`output_type='invalid'`"):

--- a/python/cuml/tests/test_tsa_deprecation.py
+++ b/python/cuml/tests/test_tsa_deprecation.py
@@ -8,7 +8,7 @@ import pytest
 
 import cuml
 from cuml.datasets import make_arima
-from cuml.internals import run_in_internal_context
+from cuml.internals import mlfunc
 from cuml.tsa import ARIMA, ExponentialSmoothing
 from cuml.tsa.auto_arima import AutoARIMA
 from cuml.tsa.seasonality import seas_test
@@ -58,7 +58,7 @@ def test_tsa_functions_warn_on_call(func, args):
         func(*args)
 
 
-@run_in_internal_context
+@mlfunc(convert_output=False)
 def _call_tsa_function(func, args):
     return func(*args)
 

--- a/python/cuml/tests/test_umap.py
+++ b/python/cuml/tests/test_umap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import copy
@@ -1506,10 +1506,14 @@ def test_umap_sigmas_rhos():
     ref_model.fit(X)
 
     # With identical KNN inputs, sigmas and rhos should match closely
-    np.testing.assert_allclose(cu_model._rhos, ref_model._rhos, atol=1e-3)
+    np.testing.assert_allclose(
+        cu_model._rhos.get(), ref_model._rhos, atol=1e-3
+    )
 
     # Sigmas are more sensitive to numerical differences
-    np.testing.assert_allclose(cu_model._sigmas, ref_model._sigmas, atol=5e-2)
+    np.testing.assert_allclose(
+        cu_model._sigmas.get(), ref_model._sigmas, atol=5e-2
+    )
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
This removes (almost) all remaining usage of:

- `cuml.internals.array.CumlArray`
- `cuml.internals.array_sparse.SparseCumlArray`
- `cuml.common.array_descriptor.CumlArrayDescriptor`
- `cuml.internals.outputs.reflect`
- `cuml.internals.outputs.run_in_internal_context`
- `cuml.internals.interop.to_cpu`
- `cuml.internals.interop.to_gpu`

within `cuml`.

It should result in no visible change in behavior, and is a very mechanical refactor.

In a followup after this I'll rip out the functionality listed above, all tests, and the two remaining call sites for `CumlArray` (test-only utilities).

Part of #8177.