### PR TITLE
X-ORG-8423: Enable docs version picker

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,6 +136,10 @@ html_theme_options = {
     "navbar_align": "right",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/cuml/versions.json",
+        "version_match": version,
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Contributes to #8423 

Let's enable the docs version picker.

N.B. I will backport this to 26.08 after the release to ensure it goes live for those docs.