### PR TITLE
Support `float64` `y` natively in `KNeighborsRegressor`

### DIFF
--- a/cpp/include/cuml/neighbors/knn.hpp
+++ b/cpp/include/cuml/neighbors/knn.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -230,6 +230,14 @@ void knn_regress(raft::handle_t& handle,
                  float* out,
                  int64_t* knn_indices,
                  std::vector<float*>& y,
+                 size_t n_index_rows,
+                 size_t n_query_rows,
+                 int k,
+                 float* sample_weight = nullptr);
+void knn_regress(raft::handle_t& handle,
+                 double* out,
+                 int64_t* knn_indices,
+                 std::vector<double*>& y,
                  size_t n_index_rows,
                  size_t n_query_rows,
                  int k,

--- a/cpp/src/knn/knn.cu
+++ b/cpp/src/knn/knn.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -433,6 +433,19 @@ void knn_regress(raft::handle_t& handle,
                  float* out,
                  int64_t* knn_indices,
                  std::vector<float*>& y,
+                 size_t n_index_rows,
+                 size_t n_query_rows,
+                 int k,
+                 float* sample_weight)
+{
+  MLCommon::Selection::knn_regress(
+    handle, out, knn_indices, y, n_index_rows, n_query_rows, k, sample_weight);
+}
+
+void knn_regress(raft::handle_t& handle,
+                 double* out,
+                 int64_t* knn_indices,
+                 std::vector<double*>& y,
                  size_t n_index_rows,
                  size_t n_query_rows,
                  int k,

--- a/python/cuml/cuml/accel/_overrides/sklearn/neighbors.py
+++ b/python/cuml/cuml/accel/_overrides/sklearn/neighbors.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -44,10 +44,6 @@ class KNeighborsClassifier(ProxyBase):
 class KNeighborsRegressor(ProxyBase):
     _gpu_class = cuml.neighbors.KNeighborsRegressor
     _other_attributes = frozenset(("_fit_method", "_tree", "_fit_X", "_y"))
-
-    def _gpu_predict(self, X):
-        # Fixup return dtype to always be float64
-        return self._gpu.predict(X).astype("float64", copy=False)
 
 
 class KernelDensity(ProxyBase):

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -181,10 +181,12 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
         }
 
     def _attrs_from_cpu(self, model):
-        return {
-            "_y": cp.asarray(model._y, order="F"),
-            **super()._attrs_from_cpu(model),
-        }
+        y = cp.asarray(
+            model._y,
+            dtype="float64" if model._y.dtype == "float64" else "float32",
+            order="F",
+        )
+        return {"_y": y, **super()._attrs_from_cpu(model)}
 
     def _attrs_to_cpu(self, model):
         return {

--- a/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
+++ b/python/cuml/cuml/neighbors/kneighbors_regressor.pyx
@@ -13,6 +13,7 @@ from cuml.neighbors.nearest_neighbors import NeighborsBase
 from cuml.neighbors.weights import compute_weights
 
 from libc.stdint cimport int64_t, uintptr_t
+from libcpp cimport bool
 from libcpp.vector cimport vector
 from pylibraft.common.handle cimport handle_t
 
@@ -24,6 +25,17 @@ cdef extern from "cuml/neighbors/knn.hpp" namespace "ML" nogil:
         float *out,
         int64_t *knn_indices,
         vector[float *] &y,
+        size_t n_index_rows,
+        size_t n_query_rows,
+        int k,
+        float *sample_weight
+    ) except +
+
+    void knn_regress(
+        handle_t &handle,
+        double *out,
+        int64_t *knn_indices,
+        vector[double *] &y,
         size_t n_index_rows,
         size_t n_query_rows,
         int k,
@@ -170,7 +182,7 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
 
     def _attrs_from_cpu(self, model):
         return {
-            "_y": cp.asarray(model._y, dtype=cp.float32, order="F"),
+            "_y": cp.asarray(model._y, order="F"),
             **super()._attrs_from_cpu(model),
         }
 
@@ -225,7 +237,7 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
             )
         super().fit(X)
 
-        y = check_y(y, dtype="float32", order="F", accept_multi_output=True)
+        y = check_y(y, dtype=("float32", "float64"), order="F", accept_multi_output=True)
         check_consistent_length(self._fit_X, y)
         self._y = y
 
@@ -251,16 +263,18 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
         res_cols = 1 if self._y.ndim == 1 else self._y.shape[1]
         res_shape = n_rows if res_cols == 1 else (n_rows, res_cols)
 
-        out = cp.zeros(res_shape, dtype=cp.float32, order="C")
+        out = cp.zeros(res_shape, dtype=self._y.dtype, order="C")
+        cdef uintptr_t out_ptr = <uintptr_t>out.data.ptr
+        cdef bool use_f32 = self._y.dtype == "float32"
 
-        cdef float* out_ptr = <float*><uintptr_t>out.data.ptr
-
-        cdef vector[float*] y_vec
-        cdef float* y_ptr
+        cdef vector[float*] y_f32_vec
+        cdef vector[double*] y_f64_vec
         for col_num in range(res_cols):
             col = self._y if res_cols == 1 else self._y[:, col_num]
-            y_ptr = <float*><uintptr_t>col.data.ptr
-            y_vec.push_back(y_ptr)
+            if use_f32:
+                y_f32_vec.push_back(<float*><uintptr_t>col.data.ptr)
+            else:
+                y_f64_vec.push_back(<double*><uintptr_t>col.data.ptr)
 
         handle = get_handle()
         cdef handle_t* handle_ = <handle_t*><size_t>handle.getHandle()
@@ -274,16 +288,28 @@ class KNeighborsRegressor(RegressorMixin, FMajorInputTagMixin, NeighborsBase):
         cdef size_t n_samples_fit = self._y.shape[0]
         cdef int n_neighbors = self.n_neighbors
         with nogil:
-            knn_regress(
-                handle_[0],
-                out_ptr,
-                inds_ptr,
-                y_vec,
-                n_samples_fit,
-                n_rows,
-                n_neighbors,
-                weights_ptr
-            )
+            if use_f32:
+                knn_regress(
+                    handle_[0],
+                    <float *>out_ptr,
+                    inds_ptr,
+                    y_f32_vec,
+                    n_samples_fit,
+                    n_rows,
+                    n_neighbors,
+                    weights_ptr
+                )
+            else:
+                knn_regress(
+                    handle_[0],
+                    <double *>out_ptr,
+                    inds_ptr,
+                    y_f64_vec,
+                    n_samples_fit,
+                    n_rows,
+                    n_neighbors,
+                    weights_ptr
+                )
 
         handle.sync()
 

--- a/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
+++ b/python/cuml/cuml_accel_tests/upstream/scikit-learn/xfail-list.yaml
@@ -340,7 +340,6 @@
   - "sklearn.model_selection.tests.test_classification_threshold::test_fit_and_score_over_thresholds_sample_weight"
   - "sklearn.model_selection.tests.test_classification_threshold::test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence"
   - "sklearn.model_selection.tests.test_validation::test_cross_val_predict_class_subset"
-  - "sklearn.neighbors.tests.test_neighbors::test_KNeighborsRegressor_multioutput_uniform_weight"
   - "sklearn.neighbors.tests.test_neighbors::test_auto_algorithm[X3-euclidean-None-kd_tree]"
   - "sklearn.neighbors.tests.test_neighbors::test_k_and_radius_neighbors_duplicates[auto]"
   - "sklearn.neighbors.tests.test_neighbors::test_k_and_radius_neighbors_duplicates[ball_tree]"
@@ -815,7 +814,6 @@
 - reason: test_estimators checks fail
   marker: cuml_accel_test_estimators
   tests:
-  - "sklearn.tests.test_common::test_estimators[KNeighborsRegressor()-check_supervised_y_no_nan]"
   - "sklearn.tests.test_common::test_estimators[RandomForestClassifier()-check_classifiers_multilabel_output_format_decision_function]"
 - reason: test_estimators checks fail
   marker: cuml_accel_test_estimators

--- a/python/cuml/tests/test_kneighbors_regressor.py
+++ b/python/cuml/tests/test_kneighbors_regressor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -87,7 +87,7 @@ def test_score(nrows, ncols, n_neighbors, n_clusters, datatype):
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_score_dtype(dtype):
+def test_predict_and_score_dtype(dtype):
     # Using make_blobs here to check averages and neighborhoods
     X, y = make_blobs(
         n_samples=1000,
@@ -102,6 +102,7 @@ def test_score_dtype(dtype):
 
     knn_cu = cuKNN(n_neighbors=5)
     knn_cu.fit(X, y)
+    assert knn_cu.predict(X).dtype == dtype
     assert knn_cu.score(X, y) >= 0.9999
 
 

--- a/python/cuml/tests/test_sklearn_compatibility.py
+++ b/python/cuml/tests/test_sklearn_compatibility.py
@@ -226,11 +226,6 @@ XFAILS = {
             "not equivalent to duplicating rows"
         ),
     },
-    KNeighborsRegressor: {
-        "check_regressor_multioutput": (
-            "predict returns float32 output, but the test expects float64"
-        ),
-    },
     LinearSVC: {
         "check_sample_weight_equivalence_on_dense_data": "Sample weights not equal to repeating data",
     },


### PR DESCRIPTION
Previously our `KNeighborsRegressor` implementation only natively supported `float32` `y` values, coercing inputs to `float32` if they weren't already. This doesn't match sklearn conventions (or our other regressors) where the input dtype of `y` is expected to be preserved.

This PR adds native support for float64 outputs (when a float64 input is provided), better matching sklearn conventions. Among other things, this lets us remove a few xfails in our sklearn compatibility and `cuml.accel` compat test suite.