### PR TITLE
Deprecate `cuml.datasets.make_arima`

### DIFF
--- a/python/cuml/cuml/datasets/arima.pyx
+++ b/python/cuml/cuml/datasets/arima.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 from random import randint
@@ -7,6 +7,7 @@ from random import randint
 import cupy as cp
 
 from cuml.internals import get_handle, reflect
+from cuml.tsa._deprecation import deprecated_tsa_api
 
 from libc.stdint cimport uint64_t, uintptr_t
 from pylibraft.common.handle cimport handle_t
@@ -40,12 +41,17 @@ cdef extern from "cuml/datasets/make_arima.hpp" namespace "ML" nogil:
     ) except +
 
 
+@deprecated_tsa_api("cuml.datasets.make_arima")
 @reflect(array=None)
 def make_arima(batch_size=1000, n_obs=100, order=(1, 1, 1),
                seasonal_order=(0, 0, 0, 0), intercept=False,
                random_state=None, dtype="float64"):
     """Generates a dataset of time series by simulating an ARIMA process
     of a given order.
+
+    .. deprecated:: 26.08
+        ``cuml.datasets.make_arima`` is deprecated and will be removed
+        in the cuML 26.12 release.
 
     Examples
     --------

--- a/python/cuml/tests/test_dataset_generator_types.py
+++ b/python/cuml/tests/test_dataset_generator_types.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -46,6 +46,10 @@ def test_xy_output_type(generator, output_str, output_types):
 
 
 @pytest.mark.parametrize("output_str,output_types", TEST_OUTPUT_TYPES)
+@pytest.mark.filterwarnings(
+    "ignore:`cuml.datasets.make_arima`, along with the entire `cuml.tsa` module, "
+    "was deprecated:FutureWarning"
+)
 def test_time_series_label_output_type(output_str, output_types):
     # Set the output type and ensure data of that type is generated
     with cuml.using_output_type(output_str):

--- a/python/cuml/tests/test_make_arima.py
+++ b/python/cuml/tests/test_make_arima.py
@@ -1,10 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import pytest
 
 import cuml
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:`cuml.datasets.make_arima`, along with the entire `cuml.tsa` module, "
+    "was deprecated:FutureWarning"
+)
 
 # Note: this test is not really strict, it only checks that the function
 # supports the given parameters and returns an output in the correct form.

--- a/python/cuml/tests/test_tsa_deprecation.py
+++ b/python/cuml/tests/test_tsa_deprecation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import cuml
+from cuml.datasets import make_arima
 from cuml.internals import run_in_internal_context
 from cuml.tsa import ARIMA, ExponentialSmoothing
 from cuml.tsa.auto_arima import AutoARIMA
@@ -49,6 +50,7 @@ def test_tsa_estimators_warn_on_construction(estimator, args):
             kpss_test,
             (np.arange(12, dtype=np.float64).reshape(-1, 1),),
         ),
+        (make_arima, ()),
     ],
 )
 def test_tsa_functions_warn_on_call(func, args):


### PR DESCRIPTION
Since we're deprecating `cuml.tsa`, we should also deprecate the corresponding dataset generator. This was missed in the PR deprecating `cuml.tsa` (#8344).