### PR TITLE
Replace `rapids-xgboost` with `xgboost` in the CI.

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -114,7 +114,6 @@ DEPENDENCIES=(
   pylibraft
   raft-dask
   rapids-dask-dependency
-  rapids-xgboost
   rmm
 )
 for DEP in "${DEPENDENCIES[@]}"; do

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 ########################
 # cuML Version Updater #

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,6 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -87,6 +86,7 @@ dependencies:
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0.0
 - umap-learn>=0.5.7,<0.5.13
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
+- xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,6 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -69,7 +70,6 @@ dependencies:
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.10.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - recommonmark
 - rich
 - rmm==26.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
+- xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,6 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -68,7 +69,6 @@ dependencies:
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.10.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - recommonmark
 - rich
 - rmm==26.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,6 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- xgboost>=3.3.0
 - cuda-bindings>=12.9.2,<13.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -86,6 +85,7 @@ dependencies:
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0.0
 - umap-learn>=0.5.7,<0.5.13
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,6 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -87,6 +86,7 @@ dependencies:
 - sysroot_linux-aarch64==2.28
 - treelite>=4.7.0,<5.0.0
 - umap-learn>=0.5.7,<0.5.13
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
+- xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,6 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -69,7 +70,6 @@ dependencies:
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.10.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - recommonmark
 - rich
 - rmm==26.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,6 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
+- conda-forge::xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -68,7 +69,6 @@ dependencies:
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.10.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
-- rapids-xgboost==26.10.*,>=0.0.0a0
 - recommonmark
 - rich
 - rmm==26.10.*,>=0.0.0a0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- conda-forge::xgboost>=3.3.0
+- xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,6 @@ dependencies:
 - ccache
 - certifi
 - cmake>=4.0
-- xgboost>=3.3.0
 - cuda-bindings>=13.0.1,<14.0
 - cuda-cudart-dev
 - cuda-nvcc
@@ -86,6 +85,7 @@ dependencies:
 - sysroot_linux-64==2.28
 - treelite>=4.7.0,<5.0.0
 - umap-learn>=0.5.7,<0.5.13
+- xgboost>=3.3.0
 - pip:
   - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -726,7 +726,7 @@ dependencies:
             packages: []
           - matrix:
             packages:
-              - rapids-xgboost==26.10.*,>=0.0.0a0
+              - conda-forge::xgboost>=3.3.0
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -726,7 +726,7 @@ dependencies:
             packages: []
           - matrix:
             packages:
-              - conda-forge::xgboost>=3.3.0
+              - xgboost>=3.3.0
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:


### PR DESCRIPTION
The CI will continue to install XGBoost from the rapidsai channel until the package is removed. See https://github.com/rapidsai/nvforest/pull/185#discussion_r3708386532