### PR TITLE
Re-enable testing on GB300

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -370,8 +370,6 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_python_singlegpu.sh"
-      # https://github.com/rapidsai/cuml/issues/8430
-      matrix_filter: map(select(.GPU != "gb300"))
   conda-python-tests-cudf-pandas-integration:
     needs: [conda-python-build, changed-files]
     permissions:
@@ -552,8 +550,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
-      # https://github.com/rapidsai/cuml/issues/8430
-      matrix_filter: map(select(.GPU != "gb300"))
   wheel-tests-cuml-dask:
     needs: [wheel-build-cuml, changed-files]
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,8 +70,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: "ci/test_python_singlegpu.sh"
-      # https://github.com/rapidsai/cuml/issues/8430
-      matrix_filter: map(select(.GPU != "gb300"))
   conda-python-tests-dask:
     permissions:
       actions: read
@@ -182,8 +180,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel.sh
-      # https://github.com/rapidsai/cuml/issues/8430
-      matrix_filter: map(select(.GPU != "gb300"))
   wheel-tests-cuml-nightly-dependencies-versions:
     permissions:
       actions: read


### PR DESCRIPTION
With https://github.com/rapidsai/cuml/issues/8430 fixed, we can re-enable the GB300 runners.