### PR TITLE
Simplify dask serializers

### DIFF
--- a/python/cuml/cuml/comm/serialize.py
+++ b/python/cuml/cuml/comm/serialize.py
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-
-
 import cudf.comm.serialize  # noqa: F401
 
 import cuml
@@ -18,38 +16,22 @@ try:
     from distributed.protocol.serialize import pickle_dumps, pickle_loads
 
     from cuml.ensemble import RandomForestClassifier, RandomForestRegressor
-    from cuml.naive_bayes import MultinomialNB
 
-    # Registering RF Regressor and Classifier to use pickling even when
-    # Base is serialized with Dask or CUDA serializations
-    @dask_serialize.register(RandomForestRegressor)
-    @cuda_serialize.register(RandomForestRegressor)
-    def rfr_serialize(rf):
-        return pickle_dumps(rf)
+    # These classes require pickling instead of automatically traversing
+    # __dict__. They contain non-serializable internal attributes, and their
+    # representation is better serialized via pickle anyway.
+    pickle_only_classes = (RandomForestRegressor, RandomForestClassifier)
 
-    @dask_deserialize.register(RandomForestRegressor)
-    @cuda_deserialize.register(RandomForestRegressor)
-    def rfr_deserialize(header, frames):
-        return pickle_loads(header, frames)
+    for name, dumps, loads in [
+        ("cuda", cuda_serialize, cuda_deserialize),
+        ("dask", dask_serialize, dask_deserialize),
+    ]:
+        # Generic implementation for `cuml.Base` estimators
+        register_generic(cuml.Base, name, dumps, loads)
 
-    @dask_serialize.register(RandomForestClassifier)
-    @cuda_serialize.register(RandomForestClassifier)
-    def rfc_serialize(rf):
-        return pickle_dumps(rf)
-
-    @dask_deserialize.register(RandomForestClassifier)
-    @cuda_deserialize.register(RandomForestClassifier)
-    def rfc_deserialize(header, frames):
-        return pickle_loads(header, frames)
-
-    register_generic(cuml.Base, "cuda", cuda_serialize, cuda_deserialize)
-
-    register_generic(cuml.Base, "dask", dask_serialize, dask_deserialize)
-
-    register_generic(MultinomialNB, "cuda", cuda_serialize, cuda_deserialize)
-
-    register_generic(MultinomialNB, "dask", dask_serialize, dask_deserialize)
+        # Overrides for pickle-only classes
+        dumps.register(pickle_only_classes, pickle_dumps)
+        loads.register(pickle_only_classes, pickle_loads)
 
 except ImportError:
-    # distributed is probably not installed on the system
     pass


### PR DESCRIPTION
- Removes serializer override for `MultinomialNB`, this is unnecessary
- Simplifies the registration of serializers for other types, and improves the comments to better state why overrides are needed.

This is a small followup to #8385. I noticed in that PR that some of the code here could be simplified/was no longer necessary.

This should have no runtime effects (the same effective code should run before and after), it's just a small code cleanup.