### PR TITLE
Remove the deprecated `convert_dtype` kwarg

### DIFF
--- a/python/cuml/cuml/cluster/agglomerative.pyx
+++ b/python/cuml/cuml/cluster/agglomerative.pyx
@@ -136,7 +136,7 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "AgglomerativeClustering":
+    def fit(self, X, y=None) -> "AgglomerativeClustering":
         """
         Fit the hierarchical clustering from features.
         """
@@ -146,7 +146,6 @@ class AgglomerativeClustering(ClusterMixin, CMajorInputTagMixin, Base):
             X,
             order="C",
             dtype="float32",
-            convert_dtype=convert_dtype,
             ensure_min_samples=2,
             reset=True,
         )

--- a/python/cuml/cuml/cluster/dbscan.pyx
+++ b/python/cuml/cuml/cluster/dbscan.pyx
@@ -305,7 +305,6 @@ class DBSCAN(InteropMixin,
         sample_weight=None,
         *,
         out_dtype="int32",
-        convert_dtype="deprecated"
     ) -> "DBSCAN":
         """
         Perform DBSCAN clustering from features.
@@ -327,7 +326,6 @@ class DBSCAN(InteropMixin,
             X,
             sample_weight=sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="C",
             return_index=True,
             reset=True,
@@ -482,7 +480,6 @@ class DBSCAN(InteropMixin,
         sample_weight=None,
         *,
         out_dtype="int32",
-        convert_dtype="deprecated",
     ):
         """
         Performs clustering on X and returns cluster labels.
