### PR TITLE
Enable building with 26.08 nvForest

### DIFF
--- a/ci/build_wheel_cuml.sh
+++ b/ci/build_wheel_cuml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -28,7 +28,7 @@ EXCLUDE_ARGS=(
   --exclude "libcusolver.so.*"
   --exclude "libcusparse.so.*"
   --exclude "libcuvs.so"
-  --exclude "libnvforest++.so"
+  --exclude "libnvforest.so"
   --exclude "libnvJitLink.so.*"
   --exclude "libraft.so"
   --exclude "librapids_logger.so"

--- a/ci/build_wheel_libcuml.sh
+++ b/ci/build_wheel_libcuml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -36,7 +36,7 @@ EXCLUDE_ARGS=(
   --exclude "libcusolver.so.*"
   --exclude "libcusparse.so.*"
   --exclude "libcuvs.so"
-  --exclude "libnvforest++.so"
+  --exclude "libnvforest.so"
   --exclude "libnvJitLink.so.*"
   --exclude "libraft.so"
   --exclude "librapids_logger.so"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -276,7 +276,7 @@ endif()
 
 if(LINK_NVFOREST)
   include(cmake/thirdparty/get_nvforest.cmake)
-  set(CUML_NVFOREST_TARGET nvforest::nvforest++)
+  set(CUML_NVFOREST_TARGET nvforest::nvforest)
 endif()
 
 if(all_algo OR treeshap_algo)

--- a/cpp/cmake/thirdparty/get_nvforest.cmake
+++ b/cpp/cmake/thirdparty/get_nvforest.cmake
@@ -1,6 +1,6 @@
 #=============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 #=============================================================================
@@ -18,7 +18,7 @@ function(find_and_configure_nvforest)
     endif()
 
     rapids_cpm_find(nvforest ${PKG_VERSION}
-            GLOBAL_TARGETS      nvforest::nvforest++
+            GLOBAL_TARGETS      nvforest::nvforest
             BUILD_EXPORT_SET    cuml-exports
             INSTALL_EXPORT_SET  cuml-exports
             CPM_ARGS

--- a/cpp/tests/sg/rf_test.cu
+++ b/cpp/tests/sg/rf_test.cu
@@ -36,7 +36,7 @@
 #include <decisiontree/batched-levelalgo/objectives.cuh>
 #include <decisiontree/batched-levelalgo/quantiles.cuh>
 #include <gtest/gtest.h>
-#include <nvforest/detail/raft_proto/device_type.hpp>
+#include <nvforest/device_type.hpp>
 #include <nvforest/infer_kind.hpp>
 #include <nvforest/tree_layout.hpp>
 #include <nvforest/treelite_importer.hpp>
@@ -256,7 +256,7 @@ std::shared_ptr<thrust::device_vector<LabelT>> nvForestPredict(
                                                               nvforest::tree_layout::breadth_first,
                                                               128,
                                                               std::is_same_v<DataT, double>,
-                                                              raft_proto::device_type::gpu,
+                                                              nvforest::device_type::gpu,
                                                               handle.get_device(),
                                                               handle.get_next_usable_stream());
   handle.sync_stream();
@@ -267,8 +267,8 @@ std::shared_ptr<thrust::device_vector<LabelT>> nvForestPredict(
                          workspace->data().get(),
                          X_transpose,
                          params.n_rows,
-                         raft_proto::device_type::gpu,
-                         raft_proto::device_type::gpu,
+                         nvforest::device_type::gpu,
+                         nvforest::device_type::gpu,
                          nvforest::infer_kind::default_kind,
                          1);
   handle.sync_stream();
@@ -327,7 +327,7 @@ auto nvForestPredictProba(const raft::handle_t& handle,
                                                               nvforest::tree_layout::breadth_first,
                                                               128,
                                                               std::is_same_v<DataT, double>,
-                                                              raft_proto::device_type::gpu,
+                                                              nvforest::device_type::gpu,
                                                               handle.get_device(),
                                                               handle.get_next_usable_stream());
   handle.sync_stream();
@@ -338,8 +338,8 @@ auto nvForestPredictProba(const raft::handle_t& handle,
                          pred->data().get(),
                          X_transpose,
                          params.n_rows,
-                         raft_proto::device_type::gpu,
-                         raft_proto::device_type::gpu,
+                         nvforest::device_type::gpu,
+                         nvforest::device_type::gpu,
                          nvforest::infer_kind::default_kind,
                          1);
   handle.sync_stream();
@@ -931,7 +931,7 @@ TEST(RfTests, IntegerOverflow)
                                                               nvforest::tree_layout::breadth_first,
                                                               128,
                                                               false,
-                                                              raft_proto::device_type::gpu,
+                                                              nvforest::device_type::gpu,
                                                               handle.get_device(),
                                                               handle.get_next_usable_stream());
   handle.sync_stream();
@@ -942,8 +942,8 @@ TEST(RfTests, IntegerOverflow)
                          pred.data().get(),
                          X.data().get(),
                          m,
-                         raft_proto::device_type::gpu,
-                         raft_proto::device_type::gpu,
+                         nvforest::device_type::gpu,
+                         nvforest::device_type::gpu,
                          nvforest::infer_kind::default_kind,
                          1);
   handle.sync_stream();


### PR DESCRIPTION
Update cuML to build with 26.08 nvForest, after a breaking change (https://github.com/rapidsai/nvforest/pull/132).