### PR TITLE
Reject negative inputs in chi-squared kernels

### DIFF
--- a/python/cuml/cuml/metrics/pairwise_kernels.py
+++ b/python/cuml/cuml/metrics/pairwise_kernels.py
@@ -278,11 +278,14 @@ def pairwise_kernels(
             [5.04347663e-07, 2.03468369e-04],
             [4.24835426e-18, 2.54366565e-13]])
     """
-    X = check_array(X, input_name="X")
+    ensure_non_negative = metric in ("additive_chi2", "chi2")
+    X = check_array(X, input_name="X", ensure_non_negative=ensure_non_negative)
     if Y is None:
         Y = X
     else:
-        Y = check_array(Y, input_name="Y")
+        Y = check_array(
+            Y, input_name="Y", ensure_non_negative=ensure_non_negative
+        )
     if X.shape[1] != Y.shape[1]:
         raise ValueError("X and Y have different dimensions.")
 

--- a/python/cuml/tests/test_kernel_ridge.py
+++ b/python/cuml/tests/test_kernel_ridge.py
@@ -107,6 +107,27 @@ def test_pairwise_kernels_basic():
     assert np.allclose(X, pairwise_kernels(X, metric="precomputed"))
 
 
+@pytest.mark.parametrize("metric", ["additive_chi2", "chi2"])
+def test_pairwise_kernels_rejects_negative_x_for_chi2(metric):
+    X = np.array([[1.0, -1.0], [2.0, 3.0]])
+
+    with pytest.raises(
+        ValueError, match="Negative values in data passed to X"
+    ):
+        pairwise_kernels(X, metric=metric)
+
+
+@pytest.mark.parametrize("metric", ["additive_chi2", "chi2"])
+def test_pairwise_kernels_rejects_negative_y_for_chi2(metric):
+    X = np.array([[1.0, 2.0]])
+    Y = np.array([[3.0, -1.0]])
+
+    with pytest.raises(
+        ValueError, match="Negative values in data passed to Y"
+    ):
+        pairwise_kernels(X, Y, metric=metric)
+
+
 @cuda.jit(device=True)
 def custom_kernel(x, y, custom_arg=5.0):
     sum = 0.0


### PR DESCRIPTION
## Summary

- Reject negative feature values for `chi2` and `additive_chi2`.
- Validate both `X` and `Y` through the existing `check_array` path.
- Add regression coverage for negative values in either input.

Chi-squared kernels are defined for non-negative feature values. Previously, negative values reached the CUDA kernel and could produce invalid similarities.

## Testing

- `pre-commit run --files python/cuml/cuml/metrics/pairwise_kernels.py python/cuml/tests/test_kernel_ridge.py`
- `python3 -m py_compile python/cuml/cuml/metrics/pairwise_kernels.py python/cuml/tests/test_kernel_ridge.py`