@@ -499,10 +496,5 @@ class DBSCAN(InteropMixin,
             negative weight may inhibit its eps-neighbor from being core.
             default: None (which is equivalent to weight 1 for all samples).
         """
-        self.fit(
-            X,
-            sample_weight=sample_weight,
-            out_dtype=out_dtype,
-            convert_dtype=convert_dtype
-        )
+        self.fit(X, sample_weight=sample_weight, out_dtype=out_dtype)
         return self.labels_

--- a/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
+++ b/python/cuml/cuml/cluster/hdbscan/hdbscan.pyx
@@ -903,7 +903,7 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "HDBSCAN":
+    def fit(self, X, y=None) -> "HDBSCAN":
         """
         Fit HDBSCAN model from features.
         """
@@ -923,7 +923,6 @@ class HDBSCAN(InteropMixin, ClusterMixin, CMajorInputTagMixin, Base):
             self,
             X,
             dtype="float32",
-            convert_dtype=convert_dtype,
             mem_type=mem_type,
             ensure_min_samples=2,
             return_index=True,
@@ -1177,12 +1176,7 @@ def all_points_membership_vectors(clusterer, int batch_size=4096):
 
 
 @mlfunc(model_arg="clusterer", array_arg="points_to_predict", preserve_index=True)
-def membership_vector(
-    clusterer,
-    points_to_predict,
-    int batch_size=4096,
-    convert_dtype="deprecated",
-):
+def membership_vector(clusterer, points_to_predict, int batch_size=4096):
     """
     Predict soft cluster membership. The result produces a vector
     for each point in ``points_to_predict`` that gives a probability that
@@ -1221,7 +1215,6 @@ def membership_vector(
         clusterer,
         points_to_predict,
         dtype="float32",
-        convert_dtype=convert_dtype,
         order="C",
     )
     cdef int n_prediction_points = points_to_predict.shape[0]
@@ -1261,7 +1254,7 @@ def membership_vector(
 
 
 @mlfunc(model_arg="clusterer", array_arg="points_to_predict", preserve_index=True)
-def approximate_predict(clusterer, points_to_predict, convert_dtype="deprecated"):
+def approximate_predict(clusterer, points_to_predict):
     """Predict the cluster label of new points. The returned labels
     will be those of the original clustering found by ``clusterer``,
     and therefore are not (necessarily) the cluster labels that would
@@ -1305,7 +1298,6 @@ def approximate_predict(clusterer, points_to_predict, convert_dtype="deprecated"
         clusterer,
         points_to_predict,
         dtype="float32",
-        convert_dtype=convert_dtype,
         order="C",
     )
     cdef int n_prediction_points = points_to_predict.shape[0]

--- a/python/cuml/cuml/cluster/kmeans.pyx
+++ b/python/cuml/cuml/cluster/kmeans.pyx
@@ -724,7 +724,7 @@ class KMeans(InteropMixin,
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, sample_weight=None, *, convert_dtype="deprecated") -> "KMeans":
+    def fit(self, X, y=None, sample_weight=None) -> "KMeans":
         """
         Compute k-means clustering with X.
 
@@ -745,7 +745,6 @@ class KMeans(InteropMixin,
             X,
             sample_weight=sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order=None,
             mem_type=None,
             reset=True,
@@ -783,7 +782,6 @@ class KMeans(InteropMixin,
                 self.init,
                 order="C",
                 dtype=X.dtype,
-                convert_dtype=convert_dtype,
             ).copy()
             if centers.shape[0] != self.n_clusters:
                 raise ValueError(
@@ -1006,7 +1004,7 @@ class KMeans(InteropMixin,
         """
         return self.fit(X, sample_weight=sample_weight).labels_
 
-    def _predict_labels_inertia(self, X, convert_dtype="deprecated", sample_weight=None):
+    def _predict_labels_inertia(self, X, sample_weight=None):
         """
         Predict the closest cluster each sample in X belongs to.
 
@@ -1016,13 +1014,6 @@ class KMeans(InteropMixin,
             Dense matrix (floats or doubles) of shape (n_samples, n_features).
             Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
             ndarray, cuda array interface compliant array like CuPy
-
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         sample_weight : array-like (device or host) shape = (n_samples,), default=None # noqa
             The weights for each observation in X. If None, all observations
@@ -1042,7 +1033,6 @@ class KMeans(InteropMixin,
             X,
             sample_weight=sample_weight,
             dtype=self.cluster_centers_.dtype,
-            convert_dtype=convert_dtype,
             order="C",
         )
         if sample_weight is None:
@@ -1068,12 +1058,12 @@ class KMeans(InteropMixin,
                                        'description': 'Cluster indexes',
                                        'shape': '(n_samples, 1)'})
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predict the closest cluster each sample in X belongs to.
 
         """
-        labels, _ = self._predict_labels_inertia(X, convert_dtype=convert_dtype)
+        labels, _ = self._predict_labels_inertia(X)
         return labels
 
     @generate_docstring(return_values={'name': 'X_new',
@@ -1081,7 +1071,7 @@ class KMeans(InteropMixin,
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
     @mlfunc(preserve_index=True)
-    def transform(self, X, *, convert_dtype="deprecated"):
+    def transform(self, X):
         """
         Transform X to a cluster-distance space.
 
@@ -1091,7 +1081,6 @@ class KMeans(InteropMixin,
             self,
             X,
             dtype=self.cluster_centers_.dtype,
-            convert_dtype=convert_dtype,
             order="C",
         )
 
@@ -1178,15 +1167,13 @@ class KMeans(InteropMixin,
                                                         of X on the K-means \
                                                         objective.'})
     @mlfunc(convert_output=False)
-    def score(self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"):
+    def score(self, X, y=None, sample_weight=None):
         """
         Opposite of the value of X on the K-means objective.
 
         """
 
-        inertia = self._predict_labels_inertia(
-            X, convert_dtype=convert_dtype, sample_weight=sample_weight
-        )[1]
+        inertia = self._predict_labels_inertia(X, sample_weight=sample_weight)[1]
         return -1 * inertia
 
     @generate_docstring(return_values={'name': 'X_new',
@@ -1194,12 +1181,10 @@ class KMeans(InteropMixin,
                                        'description': 'Transformed data',
                                        'shape': '(n_samples, n_clusters)'})
     @mlfunc(preserve_index=True)
-    def fit_transform(
-        self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"
-    ):
+    def fit_transform(self, X, y=None, sample_weight=None):
         """
         Compute clustering and transform X to cluster-distance space.
 
         """
         self.fit(X, sample_weight=sample_weight)
-        return self.transform(X, convert_dtype=convert_dtype)
+        return self.transform(X)

--- a/python/cuml/cuml/common/doc_utils.py
+++ b/python/cuml/cuml/common/doc_utils.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -54,12 +54,6 @@ _parameters_docstrings = {
     "    Acceptable dense formats: CUDA array interface compliant objects like\n"  # noqa
     "    CuPy, cuDF DataFrame/Series, NumPy ndarray and Pandas\n"
     "    DataFrame/Series.",
-    "convert_dtype": "convert_dtype : bool, optional (default = 'deprecated')\n"
-    "    .. deprecated:: 26.08\n"
-    "        `convert_dtype` was deprecated in version 26.08 and will be removed\n"
-    "        in version 26.10. cuML only copies input arrays when necessary\n"
-    "        (e.g. to unify dtypes), there is no reason to provide this keyword\n"
-    "        going forward.\n",
     "sample_weight": "sample_weight : array-like (device or host) shape = (n_samples,), default={default}\n"  # noqa
     "    The weights for each observation in X. If None, all observations\n"
     "    are assigned equal weight.\n"
@@ -107,7 +101,6 @@ _return_values_docstrings = {
 _return_values_possible_values = ["name", "type", "shape", "description"]
 
 _simple_params = [
-    "convert_dtype",
     "return_sparse",
     "sparse_tol",
     "sample_weight",
@@ -134,7 +127,6 @@ def generate_docstring(
     Currently auto detected variables include:
     - X
     - y
-    - convert_dtype
     - sample_weights
     - return_sparse
     - sparse_tol

--- a/python/cuml/cuml/covariance/empirical_covariance.py
+++ b/python/cuml/cuml/covariance/empirical_covariance.py
@@ -147,9 +147,7 @@ class EmpiricalCovariance(InteropMixin, Base):
         self.assume_centered = assume_centered
 
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y=None, *, convert_dtype="deprecated"
-    ) -> "EmpiricalCovariance":
+    def fit(self, X, y=None) -> "EmpiricalCovariance":
         """Fit the maximum likelihood covariance estimator to X.
 
         Parameters
@@ -159,12 +157,6 @@ class EmpiricalCovariance(InteropMixin, Base):
             and `n_features` is the number of features.
         y : Ignored
             Not used, present for API consistency.
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         Returns
         -------
@@ -175,7 +167,6 @@ class EmpiricalCovariance(InteropMixin, Base):
             self,
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             reset=True,
         )
         if X.shape[0] == 1:

--- a/python/cuml/cuml/covariance/ledoit_wolf.py
+++ b/python/cuml/cuml/covariance/ledoit_wolf.py
@@ -228,7 +228,7 @@ class LedoitWolf(InteropMixin, Base):
         self.block_size = block_size
 
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "LedoitWolf":
+    def fit(self, X, y=None) -> "LedoitWolf":
         """Fit the Ledoit-Wolf shrunk covariance model to X.
 
         Parameters
@@ -238,12 +238,6 @@ class LedoitWolf(InteropMixin, Base):
             and `n_features` is the number of features.
         y : Ignored
             Not used, present for API consistency.
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         Returns
         -------
@@ -254,7 +248,6 @@ class LedoitWolf(InteropMixin, Base):
             self,
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             reset=True,
         )
         if X.shape[0] == 1:

--- a/python/cuml/cuml/dask/ensemble/base.py
+++ b/python/cuml/cuml/dask/ensemble/base.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -88,7 +88,7 @@ class BaseRandomForestModel(object):
             n_estimators_per_worker[i] = n_estimators_per_worker[i] + 1
         return n_estimators_per_worker
 
-    def _fit(self, model, dataset, convert_dtype, broadcast_data):
+    def _fit(self, model, dataset, broadcast_data):
         data = DistributedDataHandler.create(dataset, client=self.client)
         self.active_workers = data.workers
         self.datatype = data.datatype
@@ -114,7 +114,6 @@ class BaseRandomForestModel(object):
                     _func_fit,
                     model[worker],
                     combined_data if broadcast_data else worker_data,
-                    convert_dtype,
                     workers=[worker],
                     pure=False,
                 )
@@ -305,10 +304,10 @@ class BaseRandomForestModel(object):
             return delayed_res.persist()
 
 
-def _func_fit(model, input_data, convert_dtype):
+def _func_fit(model, input_data):
     X = concatenate([item[0] for item in input_data])
     y = concatenate([item[1] for item in input_data])
-    return model.fit(X, y, convert_dtype=convert_dtype)
+    return model.fit(X, y)
 
 
 def _func_predict_partial(model, input_data, **kwargs):

--- a/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestclassifier.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -155,13 +155,7 @@ class RandomForestClassifier(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(
-        self,
-        X,
-        y,
-        convert_dtype="deprecated",
-        broadcast_data=False,
-    ):
+    def fit(self, X, y, broadcast_data=False):
         """
         Fit the input data with a Random Forest classifier
 
@@ -202,13 +196,6 @@ class RandomForestClassifier(
         y : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, 1)
             Labels of training examples.
             **y must be partitioned the same way as X**
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         broadcast_data : bool, optional (default = False)
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
@@ -229,7 +216,6 @@ class RandomForestClassifier(
         self._fit(
             model=self.rfs,
             dataset=(X, y),
-            convert_dtype=convert_dtype,
             broadcast_data=broadcast_data,
         )
         return self
@@ -238,7 +224,6 @@ class RandomForestClassifier(
         self,
         X,
         threshold=0.5,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -255,13 +240,6 @@ class RandomForestClassifier(
             (n_samples, n_features).
         threshold : float (default = 0.5)
             Threshold used for classification.
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -293,7 +271,6 @@ class RandomForestClassifier(
         if broadcast_data:
             return self.partial_inference(
                 X,
-                convert_dtype=convert_dtype,
                 layout=layout,
                 default_chunk_size=default_chunk_size,
                 align_bytes=align_bytes,
@@ -302,7 +279,6 @@ class RandomForestClassifier(
         return self._predict_using_fil(
             X,
             threshold=threshold,
-            convert_dtype=convert_dtype,
             layout=layout,
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,

--- a/python/cuml/cuml/dask/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/dask/ensemble/randomforestregressor.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import dask.array
@@ -138,13 +138,7 @@ class RandomForestRegressor(
             n_estimators=n_estimators, random_state=random_state, **kwargs
         )
 
-    def fit(
-        self,
-        X,
-        y,
-        convert_dtype="deprecated",
-        broadcast_data=False,
-    ):
+    def fit(self, X, y, broadcast_data=False):
         """
         Fit the input data with a Random Forest regression model
 
@@ -181,13 +175,6 @@ class RandomForestRegressor(
         y : Dask cuDF DataFrame or CuPy backed Dask Array (n_rows, 1)
             Labels of training examples.
             **y must be partitioned the same way as X**
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         broadcast_data : bool, optional (default = False)
             When set to True, the whole dataset is broadcasted
             to train the workers, otherwise each worker
@@ -197,7 +184,6 @@ class RandomForestRegressor(
         self._fit(
             model=self.rfs,
             dataset=(X, y),
-            convert_dtype=convert_dtype,
             broadcast_data=broadcast_data,
         )
         return self
@@ -205,7 +191,6 @@ class RandomForestRegressor(
     def predict(
         self,
         X,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -220,13 +205,6 @@ class RandomForestRegressor(
         X : Dask cuDF dataframe or CuPy backed Dask Array (n_rows, n_features)
             Distributed dense matrix (floats or doubles) of shape
             (n_samples, n_features).
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -257,7 +235,6 @@ class RandomForestRegressor(
         if broadcast_data:
             return self.partial_inference(
                 X,
-                convert_dtype=convert_dtype,
                 layout=layout,
                 default_chunk_size=default_chunk_size,
                 align_bytes=align_bytes,
@@ -265,7 +242,6 @@ class RandomForestRegressor(
             )
         return self._predict_using_fil(
             X,
-            convert_dtype=convert_dtype,
             layout=layout,
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,

--- a/python/cuml/cuml/dask/manifold/umap.py
+++ b/python/cuml/cuml/dask/manifold/umap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -87,7 +87,7 @@ class UMAP(BaseEstimator, DelayedTransformMixin):
 
         self._set_internal_model(model)
 
-    def transform(self, X, convert_dtype="deprecated"):
+    def transform(self, X):
         """
         Transform X into the existing embedded space and return that
         transformed output.
@@ -112,4 +112,4 @@ class UMAP(BaseEstimator, DelayedTransformMixin):
         """
         data = DistributedDataHandler.create(data=X, client=self.client)
         self.datatype = data.datatype
-        return self._transform(X, convert_dtype=convert_dtype)
+        return self._transform(X)

--- a/python/cuml/cuml/dask/neighbors/kneighbors_classifier.py
+++ b/python/cuml/cuml/dask/neighbors/kneighbors_classifier.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -130,7 +130,6 @@ class KNeighborsClassifier(NearestNeighbors):
         n_unique,
         ncols,
         rank,
-        convert_dtype,
         probas_only,
     ):
         if probas_only:
@@ -145,7 +144,6 @@ class KNeighborsClassifier(NearestNeighbors):
                 n_unique,
                 ncols,
                 rank,
-                convert_dtype,
             )
         else:
             return model.predict(
@@ -159,10 +157,9 @@ class KNeighborsClassifier(NearestNeighbors):
                 n_unique,
                 ncols,
                 rank,
-                convert_dtype,
             )
 
-    def predict(self, X, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predict labels for a query from previously stored index
         and index labels.
@@ -173,13 +170,6 @@ class KNeighborsClassifier(NearestNeighbors):
         X : array-like (device or host) shape = (n_samples, n_features)
             Query data.
             Acceptable formats: dask cuDF, dask CuPy/NumPy/Numba Array
-
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         Returns
         -------
@@ -255,7 +245,6 @@ class KNeighborsClassifier(NearestNeighbors):
                         self.n_unique,
                         X.shape[1],
                         worker_info[worker]["rank"],
-                        convert_dtype,
                         False,
                         key="%s-%s" % (key, idx),
                         workers=[worker],
@@ -277,7 +266,7 @@ class KNeighborsClassifier(NearestNeighbors):
 
         return to_output(out_futures, self.datatype).squeeze()
 
-    def score(self, X, y, convert_dtype="deprecated"):
+    def score(self, X, y):
         """
         Predict labels for a query from previously stored index
         and index labels.
@@ -297,7 +286,7 @@ class KNeighborsClassifier(NearestNeighbors):
         -------
         score
         """
-        y_pred_plain = self.predict(X, convert_dtype=convert_dtype)
+        y_pred_plain = self.predict(X)
         if not isinstance(y_pred_plain, da.Array):
             y_pred = y_pred_plain.to_dask_array(lengths=True)
         else:
@@ -310,7 +299,7 @@ class KNeighborsClassifier(NearestNeighbors):
         mean_match = matched.mean()
         return float(mean_match.compute())
 
-    def predict_proba(self, X, convert_dtype="deprecated"):
+    def predict_proba(self, X):
         """
         Provide score by comparing predictions and ground truth.
 
@@ -319,13 +308,6 @@ class KNeighborsClassifier(NearestNeighbors):
         X : array-like (device or host) shape = (n_samples, n_features)
             Query data.
             Acceptable formats: dask cuDF, dask CuPy/NumPy/Numba Array
-
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         Returns
         -------
@@ -401,7 +383,6 @@ class KNeighborsClassifier(NearestNeighbors):
                         self.n_unique,
                         X.shape[1],
                         worker_info[worker]["rank"],
-                        convert_dtype,
                         True,
                         key="%s-%s" % (key, idx),
                         workers=[worker],

--- a/python/cuml/cuml/dask/neighbors/kneighbors_regressor.py
+++ b/python/cuml/cuml/dask/neighbors/kneighbors_regressor.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -96,7 +96,6 @@ class KNeighborsRegressor(NearestNeighbors):
         ncols,
         rank,
         n_output,
-        convert_dtype,
     ):
         return model.predict(
             index,
@@ -108,10 +107,9 @@ class KNeighborsRegressor(NearestNeighbors):
             ncols,
             rank,
             n_output,
-            convert_dtype,
         )
 
-    def predict(self, X, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predict outputs for a query from previously stored index
         and outputs.
@@ -122,13 +120,6 @@ class KNeighborsRegressor(NearestNeighbors):
         X : array-like (device or host) shape = (n_samples, n_features)
             Query data.
             Acceptable formats: dask cuDF, dask CuPy/NumPy/Numba Array
-
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         Returns
         -------
@@ -203,7 +194,6 @@ class KNeighborsRegressor(NearestNeighbors):
                         X.shape[1],
                         self.n_outputs,
                         worker_info[worker]["rank"],
-                        convert_dtype,
                         key="%s-%s" % (key, idx),
                         workers=[worker],
                     ),

--- a/python/cuml/cuml/dask/neighbors/nearest_neighbors.py
+++ b/python/cuml/cuml/dask/neighbors/nearest_neighbors.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -88,7 +88,6 @@ class NearestNeighbors(BaseEstimator):
         ncols,
         rank,
         n_neighbors,
-        convert_dtype,
     ):
         return model.kneighbors(
             index,
@@ -100,7 +99,6 @@ class NearestNeighbors(BaseEstimator):
             ncols,
             rank,
             n_neighbors,
-            convert_dtype,
         )
 
     @staticmethod
@@ -206,7 +204,6 @@ class NearestNeighbors(BaseEstimator):
                         self.n_cols,
                         worker_info[worker]["rank"],
                         n_neighbors,
-                        False,
                         key="%s-%s" % (key, idx),
                         workers=[worker],
                     ),

--- a/python/cuml/cuml/decomposition/incremental_pca.py
+++ b/python/cuml/cuml/decomposition/incremental_pca.py
@@ -199,9 +199,7 @@ class IncrementalPCA(PCA):
         self.batch_size = batch_size
 
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y=None, *, convert_dtype="deprecated"
-    ) -> "IncrementalPCA":
+    def fit(self, X, y=None) -> "IncrementalPCA":
         """
         Fit the model with X, using minibatches of size batch_size.
 
@@ -230,7 +228,6 @@ class IncrementalPCA(PCA):
             X,
             accept_sparse=["csr", "csc"],
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             reset=True,
         )
 
@@ -391,7 +388,7 @@ class IncrementalPCA(PCA):
         return self
 
     @mlfunc(preserve_index=True)
-    def transform(self, X, *, convert_dtype="deprecated"):
+    def transform(self, X):
         """
         Apply dimensionality reduction to X.
 
@@ -404,13 +401,6 @@ class IncrementalPCA(PCA):
         X : array-like or sparse matrix, shape (n_samples, n_features)
             New data, where n_samples is the number of samples
             and n_features is the number of features.
-
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         Returns
         -------
@@ -428,7 +418,6 @@ class IncrementalPCA(PCA):
                 X,
                 accept_sparse=["csr", "csc"],
                 dtype=self.components_.dtype,
-                convert_dtype=convert_dtype,
             )
 
             n_samples, n_features = X.shape

--- a/python/cuml/cuml/decomposition/pca.pyx
+++ b/python/cuml/cuml/decomposition/pca.pyx
@@ -459,7 +459,7 @@ class PCA(InteropMixin,
 
     @generate_docstring(X='dense_sparse')
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "PCA":
+    def fit(self, X, y=None) -> "PCA":
         """
         Fit the model with X. y is currently ignored.
 
@@ -470,7 +470,6 @@ class PCA(InteropMixin,
             accept_sparse=["csr"],
             accept_large_sparse=True,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             ensure_min_samples=2,
             ensure_min_features=2,
             order="F",
@@ -575,7 +574,6 @@ class PCA(InteropMixin,
         self,
         X,
         *,
-        convert_dtype="deprecated",
         return_sparse=False,
         sparse_tol=1e-10,
     ):
@@ -590,7 +588,6 @@ class PCA(InteropMixin,
             X,
             accept_sparse=True,
             dtype=self.components_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
         )
         if X.shape[1] != self.n_components_:
@@ -665,7 +662,7 @@ class PCA(InteropMixin,
                                        'description': 'Transformed values',
                                        'shape': '(n_samples, n_components)'})
     @mlfunc(preserve_index=True)
-    def transform(self, X, *, convert_dtype="deprecated"):
+    def transform(self, X):
         """
         Apply dimensionality reduction to X.
 
@@ -680,7 +677,6 @@ class PCA(InteropMixin,
             X,
             accept_sparse=True,
             dtype=self.components_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
         )
         if is_sparse(X):

--- a/python/cuml/cuml/decomposition/tsvd.pyx
+++ b/python/cuml/cuml/decomposition/tsvd.pyx
@@ -297,7 +297,7 @@ class TruncatedSVD(InteropMixin,
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
     @mlfunc(set_input_type=True, preserve_index=True)
-    def fit_transform(self, X, y=None, *, convert_dtype="deprecated"):
+    def fit_transform(self, X, y=None):
         """
         Fit model to X and perform dimensionality reduction on X.
         y is currently ignored.
@@ -307,7 +307,6 @@ class TruncatedSVD(InteropMixin,
             self,
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="F",
             ensure_min_samples=2,
             ensure_min_features=2,
@@ -395,7 +394,7 @@ class TruncatedSVD(InteropMixin,
                                        'description': 'X in original space',
                                        'shape': '(n_samples, n_features)'})
     @mlfunc(preserve_index=True)
-    def inverse_transform(self, X, *, convert_dtype="deprecated"):
+    def inverse_transform(self, X):
         """
         Transform X back to its original space.
         Returns X_original whose transform would be X.
@@ -406,7 +405,6 @@ class TruncatedSVD(InteropMixin,
         X = check_array(
             X,
             dtype=self.components_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
         )
         if X.shape[1] != self.n_components:
@@ -458,7 +456,7 @@ class TruncatedSVD(InteropMixin,
                                        'description': 'Reduced version of X',
                                        'shape': '(n_samples, n_components)'})
     @mlfunc(preserve_index=True)
-    def transform(self, X, *, convert_dtype="deprecated"):
+    def transform(self, X):
         """
         Perform dimensionality reduction on X.
 
@@ -469,7 +467,6 @@ class TruncatedSVD(InteropMixin,
             self,
             X,
             dtype=self.components_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
         )
 

--- a/python/cuml/cuml/ensemble/randomforestclassifier.py
+++ b/python/cuml/cuml/ensemble/randomforestclassifier.py
@@ -255,9 +255,7 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
     )
     @generate_docstring(y="dense_intdtype")
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "RandomForestClassifier":
+    def fit(self, X, y, sample_weight=None) -> "RandomForestClassifier":
         """
         Perform Random Forest Classification on the input data
         """
@@ -267,7 +265,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
             y,
             sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="A",
             y_dtype="int32",
             sample_weight_dtype="float64",
@@ -299,7 +296,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         X,
         *,
         threshold=0.5,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -312,13 +308,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         X : {}
         threshold : float (default = 0.5)
             Threshold used for classification.
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Forest layout for GPU inference. Options: 'depth_first', 'layered',
             'breadth_first'.
@@ -342,7 +331,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
             self,
             X,
             dtype=nvforest_model.forest.get_dtype(),
-            convert_dtype=convert_dtype,
             order="C",
             mem_type="device",
         )
@@ -358,7 +346,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         self,
         X,
         *,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -369,13 +356,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         Parameters
         ----------
         X : {}
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -402,7 +382,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
             self,
             X,
             dtype=nvforest_model.forest.get_dtype(),
-            convert_dtype=convert_dtype,
             order="C",
             mem_type="device",
         )
@@ -417,7 +396,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         self,
         X,
         *,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -428,13 +406,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         Parameters
         ----------
         X : {}
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -454,7 +425,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         """
         out = self.predict_proba(
             X,
-            convert_dtype=convert_dtype,
             layout=layout,
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,
@@ -480,7 +450,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
         sample_weight=None,
         *,
         threshold=0.5,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -496,13 +465,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
             Sample weights for weighted mean accuracy.
         threshold : float (default = 0.5)
             Threshold used for classification predictions
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -525,7 +487,6 @@ class RandomForestClassifier(ClassifierMixin, BaseRandomForestModel):
             X,
             y,
             sample_weight=sample_weight,
-            convert_dtype=convert_dtype,
             threshold=threshold,
             layout=layout,
             default_chunk_size=default_chunk_size,

--- a/python/cuml/cuml/ensemble/randomforestregressor.py
+++ b/python/cuml/cuml/ensemble/randomforestregressor.py
@@ -197,9 +197,7 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
     )
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "RandomForestRegressor":
+    def fit(self, X, y, sample_weight=None) -> "RandomForestRegressor":
         """
         Perform Random Forest Regression on the input data
 
@@ -210,7 +208,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
             y,
             sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="A",
             sample_weight_dtype="float64",
             reset=True,
@@ -230,7 +227,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         self,
         X,
         *,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -241,13 +237,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         Parameters
         ----------
         X : {}
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -274,7 +263,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
             self,
             X,
             dtype=nvforest_model.forest.get_dtype(),
-            convert_dtype=convert_dtype,
             order="C",
             mem_type="device",
         )
@@ -303,7 +291,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         y,
         sample_weight=None,
         *,
-        convert_dtype="deprecated",
         layout="depth_first",
         default_chunk_size=None,
         align_bytes=None,
@@ -317,13 +304,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
         y : {}
         sample_weight : array-like, shape=(n_samples,), default=None
             Sample weights for weighted R^2.
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         layout : string (default = 'depth_first')
             Specifies the in-memory layout of nodes in FIL forests. Options:
             'depth_first', 'layered', 'breadth_first'.
@@ -345,7 +325,6 @@ class RandomForestRegressor(RegressorMixin, BaseRandomForestModel):
             X,
             y,
             sample_weight=sample_weight,
-            convert_dtype=convert_dtype,
             layout=layout,
             default_chunk_size=default_chunk_size,
             align_bytes=align_bytes,

--- a/python/cuml/cuml/explainer/tree_shap.pyx
+++ b/python/cuml/cuml/explainer/tree_shap.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import re
@@ -155,12 +155,11 @@ cdef class TreeExplainer:
     cdef object num_class
     cdef object data
 
-    def __init__(self, *, model, data=None, convert_dtype="deprecated"):
+    def __init__(self, *, model, data=None):
         if data is not None:
             data = check_array(
                 data,
                 dtype=("float32", "float64"),
-                convert_dtype=convert_dtype,
                 order="C",
                 ensure_all_finite=False,
             )
@@ -213,7 +212,7 @@ cdef class TreeExplainer:
         # Process Treelite model to extract path info
         self.path_info = extract_path_info(tl_handle)
 
-    def shap_values(self, X, convert_dtype="deprecated"):
+    def shap_values(self, X):
         """
         Estimate the SHAP values for a set of samples. For a given row, the
         SHAP values plus the `expected_value` attribute sum up to the raw
@@ -238,7 +237,6 @@ cdef class TreeExplainer:
         X = check_array(
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="C",
             ensure_all_finite=False,
         )
@@ -288,12 +286,7 @@ cdef class TreeExplainer:
             preds = preds[:, :-1]
         return preds
 
-    def shap_interaction_values(
-        self,
-        X,
-        method='shapley-interactions',
-        convert_dtype="deprecated",
-    ):
+    def shap_interaction_values(self, X, method='shapley-interactions'):
         """
         Estimate the SHAP interaction values for a set of samples. For a
         given row, the SHAP values plus the `expected_value` attribute sum
@@ -322,7 +315,6 @@ cdef class TreeExplainer:
         X = check_array(
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="C",
             ensure_all_finite=False,
         )

--- a/python/cuml/cuml/internals/validation.py
+++ b/python/cuml/cuml/internals/validation.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import numbers
@@ -538,7 +538,6 @@ def check_array(
     accept_sparse=False,
     accept_large_sparse=False,
     dtype=None,
-    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     copy=False,
@@ -570,13 +569,6 @@ def check_array(
         Pass a dtype or a list of supported dtypes to enforce a dtype for the
         output. If the input doesn't have a supported dtype, it will be
         converted to the first listed dtype.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be removed
-            in version 26.10. cuML only copies input arrays when necessary
-            (e.g. to unify dtypes), there is no reason to provide this keyword
-            going forward.
-
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray`` if dense, or a ``cupyx.scipy.sparse.spmatrix`` if
@@ -631,15 +623,6 @@ def check_array(
     if order not in ("F", "C", "A", None):
         raise ValueError(f"Unsupported {order=!r}")
 
-    if convert_dtype != "deprecated":
-        warnings.warn(
-            "`convert_dtype` was deprecated in version 26.08 and will be "
-            "removed in version 26.10. cuML only copies input arrays when "
-            "necessary (e.g. to unify dtypes), there is no reason to "
-            "provide this keyword going forward.",
-            FutureWarning,
-        )
-
     if dtype is not None:
         if not isinstance(dtype, (list, tuple)):
             dtype = [dtype]
@@ -683,14 +666,8 @@ def check_array(
         if dtype is None:
             dtype = array_dtype
         elif array_dtype not in dtype:
-            if convert_dtype is not False:
-                # Convert to first provided dtype
-                dtype = dtype[0]
-            else:
-                raise ValueError(
-                    f"Expected array with dtype in {[str(d) for d in dtype]} "
-                    f"but got {str(array_dtype)!r}"
-                )
+            # Convert to first provided dtype
+            dtype = dtype[0]
         else:
             dtype = array_dtype
     elif dtype is not None:
@@ -1045,7 +1022,6 @@ def check_y(
     y,
     *,
     dtype=None,
-    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     accept_multi_output=False,
@@ -1065,13 +1041,6 @@ def check_y(
         the input dtype will be used. Pass a dtype or a list of supported
         dtypes to enforce a dtype for the output. If the input doesn't have a
         supported dtype, it will be converted to the first listed dtype.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be removed
-            in version 26.10. cuML only copies input arrays when necessary
-            (e.g. to unify dtypes), there is no reason to provide this keyword
-            going forward.
-
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray``. If 'host', the output will be a ``numpy.ndarray``. If
@@ -1170,7 +1139,6 @@ def check_y(
         y = check_array(
             y,
             dtype=dtype,
-            convert_dtype=convert_dtype,
             mem_type=mem_type,
             order=order,
             ensure_2d=False,
@@ -1309,7 +1277,6 @@ def check_sample_weight(
     sample_weight,
     *,
     dtype=None,
-    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     ensure_non_negative=False,
@@ -1325,13 +1292,6 @@ def check_sample_weight(
         Pass a dtype or a list of supported dtypes to enforce a dtype for the
         output. If the input doesn't have a supported dtype, it will be
         converted to the first listed dtype.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be removed
-            in version 26.10. cuML only copies input arrays when necessary
-            (e.g. to unify dtypes), there is no reason to provide this keyword
-            going forward.
-
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray``. If 'host', the output will be a ``numpy.ndarray``. If
@@ -1372,7 +1332,6 @@ def check_sample_weight(
     sample_weight = check_array(
         sample_weight,
         dtype=dtype,
-        convert_dtype=convert_dtype,
         mem_type=mem_type,
         order=order,
         ensure_2d=False,
@@ -1402,7 +1361,6 @@ def check_inputs(
     dtype=None,
     y_dtype=...,
     sample_weight_dtype=...,
-    convert_dtype="deprecated",
     mem_type="device",
     order="A",
     copy=False,
@@ -1461,13 +1419,6 @@ def check_inputs(
     sample_weight_dtype : None, dtype, list[dtype], default=...
         The dtype(s) to support for sample_weight. If not specified, defaults
         to the output dtype of ``X``.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be removed
-            in version 26.10. cuML only copies input arrays when necessary
-            (e.g. to unify dtypes), there is no reason to provide this keyword
-            going forward.
-
     mem_type : {'device', 'host'} or None, default='device'
         The memory type use for the output. If 'device', the output will be a
         ``cupy.ndarray`` if dense, or a ``cupyx.scipy.sparse.spmatrix`` if
@@ -1542,7 +1493,6 @@ def check_inputs(
         accept_sparse=accept_sparse,
         accept_large_sparse=accept_large_sparse,
         dtype=dtype,
-        convert_dtype=convert_dtype,
         mem_type=mem_type,
         order=order,
         copy=copy,
@@ -1567,7 +1517,6 @@ def check_inputs(
         y = check_y(
             y,
             dtype=y_dtype,
-            convert_dtype=convert_dtype,
             mem_type=mem_type,
             order=order,
             accept_multi_output=accept_multi_output,
@@ -1584,7 +1533,6 @@ def check_inputs(
         sample_weight = check_sample_weight(
             sample_weight,
             dtype=sample_weight_dtype,
-            convert_dtype=convert_dtype,
             mem_type=mem_type,
             order=order,
         )

--- a/python/cuml/cuml/kernel_ridge/kernel_ridge.py
+++ b/python/cuml/cuml/kernel_ridge/kernel_ridge.py
@@ -285,15 +285,12 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "KernelRidge":
+    def fit(self, X, y, sample_weight=None) -> "KernelRidge":
         X, y, index = check_inputs(
             self,
             X,
             y,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             accept_multi_output=True,
             return_index=True,
             reset=True,
@@ -304,9 +301,7 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         # Unlike other solvers, we need to special-case scalar sample weights,
         # because K might be a pre-computed kernel.
         if not (np.isscalar(sample_weight) and np.isfinite(sample_weight)):
-            sample_weight = check_sample_weight(
-                sample_weight, dtype=X.dtype, convert_dtype=convert_dtype
-            )
+            sample_weight = check_sample_weight(sample_weight, dtype=X.dtype)
             check_consistent_length(X, y, sample_weight)
 
         K = self._get_kernel(X)
@@ -321,7 +316,7 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
         return self
 
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predict using the kernel ridge model.
 
@@ -339,11 +334,6 @@ class KernelRidge(InteropMixin, RegressorMixin, Base):
             Returns predicted values.
         """
         check_is_fitted(self)
-        X = check_inputs(
-            self,
-            X,
-            dtype=self.X_fit_.array.dtype,
-            convert_dtype=convert_dtype,
-        )
+        X = check_inputs(self, X, dtype=self.X_fit_.array.dtype)
         K = self._get_kernel(X, self.X_fit_.array).astype(X.dtype, copy=False)
         return cp.dot(K, self.dual_coef_)

--- a/python/cuml/cuml/linear_model/base.py
+++ b/python/cuml/cuml/linear_model/base.py
@@ -20,7 +20,7 @@ class LinearPredictMixin:
         }
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts `y` values for `X`.
         """
@@ -30,7 +30,6 @@ class LinearPredictMixin:
             self,
             X,
             dtype=self.coef_.dtype,
-            convert_dtype=convert_dtype,
             order=None,
             accept_sparse=True,
         )
@@ -51,7 +50,7 @@ class LinearClassifierMixin:
         },
     )
     @mlfunc(preserve_index=True)
-    def decision_function(self, X, *, convert_dtype="deprecated"):
+    def decision_function(self, X):
         """Predict confidence scores for samples."""
         check_is_fitted(self)
 
@@ -59,7 +58,6 @@ class LinearClassifierMixin:
             self,
             X,
             dtype=self.coef_.dtype,
-            convert_dtype=convert_dtype,
             order=None,
             accept_sparse=True,
         )

--- a/python/cuml/cuml/linear_model/elastic_net.py
+++ b/python/cuml/cuml/linear_model/elastic_net.py
@@ -223,9 +223,7 @@ class ElasticNet(
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "ElasticNet":
+    def fit(self, X, y, sample_weight=None) -> "ElasticNet":
         """
         Fit the model with X and y.
 
@@ -249,7 +247,6 @@ class ElasticNet(
                 X,
                 y,
                 sample_weight=sample_weight,
-                convert_dtype=convert_dtype,
                 loss="l2",
                 fit_intercept=self.fit_intercept,
                 l1_strength=self.alpha * self.l1_ratio,
@@ -272,7 +269,6 @@ class ElasticNet(
                 X,
                 y,
                 sample_weight=sample_weight,
-                convert_dtype=convert_dtype,
                 alpha=self.alpha,
                 fit_intercept=self.fit_intercept,
                 l1_ratio=self.l1_ratio,

--- a/python/cuml/cuml/linear_model/lars.pyx
+++ b/python/cuml/cuml/linear_model/lars.pyx
@@ -199,7 +199,7 @@ class Lars(RegressorMixin, Base):
 
     @generate_docstring(y="dense_anydtype")
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, *, convert_dtype="deprecated") -> "Lars":
+    def fit(self, X, y) -> "Lars":
         """
         Fit the model with X and y.
 
@@ -210,7 +210,6 @@ class Lars(RegressorMixin, Base):
             X,
             y,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="F",
             ensure_min_samples=2,
             reset=True,
@@ -339,7 +338,7 @@ class Lars(RegressorMixin, Base):
         }
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """Predicts `y` values for `X`."""
         check_is_fitted(self)
 
@@ -347,7 +346,6 @@ class Lars(RegressorMixin, Base):
             self,
             X,
             dtype=self.coef_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
         )
         cdef int n_rows = X.shape[0]

--- a/python/cuml/cuml/linear_model/linear_regression.pyx
+++ b/python/cuml/cuml/linear_model/linear_regression.pyx
@@ -314,14 +314,7 @@ class LinearRegression(InteropMixin,
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self,
-        X,
-        y,
-        sample_weight=None,
-        *,
-        convert_dtype="deprecated",
-    ) -> "LinearRegression":
+    def fit(self, X, y, sample_weight=None) -> "LinearRegression":
         """
         Fit the model with X and y.
 
@@ -333,7 +326,6 @@ class LinearRegression(InteropMixin,
             y,
             sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             ensure_min_samples=2,
             accept_sparse=True,
             accept_large_sparse=True,

--- a/python/cuml/cuml/linear_model/logistic_regression.py
+++ b/python/cuml/cuml/linear_model/logistic_regression.py
@@ -287,9 +287,7 @@ class LogisticRegression(
 
     @generate_docstring(X="dense_sparse")
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "LogisticRegression":
+    def fit(self, X, y, sample_weight=None) -> "LogisticRegression":
         """
         Fit the model with X and y.
         """
@@ -300,7 +298,6 @@ class LogisticRegression(
             X,
             y,
             sample_weight=sample_weight,
-            convert_dtype=convert_dtype,
             loss="logistic",
             fit_intercept=self.fit_intercept,
             l1_strength=l1_strength,
@@ -332,12 +329,12 @@ class LogisticRegression(
         },
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts the y for X.
 
         """
-        scores = self.decision_function(X, convert_dtype=convert_dtype)
+        scores = self.decision_function(X)
 
         if scores.ndim == 1:
             indices = (scores > 0).view(cp.int8)
@@ -356,11 +353,11 @@ class LogisticRegression(
         },
     )
     @mlfunc(preserve_index=True)
-    def predict_proba(self, X, *, convert_dtype="deprecated"):
+    def predict_proba(self, X):
         """
         Predicts the class probabilities for each class in X
         """
-        scores = self.decision_function(X, convert_dtype=convert_dtype)
+        scores = self.decision_function(X)
 
         n_classes = self.classes_.shape[0]
         if n_classes == 2:
@@ -385,10 +382,10 @@ class LogisticRegression(
         },
     )
     @mlfunc(preserve_index=True)
-    def predict_log_proba(self, X, *, convert_dtype="deprecated"):
+    def predict_log_proba(self, X):
         """
         Predicts the log class probabilities for each class in X
         """
-        out = self.predict_proba(X, convert_dtype=convert_dtype)
+        out = self.predict_proba(X)
         cp.log(out, out=out)
         return out

--- a/python/cuml/cuml/linear_model/mbsgd_classifier.py
+++ b/python/cuml/cuml/linear_model/mbsgd_classifier.py
@@ -171,7 +171,7 @@ class MBSGDClassifier(
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, *, convert_dtype="deprecated") -> "MBSGDClassifier":
+    def fit(self, X, y) -> "MBSGDClassifier":
         """
         Fit the model with X and y.
 
@@ -180,7 +180,6 @@ class MBSGDClassifier(
             self,
             X,
             y,
-            convert_dtype=convert_dtype,
             loss=self.loss,
             penalty=self.penalty,
             alpha=self.alpha,
@@ -210,12 +209,12 @@ class MBSGDClassifier(
         }
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts the y for X.
 
         """
-        scores = self.decision_function(X, convert_dtype=convert_dtype)
+        scores = self.decision_function(X)
         thresh = 0 if self.loss == "hinge" else 0.5
         indices = (scores > thresh).view(cp.int8)
         return ClassLabels(indices, self.classes_)

--- a/python/cuml/cuml/linear_model/mbsgd_regressor.py
+++ b/python/cuml/cuml/linear_model/mbsgd_regressor.py
@@ -160,7 +160,7 @@ class MBSGDRegressor(
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, *, convert_dtype="deprecated") -> "MBSGDRegressor":
+    def fit(self, X, y) -> "MBSGDRegressor":
         """
         Fit the model with X and y.
 
@@ -171,7 +171,6 @@ class MBSGDRegressor(
             self,
             X,
             y,
-            convert_dtype=convert_dtype,
             loss=self.loss,
             penalty=self.penalty,
             alpha=self.alpha,

--- a/python/cuml/cuml/linear_model/ridge.pyx
+++ b/python/cuml/cuml/linear_model/ridge.pyx
@@ -361,7 +361,7 @@ class Ridge(InteropMixin,
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, sample_weight=None, *, convert_dtype="deprecated") -> "Ridge":
+    def fit(self, X, y, sample_weight=None) -> "Ridge":
         """
         Fit the model with X and y.
         """
@@ -372,7 +372,6 @@ class Ridge(InteropMixin,
             y,
             sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             ensure_min_samples=2,
             accept_sparse=True,
             accept_large_sparse=True,

--- a/python/cuml/cuml/manifold/t_sne.pyx
+++ b/python/cuml/cuml/manifold/t_sne.pyx
@@ -557,7 +557,7 @@ class TSNE(InteropMixin,
     @generate_docstring(skip_parameters_heading=True,
                         X='dense_sparse')
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated", knn_graph=None) -> "TSNE":
+    def fit(self, X, y=None, *, knn_graph=None) -> "TSNE":
         """
         Fit X into an embedded space.
 
@@ -582,7 +582,6 @@ class TSNE(InteropMixin,
             self,
             X,
             dtype="float32",
-            convert_dtype=convert_dtype,
             order="F",
             accept_sparse="csr",
             ensure_min_samples=2,
@@ -681,13 +680,11 @@ class TSNE(InteropMixin,
                                                        low-dimensional space.',
                                        'shape': '(n_samples, n_components)'})
     @mlfunc(preserve_index=True)
-    def fit_transform(
-        self, X, y=None, *, convert_dtype="deprecated", knn_graph=None
-    ):
+    def fit_transform(self, X, y=None, *, knn_graph=None):
         """
         Fit X into an embedded space and return that transformed output.
         """
-        self.fit(X, convert_dtype=convert_dtype, knn_graph=knn_graph)
+        self.fit(X, knn_graph=knn_graph)
         return self.embedding_
 
     @property

--- a/python/cuml/cuml/manifold/umap/umap.pyx
+++ b/python/cuml/cuml/manifold/umap/umap.pyx
@@ -1201,7 +1201,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         skip_parameters_heading=True,
     )
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated", knn_graph=None) -> "UMAP":
+    def fit(self, X, y=None, *, knn_graph=None) -> "UMAP":
         """
         Fit X into an embedded space.
 
@@ -1227,12 +1227,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             reset=True,
         )
         if y is not None:
-            y = check_y(
-                y,
-                dtype="float32",
-                convert_dtype=convert_dtype,
-                order="C",
-            )
+            y = check_y(y, dtype="float32", order="C")
             check_consistent_length(X, y)
 
         cdef int n_rows = X.shape[0]
@@ -1265,7 +1260,6 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             X,
             mem_type=mem_type,
             dtype="float32",
-            convert_dtype=convert_dtype,
             order="C",
             accept_sparse="csr",
             ensure_min_samples=2,
@@ -1428,9 +1422,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         }
     )
     @mlfunc(preserve_index=True)
-    def fit_transform(
-        self, X, y=None, *, convert_dtype="deprecated", knn_graph=None
-    ):
+    def fit_transform(self, X, y=None, *, knn_graph=None):
         """
         Fit X into an embedded space and return that transformed
         output.
@@ -1451,7 +1443,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             over it. See the ``UMAP`` docstring on ``precomputed_knn`` for more
             information.
         """
-        self.fit(X, y, convert_dtype=convert_dtype, knn_graph=knn_graph)
+        self.fit(X, y, knn_graph=knn_graph)
         return self.embedding_
 
     @generate_docstring(
@@ -1463,7 +1455,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         }
     )
     @mlfunc(preserve_index=True)
-    def transform(self, X, *, convert_dtype="deprecated"):
+    def transform(self, X):
         """
         Transform X into the existing embedded space and return that
         transformed output.
@@ -1481,7 +1473,6 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             self,
             X,
             dtype="float32",
-            convert_dtype=convert_dtype,
             order="C",
             accept_sparse="csr",
         )
@@ -1589,7 +1580,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
         }
     )
     @mlfunc(preserve_index=True)
-    def inverse_transform(self, X, *, convert_dtype="deprecated"):
+    def inverse_transform(self, X):
         """Transform X in the existing embedded space back into the input
         data space and return that transformed output.
         """
@@ -1607,12 +1598,7 @@ class UMAP(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base):
             )
 
         # skip n_features_in_ validation
-        X = check_array(
-            X,
-            dtype="float32",
-            convert_dtype=convert_dtype,
-            order="C",
-        )
+        X = check_array(X, dtype="float32", order="C")
 
         n_samples = X.shape[0]
         if X.shape[1] != self.n_components:
@@ -1835,7 +1821,6 @@ def simplicial_set_embedding(
     metric_kwds=None,
     output_metric="euclidean",
     output_metric_kwds=None,
-    convert_dtype="deprecated",
     verbose=False,
 ):
     """Perform a fuzzy simplicial set embedding, using a specified
@@ -1928,7 +1913,6 @@ def simplicial_set_embedding(
     X = check_array(
         data,
         dtype="float32",
-        convert_dtype=convert_dtype,
         order="C",
         input_name="X",
     )
@@ -1986,7 +1970,6 @@ def simplicial_set_embedding(
         embedding = check_array(
             init,
             dtype="float32",
-            convert_dtype=convert_dtype,
             order="C",
             input_name="init",
         )

--- a/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
+++ b/python/cuml/cuml/metrics/cluster/adjusted_rand_index.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import numpy as np
@@ -19,7 +19,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
                                int n) except +
 
 
-def adjusted_rand_score(labels_true, labels_pred, convert_dtype="deprecated") -> float:
+def adjusted_rand_score(labels_true, labels_pred) -> float:
     """
     Adjusted_rand_score is a clustering similarity metric based on the Rand
     index and is corrected for chance.
@@ -44,7 +44,6 @@ def adjusted_rand_score(labels_true, labels_pred, convert_dtype="deprecated") ->
         ensure_min_samples=0,
         order='C',
         dtype=np.int32,
-        convert_dtype=convert_dtype,
         input_name='labels_true',
     )
     labels_pred = check_array(
@@ -53,7 +52,6 @@ def adjusted_rand_score(labels_true, labels_pred, convert_dtype="deprecated") ->
         ensure_min_samples=0,
         order='C',
         dtype=np.int32,
-        convert_dtype=convert_dtype,
         input_name='labels_pred',
     )
     if labels_true.ndim != 1 or labels_pred.ndim != 1:

--- a/python/cuml/cuml/metrics/cluster/silhouette_score.pyx
+++ b/python/cuml/cuml/metrics/cluster/silhouette_score.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -39,9 +39,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics::Batched" nog
         DistanceType metric) except +
 
 
-def _silhouette_coeff(
-        X, labels, metric='euclidean', sil_scores=None, chunksize=None,
-        convert_dtype="deprecated"):
+def _silhouette_coeff(X, labels, metric='euclidean', sil_scores=None, chunksize=None):
     """Function wrapped by silhouette_score and silhouette_samples to compute
     silhouette coefficients.
 
@@ -76,7 +74,6 @@ def _silhouette_coeff(
         X,
         order='C',
         dtype=[np.float32, np.float64],
-        convert_dtype=convert_dtype,
         input_name='X',
     )
     cdef int n_rows = data.shape[0]
@@ -110,7 +107,6 @@ def _silhouette_coeff(
             ensure_2d=False,
             order='C',
             dtype=[dtype],
-            convert_dtype=convert_dtype,
             input_name='sil_scores',
             ensure_all_finite=False,  # output buffer may be uninitialized
         )
@@ -145,7 +141,6 @@ def cython_silhouette_score(
     labels,
     metric='euclidean',
     chunksize=None,
-    convert_dtype="deprecated",
 ):
     """Calculate the mean silhouette coefficient for the provided data.
 
@@ -175,7 +170,6 @@ def cython_silhouette_score(
 
     return _silhouette_coeff(
         X, labels, chunksize=chunksize, metric=metric,
-        convert_dtype=convert_dtype
     )
 
 
@@ -184,7 +178,6 @@ def cython_silhouette_samples(
     labels,
     metric='euclidean',
     chunksize=None,
-    convert_dtype="deprecated",
 ):
     """Calculate the silhouette coefficient for each sample in the provided data.
 
@@ -216,7 +209,6 @@ def cython_silhouette_samples(
 
     _silhouette_coeff(
         X, labels, chunksize=chunksize, metric=metric, sil_scores=sil_scores,
-        convert_dtype=convert_dtype
     )
 
     return sil_scores

--- a/python/cuml/cuml/metrics/confusion_matrix.py
+++ b/python/cuml/cuml/metrics/confusion_matrix.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -19,7 +19,6 @@ def confusion_matrix(
     labels=None,
     sample_weight=None,
     normalize=None,
-    convert_dtype="deprecated",
 ) -> cp.ndarray:
     """Compute confusion matrix to evaluate the accuracy of a classification.
 
@@ -39,12 +38,6 @@ def confusion_matrix(
         Normalizes confusion matrix over the true (rows), predicted (columns)
         conditions or all the population. If None, confusion matrix will not be
         normalized.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
 
     Returns
     -------
@@ -55,14 +48,12 @@ def confusion_matrix(
         y_true,
         ensure_2d=False,
         dtype=("int32", "int64"),
-        convert_dtype=convert_dtype,
         input_name="y_true",
     )
     y_pred = check_array(
         y_pred,
         ensure_2d=False,
         dtype=("int32", "int64"),
-        convert_dtype=convert_dtype,
         input_name="y_pred",
     )
     if y_true.ndim != 1 or y_pred.ndim != 1:
@@ -73,7 +64,6 @@ def confusion_matrix(
     sample_weight = check_sample_weight(
         sample_weight,
         dtype=("float32", "float64", "int32", "int64"),
-        convert_dtype=convert_dtype,
     )
     check_consistent_length(y_true, y_pred, sample_weight)
 
@@ -82,7 +72,6 @@ def confusion_matrix(
             labels,
             ensure_2d=False,
             dtype=("int32", "int64"),
-            convert_dtype=convert_dtype,
             input_name="labels",
             ensure_min_samples=0,
         )

--- a/python/cuml/cuml/metrics/kl_divergence.pyx
+++ b/python/cuml/cuml/metrics/kl_divergence.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import numpy as np
@@ -24,7 +24,7 @@ cdef extern from "cuml/metrics/metrics.hpp" namespace "ML::Metrics" nogil:
         int n) except +
 
 
-def kl_divergence(P, Q, convert_dtype="deprecated"):
+def kl_divergence(P, Q):
     """
     Calculates the "Kullback-Leibler" Divergence
     The KL divergence tells us how well the probability distribution Q
@@ -44,13 +44,6 @@ def kl_divergence(P, Q, convert_dtype="deprecated"):
         Acceptable formats: cuDF DataFrame, NumPy ndarray, Numba device
         ndarray, cuda array interface compliant array like CuPy.
 
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
-
     Returns
     -------
     float
@@ -64,7 +57,6 @@ def kl_divergence(P, Q, convert_dtype="deprecated"):
         ensure_2d=False,
         order='C',
         dtype=[np.float32, np.float64],
-        convert_dtype=convert_dtype,
         input_name='P',
     )
     if P_m.ndim == 2 and P_m.shape[1] != 1:
@@ -80,7 +72,6 @@ def kl_divergence(P, Q, convert_dtype="deprecated"):
         ensure_2d=False,
         order='C',
         dtype=[dtype_p],
-        convert_dtype=convert_dtype,
         input_name='Q',
     )
     if Q_m.ndim == 2 and Q_m.shape[1] != 1:

--- a/python/cuml/cuml/metrics/pairwise_distances.pyx
+++ b/python/cuml/cuml/metrics/pairwise_distances.pyx
@@ -107,7 +107,6 @@ def nan_euclidean_distances(
     squared=False,
     missing_values=cp.nan,
     copy=True,
-    convert_dtype="deprecated",
 ):
     """Calculate the euclidean distances in the presence of missing values.
 
@@ -153,13 +152,6 @@ def nan_euclidean_distances(
         False can reduce memory usage, but may result in mutation
         of X and Y.
 
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
-
     Returns
     -------
     distances : array of shape (n_samples_X, n_samples_Y)
@@ -172,7 +164,6 @@ def nan_euclidean_distances(
         X,
         order="A",
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         ensure_all_finite="allow-nan",
         input_name="X",
         copy=copy,
@@ -190,7 +181,6 @@ def nan_euclidean_distances(
                 "A"
             ),
             dtype=X.dtype,
-            convert_dtype=convert_dtype,
             ensure_all_finite="allow-nan",
             input_name="Y",
             copy=copy,
@@ -266,9 +256,7 @@ def _ensure_boolean(X, metric):
 
 
 @mlfunc
-def pairwise_distances(
-    X, Y=None, metric="euclidean", convert_dtype="deprecated", **kwds
-):
+def pairwise_distances(X, Y=None, metric="euclidean", **kwds):
     """Compute the distance matrix from a feature array X and optional Y.
 
     This function takes either one or two feature arrays, and returns
@@ -294,13 +282,6 @@ def pairwise_distances(
           'kldivergence', 'nan_euclidean', 'russellrao'].
 
         - Supports sparse only: ['dice', 'inner_product', 'jaccard'].
-
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
 
     **kwds : optional keyword parameters
         Any additional metric-specific parameters. For example, with
@@ -345,7 +326,6 @@ def pairwise_distances(
         X,
         order="A",
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         input_name="X",
         accept_sparse="csr",
     )
@@ -364,7 +344,6 @@ def pairwise_distances(
                 "A"
             ),
             dtype=X.dtype,
-            convert_dtype=convert_dtype,
             input_name="Y",
             accept_sparse="csr",
         )
@@ -494,9 +473,7 @@ def pairwise_distances(
 
 
 @mlfunc
-def sparse_pairwise_distances(
-    X, Y=None, metric="euclidean", convert_dtype="deprecated", **kwds
-):
+def sparse_pairwise_distances(X, Y=None, metric="euclidean", **kwds):
     """
     Compute the distance matrix from a vector array `X` and optional `Y`.
 
@@ -536,13 +513,6 @@ def sparse_pairwise_distances(
         "jaccard", "hellinger", "chebyshev", "linf", "dice"}
         The metric to use when calculating distance between instances in a
         feature array.
-
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
 
     **kwds : optional keyword parameters
         Any additional metric-specific parameters. For example, with
@@ -593,6 +563,5 @@ def sparse_pairwise_distances(
         X,
         Y,
         metric=metric,
-        convert_dtype=convert_dtype,
         **kwds,
     )

--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -184,7 +184,6 @@ def pairwise_kernels(
     metric="linear",
     *,
     filter_params=False,
-    convert_dtype="deprecated",
     **kwds,
 ):
     """
@@ -224,13 +223,6 @@ def pairwise_kernels(
         kernel value as a single number.
     filter_params : bool, default=False
         Whether to filter invalid parameters or not.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
-
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the kernel function.
 

--- a/python/cuml/cuml/metrics/trustworthiness.pyx
+++ b/python/cuml/cuml/metrics/trustworthiness.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import numpy as np
@@ -40,7 +40,6 @@ def trustworthiness(
     X_embedded,
     n_neighbors=5,
     metric='euclidean',
-    convert_dtype="deprecated",
     batch_size=512,
 ) -> float:
     """
@@ -64,13 +63,6 @@ def trustworthiness(
             Metric used to compute the trustworthiness. For the moment only
             'euclidean' is supported.
 
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
-
         batch_size : int (default=512)
             The number of samples to use for each batch.
 
@@ -93,7 +85,6 @@ def trustworthiness(
         X,
         order='C',
         dtype=np.float32,
-        convert_dtype=convert_dtype,
         input_name='X',
     )
     cdef int n_samples = X_m.shape[0]
@@ -104,7 +95,6 @@ def trustworthiness(
         X_embedded,
         order='C',
         dtype=np.float32,
-        convert_dtype=convert_dtype,
         input_name='X_embedded',
     )
     check_consistent_length(X_m, X_m2)

--- a/python/cuml/cuml/naive_bayes/naive_bayes.py
+++ b/python/cuml/cuml/naive_bayes/naive_bayes.py
@@ -58,14 +58,13 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         """An optional transform to apply to X after it's been validated"""
         return X
 
-    def _check_predict(self, X, *, convert_dtype="deprecated"):
+    def _check_predict(self, X):
         """Validate and return X for predict."""
         X = check_inputs(
             self,
             X,
             dtype=self._supported_dtypes,
             sample_weight_dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             accept_sparse=["coo", "csr"],
             ensure_non_negative=self.__sklearn_tags__().input_tags.positive_only,
         )
@@ -79,7 +78,6 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         sample_weight=None,
         *,
         reset=False,
-        convert_dtype="deprecated",
     ):
         """Validate and return (X, y, classes, sample_weight) for fit."""
         if reset:
@@ -99,7 +97,6 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
             dtype=self._supported_dtypes,
             y_dtype=None,
             sample_weight_dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             accept_sparse=["coo", "csr"],
             ensure_non_negative=self.__sklearn_tags__().input_tags.positive_only,
             return_classes=(True if classes is None else classes),
@@ -147,14 +144,14 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         },
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Perform classification on an array of test vectors X.
 
         """
         check_is_fitted(self)
 
-        X = self._check_predict(X, convert_dtype=convert_dtype)
+        X = self._check_predict(X)
         jll = self._joint_log_likelihood(X)
         indices = cp.argmax(jll, axis=1)
         return ClassLabels(indices, self.classes_)
@@ -173,13 +170,13 @@ class _BaseNB(ClassifierMixin, SparseInputTagMixin, Base):
         },
     )
     @mlfunc(preserve_index=True)
-    def predict_log_proba(self, X, *, convert_dtype="deprecated"):
+    def predict_log_proba(self, X):
         """
         Return log-probability estimates for the test vector X.
 
         """
         check_is_fitted(self)
-        X = self._check_predict(X, convert_dtype=convert_dtype)
+        X = self._check_predict(X)
         jll = self._joint_log_likelihood(X)
 
         # normalize by P(X) = P(f_1, ..., f_n)
@@ -303,7 +300,6 @@ class GaussianNB(_BaseNB):
         classes=None,
         sample_weight=None,
         reset=False,
-        convert_dtype="deprecated",
     ) -> "GaussianNB":
         classes, reset = self._check_classes(classes, reset)
         X, y, classes, sample_weight = self._check_fit(
@@ -312,7 +308,6 @@ class GaussianNB(_BaseNB):
             classes=classes,
             sample_weight=sample_weight,
             reset=reset,
-            convert_dtype=convert_dtype,
         )
 
         self.epsilon_ = self.var_smoothing * (
@@ -656,7 +651,6 @@ class _BaseDiscreteNB(_BaseNB):
         y,
         classes=None,
         reset=False,
-        convert_dtype="deprecated",
     ) -> "_BaseDiscreteNB":
         if self.alpha < 0:
             raise ValueError(f"Expected alpha >= 0, got {self.alpha}")
@@ -667,7 +661,6 @@ class _BaseDiscreteNB(_BaseNB):
             y,
             classes=classes,
             reset=reset,
-            convert_dtype=convert_dtype,
         )
 
         if reset:

--- a/python/cuml/cuml/neighbors/kernel_density.pyx
+++ b/python/cuml/cuml/neighbors/kernel_density.pyx
@@ -211,9 +211,7 @@ class KernelDensity(InteropMixin, Base):
         self.metric_params = metric_params
 
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y=None, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "KernelDensity":
+    def fit(self, X, y=None, sample_weight=None) -> "KernelDensity":
         """Fit the Kernel Density model on the data.
 
         Parameters
@@ -253,7 +251,6 @@ class KernelDensity(InteropMixin, Base):
             X,
             sample_weight=sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="C",
             reset=True,
         )
@@ -277,7 +274,7 @@ class KernelDensity(InteropMixin, Base):
         return self
 
     @mlfunc(preserve_index=True)
-    def score_samples(self, X, *, convert_dtype="deprecated"):
+    def score_samples(self, X):
         """Compute the log-likelihood of each sample under the model.
 
         Parameters
@@ -298,7 +295,6 @@ class KernelDensity(InteropMixin, Base):
             self,
             X,
             dtype=[self._X.dtype],
-            convert_dtype=convert_dtype,
             order="C",
         )
         if self.metric == "russellrao":

--- a/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier.pyx
@@ -203,7 +203,7 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, *, convert_dtype="deprecated") -> "KNeighborsClassifier":
+    def fit(self, X, y) -> "KNeighborsClassifier":
         """
         Fit a GPU index for k-nearest neighbors classifier model.
 
@@ -213,11 +213,10 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
                 f"weights must be 'uniform', 'distance', or a callable, got {self.weights}"
             )
 
-        super().fit(X, convert_dtype=convert_dtype)
+        super().fit(X)
         y, classes = check_y(
             y,
             dtype="int32",
-            convert_dtype=convert_dtype,
             order="F",
             accept_multi_output=True,
             return_classes=True,
@@ -237,16 +236,14 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
                                        'description': 'Labels predicted',
                                        'shape': '(n_samples, 1)'})
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Use the trained k-nearest neighbors classifier to
         predict the labels for X
 
         """
         # Get KNN results - always get distances to compute weights
-        distances, indices = self.kneighbors(
-            X, return_distance=True, convert_dtype=convert_dtype
-        )
+        distances, indices = self.kneighbors(X, return_distance=True)
         indices = cp.ascontiguousarray(indices, dtype=cp.int64)
         cdef size_t n_rows = indices.shape[0]
 
@@ -294,16 +291,14 @@ class KNeighborsClassifier(ClassifierMixin, FMajorInputTagMixin, NeighborsBase):
                                        'description': 'Labels probabilities',
                                        'shape': '(n_samples, 1)'})
     @mlfunc(preserve_index=True)
-    def predict_proba(self, X, *, convert_dtype="deprecated"):
+    def predict_proba(self, X):
         """
         Use the trained k-nearest neighbors classifier to
         predict the label probabilities for X
 
         """
         # Get KNN results - always get distances to compute weights
-        distances, indices = self.kneighbors(
-            X, return_distance=True, convert_dtype=convert_dtype
-        )
+        distances, indices = self.kneighbors(X, return_distance=True)
         indices = cp.ascontiguousarray(indices, dtype=cp.int64)
         cdef size_t n_rows = indices.shape[0]
 

--- a/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_classifier_mg.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -64,7 +64,6 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         n_unique,
         ncols,
         rank,
-        convert_dtype
     ):
         """
         Predict labels for a query from previously stored index
@@ -84,7 +83,6 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         ncols: number of columns
         rank: rank of current worker
         n_neighbors: number of nearest neighbors to query
-        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------
@@ -96,10 +94,10 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         # Build input arrays and descriptors for native code interfacing
         input = self.gen_local_input(
             index, index_parts_to_ranks, index_nrows, query,
-            query_parts_to_ranks, query_nrows, ncols, rank, convert_dtype)
+            query_parts_to_ranks, query_nrows, ncols, rank)
 
         # Build input labels arrays and descriptors for native code interfacing
-        labels = self.gen_local_labels(index, convert_dtype, 'int32')
+        labels = self.gen_local_labels(index, 'int32')
 
         local_query_rows = [x.shape[0] for x in input['arrays']['query']]
 
@@ -171,8 +169,7 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
     @mlfunc(array_arg=None)
     def predict_proba(self, index, index_parts_to_ranks, index_nrows,
                       query, query_parts_to_ranks, query_nrows,
-                      uniq_labels, n_unique, ncols, rank,
-                      convert_dtype) -> tuple:
+                      uniq_labels, n_unique, ncols, rank) -> tuple:
         """
         Predict labels for a query from previously stored index
         and index labels.
@@ -190,7 +187,6 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         n_unique: array with number of possible labels for each columns
         ncols: number of columns
         rank: int rank of current worker
-        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------
@@ -202,10 +198,10 @@ class KNeighborsClassifierMG(NearestNeighborsMG):
         # Build input arrays and descriptors for native code interfacing
         input = self.gen_local_input(
             index, index_parts_to_ranks, index_nrows, query,
-            query_parts_to_ranks, query_nrows, ncols, rank, convert_dtype)
+            query_parts_to_ranks, query_nrows, ncols, rank)
 
         # Build input labels arrays and descriptors for native code interfacing
-        labels = self.gen_local_labels(index, convert_dtype, dtype='int32')
+        labels = self.gen_local_labels(index, dtype='int32')
 
         # Build uniq_labels_vec vector for native code interfacing
         uniq_labels_d = check_array(

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -214,7 +214,7 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, *, convert_dtype="deprecated") -> "KNeighborsRegressor":
+    def fit(self, X, y) -> "KNeighborsRegressor":
         """
         Fit a GPU index for k-nearest neighbors regression model.
 
@@ -223,15 +223,9 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
             raise ValueError(
                 f"weights must be 'uniform', 'distance', or a callable, got {self.weights}"
             )
-        super().fit(X, convert_dtype=convert_dtype)
+        super().fit(X)
 
-        y = check_y(
-            y,
-            dtype="float32",
-            convert_dtype=convert_dtype,
-            order="F",
-            accept_multi_output=True,
-        )
+        y = check_y(y, dtype="float32", order="F", accept_multi_output=True)
         check_consistent_length(self._fit_X, y)
         self._y = y
 
@@ -242,16 +236,14 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, n_features)'})
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Use the trained k-nearest neighbors regression model to
         predict the labels for X
 
         """
         # Get KNN results - always get distances to compute weights
-        distances, indices = self.kneighbors(
-            X, return_distance=True, convert_dtype=convert_dtype
-        )
+        distances, indices = self.kneighbors(X, return_distance=True)
         indices = cp.ascontiguousarray(indices, dtype=cp.int64)
         cdef size_t n_rows = indices.shape[0]
         cdef int64_t* inds_ptr = <int64_t*><uintptr_t>indices.data.ptr

--- a/python/cuml/cuml/neighbors/kneighbors_regressor_mg.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor_mg.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -55,7 +55,6 @@ class KNeighborsRegressorMG(NearestNeighborsMG):
         ncols,
         n_outputs,
         rank,
-        convert_dtype
     ):
         """
         Predict outputs for a query from previously stored index
@@ -73,7 +72,6 @@ class KNeighborsRegressorMG(NearestNeighborsMG):
         ncols: number of columns
         n_outputs: number of outputs columns
         rank: rank of current worker
-        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------
@@ -85,10 +83,10 @@ class KNeighborsRegressorMG(NearestNeighborsMG):
         # Build input arrays and descriptors for native code interfacing
         input = self.gen_local_input(
             index, index_parts_to_ranks, index_nrows, query,
-            query_parts_to_ranks, query_nrows, ncols, rank, convert_dtype)
+            query_parts_to_ranks, query_nrows, ncols, rank)
 
         # Build input labels arrays and descriptors for native code interfacing
-        labels = self.gen_local_labels(index, convert_dtype, dtype='float32')
+        labels = self.gen_local_labels(index, dtype='float32')
 
         local_query_rows = [x.shape[0] for x in input['arrays']['query']]
 

--- a/python/cuml/cuml/neighbors/nearest_neighbors.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors.pyx
@@ -602,7 +602,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
 
     @generate_docstring(X='dense_sparse')
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated") -> "NearestNeighbors":
+    def fit(self, X, y=None) -> "NearestNeighbors":
         """
         Fit GPU index for performing nearest neighbor queries.
 
@@ -617,7 +617,6 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
             X,
             dtype="float32",
             accept_sparse=["csr"],
-            convert_dtype=convert_dtype,
             order="C",
             reset=True,
         )
@@ -693,7 +692,6 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
         n_neighbors=None,
         return_distance=True,
         *,
-        convert_dtype="deprecated",
         two_pass_precision=False
     ):
         """
@@ -709,13 +707,6 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
 
         return_distance: Boolean
             If False, distances will not be returned
-
-        convert_dtype : bool, default="deprecated"
-            .. deprecated:: 26.08
-                `convert_dtype` was deprecated in version 26.08 and will be
-                removed in version 26.10. cuML only copies input arrays when
-                necessary (e.g. to unify dtypes), there is no reason to provide
-                this keyword going forward.
 
         two_pass_precision : bool, optional (default = False)
             When set to True, a slow second pass will be used to improve the
@@ -765,7 +756,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
             distances, indices = self._kneighbors_sparse(X, n_neighbors)
         else:
             distances, indices = self._kneighbors_dense(
-                X, n_neighbors, convert_dtype, two_pass_precision
+                X, n_neighbors, two_pass_precision
             )
 
         if use_training_data:
@@ -773,9 +764,7 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
 
         return (distances, indices) if return_distance else indices
 
-    def _kneighbors_dense(
-        self, X, int n_neighbors, convert_dtype="deprecated", two_pass_precision=False
-    ):
+    def _kneighbors_dense(self, X, int n_neighbors, two_pass_precision=False):
         if is_sparse(X):
             raise ValueError("A NearestNeighbors model trained on dense "
                              "data requires dense input to kneighbors()")
@@ -783,7 +772,6 @@ class NeighborsBase(InteropMixin, CMajorInputTagMixin, SparseInputTagMixin, Base
         X = check_array(
             X,
             dtype="float32",
-            convert_dtype=convert_dtype,
             order="C",
             input_name="X",
         )

--- a/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
+++ b/python/cuml/cuml/neighbors/nearest_neighbors_mg.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -40,10 +40,9 @@ cdef extern from "cuml/neighbors/knn_mg.hpp" namespace "ML::KNN::opg" nogil:
     ) except +
 
 
-def _build_part_inputs(arrays, parts_to_ranks, m, n, local_rank, convert_dtype):
+def _build_part_inputs(arrays, parts_to_ranks, m, n, local_rank):
     cupy_arrays = [
-        check_array(array, order="F", dtype="float32", convert_dtype=convert_dtype)
-        for array in arrays
+        check_array(array, order="F", dtype="float32") for array in arrays
     ]
 
     cdef vector[floatData_t*] *local_parts = new vector[floatData_t*]()
@@ -92,7 +91,6 @@ class NearestNeighborsMG(NearestNeighbors):
         ncols,
         rank,
         n_neighbors,
-        convert_dtype
     ):
         """
         Query the kneighbors of an index
@@ -108,7 +106,6 @@ class NearestNeighborsMG(NearestNeighbors):
         ncols: number of columns
         rank: rank of current worker
         n_neighbors: number of nearest neighbors to query
-        convert_dtype: deprecated, will be removed in 26.10
 
         Returns
         -------
@@ -122,7 +119,7 @@ class NearestNeighborsMG(NearestNeighbors):
         # Build input arrays and descriptors for native code interfacing
         input = self.gen_local_input(
             index, index_parts_to_ranks, index_nrows, query,
-            query_parts_to_ranks, query_nrows, ncols, rank, convert_dtype)
+            query_parts_to_ranks, query_nrows, ncols, rank)
 
         query_arrays = input['arrays']['query']
         local_query_rows = [x.shape[0] for x in query_arrays]
@@ -166,16 +163,16 @@ class NearestNeighborsMG(NearestNeighbors):
     @staticmethod
     def gen_local_input(index, index_parts_to_ranks, index_nrows,
                         query, query_parts_to_ranks, query_nrows,
-                        ncols, rank, convert_dtype):
+                        ncols, rank):
         index_dask = [d[0] if isinstance(d, (list, tuple))
                       else d for d in index]
 
         index_arrays, index_local_parts, index_desc = _build_part_inputs(
-            index_dask, index_parts_to_ranks, index_nrows, ncols, rank, convert_dtype
+            index_dask, index_parts_to_ranks, index_nrows, ncols, rank
         )
 
         query_arrays, query_local_parts, query_desc = _build_part_inputs(
-            query, query_parts_to_ranks, query_nrows, ncols, rank, convert_dtype
+            query, query_parts_to_ranks, query_nrows, ncols, rank
         )
 
         return {
@@ -194,7 +191,7 @@ class NearestNeighborsMG(NearestNeighbors):
         }
 
     @staticmethod
-    def gen_local_labels(index, convert_dtype, dtype):
+    def gen_local_labels(index, dtype):
         cdef vector[vector[int*]] *out_local_parts_i32
         cdef vector[vector[float*]] *out_local_parts_f32
 
@@ -213,7 +210,6 @@ class NearestNeighborsMG(NearestNeighbors):
             arr = check_array(
                 arr,
                 dtype=dtype,
-                convert_dtype=convert_dtype,
                 order="F",
                 ensure_2d=False,
             )

--- a/python/cuml/cuml/random_projection/random_projection.py
+++ b/python/cuml/cuml/random_projection/random_projection.py
@@ -78,7 +78,7 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y=None, *, convert_dtype="deprecated"):
+    def fit(self, X, y=None):
         """Generate a random projection matrix."""
         # Use `mem_type=None` & `order=None` to minimize copies or transfers. We
         # don't need to access the data here, just ensure it's valid and get
@@ -87,7 +87,6 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
             self,
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             mem_type=None,
             order=None,
             accept_sparse=True,
@@ -122,14 +121,13 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(preserve_index=True)
-    def transform(self, X, *, convert_dtype="deprecated"):
+    def transform(self, X):
         """Project the data by taking the matrix product with the random matrix."""
         check_is_fitted(self)
         X = check_inputs(
             self,
             X,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             accept_sparse=("csr", "csc"),
             accept_large_sparse=True,
         )
@@ -152,11 +150,9 @@ class _BaseRandomProjection(SparseInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(preserve_index=True)
-    def fit_transform(self, X, y=None, *, convert_dtype="deprecated"):
+    def fit_transform(self, X, y=None):
         """Fit to data, then transform it."""
-        return self.fit(X, convert_dtype=convert_dtype).transform(
-            X, convert_dtype=convert_dtype
-        )
+        return self.fit(X).transform(X)
 
 
 class GaussianRandomProjection(_BaseRandomProjection):

--- a/python/cuml/cuml/solvers/cd.pyx
+++ b/python/cuml/cuml/solvers/cd.pyx
@@ -79,7 +79,6 @@ def fit_cd(
     y,
     sample_weight=None,
     *,
-    convert_dtype="deprecated",
     loss="squared_loss",
     double alpha=0.0001,
     double l1_ratio=0.15,
@@ -100,13 +99,6 @@ def fit_cd(
         The target values.
     sample_weight : None or array-like, shape=(n_samples,)
         The sample weights.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
-
     **kwargs
         Remaining keyword arguments match the hyperparameters
         to ``CD``, see the ``CD`` docs for more information.
@@ -136,7 +128,6 @@ def fit_cd(
         y,
         sample_weight,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         order="F",
         ensure_min_samples=2,
         reset=True,
@@ -314,7 +305,7 @@ class CD(FMajorInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, convert_dtype="deprecated", sample_weight=None) -> "CD":
+    def fit(self, X, y, sample_weight=None) -> "CD":
         """
         Fit the model with X and y.
         """
@@ -323,7 +314,6 @@ class CD(FMajorInputTagMixin, Base):
             X,
             y,
             sample_weight=sample_weight,
-            convert_dtype=convert_dtype,
             loss=self.loss,
             alpha=self.alpha,
             l1_ratio=self.l1_ratio,
@@ -343,7 +333,7 @@ class CD(FMajorInputTagMixin, Base):
                                        'description': 'Predicted values',
                                        'shape': '(n_samples, 1)'})
     @mlfunc(preserve_index=True)
-    def predict(self, X, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts the y for X.
         """
@@ -353,7 +343,6 @@ class CD(FMajorInputTagMixin, Base):
             self,
             X,
             dtype=self.coef_.dtype,
-            convert_dtype=convert_dtype,
         )
         preds = cp.zeros(X.shape[0], dtype=self.coef_.dtype, order="F")
 

--- a/python/cuml/cuml/solvers/qn.pyx
+++ b/python/cuml/cuml/solvers/qn.pyx
@@ -125,7 +125,6 @@ def fit_qn(
     y,
     sample_weight=None,
     *,
-    convert_dtype="deprecated",
     loss="l2",
     class_weight=None,
     bool fit_intercept=True,
@@ -153,13 +152,6 @@ def fit_qn(
         The target values.
     sample_weight : None or array-like, shape=(n_samples,)
         The sample weights.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
-
     class_weight : dict or 'balanced', default=None
         Weights associated per-classes, or None for uniform weights. If 'balanced',
         weights inversely proportional to the class frequencies will be used.
@@ -190,7 +182,6 @@ def fit_qn(
         y,
         sample_weight,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         accept_sparse="csr",
         ensure_min_samples=2,
         y_dtype=(None if return_classes else ...),
@@ -244,9 +235,7 @@ def fit_qn(
     if init_coef is None:
         coef = cp.zeros(coef_shape, dtype=X.dtype, order="C")
     else:
-        coef = check_array(
-            init_coef, dtype=X.dtype, convert_dtype=convert_dtype, order="C",
-        )
+        coef = check_array(init_coef, dtype=X.dtype, order="C")
         if coef.shape != coef_shape:
             raise ValueError(f"Expected coef.shape == ({coef_shape}), got {coef.shape}")
 
@@ -541,7 +530,7 @@ class QN(Base):
 
     @generate_docstring(X="dense_sparse")
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, sample_weight=None, convert_dtype="deprecated") -> "QN":
+    def fit(self, X, y, sample_weight=None) -> "QN":
         """
         Fit the model with X and y.
         """
@@ -561,7 +550,6 @@ class QN(Base):
             X,
             y,
             sample_weight=sample_weight,
-            convert_dtype=convert_dtype,
             loss=self.loss,
             fit_intercept=self.fit_intercept,
             l1_strength=self.l1_strength,
@@ -593,7 +581,7 @@ class QN(Base):
 
     @generate_docstring(X="dense_sparse")
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """Predicts the y for X."""
         check_is_fitted(self)
 
@@ -601,7 +589,6 @@ class QN(Base):
             self,
             X,
             dtype=self.coef_.dtype,
-            convert_dtype=convert_dtype,
             accept_sparse=True,
         )
 

--- a/python/cuml/cuml/solvers/sgd.pyx
+++ b/python/cuml/cuml/solvers/sgd.pyx
@@ -101,7 +101,6 @@ def fit_sgd(
     X,
     y,
     *,
-    convert_dtype="deprecated",
     return_classes=False,
     loss="squared_loss",
     penalty=None,
@@ -174,7 +173,6 @@ def fit_sgd(
         X,
         y,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         order="F",
         return_classes=return_classes,
         reset=True,
@@ -406,7 +404,7 @@ class SGD(FMajorInputTagMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(self, X, y, *, convert_dtype="deprecated") -> "SGD":
+    def fit(self, X, y) -> "SGD":
         """
         Fit the model with X and y.
 
@@ -415,7 +413,6 @@ class SGD(FMajorInputTagMixin, Base):
             self,
             X,
             y,
-            convert_dtype=convert_dtype,
             loss=self.loss,
             penalty=self.penalty,
             alpha=self.alpha,
@@ -443,7 +440,7 @@ class SGD(FMajorInputTagMixin, Base):
         }
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts the y for X.
 
@@ -454,7 +451,6 @@ class SGD(FMajorInputTagMixin, Base):
             self,
             X,
             dtype=self.coef_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
         )
 

--- a/python/cuml/cuml/svm/linear.pyx
+++ b/python/cuml/cuml/svm/linear.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 import cupy as cp
@@ -62,7 +62,6 @@ def fit(
     y,
     sample_weight=None,
     *,
-    convert_dtype="deprecated",
     is_classifier=False,
     class_weight=None,
     n_streams=0,
@@ -162,7 +161,6 @@ def fit(
         y,
         sample_weight,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         order="F",
         y_dtype=(None if is_classifier else ...),
         return_classes=is_classifier,

--- a/python/cuml/cuml/svm/linear_svc.py
+++ b/python/cuml/cuml/svm/linear_svc.py
@@ -221,9 +221,7 @@ class LinearSVC(InteropMixin, LinearClassifierMixin, ClassifierMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "LinearSVC":
+    def fit(self, X, y, sample_weight=None) -> "LinearSVC":
         """Fit the model according to the given training data."""
         n_streams = self.n_streams
         if isinstance(n_streams, bool) or not isinstance(
@@ -243,7 +241,6 @@ class LinearSVC(InteropMixin, LinearClassifierMixin, ClassifierMixin, Base):
             X,
             y,
             sample_weight,
-            convert_dtype=convert_dtype,
             is_classifier=True,
             n_streams=n_streams,
             class_weight=self.class_weight,
@@ -274,9 +271,9 @@ class LinearSVC(InteropMixin, LinearClassifierMixin, ClassifierMixin, Base):
         },
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """Predict class labels for samples in X."""
-        scores = self.decision_function(X, convert_dtype=convert_dtype)
+        scores = self.decision_function(X)
         if scores.ndim == 1:
             indices = (scores >= 0).view(cp.int8)
         else:

--- a/python/cuml/cuml/svm/linear_svr.py
+++ b/python/cuml/cuml/svm/linear_svr.py
@@ -199,16 +199,13 @@ class LinearSVR(InteropMixin, LinearPredictMixin, RegressorMixin, Base):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "LinearSVR":
+    def fit(self, X, y, sample_weight=None) -> "LinearSVR":
         """Fit the model according to the given training data."""
         coef, intercept, n_iter, _ = cuml.svm.linear.fit(
             self,
             X,
             y,
             sample_weight=sample_weight,
-            convert_dtype=convert_dtype,
             loss=self.loss,
             penalty=self.penalty,
             fit_intercept=self.fit_intercept,

--- a/python/cuml/cuml/svm/svc.py
+++ b/python/cuml/cuml/svm/svc.py
@@ -341,9 +341,7 @@ class SVC(ClassifierMixin, SVMBase):
 
     @generate_docstring(y="dense_anydtype")
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "SVC":
+    def fit(self, X, y, sample_weight=None) -> "SVC":
         """
         Fit the model with X and y.
 
@@ -360,7 +358,6 @@ class SVC(ClassifierMixin, SVMBase):
             y,
             sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="F",
             accept_sparse="csr",
             ensure_min_samples=2,
@@ -408,7 +405,7 @@ class SVC(ClassifierMixin, SVMBase):
         }
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts the class labels for X. The returned y values are the class
         labels associated to sign(decision_function(X)).
@@ -418,7 +415,7 @@ class SVC(ClassifierMixin, SVMBase):
         if hasattr(self, "_multiclass"):
             indices = self._multiclass.predict(X)
         else:
-            res = self.decision_function(X, convert_dtype=convert_dtype)
+            res = self.decision_function(X)
             indices = (res >= 0).view(cp.int8)
 
         return ClassLabels(indices, self.classes_)
@@ -432,7 +429,7 @@ class SVC(ClassifierMixin, SVMBase):
         }
     )
     @mlfunc(preserve_index=True)
-    def decision_function(self, X, *, convert_dtype="deprecated"):
+    def decision_function(self, X):
         """
         Calculates the decision function values for X.
 
@@ -446,4 +443,4 @@ class SVC(ClassifierMixin, SVMBase):
         if hasattr(self, "_multiclass"):
             return self._multiclass.decision_function(X)
 
-        return self._predict(X, convert_dtype=convert_dtype)
+        return self._predict(X)

--- a/python/cuml/cuml/svm/svm_base.pyx
+++ b/python/cuml/cuml/svm/svm_base.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
 import cupyx.scipy.sparse as cp_sp
@@ -464,7 +464,7 @@ class SVMBase(InteropMixin,
         self._gamma = gamma
         self._sparse = sparse_X
 
-    def _predict(self, X, *, convert_dtype="deprecated"):
+    def _predict(self, X):
         """Perform `predict`."""
         check_is_fitted(self)
 
@@ -477,7 +477,6 @@ class SVMBase(InteropMixin,
             self,
             X,
             dtype=self.support_vectors_.dtype,
-            convert_dtype=convert_dtype,
             order="F",
             accept_sparse="csr",
         )

--- a/python/cuml/cuml/svm/svr.py
+++ b/python/cuml/cuml/svm/svr.py
@@ -131,9 +131,7 @@ class SVR(RegressorMixin, SVMBase):
 
     @generate_docstring()
     @mlfunc(set_input_type=True)
-    def fit(
-        self, X, y, sample_weight=None, *, convert_dtype="deprecated"
-    ) -> "SVR":
+    def fit(self, X, y, sample_weight=None) -> "SVR":
         """
         Fit the model with X and y.
 
@@ -147,7 +145,6 @@ class SVR(RegressorMixin, SVMBase):
             y,
             sample_weight,
             dtype=("float32", "float64"),
-            convert_dtype=convert_dtype,
             order="F",
             ensure_min_samples=2,
             accept_sparse="csr",
@@ -171,7 +168,7 @@ class SVR(RegressorMixin, SVMBase):
         }
     )
     @mlfunc(preserve_index=True)
-    def predict(self, X, *, convert_dtype="deprecated"):
+    def predict(self, X):
         """
         Predicts the values for X.
 
@@ -180,4 +177,4 @@ class SVR(RegressorMixin, SVMBase):
         number of samples used during fit.
 
         """
-        return self._predict(X, convert_dtype=convert_dtype)
+        return self._predict(X)

--- a/python/cuml/cuml/tsa/arima.pyx
+++ b/python/cuml/cuml/tsa/arima.pyx
@@ -186,12 +186,6 @@ class ARIMA(Base):
         type. If None, the output type set at the module level
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
 
     Attributes
     ----------
@@ -293,8 +287,7 @@ class ARIMA(Base):
                  fit_intercept=True,
                  simple_differencing=True,
                  verbose=False,
-                 output_type=None,
-                 convert_dtype="deprecated"):
+                 output_type=None):
 
         warn_deprecated_tsa_api("cuml.tsa.ARIMA")
 
@@ -327,7 +320,6 @@ class ARIMA(Base):
             endog,
             dtype="float64",
             order="F",
-            convert_dtype=convert_dtype,
             ensure_2d=False,
             ensure_all_finite=False,
         )
@@ -345,7 +337,6 @@ class ARIMA(Base):
                 exog,
                 dtype="float64",
                 order="F",
-                convert_dtype=convert_dtype,
                 ensure_2d=False,
                 ensure_all_finite=False,
             )
@@ -558,7 +549,7 @@ class ARIMA(Base):
                 params[names[i]] = getattr(self, "{}_".format(names[i]))
         return params
 
-    def set_fit_params(self, params: Mapping[str, object], convert_dtype="deprecated"):
+    def set_fit_params(self, params: Mapping[str, object]):
         """Set all the fit parameters. Not to be confused with ``set_params``
         Note: `unpack()` can be used to load a compact vector of the
         parameters
@@ -577,7 +568,6 @@ class ARIMA(Base):
                 array = check_array(
                     params[param_name],
                     dtype="float64",
-                    convert_dtype=convert_dtype,
                     ensure_2d=False,
                     ensure_all_finite=False,
                 )
@@ -618,7 +608,6 @@ class ARIMA(Base):
         end=None,
         level=None,
         exog=None,
-        convert_dtype="deprecated"
     ):
         """Compute in-sample and/or out-of-sample prediction for each series
 
@@ -705,7 +694,6 @@ class ARIMA(Base):
             d_exog_fut = check_array(
                 exog,
                 dtype="float64",
-                convert_dtype=convert_dtype,
                 order="F",
                 ensure_2d=False,
                 ensure_all_finite=False,
@@ -863,8 +851,7 @@ class ARIMA(Base):
             h: float = 1e-8,
             maxiter: int = 1000,
             method="ml",
-            truncate: int = 0,
-            convert_dtype = "deprecated") -> "ARIMA":
+            truncate: int = 0) -> "ARIMA":
         r"""Fit the ARIMA model to each time series.
 
         Parameters
@@ -906,16 +893,14 @@ class ARIMA(Base):
                 """The (batched) energy functional returning the negative
                 log-likelihood (foreach series)."""
                 # Recall: We maximize LL by minimizing -LL
-                n_llf = -self._loglike(x, True, fit_method, truncate,
-                                       convert_dtype)
+                n_llf = -self._loglike(x, True, fit_method, truncate)
                 return n_llf / (self.n_obs - 1)
 
             # Optimized finite differencing gradient for batches
             def gf(x) -> np.ndarray:
                 """The gradient of the (batched) energy functional."""
                 # Recall: We maximize LL by minimizing -LL
-                n_gllf = -self._loglike_grad(x, h, True, fit_method, truncate,
-                                             convert_dtype)
+                n_gllf = -self._loglike_grad(x, h, True, fit_method, truncate)
                 return n_gllf / (self.n_obs - 1)
 
             # Check initial parameter sanity
@@ -954,12 +939,12 @@ class ARIMA(Base):
             x, niter = fit_helper(x if method == "css-ml" else x0, "ml")
             self.niter = (self.niter + niter) if method == "css-ml" else niter
 
-        self.unpack(self._batched_transform(x), convert_dtype)
+        self.unpack(self._batched_transform(x))
         return self
 
     @nvtx.annotate(message="tsa.arima.ARIMA._loglike", domain="cuml_python")
     @mlfunc(convert_output=False)
-    def _loglike(self, x, trans=True, method="ml", truncate=0, convert_dtype="deprecated"):
+    def _loglike(self, x, trans=True, method="ml", truncate=0):
         """Compute the batched log-likelihood for the given parameters.
 
         Parameters
@@ -993,7 +978,6 @@ class ARIMA(Base):
         d_x_array = check_array(
             x,
             dtype="float64",
-            convert_dtype=convert_dtype,
             order="C",
             ensure_2d=False,
             ensure_all_finite=False,
@@ -1030,8 +1014,7 @@ class ARIMA(Base):
     @nvtx.annotate(message="tsa.arima.ARIMA._loglike_grad",
                    domain="cuml_python")
     @mlfunc(convert_output=False)
-    def _loglike_grad(self, x, h=1e-8, trans=True, method="ml", truncate=0,
-                      convert_dtype="deprecated"):
+    def _loglike_grad(self, x, h=1e-8, trans=True, method="ml", truncate=0):
         """Compute the gradient (via finite differencing) of the batched
         log-likelihood.
 
@@ -1073,7 +1056,6 @@ class ARIMA(Base):
         d_x_array = check_array(
             x,
             dtype="float64",
-            convert_dtype=convert_dtype,
             order="C",
             ensure_2d=False,
             ensure_all_finite=False,
@@ -1157,7 +1139,7 @@ class ARIMA(Base):
 
     @nvtx.annotate(message="tsa.arima.ARIMA.unpack", domain="cuml_python")
     @mlfunc(convert_output=False)
-    def unpack(self, x: Union[list, np.ndarray], convert_dtype="deprecated"):
+    def unpack(self, x: Union[list, np.ndarray]):
         """Unpack linearized parameter vector `x` into the separate
         parameter arrays of the model
 
@@ -1178,7 +1160,6 @@ class ARIMA(Base):
         d_x_array = check_array(
             x,
             dtype="float64",
-            convert_dtype=convert_dtype,
             order="C",
             ensure_2d=False,
             ensure_all_finite=False,

--- a/python/cuml/cuml/tsa/auto_arima.pyx
+++ b/python/cuml/cuml/tsa/auto_arima.pyx
@@ -120,12 +120,6 @@ class AutoARIMA(Base):
         type. If None, the output type set at the module level
         (`cuml.global_settings.output_type`) will be used. See
         :ref:`output-data-type-configuration` for more info.
-    convert_dtype : bool, default="deprecated"
-        .. deprecated:: 26.08
-            `convert_dtype` was deprecated in version 26.08 and will be
-            removed in version 26.10. cuML only copies input arrays when
-            necessary (e.g. to unify dtypes), there is no reason to provide
-            this keyword going forward.
 
     Notes
     -----
@@ -165,8 +159,7 @@ class AutoARIMA(Base):
                  *,
                  simple_differencing=True,
                  verbose=False,
-                 output_type=None,
-                 convert_dtype="deprecated"):
+                 output_type=None):
 
         warn_deprecated_tsa_api("cuml.tsa.auto_arima.AutoARIMA")
 
@@ -178,7 +171,6 @@ class AutoARIMA(Base):
         self.d_y = d_y = check_array(
             endog,
             dtype="float64",
-            convert_dtype=convert_dtype,
             order="F",
             ensure_2d=False,
             ensure_all_finite=False,

--- a/python/cuml/cuml/tsa/seasonality.py
+++ b/python/cuml/cuml/tsa/seasonality.py
@@ -10,7 +10,7 @@ from cuml.tsa._deprecation import deprecated_tsa_api
 
 @deprecated_tsa_api("cuml.tsa.seasonality.seas_test")
 @mlfunc
-def seas_test(y, s, convert_dtype="deprecated"):
+def seas_test(y, s):
     """
     Perform Wang, Smith & Hyndman's test to decide whether seasonal
     differencing is needed
@@ -46,7 +46,6 @@ def seas_test(y, s, convert_dtype="deprecated"):
     y = check_array(
         y,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         mem_type="host",
         ensure_all_finite=False,
         input_name="y",

--- a/python/cuml/cuml/tsa/stationarity.pyx
+++ b/python/cuml/cuml/tsa/stationarity.pyx
@@ -40,7 +40,6 @@ def kpss_test(
     int D=0,
     int s=0,
     double pval_threshold=0.05,
-    convert_dtype="deprecated",
 ):
     """
     Perform the KPSS stationarity test on the data differenced according
@@ -73,7 +72,6 @@ def kpss_test(
     d_y = check_array(
         y,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         order="F",
         input_name="y",
         ensure_all_finite=False,

--- a/python/cuml/tests/test_validation.py
+++ b/python/cuml/tests/test_validation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import re
 import warnings
@@ -810,45 +810,6 @@ def test_check_array_sparse_copy(mem_type, format):
     else:
         assert ptr(res.indices) != ptr(array.indices)
         assert ptr(res.indptr) != ptr(array.indptr)
-
-
-def test_convert_dtype_deprecated():
-    model = MyModel()
-    X = cp.array([[1, 2], [3, 4], [5, 6]], dtype="float32")
-    y = sample_weight = cp.array([1, 2, 3], dtype="float32")
-
-    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
-        check_array(X, dtype="float64", convert_dtype=True)
-
-    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
-        check_inputs(model, X, dtype="float64", convert_dtype=True)
-
-    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
-        check_y(y, dtype="float64", convert_dtype=True)
-
-    with pytest.warns(FutureWarning, match="`convert_dtype` was deprecated"):
-        check_sample_weight(sample_weight, dtype="float64", convert_dtype=True)
-
-
-@pytest.mark.filterwarnings(
-    "ignore:`convert_dtype` was deprecated:FutureWarning"
-)
-def test_check_array_convert_dtype():
-    array = cp.array([[1, 2, 3]], dtype="float32")
-
-    with pytest.raises(
-        ValueError,
-        match=r"Expected array with dtype in \['int32'\] but got 'float32'",
-    ):
-        check_array(array, dtype="int32", convert_dtype=False)
-
-    array = pd.DataFrame({"x": [1, 2, 3], "y": [1.5, 2.5, 3.5]})
-    with pytest.raises(ValueError, match=r"\['int32'\] but got 'float64'"):
-        check_array(array, dtype="int32", convert_dtype=False)
-
-    array = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "a"]})
-    with pytest.raises(ValueError, match=r"\['int32'\] but got 'object'"):
-        check_array(array, dtype="int32", convert_dtype=False)
 
 
 @pytest.mark.parametrize("kind", ["cudf", "pandas"])

--- a/wiki/python/DEVELOPER_GUIDE.md
+++ b/wiki/python/DEVELOPER_GUIDE.md
@@ -254,7 +254,7 @@ Prefer `check_inputs` for estimator methods that validate `X` and optional `y`
 has a non-standard shape that the higher-level helper cannot express.
 
 Validation helpers should be configured to describe what the estimator actually
-supports. Set `dtype`, `convert_dtype`, `mem_type`, `order`, `accept_sparse`,
+supports. Set `dtype`, `mem_type`, `order`, `accept_sparse`,
 `ensure_all_finite`, `ensure_non_negative`, and minimum shape requirements
 explicitly when the defaults are not correct. Do not hand-roll equivalent
 checks unless the common helpers cannot express the estimator's requirements.

--- a/wiki/python/ESTIMATOR_GUIDE.md
+++ b/wiki/python/ESTIMATOR_GUIDE.md
@@ -257,13 +257,12 @@ from cuml.internals.validation import check_inputs, check_is_fitted
 
 
 @mlfunc(set_input_type=True)
-def fit(self, X, y, *, convert_dtype=True):
+def fit(self, X, y):
     X, y = check_inputs(
         self,
         X,
         y,
         dtype=("float32", "float64"),
-        convert_dtype=convert_dtype,
         order="K",
         reset=True,
     )
@@ -273,13 +272,12 @@ def fit(self, X, y, *, convert_dtype=True):
 
 
 @mlfunc(preserve_index=True)
-def transform(self, X, *, convert_dtype=True):
+def transform(self, X):
     check_is_fitted(self)
     X = check_inputs(
         self,
         X,
         dtype=self.result_.dtype,
-        convert_dtype=convert_dtype,
         order="K",
     )
     ...


### PR DESCRIPTION
This removes the deprecated `convert_dtype` kwarg everywhere.

Part of #8225.