### PR TITLE
Update developer wiki for new machinery

### DIFF
--- a/.github/workflows/pr_issue_status_automation.yml
+++ b/.github/workflows/pr_issue_status_automation.yml
@@ -60,7 +60,7 @@ jobs:
       steps:
         - name: Checkout main branch if needed
           if: ${{ github.event.pull_request.base.ref == 'main' }}
-          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           with:
             ref: main
             persist-credentials: false
@@ -115,7 +115,7 @@ jobs:
         repository-projects: read
       steps:
         - name: Checkout base branch
-          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           with:
             ref: ${{ github.event.pull_request.base.ref }}
             persist-credentials: false

--- a/wiki/DEFINITION_OF_DONE_CRITERIA.md
+++ b/wiki/DEFINITION_OF_DONE_CRITERIA.md
@@ -40,8 +40,7 @@ Below is a quick and simple checklist for developers to determine whether an alg
 - Python class is as "near drop-in replacement" for Scikit-learn (or relevant industry standard) API as possible. This means parameters have the same names as Scikit-learn, and where differences exist, they are clearly documented in docstrings.
 - It is recommended to open an initial PR with the API design if there are going to be significant differences with reference APIs, or lack of a reference API, to have a discussion about it.
 - Python class is pickleable and a test has been added to `cuml/tests/test_pickle.py`
-- APIs use `input_to_cuml_array` to accept flexible inputs and check their datatypes and use `cumlArray.to_output()` to return configurable outputs.
-- Any internal parameters or array-based instance variables use `CumlArray`
+- Estimators follow the implementation guidelines in [ESTIMATOR_GUIDE.md](python/ESTIMATOR_GUIDE.md)
 
 #### Testing
 

--- a/wiki/python/DEVELOPER_GUIDE.md
+++ b/wiki/python/DEVELOPER_GUIDE.md
@@ -243,37 +243,49 @@ Running pytest from outside `python/cuml/` can result in import errors or missed
 
 ## Input Validation
 
-New or updated estimator code should use `cuml.internals.validation` for user-facing input validation. These helpers are the standard path for matching scikit-learn validation behavior, simplifying input ingest, and avoiding module-specific validation pipelines. See the [Estimator Guide](ESTIMATOR_GUIDE.md#input-validation) for estimator-specific patterns and examples.
+Code should use `cuml.internals.validation` for user-facing input validation.
+These helpers are the standard path for matching scikit-learn validation
+behavior, simplifying input ingest, and avoiding module-specific validation
+pipelines. See the [Estimator Guide](ESTIMATOR_GUIDE.md#input-validation) for
+estimator-specific patterns and examples.
 
-Prefer `check_inputs` for estimator methods that validate `X` and optional `y` / `sample_weight` values. Use lower-level helpers directly only when a method has a non-standard shape that the higher-level helper cannot express.
+Prefer `check_inputs` for estimator methods that validate `X` and optional `y`
+/ `sample_weight` values. Use lower-level helpers directly only when a method
+has a non-standard shape that the higher-level helper cannot express.
 
-Validation helpers should be configured to describe what the estimator actually supports. Set `dtype`, `convert_dtype`, `mem_type`, `order`, `accept_sparse`, `ensure_all_finite`, `ensure_non_negative`, and minimum shape requirements explicitly when the defaults are not correct. Do not hand-roll equivalent checks unless the common helpers cannot express the estimator's requirements.
+Validation helpers should be configured to describe what the estimator actually
+supports. Set `dtype`, `convert_dtype`, `mem_type`, `order`, `accept_sparse`,
+`ensure_all_finite`, `ensure_non_negative`, and minimum shape requirements
+explicitly when the defaults are not correct. Do not hand-roll equivalent
+checks unless the common helpers cannot express the estimator's requirements.
 
 The validation pipeline normalizes inputs to standard array containers:
 
 - `cupy.ndarray` or `cupyx.scipy.sparse.spmatrix` for device outputs
 - `numpy.ndarray` or `scipy.sparse.spmatrix` for host outputs
 
-For new code, prefer these standard containers for internal processing rather than converting user inputs through `input_to_cuml_array` or using `CumlArray` as the ingest representation. `CumlArray` is still useful at API boundaries, especially for fitted attributes managed by `CumlArrayDescriptor` and returned values that need output-type reflection or index preservation.
+Fit-like methods should validate with `reset=True` so feature metadata is set
+from the training input. Inference methods should usually call
+`check_is_fitted` and then validate with the default `reset=False` so the input
+is checked against the fitted feature metadata.
 
-Fit-like methods should validate with `reset=True` so feature metadata is set from the training input. Inference methods should usually call `check_is_fitted` and then validate with the default `reset=False` so the input is checked against the fitted feature metadata.
-
-Tests for validation changes should cover both accepted and rejected inputs, including dtype conversion, sparse support, finite/non-negative requirements, feature-count and feature-name checks, and any classifier class-encoding behavior. When changing validation behavior for an estimator, also check the scikit-learn compatibility tests and the `cuml.accel` upstream xfail list.
+Tests for validation changes should cover both accepted and rejected inputs,
+including dtype conversion, sparse support, finite/non-negative requirements,
+feature-count and feature-name checks, and any classifier class-encoding
+behavior. When changing validation behavior for an estimator, also check the
+scikit-learn compatibility tests and the `cuml.accel` upstream xfail list.
 
 ## Memory Management
 
-cuML uses RMM (RAPIDS Memory Manager) for GPU memory management and configures CuPy to allocate through RMM when `cuml` is imported. Validated user inputs should generally be processed as standard arrays (`cupy`, `numpy`, `cupyx.scipy.sparse`, or `scipy.sparse`) returned by the input validation helpers.
+cuML uses RMM (RAPIDS Memory Manager) for GPU memory management and configures
+CuPy to allocate through RMM when `cuml` is imported. Validated user inputs
+should generally be processed as standard arrays (`cupy`, `numpy`,
+`cupyx.scipy.sparse`, or `scipy.sparse`) returned by the input validation
+helpers.
 
-`CumlArray` remains useful at API boundaries, especially for fitted attributes managed by `CumlArrayDescriptor` and returned values that need output-type reflection or index preservation. Do not use `CumlArray` allocation or conversion methods for new internal array processing code; use the standard CuPy, NumPy, cuDF, or SciPy containers returned by validation.
+Use standard array libraries for allocations and conversions in new internal
+code:
 
-Current `CumlArray` memory types are:
-
-- `device`: GPU-accessible memory for CUDA operations.
-- `host`: CPU-accessible memory for host operations.
-
-Use explicit conversion parameters when a code path needs a specific location; estimators do not have a general memory-type context manager.
-
-Use standard array libraries for allocations and conversions in new internal code:
 ```python
 import cupy as cp
 import numpy as np
@@ -290,7 +302,8 @@ Additional considerations:
 - Minimize memory transfers between host and device
 - Prefer device memory for GPU kernels and host memory only when a CPU API needs it
 - Consider memory layout (C/F order) for optimal performance
-- Let `@reflect` and `CumlArrayDescriptor` handle user-facing output type conversion for estimator methods and fitted array attributes
+- Let `@mlfunc` and `ReflectedAttr` handle user-facing output type conversion
+  for estimator methods and fitted array attributes
 
 ## Thread Safety
 

--- a/wiki/python/ESTIMATOR_GUIDE.md
+++ b/wiki/python/ESTIMATOR_GUIDE.md
@@ -65,6 +65,7 @@ cuML often implements GPU-accelerated versions of estimators from CPU libraries,
 ## Quick Start Guide
 
 At a high level, all cuML Estimators must:
+
 1. Inherit from `cuml.Base`
    ```python
    from cuml.internals.base import Base
@@ -72,8 +73,13 @@ At a high level, all cuML Estimators must:
    class MyEstimator(Base):
       ...
    ```
-2. Follow the [Scikit-learn estimator developer guidelines](https://scikit-learn.org/stable/developers/develop.html)
-3. Include the `Base.__init__()` arguments available in the new Estimator's `__init__()`
+
+2. Follow the [Scikit-learn estimator developer
+   guidelines](https://scikit-learn.org/stable/developers/develop.html)
+
+3. Include the `Base.__init__()` arguments available in the new Estimator's
+   `__init__()`
+
    ```python
    from cuml.internals.base import Base
 
@@ -83,36 +89,50 @@ At a high level, all cuML Estimators must:
          super().__init__(verbose=verbose, output_type=output_type)
          ...
    ```
-4. Declare each array-like attribute the new Estimator will compute as a class variable for automatic array type conversion. An order can be specified to serve as an indicator of the order the array should be in for the C++ algorithms to work.
+
+4. Declare each public array-like attribute the new Estimator will compute as a
+   class variable for automatic array type conversion.
+
    ```python
-   from cuml.common.array_descriptor import CumlArrayDescriptor
+   from cuml.internals import ReflectedAttr
    from cuml.internals.base import Base
 
    class MyEstimator(Base):
 
-      labels_ = CumlArrayDescriptor(order='C')
+      labels_ = ReflectedAttr()
 
       def __init__(self):
          ...
    ```
-5. Use the `@reflect` decorator on public API methods that return arrays. Use `@reflect(reset=True)` on fit-like methods in combination with the appropriate `cuml.internals.validation` helpers, and use plain `@reflect` on inference methods:
+
+5. Use the `@mlfunc` decorator on public API methods that return arrays. Use
+   `@mlfunc(set_input_type=True)` on fit-like methods in combination with the
+   appropriate `cuml.internals.validation` helpers. Any inference method that
+   returns an array with `n_samples` rows (aligned with the input `X`) should
+   use `@mlfunc(preserve_index=True)` to align the output with the input's
+   index (if any). Other methods should use plain `@mlfunc`:
+
    ```python
-   from cuml.internals import reflect
-   from cuml.internals.array import CumlArray
+   from cuml.internals import mlfunc
    from cuml.internals.base import Base
 
    class MyEstimator(Base):
 
-      @reflect(reset=True)
+      @mlfunc(set_input_type=True)
       def fit(self, X) -> "MyEstimator":
          ...
 
-      @reflect
-      def predict(self, X) -> CumlArray:
+      @mlfunc(preserve_index=True)
+      def predict(self, X):
          ...
    ```
-   See [Estimator Methods](#estimator-methods) for detailed guidance on when to use `@reflect`, `@run_in_internal_context`, and `exit_internal_context`.
-6. Implement `_get_param_names()` including values returned by `super()._get_param_names()`
+
+   See [Estimator Methods](#estimator-methods) for detailed guidance on when to
+   use `@mlfunc`.
+
+6. Implement `_get_param_names()` including values returned by
+   `super()._get_param_names()`
+
    ```python
       @classmethod
       def _get_param_names(cls):
@@ -122,24 +142,28 @@ At a high level, all cuML Estimators must:
          ]
    ```
 
-7. Override estimator tags only when the defaults are wrong. Prefer existing [Mixins](../../python/cuml/cuml/internals/mixins.py) for common capabilities such as preferred input order, sparse support, string input, or NaN support. See [Estimator Tags and cuML-Specific Tags](#estimator-tags-and-cuml-specific-tags) for custom tag overrides.
+7. Override estimator tags only when the defaults are wrong. Prefer existing
+   [Mixins](../../python/cuml/cuml/internals/mixins.py) for common capabilities
+   such as preferred input order, sparse support, string input, or NaN support.
+   See [Estimator Tags and cuML-Specific
+   Tags](#estimator-tags-and-cuml-specific-tags) for custom tag overrides.
 
-For most estimators, the checklist and skeleton below are enough. The later sections explain the contract and uncommon cases.
+For most estimators, the checklist and skeleton below are enough. The later
+sections explain the contract and uncommon cases.
 
 ### Copyable Estimator Skeleton
 
-Use this as a starting point for dense estimators that follow the standard cuML pattern:
+Use this as a starting point for dense estimators that follow the standard cuML
+pattern:
 
 ```python
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals import reflect
-from cuml.internals.array import CumlArray
+from cuml.internals import mlfunc, ReflectedAttr
 from cuml.internals.base import Base
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 
 class MyEstimator(Base):
-    result_ = CumlArrayDescriptor(order="C")
+    result_ = ReflectedAttr()
 
     def __init__(self, *, extra_arg=True, verbose=False, output_type=None):
         super().__init__(verbose=verbose, output_type=output_type)
@@ -147,67 +171,93 @@ class MyEstimator(Base):
 
     @classmethod
     def _get_param_names(cls):
-        return super()._get_param_names() + ["extra_arg"]
+        return [*super()._get_param_names(), "extra_arg"]
 
-    @reflect(reset=True)
+    @mlfunc(set_input_type=True)
     def fit(self, X) -> "MyEstimator":
-        X_m = check_inputs(self, X, order="K", reset=True)
+        X = check_inputs(self, X, order="K", reset=True)
         # Replace this placeholder with estimator training.
-        self.result_ = X_m
+        self.result_ = X
         return self
 
-    @reflect
-    def transform(self, X) -> CumlArray:
+    @mlfunc(preserve_index=True)
+    def transform(self, X):
         check_is_fitted(self)
         X_m = check_inputs(self, X, order="K")
-        # Return an array-like object directly; @reflect handles conversion.
-        return X_m
+        # Return an array-like object directly; @mlfunc handles conversion.
+        return X
 ```
 
-Fit-like methods should use `@reflect(reset=True)` in combination with the appropriate validation helpers. Pass `reset=True` to validation when fitting. Methods that return scalars usually do not need `@reflect`; use `@run_in_internal_context` only when the method calls reflected methods internally.
+Fit-like methods should use `@mlfunc(set_input_type=True)` in combination with
+the appropriate validation helpers. Pass `reset=True` to validation when
+fitting. Methods that return scalars may use `@mlfunc(convert_output=False)` to
+avoid some fully disable output conversion, though a plain `@mlfunc` would work
+as well.
 
 ## Background
 
 ### Array I/O and Output Types in cuML
 
-cuML estimators should validate public inputs with `cuml.internals.validation` helpers such as `check_inputs`, `check_array`, `check_y`, and `check_sample_weight`. These helpers accept the standard cuML array-like inputs, apply estimator feature metadata checks, and normalize data to standard CuPy/NumPy or sparse array containers. Sparse estimators should configure the validation helpers for their supported sparse formats or follow the sparse-specific validation utilities used by neighboring sparse estimators.
+cuML estimators should validate public inputs with `cuml.internals.validation`
+helpers such as `check_inputs`, `check_array`, `check_y`, and
+`check_sample_weight`. These helpers accept the standard cuML array-like
+inputs, apply estimator feature metadata checks, and normalize data to standard
+CuPy/NumPy or sparse array containers. Sparse estimators should configure the
+validation helpers for their supported sparse formats or follow the
+sparse-specific validation utilities used by neighboring sparse estimators.
 
-Internally, dense array data should usually be processed as the standard arrays returned by validation. Use `CumlArray` at API boundaries, especially for descriptor-managed fitted attributes and returned values that need output-type reflection or index preservation. Low-level code that needs a specific memory location should request it explicitly through validation arguments such as `mem_type`.
+Internally, dense array data should usually be processed as the standard arrays
+returned by validation. Use `CumlArray` at API boundaries, especially for
+descriptor-managed fitted attributes and returned values that need output-type
+reflection or index preservation. Low-level code that needs a specific memory
+location should request it explicitly through validation arguments such as
+`mem_type`.
 
-Public output type conversion is handled by `@reflect` and `CumlArrayDescriptor`. Users choose output types in three ways:
+Public output type conversion is handled by `@mlfunc` and `ReflectedAttr`.
+Users choose output types in three ways:
 
 1. Set `output_type` on an estimator, for example `MyEstimator(output_type="numpy")`.
 2. Set a global override with `cuml.set_global_output_type("numpy")`.
 3. Temporarily set a global override with `cuml.using_output_type("numpy")`.
 
-The global setting stored in `cuml.global_settings.output_type` takes precedence over an estimator's `output_type`. When neither is set, reflected estimator methods normally mirror the call input type, and descriptor attributes mirror the fit-time input type.
+The global setting stored in `cuml.global_settings.output_type` takes
+precedence over an estimator's `output_type`. When neither is set, reflected
+estimator methods normally mirror the call input type, and descriptor
+attributes mirror the fit-time input type.
 
-Accepted output type strings are:
+Accepted output types are:
 
- - `None`: No global or estimator override. Reflected estimator methods infer from their input or fit-time input type.
+ - `None`: No global or estimator override. Reflected estimator methods infer
+   from their input or fit-time input type.
  - `"input"`: Mirror the relevant input type.
  - `"array"`: Return a CuPy array for device data or a NumPy array for host data.
  - `"numba"`: Return a Numba device array.
- - `"dataframe"`: Return a cuDF or pandas DataFrame based on memory location.
- - `"series"`: Return a cuDF or pandas Series based on memory location.
+ - `"dataframe"`: Return a cuDF DataFrame based on memory location.
+ - `"series"`: Return a cuDF Series based on memory location.
  - `"df_obj"`: Return a Series for single-dimensional output or a DataFrame otherwise.
  - `"cupy"`: Return a CuPy array.
  - `"numpy"`: Return a NumPy array.
  - `"cudf"`: Return a cuDF Series or DataFrame.
  - `"pandas"`: Return a pandas Series or DataFrame.
 
-The internal output type `"cuml"` may appear inside reflected calls. User-facing code should not set it.
+The internal output type `"cuml"` may appear inside reflected calls.
+User-facing code should not set it.
 
 ### Ingesting Arrays
 
-When the input array type is not known, the correct and safest way to validate estimator inputs is using `cuml.internals.validation`. For estimator methods that validate `X` and optional `y` or `sample_weight`, prefer `check_inputs`; it handles feature metadata, dtype conversion, array order, sparse support, length checks, and fit-vs-inference validation consistently with scikit-learn. Omit `y` or `sample_weight` when the method does not validate those inputs.
+When the input array type is not known, the correct and safest way to validate
+estimator inputs is using `cuml.internals.validation`. For estimator methods
+that validate `X` and optional `y` or `sample_weight`, prefer `check_inputs`;
+it handles feature metadata, dtype conversion, array order, sparse support,
+length checks, and fit-vs-inference validation consistently with scikit-learn.
+Omit `y` or `sample_weight` when the method does not validate those inputs.
 
 ```python
-from cuml.internals import reflect
+from cuml.internals import mlfunc
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 
-@reflect(reset=True)
+@mlfunc(set_input_type=True)
 def fit(self, X, y, *, convert_dtype=True):
     X_m, y_m = check_inputs(
         self,
@@ -223,7 +273,7 @@ def fit(self, X, y, *, convert_dtype=True):
     ...
 
 
-@reflect
+@mlfunc(preserve_index=True)
 def transform(self, X, *, convert_dtype=True):
     check_is_fitted(self)
     X_m = check_inputs(
@@ -236,24 +286,35 @@ def transform(self, X, *, convert_dtype=True):
     ...
 ```
 
-Use lower-level helpers directly when a method has non-standard inputs: `check_array` for a standalone array, `check_y` for targets, `check_cudf` for dataframe-oriented paths, and `check_all_finite` or `check_non_negative` for specialized checks not already covered by the higher-level helpers.
+Use lower-level helpers directly when a method has non-standard inputs:
+`check_array` for a standalone array, `check_y` for targets, `check_cudf` for
+dataframe-oriented paths, and `check_all_finite` or `check_non_negative` for
+specialized checks not already covered by the higher-level helpers.
 
 ### Returning Arrays
 
-Return array-like objects directly from reflected methods. Avoid explicit `CumlArray.to_output(...)` calls in public methods; they bypass the automatic conversion system and can cause extra or incorrect conversions.
+Return ``cupy`` or ``numpy`` arrays directly from reflected methods. The
+reflection machinery will coerce these to the proper output type.
 
 ## Estimator Design
 
-All `cuml.Base` estimators follow the [scikit-learn estimator contract](https://scikit-learn.org/stable/developers/develop.html) plus the cuML-specific rules below.
+All `cuml.Base` estimators follow the [scikit-learn estimator
+contract](https://scikit-learn.org/stable/developers/develop.html) plus the
+cuML-specific rules below.
 
 ### Initialization
 
-All estimators should accept `verbose` and `output_type`, and pass them to `super().__init__()`.
+All estimators should accept `verbose` and `output_type`, and pass them to
+`super().__init__()`.
 
-Constructor parameters should be keyword-only unless the matched source API uses positional parameters. This reduces breaking changes when parameters are added or removed:
+Constructor parameters should be keyword-only unless the matched source API
+uses positional parameters. This reduces breaking changes when parameters are
+added or removed:
 
 ```python
-# For an estimator that matches scikit-learn's API where the eps argument can be positional:
+
+# For an estimator that matches scikit-learn's API where the eps argument can
+# be positional:
 def __init__(self, eps=0.5, *, min_samples=5, max_mbytes_per_batch=None,
              calc_core_sample_indices=True, verbose=False, output_type=None):
     super().__init__(verbose=verbose, output_type=output_type)
@@ -272,9 +333,14 @@ def __init__(self, *, eps=0.5, min_samples=5, max_mbytes_per_batch=None,
     self.calc_core_sample_indices = calc_core_sample_indices
 ```
 
-Store constructor arguments exactly as passed. Do not normalize, validate, or convert them in `__init__`; doing so breaks cloning. See scikit-learn's [instantiation guidance](https://scikit-learn.org/stable/developers/develop.html#instantiation) for details.
+Store constructor arguments exactly as passed. Do not normalize, validate, or
+convert them in `__init__`; doing so breaks cloning. See scikit-learn's
+[instantiation
+guidance](https://scikit-learn.org/stable/developers/develop.html#instantiation)
+for details.
 
 For example, the following `__init__` shows what **NOT** to do:
+
 ```python
 def __init__(self, my_option="option1"):
    if (my_option == "option1"):
@@ -283,33 +349,49 @@ def __init__(self, my_option="option1"):
       self.my_option = 2
 ```
 
-Instead, save `my_option` as-is and derive any normalized value later, usually in `fit()` or a private helper.
+Instead, save `my_option` as-is and derive any normalized value later, usually
+in `fit()` or a private helper.
 
 ### Implementing `_get_param_names()`
 
-To support cloning, implement `_get_param_names()`. It should return constructor parameter names, including names from `super()._get_param_names()`. `Base.get_params()` reads these attributes and passes them to a new estimator constructor, so every returned name must be accepted by `__init__()`.
+To support cloning, implement `_get_param_names()`. It should return
+constructor parameter names, including names from `super()._get_param_names()`.
+`Base.get_params()` reads these attributes and passes them to a new estimator
+constructor, so every returned name must be accepted by `__init__()`.
 
 ```python
 @classmethod
 def _get_param_names(cls):
-   return super()._get_param_names() + [
-      "eps",
-      "min_samples",
-   ]
+    return [
+        *super()._get_param_names(),
+        "eps",
+        "min_samples",
+    ]
 ```
 
-Do not omit `super()._get_param_names()`; it includes base estimator parameters such as `verbose` and `output_type`.
+Do not omit `super()._get_param_names()`; it includes base estimator parameters
+such as `verbose` and `output_type`.
 
 ### Estimator Tags and cuML-Specific Tags
 
-Estimator tags describe capabilities such as sparse support, positive-input requirements, and preferred input layout. cuML supports the tags defined by the scikit-learn estimator [developer guide](https://scikit-learn.org/stable/developers/index.html), plus these cuML-specific tags:
+Estimator tags describe capabilities such as sparse support, positive-input
+requirements, and preferred input layout. cuML supports the tags defined by the
+scikit-learn estimator [developer
+guide](https://scikit-learn.org/stable/developers/index.html), plus these
+cuML-specific tags:
 
 - `X_types_gpu` (default=['2darray'])
-   Device-accessible input types accepted by the estimator. `2darray` includes CuPy, Numba device arrays, and cuDF objects. `sparse` includes CuPy sparse arrays.
-- `preferred_input_order` (default=None)
-   One of ['F', 'C', None]. Use `F` or `C` only when the estimator consistently benefits from that dense memory layout; otherwise leave it as `None`.
+   Device-accessible input types accepted by the estimator.`2darray` includes
+   CuPy, Numba device arrays, and cuDF objects. `sparse` includes CuPy sparse
+   arrays.
 
-Use `__sklearn_tags__()` for estimator-specific tag overrides. The method should call `super().__sklearn_tags__()`, mutate the returned structured `Tags` object, and return it:
+- `preferred_input_order` (default=None)
+   One of ['F', 'C', None]. Use `F` or `C` only when the estimator consistently
+   benefits from that dense memory layout; otherwise leave it as `None`.
+
+Use `__sklearn_tags__()` for estimator-specific tag overrides. The method
+should call `super().__sklearn_tags__()`, mutate the returned structured `Tags`
+object, and return it:
 
 ```python
 def __sklearn_tags__(self):
@@ -318,198 +400,204 @@ def __sklearn_tags__(self):
    return tags
 ```
 
-Prefer the existing tag mixins for common capabilities. Tag-providing mixins are cooperative: each mixin calls `super().__sklearn_tags__()` and mutates the returned object. Put tag mixins to the left of `Base`, following scikit-learn's [estimator MRO guidance](https://scikit-learn.org/stable/developers/develop.html), so the `super()` chain reaches the mixins before `Base` and `TagsMixin`:
+Prefer the existing tag mixins for common capabilities. Tag-providing mixins
+are cooperative: each mixin calls `super().__sklearn_tags__()` and mutates the
+returned object. Put tag mixins to the left of `Base`, following scikit-learn's
+[estimator MRO
+guidance](https://scikit-learn.org/stable/developers/develop.html), so the
+`super()` chain reaches the mixins before `Base` and `TagsMixin`:
 
 ```python
 class MyEstimator(CMajorInputTagMixin, AllowNaNTagMixin, Base):
    ...
 ```
 
-Do not add `_more_tags`, `_more_static_tags`, or `_get_tags` to new estimators. Those are legacy scikit-learn tag APIs and can cause compatibility warnings or fallback behavior in newer scikit-learn versions.
+Do not add `_more_tags`, `_more_static_tags`, or `_get_tags` to new estimators.
+Those are legacy scikit-learn tag APIs and can cause compatibility warnings or
+fallback behavior in newer scikit-learn versions.
 
 ### Estimator Array-Like Attributes
 
-Array-like fitted attributes should use `cuml.common.array_descriptor.CumlArrayDescriptor` so user-facing attribute reads respect cuML output-type settings.
+Array-like fitted attributes should use `cuml.internals.ReflectedAttr` so
+user-facing attribute reads respect cuML output-type settings.
 
-Internally, a descriptor behaves like a normal attribute and returns the value that was set. Externally, it lazily converts the value to the requested output type and caches repeated conversions.
+Internally, a descriptor behaves like a normal attribute and returns the value
+that was set. Externally, it lazily converts the value to the requested output
+type and caches repeated conversions.
 
-Lazy conversion reduces unnecessary memory use, but benchmarks must account for the first attribute read if they need to include conversion cost.
+Lazy conversion reduces unnecessary memory use, but benchmarks must account for
+the first attribute read if they need to include conversion cost.
 
 #### Defining Array-Like Attributes
 
-Declare descriptor-managed attributes as class variables. Pass `order` when the stored array should be converted to a specific memory layout for downstream code.
+Declare descriptor-managed attributes as class variables.
 
 ```python
-from cuml.common.array_descriptor import CumlArrayDescriptor
+from cuml.internals import ReflectedAttr
 from cuml.internals.base import Base
 
 class TestEstimator(Base):
 
    # Class variables outside of any function
-   my_cuml_array_ = CumlArrayDescriptor(order='C')
+   my_cuml_array_ = ReflectedAttr()
 
    def __init__(self, ...):
       ...
 ```
 
-#### Working with `CumlArrayDescriptor`
+#### Working with `ReflectedAttr`
 
-Once a descriptor attribute is defined, use it like a normal attribute inside estimator methods:
+Once a descriptor attribute is defined, use it like a normal attribute inside
+estimator methods:
 
 ```python
 import cupy as cp
-from cuml.common.array_descriptor import CumlArrayDescriptor
-from cuml.internals import reflect
+from cuml.internals import mlfunc, ReflectedAttr
 from cuml.internals.base import Base
 from cuml.internals.validation import check_inputs
 
 class SampleEstimator(Base):
 
    # Class variables outside of any function
-   my_cuml_array_ = CumlArrayDescriptor()
-   my_cupy_array_ = CumlArrayDescriptor()
-   my_other_array_ = CumlArrayDescriptor()
+   my_array_ = ReflectedAttr()
+   my_other_array_ = ReflectedAttr()
 
-   def __init__(self, ...):
-
-      # Initialize to None (not mandatory)
-      self.my_cuml_array_ = None
-
-      # Init with a cupy array
-      self.my_cupy_array_ = cp.zeros((10, 10))
-
-   @reflect(reset=True)
+   @mlfunc(set_input_Type=True)
    def fit(self, X):
       # reset=True on check_inputs sets n_features_in_ and feature_names_in_
-      X_m = check_inputs(self, X, order="K", reset=True)
+      X = check_inputs(self, X, order="K", reset=True)
 
       # Set descriptor-managed fitted attributes with validated arrays
-      self.my_cuml_array_ = X_m
-
-      # Access `my_cupy_array_` normally and set to another attribute
-      # The internal type of my_other_array_ will be a CuPy array
-      self.my_other_array_ = cp.ones((10, 10)) + self.my_cupy_array_
+      # When accessed in any `mlfunc`-decorated method, these will have the
+      # same type they were originally set with.
+      self.my_array_ = X
+      self.my_other_array_ = cp.ones((10, 10))
 
       return self
 ```
 
-Inside cuML code, descriptor attributes return the stored value. To intentionally read one with a specific output type, use `cuml.using_output_type()`:
+Inside cuML code, descriptor attributes return the stored value. To
+intentionally read one with a specific output type, use
+`cuml.using_output_type()`:
 
 ```python
+@mlfunc
 def score(self):
 
    # Set the global output type to numpy
    with cuml.using_output_type("numpy"):
-      # Accessing my_cuml_array_ will return a numpy array and
+      # Accessing my_other_array_ will return a numpy array and
       # the result can be returned directly
-      return np.sum(self.my_cuml_array_, axis=0)
+      return np.sum(self.my_other_array_, axis=0)
 ```
 
 This uses the same lazy conversion and caching path as external user reads.
 
-#### CumlArrayDescriptor External Functionality
+#### `ReflectedAttr` External Functionality
 
 Externally, descriptor attributes lazily convert to the active output type:
 
 ```python
 my_est = SampleEstimator()
 
-# Print the default output_type and value for `my_cuml_array_`
-# By default, `output_type` is None and no global output type is set.
-# Fitted descriptor attributes will mirror the fit-time input type.
-print(my_est.output_type) # Output: None
-print(my_est.my_cuml_array_) # Output: None
-print(my_est.my_other_array_) # Output: AttributeError! my_other_array_ was never set
-
 # Call fit() with a numpy array as the input
 np_arr = np.ones((10,))
 my_est.fit(np_arr) # This will load data into attributes
 
 # Externally, descriptors reflect the fit-time input type by default
-print(type(my_est.my_cuml_array_)) # Output: Numpy (saved from the input of `fit`)
+print(type(my_est.my_array_)) # Output: Numpy (saved from the input of `fit`)
 
 # Calling fit again with cupy arrays, will have a similar effect
 my_est.fit(cp.ones((10,)))
-print(type(my_est.my_cuml_array_)) # Output: CuPy
+print(type(my_est.my_array_)) # Output: CuPy
 
 # Setting the `output_type` will change all descriptor properties
 # and ignore the input type
 my_est.output_type = "cudf"
 
 # Reading any of the attributes will convert the type lazily
-print(type(my_est.my_cuml_array_)) # Output: cuDF object
+print(type(my_est.my_array_)) # Output: cuDF object
 
 # A global output type overrides the estimator output_type attribute
 with cuml.using_output_type("cupy"):
-  print(type(my_est.my_cuml_array_)) # Output: cupy
+  print(type(my_est.my_array_)) # Output: cupy
 
 # Once the global output type is restored, we return to the estimator output_type
-print(type(my_est.my_cuml_array_)) # Output: cuDF. Using a cached value!
+print(type(my_est.my_array_)) # Output: cuDF. Using a cached value!
 ```
 
 ### Estimator Methods
 
-cuML uses reflection to convert public array outputs to the user's expected type (`cupy`, `numpy`, `pandas`, `cudf`, etc.). Internal calls stay in an internal context so intermediate computations avoid unnecessary conversions.
+cuML uses reflection to convert public array outputs to the user's expected
+type (`cupy`, `numpy`, `pandas`, `cudf`, etc.). Internal calls stay in an
+internal context so intermediate computations avoid unnecessary conversions.
 
-#### Using the `@reflect` Decorator
+#### Using the `@mlfunc` Decorator
 
-Use `@reflect` on methods that return arrays to the user:
+Use `@mlfunc` on methods that return arrays to the user:
 
 ```python
 import cupy as cp
-from cuml.internals import reflect
+from cuml.internals import mlfunc, ReflectedAttr
 from cuml.internals.base import Base
 from cuml.internals.validation import check_inputs, check_is_fitted
 
 class MyEstimator(Base):
-    @reflect(reset=True)
+    coef_ = ReflectedAttr()
+
+    @mlfunc(set_input_type=True)
     def fit(self, X):
         self.coef_ = check_inputs(self, X, order="K", reset=True)
         return self
 
-    @reflect
+    @mlfunc(preserve_index=True)
     def predict(self, X):
         check_is_fitted(self)
-        X_m = check_inputs(self, X, order="K")
-        return cp.asarray(X_m) + cp.ones(X_m.shape)
+        X = check_inputs(self, X, order="K")
+        return X + cp.ones(X_m.shape)
 ```
 
 | Decorator Usage | When to Use |
 | :-------------- | :---------- |
-| `@reflect(reset=True)` | Fit-like methods that store `_input_type` through reflection while validation helpers set or check `n_features_in_`. |
-| `@reflect` | Transform/predict methods that return arrays. |
-| `@reflect(array=None)` | Methods with no array input (e.g., `forecast(nsteps)`). Uses fit-time input type. |
+| `@mlfunc(set_input_type=True)` | Fit-like methods that store `_input_type` through reflection while validation helpers set or check `n_features_in_`. |
+| `@mlfunc(preserve_index=True)` | Transform/predict methods that return arrays with `n_samples` aligned with `X` |
+| `@mlfunc(array_arg=None)` | Methods with no array input (e.g., `KernelDensity.sample()`). Uses fit-time input type. |
 
-#### Handling Special Cases
+#### Handling Class Labels
 
-For methods that need manual output handling, such as classifier `predict` with label decoding, use `@run_in_internal_context` with `exit_internal_context`:
+Some methods (like classifier `predict` methods) need to return class labels,
+which may include non-numeric dtypes. These are best handled via a custom
+`ClassLabels` wrapper. This wrapper takes a cupy array of encoded label
+indices, and a numpy array of the class labels corresponding to those indices.
+The reflection machinery will lazily revert the encoding when it converts the
+output to the requested `output_type`. If the output type doesn't support
+the label dtype (e.g. `cupy` doesn't support `object` types), an informative
+error will be raised.
 
 ```python
 import cupy as cp
-from cuml.internals import run_in_internal_context, exit_internal_context
+from cuml.internals.outputs import mlfunc, ClassLabels
 from cuml.internals.base import Base
 
 class MyClassifier(Base):
-    @run_in_internal_context
+    @mlfunc(preserve_index=True)
     def predict(self, X):
         # Reflected methods return internal arrays inside this context.
         scores = self.decision_function(X)
 
         # Manual processing
-        indices = (scores.to_output("cupy") >= 0).view(cp.int8)
+        indices = (scores >= 0).view(cp.int8)
 
-        # Exit internal context to infer the user-facing output type.
-        with exit_internal_context():
-            output_type = self._get_output_type(X)
-        return decode_labels(indices, self.classes_, output_type=output_type)
+        return ClassLabels(indices, self.classes_)
 ```
 
 #### Score Methods
 
-Score methods typically return scalars. Use `@run_in_internal_context` when they call reflected methods internally:
+Score methods typically return scalars. You may pass in `convert_output=False`
+to avoid the output conversion machinery when it's known to not be needed.
 
 ```python
-@run_in_internal_context
+@mlfunc(convert_output=False)
 def score(self, X, y):
     predictions = self.predict(X)
     return accuracy_score(y, predictions)
@@ -517,11 +605,11 @@ def score(self, X, y):
 
 #### Property Accessors
 
-Use `@reflect` on properties that return arrays:
+Use `@mlfunc` on properties that return arrays:
 
 ```python
 @property
-@reflect
+@mlfunc
 def support_(self):
     return self._support_vectors
 ```
@@ -530,77 +618,21 @@ def support_(self):
 
 Use these rules when choosing a decorator:
 
-- If a public method returns array-like data directly to the user, use `@reflect`.
-- If a fit-like method calls validation helpers directly, use `@reflect(reset=True)` and pass `reset=True` to validation.
-- If a fit-like method needs feature metadata, use `@reflect(reset=True)` in combination with the appropriate validation helper functions.
-- If a method has no array input and should use the fit-time input type for output conversion, use `@reflect(array=None)`.
-- If a method returns a scalar or needs to call reflected methods internally without automatic output conversion, use `@run_in_internal_context`.
-- If code inside an internal context needs user-facing output-type inference or needs to call an external estimator, temporarily use `exit_internal_context()`.
+- If a public method returns array-like data directly to the user, use
+  `@mlfunc`.
 
-When testing reflected methods, cover the default input-reflection behavior, estimator-level `output_type`, and global `cuml.using_output_type(...)` overrides.
+- For fit-like methods, use `@mlfunc(set_input_type=True)` along with the
+  appropriate validation helper functions.
 
-## Do's and Don'ts
+- Inference methods should typically use `@mlfunc(preserve_index=True)` to
+  ensure dataframe-like outputs have the same index as the input.
 
-### **Do:** Return Array-Like Objects Directly
+- If a method has no array input and should use the fit-time input type for
+  output conversion, use `@mlfunc(array_arg=None)`.
 
-Return array-like objects directly from reflected public methods. `@reflect` already converts the result to the user's requested output type; calling `to_output` yourself is redundant and can return the wrong type if the hardcoded choice differs from the caller's setting.
+- If a method returns a scalar or needs to call reflected methods internally
+  without automatic output conversion, use `@mlfunc(convert_output=False)`.
 
-**Do this:**
-```python
-@reflect
-def predict(self, X) -> CumlArray:
-    return cp.ones((X.shape[0],))
-```
-
-**Not this:**
-```python
-@reflect
-def predict(self, X) -> CumlArray:
-    cp_arr = cp.ones((X.shape[0],))
-    # BAD: @reflect will re-convert this; the manual call is redundant.
-    return CumlArray(cp_arr).to_output(self._get_output_type(X))
-```
-
-### **Don't:** Perform parameter modification in `__init__()`
-
-Store constructor arguments exactly as passed. Move normalization, validation, and conversion into `fit()` or a private helper so cloning works.
-
-**Do this:**
-```python
-class TestEstimator(Base):
-
-    def __init__(self, method_name: str, ...):
-        super().__init__(...)
-
-        self.method_name = method_name
-
-    def _method_int(self) -> int:
-        return 1 if self.method_name == "type1" else 0
-
-    @reflect(reset=True)
-    def fit(self, X) -> "TestEstimator":
-        X_m = check_inputs(self, X, order="K", reset=True)
-        method = self._method_int()
-
-        # Train using X_m and method.
-
-        return self
-```
-
-**Not this:**
-```python
-class TestEstimator(Base):
-
-    def __init__(self, method_name: str, ...):
-        super().__init__(...)
-
-        self.method_name = 1 if method_name == "type1" else 0
-
-    @reflect(reset=True)
-    def fit(self, X) -> "TestEstimator":
-        X_m = check_inputs(self, X, order="K", reset=True)
-
-        # This method is now coupled to a mutated constructor parameter.
-
-        return self
-```
+When testing reflected methods, cover the default input-reflection behavior,
+estimator-level `output_type`, and global `cuml.using_output_type(...)`
+overrides.

--- a/wiki/python/ESTIMATOR_GUIDE.md
+++ b/wiki/python/ESTIMATOR_GUIDE.md
@@ -207,11 +207,8 @@ validation helpers for their supported sparse formats or follow the
 sparse-specific validation utilities used by neighboring sparse estimators.
 
 Internally, dense array data should usually be processed as the standard arrays
-returned by validation. Use `CumlArray` at API boundaries, especially for
-descriptor-managed fitted attributes and returned values that need output-type
-reflection or index preservation. Low-level code that needs a specific memory
-location should request it explicitly through validation arguments such as
-`mem_type`.
+returned by validation. Low-level code that needs a specific memory location
+should request it explicitly through validation arguments such as `mem_type`.
 
 Public output type conversion is handled by `@mlfunc` and `ReflectedAttr`.
 Users choose output types in three ways:

--- a/wiki/python/ESTIMATOR_GUIDE.md
+++ b/wiki/python/ESTIMATOR_GUIDE.md
@@ -183,7 +183,7 @@ class MyEstimator(Base):
     @mlfunc(preserve_index=True)
     def transform(self, X):
         check_is_fitted(self)
-        X_m = check_inputs(self, X, order="K")
+        X = check_inputs(self, X, order="K")
         # Return an array-like object directly; @mlfunc handles conversion.
         return X
 ```
@@ -191,8 +191,8 @@ class MyEstimator(Base):
 Fit-like methods should use `@mlfunc(set_input_type=True)` in combination with
 the appropriate validation helpers. Pass `reset=True` to validation when
 fitting. Methods that return scalars may use `@mlfunc(convert_output=False)` to
-avoid some fully disable output conversion, though a plain `@mlfunc` would work
-as well.
+fully disable the output conversion code path, though a plain `@mlfunc` would
+work as well (no conversion happens for scalars anyway).
 
 ## Background
 
@@ -200,11 +200,13 @@ as well.
 
 cuML estimators should validate public inputs with `cuml.internals.validation`
 helpers such as `check_inputs`, `check_array`, `check_y`, and
-`check_sample_weight`. These helpers accept the standard cuML array-like
-inputs, apply estimator feature metadata checks, and normalize data to standard
-CuPy/NumPy or sparse array containers. Sparse estimators should configure the
-validation helpers for their supported sparse formats or follow the
-sparse-specific validation utilities used by neighboring sparse estimators.
+`check_sample_weight`. Prefer `check_inputs` for estimator methods that
+validate `X` and optional `y`/`sample_weight` values. These helpers accept the
+standard cuML array-like inputs, apply estimator feature metadata checks, and
+normalize data to standard CuPy/NumPy or sparse array containers. Sparse
+estimators should configure the validation helpers for their supported sparse
+formats or follow the sparse-specific validation utilities used by neighboring
+sparse estimators.
 
 Internally, dense array data should usually be processed as the standard arrays
 returned by validation. Low-level code that needs a specific memory location
@@ -227,15 +229,15 @@ Accepted output types are:
  - `None`: No global or estimator override. Reflected estimator methods infer
    from their input or fit-time input type.
  - `"input"`: Mirror the relevant input type.
- - `"array"`: Return a CuPy array for device data or a NumPy array for host data.
- - `"numba"`: Return a Numba device array.
- - `"dataframe"`: Return a cuDF DataFrame based on memory location.
- - `"series"`: Return a cuDF Series based on memory location.
- - `"df_obj"`: Return a Series for single-dimensional output or a DataFrame otherwise.
  - `"cupy"`: Return a CuPy array.
  - `"numpy"`: Return a NumPy array.
  - `"cudf"`: Return a cuDF Series or DataFrame.
  - `"pandas"`: Return a pandas Series or DataFrame.
+ - `"numba"`: Return a Numba device array.
+ - `"dataframe"`: Return a cuDF DataFrame.
+ - `"series"`: Return a cuDF Series.
+ - `"array"`: An alias for `"cupy"`.
+ - `"df_obj"`: An alias for `"cudf"`.
 
 The internal output type `"cuml"` may appear inside reflected calls.
 User-facing code should not set it.
@@ -256,7 +258,7 @@ from cuml.internals.validation import check_inputs, check_is_fitted
 
 @mlfunc(set_input_type=True)
 def fit(self, X, y, *, convert_dtype=True):
-    X_m, y_m = check_inputs(
+    X, y = check_inputs(
         self,
         X,
         y,
@@ -265,15 +267,15 @@ def fit(self, X, y, *, convert_dtype=True):
         order="K",
         reset=True,
     )
-    rows, cols = X_m.shape
-    dtype = X_m.dtype
+    rows, cols = X.shape
+    dtype = X.dtype
     ...
 
 
 @mlfunc(preserve_index=True)
 def transform(self, X, *, convert_dtype=True):
     check_is_fitted(self)
-    X_m = check_inputs(
+    X = check_inputs(
         self,
         X,
         dtype=self.result_.dtype,
@@ -459,7 +461,7 @@ class SampleEstimator(Base):
    my_array_ = ReflectedAttr()
    my_other_array_ = ReflectedAttr()
 
-   @mlfunc(set_input_Type=True)
+   @mlfunc(set_input_type=True)
    def fit(self, X):
       # reset=True on check_inputs sets n_features_in_ and feature_names_in_
       X = check_inputs(self, X, order="K", reset=True)
@@ -502,7 +504,7 @@ np_arr = np.ones((10,))
 my_est.fit(np_arr) # This will load data into attributes
 
 # Externally, descriptors reflect the fit-time input type by default
-print(type(my_est.my_array_)) # Output: Numpy (saved from the input of `fit`)
+print(type(my_est.my_array_)) # Output: NumPy (saved from the input of `fit`)
 
 # Calling fit again with cupy arrays, will have a similar effect
 my_est.fit(cp.ones((10,)))
@@ -551,7 +553,7 @@ class MyEstimator(Base):
     def predict(self, X):
         check_is_fitted(self)
         X = check_inputs(self, X, order="K")
-        return X + cp.ones(X_m.shape)
+        return X + cp.ones(X.shape)
 ```
 
 | Decorator Usage | When to Use |


### PR DESCRIPTION
Updates the guide to match the new decorators and descriptors. Removes all mentions of the legacy machinery. Also does some reformatting and some cleanups to more accurately reflect the recommended behaviors.

Fixes #8365.